### PR TITLE
[physics-loop][review-loop] toe-time blockG13 (STACKED on #5946) — Cycle 888: bounded theorem — S3 priced, the scope menu dissolves, the question becomes one word

### DIFF
--- a/docs/S3_SCOPE_PRICED_MENU_DISSOLVED_CYCLE888_BOUNDED_THEOREM_NOTE_2026-07-28.md
+++ b/docs/S3_SCOPE_PRICED_MENU_DISSOLVED_CYCLE888_BOUNDED_THEOREM_NOTE_2026-07-28.md
@@ -1,0 +1,207 @@
+# The menu dissolves: S3 priced, the scope is load-bearing, and the real question has one word — Cycle 888
+
+Date: 2026-08-04
+
+Authority: none
+
+Audit: unset
+
+Status: bounded worked result (owner-directed gravity axiom-up ladder;
+no axiom surface touched). Cycle 886's scope menu does not survive
+de-restriction: over the full subgroup lattice, ZERO non-circular
+clauses isolate C3, and the S3 candidate the checker exposed there is
+now fully priced. The owner-surface question sharpens from "pick one
+of six clauses" to "C3 or S3 — decided by multiplicity-freeness".
+
+Claim type: bounded_theorem
+
+Runners:
+
+- [`frontier_cycle888_s3_scope_pricing_2026_07_28.py`](../scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py)
+- [`frontier_cycle888_s3_scope_independent_check_2026_07_28.py`](../scripts/frontier_cycle888_s3_scope_independent_check_2026_07_28.py)
+
+Receipt:
+
+- [`s3_scope_pricing_cycle888_receipt_2026_07_28.json`](../outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json)
+- [`s3_scope_independent_check_cycle888_receipt_2026_07_28.json`](../outputs/s3_scope_independent_check_cycle888_receipt_2026_07_28.json)
+
+Constitutional effect: none. This package changes no axiom, foundation,
+Qualification, primitive, registry, policy, queue, audit result, or audit
+status.
+
+Worker disclosure: authored by a Claude Opus 5 worker under supervisor
+spec (codex quota exhausted; substitution disclosed). Checker
+independence is cross-context (independent lattice construction;
+independent isotype machinery with its own safety gate; two
+checker-side traps invisible to outcome-neutral primary gates by
+design). Independent audit still required.
+
+## The census, completed
+
+The full subgroup lattice of the 24 proper cubic rotations: 30
+subgroups in 11 conjugacy classes, gated on Lagrange, the class
+equation on every class, union-closure, and Sylow counts. Signatures
+(shell orbits, coarse and fine isotype decompositions at both scopes,
+2-adic profiles, triple-computed invariant multiplicities) for every
+class. A RESTRICTION GATE re-runs the identical machinery on Cycle
+886's four cyclic classes and reproduces the pinned 886 receipt
+exactly — 16/16 selectors, 4/4 reachability rules, 4/4 signatures —
+before anything new is claimed.
+
+## The menu dissolves (the block's negative headline)
+
+Cycle 886 priced the C3 scope at one supplied clause from a six-clause
+menu. Over the full lattice:
+
+- **minimal shell invariant multiplicity** now selects {S3, A4,
+  O_full} — not C3;
+- **freeness + maximal orbit length** — 886's cleanest clause — now
+  selects **{S3} alone**;
+- **internal axis-transitivity** (the closest-to-grounded route) now
+  keeps {C3, S3, A4, O_full};
+- **odd order** was BROKEN AS CODED in 886: its filter admits the
+  trivial subgroup, which sat outside 886's census — a defect
+  de-restriction exposed, disclosed as such;
+- 886's two empty selector rows (shell transitivity; shell
+  multiplicity-one) are NON-EMPTY over the full lattice — {S3, A4,
+  O_full} — so 886's route refusals R-B and R-D were artifacts of the
+  cyclic restriction, exactly as its checker's FIND-1 warned;
+- the ungrounded-selector convergence 886 recorded BREAKS: the
+  non-circular selectors now split into a C3 camp and an S3 camp, and
+  their conjunction is EMPTY.
+
+**Only the two circular clauses (the v2 demand; the reachability
+demand) still isolate C3.** The axiom-grounded conjunction keeps all
+30 subgroups — derivation stays refused over a candidate set 2.75x
+larger than 886's.
+
+## S3, fully priced
+
+The unique simply-transitive scope: one free shell orbit of length 6,
+orbit scope = shell scope = the regular representation. Coarse pair
+(1,5) with profile (0,0) — **no v2 = 1 datum under Cycle 883's native
+reading**. Fine dims [1,1,2,2], fine-top pair (1,2) with profile
+(0,1) — the datum exists under the fine reading, and 2/9 is reachable
+under the fine rules (witness 2^3 * 6^-2), unreachable under the
+coarse ones. S3 passes 12 of 16 selectors.
+
+## The SL1 transfer (the block's sharpest theorem)
+
+Cycle 883's construction is AST-recovered and rebuilt TWICE — as 883
+wrote it (nullspace on a free cyclic orbit) and group-theoretically
+(intersection of fixed spaces over the whole subgroup), the second
+form being defined for non-cyclic scopes. Both routes agree at C3 and
+reproduce 883's T6 step exactly. At S3 the verdict is
+**NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED**: the pair
+(1,2) exists, but the 2-dimensional irreducible occurs with
+MULTIPLICITY 2, so the realization is a P^1 family — six distinct
+submodules exhibited. The checker sharpened both directions: every
+realization carries the SAME character (no readout with a different
+pair exists at S3), and the span of the realizations is exactly the
+4-dimensional isotypic component (the isotypic level IS canonical;
+the irreducible level is not).
+
+**So SL1's "no free parameter" IS multiplicity-freeness** — the exact
+property C3 and C4 have and S3 lacks. That one word is now the entire
+C3-vs-S3 question.
+
+## Scope-insensitivity: MIXED (the price is not zero)
+
+The named test from 886, run over the computed menu (every scope with
+a free shell orbit of length > 1): the T6-defeating step is
+SCOPE-SENSITIVE under every reading, and the readings disagree on
+membership (orbit-coarse: {C3}; orbit-fine: {C3, S3}; shell-coarse:
+{C2_edge, C3}; shell-fine: {C3, S3}). The scope choice is
+LOAD-BEARING for the T6 defeat; its price does not drop to zero for
+this consumer, and it is S3 alone that flips with the reading.
+
+## Method note (checker FIND-3, adopted)
+
+Naive minimal-cyclic-submodule peeling is UNSAFE on this lattice: at
+V_edge the first peeled block is 2-dimensional and reducible, and a
+checker trusting it reports wrong fine dimensions. The pair-orbit
+identity gate (sum of m_i^2 [F_i : Q] = orbit count on X x X) caught
+it before any comparison. Any future re-derivation of these
+signatures needs that gate.
+
+## Checker
+
+Independent lattice construction and isotype machinery; every
+certificate SURVIVES (group, lattice, signatures, both 16-selector
+tables, reachability, SL1 transfer, scope-insensitivity, and 886-pin
+fidelity — 16/16 quotes and 16/16 grades byte-identical). Teeth 8/8,
+including two checker-side traps (a hardcoded S3 transfer row; a
+leaked insensitivity verdict) that flip NO primary gate by design —
+outcome-neutral gates cannot see them — and are caught only by
+independent recomputation. Primary's own impostor stress: 8/8 refused
+by named gates.
+
+## Trace gate
+
+```yaml
+trace_class: upstream_support
+target_claim_id: null
+target_blocker_text: "the S3 scope pricing (Cycle 886's menu-completeness gate) and the scope-insensitivity test of the T6-defeat consumer"
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+next_trace_action: "the owner-surface scope question is now C3 vs S3, decided by multiplicity-freeness of the readout — FIND-5: whether multiplicity-freeness is quotable from any axiom sentence is UNPRICED and is the named next door; carry the reading-disagreement (coarse vs fine) into any consumer of the v2 datum; 886's six-clause menu should be read with this block's dissolution table"
+```
+
+## Status fields
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the census is quadruple-gated (Lagrange, class equation, closure, Sylow) with a restriction gate reproducing the pinned 886 receipt before any new claim; the transfer verdict is computed at the isotypic and irreducible levels separately with the P^1 family exhibited; the insensitivity verdict is computed per reading; the menu dissolution is the recomputation of 886's own coded filters over the completed lattice"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Imports, derived, open
+
+### Imports
+
+- the pinned axiom memo, the 886 primary + checker + both receipts
+  (selector filters and fidelity grades carried over as pins,
+  verified byte-identical), the 883 primary (construction
+  AST-recovered), the 882 primary (obligation context).
+
+### Derived
+
+- the complete 30-subgroup census with signatures, quadruple-gated;
+- the 16 x 30 selector table and the menu-dissolution result (zero
+  non-circular isolating clauses; the camps; the empty conjunction);
+- S3's complete pricing row including per-reading reachability;
+- the SL1 transfer theorem (numerically transfers, not forced; the
+  P^1 family; character rigidity; isotypic canonicity);
+- the MIXED scope-insensitivity verdict with per-reading working sets;
+- the SEL12 defect disclosure and the R-B/R-D artifact correction
+  against 886.
+
+### Open
+
+- **FIND-5, the named next door**: is multiplicity-freeness of the
+  readout quotable from any axiom sentence, or is it the one supplied
+  clause the scope choice actually costs?
+- the coarse-vs-fine reading disagreement, now load-bearing for the
+  v2 datum's scope;
+- SL1b and the readout obligation, unchanged;
+- the owner-surface registration of the C3-vs-S3 choice.
+
+## Verdict
+
+Asked to finish pricing the menu, the block found the menu does not
+survive its own completion: every non-circular clause that once
+pointed at C3 now points somewhere else or at nothing, and the
+candidate the restriction had hidden turns out to carry the same pair
+by a different mechanism — one the axioms may or may not have an
+opinion about. What separates the landed scope from its rival is no
+longer a menu of six conventions but a single property with a name,
+multiplicity-freeness, and whether that name appears in the axioms is
+now the smallest question on the board. The scope choice, meanwhile,
+is provably load-bearing: the readings that reach the target disagree
+about who else comes along. Independent audit still required.

--- a/logs/runner-cache/frontier_cycle888_s3_scope_independent_check_2026_07_28.txt
+++ b/logs/runner-cache/frontier_cycle888_s3_scope_independent_check_2026_07_28.txt
@@ -1,0 +1,4193 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle888_s3_scope_independent_check_2026_07_28.py
+runner_sha256: 940c816bcb8ea8c7e3fc9fd2f1bac62cce0a8674cf9c7529549de59a21e503d1
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 38.041
+status: ok
+----- stdout -----
+CYCLE 888 -- INDEPENDENT CHECK OF THE S3 SCOPE PRICING
+
+[PASS] A_PINS
+    finding: 7/7 pins round-trip; the run cache declares the pinned runner digest and exit 0.
+
+[PASS] B_INDEPENDENT_GROUP  verdict=SURVIVES
+    finding: The orthogonality construction returns the same 24 matrices with order profile {1: 1, 2: 9, 3: 8, 4: 6}; the primary's group claim SURVIVES.
+
+[PASS] C_INDEPENDENT_LATTICE  verdict=SURVIVES
+    finding: 30 subgroups in 11 classes by iterated extension, identical to the subset-closure route (True); the class equation holds on every class and the Sylow congruences hold (n_2 = 3, n_3 = 4); the primary's lattice SURVIVES.
+
+[PASS] D_INDEPENDENT_ISOTYPE  verdict=SURVIVES
+    finding: All 11 class signatures reproduce by the independent route (SURVIVES); coarse (1,2) at ['C3_body'], fine (1,2) at ['C3_body', 'C4_face', 'S3_body'].
+
+[PASS] E_INDEPENDENT_SELECTORS  verdict=SURVIVES
+    finding: 16/16 selector survivor sets reproduce over the full lattice and 16/16 reproduce under the 886 restriction; C3 is isolated by ['SEL07_coarse_pair_v2_equals_one', 'SEL08_reachability_R1_orbit_scope'] and S3 by ['SEL06_maximal_free_shell_orbit'].
+
+[PASS] F_INDEPENDENT_REACHABILITY  verdict=SURVIVES
+    finding: the solver passes 6/6 self-tests and the survivor sets reproduce: R1_orbit_scope_coarse -> ['C3_body']; R2_shell_scope_coarse -> ['C2_edge', 'C3_body', 'V_face']; R3_orbit_scope_fine -> ['C3_body', 'S3_body']; R4_shell_scope_fine -> ['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']
+
+[PASS] G_SL1_TRANSFER_ATTACK  verdict=SURVIVES
+    finding: independent S3 multiplicities [[1, 1], [1, 1], [2, 2]]; 6 distinct 2-dimensional submodules found, all with the same character (True), so no readout with a different pair exists; the isotypic level is canonical (True); C3/C4 multiplicity-free and S3 not (True); the transfer claim SURVIVES.
+
+[PASS] H_INDEPENDENT_SCOPE_INSENSITIVITY  verdict=SURVIVES
+    finding: independent menu ['C2_edge', 'C2_face', 'C3_body', 'C4_face', 'S3_body', 'V_edge']; ORBIT_SCOPE_coarse -> SCOPE_SENSITIVE ['C3_body']; ORBIT_SCOPE_fine -> SCOPE_SENSITIVE ['C3_body', 'S3_body']; SHELL_SCOPE_coarse -> SCOPE_SENSITIVE ['C2_edge', 'C3_body']; SHELL_SCOPE_fine -> SCOPE_SENSITIVE ['C3_body', 'S3_body']; OVERALL MIXED (primary said MIXED)
+
+[PASS] I_UPSTREAM_PIN_FIDELITY  verdict=SURVIVES
+    finding: 16/16 quoted sentences and 16/16 fidelity grades are byte-identical to Cycle 886; the survivor expressions round-trip (True) and Cycle 883's defeat condition is present in its source (True).
+
+[PASS] J_REFUTATION_ATTEMPTS
+    finding: 0 of 9 attempts landed; every recomputation of a certified quantity reproduced the primary.
+
+[PASS] K_TEETH
+    finding: 8/8 teeth bite: T1=BITE, T2=BITE, T3=BITE, T4=BITE, T5=BITE, T6=BITE, T7=BITE, T8=BITE
+
+[PASS] L_FINDINGS
+    finding: 5 findings, 0 of which refute a certified number.
+
+[PASS] M_VERDICT
+    finding: no certificate refutes a computed number; 8 teeth bite.
+
+{
+ "A_PINS": {
+  "finding": "7/7 pins round-trip; the run cache declares the pinned runner digest and exit 0.",
+  "pass": true,
+  "rows": [
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py",
+    "exists": true,
+    "git_blob": "c3de02c94b8a11a930ad6ff8817975b118bc776d",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py",
+    "sha256": "f57fda877d35d49953c3b6a34293ab0cc6a87781ceb9d158b9c9abb5abd4bb3f",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json",
+    "exists": true,
+    "git_blob": "3e18ad52f50e72b83c56da72c31f25d104b5c830",
+    "git_blob_matches_pin": true,
+    "path": "outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json",
+    "sha256": "8a540201a84a6b8cb6868d431216718a27f200e45d6ceeb771d858e9a54280cd",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt",
+    "exists": true,
+    "git_blob": "6cd3fbdbe74e1231cd61222a798a7979bee922da",
+    "git_blob_matches_pin": true,
+    "path": "logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt",
+    "sha256": "5e4fc183efda55d1f3fbd5413bd2fe985ed5732b7ffbc8bd489296e7b22c2c84",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "exists": true,
+    "git_blob": "4a863da1f3f255354839277271a3a69a5c205133",
+    "git_blob_matches_pin": true,
+    "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "sha256": "fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+    "exists": true,
+    "git_blob": "f4493d787ffb6edc50e9dd13d37ba1cd1dd4d24a",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+    "sha256": "1dfa47a86de8cab5a91cd33a022beb845d918e2f93ceb58f360b2708a44d02a2",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+    "exists": true,
+    "git_blob": "4d9999c241b19b2670a51c809e3e39fb0d339f10",
+    "git_blob_matches_pin": true,
+    "path": "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+    "sha256": "74d64090515cf7f7c5ad5f8e6347f7d2f81a9c1cf0b41e9ec7726ad30a62d69d",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+    "exists": true,
+    "git_blob": "d563c2b9c2a261f44d7304baa51fdd3596188930",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+    "sha256": "2d96422d30f169a1c4b3215db373e4bffd7b1ef20056ea337ff4ae3f86d9511c",
+    "sha256_matches_pin": true
+   }
+  ],
+  "run_cache_declares_the_pinned_runner_digest": true,
+  "run_cache_records_exit_zero": true,
+  "statement": "The primary, its receipt, its run cache and every upstream artifact it read are pinned twice over."
+ },
+ "B_INDEPENDENT_GROUP": {
+  "candidates_scanned": 19683,
+  "closed": true,
+  "element_order_counts": {
+   "1": 1,
+   "2": 9,
+   "3": 8,
+   "4": 6
+  },
+  "finding": "The orthogonality construction returns the same 24 matrices with order profile {1: 1, 2: 9, 3: 8, 4: 6}; the primary's group claim SURVIVES.",
+  "group_order": 24,
+  "orthogonality_construction_equals_signed_permutation_construction": true,
+  "pass": true,
+  "primary_claim_reproduced": true,
+  "statement": "The rotation group rebuilt from the orthogonality condition M M^T = I with det = +1 over 19683 integer matrices -- a different construction from the primary's signed-permutation enumeration.",
+  "verdict": "SURVIVES"
+ },
+ "C_INDEPENDENT_LATTICE": {
+  "class_equation_rows": [
+   {
+    "class": "E_trivial",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 24,
+    "independent_size": 1,
+    "primary_size": 1,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "C2_face",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 8,
+    "independent_size": 3,
+    "primary_size": 3,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "C2_edge",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 4,
+    "independent_size": 6,
+    "primary_size": 6,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "C3_body",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 6,
+    "independent_size": 4,
+    "primary_size": 4,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "V_face",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 24,
+    "independent_size": 1,
+    "primary_size": 1,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "V_edge",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 8,
+    "independent_size": 3,
+    "primary_size": 3,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "C4_face",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 8,
+    "independent_size": 3,
+    "primary_size": 3,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "S3_body",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 6,
+    "independent_size": 4,
+    "primary_size": 4,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "D4_face",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 8,
+    "independent_size": 3,
+    "primary_size": 3,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "A4_tetrahedral",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 24,
+    "independent_size": 1,
+    "primary_size": 1,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   },
+   {
+    "class": "O_full",
+    "equals_the_group_order": true,
+    "independent_normalizer_order": 24,
+    "independent_size": 1,
+    "primary_size": 1,
+    "size_times_normalizer": 24,
+    "sizes_agree": true
+   }
+  ],
+  "conjugacy_classes": 11,
+  "finding": "30 subgroups in 11 classes by iterated extension, identical to the subset-closure route (True); the class equation holds on every class and the Sylow congruences hold (n_2 = 3, n_3 = 4); the primary's lattice SURVIVES.",
+  "pass": true,
+  "primary_claim_reproduced": true,
+  "primary_claimed_by_name": {
+   "A4_tetrahedral": 1,
+   "C2_edge": 6,
+   "C2_face": 3,
+   "C3_body": 4,
+   "C4_face": 3,
+   "D4_face": 3,
+   "E_trivial": 1,
+   "O_full": 1,
+   "S3_body": 4,
+   "V_edge": 3,
+   "V_face": 1
+  },
+  "statement": "The subgroup lattice rebuilt by ITERATED EXTENSION -- close <H, g> for every found H and every group element until the family is stable -- then cross-checked against a third route (closure of every subset of size <= 3), the class equation and the Sylow congruences. A dropped class cannot survive three routes.",
+  "subgroups_by_derived_name": {
+   "A4_tetrahedral": 1,
+   "C2_edge": 6,
+   "C2_face": 3,
+   "C3_body": 4,
+   "C4_face": 3,
+   "D4_face": 3,
+   "E_trivial": 1,
+   "O_full": 1,
+   "S3_body": 4,
+   "V_edge": 3,
+   "V_face": 1
+  },
+  "subgroups_found": 30,
+  "sylow_2_count": 3,
+  "sylow_3_count": 4,
+  "sylow_congruences_hold": true,
+  "third_route_subset_closure_agrees": true,
+  "verdict": "SURVIVES"
+ },
+ "D_INDEPENDENT_ISOTYPE": {
+  "classes_carrying_1_2_coarse_at_the_orbit_scope": [
+   "C3_body"
+  ],
+  "classes_carrying_1_2_fine_at_the_orbit_scope": [
+   "C3_body",
+   "C4_face",
+   "S3_body"
+  ],
+  "finding": "All 11 class signatures reproduce by the independent route (SURVIVES); coarse (1,2) at ['C3_body'], fine (1,2) at ['C3_body', 'C4_face', 'S3_body'].",
+  "pass": true,
+  "primary_claim_reproduced": true,
+  "rows": [
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": null,
+    "independent_orbit_isotypes": null,
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      2,
+      3
+     ],
+     "coarse_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      2,
+      3
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 3,
+     "fine_top_pair": [
+      1,
+      3
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 4,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 4
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 2,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 3,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 3,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "name": "A4_tetrahedral",
+    "own_gates_hold": true,
+    "primary_orbit_pair": null,
+    "primary_shell_pair": [
+     1,
+     5
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1,
+      1
+     ],
+     "coarse_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 2,
+     "pair_identity_holds": true,
+     "space_dimension": 2,
+     "sum_m_squared_field_degree": 2
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "coarse_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 3,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 18,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 18
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 3,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 3
+     },
+     {
+      "component_dimension": 3,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 3
+     }
+    ],
+    "name": "C2_edge",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     1
+    ],
+    "primary_shell_pair": [
+     3,
+     3
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1,
+      1
+     ],
+     "coarse_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 2,
+     "pair_identity_holds": true,
+     "space_dimension": 2,
+     "sum_m_squared_field_degree": 2
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "coarse_pair": [
+      4,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      2,
+      1
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      4,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      2,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 4,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 20,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 20
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 2
+     },
+     {
+      "component_dimension": 4,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 4
+     }
+    ],
+    "name": "C2_face",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     1
+    ],
+    "primary_shell_pair": [
+     4,
+     2
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1,
+      2
+     ],
+     "coarse_pair": [
+      1,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      1
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 3,
+     "pair_identity_holds": true,
+     "space_dimension": 3,
+     "sum_m_squared_field_degree": 3
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 2,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "coarse_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 2,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 12,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 12
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 2
+     },
+     {
+      "component_dimension": 4,
+      "endomorphism_field_degree": 2,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 2
+     }
+    ],
+    "name": "C3_body",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     2
+    ],
+    "primary_shell_pair": [
+     2,
+     4
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1,
+      1,
+      2
+     ],
+     "coarse_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 4,
+     "pair_identity_holds": true,
+     "space_dimension": 4,
+     "sum_m_squared_field_degree": 4
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 2,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "coarse_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      3,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 3,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 12,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 12
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 3,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 3
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 2,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "name": "C4_face",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     3
+    ],
+    "primary_shell_pair": [
+     3,
+     3
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": null,
+    "independent_orbit_isotypes": null,
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "coarse_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 2,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 7,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 7
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 2
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "name": "D4_face",
+    "own_gates_hold": true,
+    "primary_orbit_pair": null,
+    "primary_shell_pair": [
+     2,
+     4
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1
+     ],
+     "coarse_pair": [
+      1,
+      0
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      null
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 1,
+     "pair_identity_holds": true,
+     "space_dimension": 1,
+     "sum_m_squared_field_degree": 1
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "coarse_pair": [
+      6,
+      0
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      null
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      6,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      1,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 6,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 36,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 36
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 6,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 6
+     }
+    ],
+    "name": "E_trivial",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     0
+    ],
+    "primary_shell_pair": [
+     6,
+     0
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": null,
+    "independent_orbit_isotypes": null,
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      2,
+      3
+     ],
+     "coarse_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      2,
+      3
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 3,
+     "fine_top_pair": [
+      1,
+      3
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 3,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 3
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 3,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 3,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "name": "O_full",
+    "own_gates_hold": true,
+    "primary_orbit_pair": null,
+    "primary_shell_pair": [
+     1,
+     5
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "coarse_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 6,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 6
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 4,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 2
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "coarse_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 2,
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 6,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 6
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 4,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 2,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 2
+     }
+    ],
+    "name": "S3_body",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     5
+    ],
+    "primary_shell_pair": [
+     1,
+     5
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1
+     ],
+     "coarse_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 1,
+     "isotypic_decomposition_is_unique": true,
+     "ok": true,
+     "orbit_count_on_the_product_set": 4,
+     "pair_identity_holds": true,
+     "space_dimension": 4,
+     "sum_m_squared_field_degree": 4
+    },
+    "independent_orbit_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     }
+    ],
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "coarse_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      2,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      1,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 2,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 10,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 10
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 2
+     },
+     {
+      "component_dimension": 2,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 2
+     }
+    ],
+    "name": "V_edge",
+    "own_gates_hold": true,
+    "primary_orbit_pair": [
+     1,
+     3
+    ],
+    "primary_shell_pair": [
+     2,
+     4
+    ]
+   },
+   {
+    "agrees_with_the_primary": true,
+    "independent_orbit": null,
+    "independent_orbit_isotypes": null,
+    "independent_shell": {
+     "block_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "coarse_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "every_block_has_no_proper_submodule": true,
+     "fine_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_sums_to_the_space": true,
+     "fine_top": 1,
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "invariant_multiplicity_by_orbit_count": 3,
+     "isotypic_decomposition_is_unique": false,
+     "ok": true,
+     "orbit_count_on_the_product_set": 12,
+     "pair_identity_holds": true,
+     "space_dimension": 6,
+     "sum_m_squared_field_degree": 12
+    },
+    "independent_shell_isotypes": [
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 1,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": false,
+      "multiplicity": 1
+     },
+     {
+      "component_dimension": 3,
+      "endomorphism_field_degree": 1,
+      "irreducible_degree_over_Q": 1,
+      "is_the_trivial_isotype": true,
+      "multiplicity": 3
+     }
+    ],
+    "name": "V_face",
+    "own_gates_hold": true,
+    "primary_orbit_pair": null,
+    "primary_shell_pair": [
+     3,
+     3
+    ]
+   }
+  ],
+  "statement": "Every isotype number rebuilt by MINIMAL CYCLIC SUBMODULES and orthogonal complements, with block characters used to group blocks into isotypes -- no enveloping algebra, no centre, no minimal polynomial, no cyclotomics. Each block additionally carries an irreducibility certificate (no proper submodule is found by either of two routes) and the decomposition is gated against the orbit count on X x X.",
+  "verdict": "SURVIVES"
+ },
+ "E_INDEPENDENT_SELECTORS": {
+  "finding": "16/16 selector survivor sets reproduce over the full lattice and 16/16 reproduce under the 886 restriction; C3 is isolated by ['SEL07_coarse_pair_v2_equals_one', 'SEL08_reachability_R1_orbit_scope'] and S3 by ['SEL06_maximal_free_shell_orbit'].",
+  "independent_survivors_per_selector": {
+   "SEL01_free_on_shell": [
+    "C2_edge",
+    "C3_body",
+    "E_trivial",
+    "S3_body"
+   ],
+   "SEL02_transitive_on_shell": [
+    "A4_tetrahedral",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL03_multiplicity_one_orbit_scope": [
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "E_trivial",
+    "S3_body",
+    "V_edge"
+   ],
+   "SEL04_multiplicity_one_shell_scope": [
+    "A4_tetrahedral",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL05_minimal_shell_invariant_multiplicity": [
+    "A4_tetrahedral",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL06_maximal_free_shell_orbit": [
+    "S3_body"
+   ],
+   "SEL07_coarse_pair_v2_equals_one": [
+    "C3_body"
+   ],
+   "SEL08_reachability_R1_orbit_scope": [
+    "C3_body"
+   ],
+   "SEL09_reachability_R2_shell_scope": [
+    "C2_edge",
+    "C3_body",
+    "V_face"
+   ],
+   "SEL10_fine_top_pair_is_the_target": [
+    "C3_body",
+    "C4_face",
+    "S3_body"
+   ],
+   "SEL11_transitive_on_coordinate_axes": [
+    "A4_tetrahedral",
+    "C3_body",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL12_odd_order": [
+    "C3_body",
+    "E_trivial"
+   ],
+   "SEL13_count_once": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ],
+   "SEL14_content_only_readout": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ],
+   "SEL15_admissibility_covariance": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ],
+   "SEL16_no_site_privileged_read_literally": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ]
+  },
+  "pass": true,
+  "primary_claim_reproduced": true,
+  "restriction_reproduces_cycle886_independently": true,
+  "restriction_rows": [
+   {
+    "cycle886": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "id": "SEL01_free_on_shell",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [],
+    "id": "SEL02_transitive_on_shell",
+    "identical": true,
+    "independent_restricted": []
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL03_multiplicity_one_orbit_scope",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ]
+   },
+   {
+    "cycle886": [],
+    "id": "SEL04_multiplicity_one_shell_scope",
+    "identical": true,
+    "independent_restricted": []
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "id": "SEL05_minimal_shell_invariant_multiplicity",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "id": "SEL06_maximal_free_shell_orbit",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "id": "SEL07_coarse_pair_v2_equals_one",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "id": "SEL08_reachability_R1_orbit_scope",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "id": "SEL09_reachability_R2_shell_scope",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL10_fine_top_pair_is_the_target",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body",
+     "C4_face"
+    ]
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "id": "SEL11_transitive_on_coordinate_axes",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "id": "SEL12_odd_order",
+    "identical": true,
+    "independent_restricted": [
+     "C3_body"
+    ]
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL13_count_once",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ]
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL14_content_only_readout",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ]
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL15_admissibility_covariance",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ]
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL16_no_site_privileged_read_literally",
+    "identical": true,
+    "independent_restricted": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ]
+   }
+  ],
+  "rows": [
+   {
+    "id": "SEL01_free_on_shell",
+    "identical": true,
+    "independent_survivors": [
+     "C2_edge",
+     "C3_body",
+     "E_trivial",
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "C2_edge",
+     "C3_body",
+     "E_trivial",
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL02_transitive_on_shell",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL03_multiplicity_one_orbit_scope",
+    "identical": true,
+    "independent_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "E_trivial",
+     "S3_body",
+     "V_edge"
+    ],
+    "primary_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "E_trivial",
+     "S3_body",
+     "V_edge"
+    ]
+   },
+   {
+    "id": "SEL04_multiplicity_one_shell_scope",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL05_minimal_shell_invariant_multiplicity",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL06_maximal_free_shell_orbit",
+    "identical": true,
+    "independent_survivors": [
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL07_coarse_pair_v2_equals_one",
+    "identical": true,
+    "independent_survivors": [
+     "C3_body"
+    ],
+    "primary_survivors": [
+     "C3_body"
+    ]
+   },
+   {
+    "id": "SEL08_reachability_R1_orbit_scope",
+    "identical": true,
+    "independent_survivors": [
+     "C3_body"
+    ],
+    "primary_survivors": [
+     "C3_body"
+    ]
+   },
+   {
+    "id": "SEL09_reachability_R2_shell_scope",
+    "identical": true,
+    "independent_survivors": [
+     "C2_edge",
+     "C3_body",
+     "V_face"
+    ],
+    "primary_survivors": [
+     "C2_edge",
+     "C3_body",
+     "V_face"
+    ]
+   },
+   {
+    "id": "SEL10_fine_top_pair_is_the_target",
+    "identical": true,
+    "independent_survivors": [
+     "C3_body",
+     "C4_face",
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "C3_body",
+     "C4_face",
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL11_transitive_on_coordinate_axes",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "C3_body",
+     "O_full",
+     "S3_body"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "C3_body",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "id": "SEL12_odd_order",
+    "identical": true,
+    "independent_survivors": [
+     "C3_body",
+     "E_trivial"
+    ],
+    "primary_survivors": [
+     "C3_body",
+     "E_trivial"
+    ]
+   },
+   {
+    "id": "SEL13_count_once",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   },
+   {
+    "id": "SEL14_content_only_readout",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   },
+   {
+    "id": "SEL15_admissibility_covariance",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   },
+   {
+    "id": "SEL16_no_site_privileged_read_literally",
+    "identical": true,
+    "independent_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "primary_survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   }
+  ],
+  "selectors_isolating_C3_body": [
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope"
+  ],
+  "selectors_isolating_S3_body": [
+   "SEL06_maximal_free_shell_orbit"
+  ],
+  "statement": "All sixteen selector survivor sets recomputed over all thirty subgroups from the checker's own signatures, and the Cycle-886 restriction independently re-derived and compared against the pinned 886 receipt.",
+  "verdict": "SURVIVES"
+ },
+ "F_INDEPENDENT_REACHABILITY": {
+  "finding": "the solver passes 6/6 self-tests and the survivor sets reproduce: R1_orbit_scope_coarse -> ['C3_body']; R2_shell_scope_coarse -> ['C2_edge', 'C3_body', 'V_face']; R3_orbit_scope_fine -> ['C3_body', 'S3_body']; R4_shell_scope_fine -> ['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']",
+  "independent_survivors_by_rule": {
+   "R1_orbit_scope_coarse": [
+    "C3_body"
+   ],
+   "R2_shell_scope_coarse": [
+    "C2_edge",
+    "C3_body",
+    "V_face"
+   ],
+   "R3_orbit_scope_fine": [
+    "C3_body",
+    "S3_body"
+   ],
+   "R4_shell_scope_fine": [
+    "A4_tetrahedral",
+    "C3_body",
+    "O_full",
+    "S3_body"
+   ]
+  },
+  "pass": true,
+  "primary_claim_reproduced": true,
+  "primary_survivors_by_rule": {
+   "R1_orbit_scope_coarse": [
+    "C3_body"
+   ],
+   "R2_shell_scope_coarse": [
+    "C2_edge",
+    "C3_body",
+    "V_face"
+   ],
+   "R3_orbit_scope_fine": [
+    "C3_body",
+    "S3_body"
+   ],
+   "R4_shell_scope_fine": [
+    "A4_tetrahedral",
+    "C3_body",
+    "O_full",
+    "S3_body"
+   ]
+  },
+  "reading_dependence_present": true,
+  "rows": [
+   {
+    "name": "E_trivial",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       6
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C2_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "reachable": true
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "C4_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C4_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "C4_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "V_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "V_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "V_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       3,
+       4
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "V_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       3
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R2_shell_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R3_orbit_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       6
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "D4_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "D4_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "D4_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       4
+      ],
+      "reachable": false
+     }
+    }
+   },
+   {
+    "name": "A4_tetrahedral",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       3,
+       6
+      ],
+      "reachable": true
+     }
+    }
+   },
+   {
+    "name": "O_full",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generators": [
+       5,
+       6
+      ],
+      "reachable": false
+     },
+     "R4_shell_scope_fine": {
+      "generators": [
+       2,
+       3,
+       6
+      ],
+      "reachable": true
+     }
+    }
+   }
+  ],
+  "scope_circularity_still_present": true,
+  "solver_self_test_passed": true,
+  "solver_self_tests": [
+   {
+    "computed": false,
+    "expected": false,
+    "matrix": [
+     [
+      1
+     ],
+     [
+      0
+     ]
+    ],
+    "ok": true,
+    "target": [
+     1,
+     -2
+    ]
+   },
+   {
+    "computed": true,
+    "expected": true,
+    "matrix": [
+     [
+      1,
+      0
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    "ok": true,
+    "target": [
+     1,
+     -2
+    ]
+   },
+   {
+    "computed": false,
+    "expected": false,
+    "matrix": [
+     [
+      2,
+      0
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    "ok": true,
+    "target": [
+     1,
+     -2
+    ]
+   },
+   {
+    "computed": true,
+    "expected": true,
+    "matrix": [
+     [
+      2,
+      0
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    "ok": true,
+    "target": [
+     4,
+     -2
+    ]
+   },
+   {
+    "computed": true,
+    "expected": true,
+    "matrix": [
+     [
+      0
+     ],
+     [
+      1
+     ]
+    ],
+    "ok": true,
+    "target": [
+     0,
+     5
+    ]
+   },
+   {
+    "computed": true,
+    "expected": true,
+    "matrix": [
+     [
+      1,
+      1
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    "ok": true,
+    "target": [
+     1,
+     -2
+    ]
+   }
+  ],
+  "statement": "Multiplicative reachability of 2/9 re-decided by Smith-style diagonalization with a tracked left transform, self-tested on six lattices with known answers before it is trusted.",
+  "verdict": "SURVIVES"
+ },
+ "G_SL1_TRANSFER_ATTACK": {
+  "attack_1_second_readout_with_a_different_pair": {
+   "a_readout_with_a_DIFFERENT_pair_exists": false,
+   "achievable_fine_top_pairs": [
+    [
+     1,
+     1
+    ],
+    [
+     1,
+     2
+    ]
+   ],
+   "all_top_degree_submodules_are_isomorphic": true,
+   "distinct_characters_by_degree": {
+    "1": 2,
+    "2": 1
+   },
+   "distinct_submodules_found_by_degree": {
+    "1": 2,
+    "2": 6
+   },
+   "distinct_top_degree_submodules": 6,
+   "irreducible_degrees_present": [
+    1,
+    2
+   ],
+   "result": "the pair (1, 2) is stable across every readout choice, so the NUMBER transfers -- the primary's claim survives this attack",
+   "sample_top_degree_submodules": [
+    {
+     "basis": [
+      [
+       "1/1",
+       "0/1",
+       "-1/1",
+       "1/1",
+       "0/1",
+       "-1/1"
+      ],
+      [
+       "0/1",
+       "1/1",
+       "-1/1",
+       "1/1",
+       "-1/1",
+       "0/1"
+      ]
+     ],
+     "character": [
+      "0/1",
+      "0/1",
+      "0/1",
+      "-1/1",
+      "-1/1",
+      "2/1"
+     ],
+     "generator": [
+      "-1/1",
+      "0/1",
+      "1/1",
+      "-1/1",
+      "0/1",
+      "1/1"
+     ]
+    },
+    {
+     "basis": [
+      [
+       "1/1",
+       "0/1",
+       "-1/1",
+       "1/1",
+       "-1/1",
+       "0/1"
+      ],
+      [
+       "0/1",
+       "1/1",
+       "-1/1",
+       "0/1",
+       "-1/1",
+       "1/1"
+      ]
+     ],
+     "character": [
+      "0/1",
+      "0/1",
+      "0/1",
+      "-1/1",
+      "-1/1",
+      "2/1"
+     ],
+     "generator": [
+      "-1/1",
+      "0/1",
+      "1/1",
+      "-1/1",
+      "1/1",
+      "0/1"
+     ]
+    },
+    {
+     "basis": [
+      [
+       "1/1",
+       "0/1",
+       "-1/1",
+       "0/1",
+       "1/1",
+       "-1/1"
+      ],
+      [
+       "0/1",
+       "1/1",
+       "-1/1",
+       "1/1",
+       "0/1",
+       "-1/1"
+      ]
+     ],
+     "character": [
+      "0/1",
+      "0/1",
+      "0/1",
+      "-1/1",
+      "-1/1",
+      "2/1"
+     ],
+     "generator": [
+      "-1/1",
+      "0/1",
+      "1/1",
+      "0/1",
+      "-1/1",
+      "1/1"
+     ]
+    }
+   ]
+  },
+  "attack_2_is_the_isotypic_component_canonical": {
+   "isotypic_level_is_canonical": true,
+   "result": "the isotypic decomposition IS forced while the split into irreducibles is NOT -- exactly the distinction the primary draws",
+   "span_of_all_top_degree_submodules": 4,
+   "top_isotypic_component_dimension": 4
+  },
+  "attack_3_peer_comparison": {
+   "C3_and_C4_are_multiplicity_free_and_S3_is_not": true,
+   "peers": [
+    {
+     "class": "C3_body",
+     "free_orbit_length": 3,
+     "independent_coarse_pair": [
+      1,
+      2
+     ],
+     "independent_decomposition_is_unique": true,
+     "independent_fine_dims": [
+      1,
+      2
+     ],
+     "independent_fine_top_pair": [
+      1,
+      2
+     ],
+     "independent_multiplicities": [
+      1,
+      1
+     ]
+    },
+    {
+     "class": "C4_face",
+     "free_orbit_length": 4,
+     "independent_coarse_pair": [
+      1,
+      3
+     ],
+     "independent_decomposition_is_unique": true,
+     "independent_fine_dims": [
+      1,
+      1,
+      2
+     ],
+     "independent_fine_top_pair": [
+      1,
+      2
+     ],
+     "independent_multiplicities": [
+      1,
+      1,
+      1
+     ]
+    },
+    {
+     "class": "S3_body",
+     "free_orbit_length": 6,
+     "independent_coarse_pair": [
+      1,
+      5
+     ],
+     "independent_decomposition_is_unique": false,
+     "independent_fine_dims": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "independent_fine_top_pair": [
+      1,
+      2
+     ],
+     "independent_multiplicities": [
+      1,
+      1,
+      2
+     ]
+    }
+   ],
+   "result": "the peer comparison stands"
+  },
+  "coarse_pair_agrees": true,
+  "finding": "independent S3 multiplicities [[1, 1], [1, 1], [2, 2]]; 6 distinct 2-dimensional submodules found, all with the same character (True), so no readout with a different pair exists; the isotypic level is canonical (True); C3/C4 multiplicity-free and S3 not (True); the transfer claim SURVIVES.",
+  "fine_top_pair_agrees": true,
+  "independent_S3_isotypes": [
+   {
+    "component_dimension": 1,
+    "endomorphism_field_degree": 1,
+    "irreducible_degree_over_Q": 1,
+    "is_the_trivial_isotype": true,
+    "multiplicity": 1
+   },
+   {
+    "component_dimension": 1,
+    "endomorphism_field_degree": 1,
+    "irreducible_degree_over_Q": 1,
+    "is_the_trivial_isotype": false,
+    "multiplicity": 1
+   },
+   {
+    "component_dimension": 4,
+    "endomorphism_field_degree": 1,
+    "irreducible_degree_over_Q": 2,
+    "is_the_trivial_isotype": false,
+    "multiplicity": 2
+   }
+  ],
+  "independent_S3_signature": {
+   "block_dimensions": [
+    1,
+    1,
+    2,
+    2
+   ],
+   "coarse_pair": [
+    1,
+    5
+   ],
+   "coarse_two_adic_profile": [
+    0,
+    0
+   ],
+   "every_block_has_no_proper_submodule": true,
+   "fine_dimensions": [
+    1,
+    1,
+    2,
+    2
+   ],
+   "fine_sums_to_the_space": true,
+   "fine_top": 2,
+   "fine_top_pair": [
+    1,
+    2
+   ],
+   "fine_top_two_adic_profile": [
+    0,
+    1
+   ],
+   "invariant_multiplicity_by_orbit_count": 1,
+   "isotypic_decomposition_is_unique": false,
+   "ok": true,
+   "orbit_count_on_the_product_set": 6,
+   "pair_identity_holds": true,
+   "space_dimension": 6,
+   "sum_m_squared_field_degree": 6
+  },
+  "independent_multiplicities": [
+   [
+    1,
+    1
+   ],
+   [
+    1,
+    1
+   ],
+   [
+    2,
+    2
+   ]
+  ],
+  "independent_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+  "pass": true,
+  "primary_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+  "statement": "THE SL1-TRANSFER CLAIM, ATTACKED. The primary says the S3 readout's fine-top pair (1, 2) transfers as a NUMBER but not as a forced subspace. Refuting that requires either (i) a second inequivalent readout construction at S3 scope carrying a DIFFERENT pair, or (ii) showing the S3 decomposition is in fact unique, or (iii) breaking the peer comparison at C3 and C4. All three are attempted here.",
+  "verdict": "SURVIVES",
+  "verdicts_agree": true
+ },
+ "H_INDEPENDENT_SCOPE_INSENSITIVITY": {
+  "finding": "independent menu ['C2_edge', 'C2_face', 'C3_body', 'C4_face', 'S3_body', 'V_edge']; ORBIT_SCOPE_coarse -> SCOPE_SENSITIVE ['C3_body']; ORBIT_SCOPE_fine -> SCOPE_SENSITIVE ['C3_body', 'S3_body']; SHELL_SCOPE_coarse -> SCOPE_SENSITIVE ['C2_edge', 'C3_body']; SHELL_SCOPE_fine -> SCOPE_SENSITIVE ['C3_body', 'S3_body']; OVERALL MIXED (primary said MIXED)",
+  "independent_menu": [
+   "C2_edge",
+   "C2_face",
+   "C3_body",
+   "C4_face",
+   "S3_body",
+   "V_edge"
+  ],
+  "independent_overall_verdict": "MIXED",
+  "menus_agree": true,
+  "overall_verdicts_agree": true,
+  "pass": true,
+  "per_reading_comparison": [
+   {
+    "identical": true,
+    "independent_verdict": "SCOPE_SENSITIVE",
+    "independent_working_set": [
+     "C3_body"
+    ],
+    "primary_verdict": "SCOPE_SENSITIVE",
+    "primary_working_set": [
+     "C3_body"
+    ],
+    "reading": "ORBIT_SCOPE_coarse_reading"
+   },
+   {
+    "identical": true,
+    "independent_verdict": "SCOPE_SENSITIVE",
+    "independent_working_set": [
+     "C3_body",
+     "S3_body"
+    ],
+    "primary_verdict": "SCOPE_SENSITIVE",
+    "primary_working_set": [
+     "C3_body",
+     "S3_body"
+    ],
+    "reading": "ORBIT_SCOPE_fine_reading"
+   },
+   {
+    "identical": true,
+    "independent_verdict": "SCOPE_SENSITIVE",
+    "independent_working_set": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "primary_verdict": "SCOPE_SENSITIVE",
+    "primary_working_set": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "reading": "SHELL_SCOPE_coarse_reading"
+   },
+   {
+    "identical": true,
+    "independent_verdict": "SCOPE_SENSITIVE",
+    "independent_working_set": [
+     "C3_body",
+     "S3_body"
+    ],
+    "primary_verdict": "SCOPE_SENSITIVE",
+    "primary_working_set": [
+     "C3_body",
+     "S3_body"
+    ],
+    "reading": "SHELL_SCOPE_fine_reading"
+   }
+  ],
+  "primary_claim_reproduced": true,
+  "primary_menu": [
+   "C2_edge",
+   "C2_face",
+   "C3_body",
+   "C4_face",
+   "S3_body",
+   "V_edge"
+  ],
+  "primary_overall_verdict": "MIXED",
+  "rows": [
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "scope_class": "C2_edge"
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "scope_class": "C2_face"
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "scope_class": "C3_body"
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "scope_class": "C4_face"
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_reachable": true
+    },
+    "scope_class": "S3_body"
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "base_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_reachable": false
+    },
+    "scope_class": "V_edge"
+   }
+  ],
+  "statement": "The scope-insensitivity verdicts recomputed from scratch: the menu membership rule re-applied to the checker's own orbit structures, Cycle 883's widening step re-evaluated at every menu scope under both readings at both scopes, and the verdicts re-derived.",
+  "verdict": "SURVIVES"
+ },
+ "I_UPSTREAM_PIN_FIDELITY": {
+  "cycle883_defeat_condition": "defeated = (not old_reach) and new_reach",
+  "cycle883_defeat_condition_present_in_883_source": true,
+  "fidelity_grades_carried_unchanged": true,
+  "finding": "16/16 quoted sentences and 16/16 fidelity grades are byte-identical to Cycle 886; the survivor expressions round-trip (True) and Cycle 883's defeat condition is present in its source (True).",
+  "grade_rows": [
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL01_free_on_shell",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL02_transitive_on_shell",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL03_multiplicity_one_orbit_scope",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL04_multiplicity_one_shell_scope",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL05_minimal_shell_invariant_multiplicity",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL06_maximal_free_shell_orbit",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "EXACT",
+    "carried_grounded": false,
+    "cycle886_fidelity": "EXACT",
+    "cycle886_grounded": false,
+    "id": "SEL07_coarse_pair_v2_equals_one",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "PARTIAL",
+    "carried_grounded": false,
+    "cycle886_fidelity": "PARTIAL",
+    "cycle886_grounded": false,
+    "id": "SEL08_reachability_R1_orbit_scope",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "PARTIAL",
+    "carried_grounded": false,
+    "cycle886_fidelity": "PARTIAL",
+    "cycle886_grounded": false,
+    "id": "SEL09_reachability_R2_shell_scope",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL10_fine_top_pair_is_the_target",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "PARTIAL",
+    "carried_grounded": false,
+    "cycle886_fidelity": "PARTIAL",
+    "cycle886_grounded": false,
+    "id": "SEL11_transitive_on_coordinate_axes",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "NONE",
+    "carried_grounded": false,
+    "cycle886_fidelity": "NONE",
+    "cycle886_grounded": false,
+    "id": "SEL12_odd_order",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "EXACT",
+    "carried_grounded": true,
+    "cycle886_fidelity": "EXACT",
+    "cycle886_grounded": true,
+    "id": "SEL13_count_once",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "EXACT",
+    "carried_grounded": true,
+    "cycle886_fidelity": "EXACT",
+    "cycle886_grounded": true,
+    "id": "SEL14_content_only_readout",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "EXACT",
+    "carried_grounded": true,
+    "cycle886_fidelity": "EXACT",
+    "cycle886_grounded": true,
+    "id": "SEL15_admissibility_covariance",
+    "identical": true
+   },
+   {
+    "carried_fidelity": "EXACT",
+    "carried_grounded": true,
+    "cycle886_fidelity": "EXACT",
+    "cycle886_grounded": true,
+    "id": "SEL16_no_site_privileged_read_literally",
+    "identical": true
+   }
+  ],
+  "pass": true,
+  "primary_claim_reproduced": true,
+  "quote_rows": [
+   {
+    "id": "SEL01_free_on_shell",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "No site is privileged. Sites are distinguished by the suppli...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL02_transitive_on_shell",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "No site is privileged. Sites are distinguished by the suppli...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL03_multiplicity_one_orbit_scope",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "For any finite collection of pairwise-disjoint records, scal...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL04_multiplicity_one_shell_scope",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "For any finite collection of pairwise-disjoint records, scal...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL05_minimal_shell_invariant_multiplicity",
+    "in_axiom_memo": null,
+    "ok": true,
+    "quoted": null,
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL06_maximal_free_shell_orbit",
+    "in_axiom_memo": null,
+    "ok": true,
+    "quoted": null,
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL07_coarse_pair_v2_equals_one",
+    "in_axiom_memo": false,
+    "ok": true,
+    "quoted": "A Record-facing datum with v_2 = 1 must enter. Concretely: d...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL08_reachability_R1_orbit_scope",
+    "in_axiom_memo": false,
+    "ok": true,
+    "quoted": "A Record-facing datum with v_2 = 1 must enter. Concretely: d...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL09_reachability_R2_shell_scope",
+    "in_axiom_memo": false,
+    "ok": true,
+    "quoted": "A Record-facing datum with v_2 = 1 must enter. Concretely: d...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL10_fine_top_pair_is_the_target",
+    "in_axiom_memo": null,
+    "ok": true,
+    "quoted": null,
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL11_transitive_on_coordinate_axes",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "Physical sites are the points of the cubic lattice `Z^3`, wi...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL12_odd_order",
+    "in_axiom_memo": null,
+    "ok": true,
+    "quoted": null,
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL13_count_once",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "A site never carries more than one record; records are perma...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL14_content_only_readout",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "Only records are readable. A readout value is determined by ...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL15_admissibility_covariance",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "There is one fixed nearest-neighbor admissibility rule, cova...",
+    "verbatim_in_886_source": true
+   },
+   {
+    "id": "SEL16_no_site_privileged_read_literally",
+    "in_axiom_memo": true,
+    "ok": true,
+    "quoted": "No site is privileged. Sites are distinguished by the suppli...",
+    "verbatim_in_886_source": true
+   }
+  ],
+  "quoted_sentences_are_verbatim_886_material": true,
+  "statement": "Everything the primary CARRIED OVER as a pin from Cycle 886 and Cycle 883 is verified byte-identical against the pinned sources here: the byte-quoted sentences, the fidelity grades, the grounding flags, the survivor expressions the primary re-implemented, and Cycle 883's defeat condition.",
+  "survivor_expressions_are_verbatim_886_source": true,
+  "verdict": "SURVIVES"
+ },
+ "J_REFUTATION_ATTEMPTS": {
+  "attempts": [
+   {
+    "attack": "the 24-element group is wrong",
+    "method": "rebuilt from M M^T = I over 19683 integer matrices",
+    "n": 1,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "a subgroup or a whole conjugacy class was dropped from the 30-member lattice",
+    "method": "iterated extension <H, g>, cross-checked against closure of every subset of size <= 3, the class equation and the Sylow congruences",
+    "n": 2,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "a fine decomposition is wrong -- in particular the S3 multiplicity ledger",
+    "method": "minimal cyclic submodules and orthogonal complements with block characters; no enveloping algebra, no centre, no minimal polynomial",
+    "n": 3,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "a selector survivor set over the full lattice is wrong, or the restriction to the 886 census does not really reproduce 886",
+    "method": "all sixteen recomputed over all thirty subgroups from the checker's own signatures, then restricted and compared against the pinned 886 receipt",
+    "n": 4,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "an unreachability verdict is a window artifact",
+    "method": "Smith-style diagonalization, self-tested on six lattices",
+    "n": 5,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "the SL1-transfer claim is wrong: either a second readout at S3 carries a DIFFERENT pair, or the S3 decomposition is actually forced, or the C3/C4 peer comparison breaks",
+    "method": "every irreducible submodule of each degree enumerated and characterised; the span of the top-degree submodules compared against the isotypic component; C3 and C4 multiplicity ledgers recomputed",
+    "n": 6,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "the scope-insensitivity verdict is wrong or was leaked rather than computed",
+    "method": "menu rule re-applied, Cycle 883's widening step re-evaluated at every menu scope under both readings at both scopes, verdicts re-derived",
+    "n": 7,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "the 886/883 material the primary carried over as pins was altered",
+    "method": "byte comparison of every quoted sentence, fidelity grade, grounding flag and survivor expression against the pinned 886 and 883 sources",
+    "n": 8,
+    "result": "SURVIVES"
+   },
+   {
+    "attack": "the primary imported or executed a pinned artifact",
+    "method": "meta-path firewall plus module-table inspection here, and the primary's own firewall record",
+    "n": 9,
+    "result": "SURVIVES: no pinned module is loadable in this process either"
+   }
+  ],
+  "attempts_that_landed": [],
+  "attempts_that_landed_count": 0,
+  "finding": "0 of 9 attempts landed; every recomputation of a certified quantity reproduced the primary.",
+  "no_computed_number_was_refuted": true,
+  "pass": true,
+  "statement": "Nine numbered refutation attempts against the block."
+ },
+ "K_TEETH": {
+  "all_teeth_bite": true,
+  "finding": "8/8 teeth bite: T1=BITE, T2=BITE, T3=BITE, T4=BITE, T5=BITE, T6=BITE, T7=BITE, T8=BITE",
+  "pass": true,
+  "rows": [
+   {
+    "bites": true,
+    "expected_exit": 2,
+    "expected_failing_certificate": null,
+    "id": "T1_tampered_pin",
+    "observed_exit": 2,
+    "observed_failing_certificates": [],
+    "patch_applied_exactly_once": true,
+    "patch_sites_found": 1,
+    "stderr_head": [
+     "PREFLIGHT HARD FAIL: pin digest mismatch: docs/MINIMAL_AXIOMS_2026-06-29.md sha256 fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697 != 0000000000000000000000000000000000000000000000000000000000000000"
+    ],
+    "target_certificate_or_gate": "preflight pin digest check"
+   },
+   {
+    "bites": true,
+    "expected_exit": 1,
+    "expected_failing_certificate": "D_SUBGROUP_LATTICE",
+    "id": "T2_dropped_subgroup_class",
+    "observed_exit": 1,
+    "observed_failing_certificates": [
+     "D_SUBGROUP_LATTICE",
+     "O_IMPOSTOR_STRESS"
+    ],
+    "patch_applied_exactly_once": true,
+    "patch_sites_found": 1,
+    "stderr_head": [],
+    "target_certificate_or_gate": "the 30-subgroup / 11-class census and the class equation"
+   },
+   {
+    "bites": true,
+    "expected_exit": 1,
+    "expected_failing_certificate": "D_SUBGROUP_LATTICE",
+    "id": "T3_broken_class_equation",
+    "observed_exit": 1,
+    "observed_failing_certificates": [
+     "D_SUBGROUP_LATTICE"
+    ],
+    "patch_applied_exactly_once": true,
+    "patch_sites_found": 1,
+    "stderr_head": [],
+    "target_certificate_or_gate": "class_equation_holds_on_every_class"
+   },
+   {
+    "bites": true,
+    "expected_exit": 1,
+    "expected_failing_certificate": "G_ISOTYPE_SIGNATURES",
+    "id": "T4_broken_dimension_sum",
+    "observed_exit": 1,
+    "observed_failing_certificates": [
+     "G_ISOTYPE_SIGNATURES",
+     "H_CLASS_INVARIANCE",
+     "L_RESTRICTION_GATE",
+     "M_S3_PRICING_ROW",
+     "O_IMPOSTOR_STRESS"
+    ],
+    "patch_applied_exactly_once": true,
+    "patch_sites_found": 1,
+    "stderr_head": [],
+    "target_certificate_or_gate": "fine_decomposition_sums_to_the_space"
+   },
+   {
+    "bites": true,
+    "expected_exit": 1,
+    "expected_failing_certificate": "L_RESTRICTION_GATE",
+    "id": "T5_hardcoded_selector_row",
+    "observed_exit": 1,
+    "observed_failing_certificates": [
+     "L_RESTRICTION_GATE"
+    ],
+    "patch_applied_exactly_once": true,
+    "patch_sites_found": 1,
+    "stderr_head": [],
+    "target_certificate_or_gate": "byte-level reproduction of the pinned Cycle-886 receipt"
+   },
+   {
+    "bites": true,
+    "expected_exit": 1,
+    "expected_failing_certificate": "N_SCOPE_INSENSITIVITY",
+    "id": "T6_skipped_scope",
+    "observed_exit": 1,
+    "observed_failing_certificates": [
+     "N_SCOPE_INSENSITIVITY"
+    ],
+    "patch_applied_exactly_once": true,
+    "patch_sites_found": 1,
+    "stderr_head": [],
+    "target_certificate_or_gate": "table_is_complete over the whole menu"
+   },
+   {
+    "bites": true,
+    "checker_verdict_on_the_trapped_receipt": "REFUTED",
+    "id": "T7_hardcoded_S3_transfer_row_on_the_checker",
+    "independent_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+    "method": "the primary's receipt is mutated in memory so the S3 transfer row declares the decomposition FORCED -- the reading that would make S3 a clean SL1 transfer. No primary gate can see this, by design: the primary's gates are outcome-neutral. Only the independent recomputation catches it.",
+    "target_certificate_or_gate": "G_SL1_TRANSFER_ATTACK / verdicts_agree"
+   },
+   {
+    "bites": true,
+    "checker_verdict_on_the_trapped_receipt": "REFUTED",
+    "id": "T8_leaked_scope_insensitivity_verdict_on_the_checker",
+    "independent_overall_verdict": "MIXED",
+    "method": "the primary's receipt is mutated in memory to declare the downstream obligation SCOPE_INSENSITIVE -- the verdict that would drop the menu price to zero. Again invisible to every outcome-neutral gate and caught only by recomputation.",
+    "target_certificate_or_gate": "H_INDEPENDENT_SCOPE_INSENSITIVITY / overall_verdicts_agree"
+   }
+  ],
+  "statement": "Eight deliberate mutations. Six patch the primary and must flip a NAMED certificate or the preflight; two are traps on this checker -- a hardcoded S3 transfer row and a leaked scope-insensitivity verdict -- which no outcome-neutral primary gate can catch and which must be caught by independent recomputation.",
+  "teeth_that_bite": 8
+ },
+ "L_FINDINGS": {
+  "finding": "5 findings, 0 of which refute a certified number.",
+  "findings": [
+   {
+    "does_it_refute_a_number": false,
+    "id": "FIND-1",
+    "severity": "adopted from the primary, confirmed",
+    "text": "The odd-order clause -- Cycle 886's cheapest non-circular pin for C3 -- admits ['C3_body', 'E_trivial'] once the trivial subgroup enters the census, because the filter Cycle 886 actually coded is `order % 2 == 1` while its demand string said 'greater than 1'. The primary flags this; the checker confirms it independently. Consequence: over the full lattice ZERO of Cycle 886's six menu clauses is both non-circular and isolating as coded."
+   },
+   {
+    "does_it_refute_a_number": false,
+    "id": "FIND-2",
+    "severity": "sharpening",
+    "text": "The primary reports S3's non-uniqueness by exhibiting submodules. The checker shows the stronger statement: the top-degree irreducible submodules of the S3 readout span EXACTLY the 4-dimensional isotypic component and all carry the SAME character. So the ambiguity is exactly a P^1 of isomorphic copies -- the isotypic level is canonical, the irreducible level is not, and no readout with a different pair exists. That is a cleaner statement of the transfer failure than 'the subspace is not unique'."
+   },
+   {
+    "does_it_refute_a_number": false,
+    "id": "FIND-3",
+    "severity": "method note",
+    "text": "A naive minimal-cyclic-submodule decomposition is NOT safe on this lattice: at V_edge the first peeled block is 2-dimensional and reducible, and a checker that trusted it would report fine dimensions [1,1,1,1,2] instead of the correct six 1-dimensional blocks. The checker's own pair-orbit gate caught this before any comparison was made. Any future re-derivation of these signatures should carry the same gate."
+   },
+   {
+    "does_it_refute_a_number": false,
+    "id": "FIND-4",
+    "severity": "scope note",
+    "text": "The MIXED scope-insensitivity verdict is driven by ONE class: S3 defeats C882-T6 under the fine reading and fails under the coarse reading. Every other menu member gives the same answer under both readings at the orbit scope. So the reading-dependence Cycle 886 discovered at C4 reappears at S3 in a load-bearing place: it decides menu membership for the downstream consumer, not just a signature entry."
+   },
+   {
+    "does_it_refute_a_number": false,
+    "id": "FIND-5",
+    "severity": "open",
+    "text": "Neither runner asks whether MULTIPLICITY-FREENESS of the readout -- the property that separates C3 and C4 from S3 -- is quotable from any axiom sentence. It is the smallest clause that would restore SL1's uniqueness at a chosen scope, and it is unpriced. Named here, not answered."
+   }
+  ],
+  "findings_that_refute_a_number": [],
+  "pass": true,
+  "statement": "What the primary should have done and did not, plus what the checker learned that the primary could not."
+ },
+ "M_VERDICT": {
+  "all_teeth_bite": true,
+  "any_certified_number_refuted": false,
+  "certificates_that_refute": [],
+  "finding": "no certificate refutes a computed number; 8 teeth bite.",
+  "overall": "BLOCK SURVIVES INDEPENDENT CHECK",
+  "pass": true,
+  "statement": "The independent check's overall verdict on the Cycle-888 block.",
+  "teeth_that_bite": 8,
+  "verdict_by_certificate": {
+   "B_INDEPENDENT_GROUP": "SURVIVES",
+   "C_INDEPENDENT_LATTICE": "SURVIVES",
+   "D_INDEPENDENT_ISOTYPE": "SURVIVES",
+   "E_INDEPENDENT_SELECTORS": "SURVIVES",
+   "F_INDEPENDENT_REACHABILITY": "SURVIVES",
+   "G_SL1_TRANSFER_ATTACK": "SURVIVES",
+   "H_INDEPENDENT_SCOPE_INSENSITIVITY": "SURVIVES",
+   "I_UPSTREAM_PIN_FIDELITY": "SURVIVES"
+  },
+  "what_survives": "The 30-subgroup / 11-class lattice with the class equation and the Sylow congruences; every signature at both scopes under both readings; all sixteen selector survivor sets over the full lattice AND under the 886 restriction; the reachability survivors under all four rules; the S3 pricing row; the SL1-transfer verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED; and the MIXED scope-insensitivity verdict with its working sets."
+ }
+}
+
+controls: runtime=33.574s stdout=95349B teeth=8/8 overall=BLOCK SURVIVES INDEPENDENT CHECK

--- a/logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt
+++ b/logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt
@@ -1,0 +1,14983 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py
+runner_sha256: f57fda877d35d49953c3b6a34293ab0cc6a87781ceb9d158b9c9abb5abd4bb3f
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 5.586
+status: ok
+----- stdout -----
+CYCLE 888 -- THE S3 SCOPE, PRICED OVER THE FULL SUBGROUP LATTICE
+
+[PASS] A_PINS
+    finding: 7/7 pinned artifacts round-trip on both SHA-256 and git blob.
+
+[PASS] B_QUOTED_SENTENCES
+    finding: 10/10 axiom sentences round-trip byte for byte; the Cycle-882 obligation sentence is AST-recovered and confirmed ABSENT from the axiom memo; 16 selector rows and Cycle 883's widening argument are recovered as pins.
+
+[PASS] C_ROTATION_GROUP
+    finding: 24 proper rotations, order profile {1: 1, 2: 9, 3: 8, 4: 6}, 576 products and 13824 associativity triples verified; Burnside gives 1/1 shell orbit, matching the direct count 1.
+
+[PASS] D_SUBGROUP_LATTICE
+    finding: 30 subgroups in 11 conjugacy classes: E_trivial x1, C2_face x3, C2_edge x6, C3_body x4, V_face x1, V_edge x3, C4_face x3, S3_body x4, D4_face x3, A4_tetrahedral x1, O_full x1; the class equation, Lagrange, union-closure and the Sylow congruences (n_2 = 3, n_3 = 4) all hold.
+
+[PASS] E_SHELL_ORBIT_STRUCTURE
+    finding: shell orbit-length profiles by class: A4_tetrahedral -> (6,); C2_edge -> (2, 2, 2); C2_face -> (1, 1, 2, 2); C3_body -> (3, 3); C4_face -> (1, 1, 4); D4_face -> (2, 4); E_trivial -> (1, 1, 1, 1, 1, 1); O_full -> (6,); S3_body -> (6,); V_edge -> (2, 4); V_face -> (2, 2, 2); simply transitive: ['S3_body'] (4 subgroups)
+
+[PASS] F_C883_CONSTRUCTION_AND_T6_REBUILT
+    finding: The pinned construction round-trips by AST, follows (1, n-1) on all 7 cyclic orbit lengths, agrees with the group-theoretic route at C3, and its T6 step is reproduced: <3> misses 2/9 and <2, 3> hits it at exponents [1, -2].
+
+[PASS] G_ISOTYPE_SIGNATURES
+    finding: A4_tetrahedral: orbit None fine None | shell [1, 5] fine [1, 2, 3]; C2_edge: orbit [1, 1] fine [1, 1] | shell [3, 3] fine [1, 1, 1, 1, 1, 1]; C2_face: orbit [1, 1] fine [1, 1] | shell [4, 2] fine [1, 1, 1, 1, 1, 1]; C3_body: orbit [1, 2] fine [1, 2] | shell [2, 4] fine [1, 1, 2, 2]; C4_face: orbit [1, 3] fine [1, 1, 2] | shell [3, 3] fine [1, 1, 1, 1, 2]; D4_face: orbit None fine None | shell [2, 4] fine [1, 1, 1, 1, 2]; E_trivial: orbit [1, 0] fine [1] | shell [6, 0] fine [1, 1, 1, 1, 1, 1]; O_full: orbit None fine None | shell [1, 5] fine [1, 2, 3]; S3_body: orbit [1, 5] fine [1, 1, 2, 2] | shell [1, 5] fine [1, 1, 2, 2]; V_edge: orbit [1, 3] fine [1, 1, 1, 1] | shell [2, 4] fine [1, 1, 1, 1, 1, 1]; V_face: orbit None fine None | shell [3, 3] fine [1, 1, 1, 1, 1, 1]
+
+[PASS] H_CLASS_INVARIANCE
+    finding: All 30 subgroups collapse to 11 distinct signatures, one per conjugacy class.
+
+[PASS] I_SELECTOR_TABLE
+    finding: SEL01=['C2_edge', 'C3_body', 'E_trivial', 'S3_body']; SEL02=['A4_tetrahedral', 'O_full', 'S3_body']; SEL03=['C2_edge', 'C2_face', 'C3_body', 'C4_face', 'E_trivial', 'S3_body', 'V_edge']; SEL04=['A4_tetrahedral', 'O_full', 'S3_body']; SEL05=['A4_tetrahedral', 'O_full', 'S3_body']; SEL06=['S3_body']; SEL07=['C3_body']; SEL08=['C3_body']; SEL09=['C2_edge', 'C3_body', 'V_face']; SEL10=['C3_body', 'C4_face', 'S3_body']; SEL11=['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']; SEL12=['C3_body', 'E_trivial']; SEL13=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; SEL14=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; SEL15=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; SEL16=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']
+
+[PASS] J_CONJUNCTIONS
+    finding: axiom-grounded conjunction survivors ['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; non-empty-selector conjunction survivors []; unrestricted conjunction survivors []; C3 camp ['SEL07_coarse_pair_v2_equals_one', 'SEL08_reachability_R1_orbit_scope']; S3 camp ['SEL06_maximal_free_shell_orbit'].
+
+[PASS] K_ANCHOR_REACHABILITY
+    finding: survivors by rule: R1_orbit_scope_coarse -> ['C3_body']; R2_shell_scope_coarse -> ['C2_edge', 'C3_body', 'V_face']; R3_orbit_scope_fine -> ['C3_body', 'S3_body']; R4_shell_scope_fine -> ['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']
+
+[PASS] L_RESTRICTION_GATE
+    finding: restricted to ('C2_edge', 'C2_face', 'C3_body', 'C4_face'): 16/16 selector survivor sets, 4/4 reachability rules and 4/4 class signatures reproduce the pinned Cycle-886 receipt exactly.
+
+[PASS] M_S3_PRICING_ROW
+    finding: S3 is simply transitive on the shell (orbit scope = shell scope, dimension 6); coarse pair [1, 5] profile [0, 0]; fine dims [1, 1, 2, 2] top pair [1, 2] profile [0, 1]; reaches 2/9 under ['R3_orbit_scope_fine', 'R4_shell_scope_fine']; passes 12 of 16 selectors; SL1 transfer verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED.
+
+[PASS] N_SCOPE_INSENSITIVITY
+    finding: ORBIT_SCOPE_coarse_reading -> SCOPE_SENSITIVE working ['C3_body']; ORBIT_SCOPE_fine_reading -> SCOPE_SENSITIVE working ['C3_body', 'S3_body']; SHELL_SCOPE_coarse_reading -> SCOPE_SENSITIVE working ['C2_edge', 'C3_body']; SHELL_SCOPE_fine_reading -> SCOPE_SENSITIVE working ['C3_body', 'S3_body']; OVERALL MIXED
+
+[PASS] O_IMPOSTOR_STRESS
+    finding: 8/8 impostors refused by named gates.
+
+[PASS] P_OUTCOME
+    finding: Q1: 30 subgroups / 11 classes; the grounded conjunction keeps all 11; 2/6 of Cycle 886's menu clauses still isolate C3 and only 0 of those is non-circular; S3 transfer verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED. Q2: MIXED.
+
+{
+ "A_PINS": {
+  "finding": "7/7 pinned artifacts round-trip on both SHA-256 and git blob.",
+  "pass": true,
+  "read_mode": "text/AST/JSON only; import blocked by meta-path firewall",
+  "rows": [
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "exists": true,
+    "git_blob": "4a863da1f3f255354839277271a3a69a5c205133",
+    "git_blob_matches_pin": true,
+    "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "sha256": "fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+    "exists": true,
+    "git_blob": "f4493d787ffb6edc50e9dd13d37ba1cd1dd4d24a",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+    "sha256": "1dfa47a86de8cab5a91cd33a022beb845d918e2f93ceb58f360b2708a44d02a2",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle886_sl0_independent_check_2026_07_28.py",
+    "exists": true,
+    "git_blob": "c3a3785a758123d95b8506d34d143420765ed15e",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle886_sl0_independent_check_2026_07_28.py",
+    "sha256": "3a666e41a59a51e3d5f182578e71c0d91e2b6a386b1c92105b06c01a97d6693f",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+    "exists": true,
+    "git_blob": "4d9999c241b19b2670a51c809e3e39fb0d339f10",
+    "git_blob_matches_pin": true,
+    "path": "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+    "sha256": "74d64090515cf7f7c5ad5f8e6347f7d2f81a9c1cf0b41e9ec7726ad30a62d69d",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/outputs/sl0_independent_check_cycle886_receipt_2026_07_28.json",
+    "exists": true,
+    "git_blob": "1680a44f70cda252e8edb71f0ed95837a5e5dcb4",
+    "git_blob_matches_pin": true,
+    "path": "outputs/sl0_independent_check_cycle886_receipt_2026_07_28.json",
+    "sha256": "80e85dbaebd2e031669bf17622d11325be66f47128cc3494e90c9b65396d7aed",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+    "exists": true,
+    "git_blob": "d563c2b9c2a261f44d7304baa51fdd3596188930",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+    "sha256": "2d96422d30f169a1c4b3215db373e4bffd7b1ef20056ea337ff4ae3f86d9511c",
+    "sha256_matches_pin": true
+   },
+   {
+    "absolute_path": "/Users/jonBridger/Toy Physics/.claude/worktrees/c5-g13/scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+    "exists": true,
+    "git_blob": "c13380757eae27bdee05bc0d4be65a40c2865585",
+    "git_blob_matches_pin": true,
+    "path": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+    "sha256": "cd8126381cca2bf2a852de4daf14ef6955a3af122d2781acd400ebe674efbf2a",
+    "sha256_matches_pin": true
+   }
+  ],
+  "statement": "Every cited artifact is pinned by absolute path, SHA-256 and git blob and read as text/AST/JSON only. A missing or moved pin is a hard preflight failure (exit 2)."
+ },
+ "B_QUOTED_SENTENCES": {
+  "axiom_sentence_count": 10,
+  "axiom_sentences": [
+   {
+    "byte_quoted_sentence": "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.",
+    "id": "admissibility_covariance",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "Axioms and approved primitives are the complete supplied foundation.",
+    "id": "axioms_and_primitives_complete",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "Only records are readable. A readout value is determined by record content alone.",
+    "id": "content_only_readout",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "A site never carries more than one record; records are permanent.",
+    "id": "count_once",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.",
+    "id": "finite_additive_readout",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.",
+    "id": "lattice_rotations",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "A law privileges no states.",
+    "id": "law_privileges_no_states",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+    "id": "no_site_privileged",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "These axioms state only their named primitive content.",
+    "id": "only_named_primitive_content",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   },
+   {
+    "byte_quoted_sentence": "A choice not fixed by the supplied structure remains a named conditional or open dependency.",
+    "id": "unfixed_choice_stays_conditional",
+    "present_in_the_pinned_axiom_memo": true,
+    "recovered_from_the_886_primary_by_AST": true
+   }
+  ],
+  "cycle882_t6_obligation_sentence": {
+   "class": "OBLIGATION sentence, not an axiom sentence",
+   "present_in_the_axiom_memo": false,
+   "recovered_from_the_882_primary_by_AST": true,
+   "sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'."
+  },
+  "cycle883_t6_argument_recovered": true,
+  "cycle883_t6_widening_argument": {
+   "ast_recovered_ORBIT_LENGTH": 3,
+   "ast_recovered_TARGET_PAIR": [
+    1,
+    2
+   ],
+   "ast_recovered_WRONG_PAIRS": [
+    [
+     1,
+     1
+    ],
+    [
+     1,
+     3
+    ],
+    [
+     2,
+     2
+    ],
+    [
+     2,
+     4
+    ],
+    [
+     3,
+     6
+    ]
+   ],
+   "declares_cycle882_generator_set_of_the_orbit_length_alone": true,
+   "defeat_condition_source": "defeated = (not old_reach) and new_reach",
+   "function": "bridge_back_t6_certificate",
+   "widens_to_the_isotype_dimensions": true
+  },
+  "cycle886_fidelity_grades_carried_over_as_pins": {
+   "SEL01_free_on_shell": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL02_transitive_on_shell": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL03_multiplicity_one_orbit_scope": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL04_multiplicity_one_shell_scope": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL05_minimal_shell_invariant_multiplicity": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL06_maximal_free_shell_orbit": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL07_coarse_pair_v2_equals_one": {
+    "fidelity": "EXACT",
+    "grounded": false,
+    "grounding_defect": "target-facing, not axiom-grounded"
+   },
+   "SEL08_reachability_R1_orbit_scope": {
+    "fidelity": "PARTIAL",
+    "grounded": false,
+    "grounding_defect": "target-facing, not axiom-grounded"
+   },
+   "SEL09_reachability_R2_shell_scope": {
+    "fidelity": "PARTIAL",
+    "grounded": false,
+    "grounding_defect": "target-facing and scope-circular"
+   },
+   "SEL10_fine_top_pair_is_the_target": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL11_transitive_on_coordinate_axes": {
+    "fidelity": "PARTIAL",
+    "grounded": false,
+    "grounding_defect": "the sentence grounds axis-equivalence for the whole group, not internal axis-transitivity for the scope subgroup"
+   },
+   "SEL12_odd_order": {
+    "fidelity": "NONE",
+    "grounded": false,
+    "grounding_defect": null
+   },
+   "SEL13_count_once": {
+    "fidelity": "EXACT",
+    "grounded": true,
+    "grounding_defect": null
+   },
+   "SEL14_content_only_readout": {
+    "fidelity": "EXACT",
+    "grounded": true,
+    "grounding_defect": null
+   },
+   "SEL15_admissibility_covariance": {
+    "fidelity": "EXACT",
+    "grounded": true,
+    "grounding_defect": null
+   },
+   "SEL16_no_site_privileged_read_literally": {
+    "fidelity": "EXACT",
+    "grounded": true,
+    "grounding_defect": null
+   }
+  },
+  "cycle886_selector_ids": [
+   "SEL01_free_on_shell",
+   "SEL02_transitive_on_shell",
+   "SEL03_multiplicity_one_orbit_scope",
+   "SEL04_multiplicity_one_shell_scope",
+   "SEL05_minimal_shell_invariant_multiplicity",
+   "SEL06_maximal_free_shell_orbit",
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope",
+   "SEL09_reachability_R2_shell_scope",
+   "SEL10_fine_top_pair_is_the_target",
+   "SEL11_transitive_on_coordinate_axes",
+   "SEL12_odd_order",
+   "SEL13_count_once",
+   "SEL14_content_only_readout",
+   "SEL15_admissibility_covariance",
+   "SEL16_no_site_privileged_read_literally"
+  ],
+  "cycle886_selector_ids_match_the_pinned_list": true,
+  "cycle886_selector_rows_recovered": 16,
+  "finding": "10/10 axiom sentences round-trip byte for byte; the Cycle-882 obligation sentence is AST-recovered and confirmed ABSENT from the axiom memo; 16 selector rows and Cycle 883's widening argument are recovered as pins.",
+  "pass": true,
+  "statement": "Every sentence this cycle quotes is recovered by AST from a pinned artifact and, for axiom sentences, verified present in the pinned axiom memo character for character. Cycle 886's sixteen selector rows and Cycle 883's anchor-widening argument are recovered the same way and carried over as PINS, not retyped."
+ },
+ "C_ROTATION_GROUP": {
+  "associative": true,
+  "associativity_triples_checked": 13824,
+  "axiom_sentence_used": "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.",
+  "burnside_orbit_count_on_the_shell": "1/1",
+  "closed_under_composition": true,
+  "closure_products_checked": 576,
+  "element_order_counts": {
+   "1": 1,
+   "2": 9,
+   "3": 8,
+   "4": 6
+  },
+  "every_element_has_an_inverse": true,
+  "every_element_has_determinant_plus_one": true,
+  "finding": "24 proper rotations, order profile {1: 1, 2: 9, 3: 8, 4: 6}, 576 products and 13824 associativity triples verified; Burnside gives 1/1 shell orbit, matching the direct count 1.",
+  "orbit_count_computed_directly": 1,
+  "pass": true,
+  "proper_rotations": 24,
+  "statement": "GATE C888-G1. The Lattice axiom's 'proper cubic rotations about each site' rebuild as the 24 determinant-one signed permutation matrices; the group axioms are checked exhaustively and Burnside is verified on the 6-neighbour shell."
+ },
+ "D_SUBGROUP_LATTICE": {
+  "class_equation_holds_on_every_class": true,
+  "class_sizes_sum_to_the_lattice": true,
+  "closing_unions_of_found_subgroups_adds_nothing": true,
+  "conjugacy_class_table": [
+   {
+    "class_index": 0,
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "E_trivial",
+    "normal_in_the_full_group": true,
+    "normalizer_order": 24,
+    "order": 1,
+    "size": 1
+   },
+   {
+    "class_index": 1,
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_face",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 8,
+    "order": 2,
+    "size": 3
+   },
+   {
+    "class_index": 2,
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 4,
+    "order": 2,
+    "size": 6
+   },
+   {
+    "class_index": 3,
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C3_body",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 6,
+    "order": 3,
+    "size": 4
+   },
+   {
+    "class_index": 4,
+    "is_abelian": true,
+    "is_cyclic": false,
+    "name": "V_face",
+    "normal_in_the_full_group": true,
+    "normalizer_order": 24,
+    "order": 4,
+    "size": 1
+   },
+   {
+    "class_index": 5,
+    "is_abelian": true,
+    "is_cyclic": false,
+    "name": "V_edge",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 8,
+    "order": 4,
+    "size": 3
+   },
+   {
+    "class_index": 6,
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C4_face",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 8,
+    "order": 4,
+    "size": 3
+   },
+   {
+    "class_index": 7,
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "S3_body",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 6,
+    "order": 6,
+    "size": 4
+   },
+   {
+    "class_index": 8,
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "D4_face",
+    "normal_in_the_full_group": false,
+    "normalizer_order": 8,
+    "order": 8,
+    "size": 3
+   },
+   {
+    "class_index": 9,
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "A4_tetrahedral",
+    "normal_in_the_full_group": true,
+    "normalizer_order": 24,
+    "order": 12,
+    "size": 1
+   },
+   {
+    "class_index": 10,
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "O_full",
+    "normal_in_the_full_group": true,
+    "normalizer_order": 24,
+    "order": 24,
+    "size": 1
+   }
+  ],
+  "conjugacy_classes": 11,
+  "declared_classification_supplied_for_comparison_only": {
+   "class_sizes_by_declared_name": {
+    "A4": 1,
+    "C2_edge": 6,
+    "C2_face": 3,
+    "C3_body": 4,
+    "C4_face": 3,
+    "D4": 3,
+    "S3": 4,
+    "V_edge_nonnormal_Klein": 3,
+    "V_face_normal_Klein": 1,
+    "full": 1,
+    "trivial": 1
+   },
+   "conjugacy_classes": 11,
+   "subgroups": 30
+  },
+  "derived_names_are_constant_on_classes": true,
+  "derived_names_are_distinct_across_classes": true,
+  "every_subgroup_closed_under_composition": true,
+  "every_subgroup_closed_under_inverses": true,
+  "every_subgroup_contains_the_identity": true,
+  "every_subgroup_order_divides_24": true,
+  "finding": "30 subgroups in 11 conjugacy classes: E_trivial x1, C2_face x3, C2_edge x6, C3_body x4, V_face x1, V_edge x3, C4_face x3, S3_body x4, D4_face x3, A4_tetrahedral x1, O_full x1; the class equation, Lagrange, union-closure and the Sylow congruences (n_2 = 3, n_3 = 4) all hold.",
+  "lattice": [
+   {
+    "class_index": 0,
+    "element_indices": [
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "E_trivial",
+    "normalizer_order": 24,
+    "order": 1
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     1,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normalizer_order": 4,
+    "order": 2
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     2,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normalizer_order": 4,
+    "order": 2
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     4,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normalizer_order": 4,
+    "order": 2
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     9,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normalizer_order": 4,
+    "order": 2
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     13,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normalizer_order": 4,
+    "order": 2
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     19,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_edge",
+    "normalizer_order": 4,
+    "order": 2
+   },
+   {
+    "class_index": 1,
+    "element_indices": [
+     0,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_face",
+    "normalizer_order": 8,
+    "order": 2
+   },
+   {
+    "class_index": 1,
+    "element_indices": [
+     3,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_face",
+    "normalizer_order": 8,
+    "order": 2
+   },
+   {
+    "class_index": 1,
+    "element_indices": [
+     20,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C2_face",
+    "normalizer_order": 8,
+    "order": 2
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     5,
+     12,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C3_body",
+    "normalizer_order": 6,
+    "order": 3
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     6,
+     8,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C3_body",
+    "normalizer_order": 6,
+    "order": 3
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     11,
+     17,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C3_body",
+    "normalizer_order": 6,
+    "order": 3
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     15,
+     18,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C3_body",
+    "normalizer_order": 6,
+    "order": 3
+   },
+   {
+    "class_index": 6,
+    "element_indices": [
+     0,
+     7,
+     16,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C4_face",
+    "normalizer_order": 8,
+    "order": 4
+   },
+   {
+    "class_index": 6,
+    "element_indices": [
+     3,
+     10,
+     14,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C4_face",
+    "normalizer_order": 8,
+    "order": 4
+   },
+   {
+    "class_index": 6,
+    "element_indices": [
+     20,
+     21,
+     22,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": true,
+    "name": "C4_face",
+    "normalizer_order": 8,
+    "order": 4
+   },
+   {
+    "class_index": 5,
+    "element_indices": [
+     0,
+     4,
+     19,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": false,
+    "name": "V_edge",
+    "normalizer_order": 8,
+    "order": 4
+   },
+   {
+    "class_index": 5,
+    "element_indices": [
+     1,
+     2,
+     20,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": false,
+    "name": "V_edge",
+    "normalizer_order": 8,
+    "order": 4
+   },
+   {
+    "class_index": 5,
+    "element_indices": [
+     3,
+     9,
+     13,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": false,
+    "name": "V_edge",
+    "normalizer_order": 8,
+    "order": 4
+   },
+   {
+    "class_index": 4,
+    "element_indices": [
+     0,
+     3,
+     20,
+     23
+    ],
+    "is_abelian": true,
+    "is_cyclic": false,
+    "name": "V_face",
+    "normalizer_order": 24,
+    "order": 4
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     1,
+     4,
+     9,
+     15,
+     18,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "S3_body",
+    "normalizer_order": 6,
+    "order": 6
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     1,
+     6,
+     8,
+     13,
+     19,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "S3_body",
+    "normalizer_order": 6,
+    "order": 6
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     2,
+     4,
+     11,
+     13,
+     17,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "S3_body",
+    "normalizer_order": 6,
+    "order": 6
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     2,
+     5,
+     9,
+     12,
+     19,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "S3_body",
+    "normalizer_order": 6,
+    "order": 6
+   },
+   {
+    "class_index": 8,
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     20,
+     21,
+     22,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "D4_face",
+    "normalizer_order": 8,
+    "order": 8
+   },
+   {
+    "class_index": 8,
+    "element_indices": [
+     0,
+     3,
+     4,
+     7,
+     16,
+     19,
+     20,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "D4_face",
+    "normalizer_order": 8,
+    "order": 8
+   },
+   {
+    "class_index": 8,
+    "element_indices": [
+     0,
+     3,
+     9,
+     10,
+     13,
+     14,
+     20,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "D4_face",
+    "normalizer_order": 8,
+    "order": 8
+   },
+   {
+    "class_index": 9,
+    "element_indices": [
+     0,
+     3,
+     5,
+     6,
+     8,
+     11,
+     12,
+     15,
+     17,
+     18,
+     20,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "A4_tetrahedral",
+    "normalizer_order": 24,
+    "order": 12
+   },
+   {
+    "class_index": 10,
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     4,
+     5,
+     6,
+     7,
+     8,
+     9,
+     10,
+     11,
+     12,
+     13,
+     14,
+     15,
+     16,
+     17,
+     18,
+     19,
+     20,
+     21,
+     22,
+     23
+    ],
+    "is_abelian": false,
+    "is_cyclic": false,
+    "name": "O_full",
+    "normalizer_order": 24,
+    "order": 24
+   }
+  ],
+  "normalizer_order_is_constant_on_each_class": true,
+  "pass": true,
+  "recomputation_matches_the_declared_classification": true,
+  "statement": "GATE C888-G2. THE FULL SUBGROUP LATTICE. Every subgroup of the 24 proper cubic rotations is built by closing every ordered PAIR of group elements, then grouped into conjugacy classes. Completeness is gated by Lagrange, by the class equation |class| * |N_G(H)| = |G|, by union-closure adding nothing, and by the Sylow congruences. Class NAMES are DERIVED from order, cyclicity, commutativity and the axis-kind multiset -- never hardcoded per subgroup.",
+  "subgroups_by_order": {
+   "1": 1,
+   "2": 9,
+   "3": 4,
+   "4": 7,
+   "6": 4,
+   "8": 3,
+   "12": 1,
+   "24": 1
+  },
+  "subgroups_found": 30,
+  "sylow_2_subgroup_count": 3,
+  "sylow_3_subgroup_count": 4,
+  "sylow_congruences_hold": true
+ },
+ "E_SHELL_ORBIT_STRUCTURE": {
+  "every_orbit_length_divides_its_subgroup_order": true,
+  "every_partition_sums_to_six": true,
+  "finding": "shell orbit-length profiles by class: A4_tetrahedral -> (6,); C2_edge -> (2, 2, 2); C2_face -> (1, 1, 2, 2); C3_body -> (3, 3); C4_face -> (1, 1, 4); D4_face -> (2, 4); E_trivial -> (1, 1, 1, 1, 1, 1); O_full -> (6,); S3_body -> (6,); V_edge -> (2, 4); V_face -> (2, 2, 2); simply transitive: ['S3_body'] (4 subgroups)",
+  "pass": true,
+  "rows": [
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 0,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     1,
+     1
+    ],
+    "element_indices": [
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      1,
+      0,
+      0
+     ],
+     [
+      0,
+      1,
+      0
+     ],
+     [
+      0,
+      0,
+      1
+     ],
+     [
+      -1,
+      0,
+      0
+     ],
+     [
+      0,
+      -1,
+      0
+     ],
+     [
+      0,
+      0,
+      -1
+     ]
+    ],
+    "free_orbit_count": 6,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 1,
+    "maximal_orbit_length": 1,
+    "name": "E_trivial",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 1,
+    "shell_orbit_count": 6,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 2,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     1,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 3,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 2,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     2,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 3,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 2,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     4,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 3,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 2,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     9,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 3,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 2,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     13,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 3,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 2,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     19,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 3,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 1,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     1,
+     1
+    ],
+    "element_indices": [
+     0,
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      0,
+      0,
+      1
+     ],
+     [
+      0,
+      0,
+      -1
+     ]
+    ],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 4,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 1,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     1,
+     1
+    ],
+    "element_indices": [
+     3,
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      0,
+      1,
+      0
+     ],
+     [
+      0,
+      -1,
+      0
+     ]
+    ],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 4,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 1,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     1,
+     1
+    ],
+    "element_indices": [
+     20,
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      1,
+      0,
+      0
+     ],
+     [
+      -1,
+      0,
+      0
+     ]
+    ],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 2,
+    "maximal_orbit_length": 2,
+    "name": "C2_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 2,
+    "shell_orbit_count": 4,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 3,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     5,
+     12,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 3,
+    "maximal_orbit_length": 3,
+    "name": "C3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 3,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     3,
+     3
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 3,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     6,
+     8,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 3,
+    "maximal_orbit_length": 3,
+    "name": "C3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 3,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     3,
+     3
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 3,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     11,
+     17,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 3,
+    "maximal_orbit_length": 3,
+    "name": "C3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 3,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     3,
+     3
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 3,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     15,
+     18,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 2,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 3,
+    "maximal_orbit_length": 3,
+    "name": "C3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 3,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     3,
+     3
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 6,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     0,
+     7,
+     16,
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      0,
+      0,
+      1
+     ],
+     [
+      0,
+      0,
+      -1
+     ]
+    ],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 4,
+    "maximal_orbit_length": 4,
+    "name": "C4_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 6,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     3,
+     10,
+     14,
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      0,
+      1,
+      0
+     ],
+     [
+      0,
+      -1,
+      0
+     ]
+    ],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 4,
+    "maximal_orbit_length": 4,
+    "name": "C4_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 6,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     20,
+     21,
+     22,
+     23
+    ],
+    "fixed_shell_sites": [
+     [
+      1,
+      0,
+      0
+     ],
+     [
+      -1,
+      0,
+      0
+     ]
+    ],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": true,
+    "maximal_FREE_orbit_length": 4,
+    "maximal_orbit_length": 4,
+    "name": "C4_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 5,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     0,
+     4,
+     19,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 4,
+    "maximal_orbit_length": 4,
+    "name": "V_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 5,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     1,
+     2,
+     20,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 4,
+    "maximal_orbit_length": 4,
+    "name": "V_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 5,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     3,
+     9,
+     13,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 4,
+    "maximal_orbit_length": 4,
+    "name": "V_edge",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 4,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     1,
+     1
+    ],
+    "element_indices": [
+     0,
+     3,
+     20,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 0,
+    "has_a_free_orbit_on_the_shell": false,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 0,
+    "maximal_orbit_length": 2,
+    "name": "V_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 4,
+    "shell_orbit_count": 3,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 7,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     1,
+     4,
+     9,
+     15,
+     18,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 6,
+    "maximal_orbit_length": 6,
+    "name": "S3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 6,
+    "shell_orbit_count": 1,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "simply_transitive_on_the_shell": true,
+    "transitive_on_the_shell": true,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 7,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     1,
+     6,
+     8,
+     13,
+     19,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 6,
+    "maximal_orbit_length": 6,
+    "name": "S3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 6,
+    "shell_orbit_count": 1,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "simply_transitive_on_the_shell": true,
+    "transitive_on_the_shell": true,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 7,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     2,
+     4,
+     11,
+     13,
+     17,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 6,
+    "maximal_orbit_length": 6,
+    "name": "S3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 6,
+    "shell_orbit_count": 1,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "simply_transitive_on_the_shell": true,
+    "transitive_on_the_shell": true,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": true,
+    "class_index": 7,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     2,
+     5,
+     9,
+     12,
+     19,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 1,
+    "has_a_free_orbit_on_the_shell": true,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 6,
+    "maximal_orbit_length": 6,
+    "name": "S3_body",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 6,
+    "shell_orbit_count": 1,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "simply_transitive_on_the_shell": true,
+    "transitive_on_the_shell": true,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 8,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     20,
+     21,
+     22,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 0,
+    "has_a_free_orbit_on_the_shell": false,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 0,
+    "maximal_orbit_length": 4,
+    "name": "D4_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 8,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 8,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     0,
+     3,
+     4,
+     7,
+     16,
+     19,
+     20,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 0,
+    "has_a_free_orbit_on_the_shell": false,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 0,
+    "maximal_orbit_length": 4,
+    "name": "D4_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 8,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 8,
+    "coordinate_axis_orbit_sizes": [
+     1,
+     2
+    ],
+    "element_indices": [
+     0,
+     3,
+     9,
+     10,
+     13,
+     14,
+     20,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 0,
+    "has_a_free_orbit_on_the_shell": false,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 0,
+    "maximal_orbit_length": 4,
+    "name": "D4_face",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 8,
+    "shell_orbit_count": 2,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": false,
+    "transitive_on_the_three_coordinate_axes": false
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 9,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     0,
+     3,
+     5,
+     6,
+     8,
+     11,
+     12,
+     15,
+     17,
+     18,
+     20,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 0,
+    "has_a_free_orbit_on_the_shell": false,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 0,
+    "maximal_orbit_length": 6,
+    "name": "A4_tetrahedral",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 12,
+    "shell_orbit_count": 1,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": true,
+    "transitive_on_the_three_coordinate_axes": true
+   },
+   {
+    "acts_freely_on_the_shell": false,
+    "class_index": 10,
+    "coordinate_axis_orbit_sizes": [
+     3
+    ],
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     4,
+     5,
+     6,
+     7,
+     8,
+     9,
+     10,
+     11,
+     12,
+     13,
+     14,
+     15,
+     16,
+     17,
+     18,
+     19,
+     20,
+     21,
+     22,
+     23
+    ],
+    "fixed_shell_sites": [],
+    "free_orbit_count": 0,
+    "has_a_free_orbit_on_the_shell": false,
+    "is_cyclic": false,
+    "maximal_FREE_orbit_length": 0,
+    "maximal_orbit_length": 6,
+    "name": "O_full",
+    "orbit_lengths_divide_the_subgroup_order": true,
+    "orbit_lengths_sum_to_six": true,
+    "order": 24,
+    "shell_orbit_count": 1,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "simply_transitive_on_the_shell": false,
+    "transitive_on_the_shell": true,
+    "transitive_on_the_three_coordinate_axes": true
+   }
+  ],
+  "simply_transitive_subgroup_count": 4,
+  "statement": "GATE C888-G3. Shell and coordinate-axis orbit structure of ALL thirty subgroups, gated by orbit-stabilizer (every orbit length divides the subgroup order) and by the partition identity.",
+  "subgroups_acting_simply_transitively_on_the_shell": [
+   "S3_body"
+  ]
+ },
+ "F_C883_CONSTRUCTION_AND_T6_REBUILT": {
+  "C3_group_theoretic_route": [
+   1,
+   2
+  ],
+  "T6_defeated_at_the_C3_scope": true,
+  "ast_recovered_argument": {
+   "ast_recovered_ORBIT_LENGTH": 3,
+   "ast_recovered_TARGET_PAIR": [
+    1,
+    2
+   ],
+   "ast_recovered_WRONG_PAIRS": [
+    [
+     1,
+     1
+    ],
+    [
+     1,
+     3
+    ],
+    [
+     2,
+     2
+    ],
+    [
+     2,
+     4
+    ],
+    [
+     3,
+     6
+    ]
+   ],
+   "declares_cycle882_generator_set_of_the_orbit_length_alone": true,
+   "defeat_condition_source": "defeated = (not old_reach) and new_reach",
+   "function": "bridge_back_t6_certificate",
+   "source": "def bridge_back_t6_certificate() -> dict:\n    \"\"\"Recompute C882-T6 with the derived isotype datum admitted.\"\"\"\n    window = range(-6, 7)\n    old_elements = {Fraction(3) ** e for e in window}\n    old_valuations = sorted({v2(x) for x in old_elements})\n    old_reach = L3_FIXED_LOCUS_DENSITY in old_elements\n\n    # The derived datum admits the isotype dimensions {1, 2} alongside the\n    # orbit length 3.  Build the multiplicative group they generate.\n    generators = (2, 3)\n    new_elements = set()\n    for exps in product(window, repeat=len(generators)):\n        value = Fraction(1)\n        for g, e in zip(generators, exps):\n            value *= Fraction(g) ** e\n        new_elements.add(value)\n    new_valuations = sorted({v2(x) for x in new_elements})\n    new_reach = L3_FIXED_LOCUS_DENSITY in new_elements\n    witness_exponents = None\n    for a in window:\n        for b in window:\n            if Fraction(2) ** a * Fraction(3) ** b == L3_FIXED_LOCUS_DENSITY:\n                witness_exponents = {\"two\": a, \"three\": b}\n                break\n        if witness_exponents:\n            break\n\n    defeated = (not old_reach) and new_reach\n    return {\n        \"recomputed_theorem\": \"C882-T6 (2-adic exclusion)\",\n        \"cycle882_generator_set\": [3],\n        \"cycle882_distinct_2_adic_valuations\": old_valuations,\n        \"cycle882_target_reachable\": old_reach,\n        \"cycle883_generator_set\": list(generators),\n        \"cycle883_generators_provenance\": (\n            \"2 = the derived complement isotype dimension (C883-T4); \"\n            \"3 = the orbit length, already pinned by Cycle 882\"\n        ),\n        \"cycle883_distinct_2_adic_valuations\": new_valuations,\n        \"cycle883_target_reachable\": new_reach,\n        \"target_anchor\": q(L3_FIXED_LOCUS_DENSITY),\n        \"target_2_adic_valuation\": v2(L3_FIXED_LOCUS_DENSITY),\n        \"target_3_adic_valuation\": v3(L3_FIXED_LOCUS_DENSITY),\n        \"witness_exponents\": witness_exponents,\n        \"obstruction_defeated\": defeated,\n        \"exactly_what_changed\": (\n            \"C882-T6 excluded 2/9 because every element of <3> has v_2 = 0. \"\n            \"Admitting the derived complement dimension 2 widens the group to \"\n            \"<2, 3>, whose 2-adic valuations now range over the scanned window, \"\n            \"and 2/9 = 2^1 * 3^-2 is a member. The named escape condition of \"\n            \"C882-T6 is met by a DERIVED datum, not a supplied one.\"\n        ),\n        \"what_is_NOT_claimed\": (\n            \"Reachability is not selection. C882-T7 is untouched by this \"\n            \"widening and is recomputed separately in certificate L.\"\n        ),\n        \"finding\": (\n            f\"With the derived isotype dimension admitted the anchor group \"\n            f\"widens from valuations {old_valuations} to {new_valuations} and \"\n            f\"the target {q(L3_FIXED_LOCUS_DENSITY)} becomes reachable at \"\n            f\"{witness_exponents}, so the C882-T6 obstruction is defeated.\"\n        ),\n        \"pass\": defeated and v2(L3_FIXED_LOCUS_DENSITY) == 1,\n    }",
+   "widens_to_the_isotype_dimensions": true
+  },
+  "both_routes_agree_at_C3": true,
+  "cycle882_generator_set_from_the_orbit_length_alone": [
+   3
+  ],
+  "cycle882_target_reachable": false,
+  "cycle883_target_reachable": true,
+  "cycle883_widened_generator_set": [
+   3,
+   1,
+   2
+  ],
+  "cycle883_witness_exponents": [
+   1,
+   -2
+  ],
+  "cyclic_formula_table": [
+   {
+    "cycle883_rows_route": [
+     1,
+     1
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 2
+   },
+   {
+    "cycle883_rows_route": [
+     1,
+     2
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 3
+   },
+   {
+    "cycle883_rows_route": [
+     1,
+     3
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 4
+   },
+   {
+    "cycle883_rows_route": [
+     1,
+     4
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 5
+   },
+   {
+    "cycle883_rows_route": [
+     1,
+     5
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 6
+   },
+   {
+    "cycle883_rows_route": [
+     1,
+     6
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 7
+   },
+   {
+    "cycle883_rows_route": [
+     1,
+     7
+    ],
+    "matches_1_n_minus_1": true,
+    "n": 8
+   }
+  ],
+  "defeat_condition_as_cycle883_wrote_it": "defeated = (not old_reach) and new_reach",
+  "finding": "The pinned construction round-trips by AST, follows (1, n-1) on all 7 cyclic orbit lengths, agrees with the group-theoretic route at C3, and its T6 step is reproduced: <3> misses 2/9 and <2, 3> hits it at exponents [1, -2].",
+  "pair_follows_1_n_minus_1_on_every_cyclic_orbit_length": true,
+  "pass": true,
+  "reproduces_the_landed_cycle883_result": true,
+  "statement": "The Cycle-883 readout construction and its T6 step are recovered from the pinned 883 primary by AST -- never imported -- and rebuilt here twice: once as Cycle 883 wrote it (nullspace of a_i - a_{i+1} on a free cyclic orbit) and once group-theoretically (the intersection of ker(rho(h) - 1) over the whole subgroup). The second form is DEFINED for non-cyclic subgroups, which is exactly what makes the transfer question to S3 answerable.",
+  "what_this_licenses": "The construction generalizes verbatim to ANY subgroup acting freely on a set of records: it is 'the linear additive readout on the free orbit, decomposed under the acting group'. Nothing in it mentions the number 3, and nothing in it mentions cyclicity.",
+  "witness_multiplies_back_out_to_the_target": true
+ },
+ "G_ISOTYPE_SIGNATURES": {
+  "by_class": [
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "A4_tetrahedral",
+    "orbit_scope_decomposition_is_unique": null,
+    "orbit_scope_exists": false,
+    "orbit_scope_fine_dims": null,
+    "orbit_scope_fine_top_pair": null,
+    "orbit_scope_pair": null,
+    "orbit_scope_profile": null,
+    "order": 12,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "shell_scope_decomposition_is_unique": true,
+    "shell_scope_fine_dims": [
+     1,
+     2,
+     3
+    ],
+    "shell_scope_fine_top_pair": [
+     1,
+     3
+    ],
+    "shell_scope_pair": [
+     1,
+     5
+    ],
+    "shell_scope_profile": [
+     0,
+     0
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "C2_edge",
+    "orbit_scope_decomposition_is_unique": true,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1,
+     1
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_profile": [
+     0,
+     0
+    ],
+    "order": 2,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "shell_scope_fine_top_pair": [
+     3,
+     1
+    ],
+    "shell_scope_pair": [
+     3,
+     3
+    ],
+    "shell_scope_profile": [
+     0,
+     0
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "C2_face",
+    "orbit_scope_decomposition_is_unique": true,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1,
+     1
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_profile": [
+     0,
+     0
+    ],
+    "order": 2,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "shell_scope_fine_top_pair": [
+     4,
+     1
+    ],
+    "shell_scope_pair": [
+     4,
+     2
+    ],
+    "shell_scope_profile": [
+     2,
+     1
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": true,
+    "carries_the_target_pair_fine_at_the_orbit_scope": true,
+    "name": "C3_body",
+    "orbit_scope_decomposition_is_unique": true,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1,
+     2
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_profile": [
+     0,
+     1
+    ],
+    "order": 3,
+    "shell_orbit_lengths": [
+     3,
+     3
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "shell_scope_fine_top_pair": [
+     2,
+     2
+    ],
+    "shell_scope_pair": [
+     2,
+     4
+    ],
+    "shell_scope_profile": [
+     1,
+     2
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": true,
+    "name": "C4_face",
+    "orbit_scope_decomposition_is_unique": true,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1,
+     1,
+     2
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_pair": [
+     1,
+     3
+    ],
+    "orbit_scope_profile": [
+     0,
+     0
+    ],
+    "order": 4,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     4
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     2
+    ],
+    "shell_scope_fine_top_pair": [
+     3,
+     2
+    ],
+    "shell_scope_pair": [
+     3,
+     3
+    ],
+    "shell_scope_profile": [
+     0,
+     0
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "D4_face",
+    "orbit_scope_decomposition_is_unique": null,
+    "orbit_scope_exists": false,
+    "orbit_scope_fine_dims": null,
+    "orbit_scope_fine_top_pair": null,
+    "orbit_scope_pair": null,
+    "orbit_scope_profile": null,
+    "order": 8,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     2
+    ],
+    "shell_scope_fine_top_pair": [
+     2,
+     2
+    ],
+    "shell_scope_pair": [
+     2,
+     4
+    ],
+    "shell_scope_profile": [
+     1,
+     2
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "E_trivial",
+    "orbit_scope_decomposition_is_unique": true,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_pair": [
+     1,
+     0
+    ],
+    "orbit_scope_profile": [
+     0,
+     null
+    ],
+    "order": 1,
+    "shell_orbit_lengths": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "shell_scope_fine_top_pair": [
+     6,
+     1
+    ],
+    "shell_scope_pair": [
+     6,
+     0
+    ],
+    "shell_scope_profile": [
+     1,
+     null
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "O_full",
+    "orbit_scope_decomposition_is_unique": null,
+    "orbit_scope_exists": false,
+    "orbit_scope_fine_dims": null,
+    "orbit_scope_fine_top_pair": null,
+    "orbit_scope_pair": null,
+    "orbit_scope_profile": null,
+    "order": 24,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "shell_scope_decomposition_is_unique": true,
+    "shell_scope_fine_dims": [
+     1,
+     2,
+     3
+    ],
+    "shell_scope_fine_top_pair": [
+     1,
+     3
+    ],
+    "shell_scope_pair": [
+     1,
+     5
+    ],
+    "shell_scope_profile": [
+     0,
+     0
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": true,
+    "name": "S3_body",
+    "orbit_scope_decomposition_is_unique": false,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_pair": [
+     1,
+     5
+    ],
+    "orbit_scope_profile": [
+     0,
+     0
+    ],
+    "order": 6,
+    "shell_orbit_lengths": [
+     6
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "shell_scope_fine_top_pair": [
+     1,
+     2
+    ],
+    "shell_scope_pair": [
+     1,
+     5
+    ],
+    "shell_scope_profile": [
+     0,
+     0
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "V_edge",
+    "orbit_scope_decomposition_is_unique": true,
+    "orbit_scope_exists": true,
+    "orbit_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1
+    ],
+    "orbit_scope_fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_pair": [
+     1,
+     3
+    ],
+    "orbit_scope_profile": [
+     0,
+     0
+    ],
+    "order": 4,
+    "shell_orbit_lengths": [
+     2,
+     4
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "shell_scope_fine_top_pair": [
+     2,
+     1
+    ],
+    "shell_scope_pair": [
+     2,
+     4
+    ],
+    "shell_scope_profile": [
+     1,
+     2
+    ]
+   },
+   {
+    "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+    "carries_the_target_pair_fine_at_the_orbit_scope": false,
+    "name": "V_face",
+    "orbit_scope_decomposition_is_unique": null,
+    "orbit_scope_exists": false,
+    "orbit_scope_fine_dims": null,
+    "orbit_scope_fine_top_pair": null,
+    "orbit_scope_pair": null,
+    "orbit_scope_profile": null,
+    "order": 4,
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ],
+    "shell_scope_decomposition_is_unique": false,
+    "shell_scope_fine_dims": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "shell_scope_fine_top_pair": [
+     3,
+     1
+    ],
+    "shell_scope_pair": [
+     3,
+     3
+    ],
+    "shell_scope_profile": [
+     0,
+     0
+    ]
+   }
+  ],
+  "classes_carrying_1_2_coarse_at_the_orbit_scope": [
+   "C3_body"
+  ],
+  "classes_carrying_1_2_fine_at_the_orbit_scope": [
+   "C3_body",
+   "C4_face",
+   "S3_body"
+  ],
+  "every_signature_gate_passes": true,
+  "finding": "A4_tetrahedral: orbit None fine None | shell [1, 5] fine [1, 2, 3]; C2_edge: orbit [1, 1] fine [1, 1] | shell [3, 3] fine [1, 1, 1, 1, 1, 1]; C2_face: orbit [1, 1] fine [1, 1] | shell [4, 2] fine [1, 1, 1, 1, 1, 1]; C3_body: orbit [1, 2] fine [1, 2] | shell [2, 4] fine [1, 1, 2, 2]; C4_face: orbit [1, 3] fine [1, 1, 2] | shell [3, 3] fine [1, 1, 1, 1, 2]; D4_face: orbit None fine None | shell [2, 4] fine [1, 1, 1, 1, 2]; E_trivial: orbit [1, 0] fine [1] | shell [6, 0] fine [1, 1, 1, 1, 1, 1]; O_full: orbit None fine None | shell [1, 5] fine [1, 2, 3]; S3_body: orbit [1, 5] fine [1, 1, 2, 2] | shell [1, 5] fine [1, 1, 2, 2]; V_edge: orbit [1, 3] fine [1, 1, 1, 1] | shell [2, 4] fine [1, 1, 1, 1, 1, 1]; V_face: orbit None fine None | shell [3, 3] fine [1, 1, 1, 1, 1, 1]",
+  "pass": true,
+  "rows": [
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "1/1",
+     "centre_dimension": 1,
+     "coarse_ordered_pair": [
+      1,
+      0
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      null
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 1,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 1,
+     "space_dimension": 1,
+     "subgroup_order": 1
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "36/1",
+     "centre_dimension": 1,
+     "coarse_ordered_pair": [
+      6,
+      0
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      null
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 1,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      6,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      1,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "6/1",
+     "invariant_dim_by_nullspace": 6,
+     "invariant_dim_by_orbit_count": 6,
+     "isotypes": [
+      {
+       "component_dimension": 6,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 6
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 36,
+     "space_dimension": 6,
+     "subgroup_order": 1
+    },
+    "class_index": 0,
+    "element_indices": [
+     23
+    ],
+    "name": "E_trivial",
+    "order": 1
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "18/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 18,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 2,
+    "element_indices": [
+     1,
+     23
+    ],
+    "name": "C2_edge",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "18/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 18,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 2,
+    "element_indices": [
+     2,
+     23
+    ],
+    "name": "C2_edge",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "18/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 18,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 2,
+    "element_indices": [
+     4,
+     23
+    ],
+    "name": "C2_edge",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "18/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 18,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 2,
+    "element_indices": [
+     9,
+     23
+    ],
+    "name": "C2_edge",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "18/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 18,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 2,
+    "element_indices": [
+     13,
+     23
+    ],
+    "name": "C2_edge",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "18/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 18,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 2,
+    "element_indices": [
+     19,
+     23
+    ],
+    "name": "C2_edge",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "20/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      4,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      2,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      4,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      2,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "4/1",
+     "invariant_dim_by_nullspace": 4,
+     "invariant_dim_by_orbit_count": 4,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 4
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 20,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 1,
+    "element_indices": [
+     0,
+     23
+    ],
+    "name": "C2_face",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "20/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      4,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      2,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      4,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      2,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "4/1",
+     "invariant_dim_by_nullspace": 4,
+     "invariant_dim_by_orbit_count": 4,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 4
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 20,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 1,
+    "element_indices": [
+     3,
+     23
+    ],
+    "name": "C2_face",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "2/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      1,
+      1
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 2,
+     "space_dimension": 2,
+     "subgroup_order": 2
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "20/1",
+     "centre_dimension": 2,
+     "coarse_ordered_pair": [
+      4,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      2,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 2,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      4,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      2,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "4/1",
+     "invariant_dim_by_nullspace": 4,
+     "invariant_dim_by_orbit_count": 4,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 4
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 20,
+     "space_dimension": 6,
+     "subgroup_order": 2
+    },
+    "class_index": 1,
+    "element_indices": [
+     20,
+     23
+    ],
+    "name": "C2_face",
+    "order": 2
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "3/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 3,
+     "space_dimension": 3,
+     "subgroup_order": 3
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 3
+    },
+    "class_index": 3,
+    "element_indices": [
+     5,
+     12,
+     23
+    ],
+    "name": "C3_body",
+    "order": 3
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "3/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 3,
+     "space_dimension": 3,
+     "subgroup_order": 3
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 3
+    },
+    "class_index": 3,
+    "element_indices": [
+     6,
+     8,
+     23
+    ],
+    "name": "C3_body",
+    "order": 3
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "3/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 3,
+     "space_dimension": 3,
+     "subgroup_order": 3
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 3
+    },
+    "class_index": 3,
+    "element_indices": [
+     11,
+     17,
+     23
+    ],
+    "name": "C3_body",
+    "order": 3
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "3/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      2
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      1
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 3,
+     "space_dimension": 3,
+     "subgroup_order": 3
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 3,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 3
+    },
+    "class_index": 3,
+    "element_indices": [
+     15,
+     18,
+     23
+    ],
+    "name": "C3_body",
+    "order": 3
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 4,
+     "subgroup_order": 4
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      3,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 6,
+    "element_indices": [
+     0,
+     7,
+     16,
+     23
+    ],
+    "name": "C4_face",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 4,
+     "subgroup_order": 4
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      3,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 6,
+    "element_indices": [
+     3,
+     10,
+     14,
+     23
+    ],
+    "name": "C4_face",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 4,
+     "subgroup_order": 4
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      3,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 3
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 6,
+    "element_indices": [
+     20,
+     21,
+     22,
+     23
+    ],
+    "name": "C4_face",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 4,
+     "subgroup_order": 4
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "10/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      2,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      1,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 10,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 5,
+    "element_indices": [
+     0,
+     4,
+     19,
+     23
+    ],
+    "name": "V_edge",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 4,
+     "subgroup_order": 4
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "10/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      2,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      1,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 10,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 5,
+    "element_indices": [
+     1,
+     2,
+     20,
+     23
+    ],
+    "name": "V_edge",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      1,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 4,
+     "subgroup_order": 4
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "10/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      2,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      1,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 10,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 5,
+    "element_indices": [
+     3,
+     9,
+     13,
+     23
+    ],
+    "name": "V_edge",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": null,
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "12/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      3,
+      3
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 4,
+     "fine_dimensions_with_a_v2_equal_to_one": [],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "fine_top_pair": [
+      3,
+      1
+     ],
+     "fine_top_rational_irreducible_dimension": 1,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "3/1",
+     "invariant_dim_by_nullspace": 3,
+     "invariant_dim_by_orbit_count": 3,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 3
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 12,
+     "space_dimension": 6,
+     "subgroup_order": 4
+    },
+    "class_index": 4,
+    "element_indices": [
+     0,
+     3,
+     20,
+     23
+    ],
+    "name": "V_face",
+    "order": 4
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "class_index": 7,
+    "element_indices": [
+     1,
+     4,
+     9,
+     15,
+     18,
+     23
+    ],
+    "name": "S3_body",
+    "order": 6
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "class_index": 7,
+    "element_indices": [
+     1,
+     6,
+     8,
+     13,
+     19,
+     23
+    ],
+    "name": "S3_body",
+    "order": 6
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "class_index": 7,
+    "element_indices": [
+     2,
+     4,
+     11,
+     13,
+     17,
+     23
+    ],
+    "name": "S3_body",
+    "order": 6
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "6/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 6,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      0,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 4,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 2
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 6,
+     "space_dimension": 6,
+     "subgroup_order": 6
+    },
+    "class_index": 7,
+    "element_indices": [
+     2,
+     5,
+     9,
+     12,
+     19,
+     23
+    ],
+    "name": "S3_body",
+    "order": 6
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": null,
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "7/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 7,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -5,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 7,
+     "space_dimension": 6,
+     "subgroup_order": 8
+    },
+    "class_index": 8,
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     20,
+     21,
+     22,
+     23
+    ],
+    "name": "D4_face",
+    "order": 8
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": null,
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "7/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 7,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -5,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 7,
+     "space_dimension": 6,
+     "subgroup_order": 8
+    },
+    "class_index": 8,
+    "element_indices": [
+     0,
+     3,
+     4,
+     7,
+     16,
+     19,
+     20,
+     23
+    ],
+    "name": "D4_face",
+    "order": 8
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": null,
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "7/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      2,
+      4
+     ],
+     "coarse_two_adic_profile": [
+      1,
+      2
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 7,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      2,
+      2
+     ],
+     "fine_top_rational_irreducible_dimension": 2,
+     "fine_top_two_adic_profile": [
+      1,
+      1
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "2/1",
+     "invariant_dim_by_nullspace": 2,
+     "invariant_dim_by_orbit_count": 2,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        3,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -5,
+        1
+       ],
+       "multiplicity": 2
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": false,
+     "orbit_count_on_the_product_set": 7,
+     "space_dimension": 6,
+     "subgroup_order": 8
+    },
+    "class_index": 8,
+    "element_indices": [
+     0,
+     3,
+     9,
+     10,
+     13,
+     14,
+     20,
+     23
+    ],
+    "name": "D4_face",
+    "order": 8
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": null,
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "4/1",
+     "centre_dimension": 4,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 12,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      2,
+      3
+     ],
+     "fine_top_pair": [
+      1,
+      3
+     ],
+     "fine_top_rational_irreducible_dimension": 3,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -4,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 2,
+       "endomorphism_field_degree": 2,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        16,
+        4,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 9,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 3,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        0,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 4,
+     "space_dimension": 6,
+     "subgroup_order": 12
+    },
+    "class_index": 9,
+    "element_indices": [
+     0,
+     3,
+     5,
+     6,
+     8,
+     11,
+     12,
+     15,
+     17,
+     18,
+     20,
+     23
+    ],
+    "name": "A4_tetrahedral",
+    "order": 12
+   },
+   {
+    "ORBIT_SCOPE_cycle883_construction": null,
+    "SHELL_SCOPE_whole_neighbourhood": {
+     "all_gates_pass": true,
+     "burnside_pair_count": "3/1",
+     "centre_dimension": 3,
+     "coarse_ordered_pair": [
+      1,
+      5
+     ],
+     "coarse_two_adic_profile": [
+      0,
+      0
+     ],
+     "decomposition_failure_reason": null,
+     "enveloping_algebra_dimension": 14,
+     "fine_dimensions_with_a_v2_equal_to_one": [
+      2
+     ],
+     "fine_rational_irreducible_dimensions": [
+      1,
+      2,
+      3
+     ],
+     "fine_top_pair": [
+      1,
+      3
+     ],
+     "fine_top_rational_irreducible_dimension": 3,
+     "fine_top_two_adic_profile": [
+      0,
+      0
+     ],
+     "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+     },
+     "invariant_dim_by_burnside": "1/1",
+     "invariant_dim_by_nullspace": 1,
+     "invariant_dim_by_orbit_count": 1,
+     "isotypes": [
+      {
+       "component_dimension": 1,
+       "dim_Q_of_the_component_algebra": 1,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 1,
+       "is_the_trivial_isotype": true,
+       "minimal_polynomial_factor": [
+        -5,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 2,
+       "dim_Q_of_the_component_algebra": 4,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 2,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        1,
+        1
+       ],
+       "multiplicity": 1
+      },
+      {
+       "component_dimension": 3,
+       "dim_Q_of_the_component_algebra": 9,
+       "endomorphism_field_degree": 1,
+       "irreducible_degree_over_Q": 3,
+       "is_the_trivial_isotype": false,
+       "minimal_polynomial_factor": [
+        -1,
+        1
+       ],
+       "multiplicity": 1
+      }
+     ],
+     "isotypic_decomposition_is_unique": true,
+     "orbit_count_on_the_product_set": 3,
+     "space_dimension": 6,
+     "subgroup_order": 24
+    },
+    "class_index": 10,
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     4,
+     5,
+     6,
+     7,
+     8,
+     9,
+     10,
+     11,
+     12,
+     13,
+     14,
+     15,
+     16,
+     17,
+     18,
+     19,
+     20,
+     21,
+     22,
+     23
+    ],
+    "name": "O_full",
+    "order": 24
+   }
+  ],
+  "statement": "GATE C888-G4 + THE SIGNATURE TABLE. For every subgroup, at both scopes and under both readings: invariant multiplicity by three independent routes; the coarse ordered weight pair with its 2-adic profile; the FINE rational-irreducible decomposition, computed with NO character table by the enveloping algebra/centre/minimal-polynomial route; and the uniqueness of that decomposition. Three gates hold every row down: the fine dimensions sum to the space, the trivial isotype multiplicity equals the orbit count, and sum_i m_i^2 [F_i:Q] equals the orbit count on X x X. NO gate tests for a preferred subgroup."
+ },
+ "H_CLASS_INVARIANCE": {
+  "basis_dependent_keys_projected_out": [
+   "minimal_polynomial_factor"
+  ],
+  "candidate_scope_answers": 11,
+  "every_signature_is_a_class_function": true,
+  "finding": "All 30 subgroups collapse to 11 distinct signatures, one per conjugacy class.",
+  "pass": true,
+  "rows": [
+   {
+    "class_index": 0,
+    "distinct_signature_digests": 1,
+    "members": 1,
+    "name": "E_trivial",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 1,
+    "distinct_signature_digests": 1,
+    "members": 3,
+    "name": "C2_face",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 2,
+    "distinct_signature_digests": 1,
+    "members": 6,
+    "name": "C2_edge",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 3,
+    "distinct_signature_digests": 1,
+    "members": 4,
+    "name": "C3_body",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 4,
+    "distinct_signature_digests": 1,
+    "members": 1,
+    "name": "V_face",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 5,
+    "distinct_signature_digests": 1,
+    "members": 3,
+    "name": "V_edge",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 6,
+    "distinct_signature_digests": 1,
+    "members": 3,
+    "name": "C4_face",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 7,
+    "distinct_signature_digests": 1,
+    "members": 4,
+    "name": "S3_body",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 8,
+    "distinct_signature_digests": 1,
+    "members": 3,
+    "name": "D4_face",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 9,
+    "distinct_signature_digests": 1,
+    "members": 1,
+    "name": "A4_tetrahedral",
+    "signature_is_constant_on_the_class": true
+   },
+   {
+    "class_index": 10,
+    "distinct_signature_digests": 1,
+    "members": 1,
+    "name": "O_full",
+    "signature_is_constant_on_the_class": true
+   }
+  ],
+  "statement": "GATE C888-G5. Every computed signature is constant on each conjugacy class of subgroups, so any selector compatible with 'no site is privileged' is a function of the CLASS: the scope question has exactly as many candidate answers as there are classes. Basis-dependent bookkeeping (the minimal polynomial of the chosen centre generator) is projected out first, and named here rather than hidden."
+ },
+ "I_SELECTOR_TABLE": {
+  "candidate_classes": [
+   "A4_tetrahedral",
+   "C2_edge",
+   "C2_face",
+   "C3_body",
+   "C4_face",
+   "D4_face",
+   "E_trivial",
+   "O_full",
+   "S3_body",
+   "V_edge",
+   "V_face"
+  ],
+  "candidate_subgroups": 30,
+  "every_survivor_set_is_a_subset_of_the_candidates": true,
+  "every_verdict_is_constant_on_conjugacy_classes": true,
+  "finding": "SEL01=['C2_edge', 'C3_body', 'E_trivial', 'S3_body']; SEL02=['A4_tetrahedral', 'O_full', 'S3_body']; SEL03=['C2_edge', 'C2_face', 'C3_body', 'C4_face', 'E_trivial', 'S3_body', 'V_edge']; SEL04=['A4_tetrahedral', 'O_full', 'S3_body']; SEL05=['A4_tetrahedral', 'O_full', 'S3_body']; SEL06=['S3_body']; SEL07=['C3_body']; SEL08=['C3_body']; SEL09=['C2_edge', 'C3_body', 'V_face']; SEL10=['C3_body', 'C4_face', 'S3_body']; SEL11=['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']; SEL12=['C3_body', 'E_trivial']; SEL13=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; SEL14=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; SEL15=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; SEL16=['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']",
+  "grounded_selector_ids": [
+   "SEL13_count_once",
+   "SEL14_content_only_readout",
+   "SEL15_admissibility_covariance",
+   "SEL16_no_site_privileged_read_literally"
+  ],
+  "grounded_selectors_that_isolate_C3": [],
+  "pass": true,
+  "scope_of_the_table": "the FULL 30-subgroup lattice",
+  "selectors": [
+   {
+    "demand": "the subgroup acts with NO fixed site on the 6-neighbour shell",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "The sentence's second clause explicitly LICENSES distinguishing sites by supplied lattice structure. A rotation axis IS supplied lattice structure, so the two sites a face-C2 fixes are distinguished exactly the way the sentence permits. The sentence forbids privileging by fiat; it does not forbid a subgroup from having fixed points.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL01_free_on_shell",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+    "subgroups_tested": 30,
+    "survivor_count": 4,
+    "survivor_expression_source_886": "sorted(free_labels)",
+    "survivors": [
+     "C2_edge",
+     "C3_body",
+     "E_trivial",
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": true,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": true,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "whether the subgroup's action fixes any of the six neighbour sites",
+    "what_the_sentence_says": "no site is privileged, AND sites are distinguished by the supplied lattice structure alone"
+   },
+   {
+    "demand": "the subgroup acts transitively on the 6-neighbour shell",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "Same defect as SEL01, and strictly worse: no cyclic subgroup of a 24-element group with maximal element order 4 can act transitively on six points, so this reading of the sentence eliminates C3 along with everything else.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL02_transitive_on_shell",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+    "subgroups_tested": 30,
+    "survivor_count": 3,
+    "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if by_label[lab][\"transitive_on_the_shell\"])",
+    "survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": false,
+     "13,23": false,
+     "15,18,23": false,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": false,
+     "6,8,23": false,
+     "9,23": false
+    },
+    "what_the_filter_computes": "whether the shell is a single orbit of the subgroup",
+    "what_the_sentence_says": "no site is privileged"
+   },
+   {
+    "demand": "trivial isotype multiplicity is exactly 1 on the readout space",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "Additivity fixes that the readout is LINEAR. It says nothing about how many invariant directions that linear space has. The multiplicity-one demand is a modelling convention.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL03_multiplicity_one_orbit_scope",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.",
+    "subgroups_tested": 30,
+    "survivor_count": 7,
+    "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if sig[lab][\"ORBIT_SCOPE_cycle883_construction\"]\n                and sig[lab][\"ORBIT_SCOPE_cycle883_construction\"]\n                [\"invariant_dim_by_nullspace\"] == 1\n            )",
+    "survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "E_trivial",
+     "S3_body",
+     "V_edge"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": true,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": true,
+     "0,7,16,23": true,
+     "1,2,20,23": true,
+     "1,23": true,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": true,
+     "20,23": true,
+     "23": true,
+     "3,10,14,23": true,
+     "3,23": true,
+     "3,9,13,23": true,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "the dimension of the invariant subspace of the orbit readout space",
+    "what_the_sentence_says": "scalar readout is additive over disjoint records, I(empty)=0"
+   },
+   {
+    "demand": "trivial isotype multiplicity is exactly 1 on the whole shell",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "as SEL03",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL04_multiplicity_one_shell_scope",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.",
+    "subgroups_tested": 30,
+    "survivor_count": 3,
+    "survivor_expression_source_886": "sorted(lab for lab in labels if shell_inv[lab] == 1)",
+    "survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": false,
+     "13,23": false,
+     "15,18,23": false,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": false,
+     "6,8,23": false,
+     "9,23": false
+    },
+    "what_the_filter_computes": "the invariant dimension of the 6-dimensional shell readout space",
+    "what_the_sentence_says": "as SEL03"
+   },
+   {
+    "demand": "the subgroup MINIMIZES the trivial multiplicity on the shell",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "No axiom sentence contains a minimization. This is an economy criterion supplied from outside the axiom set.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL05_minimal_shell_invariant_multiplicity",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": null,
+    "quoted_sentence": null,
+    "subgroups_tested": 30,
+    "survivor_count": 3,
+    "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if shell_inv[lab] == min_shell_inv)",
+    "survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": false,
+     "13,23": false,
+     "15,18,23": false,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": false,
+     "6,8,23": false,
+     "9,23": false
+    },
+    "what_the_filter_computes": "argmin over subgroups of the shell invariant dimension",
+    "what_the_sentence_says": null
+   },
+   {
+    "demand": "among subgroups acting freely on the shell, orbit length is maximal",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "Two supplied clauses in a trenchcoat: freeness (SEL01, ungrounded) and maximality (no sentence contains it).",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL06_maximal_free_shell_orbit",
+    "isolates_C3_body": false,
+    "isolates_S3_body": true,
+    "quote_source": null,
+    "quoted_sentence": null,
+    "subgroups_tested": 30,
+    "survivor_count": 1,
+    "survivor_expression_source_886": "sorted(\n                lab for lab in free_labels\n                if by_label[lab][\"maximal_FREE_orbit_length\"] == max_free_len\n            )",
+    "survivors": [
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": false,
+     "13,23": false,
+     "15,18,23": false,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": false,
+     "6,8,23": false,
+     "9,23": false
+    },
+    "what_the_filter_computes": "argmax of free orbit length over the freely-acting subgroups",
+    "what_the_sentence_says": null
+   },
+   {
+    "demand": "the coarse weight pair has 2-adic profile (0, 1)",
+    "fidelity_grade_pinned_from_886": "EXACT",
+    "fidelity_reason_pinned_from_886": "The filter computes precisely what the sentence demands. But the sentence is an OBLIGATION sentence recovered from the Cycle-882 primary, NOT an axiom sentence -- it states the target, so using it to select the scope selects the scope by reading the answer.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": "target-facing, not axiom-grounded",
+    "id": "SEL07_coarse_pair_v2_equals_one",
+    "isolates_C3_body": true,
+    "isolates_S3_body": false,
+    "quote_source": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+    "quoted_sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'.",
+    "subgroups_tested": 30,
+    "survivor_count": 1,
+    "survivor_expression_source_886": "sorted(lab for lab in labels if orbit_v2(lab) == 1)",
+    "survivors": [
+     "C3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": false,
+     "1,6,8,13,19,23": false,
+     "11,17,23": true,
+     "13,23": false,
+     "15,18,23": true,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": false,
+     "2,5,9,12,19,23": false,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": false
+    },
+    "what_the_filter_computes": "v_2 of the complement dimension of the orbit readout space",
+    "what_the_sentence_says": "a Record-facing datum with v_2 = 1 must enter, concretely the weight pair (1, 2)"
+   },
+   {
+    "demand": "the subgroup's own numbers multiplicatively reach 2/9",
+    "fidelity_grade_pinned_from_886": "PARTIAL",
+    "fidelity_reason_pinned_from_886": "The sentence asks for a v_2 = 1 datum, not for multiplicative reachability of 2/9; the filter is strictly stronger than the quote. And it is target-facing either way.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": "target-facing, not axiom-grounded",
+    "id": "SEL08_reachability_R1_orbit_scope",
+    "isolates_C3_body": true,
+    "isolates_S3_body": false,
+    "quote_source": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+    "quoted_sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'.",
+    "subgroups_tested": 30,
+    "survivor_count": 1,
+    "survivor_expression_source_886": "reach_by_rule[\"R1_orbit_scope_coarse\"]",
+    "survivors": [
+     "C3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": false,
+     "1,6,8,13,19,23": false,
+     "11,17,23": true,
+     "13,23": false,
+     "15,18,23": true,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": false,
+     "2,5,9,12,19,23": false,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": false
+    },
+    "what_the_filter_computes": "generators = {free orbit length} U {coarse pair entries}, values > 1 -- exactly the data Cycle 883 fed to its own T6 recomputation",
+    "what_the_sentence_says": "as SEL07"
+   },
+   {
+    "demand": "the subgroup's shell numbers multiplicatively reach 2/9",
+    "fidelity_grade_pinned_from_886": "PARTIAL",
+    "fidelity_reason_pinned_from_886": "Same filter as SEL08 at a different scope, and the survivor set MOVES -- which shows the selector is scope-dependent and so cannot itself fix the scope.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": "target-facing and scope-circular",
+    "id": "SEL09_reachability_R2_shell_scope",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+    "quoted_sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'.",
+    "subgroups_tested": 30,
+    "survivor_count": 3,
+    "survivor_expression_source_886": "reach_by_rule[\"R2_shell_scope_coarse\"]",
+    "survivors": [
+     "C2_edge",
+     "C3_body",
+     "V_face"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": true,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": true,
+     "1,4,9,15,18,23": false,
+     "1,6,8,13,19,23": false,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": false,
+     "2,5,9,12,19,23": false,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "generators = {distinct shell orbit lengths} U {shell coarse pair entries}, values > 1",
+    "what_the_sentence_says": "as SEL07"
+   },
+   {
+    "demand": "(invariant dim, top rational irreducible dim) == (1, 2)",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "No sentence fixes which reading of 'weight pair' is meant. This alternative reading is legitimate and it admits C4_face as well, because Q[C4] contains the 2-dimensional block Q(i).",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL10_fine_top_pair_is_the_target",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": null,
+    "quoted_sentence": null,
+    "subgroups_tested": 30,
+    "survivor_count": 3,
+    "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if fine_top(lab) == TARGET_PAIR)",
+    "survivors": [
+     "C3_body",
+     "C4_face",
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": true,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": false,
+     "15,18,23": true,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": true,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": true,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": false
+    },
+    "what_the_filter_computes": "the fine reading of the weight pair on the orbit readout space",
+    "what_the_sentence_says": null
+   },
+   {
+    "demand": "the subgroup permutes the three coordinate axes transitively",
+    "fidelity_grade_pinned_from_886": "PARTIAL",
+    "fidelity_reason_pinned_from_886": "The word 'cubic' does carry the equivalence of the three axis directions -- but the FULL 24-element group already realizes that equivalence. The filter demands that a single CYCLIC SUBGROUP realize it internally, which is strictly stronger than anything the sentence says. This is the closest any route gets to a derivation, and it still falls short.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": "the sentence grounds axis-equivalence for the whole group, not internal axis-transitivity for the scope subgroup",
+    "id": "SEL11_transitive_on_coordinate_axes",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.",
+    "subgroups_tested": 30,
+    "survivor_count": 4,
+    "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if by_label[lab][\"transitive_on_the_three_coordinate_axes\"]\n            )",
+    "survivors": [
+     "A4_tetrahedral",
+     "C3_body",
+     "O_full",
+     "S3_body"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": false,
+     "15,18,23": true,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": false,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": false
+    },
+    "what_the_filter_computes": "whether the subgroup alone acts transitively on {x, y, z}",
+    "what_the_sentence_says": "sites are the points of the CUBIC lattice Z^3 with proper cubic rotations about each site"
+   },
+   {
+    "demand": "the subgroup has odd order greater than 1",
+    "fidelity_grade_pinned_from_886": "NONE",
+    "fidelity_reason_pinned_from_886": "No axiom sentence mentions parity. Listed because it is the CHEAPEST single supplied clause that pins the answer: order 3 is the only odd nontrivial element order in a group of order 24 whose element orders are 1, 2, 3, 4.",
+    "grounded_pinned_from_886": false,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL12_odd_order",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": null,
+    "quoted_sentence": null,
+    "subgroups_tested": 30,
+    "survivor_count": 2,
+    "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if sig[lab][\"order\"] % 2 == 1)",
+    "survivors": [
+     "C3_body",
+     "E_trivial"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": false,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+     "0,23": false,
+     "0,3,20,23": false,
+     "0,3,4,7,16,19,20,23": false,
+     "0,3,5,6,8,11,12,15,17,18,20,23": false,
+     "0,3,9,10,13,14,20,23": false,
+     "0,4,19,23": false,
+     "0,7,16,23": false,
+     "1,2,20,23": false,
+     "1,23": false,
+     "1,4,9,15,18,23": false,
+     "1,6,8,13,19,23": false,
+     "11,17,23": true,
+     "13,23": false,
+     "15,18,23": true,
+     "19,23": false,
+     "2,23": false,
+     "2,4,11,13,17,23": false,
+     "2,5,9,12,19,23": false,
+     "20,21,22,23": false,
+     "20,23": false,
+     "23": true,
+     "3,10,14,23": false,
+     "3,23": false,
+     "3,9,13,23": false,
+     "4,23": false,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": false
+    },
+    "what_the_filter_computes": "parity of the subgroup order",
+    "what_the_sentence_says": null
+   },
+   {
+    "demand": "one record per site, permanently",
+    "fidelity_grade_pinned_from_886": "EXACT",
+    "fidelity_reason_pinned_from_886": "The filter computes exactly the sentence's content -- and the sentence's content is satisfied by every group action, since orbits of a group action always partition the set. The clause is true of all 16 nontrivial cyclic subgroups.",
+    "grounded_pinned_from_886": true,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL13_count_once",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "A site never carries more than one record; records are permanent.",
+    "subgroups_tested": 30,
+    "survivor_count": 11,
+    "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if sum(len(o) for o in subgroup_shell_orbits_by_label(sig[lab]))\n                == len(NEAREST_NEIGHBOURS)\n            )",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": true,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": true,
+     "0,3,20,23": true,
+     "0,3,4,7,16,19,20,23": true,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": true,
+     "0,4,19,23": true,
+     "0,7,16,23": true,
+     "1,2,20,23": true,
+     "1,23": true,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": true,
+     "20,23": true,
+     "23": true,
+     "3,10,14,23": true,
+     "3,23": true,
+     "3,9,13,23": true,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "whether the subgroup's shell orbits are a PARTITION, i.e. whether any site would be counted twice",
+    "what_the_sentence_says": "a site never carries more than one record; records are permanent"
+   },
+   {
+    "demand": "the readout value depends on record content alone",
+    "fidelity_grade_pinned_from_886": "EXACT",
+    "fidelity_reason_pinned_from_886": "The filter computes exactly what the sentence says, and the sentence is satisfied by every subgroup: the permutation representation on record coordinates is content-only by construction for any acting group.",
+    "grounded_pinned_from_886": true,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL14_content_only_readout",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "Only records are readable. A readout value is determined by record content alone.",
+    "subgroups_tested": 30,
+    "survivor_count": 11,
+    "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if sig[lab][\"SHELL_SCOPE_whole_neighbourhood\"][\"space_dimension\"]\n                == len(NEAREST_NEIGHBOURS)\n            )",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": true,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": true,
+     "0,3,20,23": true,
+     "0,3,4,7,16,19,20,23": true,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": true,
+     "0,4,19,23": true,
+     "0,7,16,23": true,
+     "1,2,20,23": true,
+     "1,23": true,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": true,
+     "20,23": true,
+     "23": true,
+     "3,10,14,23": true,
+     "3,23": true,
+     "3,9,13,23": true,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "whether the subgroup's readout space is spanned by the record coordinates, i.e. carries no data beyond record content",
+    "what_the_sentence_says": "only records are readable; readout is determined by record content"
+   },
+   {
+    "demand": "the scope must lie inside the covariance group of the admissibility rule",
+    "fidelity_grade_pinned_from_886": "EXACT",
+    "fidelity_reason_pinned_from_886": "The filter computes exactly the sentence's content. The sentence names the covariance group as a WHOLE; every cyclic subgroup sits inside it, so the clause is an ANTI-selector: it is the textual reason all sixteen nontrivial cyclic subgroups are equally supplied.",
+    "grounded_pinned_from_886": true,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL15_admissibility_covariance",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.",
+    "subgroups_tested": 30,
+    "survivor_count": 11,
+    "survivor_expression_source_886": "sorted(labels)",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": true,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": true,
+     "0,3,20,23": true,
+     "0,3,4,7,16,19,20,23": true,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": true,
+     "0,4,19,23": true,
+     "0,7,16,23": true,
+     "1,2,20,23": true,
+     "1,23": true,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": true,
+     "20,23": true,
+     "23": true,
+     "3,10,14,23": true,
+     "3,23": true,
+     "3,9,13,23": true,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "whether the subgroup is a subgroup of the 24 proper rotations",
+    "what_the_sentence_says": "one fixed nearest-neighbour rule, covariant under lattice translations and proper cubic rotations"
+   },
+   {
+    "demand": "no site is privileged except by supplied lattice structure -- read with BOTH of its clauses",
+    "fidelity_grade_pinned_from_886": "EXACT",
+    "fidelity_reason_pinned_from_886": "This is the sentence read with both clauses instead of only the first. Every cyclic subgroup's orbit partition is determined by its axis, which is supplied lattice structure, so the sentence is satisfied by all of them. SEL01 and SEL02 are strengthenings of this filter, and the strengthenings are where their grounding is lost.",
+    "grounded_pinned_from_886": true,
+    "grounding_defect_pinned_from_886": null,
+    "id": "SEL16_no_site_privileged_read_literally",
+    "isolates_C3_body": false,
+    "isolates_S3_body": false,
+    "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+    "subgroups_tested": 30,
+    "survivor_count": 11,
+    "survivor_expression_source_886": "sorted(labels)",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ],
+    "verdict_is_constant_on_every_conjugacy_class": true,
+    "verdicts_by_subgroup": {
+     "0,1,2,3,20,21,22,23": true,
+     "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+     "0,23": true,
+     "0,3,20,23": true,
+     "0,3,4,7,16,19,20,23": true,
+     "0,3,5,6,8,11,12,15,17,18,20,23": true,
+     "0,3,9,10,13,14,20,23": true,
+     "0,4,19,23": true,
+     "0,7,16,23": true,
+     "1,2,20,23": true,
+     "1,23": true,
+     "1,4,9,15,18,23": true,
+     "1,6,8,13,19,23": true,
+     "11,17,23": true,
+     "13,23": true,
+     "15,18,23": true,
+     "19,23": true,
+     "2,23": true,
+     "2,4,11,13,17,23": true,
+     "2,5,9,12,19,23": true,
+     "20,21,22,23": true,
+     "20,23": true,
+     "23": true,
+     "3,10,14,23": true,
+     "3,23": true,
+     "3,9,13,23": true,
+     "4,23": true,
+     "5,12,23": true,
+     "6,8,23": true,
+     "9,23": true
+    },
+    "what_the_filter_computes": "whether the subgroup's shell orbit partition is determined by supplied lattice structure (the rotation axis) rather than by an external stipulation",
+    "what_the_sentence_says": "no site is privileged; sites are distinguished by the supplied lattice structure alone"
+   }
+  ],
+  "selectors_that_isolate_C3": [
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope"
+  ],
+  "selectors_that_isolate_S3": [
+   "SEL06_maximal_free_shell_orbit"
+  ],
+  "statement": "Cycle 886's sixteen selectors, rebuilt by AST extraction and re-run over 30 subgroups (the FULL 30-subgroup lattice). Each row carries its byte-quoted sentence and its 886 fidelity grade as PINS, and its survivor set as DATA. Table completeness is 16 x 30.",
+  "survivors_per_selector": {
+   "SEL01_free_on_shell": [
+    "C2_edge",
+    "C3_body",
+    "E_trivial",
+    "S3_body"
+   ],
+   "SEL02_transitive_on_shell": [
+    "A4_tetrahedral",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL03_multiplicity_one_orbit_scope": [
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "E_trivial",
+    "S3_body",
+    "V_edge"
+   ],
+   "SEL04_multiplicity_one_shell_scope": [
+    "A4_tetrahedral",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL05_minimal_shell_invariant_multiplicity": [
+    "A4_tetrahedral",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL06_maximal_free_shell_orbit": [
+    "S3_body"
+   ],
+   "SEL07_coarse_pair_v2_equals_one": [
+    "C3_body"
+   ],
+   "SEL08_reachability_R1_orbit_scope": [
+    "C3_body"
+   ],
+   "SEL09_reachability_R2_shell_scope": [
+    "C2_edge",
+    "C3_body",
+    "V_face"
+   ],
+   "SEL10_fine_top_pair_is_the_target": [
+    "C3_body",
+    "C4_face",
+    "S3_body"
+   ],
+   "SEL11_transitive_on_coordinate_axes": [
+    "A4_tetrahedral",
+    "C3_body",
+    "O_full",
+    "S3_body"
+   ],
+   "SEL12_odd_order": [
+    "C3_body",
+    "E_trivial"
+   ],
+   "SEL13_count_once": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ],
+   "SEL14_content_only_readout": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ],
+   "SEL15_admissibility_covariance": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ],
+   "SEL16_no_site_privileged_read_literally": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ]
+  },
+  "table_cells": 480,
+  "table_is_complete": true
+ },
+ "J_CONJUNCTIONS": {
+  "all_selector_conjunction": {
+   "is_empty": true,
+   "survivors": []
+  },
+  "finding": "axiom-grounded conjunction survivors ['A4_tetrahedral', 'C2_edge', 'C2_face', 'C3_body', 'C4_face', 'D4_face', 'E_trivial', 'O_full', 'S3_body', 'V_edge', 'V_face']; non-empty-selector conjunction survivors []; unrestricted conjunction survivors []; C3 camp ['SEL07_coarse_pair_v2_equals_one', 'SEL08_reachability_R1_orbit_scope']; S3 camp ['SEL06_maximal_free_shell_orbit'].",
+  "grounded_conjunction": {
+   "isolates_anything": false,
+   "keeps_every_candidate": true,
+   "selector_ids": [
+    "SEL13_count_once",
+    "SEL14_content_only_readout",
+    "SEL15_admissibility_covariance",
+    "SEL16_no_site_privileged_read_literally"
+   ],
+   "survivors": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+   ]
+  },
+  "nonempty_selector_conjunction": {
+   "is_empty": true,
+   "selector_ids": [
+    "SEL01_free_on_shell",
+    "SEL02_transitive_on_shell",
+    "SEL03_multiplicity_one_orbit_scope",
+    "SEL04_multiplicity_one_shell_scope",
+    "SEL05_minimal_shell_invariant_multiplicity",
+    "SEL06_maximal_free_shell_orbit",
+    "SEL07_coarse_pair_v2_equals_one",
+    "SEL08_reachability_R1_orbit_scope",
+    "SEL09_reachability_R2_shell_scope",
+    "SEL10_fine_top_pair_is_the_target",
+    "SEL11_transitive_on_coordinate_axes",
+    "SEL12_odd_order",
+    "SEL13_count_once",
+    "SEL14_content_only_readout",
+    "SEL15_admissibility_covariance",
+    "SEL16_no_site_privileged_read_literally"
+   ],
+   "survivors": []
+  },
+  "pass": true,
+  "reading": "Over the cyclic-only census of Cycle 886 the ungrounded selectors CONVERGED on C3. Over the full lattice they do not: they split into a C3 camp and an S3 camp, so their conjunction is EMPTY. The convergence Cycle 886 recorded was an artifact of the unpriced cyclic restriction.",
+  "selectors_isolating_C3_body": [
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope"
+  ],
+  "selectors_isolating_S3_body": [
+   "SEL06_maximal_free_shell_orbit"
+  ],
+  "statement": "The conjunctions over the FULL lattice. If the AXIOM-GROUNDED conjunction were exactly one class the outcome would be a DERIVATION of that scope.",
+  "the_convergence_splits": true,
+  "ungrounded_nonempty_conjunction": {
+   "is_empty": true,
+   "selector_ids": [
+    "SEL01_free_on_shell",
+    "SEL02_transitive_on_shell",
+    "SEL03_multiplicity_one_orbit_scope",
+    "SEL04_multiplicity_one_shell_scope",
+    "SEL05_minimal_shell_invariant_multiplicity",
+    "SEL06_maximal_free_shell_orbit",
+    "SEL07_coarse_pair_v2_equals_one",
+    "SEL08_reachability_R1_orbit_scope",
+    "SEL09_reachability_R2_shell_scope",
+    "SEL10_fine_top_pair_is_the_target",
+    "SEL11_transitive_on_coordinate_axes",
+    "SEL12_odd_order"
+   ],
+   "survivors": []
+  }
+ },
+ "K_ANCHOR_REACHABILITY": {
+  "every_reachable_verdict_has_a_verified_witness": true,
+  "every_windowed_scan_agrees_with_the_lattice_proof": true,
+  "finding": "survivors by rule: R1_orbit_scope_coarse -> ['C3_body']; R2_shell_scope_coarse -> ['C2_edge', 'C3_body', 'V_face']; R3_orbit_scope_fine -> ['C3_body', 'S3_body']; R4_shell_scope_fine -> ['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']",
+  "generator_rules": {
+   "R1_orbit_scope_coarse": "generators = {free orbit length} U {coarse pair entries}, values > 1 -- exactly the data Cycle 883 fed to its own T6 recomputation",
+   "R2_shell_scope_coarse": "generators = {distinct shell orbit lengths} U {shell coarse pair entries}, values > 1",
+   "R3_orbit_scope_fine": "generators = {free orbit length} U {fine rational irreducible dimensions}, values > 1",
+   "R4_shell_scope_fine": "generators = {distinct shell orbit lengths} U {fine rational irreducible dimensions on the shell}, values > 1"
+  },
+  "pass": true,
+  "rows": [
+   {
+    "class_index": 0,
+    "element_indices": [
+     23
+    ],
+    "name": "E_trivial",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [],
+      "generators": [],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [],
+      "generators": [],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [],
+      "generators": [],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     1,
+     23
+    ],
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     2,
+     23
+    ],
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     4,
+     23
+    ],
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     9,
+     23
+    ],
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     13,
+     23
+    ],
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 2,
+    "element_indices": [
+     19,
+     23
+    ],
+    "name": "C2_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 1,
+    "element_indices": [
+     0,
+     23
+    ],
+    "name": "C2_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 1,
+    "element_indices": [
+     3,
+     23
+    ],
+    "name": "C2_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 1,
+    "element_indices": [
+     20,
+     23
+    ],
+    "name": "C2_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     5,
+     12,
+     23
+    ],
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2,
+       0
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     6,
+     8,
+     23
+    ],
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2,
+       0
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     11,
+     17,
+     23
+    ],
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2,
+       0
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 3,
+    "element_indices": [
+     15,
+     18,
+     23
+    ],
+    "name": "C3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2,
+       0
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 6,
+    "element_indices": [
+     0,
+     7,
+     16,
+     23
+    ],
+    "name": "C4_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 6,
+    "element_indices": [
+     3,
+     10,
+     14,
+     23
+    ],
+    "name": "C4_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 6,
+    "element_indices": [
+     20,
+     21,
+     22,
+     23
+    ],
+    "name": "C4_face",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 5,
+    "element_indices": [
+     0,
+     4,
+     19,
+     23
+    ],
+    "name": "V_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 5,
+    "element_indices": [
+     1,
+     2,
+     20,
+     23
+    ],
+    "name": "V_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 5,
+    "element_indices": [
+     3,
+     9,
+     13,
+     23
+    ],
+    "name": "V_edge",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        1
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       3,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 4,
+    "element_indices": [
+     0,
+     3,
+     20,
+     23
+    ],
+    "name": "V_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       2
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     1,
+     4,
+     9,
+     15,
+     18,
+     23
+    ],
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     1,
+     6,
+     8,
+     13,
+     19,
+     23
+    ],
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     2,
+     4,
+     11,
+     13,
+     17,
+     23
+    ],
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 7,
+    "element_indices": [
+     2,
+     5,
+     9,
+     12,
+     19,
+     23
+    ],
+    "name": "S3_body",
+    "per_rule": {
+     "R1_orbit_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R3_orbit_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       3,
+       -2
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 8,
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     20,
+     21,
+     22,
+     23
+    ],
+    "name": "D4_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 8,
+    "element_indices": [
+     0,
+     3,
+     4,
+     7,
+     16,
+     19,
+     20,
+     23
+    ],
+    "name": "D4_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 8,
+    "element_indices": [
+     0,
+     3,
+     9,
+     10,
+     13,
+     14,
+     20,
+     23
+    ],
+    "name": "D4_face",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        2,
+        0
+       ]
+      ],
+      "generators": [
+       2,
+       4
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     }
+    }
+   },
+   {
+    "class_index": 9,
+    "element_indices": [
+     0,
+     3,
+     5,
+     6,
+     8,
+     11,
+     12,
+     15,
+     17,
+     18,
+     20,
+     23
+    ],
+    "name": "A4_tetrahedral",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2,
+       0
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   },
+   {
+    "class_index": 10,
+    "element_indices": [
+     0,
+     1,
+     2,
+     3,
+     4,
+     5,
+     6,
+     7,
+     8,
+     9,
+     10,
+     11,
+     12,
+     13,
+     14,
+     15,
+     16,
+     17,
+     18,
+     19,
+     20,
+     21,
+     22,
+     23
+    ],
+    "name": "O_full",
+    "per_rule": {
+     "R2_shell_scope_coarse": {
+      "generator_valuation_vectors": [
+       [
+        0,
+        0,
+        1
+       ],
+       [
+        1,
+        1,
+        0
+       ]
+      ],
+      "generators": [
+       5,
+       6
+      ],
+      "primes": [
+       2,
+       3,
+       5
+      ],
+      "reachable": false,
+      "target_valuation_vector": [
+       1,
+       -2,
+       0
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": false,
+      "witness_exponents": null,
+      "witness_recomputes_the_target": null
+     },
+     "R4_shell_scope_fine": {
+      "generator_valuation_vectors": [
+       [
+        1,
+        0
+       ],
+       [
+        0,
+        1
+       ],
+       [
+        1,
+        1
+       ]
+      ],
+      "generators": [
+       2,
+       3,
+       6
+      ],
+      "primes": [
+       2,
+       3
+      ],
+      "reachable": true,
+      "target_valuation_vector": [
+       1,
+       -2
+      ],
+      "window_agrees_with_the_lattice_proof": true,
+      "windowed_scan_in_minus6_to_6": true,
+      "witness_exponents": [
+       1,
+       -2,
+       0
+      ],
+      "witness_recomputes_the_target": true
+     }
+    }
+   }
+  ],
+  "statement": "Cycle 882's C882-T6 reachability question, RECOMPUTED here for every subgroup in the full lattice and never cited. Membership in the multiplicative group generated by a subgroup's own numerical data is decided EXACTLY by integer-lattice membership over the prime valuation vectors, and every REACHABLE verdict carries an explicit exponent witness that is multiplied back out and checked.",
+  "survivor_set_is_rule_invariant": false,
+  "survivors_by_rule": {
+   "R1_orbit_scope_coarse": [
+    "C3_body"
+   ],
+   "R2_shell_scope_coarse": [
+    "C2_edge",
+    "C3_body",
+    "V_face"
+   ],
+   "R3_orbit_scope_fine": [
+    "C3_body",
+    "S3_body"
+   ],
+   "R4_shell_scope_fine": [
+    "A4_tetrahedral",
+    "C3_body",
+    "O_full",
+    "S3_body"
+   ]
+  },
+  "target_2_adic_valuation": 1,
+  "target_3_adic_valuation": -2,
+  "target_anchor": "2/9"
+ },
+ "L_RESTRICTION_GATE": {
+  "finding": "restricted to ('C2_edge', 'C2_face', 'C3_body', 'C4_face'): 16/16 selector survivor sets, 4/4 reachability rules and 4/4 class signatures reproduce the pinned Cycle-886 receipt exactly.",
+  "pass": true,
+  "reachability_comparison": [
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "cycle888_restricted": [
+     "C3_body"
+    ],
+    "identical": true,
+    "rule": "R1_orbit_scope_coarse"
+   },
+   {
+    "cycle886": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "cycle888_restricted": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "identical": true,
+    "rule": "R2_shell_scope_coarse"
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "cycle888_restricted": [
+     "C3_body"
+    ],
+    "identical": true,
+    "rule": "R3_orbit_scope_fine"
+   },
+   {
+    "cycle886": [
+     "C3_body"
+    ],
+    "cycle888_restricted": [
+     "C3_body"
+    ],
+    "identical": true,
+    "rule": "R4_shell_scope_fine"
+   }
+  ],
+  "reachability_survivors_reproduce_cycle886": true,
+  "restricted_selector_table": {
+   "candidate_classes": [
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face"
+   ],
+   "candidate_subgroups": 16,
+   "every_survivor_set_is_a_subset_of_the_candidates": true,
+   "every_verdict_is_constant_on_conjugacy_classes": true,
+   "finding": "SEL01=['C2_edge', 'C3_body']; SEL02=[]; SEL03=['C2_edge', 'C2_face', 'C3_body', 'C4_face']; SEL04=[]; SEL05=['C3_body']; SEL06=['C3_body']; SEL07=['C3_body']; SEL08=['C3_body']; SEL09=['C2_edge', 'C3_body']; SEL10=['C3_body', 'C4_face']; SEL11=['C3_body']; SEL12=['C3_body']; SEL13=['C2_edge', 'C2_face', 'C3_body', 'C4_face']; SEL14=['C2_edge', 'C2_face', 'C3_body', 'C4_face']; SEL15=['C2_edge', 'C2_face', 'C3_body', 'C4_face']; SEL16=['C2_edge', 'C2_face', 'C3_body', 'C4_face']",
+   "grounded_selector_ids": [
+    "SEL13_count_once",
+    "SEL14_content_only_readout",
+    "SEL15_admissibility_covariance",
+    "SEL16_no_site_privileged_read_literally"
+   ],
+   "grounded_selectors_that_isolate_C3": [],
+   "pass": true,
+   "scope_of_the_table": "the four nontrivial CYCLIC classes of Cycle 886",
+   "selectors_that_isolate_C3": [
+    "SEL05_minimal_shell_invariant_multiplicity",
+    "SEL06_maximal_free_shell_orbit",
+    "SEL07_coarse_pair_v2_equals_one",
+    "SEL08_reachability_R1_orbit_scope",
+    "SEL11_transitive_on_coordinate_axes",
+    "SEL12_odd_order"
+   ],
+   "selectors_that_isolate_S3": [],
+   "statement": "Cycle 886's sixteen selectors, rebuilt by AST extraction and re-run over 16 subgroups (the four nontrivial CYCLIC classes of Cycle 886). Each row carries its byte-quoted sentence and its 886 fidelity grade as PINS, and its survivor set as DATA. Table completeness is 16 x 16.",
+   "survivors_per_selector": {
+    "SEL01_free_on_shell": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "SEL02_transitive_on_shell": [],
+    "SEL03_multiplicity_one_orbit_scope": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "SEL04_multiplicity_one_shell_scope": [],
+    "SEL05_minimal_shell_invariant_multiplicity": [
+     "C3_body"
+    ],
+    "SEL06_maximal_free_shell_orbit": [
+     "C3_body"
+    ],
+    "SEL07_coarse_pair_v2_equals_one": [
+     "C3_body"
+    ],
+    "SEL08_reachability_R1_orbit_scope": [
+     "C3_body"
+    ],
+    "SEL09_reachability_R2_shell_scope": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "SEL10_fine_top_pair_is_the_target": [
+     "C3_body",
+     "C4_face"
+    ],
+    "SEL11_transitive_on_coordinate_axes": [
+     "C3_body"
+    ],
+    "SEL12_odd_order": [
+     "C3_body"
+    ],
+    "SEL13_count_once": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "SEL14_content_only_readout": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "SEL15_admissibility_covariance": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "SEL16_no_site_privileged_read_literally": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ]
+   },
+   "table_cells": 256,
+   "table_is_complete": true
+  },
+  "restricted_selector_verdicts_by_subgroup": {
+   "SEL01_free_on_shell": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   },
+   "SEL02_transitive_on_shell": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": false,
+    "13,23": false,
+    "15,18,23": false,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": false,
+    "6,8,23": false,
+    "9,23": false
+   },
+   "SEL03_multiplicity_one_orbit_scope": {
+    "0,23": true,
+    "0,7,16,23": true,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": true,
+    "20,23": true,
+    "3,10,14,23": true,
+    "3,23": true,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   },
+   "SEL04_multiplicity_one_shell_scope": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": false,
+    "13,23": false,
+    "15,18,23": false,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": false,
+    "6,8,23": false,
+    "9,23": false
+   },
+   "SEL05_minimal_shell_invariant_multiplicity": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL06_maximal_free_shell_orbit": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL07_coarse_pair_v2_equals_one": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL08_reachability_R1_orbit_scope": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL09_reachability_R2_shell_scope": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   },
+   "SEL10_fine_top_pair_is_the_target": {
+    "0,23": false,
+    "0,7,16,23": true,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": true,
+    "20,23": false,
+    "3,10,14,23": true,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL11_transitive_on_coordinate_axes": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL12_odd_order": {
+    "0,23": false,
+    "0,7,16,23": false,
+    "1,23": false,
+    "11,17,23": true,
+    "13,23": false,
+    "15,18,23": true,
+    "19,23": false,
+    "2,23": false,
+    "20,21,22,23": false,
+    "20,23": false,
+    "3,10,14,23": false,
+    "3,23": false,
+    "4,23": false,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": false
+   },
+   "SEL13_count_once": {
+    "0,23": true,
+    "0,7,16,23": true,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": true,
+    "20,23": true,
+    "3,10,14,23": true,
+    "3,23": true,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   },
+   "SEL14_content_only_readout": {
+    "0,23": true,
+    "0,7,16,23": true,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": true,
+    "20,23": true,
+    "3,10,14,23": true,
+    "3,23": true,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   },
+   "SEL15_admissibility_covariance": {
+    "0,23": true,
+    "0,7,16,23": true,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": true,
+    "20,23": true,
+    "3,10,14,23": true,
+    "3,23": true,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   },
+   "SEL16_no_site_privileged_read_literally": {
+    "0,23": true,
+    "0,7,16,23": true,
+    "1,23": true,
+    "11,17,23": true,
+    "13,23": true,
+    "15,18,23": true,
+    "19,23": true,
+    "2,23": true,
+    "20,21,22,23": true,
+    "20,23": true,
+    "3,10,14,23": true,
+    "3,23": true,
+    "4,23": true,
+    "5,12,23": true,
+    "6,8,23": true,
+    "9,23": true
+   }
+  },
+  "selector_comparison": [
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "id": "SEL01_free_on_shell",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [],
+    "cycle888_restricted_survivors": [],
+    "id": "SEL02_transitive_on_shell",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL03_multiplicity_one_orbit_scope",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [],
+    "cycle888_restricted_survivors": [],
+    "id": "SEL04_multiplicity_one_shell_scope",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body"
+    ],
+    "id": "SEL05_minimal_shell_invariant_multiplicity",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body"
+    ],
+    "id": "SEL06_maximal_free_shell_orbit",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body"
+    ],
+    "id": "SEL07_coarse_pair_v2_equals_one",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body"
+    ],
+    "id": "SEL08_reachability_R1_orbit_scope",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C3_body"
+    ],
+    "id": "SEL09_reachability_R2_shell_scope",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body",
+     "C4_face"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL10_fine_top_pair_is_the_target",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body"
+    ],
+    "id": "SEL11_transitive_on_coordinate_axes",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C3_body"
+    ],
+    "cycle888_restricted_survivors": [
+     "C3_body"
+    ],
+    "id": "SEL12_odd_order",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL13_count_once",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL14_content_only_readout",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL15_admissibility_covariance",
+    "identical": true
+   },
+   {
+    "cycle886_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "cycle888_restricted_survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face"
+    ],
+    "id": "SEL16_no_site_privileged_read_literally",
+    "identical": true
+   }
+  ],
+  "selector_survivors_reproduce_cycle886": true,
+  "signature_comparison": [
+   {
+    "class": "C2_edge",
+    "cycle886": {
+     "carries_the_target_pair_coarse_orbit_scope": false,
+     "carries_the_target_pair_fine_top_orbit_scope": false,
+     "label": "C2_edge",
+     "orbit_scope_fine_dims": [
+      1,
+      1
+     ],
+     "orbit_scope_fine_top_pair": [
+      1,
+      1
+     ],
+     "orbit_scope_pair": [
+      1,
+      1
+     ],
+     "orbit_scope_profile": [
+      0,
+      0
+     ],
+     "shell_scope_fine_dims": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "shell_scope_pair": [
+      3,
+      3
+     ],
+     "shell_scope_profile": [
+      0,
+      0
+     ]
+    },
+    "cycle888_orbit_fine": [
+     1,
+     1
+    ],
+    "cycle888_orbit_pair": [
+     1,
+     1
+    ],
+    "cycle888_shell_fine": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "cycle888_shell_pair": [
+     3,
+     3
+    ],
+    "identical": true
+   },
+   {
+    "class": "C2_face",
+    "cycle886": {
+     "carries_the_target_pair_coarse_orbit_scope": false,
+     "carries_the_target_pair_fine_top_orbit_scope": false,
+     "label": "C2_face",
+     "orbit_scope_fine_dims": [
+      1,
+      1
+     ],
+     "orbit_scope_fine_top_pair": [
+      1,
+      1
+     ],
+     "orbit_scope_pair": [
+      1,
+      1
+     ],
+     "orbit_scope_profile": [
+      0,
+      0
+     ],
+     "shell_scope_fine_dims": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+     ],
+     "shell_scope_pair": [
+      4,
+      2
+     ],
+     "shell_scope_profile": [
+      2,
+      1
+     ]
+    },
+    "cycle888_orbit_fine": [
+     1,
+     1
+    ],
+    "cycle888_orbit_pair": [
+     1,
+     1
+    ],
+    "cycle888_shell_fine": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ],
+    "cycle888_shell_pair": [
+     4,
+     2
+    ],
+    "identical": true
+   },
+   {
+    "class": "C3_body",
+    "cycle886": {
+     "carries_the_target_pair_coarse_orbit_scope": true,
+     "carries_the_target_pair_fine_top_orbit_scope": true,
+     "label": "C3_body",
+     "orbit_scope_fine_dims": [
+      1,
+      2
+     ],
+     "orbit_scope_fine_top_pair": [
+      1,
+      2
+     ],
+     "orbit_scope_pair": [
+      1,
+      2
+     ],
+     "orbit_scope_profile": [
+      0,
+      1
+     ],
+     "shell_scope_fine_dims": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "shell_scope_pair": [
+      2,
+      4
+     ],
+     "shell_scope_profile": [
+      1,
+      2
+     ]
+    },
+    "cycle888_orbit_fine": [
+     1,
+     2
+    ],
+    "cycle888_orbit_pair": [
+     1,
+     2
+    ],
+    "cycle888_shell_fine": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "cycle888_shell_pair": [
+     2,
+     4
+    ],
+    "identical": true
+   },
+   {
+    "class": "C4_face",
+    "cycle886": {
+     "carries_the_target_pair_coarse_orbit_scope": false,
+     "carries_the_target_pair_fine_top_orbit_scope": true,
+     "label": "C4_face",
+     "orbit_scope_fine_dims": [
+      1,
+      1,
+      2
+     ],
+     "orbit_scope_fine_top_pair": [
+      1,
+      2
+     ],
+     "orbit_scope_pair": [
+      1,
+      3
+     ],
+     "orbit_scope_profile": [
+      0,
+      0
+     ],
+     "shell_scope_fine_dims": [
+      1,
+      1,
+      1,
+      1,
+      2
+     ],
+     "shell_scope_pair": [
+      3,
+      3
+     ],
+     "shell_scope_profile": [
+      0,
+      0
+     ]
+    },
+    "cycle888_orbit_fine": [
+     1,
+     1,
+     2
+    ],
+    "cycle888_orbit_pair": [
+     1,
+     3
+    ],
+    "cycle888_shell_fine": [
+     1,
+     1,
+     1,
+     1,
+     2
+    ],
+    "cycle888_shell_pair": [
+     3,
+     3
+    ],
+    "identical": true
+   }
+  ],
+  "signatures_reproduce_cycle886": true,
+  "statement": "THE RESTRICTION GATE. The identical Cycle-888 machinery is re-run with the candidate set restricted to Cycle 886's four nontrivial cyclic classes. It must reproduce the pinned 886 receipt survivor for survivor, signature for signature, rule for rule. This is what licenses reading the FULL-lattice table as the same experiment with the restriction lifted -- and it is also the reason the argmin/argmax selectors MOVE: they are functions of the candidate set, not of the subgroup."
+ },
+ "M_S3_PRICING_ROW": {
+  "ORBIT_SCOPE": {
+   "all_gates_pass": true,
+   "burnside_pair_count": "6/1",
+   "centre_dimension": 3,
+   "coarse_ordered_pair": [
+    1,
+    5
+   ],
+   "coarse_two_adic_profile": [
+    0,
+    0
+   ],
+   "decomposition_failure_reason": null,
+   "enveloping_algebra_dimension": 6,
+   "fine_dimensions_with_a_v2_equal_to_one": [
+    2,
+    2
+   ],
+   "fine_rational_irreducible_dimensions": [
+    1,
+    1,
+    2,
+    2
+   ],
+   "fine_top_pair": [
+    1,
+    2
+   ],
+   "fine_top_rational_irreducible_dimension": 2,
+   "fine_top_two_adic_profile": [
+    0,
+    1
+   ],
+   "gates": {
+    "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+    "decomposition_succeeded": true,
+    "fine_decomposition_sums_to_the_space": true,
+    "fine_top_equals_the_maximum_fine_dimension": true,
+    "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+    "three_routes_agree_on_the_invariant_multiplicity": true,
+    "trivial_isotype_multiplicity_equals_the_orbit_count": true
+   },
+   "invariant_dim_by_burnside": "1/1",
+   "invariant_dim_by_nullspace": 1,
+   "invariant_dim_by_orbit_count": 1,
+   "isotypes": [
+    {
+     "component_dimension": 1,
+     "dim_Q_of_the_component_algebra": 1,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 1,
+     "is_the_trivial_isotype": true,
+     "minimal_polynomial_factor": [
+      -3,
+      1
+     ],
+     "multiplicity": 1
+    },
+    {
+     "component_dimension": 1,
+     "dim_Q_of_the_component_algebra": 1,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 1,
+     "is_the_trivial_isotype": false,
+     "minimal_polynomial_factor": [
+      3,
+      1
+     ],
+     "multiplicity": 1
+    },
+    {
+     "component_dimension": 4,
+     "dim_Q_of_the_component_algebra": 4,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 2,
+     "is_the_trivial_isotype": false,
+     "minimal_polynomial_factor": [
+      0,
+      1
+     ],
+     "multiplicity": 2
+    }
+   ],
+   "isotypic_decomposition_is_unique": false,
+   "orbit_count_on_the_product_set": 6,
+   "space_dimension": 6,
+   "subgroup_order": 6
+  },
+  "SHELL_SCOPE": {
+   "all_gates_pass": true,
+   "burnside_pair_count": "6/1",
+   "centre_dimension": 3,
+   "coarse_ordered_pair": [
+    1,
+    5
+   ],
+   "coarse_two_adic_profile": [
+    0,
+    0
+   ],
+   "decomposition_failure_reason": null,
+   "enveloping_algebra_dimension": 6,
+   "fine_dimensions_with_a_v2_equal_to_one": [
+    2,
+    2
+   ],
+   "fine_rational_irreducible_dimensions": [
+    1,
+    1,
+    2,
+    2
+   ],
+   "fine_top_pair": [
+    1,
+    2
+   ],
+   "fine_top_rational_irreducible_dimension": 2,
+   "fine_top_two_adic_profile": [
+    0,
+    1
+   ],
+   "gates": {
+    "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+    "decomposition_succeeded": true,
+    "fine_decomposition_sums_to_the_space": true,
+    "fine_top_equals_the_maximum_fine_dimension": true,
+    "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+    "three_routes_agree_on_the_invariant_multiplicity": true,
+    "trivial_isotype_multiplicity_equals_the_orbit_count": true
+   },
+   "invariant_dim_by_burnside": "1/1",
+   "invariant_dim_by_nullspace": 1,
+   "invariant_dim_by_orbit_count": 1,
+   "isotypes": [
+    {
+     "component_dimension": 1,
+     "dim_Q_of_the_component_algebra": 1,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 1,
+     "is_the_trivial_isotype": true,
+     "minimal_polynomial_factor": [
+      -3,
+      1
+     ],
+     "multiplicity": 1
+    },
+    {
+     "component_dimension": 1,
+     "dim_Q_of_the_component_algebra": 1,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 1,
+     "is_the_trivial_isotype": false,
+     "minimal_polynomial_factor": [
+      3,
+      1
+     ],
+     "multiplicity": 1
+    },
+    {
+     "component_dimension": 4,
+     "dim_Q_of_the_component_algebra": 4,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 2,
+     "is_the_trivial_isotype": false,
+     "minimal_polynomial_factor": [
+      0,
+      1
+     ],
+     "multiplicity": 2
+    }
+   ],
+   "isotypic_decomposition_is_unique": false,
+   "orbit_count_on_the_product_set": 6,
+   "space_dimension": 6,
+   "subgroup_order": 6
+  },
+  "SL1_TRANSFER": {
+   "every_isotypic_multiplicity_is_one": false,
+   "isotypes": [
+    {
+     "component_dimension": 1,
+     "dim_Q_of_the_component_algebra": 1,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 1,
+     "is_the_trivial_isotype": true,
+     "minimal_polynomial_factor": [
+      -3,
+      1
+     ],
+     "multiplicity": 1
+    },
+    {
+     "component_dimension": 1,
+     "dim_Q_of_the_component_algebra": 1,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 1,
+     "is_the_trivial_isotype": false,
+     "minimal_polynomial_factor": [
+      3,
+      1
+     ],
+     "multiplicity": 1
+    },
+    {
+     "component_dimension": 4,
+     "dim_Q_of_the_component_algebra": 4,
+     "endomorphism_field_degree": 1,
+     "irreducible_degree_over_Q": 2,
+     "is_the_trivial_isotype": false,
+     "minimal_polynomial_factor": [
+      0,
+      1
+     ],
+     "multiplicity": 2
+    }
+   ],
+   "isotypic_multiplicities": [
+    1,
+    1,
+    2
+   ],
+   "multiplicity_greater_than_one_components": [
+    {
+     "component_dimension": 4,
+     "degree": 2,
+     "multiplicity": 2
+    }
+   ],
+   "non_uniqueness_exhibits": [
+    {
+     "component_dimension": 4,
+     "distinct_irreducible_submodules_exhibited": 6,
+     "isotype_degree": 2,
+     "isotype_multiplicity": 2,
+     "submodules": [
+      {
+       "dimension": 2,
+       "generator_coefficients_in_the_component": [
+        -1,
+        -1,
+        -1,
+        -1
+       ],
+       "generator_vector": [
+        "2/1",
+        "-1/1",
+        "-1/1",
+        "2/1",
+        "-1/1",
+        "-1/1"
+       ],
+       "row_reduced_basis": [
+        [
+         "1/1",
+         "0/1",
+         "-1/1",
+         "1/1",
+         "-1/1",
+         "0/1"
+        ],
+        [
+         "0/1",
+         "1/1",
+         "-1/1",
+         "0/1",
+         "-1/1",
+         "1/1"
+        ]
+       ]
+      },
+      {
+       "dimension": 2,
+       "generator_coefficients_in_the_component": [
+        -1,
+        -1,
+        1,
+        1
+       ],
+       "generator_vector": [
+        "2/1",
+        "-1/1",
+        "-1/1",
+        "-2/1",
+        "1/1",
+        "1/1"
+       ],
+       "row_reduced_basis": [
+        [
+         "1/1",
+         "0/1",
+         "-1/1",
+         "-1/1",
+         "1/1",
+         "0/1"
+        ],
+        [
+         "0/1",
+         "1/1",
+         "-1/1",
+         "0/1",
+         "1/1",
+         "-1/1"
+        ]
+       ]
+      },
+      {
+       "dimension": 2,
+       "generator_coefficients_in_the_component": [
+        -1,
+        0,
+        -1,
+        0
+       ],
+       "generator_vector": [
+        "1/1",
+        "-1/1",
+        "0/1",
+        "1/1",
+        "-1/1",
+        "0/1"
+       ],
+       "row_reduced_basis": [
+        [
+         "1/1",
+         "0/1",
+         "-1/1",
+         "0/1",
+         "-1/1",
+         "1/1"
+        ],
+        [
+         "0/1",
+         "1/1",
+         "-1/1",
+         "-1/1",
+         "0/1",
+         "1/1"
+        ]
+       ]
+      },
+      {
+       "dimension": 2,
+       "generator_coefficients_in_the_component": [
+        -1,
+        0,
+        -1,
+        1
+       ],
+       "generator_vector": [
+        "1/1",
+        "-1/1",
+        "0/1",
+        "0/1",
+        "-1/1",
+        "1/1"
+       ],
+       "row_reduced_basis": [
+        [
+         "1/1",
+         "0/1",
+         "-1/1",
+         "-1/1",
+         "0/1",
+         "1/1"
+        ],
+        [
+         "0/1",
+         "1/1",
+         "-1/1",
+         "-1/1",
+         "1/1",
+         "0/1"
+        ]
+       ]
+      },
+      {
+       "dimension": 2,
+       "generator_coefficients_in_the_component": [
+        -1,
+        0,
+        1,
+        -1
+       ],
+       "generator_vector": [
+        "1/1",
+        "-1/1",
+        "0/1",
+        "0/1",
+        "1/1",
+        "-1/1"
+       ],
+       "row_reduced_basis": [
+        [
+         "1/1",
+         "0/1",
+         "-1/1",
+         "1/1",
+         "0/1",
+         "-1/1"
+        ],
+        [
+         "0/1",
+         "1/1",
+         "-1/1",
+         "1/1",
+         "-1/1",
+         "0/1"
+        ]
+       ]
+      },
+      {
+       "dimension": 2,
+       "generator_coefficients_in_the_component": [
+        -1,
+        0,
+        1,
+        0
+       ],
+       "generator_vector": [
+        "1/1",
+        "-1/1",
+        "0/1",
+        "-1/1",
+        "1/1",
+        "0/1"
+       ],
+       "row_reduced_basis": [
+        [
+         "1/1",
+         "0/1",
+         "-1/1",
+         "0/1",
+         "1/1",
+         "-1/1"
+        ],
+        [
+         "0/1",
+         "1/1",
+         "-1/1",
+         "1/1",
+         "0/1",
+         "-1/1"
+        ]
+       ]
+      }
+     ],
+     "the_realizing_subspace_is_not_unique": true
+    }
+   ],
+   "peer_comparison": [
+    {
+     "class": "C3_body",
+     "coarse_pair": [
+      1,
+      2
+     ],
+     "coarse_profile": [
+      0,
+      1
+     ],
+     "decomposition_is_unique": true,
+     "fine_dims": [
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_profile": [
+      0,
+      1
+     ],
+     "free_orbit_length": 3,
+     "isotypic_multiplicities": [
+      1,
+      1
+     ]
+    },
+    {
+     "class": "C4_face",
+     "coarse_pair": [
+      1,
+      3
+     ],
+     "coarse_profile": [
+      0,
+      0
+     ],
+     "decomposition_is_unique": true,
+     "fine_dims": [
+      1,
+      1,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_profile": [
+      0,
+      1
+     ],
+     "free_orbit_length": 4,
+     "isotypic_multiplicities": [
+      1,
+      1,
+      1
+     ]
+    },
+    {
+     "class": "S3_body",
+     "coarse_pair": [
+      1,
+      5
+     ],
+     "coarse_profile": [
+      0,
+      0
+     ],
+     "decomposition_is_unique": false,
+     "fine_dims": [
+      1,
+      1,
+      2,
+      2
+     ],
+     "fine_top_pair": [
+      1,
+      2
+     ],
+     "fine_top_profile": [
+      0,
+      1
+     ],
+     "free_orbit_length": 6,
+     "isotypic_multiplicities": [
+      1,
+      1,
+      2
+     ]
+    }
+   ],
+   "question": "Cycle 883 built its readout on TWO free C3 orbits of length 3 and derived the pair (1, 2) with no free parameter. S3 has ONE free orbit of length 6. Rebuild the analogous readout space and ask whether the isotype split is still forced.",
+   "readout_space_dimension": 6,
+   "verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+   "what_the_weight_pair_becomes": "Under Cycle 883's OWN reading -- (invariant, complement) of the readout space -- the S3 pair is [1, 5] with 2-adic profile [0, 0], so there is NO v_2 = 1 datum at S3 under that reading. Under the fine rational-irreducible reading the top pair is [1, 2] with profile [0, 1], which DOES carry v_2 = 1 -- but the 2-dimensional irreducible occurs with multiplicity [2], so the readout SUBSPACE carrying that '2' is not unique.",
+   "why_this_is_not_a_transfer": "At C3 (and at C4) every isotypic multiplicity is 1, so the decomposition of the readout space is canonical and the pair carries no free parameter -- that was the load-bearing clause of SL1. At S3 the standard 2-dimensional irreducible appears TWICE in the regular representation, so the isotypic decomposition (1, 1, 4) is forced but the split of the 4-dimensional component into two 2-dimensional readouts is a P^1 family: distinct submodules are exhibited above. The NUMBER (1, 2) transfers as an isotype-degree datum; the 'no free parameter' property does NOT."
+  },
+  "acts_simply_transitively_on_the_shell": true,
+  "class_size": 4,
+  "coarse_reading_supplies_a_v2_equals_1_datum": false,
+  "coarse_reading_two_adic_profile": [
+   0,
+   0
+  ],
+  "coarse_reading_weight_pair": [
+   1,
+   5
+  ],
+  "finding": "S3 is simply transitive on the shell (orbit scope = shell scope, dimension 6); coarse pair [1, 5] profile [0, 0]; fine dims [1, 1, 2, 2] top pair [1, 2] profile [0, 1]; reaches 2/9 under ['R3_orbit_scope_fine', 'R4_shell_scope_fine']; passes 12 of 16 selectors; SL1 transfer verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED.",
+  "fine_reading_dimensions": [
+   1,
+   1,
+   2,
+   2
+  ],
+  "fine_reading_supplies_a_v2_equals_1_datum": true,
+  "fine_reading_top_pair": [
+   1,
+   2
+  ],
+  "fine_reading_two_adic_profile": [
+   0,
+   1
+  ],
+  "group_theoretic_route_pair": [
+   1,
+   5
+  ],
+  "orbit_scope_equals_shell_scope": true,
+  "order": 6,
+  "pass": true,
+  "reachability_by_rule": {
+   "R1_orbit_scope_coarse": false,
+   "R2_shell_scope_coarse": false,
+   "R3_orbit_scope_fine": true,
+   "R4_shell_scope_fine": true
+  },
+  "reachability_generators_by_rule": {
+   "R1_orbit_scope_coarse": [
+    5,
+    6
+   ],
+   "R2_shell_scope_coarse": [
+    5,
+    6
+   ],
+   "R3_orbit_scope_fine": [
+    2,
+    6
+   ],
+   "R4_shell_scope_fine": [
+    2,
+    6
+   ]
+  },
+  "reachability_witnesses_by_rule": {
+   "R1_orbit_scope_coarse": null,
+   "R2_shell_scope_coarse": null,
+   "R3_orbit_scope_fine": [
+    3,
+    -2
+   ],
+   "R4_shell_scope_fine": [
+    3,
+    -2
+   ]
+  },
+  "selector_row": [
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL01_free_on_shell",
+    "survivors": [
+     "C2_edge",
+     "C3_body",
+     "E_trivial",
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL02_transitive_on_shell",
+    "survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL03_multiplicity_one_orbit_scope",
+    "survivors": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "E_trivial",
+     "S3_body",
+     "V_edge"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL04_multiplicity_one_shell_scope",
+    "survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL05_minimal_shell_invariant_multiplicity",
+    "survivors": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL06_maximal_free_shell_orbit",
+    "survivors": [
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": false,
+    "fidelity_pinned_from_886": "EXACT",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL07_coarse_pair_v2_equals_one",
+    "survivors": [
+     "C3_body"
+    ]
+   },
+   {
+    "S3_survives": false,
+    "fidelity_pinned_from_886": "PARTIAL",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL08_reachability_R1_orbit_scope",
+    "survivors": [
+     "C3_body"
+    ]
+   },
+   {
+    "S3_survives": false,
+    "fidelity_pinned_from_886": "PARTIAL",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL09_reachability_R2_shell_scope",
+    "survivors": [
+     "C2_edge",
+     "C3_body",
+     "V_face"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL10_fine_top_pair_is_the_target",
+    "survivors": [
+     "C3_body",
+     "C4_face",
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "PARTIAL",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL11_transitive_on_coordinate_axes",
+    "survivors": [
+     "A4_tetrahedral",
+     "C3_body",
+     "O_full",
+     "S3_body"
+    ]
+   },
+   {
+    "S3_survives": false,
+    "fidelity_pinned_from_886": "NONE",
+    "grounded_pinned_from_886": false,
+    "selector": "SEL12_odd_order",
+    "survivors": [
+     "C3_body",
+     "E_trivial"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "EXACT",
+    "grounded_pinned_from_886": true,
+    "selector": "SEL13_count_once",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "EXACT",
+    "grounded_pinned_from_886": true,
+    "selector": "SEL14_content_only_readout",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "EXACT",
+    "grounded_pinned_from_886": true,
+    "selector": "SEL15_admissibility_covariance",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   },
+   {
+    "S3_survives": true,
+    "fidelity_pinned_from_886": "EXACT",
+    "grounded_pinned_from_886": true,
+    "selector": "SEL16_no_site_privileged_read_literally",
+    "survivors": [
+     "A4_tetrahedral",
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "D4_face",
+     "E_trivial",
+     "O_full",
+     "S3_body",
+     "V_edge",
+     "V_face"
+    ]
+   }
+  ],
+  "selectors_S3_passes": [
+   "SEL01_free_on_shell",
+   "SEL02_transitive_on_shell",
+   "SEL03_multiplicity_one_orbit_scope",
+   "SEL04_multiplicity_one_shell_scope",
+   "SEL05_minimal_shell_invariant_multiplicity",
+   "SEL06_maximal_free_shell_orbit",
+   "SEL10_fine_top_pair_is_the_target",
+   "SEL11_transitive_on_coordinate_axes",
+   "SEL13_count_once",
+   "SEL14_content_only_readout",
+   "SEL15_admissibility_covariance",
+   "SEL16_no_site_privileged_read_literally"
+  ],
+  "selectors_S3_passes_count": 12,
+  "shell_orbit_lengths": [
+   6
+  ],
+  "statement": "S3's COMPLETE PRICING ROW. The order-6 body-diagonal stabilizer acts simply transitively on the 6-neighbour shell, so its orbit scope and its shell scope COINCIDE and the readout space is the regular representation of S3. Every selector, every reachability rule, both readings, and the SL1-transfer question are computed here."
+ },
+ "N_SCOPE_INSENSITIVITY": {
+  "OVERALL_VERDICT": "MIXED",
+  "cycle883_defeat_condition": "defeated = (not old_reach) and new_reach",
+  "finding": "ORBIT_SCOPE_coarse_reading -> SCOPE_SENSITIVE working ['C3_body']; ORBIT_SCOPE_fine_reading -> SCOPE_SENSITIVE working ['C3_body', 'S3_body']; SHELL_SCOPE_coarse_reading -> SCOPE_SENSITIVE working ['C2_edge', 'C3_body']; SHELL_SCOPE_fine_reading -> SCOPE_SENSITIVE working ['C3_body', 'S3_body']; OVERALL MIXED",
+  "menu": [
+   {
+    "class": "C2_edge",
+    "maximal_FREE_orbit_length": 2,
+    "on_the_menu": true,
+    "order": 2,
+    "reason": "a free shell orbit of length 2 realizes the Cycle-883 readout",
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ]
+   },
+   {
+    "class": "C2_face",
+    "maximal_FREE_orbit_length": 2,
+    "on_the_menu": true,
+    "order": 2,
+    "reason": "a free shell orbit of length 2 realizes the Cycle-883 readout",
+    "shell_orbit_lengths": [
+     1,
+     1,
+     2,
+     2
+    ]
+   },
+   {
+    "class": "C3_body",
+    "maximal_FREE_orbit_length": 3,
+    "on_the_menu": true,
+    "order": 3,
+    "reason": "a free shell orbit of length 3 realizes the Cycle-883 readout",
+    "shell_orbit_lengths": [
+     3,
+     3
+    ]
+   },
+   {
+    "class": "C4_face",
+    "maximal_FREE_orbit_length": 4,
+    "on_the_menu": true,
+    "order": 4,
+    "reason": "a free shell orbit of length 4 realizes the Cycle-883 readout",
+    "shell_orbit_lengths": [
+     1,
+     1,
+     4
+    ]
+   },
+   {
+    "class": "S3_body",
+    "maximal_FREE_orbit_length": 6,
+    "on_the_menu": true,
+    "order": 6,
+    "reason": "a free shell orbit of length 6 realizes the Cycle-883 readout",
+    "shell_orbit_lengths": [
+     6
+    ]
+   },
+   {
+    "class": "V_edge",
+    "maximal_FREE_orbit_length": 4,
+    "on_the_menu": true,
+    "order": 4,
+    "reason": "a free shell orbit of length 4 realizes the Cycle-883 readout",
+    "shell_orbit_lengths": [
+     2,
+     4
+    ]
+   }
+  ],
+  "menu_classes": [
+   "C2_edge",
+   "C2_face",
+   "C3_body",
+   "C4_face",
+   "S3_body",
+   "V_edge"
+  ],
+  "menu_membership_rule": "A class is on the honest scope menu iff the Cycle-883 construction is REALIZABLE at it: the subgroup must have a lattice-realized FREE orbit on the 6-neighbour shell of length greater than one, so that the readout space is a nondegenerate free-orbit readout. Membership is decided by the computed orbit structure, not by a list.",
+  "off_menu": [
+   {
+    "class": "A4_tetrahedral",
+    "maximal_FREE_orbit_length": 0,
+    "on_the_menu": false,
+    "order": 12,
+    "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+    "shell_orbit_lengths": [
+     6
+    ]
+   },
+   {
+    "class": "D4_face",
+    "maximal_FREE_orbit_length": 0,
+    "on_the_menu": false,
+    "order": 8,
+    "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+    "shell_orbit_lengths": [
+     2,
+     4
+    ]
+   },
+   {
+    "class": "E_trivial",
+    "maximal_FREE_orbit_length": 1,
+    "on_the_menu": false,
+    "order": 1,
+    "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+    "shell_orbit_lengths": [
+     1,
+     1,
+     1,
+     1,
+     1,
+     1
+    ]
+   },
+   {
+    "class": "O_full",
+    "maximal_FREE_orbit_length": 0,
+    "on_the_menu": false,
+    "order": 24,
+    "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+    "shell_orbit_lengths": [
+     6
+    ]
+   },
+   {
+    "class": "V_face",
+    "maximal_FREE_orbit_length": 0,
+    "on_the_menu": false,
+    "order": 4,
+    "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+    "shell_orbit_lengths": [
+     2,
+     2,
+     2
+    ]
+   }
+  ],
+  "outcome_classes_available": [
+   "SCOPE_INSENSITIVE",
+   "SCOPE_SENSITIVE",
+   "MIXED",
+   "NO_SCOPE_WORKS"
+  ],
+  "pass": true,
+  "per_reading": {
+   "ORBIT_SCOPE_coarse_reading": {
+    "menu": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "S3_body",
+     "V_edge"
+    ],
+    "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C3_body']",
+    "verdict": "SCOPE_SENSITIVE",
+    "working_set": [
+     "C3_body"
+    ]
+   },
+   "ORBIT_SCOPE_fine_reading": {
+    "menu": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "S3_body",
+     "V_edge"
+    ],
+    "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C3_body', 'S3_body']",
+    "verdict": "SCOPE_SENSITIVE",
+    "working_set": [
+     "C3_body",
+     "S3_body"
+    ]
+   },
+   "SHELL_SCOPE_coarse_reading": {
+    "menu": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "S3_body",
+     "V_edge"
+    ],
+    "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C2_edge', 'C3_body']",
+    "verdict": "SCOPE_SENSITIVE",
+    "working_set": [
+     "C2_edge",
+     "C3_body"
+    ]
+   },
+   "SHELL_SCOPE_fine_reading": {
+    "menu": [
+     "C2_edge",
+     "C2_face",
+     "C3_body",
+     "C4_face",
+     "S3_body",
+     "V_edge"
+    ],
+    "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C3_body', 'S3_body']",
+    "verdict": "SCOPE_SENSITIVE",
+    "working_set": [
+     "C3_body",
+     "S3_body"
+    ]
+   }
+  },
+  "readings_disagree_on_the_working_set": true,
+  "statement": "THE SCOPE-INSENSITIVITY TEST -- Cycle 886's named-but-not-run test, run. The downstream consumer is the readout obligation lineage: Cycle 882's C882-T6 is defeated only if a v_2 = 1 datum widens the anchor group from the orbit-cardinality group to one containing 2/9. Cycle 883's widening argument, AST-recovered, is evaluated at EVERY scope on the honest menu, under BOTH readings, at BOTH scopes. The three honest outcomes are SCOPE_INSENSITIVE (the scope choice is gauge for this consumer and the menu price drops to zero for it), SCOPE_SENSITIVE (the working set is the real menu) and MIXED (the readings disagree). Every gate below passes identically in all three cases.",
+  "table": [
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      3
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      1,
+      -2
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "coarse_pair": [
+     1,
+     1
+    ],
+    "coarse_profile": [
+     0,
+     0
+    ],
+    "fine_dims": [
+     1,
+     1
+    ],
+    "fine_profile": [
+     0,
+     0
+    ],
+    "fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_dimension": 2,
+    "order": 2,
+    "scope_class": "C2_edge",
+    "supplies_a_v2_equals_1_datum_coarse": false,
+    "supplies_a_v2_equals_1_datum_fine": false
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      2
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "coarse_pair": [
+     1,
+     1
+    ],
+    "coarse_profile": [
+     0,
+     0
+    ],
+    "fine_dims": [
+     1,
+     1
+    ],
+    "fine_profile": [
+     0,
+     0
+    ],
+    "fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_dimension": 2,
+    "order": 2,
+    "scope_class": "C2_face",
+    "supplies_a_v2_equals_1_datum_coarse": false,
+    "supplies_a_v2_equals_1_datum_fine": false
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      3
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      3
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      1,
+      -2
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      3
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      3
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      1,
+      -2
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      3
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      3,
+      4
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      1,
+      -2,
+      0
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      3
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      3
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      1,
+      -2
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "coarse_pair": [
+     1,
+     2
+    ],
+    "coarse_profile": [
+     0,
+     1
+    ],
+    "fine_dims": [
+     1,
+     2
+    ],
+    "fine_profile": [
+     0,
+     1
+    ],
+    "fine_top_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_dimension": 3,
+    "order": 3,
+    "scope_class": "C3_body",
+    "supplies_a_v2_equals_1_datum_coarse": true,
+    "supplies_a_v2_equals_1_datum_fine": true
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      3,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      3,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "coarse_pair": [
+     1,
+     3
+    ],
+    "coarse_profile": [
+     0,
+     0
+    ],
+    "fine_dims": [
+     1,
+     1,
+     2
+    ],
+    "fine_profile": [
+     0,
+     1
+    ],
+    "fine_top_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_dimension": 4,
+    "order": 4,
+    "scope_class": "C4_face",
+    "supplies_a_v2_equals_1_datum_coarse": false,
+    "supplies_a_v2_equals_1_datum_fine": true
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      6
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      5,
+      6
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      6
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      6
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      3,
+      -2
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      6
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      5,
+      6
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      6
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": true,
+     "widened_generator_set": [
+      2,
+      6
+     ],
+     "widened_target_reachable": true,
+     "witness_exponents": [
+      3,
+      -2
+     ],
+     "witness_recomputes_the_target": true
+    },
+    "coarse_pair": [
+     1,
+     5
+    ],
+    "coarse_profile": [
+     0,
+     0
+    ],
+    "fine_dims": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "fine_profile": [
+     0,
+     1
+    ],
+    "fine_top_pair": [
+     1,
+     2
+    ],
+    "orbit_scope_dimension": 6,
+    "order": 6,
+    "scope_class": "S3_body",
+    "supplies_a_v2_equals_1_datum_coarse": false,
+    "supplies_a_v2_equals_1_datum_fine": true
+   },
+   {
+    "ORBIT_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      3,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "ORBIT_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_coarse_reading": {
+     "cycle882_generator_set": [
+      2,
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "SHELL_SCOPE_fine_reading": {
+     "cycle882_generator_set": [
+      2,
+      4
+     ],
+     "cycle882_target_reachable": false,
+     "defeats_C882_T6": false,
+     "widened_generator_set": [
+      2,
+      4
+     ],
+     "widened_target_reachable": false,
+     "witness_exponents": null,
+     "witness_recomputes_the_target": null
+    },
+    "coarse_pair": [
+     1,
+     3
+    ],
+    "coarse_profile": [
+     0,
+     0
+    ],
+    "fine_dims": [
+     1,
+     1,
+     1,
+     1
+    ],
+    "fine_profile": [
+     0,
+     0
+    ],
+    "fine_top_pair": [
+     1,
+     1
+    ],
+    "orbit_scope_dimension": 4,
+    "order": 4,
+    "scope_class": "V_edge",
+    "supplies_a_v2_equals_1_datum_coarse": false,
+    "supplies_a_v2_equals_1_datum_fine": false
+   }
+  ],
+  "table_is_complete": true,
+  "target_2_adic_valuation": 1,
+  "target_anchor": "2/9",
+  "verdict_at_the_883_native_scope_coarse_reading": "SCOPE_SENSITIVE",
+  "verdict_at_the_883_native_scope_fine_reading": "SCOPE_SENSITIVE"
+ },
+ "O_IMPOSTOR_STRESS": {
+  "every_impostor_refused": true,
+  "finding": "8/8 impostors refused by named gates.",
+  "pass": true,
+  "rows": [
+   {
+    "appears_in_the_lattice": false,
+    "impostor": "a NON-CLOSED set {e, r3} passed off as a subgroup",
+    "is_closed": false,
+    "refused": true,
+    "refused_by_gate": "D_SUBGROUP_LATTICE / every_subgroup_closed_under_composition"
+   },
+   {
+    "conjugate_class_index": 7,
+    "conjugate_is_already_in_the_lattice": true,
+    "conjugating_element_index": 0,
+    "derived_name_of_the_conjugate": "S3_body",
+    "impostor": "a CONJUGATE of an S3 subgroup relabelled as a new class",
+    "original_class_index": 7,
+    "refused": true,
+    "refused_by_gate": "D_SUBGROUP_LATTICE / conjugacy_classes == 11 and derived_names_are_constant_on_classes",
+    "would_have_created_a_twelfth_class": false
+   },
+   {
+    "cyclic_subgroups_of_order_8_in_the_lattice": 0,
+    "elements_of_order_8_in_the_group": 0,
+    "impostor": "a FABRICATED order-8 CYCLIC subgroup C8",
+    "order_8_subgroups_that_do_exist_are_cyclic": [
+     false,
+     false,
+     false
+    ],
+    "refused": true,
+    "refused_by_gate": "C_ROTATION_GROUP / element_order_counts and D_SUBGROUP_LATTICE / derived name is D4_face"
+   },
+   {
+    "appears_in_the_lattice": false,
+    "determinant": -1,
+    "impostor": "the inversion -I smuggled in as a C2 (an IMPROPER rotation)",
+    "refused": true,
+    "refused_by_gate": "C_ROTATION_GROUP / every_element_has_determinant_plus_one"
+   },
+   {
+    "claimed_dimensions": [
+     1,
+     1,
+     1,
+     1
+    ],
+    "claimed_sum": 4,
+    "computed_dimensions": [
+     1,
+     1,
+     2,
+     2
+    ],
+    "computed_sum": 6,
+    "impostor": "a WRONG DECOMPOSITION: S3's shell readout claimed as 1 + 1 + 1 + 1",
+    "refused": true,
+    "refused_by_gate": "G_ISOTYPE_SIGNATURES / fine_decomposition_sums_to_the_space",
+    "space_dimension": 6
+   },
+   {
+    "claimed_sum_m_squared_field_degree": 3,
+    "computed_sum_m_squared_field_degree": 6,
+    "impostor": "a WRONG MULTIPLICITY LEDGER for S3 (m = 1 everywhere, which would make the SL1 transfer forced)",
+    "orbit_count_on_the_product_set": 6,
+    "refused": true,
+    "refused_by_gate": "G_ISOTYPE_SIGNATURES / sum_m_squared_field_degree_equals_the_orbit_count_on_pairs"
+   },
+   {
+    "fabricated_class": "C5_body",
+    "impostor": "a survivor set naming a class that is not in the lattice",
+    "present_in_the_lattice": false,
+    "refused": true,
+    "refused_by_gate": "I_SELECTOR_TABLE / every_survivor_set_is_a_subset_of_the_candidates"
+   },
+   {
+    "claimed_classes": 10,
+    "claimed_subgroups": 29,
+    "computed_classes": 11,
+    "computed_subgroups": 30,
+    "impostor": "a census claiming 29 subgroups in 10 classes",
+    "refused": true,
+    "refused_by_gate": "D_SUBGROUP_LATTICE / class_sizes_sum_to_the_lattice and class_equation_holds_on_every_class"
+   }
+  ],
+  "statement": "Eight impostors are offered to the gates. Each must be refused by a NAMED gate and the refusal must be computed here, not asserted."
+ },
+ "P_OUTCOME": {
+  "Q1_answer": "The lattice has 30 subgroups in 11 conjugacy classes. Every axiom-grounded selector keeps ALL of them, so the derivation route stays refused with the restriction lifted -- and it is now refused over a candidate set 2.75x larger. The S3 class is a genuine rival: it is the ONLY simply-transitive scope, it is the unique survivor of freeness-plus-maximality, and it satisfies twelve of the sixteen selectors. But its coarse weight pair is (1, 5), not (1, 2), and its fine (1, 2) is carried by an irreducible of MULTIPLICITY TWO, so the readout subspace is a P^1 family rather than a forced split.",
+  "Q2_answer": "MIXED. The working sets are ['C3_body'] under the coarse reading and ['C3_body', 'S3_body'] under the fine reading, at the Cycle-883 native orbit scope. The menu price for this consumer is therefore NOT zero: the scope choice is load-bearing for the T6 defeat.",
+  "S3_transfer_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+  "S3_weight_pair_coarse": [
+   1,
+   5
+  ],
+  "S3_weight_pair_coarse_profile": [
+   0,
+   0
+  ],
+  "S3_weight_pair_fine_profile": [
+   0,
+   1
+  ],
+  "S3_weight_pair_fine_top": [
+   1,
+   2
+  ],
+  "axiom_grounded_conjunction_keeps_everything": true,
+  "axiom_grounded_conjunction_survivors": [
+   "A4_tetrahedral",
+   "C2_edge",
+   "C2_face",
+   "C3_body",
+   "C4_face",
+   "D4_face",
+   "E_trivial",
+   "O_full",
+   "S3_body",
+   "V_edge",
+   "V_face"
+  ],
+  "cycle886_single_clause_menu": [
+   "SEL05_minimal_shell_invariant_multiplicity",
+   "SEL06_maximal_free_shell_orbit",
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope",
+   "SEL11_transitive_on_coordinate_axes",
+   "SEL12_odd_order"
+  ],
+  "derivation_route_still_refused": true,
+  "finding": "Q1: 30 subgroups / 11 classes; the grounded conjunction keeps all 11; 2/6 of Cycle 886's menu clauses still isolate C3 and only 0 of those is non-circular; S3 transfer verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED. Q2: MIXED.",
+  "menu_clauses_that_moved_off_C3": [
+   "SEL05_minimal_shell_invariant_multiplicity",
+   "SEL06_maximal_free_shell_orbit",
+   "SEL11_transitive_on_coordinate_axes",
+   "SEL12_odd_order"
+  ],
+  "menu_clauses_that_still_isolate_C3": [
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope"
+  ],
+  "menu_movement_under_de_restriction": [
+   {
+    "cycle886_survivors_over_the_cyclic_census": [
+     "C3_body"
+    ],
+    "cycle888_survivors_over_the_full_lattice": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "now_selects_instead": [
+     "A4_tetrahedral",
+     "O_full",
+     "S3_body"
+    ],
+    "selector": "SEL05_minimal_shell_invariant_multiplicity",
+    "still_isolates_C3_body": false
+   },
+   {
+    "cycle886_survivors_over_the_cyclic_census": [
+     "C3_body"
+    ],
+    "cycle888_survivors_over_the_full_lattice": [
+     "S3_body"
+    ],
+    "now_selects_instead": [
+     "S3_body"
+    ],
+    "selector": "SEL06_maximal_free_shell_orbit",
+    "still_isolates_C3_body": false
+   },
+   {
+    "cycle886_survivors_over_the_cyclic_census": [
+     "C3_body"
+    ],
+    "cycle888_survivors_over_the_full_lattice": [
+     "C3_body"
+    ],
+    "now_selects_instead": null,
+    "selector": "SEL07_coarse_pair_v2_equals_one",
+    "still_isolates_C3_body": true
+   },
+   {
+    "cycle886_survivors_over_the_cyclic_census": [
+     "C3_body"
+    ],
+    "cycle888_survivors_over_the_full_lattice": [
+     "C3_body"
+    ],
+    "now_selects_instead": null,
+    "selector": "SEL08_reachability_R1_orbit_scope",
+    "still_isolates_C3_body": true
+   },
+   {
+    "cycle886_survivors_over_the_cyclic_census": [
+     "C3_body"
+    ],
+    "cycle888_survivors_over_the_full_lattice": [
+     "A4_tetrahedral",
+     "C3_body",
+     "O_full",
+     "S3_body"
+    ],
+    "now_selects_instead": [
+     "A4_tetrahedral",
+     "C3_body",
+     "O_full",
+     "S3_body"
+    ],
+    "selector": "SEL11_transitive_on_coordinate_axes",
+    "still_isolates_C3_body": false
+   },
+   {
+    "cycle886_survivors_over_the_cyclic_census": [
+     "C3_body"
+    ],
+    "cycle888_survivors_over_the_full_lattice": [
+     "C3_body",
+     "E_trivial"
+    ],
+    "now_selects_instead": [
+     "C3_body",
+     "E_trivial"
+    ],
+    "selector": "SEL12_odd_order",
+    "still_isolates_C3_body": false
+   }
+  ],
+  "next_attackable_question": "Either (i) register the scope choice on the owner surface with the corrected three-clause menu and the odd-order repair attached; or (ii) ask whether multiplicity-freeness of the readout is itself derivable -- it is the property that separates C3 and C4 from S3 and it is not yet quoted from any sentence; or (iii) take the MIXED scope-insensitivity verdict downstream: the consumer's dependence on the reading, not just on the scope, is now the load-bearing residual.",
+  "non_circular_clauses_that_still_pin_C3": [],
+  "pass": true,
+  "question": "Q1: price the S3 scope over the FULL 30-subgroup lattice and close the cyclic-restriction gap. Q2: is the downstream readout obligation scope-insensitive?",
+  "restriction_gate_reproduces_cycle886": true,
+  "scope_insensitivity_by_reading": {
+   "ORBIT_SCOPE_coarse_reading": "SCOPE_SENSITIVE",
+   "ORBIT_SCOPE_fine_reading": "SCOPE_SENSITIVE",
+   "SHELL_SCOPE_coarse_reading": "SCOPE_SENSITIVE",
+   "SHELL_SCOPE_fine_reading": "SCOPE_SENSITIVE"
+  },
+  "scope_insensitivity_verdict": "MIXED",
+  "target_facing_circular_clauses": [
+   "SEL07_coarse_pair_v2_equals_one",
+   "SEL08_reachability_R1_orbit_scope",
+   "SEL09_reachability_R2_shell_scope"
+  ],
+  "the_convergence_broke": true,
+  "the_fragility_headline": "Cycle 886 priced C3 at one supplied clause chosen from a menu of 6. Over the full lattice only 2 of those 6 still isolate C3, and only 0 of those is not target-facing. Three of the four non-circular conventions FLIP: SEL05_minimal_shell_invariant_multiplicity -> ['A4_tetrahedral', 'O_full', 'S3_body']; SEL06_maximal_free_shell_orbit -> ['S3_body']; SEL11_transitive_on_coordinate_axes -> ['A4_tetrahedral', 'C3_body', 'O_full', 'S3_body']; SEL12_odd_order -> ['C3_body', 'E_trivial'].",
+  "the_sharpest_new_facts": [
+   "The S3 scope is NOT a transfer of SL1. At C3 and C4 every isotypic multiplicity is 1, so the readout decomposition is canonical and the pair carries no free parameter -- SL1's load-bearing clause. At S3 the 2-dimensional irreducible appears TWICE in the regular representation, so the (1, 2) fine-top pair is realized by a P^1 family of readout subspaces, exhibited explicitly. Under Cycle 883's OWN (coarse) reading S3 does not carry (1, 2) at all: it carries (1, 5), profile (0, 0).",
+   "Lifting the cyclic restriction BREAKS the convergence Cycle 886 recorded. Its ungrounded selectors no longer point one way: freeness-plus-maximality now isolates S3, minimal shell multiplicity and shell transitivity and shell multiplicity-one all select {S3, A4, O}, internal axis-transitivity keeps {C3, S3, A4, O}, and only odd order and the two target-facing clauses still isolate C3. The ungrounded conjunction is now EMPTY.",
+   "The odd-order clause, Cycle 886's cheapest non-circular pin, needs a SECOND conjunct once the census is complete: the trivial subgroup has odd order too, so the filter as Cycle 886 coded it (order % 2 == 1) admits {C3_body, E_trivial}. Cycle 886's own demand string said 'greater than 1' but its filter never computed it, because the trivial subgroup was outside its census.",
+   "The scope-insensitivity test comes back MIXED, not insensitive: the T6 defeat works at C3 under both readings, at S3 under the fine reading only, at C2_edge under the shell-scope coarse reading only, and nowhere else on the menu."
+  ],
+  "what_this_does_to_SL0": "SL0's answer stays PRICING, and the price goes UP. The menu is not six clauses over four classes; it is three clauses over eleven classes, two of them circular, and the one non-circular survivor needs a repair. The rival that survives de-restriction best -- S3 -- is the one scope at which SL1's no-free-parameter property fails.",
+  "what_this_does_to_SL1": "SL1 is still untouched AT the C3 scope. What is new is that the obvious generalization to the simply-transitive scope does not reproduce it: the S3 readout has a free parameter that the C3 readout does not. SL1's uniqueness is a property of multiplicity-free scopes, and that is now computed rather than assumed."
+ }
+}
+
+controls: deterministic=True runtime=4.781s stdout=363067B receipt=8a540201a84a6b8c

--- a/outputs/s3_scope_block_cycle888_ship_receipt_2026_07_28.json
+++ b/outputs/s3_scope_block_cycle888_ship_receipt_2026_07_28.json
@@ -1,0 +1,53 @@
+{
+  "audit": "unset",
+  "authority": "none",
+  "authorship": "one Claude Opus 5 worker-authored primary and checker under supervisor spec (substitution disclosed); supervisor line-by-line review",
+  "block": "toe-time-blockG13-20260802",
+  "campaign": "toe-time-expansion-20260802",
+  "certificates": {
+    "checker": "exit 0; all verdicts SURVIVES; 886-pin fidelity 16/16+16/16 byte-identical; 8/8 teeth; 38.0s",
+    "primary": "16/16 PASS incl. restriction gate reproducing the pinned 886 receipt; 8/8 impostors refused; 4.8s"
+  },
+  "claim_type": "bounded_theorem",
+  "cluster_cap_evaluation": "OPEN \u2014 13th gravity-family PR: closes 886's completeness gate with a menu-dissolving recomputation, a transfer theorem (P^1 family), a MIXED load-bearing verdict, and two corrections against the parent block; distinct claim type vs G11; nothing corollary",
+  "cycles": [
+    888
+  ],
+  "files": {
+    "docs/S3_SCOPE_PRICED_MENU_DISSOLVED_CYCLE888_BOUNDED_THEOREM_NOTE_2026-07-28.md": {
+      "git_blob": "dfd80b753b9e1142166ec9fa84f9c22ea3f6f421",
+      "sha256": "a7372ce901de72215e221d2f3604c78070bb3e5d8781b8117809a7ad3217c7d8"
+    },
+    "logs/runner-cache/frontier_cycle888_s3_scope_independent_check_2026_07_28.txt": {
+      "git_blob": "e6880c8df765fddef6d538ae82df87bd59591e1c",
+      "sha256": "2442e8d4548141bce7fa84065b8c88e545e0b16e7798a5a508e23f123f2284c0"
+    },
+    "logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt": {
+      "git_blob": "6cd3fbdbe74e1231cd61222a798a7979bee922da",
+      "sha256": "5e4fc183efda55d1f3fbd5413bd2fe985ed5732b7ffbc8bd489296e7b22c2c84"
+    },
+    "outputs/s3_scope_independent_check_cycle888_receipt_2026_07_28.json": {
+      "git_blob": "54e58b22107696edc4ccca0eebb8a5d62ab14805",
+      "sha256": "f689f85a29c9c67f3c32984d8db9f8a0ffa8c277164549a5d1fea1b6481e727d"
+    },
+    "outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json": {
+      "git_blob": "3e18ad52f50e72b83c56da72c31f25d104b5c830",
+      "sha256": "8a540201a84a6b8cb6868d431216718a27f200e45d6ceeb771d858e9a54280cd"
+    },
+    "scripts/frontier_cycle888_s3_scope_independent_check_2026_07_28.py": {
+      "git_blob": "37bb3bc9f1168f2ddf17a7c7cf558555bc7192ab",
+      "sha256": "940c816bcb8ea8c7e3fc9fd2f1bac62cce0a8674cf9c7529549de59a21e503d1"
+    },
+    "scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py": {
+      "git_blob": "c3de02c94b8a11a930ad6ff8817975b118bc776d",
+      "sha256": "f57fda877d35d49953c3b6a34293ab0cc6a87781ceb9d158b9c9abb5abd4bb3f"
+    }
+  },
+  "headline": "S3 priced, 886's menu DISSOLVED: over the full 30-subgroup lattice zero non-circular clauses isolate C3 (freeness+maximality now selects S3 alone; SEL12 was broken as coded; 886's empty rows were restriction artifacts); S3 = regular representation, coarse (1,5)/(0,0) \u2014 no v2=1 under 883's native reading \u2014 fine-top (1,2)/(0,1) reachable; SL1 transfer NUMERICALLY_TRANSFERS_BUT_NOT_FORCED (multiplicity-2 P^1 family; character-rigid; isotypic level canonical) => SL1's no-free-parameter IS multiplicity-freeness; scope-insensitivity MIXED (sensitive under every reading, readings disagree) \u2014 the scope is load-bearing; FIND-5 named: is multiplicity-freeness quotable?",
+  "independence": "cross-context (independent lattice construction; independent isotype machinery with the pair-orbit safety gate; two checker-side traps invisible to outcome-neutral primary gates; 8/8 teeth)",
+  "note": "docs/S3_SCOPE_PRICED_MENU_DISSOLVED_CYCLE888_BOUNDED_THEOREM_NOTE_2026-07-28.md",
+  "runtime_seconds": {
+    "checker": 38.0,
+    "primary": 4.8
+  }
+}

--- a/outputs/s3_scope_independent_check_cycle888_receipt_2026_07_28.json
+++ b/outputs/s3_scope_independent_check_cycle888_receipt_2026_07_28.json
@@ -1,0 +1,2514 @@
+{
+  "any_certified_number_refuted": false,
+  "checked_runner": "scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py",
+  "checked_runner_sha256": "f57fda877d35d49953c3b6a34293ab0cc6a87781ceb9d158b9c9abb5abd4bb3f",
+  "controls": {
+    "blocked_modules_loaded": [],
+    "exit_is_independent_of_claim_survival": true,
+    "firewall_hits": [],
+    "runtime_limit_seconds": 900,
+    "runtime_seconds": 33.573745,
+    "runtime_under_limit": true,
+    "stdout_bytes": 95349,
+    "stdout_under_limit": true
+  },
+  "cycle": 888,
+  "findings": [
+    {
+      "does_it_refute_a_number": false,
+      "id": "FIND-1",
+      "severity": "adopted from the primary, confirmed",
+      "text": "The odd-order clause -- Cycle 886's cheapest non-circular pin for C3 -- admits ['C3_body', 'E_trivial'] once the trivial subgroup enters the census, because the filter Cycle 886 actually coded is `order % 2 == 1` while its demand string said 'greater than 1'. The primary flags this; the checker confirms it independently. Consequence: over the full lattice ZERO of Cycle 886's six menu clauses is both non-circular and isolating as coded."
+    },
+    {
+      "does_it_refute_a_number": false,
+      "id": "FIND-2",
+      "severity": "sharpening",
+      "text": "The primary reports S3's non-uniqueness by exhibiting submodules. The checker shows the stronger statement: the top-degree irreducible submodules of the S3 readout span EXACTLY the 4-dimensional isotypic component and all carry the SAME character. So the ambiguity is exactly a P^1 of isomorphic copies -- the isotypic level is canonical, the irreducible level is not, and no readout with a different pair exists. That is a cleaner statement of the transfer failure than 'the subspace is not unique'."
+    },
+    {
+      "does_it_refute_a_number": false,
+      "id": "FIND-3",
+      "severity": "method note",
+      "text": "A naive minimal-cyclic-submodule decomposition is NOT safe on this lattice: at V_edge the first peeled block is 2-dimensional and reducible, and a checker that trusted it would report fine dimensions [1,1,1,1,2] instead of the correct six 1-dimensional blocks. The checker's own pair-orbit gate caught this before any comparison was made. Any future re-derivation of these signatures should carry the same gate."
+    },
+    {
+      "does_it_refute_a_number": false,
+      "id": "FIND-4",
+      "severity": "scope note",
+      "text": "The MIXED scope-insensitivity verdict is driven by ONE class: S3 defeats C882-T6 under the fine reading and fails under the coarse reading. Every other menu member gives the same answer under both readings at the orbit scope. So the reading-dependence Cycle 886 discovered at C4 reappears at S3 in a load-bearing place: it decides menu membership for the downstream consumer, not just a signature entry."
+    },
+    {
+      "does_it_refute_a_number": false,
+      "id": "FIND-5",
+      "severity": "open",
+      "text": "Neither runner asks whether MULTIPLICITY-FREENESS of the readout -- the property that separates C3 and C4 from S3 -- is quotable from any axiom sentence. It is the smallest clause that would restore SL1's uniqueness at a chosen scope, and it is unpriced. Named here, not answered."
+    }
+  ],
+  "independent_lattice": {
+    "by_derived_name": {
+      "A4_tetrahedral": 1,
+      "C2_edge": 6,
+      "C2_face": 3,
+      "C3_body": 4,
+      "C4_face": 3,
+      "D4_face": 3,
+      "E_trivial": 1,
+      "O_full": 1,
+      "S3_body": 4,
+      "V_edge": 3,
+      "V_face": 1
+    },
+    "class_equation_rows": [
+      {
+        "class": "E_trivial",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 24,
+        "independent_size": 1,
+        "primary_size": 1,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "C2_face",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 8,
+        "independent_size": 3,
+        "primary_size": 3,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "C2_edge",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 4,
+        "independent_size": 6,
+        "primary_size": 6,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "C3_body",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 6,
+        "independent_size": 4,
+        "primary_size": 4,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "V_face",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 24,
+        "independent_size": 1,
+        "primary_size": 1,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "V_edge",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 8,
+        "independent_size": 3,
+        "primary_size": 3,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "C4_face",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 8,
+        "independent_size": 3,
+        "primary_size": 3,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "S3_body",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 6,
+        "independent_size": 4,
+        "primary_size": 4,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "D4_face",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 8,
+        "independent_size": 3,
+        "primary_size": 3,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "A4_tetrahedral",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 24,
+        "independent_size": 1,
+        "primary_size": 1,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      },
+      {
+        "class": "O_full",
+        "equals_the_group_order": true,
+        "independent_normalizer_order": 24,
+        "independent_size": 1,
+        "primary_size": 1,
+        "size_times_normalizer": 24,
+        "sizes_agree": true
+      }
+    ],
+    "conjugacy_classes": 11,
+    "subgroups": 30
+  },
+  "independent_reachability": {
+    "R1_orbit_scope_coarse": [
+      "C3_body"
+    ],
+    "R2_shell_scope_coarse": [
+      "C2_edge",
+      "C3_body",
+      "V_face"
+    ],
+    "R3_orbit_scope_fine": [
+      "C3_body",
+      "S3_body"
+    ],
+    "R4_shell_scope_fine": [
+      "A4_tetrahedral",
+      "C3_body",
+      "O_full",
+      "S3_body"
+    ]
+  },
+  "independent_signatures": [
+    {
+      "agrees_with_the_primary": true,
+      "name": "A4_tetrahedral",
+      "orbit": null,
+      "orbit_isotypes": null,
+      "shell": {
+        "block_dimensions": [
+          1,
+          2,
+          3
+        ],
+        "coarse_pair": [
+          1,
+          5
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          2,
+          3
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 3,
+        "fine_top_pair": [
+          1,
+          3
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 4,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 4
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 2,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 3,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 3,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "C2_edge",
+      "orbit": {
+        "block_dimensions": [
+          1,
+          1
+        ],
+        "coarse_pair": [
+          1,
+          1
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 2,
+        "pair_identity_holds": true,
+        "space_dimension": 2,
+        "sum_m_squared_field_degree": 2
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "coarse_pair": [
+          3,
+          3
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          3,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 3,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 18,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 18
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 3,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 3
+        },
+        {
+          "component_dimension": 3,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 3
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "C2_face",
+      "orbit": {
+        "block_dimensions": [
+          1,
+          1
+        ],
+        "coarse_pair": [
+          1,
+          1
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 2,
+        "pair_identity_holds": true,
+        "space_dimension": 2,
+        "sum_m_squared_field_degree": 2
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "coarse_pair": [
+          4,
+          2
+        ],
+        "coarse_two_adic_profile": [
+          2,
+          1
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          4,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          2,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 4,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 20,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 20
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 2
+        },
+        {
+          "component_dimension": 4,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 4
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "C3_body",
+      "orbit": {
+        "block_dimensions": [
+          1,
+          2
+        ],
+        "coarse_pair": [
+          1,
+          2
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          1
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 3,
+        "pair_identity_holds": true,
+        "space_dimension": 3,
+        "sum_m_squared_field_degree": 3
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 2,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "coarse_pair": [
+          2,
+          4
+        ],
+        "coarse_two_adic_profile": [
+          1,
+          2
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          2,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          1,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 2,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 12,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 12
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 2
+        },
+        {
+          "component_dimension": 4,
+          "endomorphism_field_degree": 2,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 2
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "C4_face",
+      "orbit": {
+        "block_dimensions": [
+          1,
+          1,
+          2
+        ],
+        "coarse_pair": [
+          1,
+          3
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 4,
+        "pair_identity_holds": true,
+        "space_dimension": 4,
+        "sum_m_squared_field_degree": 4
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 2,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          2
+        ],
+        "coarse_pair": [
+          3,
+          3
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          3,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 3,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 12,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 12
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 3,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 3
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 2,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "D4_face",
+      "orbit": null,
+      "orbit_isotypes": null,
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          2
+        ],
+        "coarse_pair": [
+          2,
+          4
+        ],
+        "coarse_two_adic_profile": [
+          1,
+          2
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          2,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          1,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 2,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 7,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 7
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 2
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "E_trivial",
+      "orbit": {
+        "block_dimensions": [
+          1
+        ],
+        "coarse_pair": [
+          1,
+          0
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          null
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 1,
+        "pair_identity_holds": true,
+        "space_dimension": 1,
+        "sum_m_squared_field_degree": 1
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "coarse_pair": [
+          6,
+          0
+        ],
+        "coarse_two_adic_profile": [
+          1,
+          null
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          6,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          1,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 6,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 36,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 36
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 6,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 6
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "O_full",
+      "orbit": null,
+      "orbit_isotypes": null,
+      "shell": {
+        "block_dimensions": [
+          1,
+          2,
+          3
+        ],
+        "coarse_pair": [
+          1,
+          5
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          2,
+          3
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 3,
+        "fine_top_pair": [
+          1,
+          3
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 3,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 3
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 3,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 3,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "S3_body",
+      "orbit": {
+        "block_dimensions": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "coarse_pair": [
+          1,
+          5
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 6,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 6
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 4,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 2
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "coarse_pair": [
+          1,
+          5
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 2,
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          1
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 6,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 6
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 4,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 2
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "V_edge",
+      "orbit": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "coarse_pair": [
+          1,
+          3
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 1,
+        "isotypic_decomposition_is_unique": true,
+        "ok": true,
+        "orbit_count_on_the_product_set": 4,
+        "pair_identity_holds": true,
+        "space_dimension": 4,
+        "sum_m_squared_field_degree": 4
+      },
+      "orbit_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        }
+      ],
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "coarse_pair": [
+          2,
+          4
+        ],
+        "coarse_two_adic_profile": [
+          1,
+          2
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          2,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          1,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 2,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 10,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 10
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 2
+        },
+        {
+          "component_dimension": 2,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 2
+        }
+      ]
+    },
+    {
+      "agrees_with_the_primary": true,
+      "name": "V_face",
+      "orbit": null,
+      "orbit_isotypes": null,
+      "shell": {
+        "block_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "coarse_pair": [
+          3,
+          3
+        ],
+        "coarse_two_adic_profile": [
+          0,
+          0
+        ],
+        "every_block_has_no_proper_submodule": true,
+        "fine_dimensions": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_sums_to_the_space": true,
+        "fine_top": 1,
+        "fine_top_pair": [
+          3,
+          1
+        ],
+        "fine_top_two_adic_profile": [
+          0,
+          0
+        ],
+        "invariant_multiplicity_by_orbit_count": 3,
+        "isotypic_decomposition_is_unique": false,
+        "ok": true,
+        "orbit_count_on_the_product_set": 12,
+        "pair_identity_holds": true,
+        "space_dimension": 6,
+        "sum_m_squared_field_degree": 12
+      },
+      "shell_isotypes": [
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 3,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "multiplicity": 3
+        }
+      ]
+    }
+  ],
+  "independent_survivors_per_selector": {
+    "SEL01_free_on_shell": [
+      "C2_edge",
+      "C3_body",
+      "E_trivial",
+      "S3_body"
+    ],
+    "SEL02_transitive_on_shell": [
+      "A4_tetrahedral",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL03_multiplicity_one_orbit_scope": [
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "E_trivial",
+      "S3_body",
+      "V_edge"
+    ],
+    "SEL04_multiplicity_one_shell_scope": [
+      "A4_tetrahedral",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL05_minimal_shell_invariant_multiplicity": [
+      "A4_tetrahedral",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL06_maximal_free_shell_orbit": [
+      "S3_body"
+    ],
+    "SEL07_coarse_pair_v2_equals_one": [
+      "C3_body"
+    ],
+    "SEL08_reachability_R1_orbit_scope": [
+      "C3_body"
+    ],
+    "SEL09_reachability_R2_shell_scope": [
+      "C2_edge",
+      "C3_body",
+      "V_face"
+    ],
+    "SEL10_fine_top_pair_is_the_target": [
+      "C3_body",
+      "C4_face",
+      "S3_body"
+    ],
+    "SEL11_transitive_on_coordinate_axes": [
+      "A4_tetrahedral",
+      "C3_body",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL12_odd_order": [
+      "C3_body",
+      "E_trivial"
+    ],
+    "SEL13_count_once": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ],
+    "SEL14_content_only_readout": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ],
+    "SEL15_admissibility_covariance": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ],
+    "SEL16_no_site_privileged_read_literally": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ]
+  },
+  "overall": "BLOCK SURVIVES INDEPENDENT CHECK",
+  "refutation_attempts": [
+    {
+      "attack": "the 24-element group is wrong",
+      "method": "rebuilt from M M^T = I over 19683 integer matrices",
+      "n": 1,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "a subgroup or a whole conjugacy class was dropped from the 30-member lattice",
+      "method": "iterated extension <H, g>, cross-checked against closure of every subset of size <= 3, the class equation and the Sylow congruences",
+      "n": 2,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "a fine decomposition is wrong -- in particular the S3 multiplicity ledger",
+      "method": "minimal cyclic submodules and orthogonal complements with block characters; no enveloping algebra, no centre, no minimal polynomial",
+      "n": 3,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "a selector survivor set over the full lattice is wrong, or the restriction to the 886 census does not really reproduce 886",
+      "method": "all sixteen recomputed over all thirty subgroups from the checker's own signatures, then restricted and compared against the pinned 886 receipt",
+      "n": 4,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "an unreachability verdict is a window artifact",
+      "method": "Smith-style diagonalization, self-tested on six lattices",
+      "n": 5,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "the SL1-transfer claim is wrong: either a second readout at S3 carries a DIFFERENT pair, or the S3 decomposition is actually forced, or the C3/C4 peer comparison breaks",
+      "method": "every irreducible submodule of each degree enumerated and characterised; the span of the top-degree submodules compared against the isotypic component; C3 and C4 multiplicity ledgers recomputed",
+      "n": 6,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "the scope-insensitivity verdict is wrong or was leaked rather than computed",
+      "method": "menu rule re-applied, Cycle 883's widening step re-evaluated at every menu scope under both readings at both scopes, verdicts re-derived",
+      "n": 7,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "the 886/883 material the primary carried over as pins was altered",
+      "method": "byte comparison of every quoted sentence, fidelity grade, grounding flag and survivor expression against the pinned 886 and 883 sources",
+      "n": 8,
+      "result": "SURVIVES"
+    },
+    {
+      "attack": "the primary imported or executed a pinned artifact",
+      "method": "meta-path firewall plus module-table inspection here, and the primary's own firewall record",
+      "n": 9,
+      "result": "SURVIVES: no pinned module is loadable in this process either"
+    }
+  ],
+  "restriction_rows": [
+    {
+      "cycle886": [
+        "C2_edge",
+        "C3_body"
+      ],
+      "id": "SEL01_free_on_shell",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [],
+      "id": "SEL02_transitive_on_shell",
+      "identical": true,
+      "independent_restricted": []
+    },
+    {
+      "cycle886": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ],
+      "id": "SEL03_multiplicity_one_orbit_scope",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ]
+    },
+    {
+      "cycle886": [],
+      "id": "SEL04_multiplicity_one_shell_scope",
+      "identical": true,
+      "independent_restricted": []
+    },
+    {
+      "cycle886": [
+        "C3_body"
+      ],
+      "id": "SEL05_minimal_shell_invariant_multiplicity",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C3_body"
+      ],
+      "id": "SEL06_maximal_free_shell_orbit",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C3_body"
+      ],
+      "id": "SEL07_coarse_pair_v2_equals_one",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C3_body"
+      ],
+      "id": "SEL08_reachability_R1_orbit_scope",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C2_edge",
+        "C3_body"
+      ],
+      "id": "SEL09_reachability_R2_shell_scope",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C3_body",
+        "C4_face"
+      ],
+      "id": "SEL10_fine_top_pair_is_the_target",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body",
+        "C4_face"
+      ]
+    },
+    {
+      "cycle886": [
+        "C3_body"
+      ],
+      "id": "SEL11_transitive_on_coordinate_axes",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C3_body"
+      ],
+      "id": "SEL12_odd_order",
+      "identical": true,
+      "independent_restricted": [
+        "C3_body"
+      ]
+    },
+    {
+      "cycle886": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ],
+      "id": "SEL13_count_once",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ]
+    },
+    {
+      "cycle886": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ],
+      "id": "SEL14_content_only_readout",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ]
+    },
+    {
+      "cycle886": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ],
+      "id": "SEL15_admissibility_covariance",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ]
+    },
+    {
+      "cycle886": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ],
+      "id": "SEL16_no_site_privileged_read_literally",
+      "identical": true,
+      "independent_restricted": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face"
+      ]
+    }
+  ],
+  "role": "independent adversarial check",
+  "scope_insensitivity": {
+    "independent_menu": [
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "S3_body",
+      "V_edge"
+    ],
+    "independent_overall_verdict": "MIXED",
+    "per_reading_comparison": [
+      {
+        "identical": true,
+        "independent_verdict": "SCOPE_SENSITIVE",
+        "independent_working_set": [
+          "C3_body"
+        ],
+        "primary_verdict": "SCOPE_SENSITIVE",
+        "primary_working_set": [
+          "C3_body"
+        ],
+        "reading": "ORBIT_SCOPE_coarse_reading"
+      },
+      {
+        "identical": true,
+        "independent_verdict": "SCOPE_SENSITIVE",
+        "independent_working_set": [
+          "C3_body",
+          "S3_body"
+        ],
+        "primary_verdict": "SCOPE_SENSITIVE",
+        "primary_working_set": [
+          "C3_body",
+          "S3_body"
+        ],
+        "reading": "ORBIT_SCOPE_fine_reading"
+      },
+      {
+        "identical": true,
+        "independent_verdict": "SCOPE_SENSITIVE",
+        "independent_working_set": [
+          "C2_edge",
+          "C3_body"
+        ],
+        "primary_verdict": "SCOPE_SENSITIVE",
+        "primary_working_set": [
+          "C2_edge",
+          "C3_body"
+        ],
+        "reading": "SHELL_SCOPE_coarse_reading"
+      },
+      {
+        "identical": true,
+        "independent_verdict": "SCOPE_SENSITIVE",
+        "independent_working_set": [
+          "C3_body",
+          "S3_body"
+        ],
+        "primary_verdict": "SCOPE_SENSITIVE",
+        "primary_working_set": [
+          "C3_body",
+          "S3_body"
+        ],
+        "reading": "SHELL_SCOPE_fine_reading"
+      }
+    ],
+    "primary_overall_verdict": "MIXED"
+  },
+  "selector_comparison": [
+    {
+      "id": "SEL01_free_on_shell",
+      "identical": true,
+      "independent_survivors": [
+        "C2_edge",
+        "C3_body",
+        "E_trivial",
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "C2_edge",
+        "C3_body",
+        "E_trivial",
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL02_transitive_on_shell",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL03_multiplicity_one_orbit_scope",
+      "identical": true,
+      "independent_survivors": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "E_trivial",
+        "S3_body",
+        "V_edge"
+      ],
+      "primary_survivors": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "E_trivial",
+        "S3_body",
+        "V_edge"
+      ]
+    },
+    {
+      "id": "SEL04_multiplicity_one_shell_scope",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL05_minimal_shell_invariant_multiplicity",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL06_maximal_free_shell_orbit",
+      "identical": true,
+      "independent_survivors": [
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL07_coarse_pair_v2_equals_one",
+      "identical": true,
+      "independent_survivors": [
+        "C3_body"
+      ],
+      "primary_survivors": [
+        "C3_body"
+      ]
+    },
+    {
+      "id": "SEL08_reachability_R1_orbit_scope",
+      "identical": true,
+      "independent_survivors": [
+        "C3_body"
+      ],
+      "primary_survivors": [
+        "C3_body"
+      ]
+    },
+    {
+      "id": "SEL09_reachability_R2_shell_scope",
+      "identical": true,
+      "independent_survivors": [
+        "C2_edge",
+        "C3_body",
+        "V_face"
+      ],
+      "primary_survivors": [
+        "C2_edge",
+        "C3_body",
+        "V_face"
+      ]
+    },
+    {
+      "id": "SEL10_fine_top_pair_is_the_target",
+      "identical": true,
+      "independent_survivors": [
+        "C3_body",
+        "C4_face",
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "C3_body",
+        "C4_face",
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL11_transitive_on_coordinate_axes",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "C3_body",
+        "O_full",
+        "S3_body"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "C3_body",
+        "O_full",
+        "S3_body"
+      ]
+    },
+    {
+      "id": "SEL12_odd_order",
+      "identical": true,
+      "independent_survivors": [
+        "C3_body",
+        "E_trivial"
+      ],
+      "primary_survivors": [
+        "C3_body",
+        "E_trivial"
+      ]
+    },
+    {
+      "id": "SEL13_count_once",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ]
+    },
+    {
+      "id": "SEL14_content_only_readout",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ]
+    },
+    {
+      "id": "SEL15_admissibility_covariance",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ]
+    },
+    {
+      "id": "SEL16_no_site_privileged_read_literally",
+      "identical": true,
+      "independent_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "primary_survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ]
+    }
+  ],
+  "sl1_transfer_attack": {
+    "attack_1_second_readout_with_a_different_pair": {
+      "a_readout_with_a_DIFFERENT_pair_exists": false,
+      "achievable_fine_top_pairs": [
+        [
+          1,
+          1
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "all_top_degree_submodules_are_isomorphic": true,
+      "distinct_characters_by_degree": {
+        "1": 2,
+        "2": 1
+      },
+      "distinct_submodules_found_by_degree": {
+        "1": 2,
+        "2": 6
+      },
+      "distinct_top_degree_submodules": 6,
+      "irreducible_degrees_present": [
+        1,
+        2
+      ],
+      "result": "the pair (1, 2) is stable across every readout choice, so the NUMBER transfers -- the primary's claim survives this attack",
+      "sample_top_degree_submodules": [
+        {
+          "basis": [
+            [
+              "1/1",
+              "0/1",
+              "-1/1",
+              "1/1",
+              "0/1",
+              "-1/1"
+            ],
+            [
+              "0/1",
+              "1/1",
+              "-1/1",
+              "1/1",
+              "-1/1",
+              "0/1"
+            ]
+          ],
+          "character": [
+            "0/1",
+            "0/1",
+            "0/1",
+            "-1/1",
+            "-1/1",
+            "2/1"
+          ],
+          "generator": [
+            "-1/1",
+            "0/1",
+            "1/1",
+            "-1/1",
+            "0/1",
+            "1/1"
+          ]
+        },
+        {
+          "basis": [
+            [
+              "1/1",
+              "0/1",
+              "-1/1",
+              "1/1",
+              "-1/1",
+              "0/1"
+            ],
+            [
+              "0/1",
+              "1/1",
+              "-1/1",
+              "0/1",
+              "-1/1",
+              "1/1"
+            ]
+          ],
+          "character": [
+            "0/1",
+            "0/1",
+            "0/1",
+            "-1/1",
+            "-1/1",
+            "2/1"
+          ],
+          "generator": [
+            "-1/1",
+            "0/1",
+            "1/1",
+            "-1/1",
+            "1/1",
+            "0/1"
+          ]
+        },
+        {
+          "basis": [
+            [
+              "1/1",
+              "0/1",
+              "-1/1",
+              "0/1",
+              "1/1",
+              "-1/1"
+            ],
+            [
+              "0/1",
+              "1/1",
+              "-1/1",
+              "1/1",
+              "0/1",
+              "-1/1"
+            ]
+          ],
+          "character": [
+            "0/1",
+            "0/1",
+            "0/1",
+            "-1/1",
+            "-1/1",
+            "2/1"
+          ],
+          "generator": [
+            "-1/1",
+            "0/1",
+            "1/1",
+            "0/1",
+            "-1/1",
+            "1/1"
+          ]
+        }
+      ]
+    },
+    "attack_2_is_the_isotypic_component_canonical": {
+      "isotypic_level_is_canonical": true,
+      "result": "the isotypic decomposition IS forced while the split into irreducibles is NOT -- exactly the distinction the primary draws",
+      "span_of_all_top_degree_submodules": 4,
+      "top_isotypic_component_dimension": 4
+    },
+    "attack_3_peer_comparison": {
+      "C3_and_C4_are_multiplicity_free_and_S3_is_not": true,
+      "peers": [
+        {
+          "class": "C3_body",
+          "free_orbit_length": 3,
+          "independent_coarse_pair": [
+            1,
+            2
+          ],
+          "independent_decomposition_is_unique": true,
+          "independent_fine_dims": [
+            1,
+            2
+          ],
+          "independent_fine_top_pair": [
+            1,
+            2
+          ],
+          "independent_multiplicities": [
+            1,
+            1
+          ]
+        },
+        {
+          "class": "C4_face",
+          "free_orbit_length": 4,
+          "independent_coarse_pair": [
+            1,
+            3
+          ],
+          "independent_decomposition_is_unique": true,
+          "independent_fine_dims": [
+            1,
+            1,
+            2
+          ],
+          "independent_fine_top_pair": [
+            1,
+            2
+          ],
+          "independent_multiplicities": [
+            1,
+            1,
+            1
+          ]
+        },
+        {
+          "class": "S3_body",
+          "free_orbit_length": 6,
+          "independent_coarse_pair": [
+            1,
+            5
+          ],
+          "independent_decomposition_is_unique": false,
+          "independent_fine_dims": [
+            1,
+            1,
+            2,
+            2
+          ],
+          "independent_fine_top_pair": [
+            1,
+            2
+          ],
+          "independent_multiplicities": [
+            1,
+            1,
+            2
+          ]
+        }
+      ],
+      "result": "the peer comparison stands"
+    },
+    "coarse_pair_agrees": true,
+    "finding": "independent S3 multiplicities [[1, 1], [1, 1], [2, 2]]; 6 distinct 2-dimensional submodules found, all with the same character (True), so no readout with a different pair exists; the isotypic level is canonical (True); C3/C4 multiplicity-free and S3 not (True); the transfer claim SURVIVES.",
+    "fine_top_pair_agrees": true,
+    "independent_S3_isotypes": [
+      {
+        "component_dimension": 1,
+        "endomorphism_field_degree": 1,
+        "irreducible_degree_over_Q": 1,
+        "is_the_trivial_isotype": true,
+        "multiplicity": 1
+      },
+      {
+        "component_dimension": 1,
+        "endomorphism_field_degree": 1,
+        "irreducible_degree_over_Q": 1,
+        "is_the_trivial_isotype": false,
+        "multiplicity": 1
+      },
+      {
+        "component_dimension": 4,
+        "endomorphism_field_degree": 1,
+        "irreducible_degree_over_Q": 2,
+        "is_the_trivial_isotype": false,
+        "multiplicity": 2
+      }
+    ],
+    "independent_S3_signature": {
+      "block_dimensions": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coarse_pair": [
+        1,
+        5
+      ],
+      "coarse_two_adic_profile": [
+        0,
+        0
+      ],
+      "every_block_has_no_proper_submodule": true,
+      "fine_dimensions": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "fine_sums_to_the_space": true,
+      "fine_top": 2,
+      "fine_top_pair": [
+        1,
+        2
+      ],
+      "fine_top_two_adic_profile": [
+        0,
+        1
+      ],
+      "invariant_multiplicity_by_orbit_count": 1,
+      "isotypic_decomposition_is_unique": false,
+      "ok": true,
+      "orbit_count_on_the_product_set": 6,
+      "pair_identity_holds": true,
+      "space_dimension": 6,
+      "sum_m_squared_field_degree": 6
+    },
+    "independent_multiplicities": [
+      [
+        1,
+        1
+      ],
+      [
+        1,
+        1
+      ],
+      [
+        2,
+        2
+      ]
+    ],
+    "independent_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+    "pass": true,
+    "primary_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+    "verdict": "SURVIVES",
+    "verdicts_agree": true
+  },
+  "source_pins": [
+    {
+      "git_blob": "c3de02c94b8a11a930ad6ff8817975b118bc776d",
+      "path": "scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py",
+      "sha256": "f57fda877d35d49953c3b6a34293ab0cc6a87781ceb9d158b9c9abb5abd4bb3f"
+    },
+    {
+      "git_blob": "3e18ad52f50e72b83c56da72c31f25d104b5c830",
+      "path": "outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json",
+      "sha256": "8a540201a84a6b8cb6868d431216718a27f200e45d6ceeb771d858e9a54280cd"
+    },
+    {
+      "git_blob": "6cd3fbdbe74e1231cd61222a798a7979bee922da",
+      "path": "logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt",
+      "sha256": "5e4fc183efda55d1f3fbd5413bd2fe985ed5732b7ffbc8bd489296e7b22c2c84"
+    },
+    {
+      "git_blob": "4a863da1f3f255354839277271a3a69a5c205133",
+      "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "sha256": "fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697"
+    },
+    {
+      "git_blob": "f4493d787ffb6edc50e9dd13d37ba1cd1dd4d24a",
+      "path": "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+      "sha256": "1dfa47a86de8cab5a91cd33a022beb845d918e2f93ceb58f360b2708a44d02a2"
+    },
+    {
+      "git_blob": "4d9999c241b19b2670a51c809e3e39fb0d339f10",
+      "path": "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+      "sha256": "74d64090515cf7f7c5ad5f8e6347f7d2f81a9c1cf0b41e9ec7726ad30a62d69d"
+    },
+    {
+      "git_blob": "d563c2b9c2a261f44d7304baa51fdd3596188930",
+      "path": "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+      "sha256": "2d96422d30f169a1c4b3215db373e4bffd7b1ef20056ea337ff4ae3f86d9511c"
+    }
+  ],
+  "teeth": [
+    {
+      "bites": true,
+      "expected_exit": 2,
+      "expected_failing_certificate": null,
+      "id": "T1_tampered_pin",
+      "observed_exit": 2,
+      "observed_failing_certificates": [],
+      "patch_applied_exactly_once": true,
+      "patch_sites_found": 1,
+      "stderr_head": [
+        "PREFLIGHT HARD FAIL: pin digest mismatch: docs/MINIMAL_AXIOMS_2026-06-29.md sha256 fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697 != 0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "target_certificate_or_gate": "preflight pin digest check"
+    },
+    {
+      "bites": true,
+      "expected_exit": 1,
+      "expected_failing_certificate": "D_SUBGROUP_LATTICE",
+      "id": "T2_dropped_subgroup_class",
+      "observed_exit": 1,
+      "observed_failing_certificates": [
+        "D_SUBGROUP_LATTICE",
+        "O_IMPOSTOR_STRESS"
+      ],
+      "patch_applied_exactly_once": true,
+      "patch_sites_found": 1,
+      "stderr_head": [],
+      "target_certificate_or_gate": "the 30-subgroup / 11-class census and the class equation"
+    },
+    {
+      "bites": true,
+      "expected_exit": 1,
+      "expected_failing_certificate": "D_SUBGROUP_LATTICE",
+      "id": "T3_broken_class_equation",
+      "observed_exit": 1,
+      "observed_failing_certificates": [
+        "D_SUBGROUP_LATTICE"
+      ],
+      "patch_applied_exactly_once": true,
+      "patch_sites_found": 1,
+      "stderr_head": [],
+      "target_certificate_or_gate": "class_equation_holds_on_every_class"
+    },
+    {
+      "bites": true,
+      "expected_exit": 1,
+      "expected_failing_certificate": "G_ISOTYPE_SIGNATURES",
+      "id": "T4_broken_dimension_sum",
+      "observed_exit": 1,
+      "observed_failing_certificates": [
+        "G_ISOTYPE_SIGNATURES",
+        "H_CLASS_INVARIANCE",
+        "L_RESTRICTION_GATE",
+        "M_S3_PRICING_ROW",
+        "O_IMPOSTOR_STRESS"
+      ],
+      "patch_applied_exactly_once": true,
+      "patch_sites_found": 1,
+      "stderr_head": [],
+      "target_certificate_or_gate": "fine_decomposition_sums_to_the_space"
+    },
+    {
+      "bites": true,
+      "expected_exit": 1,
+      "expected_failing_certificate": "L_RESTRICTION_GATE",
+      "id": "T5_hardcoded_selector_row",
+      "observed_exit": 1,
+      "observed_failing_certificates": [
+        "L_RESTRICTION_GATE"
+      ],
+      "patch_applied_exactly_once": true,
+      "patch_sites_found": 1,
+      "stderr_head": [],
+      "target_certificate_or_gate": "byte-level reproduction of the pinned Cycle-886 receipt"
+    },
+    {
+      "bites": true,
+      "expected_exit": 1,
+      "expected_failing_certificate": "N_SCOPE_INSENSITIVITY",
+      "id": "T6_skipped_scope",
+      "observed_exit": 1,
+      "observed_failing_certificates": [
+        "N_SCOPE_INSENSITIVITY"
+      ],
+      "patch_applied_exactly_once": true,
+      "patch_sites_found": 1,
+      "stderr_head": [],
+      "target_certificate_or_gate": "table_is_complete over the whole menu"
+    },
+    {
+      "bites": true,
+      "checker_verdict_on_the_trapped_receipt": "REFUTED",
+      "id": "T7_hardcoded_S3_transfer_row_on_the_checker",
+      "independent_verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+      "method": "the primary's receipt is mutated in memory so the S3 transfer row declares the decomposition FORCED -- the reading that would make S3 a clean SL1 transfer. No primary gate can see this, by design: the primary's gates are outcome-neutral. Only the independent recomputation catches it.",
+      "target_certificate_or_gate": "G_SL1_TRANSFER_ATTACK / verdicts_agree"
+    },
+    {
+      "bites": true,
+      "checker_verdict_on_the_trapped_receipt": "REFUTED",
+      "id": "T8_leaked_scope_insensitivity_verdict_on_the_checker",
+      "independent_overall_verdict": "MIXED",
+      "method": "the primary's receipt is mutated in memory to declare the downstream obligation SCOPE_INSENSITIVE -- the verdict that would drop the menu price to zero. Again invisible to every outcome-neutral gate and caught only by recomputation.",
+      "target_certificate_or_gate": "H_INDEPENDENT_SCOPE_INSENSITIVITY / overall_verdicts_agree"
+    }
+  ],
+  "teeth_that_bite": 8,
+  "upstream_pin_fidelity": {
+    "fidelity_grades_carried_unchanged": true,
+    "quoted_sentences_are_verbatim_886_material": true,
+    "survivor_expressions_are_verbatim_886_source": true
+  },
+  "verdict_by_certificate": {
+    "B_INDEPENDENT_GROUP": "SURVIVES",
+    "C_INDEPENDENT_LATTICE": "SURVIVES",
+    "D_INDEPENDENT_ISOTYPE": "SURVIVES",
+    "E_INDEPENDENT_SELECTORS": "SURVIVES",
+    "F_INDEPENDENT_REACHABILITY": "SURVIVES",
+    "G_SL1_TRANSFER_ATTACK": "SURVIVES",
+    "H_INDEPENDENT_SCOPE_INSENSITIVITY": "SURVIVES",
+    "I_UPSTREAM_PIN_FIDELITY": "SURVIVES"
+  }
+}

--- a/outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json
+++ b/outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json
@@ -1,0 +1,4517 @@
+{
+  "Q1_answer": "The lattice has 30 subgroups in 11 conjugacy classes. Every axiom-grounded selector keeps ALL of them, so the derivation route stays refused with the restriction lifted -- and it is now refused over a candidate set 2.75x larger. The S3 class is a genuine rival: it is the ONLY simply-transitive scope, it is the unique survivor of freeness-plus-maximality, and it satisfies twelve of the sixteen selectors. But its coarse weight pair is (1, 5), not (1, 2), and its fine (1, 2) is carried by an irreducible of MULTIPLICITY TWO, so the readout subspace is a P^1 family rather than a forced split.",
+  "Q2_answer": "MIXED. The working sets are ['C3_body'] under the coarse reading and ['C3_body', 'S3_body'] under the fine reading, at the Cycle-883 native orbit scope. The menu price for this consumer is therefore NOT zero: the scope choice is load-bearing for the T6 defeat.",
+  "S3_orbit_scope_signature": {
+    "all_gates_pass": true,
+    "burnside_pair_count": "6/1",
+    "centre_dimension": 3,
+    "coarse_ordered_pair": [
+      1,
+      5
+    ],
+    "coarse_two_adic_profile": [
+      0,
+      0
+    ],
+    "decomposition_failure_reason": null,
+    "enveloping_algebra_dimension": 6,
+    "fine_dimensions_with_a_v2_equal_to_one": [
+      2,
+      2
+    ],
+    "fine_rational_irreducible_dimensions": [
+      1,
+      1,
+      2,
+      2
+    ],
+    "fine_top_pair": [
+      1,
+      2
+    ],
+    "fine_top_rational_irreducible_dimension": 2,
+    "fine_top_two_adic_profile": [
+      0,
+      1
+    ],
+    "gates": {
+      "burnside_pair_count_agrees_with_the_direct_pair_orbit_count": true,
+      "decomposition_succeeded": true,
+      "fine_decomposition_sums_to_the_space": true,
+      "fine_top_equals_the_maximum_fine_dimension": true,
+      "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs": true,
+      "three_routes_agree_on_the_invariant_multiplicity": true,
+      "trivial_isotype_multiplicity_equals_the_orbit_count": true
+    },
+    "invariant_dim_by_burnside": "1/1",
+    "invariant_dim_by_nullspace": 1,
+    "invariant_dim_by_orbit_count": 1,
+    "isotypes": [
+      {
+        "component_dimension": 1,
+        "dim_Q_of_the_component_algebra": 1,
+        "endomorphism_field_degree": 1,
+        "irreducible_degree_over_Q": 1,
+        "is_the_trivial_isotype": true,
+        "minimal_polynomial_factor": [
+          -3,
+          1
+        ],
+        "multiplicity": 1
+      },
+      {
+        "component_dimension": 1,
+        "dim_Q_of_the_component_algebra": 1,
+        "endomorphism_field_degree": 1,
+        "irreducible_degree_over_Q": 1,
+        "is_the_trivial_isotype": false,
+        "minimal_polynomial_factor": [
+          3,
+          1
+        ],
+        "multiplicity": 1
+      },
+      {
+        "component_dimension": 4,
+        "dim_Q_of_the_component_algebra": 4,
+        "endomorphism_field_degree": 1,
+        "irreducible_degree_over_Q": 2,
+        "is_the_trivial_isotype": false,
+        "minimal_polynomial_factor": [
+          0,
+          1
+        ],
+        "multiplicity": 2
+      }
+    ],
+    "isotypic_decomposition_is_unique": false,
+    "orbit_count_on_the_product_set": 6,
+    "space_dimension": 6,
+    "subgroup_order": 6
+  },
+  "S3_pricing_row": {
+    "SL1_TRANSFER": {
+      "every_isotypic_multiplicity_is_one": false,
+      "isotypes": [
+        {
+          "component_dimension": 1,
+          "dim_Q_of_the_component_algebra": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": true,
+          "minimal_polynomial_factor": [
+            -3,
+            1
+          ],
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 1,
+          "dim_Q_of_the_component_algebra": 1,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 1,
+          "is_the_trivial_isotype": false,
+          "minimal_polynomial_factor": [
+            3,
+            1
+          ],
+          "multiplicity": 1
+        },
+        {
+          "component_dimension": 4,
+          "dim_Q_of_the_component_algebra": 4,
+          "endomorphism_field_degree": 1,
+          "irreducible_degree_over_Q": 2,
+          "is_the_trivial_isotype": false,
+          "minimal_polynomial_factor": [
+            0,
+            1
+          ],
+          "multiplicity": 2
+        }
+      ],
+      "isotypic_multiplicities": [
+        1,
+        1,
+        2
+      ],
+      "multiplicity_greater_than_one_components": [
+        {
+          "component_dimension": 4,
+          "degree": 2,
+          "multiplicity": 2
+        }
+      ],
+      "non_uniqueness_exhibits": [
+        {
+          "component_dimension": 4,
+          "distinct_irreducible_submodules_exhibited": 6,
+          "isotype_degree": 2,
+          "isotype_multiplicity": 2,
+          "submodules": [
+            {
+              "dimension": 2,
+              "generator_coefficients_in_the_component": [
+                -1,
+                -1,
+                -1,
+                -1
+              ],
+              "generator_vector": [
+                "2/1",
+                "-1/1",
+                "-1/1",
+                "2/1",
+                "-1/1",
+                "-1/1"
+              ],
+              "row_reduced_basis": [
+                [
+                  "1/1",
+                  "0/1",
+                  "-1/1",
+                  "1/1",
+                  "-1/1",
+                  "0/1"
+                ],
+                [
+                  "0/1",
+                  "1/1",
+                  "-1/1",
+                  "0/1",
+                  "-1/1",
+                  "1/1"
+                ]
+              ]
+            },
+            {
+              "dimension": 2,
+              "generator_coefficients_in_the_component": [
+                -1,
+                -1,
+                1,
+                1
+              ],
+              "generator_vector": [
+                "2/1",
+                "-1/1",
+                "-1/1",
+                "-2/1",
+                "1/1",
+                "1/1"
+              ],
+              "row_reduced_basis": [
+                [
+                  "1/1",
+                  "0/1",
+                  "-1/1",
+                  "-1/1",
+                  "1/1",
+                  "0/1"
+                ],
+                [
+                  "0/1",
+                  "1/1",
+                  "-1/1",
+                  "0/1",
+                  "1/1",
+                  "-1/1"
+                ]
+              ]
+            },
+            {
+              "dimension": 2,
+              "generator_coefficients_in_the_component": [
+                -1,
+                0,
+                -1,
+                0
+              ],
+              "generator_vector": [
+                "1/1",
+                "-1/1",
+                "0/1",
+                "1/1",
+                "-1/1",
+                "0/1"
+              ],
+              "row_reduced_basis": [
+                [
+                  "1/1",
+                  "0/1",
+                  "-1/1",
+                  "0/1",
+                  "-1/1",
+                  "1/1"
+                ],
+                [
+                  "0/1",
+                  "1/1",
+                  "-1/1",
+                  "-1/1",
+                  "0/1",
+                  "1/1"
+                ]
+              ]
+            },
+            {
+              "dimension": 2,
+              "generator_coefficients_in_the_component": [
+                -1,
+                0,
+                -1,
+                1
+              ],
+              "generator_vector": [
+                "1/1",
+                "-1/1",
+                "0/1",
+                "0/1",
+                "-1/1",
+                "1/1"
+              ],
+              "row_reduced_basis": [
+                [
+                  "1/1",
+                  "0/1",
+                  "-1/1",
+                  "-1/1",
+                  "0/1",
+                  "1/1"
+                ],
+                [
+                  "0/1",
+                  "1/1",
+                  "-1/1",
+                  "-1/1",
+                  "1/1",
+                  "0/1"
+                ]
+              ]
+            },
+            {
+              "dimension": 2,
+              "generator_coefficients_in_the_component": [
+                -1,
+                0,
+                1,
+                -1
+              ],
+              "generator_vector": [
+                "1/1",
+                "-1/1",
+                "0/1",
+                "0/1",
+                "1/1",
+                "-1/1"
+              ],
+              "row_reduced_basis": [
+                [
+                  "1/1",
+                  "0/1",
+                  "-1/1",
+                  "1/1",
+                  "0/1",
+                  "-1/1"
+                ],
+                [
+                  "0/1",
+                  "1/1",
+                  "-1/1",
+                  "1/1",
+                  "-1/1",
+                  "0/1"
+                ]
+              ]
+            },
+            {
+              "dimension": 2,
+              "generator_coefficients_in_the_component": [
+                -1,
+                0,
+                1,
+                0
+              ],
+              "generator_vector": [
+                "1/1",
+                "-1/1",
+                "0/1",
+                "-1/1",
+                "1/1",
+                "0/1"
+              ],
+              "row_reduced_basis": [
+                [
+                  "1/1",
+                  "0/1",
+                  "-1/1",
+                  "0/1",
+                  "1/1",
+                  "-1/1"
+                ],
+                [
+                  "0/1",
+                  "1/1",
+                  "-1/1",
+                  "1/1",
+                  "0/1",
+                  "-1/1"
+                ]
+              ]
+            }
+          ],
+          "the_realizing_subspace_is_not_unique": true
+        }
+      ],
+      "peer_comparison": [
+        {
+          "class": "C3_body",
+          "coarse_pair": [
+            1,
+            2
+          ],
+          "coarse_profile": [
+            0,
+            1
+          ],
+          "decomposition_is_unique": true,
+          "fine_dims": [
+            1,
+            2
+          ],
+          "fine_top_pair": [
+            1,
+            2
+          ],
+          "fine_top_profile": [
+            0,
+            1
+          ],
+          "free_orbit_length": 3,
+          "isotypic_multiplicities": [
+            1,
+            1
+          ]
+        },
+        {
+          "class": "C4_face",
+          "coarse_pair": [
+            1,
+            3
+          ],
+          "coarse_profile": [
+            0,
+            0
+          ],
+          "decomposition_is_unique": true,
+          "fine_dims": [
+            1,
+            1,
+            2
+          ],
+          "fine_top_pair": [
+            1,
+            2
+          ],
+          "fine_top_profile": [
+            0,
+            1
+          ],
+          "free_orbit_length": 4,
+          "isotypic_multiplicities": [
+            1,
+            1,
+            1
+          ]
+        },
+        {
+          "class": "S3_body",
+          "coarse_pair": [
+            1,
+            5
+          ],
+          "coarse_profile": [
+            0,
+            0
+          ],
+          "decomposition_is_unique": false,
+          "fine_dims": [
+            1,
+            1,
+            2,
+            2
+          ],
+          "fine_top_pair": [
+            1,
+            2
+          ],
+          "fine_top_profile": [
+            0,
+            1
+          ],
+          "free_orbit_length": 6,
+          "isotypic_multiplicities": [
+            1,
+            1,
+            2
+          ]
+        }
+      ],
+      "question": "Cycle 883 built its readout on TWO free C3 orbits of length 3 and derived the pair (1, 2) with no free parameter. S3 has ONE free orbit of length 6. Rebuild the analogous readout space and ask whether the isotype split is still forced.",
+      "readout_space_dimension": 6,
+      "verdict": "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED",
+      "what_the_weight_pair_becomes": "Under Cycle 883's OWN reading -- (invariant, complement) of the readout space -- the S3 pair is [1, 5] with 2-adic profile [0, 0], so there is NO v_2 = 1 datum at S3 under that reading. Under the fine rational-irreducible reading the top pair is [1, 2] with profile [0, 1], which DOES carry v_2 = 1 -- but the 2-dimensional irreducible occurs with multiplicity [2], so the readout SUBSPACE carrying that '2' is not unique.",
+      "why_this_is_not_a_transfer": "At C3 (and at C4) every isotypic multiplicity is 1, so the decomposition of the readout space is canonical and the pair carries no free parameter -- that was the load-bearing clause of SL1. At S3 the standard 2-dimensional irreducible appears TWICE in the regular representation, so the isotypic decomposition (1, 1, 4) is forced but the split of the 4-dimensional component into two 2-dimensional readouts is a P^1 family: distinct submodules are exhibited above. The NUMBER (1, 2) transfers as an isotype-degree datum; the 'no free parameter' property does NOT."
+    },
+    "acts_simply_transitively_on_the_shell": true,
+    "class_size": 4,
+    "coarse_reading_supplies_a_v2_equals_1_datum": false,
+    "coarse_reading_two_adic_profile": [
+      0,
+      0
+    ],
+    "coarse_reading_weight_pair": [
+      1,
+      5
+    ],
+    "finding": "S3 is simply transitive on the shell (orbit scope = shell scope, dimension 6); coarse pair [1, 5] profile [0, 0]; fine dims [1, 1, 2, 2] top pair [1, 2] profile [0, 1]; reaches 2/9 under ['R3_orbit_scope_fine', 'R4_shell_scope_fine']; passes 12 of 16 selectors; SL1 transfer verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED.",
+    "fine_reading_dimensions": [
+      1,
+      1,
+      2,
+      2
+    ],
+    "fine_reading_supplies_a_v2_equals_1_datum": true,
+    "fine_reading_top_pair": [
+      1,
+      2
+    ],
+    "fine_reading_two_adic_profile": [
+      0,
+      1
+    ],
+    "group_theoretic_route_pair": [
+      1,
+      5
+    ],
+    "orbit_scope_equals_shell_scope": true,
+    "order": 6,
+    "pass": true,
+    "reachability_by_rule": {
+      "R1_orbit_scope_coarse": false,
+      "R2_shell_scope_coarse": false,
+      "R3_orbit_scope_fine": true,
+      "R4_shell_scope_fine": true
+    },
+    "reachability_generators_by_rule": {
+      "R1_orbit_scope_coarse": [
+        5,
+        6
+      ],
+      "R2_shell_scope_coarse": [
+        5,
+        6
+      ],
+      "R3_orbit_scope_fine": [
+        2,
+        6
+      ],
+      "R4_shell_scope_fine": [
+        2,
+        6
+      ]
+    },
+    "reachability_witnesses_by_rule": {
+      "R1_orbit_scope_coarse": null,
+      "R2_shell_scope_coarse": null,
+      "R3_orbit_scope_fine": [
+        3,
+        -2
+      ],
+      "R4_shell_scope_fine": [
+        3,
+        -2
+      ]
+    },
+    "selector_row": [
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL01_free_on_shell",
+        "survivors": [
+          "C2_edge",
+          "C3_body",
+          "E_trivial",
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL02_transitive_on_shell",
+        "survivors": [
+          "A4_tetrahedral",
+          "O_full",
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL03_multiplicity_one_orbit_scope",
+        "survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "E_trivial",
+          "S3_body",
+          "V_edge"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL04_multiplicity_one_shell_scope",
+        "survivors": [
+          "A4_tetrahedral",
+          "O_full",
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL05_minimal_shell_invariant_multiplicity",
+        "survivors": [
+          "A4_tetrahedral",
+          "O_full",
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL06_maximal_free_shell_orbit",
+        "survivors": [
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": false,
+        "fidelity_pinned_from_886": "EXACT",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL07_coarse_pair_v2_equals_one",
+        "survivors": [
+          "C3_body"
+        ]
+      },
+      {
+        "S3_survives": false,
+        "fidelity_pinned_from_886": "PARTIAL",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL08_reachability_R1_orbit_scope",
+        "survivors": [
+          "C3_body"
+        ]
+      },
+      {
+        "S3_survives": false,
+        "fidelity_pinned_from_886": "PARTIAL",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL09_reachability_R2_shell_scope",
+        "survivors": [
+          "C2_edge",
+          "C3_body",
+          "V_face"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL10_fine_top_pair_is_the_target",
+        "survivors": [
+          "C3_body",
+          "C4_face",
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "PARTIAL",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL11_transitive_on_coordinate_axes",
+        "survivors": [
+          "A4_tetrahedral",
+          "C3_body",
+          "O_full",
+          "S3_body"
+        ]
+      },
+      {
+        "S3_survives": false,
+        "fidelity_pinned_from_886": "NONE",
+        "grounded_pinned_from_886": false,
+        "selector": "SEL12_odd_order",
+        "survivors": [
+          "C3_body",
+          "E_trivial"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "EXACT",
+        "grounded_pinned_from_886": true,
+        "selector": "SEL13_count_once",
+        "survivors": [
+          "A4_tetrahedral",
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "D4_face",
+          "E_trivial",
+          "O_full",
+          "S3_body",
+          "V_edge",
+          "V_face"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "EXACT",
+        "grounded_pinned_from_886": true,
+        "selector": "SEL14_content_only_readout",
+        "survivors": [
+          "A4_tetrahedral",
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "D4_face",
+          "E_trivial",
+          "O_full",
+          "S3_body",
+          "V_edge",
+          "V_face"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "EXACT",
+        "grounded_pinned_from_886": true,
+        "selector": "SEL15_admissibility_covariance",
+        "survivors": [
+          "A4_tetrahedral",
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "D4_face",
+          "E_trivial",
+          "O_full",
+          "S3_body",
+          "V_edge",
+          "V_face"
+        ]
+      },
+      {
+        "S3_survives": true,
+        "fidelity_pinned_from_886": "EXACT",
+        "grounded_pinned_from_886": true,
+        "selector": "SEL16_no_site_privileged_read_literally",
+        "survivors": [
+          "A4_tetrahedral",
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "D4_face",
+          "E_trivial",
+          "O_full",
+          "S3_body",
+          "V_edge",
+          "V_face"
+        ]
+      }
+    ],
+    "selectors_S3_passes": [
+      "SEL01_free_on_shell",
+      "SEL02_transitive_on_shell",
+      "SEL03_multiplicity_one_orbit_scope",
+      "SEL04_multiplicity_one_shell_scope",
+      "SEL05_minimal_shell_invariant_multiplicity",
+      "SEL06_maximal_free_shell_orbit",
+      "SEL10_fine_top_pair_is_the_target",
+      "SEL11_transitive_on_coordinate_axes",
+      "SEL13_count_once",
+      "SEL14_content_only_readout",
+      "SEL15_admissibility_covariance",
+      "SEL16_no_site_privileged_read_literally"
+    ],
+    "selectors_S3_passes_count": 12,
+    "shell_orbit_lengths": [
+      6
+    ]
+  },
+  "conjugacy_classes": 11,
+  "cycle": 888,
+  "grounded_conjunction_survivors": [
+    "A4_tetrahedral",
+    "C2_edge",
+    "C2_face",
+    "C3_body",
+    "C4_face",
+    "D4_face",
+    "E_trivial",
+    "O_full",
+    "S3_body",
+    "V_edge",
+    "V_face"
+  ],
+  "impostor_stress": [
+    {
+      "appears_in_the_lattice": false,
+      "impostor": "a NON-CLOSED set {e, r3} passed off as a subgroup",
+      "is_closed": false,
+      "refused": true,
+      "refused_by_gate": "D_SUBGROUP_LATTICE / every_subgroup_closed_under_composition"
+    },
+    {
+      "conjugate_class_index": 7,
+      "conjugate_is_already_in_the_lattice": true,
+      "conjugating_element_index": 0,
+      "derived_name_of_the_conjugate": "S3_body",
+      "impostor": "a CONJUGATE of an S3 subgroup relabelled as a new class",
+      "original_class_index": 7,
+      "refused": true,
+      "refused_by_gate": "D_SUBGROUP_LATTICE / conjugacy_classes == 11 and derived_names_are_constant_on_classes",
+      "would_have_created_a_twelfth_class": false
+    },
+    {
+      "cyclic_subgroups_of_order_8_in_the_lattice": 0,
+      "elements_of_order_8_in_the_group": 0,
+      "impostor": "a FABRICATED order-8 CYCLIC subgroup C8",
+      "order_8_subgroups_that_do_exist_are_cyclic": [
+        false,
+        false,
+        false
+      ],
+      "refused": true,
+      "refused_by_gate": "C_ROTATION_GROUP / element_order_counts and D_SUBGROUP_LATTICE / derived name is D4_face"
+    },
+    {
+      "appears_in_the_lattice": false,
+      "determinant": -1,
+      "impostor": "the inversion -I smuggled in as a C2 (an IMPROPER rotation)",
+      "refused": true,
+      "refused_by_gate": "C_ROTATION_GROUP / every_element_has_determinant_plus_one"
+    },
+    {
+      "claimed_dimensions": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "claimed_sum": 4,
+      "computed_dimensions": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "computed_sum": 6,
+      "impostor": "a WRONG DECOMPOSITION: S3's shell readout claimed as 1 + 1 + 1 + 1",
+      "refused": true,
+      "refused_by_gate": "G_ISOTYPE_SIGNATURES / fine_decomposition_sums_to_the_space",
+      "space_dimension": 6
+    },
+    {
+      "claimed_sum_m_squared_field_degree": 3,
+      "computed_sum_m_squared_field_degree": 6,
+      "impostor": "a WRONG MULTIPLICITY LEDGER for S3 (m = 1 everywhere, which would make the SL1 transfer forced)",
+      "orbit_count_on_the_product_set": 6,
+      "refused": true,
+      "refused_by_gate": "G_ISOTYPE_SIGNATURES / sum_m_squared_field_degree_equals_the_orbit_count_on_pairs"
+    },
+    {
+      "fabricated_class": "C5_body",
+      "impostor": "a survivor set naming a class that is not in the lattice",
+      "present_in_the_lattice": false,
+      "refused": true,
+      "refused_by_gate": "I_SELECTOR_TABLE / every_survivor_set_is_a_subset_of_the_candidates"
+    },
+    {
+      "claimed_classes": 10,
+      "claimed_subgroups": 29,
+      "computed_classes": 11,
+      "computed_subgroups": 30,
+      "impostor": "a census claiming 29 subgroups in 10 classes",
+      "refused": true,
+      "refused_by_gate": "D_SUBGROUP_LATTICE / class_sizes_sum_to_the_lattice and class_equation_holds_on_every_class"
+    }
+  ],
+  "menu_clauses_that_still_isolate_C3": [
+    "SEL07_coarse_pair_v2_equals_one",
+    "SEL08_reachability_R1_orbit_scope"
+  ],
+  "menu_movement_under_de_restriction": [
+    {
+      "cycle886_survivors_over_the_cyclic_census": [
+        "C3_body"
+      ],
+      "cycle888_survivors_over_the_full_lattice": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "now_selects_instead": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "selector": "SEL05_minimal_shell_invariant_multiplicity",
+      "still_isolates_C3_body": false
+    },
+    {
+      "cycle886_survivors_over_the_cyclic_census": [
+        "C3_body"
+      ],
+      "cycle888_survivors_over_the_full_lattice": [
+        "S3_body"
+      ],
+      "now_selects_instead": [
+        "S3_body"
+      ],
+      "selector": "SEL06_maximal_free_shell_orbit",
+      "still_isolates_C3_body": false
+    },
+    {
+      "cycle886_survivors_over_the_cyclic_census": [
+        "C3_body"
+      ],
+      "cycle888_survivors_over_the_full_lattice": [
+        "C3_body"
+      ],
+      "now_selects_instead": null,
+      "selector": "SEL07_coarse_pair_v2_equals_one",
+      "still_isolates_C3_body": true
+    },
+    {
+      "cycle886_survivors_over_the_cyclic_census": [
+        "C3_body"
+      ],
+      "cycle888_survivors_over_the_full_lattice": [
+        "C3_body"
+      ],
+      "now_selects_instead": null,
+      "selector": "SEL08_reachability_R1_orbit_scope",
+      "still_isolates_C3_body": true
+    },
+    {
+      "cycle886_survivors_over_the_cyclic_census": [
+        "C3_body"
+      ],
+      "cycle888_survivors_over_the_full_lattice": [
+        "A4_tetrahedral",
+        "C3_body",
+        "O_full",
+        "S3_body"
+      ],
+      "now_selects_instead": [
+        "A4_tetrahedral",
+        "C3_body",
+        "O_full",
+        "S3_body"
+      ],
+      "selector": "SEL11_transitive_on_coordinate_axes",
+      "still_isolates_C3_body": false
+    },
+    {
+      "cycle886_survivors_over_the_cyclic_census": [
+        "C3_body"
+      ],
+      "cycle888_survivors_over_the_full_lattice": [
+        "C3_body",
+        "E_trivial"
+      ],
+      "now_selects_instead": [
+        "C3_body",
+        "E_trivial"
+      ],
+      "selector": "SEL12_odd_order",
+      "still_isolates_C3_body": false
+    }
+  ],
+  "next_attackable_question": "Either (i) register the scope choice on the owner surface with the corrected three-clause menu and the odd-order repair attached; or (ii) ask whether multiplicity-freeness of the readout is itself derivable -- it is the property that separates C3 and C4 from S3 and it is not yet quoted from any sentence; or (iii) take the MIXED scope-insensitivity verdict downstream: the consumer's dependence on the reading, not just on the scope, is now the load-bearing residual.",
+  "non_circular_clauses_that_still_pin_C3": [],
+  "question": "Price the S3 scope over the FULL 30-subgroup lattice of the proper cubic rotation group, and run Cycle 886's named scope-insensitivity test on the readout obligation lineage.",
+  "reachability_generator_rules": {
+    "R1_orbit_scope_coarse": "generators = {free orbit length} U {coarse pair entries}, values > 1 -- exactly the data Cycle 883 fed to its own T6 recomputation",
+    "R2_shell_scope_coarse": "generators = {distinct shell orbit lengths} U {shell coarse pair entries}, values > 1",
+    "R3_orbit_scope_fine": "generators = {free orbit length} U {fine rational irreducible dimensions}, values > 1",
+    "R4_shell_scope_fine": "generators = {distinct shell orbit lengths} U {fine rational irreducible dimensions on the shell}, values > 1"
+  },
+  "reachability_survivors_by_rule": {
+    "R1_orbit_scope_coarse": [
+      "C3_body"
+    ],
+    "R2_shell_scope_coarse": [
+      "C2_edge",
+      "C3_body",
+      "V_face"
+    ],
+    "R3_orbit_scope_fine": [
+      "C3_body",
+      "S3_body"
+    ],
+    "R4_shell_scope_fine": [
+      "A4_tetrahedral",
+      "C3_body",
+      "O_full",
+      "S3_body"
+    ]
+  },
+  "restriction_gate": {
+    "reachability_survivors_reproduce_cycle886": true,
+    "selector_comparison": [
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C3_body"
+        ],
+        "id": "SEL01_free_on_shell",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [],
+        "cycle888_restricted_survivors": [],
+        "id": "SEL02_transitive_on_shell",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "id": "SEL03_multiplicity_one_orbit_scope",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [],
+        "cycle888_restricted_survivors": [],
+        "id": "SEL04_multiplicity_one_shell_scope",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body"
+        ],
+        "id": "SEL05_minimal_shell_invariant_multiplicity",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body"
+        ],
+        "id": "SEL06_maximal_free_shell_orbit",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body"
+        ],
+        "id": "SEL07_coarse_pair_v2_equals_one",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body"
+        ],
+        "id": "SEL08_reachability_R1_orbit_scope",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C3_body"
+        ],
+        "id": "SEL09_reachability_R2_shell_scope",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body",
+          "C4_face"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body",
+          "C4_face"
+        ],
+        "id": "SEL10_fine_top_pair_is_the_target",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body"
+        ],
+        "id": "SEL11_transitive_on_coordinate_axes",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C3_body"
+        ],
+        "cycle888_restricted_survivors": [
+          "C3_body"
+        ],
+        "id": "SEL12_odd_order",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "id": "SEL13_count_once",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "id": "SEL14_content_only_readout",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "id": "SEL15_admissibility_covariance",
+        "identical": true
+      },
+      {
+        "cycle886_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "cycle888_restricted_survivors": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face"
+        ],
+        "id": "SEL16_no_site_privileged_read_literally",
+        "identical": true
+      }
+    ],
+    "selector_survivors_reproduce_cycle886": true,
+    "signatures_reproduce_cycle886": true
+  },
+  "scope_insensitivity": {
+    "OVERALL_VERDICT": "MIXED",
+    "menu_classes": [
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "S3_body",
+      "V_edge"
+    ],
+    "menu_membership_rule": "A class is on the honest scope menu iff the Cycle-883 construction is REALIZABLE at it: the subgroup must have a lattice-realized FREE orbit on the 6-neighbour shell of length greater than one, so that the readout space is a nondegenerate free-orbit readout. Membership is decided by the computed orbit structure, not by a list.",
+    "off_menu": [
+      {
+        "class": "A4_tetrahedral",
+        "maximal_FREE_orbit_length": 0,
+        "on_the_menu": false,
+        "order": 12,
+        "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+        "shell_orbit_lengths": [
+          6
+        ]
+      },
+      {
+        "class": "D4_face",
+        "maximal_FREE_orbit_length": 0,
+        "on_the_menu": false,
+        "order": 8,
+        "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+        "shell_orbit_lengths": [
+          2,
+          4
+        ]
+      },
+      {
+        "class": "E_trivial",
+        "maximal_FREE_orbit_length": 1,
+        "on_the_menu": false,
+        "order": 1,
+        "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+        "shell_orbit_lengths": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "class": "O_full",
+        "maximal_FREE_orbit_length": 0,
+        "on_the_menu": false,
+        "order": 24,
+        "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+        "shell_orbit_lengths": [
+          6
+        ]
+      },
+      {
+        "class": "V_face",
+        "maximal_FREE_orbit_length": 0,
+        "on_the_menu": false,
+        "order": 4,
+        "reason": "no free shell orbit of length > 1: the Cycle-883 construction has no nondegenerate readout space here",
+        "shell_orbit_lengths": [
+          2,
+          2,
+          2
+        ]
+      }
+    ],
+    "per_reading": {
+      "ORBIT_SCOPE_coarse_reading": {
+        "menu": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "S3_body",
+          "V_edge"
+        ],
+        "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C3_body']",
+        "verdict": "SCOPE_SENSITIVE",
+        "working_set": [
+          "C3_body"
+        ]
+      },
+      "ORBIT_SCOPE_fine_reading": {
+        "menu": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "S3_body",
+          "V_edge"
+        ],
+        "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C3_body', 'S3_body']",
+        "verdict": "SCOPE_SENSITIVE",
+        "working_set": [
+          "C3_body",
+          "S3_body"
+        ]
+      },
+      "SHELL_SCOPE_coarse_reading": {
+        "menu": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "S3_body",
+          "V_edge"
+        ],
+        "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C2_edge', 'C3_body']",
+        "verdict": "SCOPE_SENSITIVE",
+        "working_set": [
+          "C2_edge",
+          "C3_body"
+        ]
+      },
+      "SHELL_SCOPE_fine_reading": {
+        "menu": [
+          "C2_edge",
+          "C2_face",
+          "C3_body",
+          "C4_face",
+          "S3_body",
+          "V_edge"
+        ],
+        "menu_price_for_this_consumer": "NONZERO -- the real menu for this consumer is ['C3_body', 'S3_body']",
+        "verdict": "SCOPE_SENSITIVE",
+        "working_set": [
+          "C3_body",
+          "S3_body"
+        ]
+      }
+    },
+    "table": [
+      {
+        "ORBIT_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "ORBIT_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            3
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            1,
+            -2
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "SHELL_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "coarse_pair": [
+          1,
+          1
+        ],
+        "coarse_profile": [
+          0,
+          0
+        ],
+        "fine_dims": [
+          1,
+          1
+        ],
+        "fine_profile": [
+          0,
+          0
+        ],
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "orbit_scope_dimension": 2,
+        "order": 2,
+        "scope_class": "C2_edge",
+        "supplies_a_v2_equals_1_datum_coarse": false,
+        "supplies_a_v2_equals_1_datum_fine": false
+      },
+      {
+        "ORBIT_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "ORBIT_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            2
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "coarse_pair": [
+          1,
+          1
+        ],
+        "coarse_profile": [
+          0,
+          0
+        ],
+        "fine_dims": [
+          1,
+          1
+        ],
+        "fine_profile": [
+          0,
+          0
+        ],
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "orbit_scope_dimension": 2,
+        "order": 2,
+        "scope_class": "C2_face",
+        "supplies_a_v2_equals_1_datum_coarse": false,
+        "supplies_a_v2_equals_1_datum_fine": false
+      },
+      {
+        "ORBIT_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            3
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            3
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            1,
+            -2
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "ORBIT_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            3
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            3
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            1,
+            -2
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "SHELL_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            3
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            3,
+            4
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            1,
+            -2,
+            0
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "SHELL_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            3
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            3
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            1,
+            -2
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "coarse_pair": [
+          1,
+          2
+        ],
+        "coarse_profile": [
+          0,
+          1
+        ],
+        "fine_dims": [
+          1,
+          2
+        ],
+        "fine_profile": [
+          0,
+          1
+        ],
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "orbit_scope_dimension": 3,
+        "order": 3,
+        "scope_class": "C3_body",
+        "supplies_a_v2_equals_1_datum_coarse": true,
+        "supplies_a_v2_equals_1_datum_fine": true
+      },
+      {
+        "ORBIT_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            3,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "ORBIT_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            3,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "coarse_pair": [
+          1,
+          3
+        ],
+        "coarse_profile": [
+          0,
+          0
+        ],
+        "fine_dims": [
+          1,
+          1,
+          2
+        ],
+        "fine_profile": [
+          0,
+          1
+        ],
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "orbit_scope_dimension": 4,
+        "order": 4,
+        "scope_class": "C4_face",
+        "supplies_a_v2_equals_1_datum_coarse": false,
+        "supplies_a_v2_equals_1_datum_fine": true
+      },
+      {
+        "ORBIT_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            6
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            5,
+            6
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "ORBIT_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            6
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            6
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            3,
+            -2
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "SHELL_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            6
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            5,
+            6
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            6
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": true,
+          "widened_generator_set": [
+            2,
+            6
+          ],
+          "widened_target_reachable": true,
+          "witness_exponents": [
+            3,
+            -2
+          ],
+          "witness_recomputes_the_target": true
+        },
+        "coarse_pair": [
+          1,
+          5
+        ],
+        "coarse_profile": [
+          0,
+          0
+        ],
+        "fine_dims": [
+          1,
+          1,
+          2,
+          2
+        ],
+        "fine_profile": [
+          0,
+          1
+        ],
+        "fine_top_pair": [
+          1,
+          2
+        ],
+        "orbit_scope_dimension": 6,
+        "order": 6,
+        "scope_class": "S3_body",
+        "supplies_a_v2_equals_1_datum_coarse": false,
+        "supplies_a_v2_equals_1_datum_fine": true
+      },
+      {
+        "ORBIT_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            3,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "ORBIT_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_coarse_reading": {
+          "cycle882_generator_set": [
+            2,
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "SHELL_SCOPE_fine_reading": {
+          "cycle882_generator_set": [
+            2,
+            4
+          ],
+          "cycle882_target_reachable": false,
+          "defeats_C882_T6": false,
+          "widened_generator_set": [
+            2,
+            4
+          ],
+          "widened_target_reachable": false,
+          "witness_exponents": null,
+          "witness_recomputes_the_target": null
+        },
+        "coarse_pair": [
+          1,
+          3
+        ],
+        "coarse_profile": [
+          0,
+          0
+        ],
+        "fine_dims": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "fine_profile": [
+          0,
+          0
+        ],
+        "fine_top_pair": [
+          1,
+          1
+        ],
+        "orbit_scope_dimension": 4,
+        "order": 4,
+        "scope_class": "V_edge",
+        "supplies_a_v2_equals_1_datum_coarse": false,
+        "supplies_a_v2_equals_1_datum_fine": false
+      }
+    ]
+  },
+  "selector_table_cells": 480,
+  "selectors": [
+    {
+      "demand": "the subgroup acts with NO fixed site on the 6-neighbour shell",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL01_free_on_shell",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+      "survivor_expression_source_886": "sorted(free_labels)",
+      "survivors": [
+        "C2_edge",
+        "C3_body",
+        "E_trivial",
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": true,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": true,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    },
+    {
+      "demand": "the subgroup acts transitively on the 6-neighbour shell",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL02_transitive_on_shell",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+      "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if by_label[lab][\"transitive_on_the_shell\"])",
+      "survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": false,
+        "13,23": false,
+        "15,18,23": false,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": false,
+        "6,8,23": false,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "trivial isotype multiplicity is exactly 1 on the readout space",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL03_multiplicity_one_orbit_scope",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.",
+      "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if sig[lab][\"ORBIT_SCOPE_cycle883_construction\"]\n                and sig[lab][\"ORBIT_SCOPE_cycle883_construction\"]\n                [\"invariant_dim_by_nullspace\"] == 1\n            )",
+      "survivors": [
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "E_trivial",
+        "S3_body",
+        "V_edge"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": true,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": true,
+        "0,7,16,23": true,
+        "1,2,20,23": true,
+        "1,23": true,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": true,
+        "20,23": true,
+        "23": true,
+        "3,10,14,23": true,
+        "3,23": true,
+        "3,9,13,23": true,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    },
+    {
+      "demand": "trivial isotype multiplicity is exactly 1 on the whole shell",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL04_multiplicity_one_shell_scope",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.",
+      "survivor_expression_source_886": "sorted(lab for lab in labels if shell_inv[lab] == 1)",
+      "survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": false,
+        "13,23": false,
+        "15,18,23": false,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": false,
+        "6,8,23": false,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "the subgroup MINIMIZES the trivial multiplicity on the shell",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL05_minimal_shell_invariant_multiplicity",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": null,
+      "quoted_sentence": null,
+      "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if shell_inv[lab] == min_shell_inv)",
+      "survivors": [
+        "A4_tetrahedral",
+        "O_full",
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": false,
+        "13,23": false,
+        "15,18,23": false,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": false,
+        "6,8,23": false,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "among subgroups acting freely on the shell, orbit length is maximal",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL06_maximal_free_shell_orbit",
+      "isolates_C3_body": false,
+      "isolates_S3_body": true,
+      "quote_source": null,
+      "quoted_sentence": null,
+      "survivor_expression_source_886": "sorted(\n                lab for lab in free_labels\n                if by_label[lab][\"maximal_FREE_orbit_length\"] == max_free_len\n            )",
+      "survivors": [
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": false,
+        "13,23": false,
+        "15,18,23": false,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": false,
+        "6,8,23": false,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "the coarse weight pair has 2-adic profile (0, 1)",
+      "fidelity_grade_pinned_from_886": "EXACT",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": "target-facing, not axiom-grounded",
+      "id": "SEL07_coarse_pair_v2_equals_one",
+      "isolates_C3_body": true,
+      "isolates_S3_body": false,
+      "quote_source": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+      "quoted_sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'.",
+      "survivor_expression_source_886": "sorted(lab for lab in labels if orbit_v2(lab) == 1)",
+      "survivors": [
+        "C3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": false,
+        "1,6,8,13,19,23": false,
+        "11,17,23": true,
+        "13,23": false,
+        "15,18,23": true,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": false,
+        "2,5,9,12,19,23": false,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "the subgroup's own numbers multiplicatively reach 2/9",
+      "fidelity_grade_pinned_from_886": "PARTIAL",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": "target-facing, not axiom-grounded",
+      "id": "SEL08_reachability_R1_orbit_scope",
+      "isolates_C3_body": true,
+      "isolates_S3_body": false,
+      "quote_source": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+      "quoted_sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'.",
+      "survivor_expression_source_886": "reach_by_rule[\"R1_orbit_scope_coarse\"]",
+      "survivors": [
+        "C3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": false,
+        "1,6,8,13,19,23": false,
+        "11,17,23": true,
+        "13,23": false,
+        "15,18,23": true,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": false,
+        "2,5,9,12,19,23": false,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "the subgroup's shell numbers multiplicatively reach 2/9",
+      "fidelity_grade_pinned_from_886": "PARTIAL",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": "target-facing and scope-circular",
+      "id": "SEL09_reachability_R2_shell_scope",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+      "quoted_sentence": "A Record-facing datum with v_2 = 1 must enter. Concretely: derive that the charged-lepton record carries the fixed-locus weight pair (1, 2) as Record content. That is a sharper successor target than 'derive h-class'.",
+      "survivor_expression_source_886": "reach_by_rule[\"R2_shell_scope_coarse\"]",
+      "survivors": [
+        "C2_edge",
+        "C3_body",
+        "V_face"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": true,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": true,
+        "1,4,9,15,18,23": false,
+        "1,6,8,13,19,23": false,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": false,
+        "2,5,9,12,19,23": false,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    },
+    {
+      "demand": "(invariant dim, top rational irreducible dim) == (1, 2)",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL10_fine_top_pair_is_the_target",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": null,
+      "quoted_sentence": null,
+      "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if fine_top(lab) == TARGET_PAIR)",
+      "survivors": [
+        "C3_body",
+        "C4_face",
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": true,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": false,
+        "15,18,23": true,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": true,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": true,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "the subgroup permutes the three coordinate axes transitively",
+      "fidelity_grade_pinned_from_886": "PARTIAL",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": "the sentence grounds axis-equivalence for the whole group, not internal axis-transitivity for the scope subgroup",
+      "id": "SEL11_transitive_on_coordinate_axes",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.",
+      "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if by_label[lab][\"transitive_on_the_three_coordinate_axes\"]\n            )",
+      "survivors": [
+        "A4_tetrahedral",
+        "C3_body",
+        "O_full",
+        "S3_body"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": false,
+        "15,18,23": true,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": false,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "the subgroup has odd order greater than 1",
+      "fidelity_grade_pinned_from_886": "NONE",
+      "grounded_pinned_from_886": false,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL12_odd_order",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": null,
+      "quoted_sentence": null,
+      "survivor_expression_source_886": "sorted(lab for lab in labels\n                                if sig[lab][\"order\"] % 2 == 1)",
+      "survivors": [
+        "C3_body",
+        "E_trivial"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": false,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": false,
+        "0,23": false,
+        "0,3,20,23": false,
+        "0,3,4,7,16,19,20,23": false,
+        "0,3,5,6,8,11,12,15,17,18,20,23": false,
+        "0,3,9,10,13,14,20,23": false,
+        "0,4,19,23": false,
+        "0,7,16,23": false,
+        "1,2,20,23": false,
+        "1,23": false,
+        "1,4,9,15,18,23": false,
+        "1,6,8,13,19,23": false,
+        "11,17,23": true,
+        "13,23": false,
+        "15,18,23": true,
+        "19,23": false,
+        "2,23": false,
+        "2,4,11,13,17,23": false,
+        "2,5,9,12,19,23": false,
+        "20,21,22,23": false,
+        "20,23": false,
+        "23": true,
+        "3,10,14,23": false,
+        "3,23": false,
+        "3,9,13,23": false,
+        "4,23": false,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": false
+      }
+    },
+    {
+      "demand": "one record per site, permanently",
+      "fidelity_grade_pinned_from_886": "EXACT",
+      "grounded_pinned_from_886": true,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL13_count_once",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "A site never carries more than one record; records are permanent.",
+      "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if sum(len(o) for o in subgroup_shell_orbits_by_label(sig[lab]))\n                == len(NEAREST_NEIGHBOURS)\n            )",
+      "survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": true,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": true,
+        "0,3,20,23": true,
+        "0,3,4,7,16,19,20,23": true,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": true,
+        "0,4,19,23": true,
+        "0,7,16,23": true,
+        "1,2,20,23": true,
+        "1,23": true,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": true,
+        "20,23": true,
+        "23": true,
+        "3,10,14,23": true,
+        "3,23": true,
+        "3,9,13,23": true,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    },
+    {
+      "demand": "the readout value depends on record content alone",
+      "fidelity_grade_pinned_from_886": "EXACT",
+      "grounded_pinned_from_886": true,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL14_content_only_readout",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "Only records are readable. A readout value is determined by record content alone.",
+      "survivor_expression_source_886": "sorted(\n                lab for lab in labels\n                if sig[lab][\"SHELL_SCOPE_whole_neighbourhood\"][\"space_dimension\"]\n                == len(NEAREST_NEIGHBOURS)\n            )",
+      "survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": true,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": true,
+        "0,3,20,23": true,
+        "0,3,4,7,16,19,20,23": true,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": true,
+        "0,4,19,23": true,
+        "0,7,16,23": true,
+        "1,2,20,23": true,
+        "1,23": true,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": true,
+        "20,23": true,
+        "23": true,
+        "3,10,14,23": true,
+        "3,23": true,
+        "3,9,13,23": true,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    },
+    {
+      "demand": "the scope must lie inside the covariance group of the admissibility rule",
+      "fidelity_grade_pinned_from_886": "EXACT",
+      "grounded_pinned_from_886": true,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL15_admissibility_covariance",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.",
+      "survivor_expression_source_886": "sorted(labels)",
+      "survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": true,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": true,
+        "0,3,20,23": true,
+        "0,3,4,7,16,19,20,23": true,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": true,
+        "0,4,19,23": true,
+        "0,7,16,23": true,
+        "1,2,20,23": true,
+        "1,23": true,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": true,
+        "20,23": true,
+        "23": true,
+        "3,10,14,23": true,
+        "3,23": true,
+        "3,9,13,23": true,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    },
+    {
+      "demand": "no site is privileged except by supplied lattice structure -- read with BOTH of its clauses",
+      "fidelity_grade_pinned_from_886": "EXACT",
+      "grounded_pinned_from_886": true,
+      "grounding_defect_pinned_from_886": null,
+      "id": "SEL16_no_site_privileged_read_literally",
+      "isolates_C3_body": false,
+      "isolates_S3_body": false,
+      "quote_source": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "quoted_sentence": "No site is privileged. Sites are distinguished by the supplied lattice structure alone.",
+      "survivor_expression_source_886": "sorted(labels)",
+      "survivors": [
+        "A4_tetrahedral",
+        "C2_edge",
+        "C2_face",
+        "C3_body",
+        "C4_face",
+        "D4_face",
+        "E_trivial",
+        "O_full",
+        "S3_body",
+        "V_edge",
+        "V_face"
+      ],
+      "verdicts_by_subgroup": {
+        "0,1,2,3,20,21,22,23": true,
+        "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23": true,
+        "0,23": true,
+        "0,3,20,23": true,
+        "0,3,4,7,16,19,20,23": true,
+        "0,3,5,6,8,11,12,15,17,18,20,23": true,
+        "0,3,9,10,13,14,20,23": true,
+        "0,4,19,23": true,
+        "0,7,16,23": true,
+        "1,2,20,23": true,
+        "1,23": true,
+        "1,4,9,15,18,23": true,
+        "1,6,8,13,19,23": true,
+        "11,17,23": true,
+        "13,23": true,
+        "15,18,23": true,
+        "19,23": true,
+        "2,23": true,
+        "2,4,11,13,17,23": true,
+        "2,5,9,12,19,23": true,
+        "20,21,22,23": true,
+        "20,23": true,
+        "23": true,
+        "3,10,14,23": true,
+        "3,23": true,
+        "3,9,13,23": true,
+        "4,23": true,
+        "5,12,23": true,
+        "6,8,23": true,
+        "9,23": true
+      }
+    }
+  ],
+  "selectors_isolating_C3_body": [
+    "SEL07_coarse_pair_v2_equals_one",
+    "SEL08_reachability_R1_orbit_scope"
+  ],
+  "selectors_isolating_S3_body": [
+    "SEL06_maximal_free_shell_orbit"
+  ],
+  "sharpest_new_facts": [
+    "The S3 scope is NOT a transfer of SL1. At C3 and C4 every isotypic multiplicity is 1, so the readout decomposition is canonical and the pair carries no free parameter -- SL1's load-bearing clause. At S3 the 2-dimensional irreducible appears TWICE in the regular representation, so the (1, 2) fine-top pair is realized by a P^1 family of readout subspaces, exhibited explicitly. Under Cycle 883's OWN (coarse) reading S3 does not carry (1, 2) at all: it carries (1, 5), profile (0, 0).",
+    "Lifting the cyclic restriction BREAKS the convergence Cycle 886 recorded. Its ungrounded selectors no longer point one way: freeness-plus-maximality now isolates S3, minimal shell multiplicity and shell transitivity and shell multiplicity-one all select {S3, A4, O}, internal axis-transitivity keeps {C3, S3, A4, O}, and only odd order and the two target-facing clauses still isolate C3. The ungrounded conjunction is now EMPTY.",
+    "The odd-order clause, Cycle 886's cheapest non-circular pin, needs a SECOND conjunct once the census is complete: the trivial subgroup has odd order too, so the filter as Cycle 886 coded it (order % 2 == 1) admits {C3_body, E_trivial}. Cycle 886's own demand string said 'greater than 1' but its filter never computed it, because the trivial subgroup was outside its census.",
+    "The scope-insensitivity test comes back MIXED, not insensitive: the T6 defeat works at C3 under both readings, at S3 under the fine reading only, at C2_edge under the shell-scope coarse reading only, and nowhere else on the menu."
+  ],
+  "shell_orbit_rows": [
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 0,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        1,
+        1
+      ],
+      "element_indices": [
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          1,
+          0,
+          0
+        ],
+        [
+          0,
+          1,
+          0
+        ],
+        [
+          0,
+          0,
+          1
+        ],
+        [
+          -1,
+          0,
+          0
+        ],
+        [
+          0,
+          -1,
+          0
+        ],
+        [
+          0,
+          0,
+          -1
+        ]
+      ],
+      "free_orbit_count": 6,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 1,
+      "maximal_orbit_length": 1,
+      "name": "E_trivial",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 1,
+      "shell_orbit_count": 6,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 2,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        1,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 3,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 2,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        2,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 3,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 2,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        4,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 3,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 2,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        9,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 3,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 2,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        13,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 3,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 2,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        19,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 3,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 1,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        1,
+        1
+      ],
+      "element_indices": [
+        0,
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          0,
+          0,
+          1
+        ],
+        [
+          0,
+          0,
+          -1
+        ]
+      ],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 4,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 1,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        1,
+        1
+      ],
+      "element_indices": [
+        3,
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          0,
+          1,
+          0
+        ],
+        [
+          0,
+          -1,
+          0
+        ]
+      ],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 4,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 1,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        1,
+        1
+      ],
+      "element_indices": [
+        20,
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          1,
+          0,
+          0
+        ],
+        [
+          -1,
+          0,
+          0
+        ]
+      ],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 2,
+      "maximal_orbit_length": 2,
+      "name": "C2_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 2,
+      "shell_orbit_count": 4,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 3,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        5,
+        12,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 3,
+      "maximal_orbit_length": 3,
+      "name": "C3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 3,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        3,
+        3
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 3,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        6,
+        8,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 3,
+      "maximal_orbit_length": 3,
+      "name": "C3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 3,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        3,
+        3
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 3,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        11,
+        17,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 3,
+      "maximal_orbit_length": 3,
+      "name": "C3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 3,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        3,
+        3
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 3,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        15,
+        18,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 2,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 3,
+      "maximal_orbit_length": 3,
+      "name": "C3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 3,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        3,
+        3
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 6,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        0,
+        7,
+        16,
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          0,
+          0,
+          1
+        ],
+        [
+          0,
+          0,
+          -1
+        ]
+      ],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 4,
+      "maximal_orbit_length": 4,
+      "name": "C4_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 6,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        3,
+        10,
+        14,
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          0,
+          1,
+          0
+        ],
+        [
+          0,
+          -1,
+          0
+        ]
+      ],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 4,
+      "maximal_orbit_length": 4,
+      "name": "C4_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 6,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        20,
+        21,
+        22,
+        23
+      ],
+      "fixed_shell_sites": [
+        [
+          1,
+          0,
+          0
+        ],
+        [
+          -1,
+          0,
+          0
+        ]
+      ],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": true,
+      "maximal_FREE_orbit_length": 4,
+      "maximal_orbit_length": 4,
+      "name": "C4_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 5,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        0,
+        4,
+        19,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 4,
+      "maximal_orbit_length": 4,
+      "name": "V_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 5,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        1,
+        2,
+        20,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 4,
+      "maximal_orbit_length": 4,
+      "name": "V_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 5,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        3,
+        9,
+        13,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 4,
+      "maximal_orbit_length": 4,
+      "name": "V_edge",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 4,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        1,
+        1
+      ],
+      "element_indices": [
+        0,
+        3,
+        20,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 0,
+      "has_a_free_orbit_on_the_shell": false,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 0,
+      "maximal_orbit_length": 2,
+      "name": "V_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 4,
+      "shell_orbit_count": 3,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 7,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        1,
+        4,
+        9,
+        15,
+        18,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 6,
+      "maximal_orbit_length": 6,
+      "name": "S3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 6,
+      "shell_orbit_count": 1,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "simply_transitive_on_the_shell": true,
+      "transitive_on_the_shell": true,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 7,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        1,
+        6,
+        8,
+        13,
+        19,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 6,
+      "maximal_orbit_length": 6,
+      "name": "S3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 6,
+      "shell_orbit_count": 1,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "simply_transitive_on_the_shell": true,
+      "transitive_on_the_shell": true,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 7,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        2,
+        4,
+        11,
+        13,
+        17,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 6,
+      "maximal_orbit_length": 6,
+      "name": "S3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 6,
+      "shell_orbit_count": 1,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "simply_transitive_on_the_shell": true,
+      "transitive_on_the_shell": true,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": true,
+      "class_index": 7,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        2,
+        5,
+        9,
+        12,
+        19,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 1,
+      "has_a_free_orbit_on_the_shell": true,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 6,
+      "maximal_orbit_length": 6,
+      "name": "S3_body",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 6,
+      "shell_orbit_count": 1,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "simply_transitive_on_the_shell": true,
+      "transitive_on_the_shell": true,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 8,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        0,
+        1,
+        2,
+        3,
+        20,
+        21,
+        22,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 0,
+      "has_a_free_orbit_on_the_shell": false,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 0,
+      "maximal_orbit_length": 4,
+      "name": "D4_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 8,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 8,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        0,
+        3,
+        4,
+        7,
+        16,
+        19,
+        20,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 0,
+      "has_a_free_orbit_on_the_shell": false,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 0,
+      "maximal_orbit_length": 4,
+      "name": "D4_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 8,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 8,
+      "coordinate_axis_orbit_sizes": [
+        1,
+        2
+      ],
+      "element_indices": [
+        0,
+        3,
+        9,
+        10,
+        13,
+        14,
+        20,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 0,
+      "has_a_free_orbit_on_the_shell": false,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 0,
+      "maximal_orbit_length": 4,
+      "name": "D4_face",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 8,
+      "shell_orbit_count": 2,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": false,
+      "transitive_on_the_three_coordinate_axes": false
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 9,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        0,
+        3,
+        5,
+        6,
+        8,
+        11,
+        12,
+        15,
+        17,
+        18,
+        20,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 0,
+      "has_a_free_orbit_on_the_shell": false,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 0,
+      "maximal_orbit_length": 6,
+      "name": "A4_tetrahedral",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 12,
+      "shell_orbit_count": 1,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": true,
+      "transitive_on_the_three_coordinate_axes": true
+    },
+    {
+      "acts_freely_on_the_shell": false,
+      "class_index": 10,
+      "coordinate_axis_orbit_sizes": [
+        3
+      ],
+      "element_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
+      "fixed_shell_sites": [],
+      "free_orbit_count": 0,
+      "has_a_free_orbit_on_the_shell": false,
+      "is_cyclic": false,
+      "maximal_FREE_orbit_length": 0,
+      "maximal_orbit_length": 6,
+      "name": "O_full",
+      "orbit_lengths_divide_the_subgroup_order": true,
+      "orbit_lengths_sum_to_six": true,
+      "order": 24,
+      "shell_orbit_count": 1,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "simply_transitive_on_the_shell": false,
+      "transitive_on_the_shell": true,
+      "transitive_on_the_three_coordinate_axes": true
+    }
+  ],
+  "signatures_by_class": [
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "A4_tetrahedral",
+      "orbit_scope_decomposition_is_unique": null,
+      "orbit_scope_exists": false,
+      "orbit_scope_fine_dims": null,
+      "orbit_scope_fine_top_pair": null,
+      "orbit_scope_pair": null,
+      "orbit_scope_profile": null,
+      "order": 12,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "shell_scope_decomposition_is_unique": true,
+      "shell_scope_fine_dims": [
+        1,
+        2,
+        3
+      ],
+      "shell_scope_fine_top_pair": [
+        1,
+        3
+      ],
+      "shell_scope_pair": [
+        1,
+        5
+      ],
+      "shell_scope_profile": [
+        0,
+        0
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "C2_edge",
+      "orbit_scope_decomposition_is_unique": true,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1,
+        1
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        1
+      ],
+      "orbit_scope_pair": [
+        1,
+        1
+      ],
+      "orbit_scope_profile": [
+        0,
+        0
+      ],
+      "order": 2,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "shell_scope_fine_top_pair": [
+        3,
+        1
+      ],
+      "shell_scope_pair": [
+        3,
+        3
+      ],
+      "shell_scope_profile": [
+        0,
+        0
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "C2_face",
+      "orbit_scope_decomposition_is_unique": true,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1,
+        1
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        1
+      ],
+      "orbit_scope_pair": [
+        1,
+        1
+      ],
+      "orbit_scope_profile": [
+        0,
+        0
+      ],
+      "order": 2,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "shell_scope_fine_top_pair": [
+        4,
+        1
+      ],
+      "shell_scope_pair": [
+        4,
+        2
+      ],
+      "shell_scope_profile": [
+        2,
+        1
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": true,
+      "carries_the_target_pair_fine_at_the_orbit_scope": true,
+      "name": "C3_body",
+      "orbit_scope_decomposition_is_unique": true,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1,
+        2
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        2
+      ],
+      "orbit_scope_pair": [
+        1,
+        2
+      ],
+      "orbit_scope_profile": [
+        0,
+        1
+      ],
+      "order": 3,
+      "shell_orbit_lengths": [
+        3,
+        3
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "shell_scope_fine_top_pair": [
+        2,
+        2
+      ],
+      "shell_scope_pair": [
+        2,
+        4
+      ],
+      "shell_scope_profile": [
+        1,
+        2
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": true,
+      "name": "C4_face",
+      "orbit_scope_decomposition_is_unique": true,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1,
+        1,
+        2
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        2
+      ],
+      "orbit_scope_pair": [
+        1,
+        3
+      ],
+      "orbit_scope_profile": [
+        0,
+        0
+      ],
+      "order": 4,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        4
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      "shell_scope_fine_top_pair": [
+        3,
+        2
+      ],
+      "shell_scope_pair": [
+        3,
+        3
+      ],
+      "shell_scope_profile": [
+        0,
+        0
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "D4_face",
+      "orbit_scope_decomposition_is_unique": null,
+      "orbit_scope_exists": false,
+      "orbit_scope_fine_dims": null,
+      "orbit_scope_fine_top_pair": null,
+      "orbit_scope_pair": null,
+      "orbit_scope_profile": null,
+      "order": 8,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      "shell_scope_fine_top_pair": [
+        2,
+        2
+      ],
+      "shell_scope_pair": [
+        2,
+        4
+      ],
+      "shell_scope_profile": [
+        1,
+        2
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "E_trivial",
+      "orbit_scope_decomposition_is_unique": true,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        1
+      ],
+      "orbit_scope_pair": [
+        1,
+        0
+      ],
+      "orbit_scope_profile": [
+        0,
+        null
+      ],
+      "order": 1,
+      "shell_orbit_lengths": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "shell_scope_fine_top_pair": [
+        6,
+        1
+      ],
+      "shell_scope_pair": [
+        6,
+        0
+      ],
+      "shell_scope_profile": [
+        1,
+        null
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "O_full",
+      "orbit_scope_decomposition_is_unique": null,
+      "orbit_scope_exists": false,
+      "orbit_scope_fine_dims": null,
+      "orbit_scope_fine_top_pair": null,
+      "orbit_scope_pair": null,
+      "orbit_scope_profile": null,
+      "order": 24,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "shell_scope_decomposition_is_unique": true,
+      "shell_scope_fine_dims": [
+        1,
+        2,
+        3
+      ],
+      "shell_scope_fine_top_pair": [
+        1,
+        3
+      ],
+      "shell_scope_pair": [
+        1,
+        5
+      ],
+      "shell_scope_profile": [
+        0,
+        0
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": true,
+      "name": "S3_body",
+      "orbit_scope_decomposition_is_unique": false,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        2
+      ],
+      "orbit_scope_pair": [
+        1,
+        5
+      ],
+      "orbit_scope_profile": [
+        0,
+        0
+      ],
+      "order": 6,
+      "shell_orbit_lengths": [
+        6
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "shell_scope_fine_top_pair": [
+        1,
+        2
+      ],
+      "shell_scope_pair": [
+        1,
+        5
+      ],
+      "shell_scope_profile": [
+        0,
+        0
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "V_edge",
+      "orbit_scope_decomposition_is_unique": true,
+      "orbit_scope_exists": true,
+      "orbit_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "orbit_scope_fine_top_pair": [
+        1,
+        1
+      ],
+      "orbit_scope_pair": [
+        1,
+        3
+      ],
+      "orbit_scope_profile": [
+        0,
+        0
+      ],
+      "order": 4,
+      "shell_orbit_lengths": [
+        2,
+        4
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "shell_scope_fine_top_pair": [
+        2,
+        1
+      ],
+      "shell_scope_pair": [
+        2,
+        4
+      ],
+      "shell_scope_profile": [
+        1,
+        2
+      ]
+    },
+    {
+      "carries_the_target_pair_coarse_at_the_orbit_scope": false,
+      "carries_the_target_pair_fine_at_the_orbit_scope": false,
+      "name": "V_face",
+      "orbit_scope_decomposition_is_unique": null,
+      "orbit_scope_exists": false,
+      "orbit_scope_fine_dims": null,
+      "orbit_scope_fine_top_pair": null,
+      "orbit_scope_pair": null,
+      "orbit_scope_profile": null,
+      "order": 4,
+      "shell_orbit_lengths": [
+        2,
+        2,
+        2
+      ],
+      "shell_scope_decomposition_is_unique": false,
+      "shell_scope_fine_dims": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "shell_scope_fine_top_pair": [
+        3,
+        1
+      ],
+      "shell_scope_pair": [
+        3,
+        3
+      ],
+      "shell_scope_profile": [
+        0,
+        0
+      ]
+    }
+  ],
+  "source_pins": [
+    {
+      "git_blob": "4a863da1f3f255354839277271a3a69a5c205133",
+      "path": "docs/MINIMAL_AXIOMS_2026-06-29.md",
+      "sha256": "fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697"
+    },
+    {
+      "git_blob": "f4493d787ffb6edc50e9dd13d37ba1cd1dd4d24a",
+      "path": "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+      "sha256": "1dfa47a86de8cab5a91cd33a022beb845d918e2f93ceb58f360b2708a44d02a2"
+    },
+    {
+      "git_blob": "c3a3785a758123d95b8506d34d143420765ed15e",
+      "path": "scripts/frontier_cycle886_sl0_independent_check_2026_07_28.py",
+      "sha256": "3a666e41a59a51e3d5f182578e71c0d91e2b6a386b1c92105b06c01a97d6693f"
+    },
+    {
+      "git_blob": "4d9999c241b19b2670a51c809e3e39fb0d339f10",
+      "path": "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+      "sha256": "74d64090515cf7f7c5ad5f8e6347f7d2f81a9c1cf0b41e9ec7726ad30a62d69d"
+    },
+    {
+      "git_blob": "1680a44f70cda252e8edb71f0ed95837a5e5dcb4",
+      "path": "outputs/sl0_independent_check_cycle886_receipt_2026_07_28.json",
+      "sha256": "80e85dbaebd2e031669bf17622d11325be66f47128cc3494e90c9b65396d7aed"
+    },
+    {
+      "git_blob": "d563c2b9c2a261f44d7304baa51fdd3596188930",
+      "path": "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+      "sha256": "2d96422d30f169a1c4b3215db373e4bffd7b1ef20056ea337ff4ae3f86d9511c"
+    },
+    {
+      "git_blob": "c13380757eae27bdee05bc0d4be65a40c2865585",
+      "path": "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+      "sha256": "cd8126381cca2bf2a852de4daf14ef6955a3af122d2781acd400ebe674efbf2a"
+    }
+  ],
+  "subgroup_lattice_census": [
+    {
+      "class_index": 0,
+      "is_abelian": true,
+      "is_cyclic": true,
+      "name": "E_trivial",
+      "normal_in_the_full_group": true,
+      "normalizer_order": 24,
+      "order": 1,
+      "size": 1
+    },
+    {
+      "class_index": 1,
+      "is_abelian": true,
+      "is_cyclic": true,
+      "name": "C2_face",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 8,
+      "order": 2,
+      "size": 3
+    },
+    {
+      "class_index": 2,
+      "is_abelian": true,
+      "is_cyclic": true,
+      "name": "C2_edge",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 4,
+      "order": 2,
+      "size": 6
+    },
+    {
+      "class_index": 3,
+      "is_abelian": true,
+      "is_cyclic": true,
+      "name": "C3_body",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 6,
+      "order": 3,
+      "size": 4
+    },
+    {
+      "class_index": 4,
+      "is_abelian": true,
+      "is_cyclic": false,
+      "name": "V_face",
+      "normal_in_the_full_group": true,
+      "normalizer_order": 24,
+      "order": 4,
+      "size": 1
+    },
+    {
+      "class_index": 5,
+      "is_abelian": true,
+      "is_cyclic": false,
+      "name": "V_edge",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 8,
+      "order": 4,
+      "size": 3
+    },
+    {
+      "class_index": 6,
+      "is_abelian": true,
+      "is_cyclic": true,
+      "name": "C4_face",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 8,
+      "order": 4,
+      "size": 3
+    },
+    {
+      "class_index": 7,
+      "is_abelian": false,
+      "is_cyclic": false,
+      "name": "S3_body",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 6,
+      "order": 6,
+      "size": 4
+    },
+    {
+      "class_index": 8,
+      "is_abelian": false,
+      "is_cyclic": false,
+      "name": "D4_face",
+      "normal_in_the_full_group": false,
+      "normalizer_order": 8,
+      "order": 8,
+      "size": 3
+    },
+    {
+      "class_index": 9,
+      "is_abelian": false,
+      "is_cyclic": false,
+      "name": "A4_tetrahedral",
+      "normal_in_the_full_group": true,
+      "normalizer_order": 24,
+      "order": 12,
+      "size": 1
+    },
+    {
+      "class_index": 10,
+      "is_abelian": false,
+      "is_cyclic": false,
+      "name": "O_full",
+      "normal_in_the_full_group": true,
+      "normalizer_order": 24,
+      "order": 24,
+      "size": 1
+    }
+  ],
+  "subgroups_found": 30,
+  "survivors_per_selector": {
+    "SEL01_free_on_shell": [
+      "C2_edge",
+      "C3_body",
+      "E_trivial",
+      "S3_body"
+    ],
+    "SEL02_transitive_on_shell": [
+      "A4_tetrahedral",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL03_multiplicity_one_orbit_scope": [
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "E_trivial",
+      "S3_body",
+      "V_edge"
+    ],
+    "SEL04_multiplicity_one_shell_scope": [
+      "A4_tetrahedral",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL05_minimal_shell_invariant_multiplicity": [
+      "A4_tetrahedral",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL06_maximal_free_shell_orbit": [
+      "S3_body"
+    ],
+    "SEL07_coarse_pair_v2_equals_one": [
+      "C3_body"
+    ],
+    "SEL08_reachability_R1_orbit_scope": [
+      "C3_body"
+    ],
+    "SEL09_reachability_R2_shell_scope": [
+      "C2_edge",
+      "C3_body",
+      "V_face"
+    ],
+    "SEL10_fine_top_pair_is_the_target": [
+      "C3_body",
+      "C4_face",
+      "S3_body"
+    ],
+    "SEL11_transitive_on_coordinate_axes": [
+      "A4_tetrahedral",
+      "C3_body",
+      "O_full",
+      "S3_body"
+    ],
+    "SEL12_odd_order": [
+      "C3_body",
+      "E_trivial"
+    ],
+    "SEL13_count_once": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ],
+    "SEL14_content_only_readout": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ],
+    "SEL15_admissibility_covariance": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ],
+    "SEL16_no_site_privileged_read_literally": [
+      "A4_tetrahedral",
+      "C2_edge",
+      "C2_face",
+      "C3_body",
+      "C4_face",
+      "D4_face",
+      "E_trivial",
+      "O_full",
+      "S3_body",
+      "V_edge",
+      "V_face"
+    ]
+  },
+  "ungrounded_nonempty_conjunction_survivors": [],
+  "what_this_does_to_SL0": "SL0's answer stays PRICING, and the price goes UP. The menu is not six clauses over four classes; it is three clauses over eleven classes, two of them circular, and the one non-circular survivor needs a repair. The rival that survives de-restriction best -- S3 -- is the one scope at which SL1's no-free-parameter property fails.",
+  "what_this_does_to_SL1": "SL1 is still untouched AT the C3 scope. What is new is that the obvious generalization to the simply-transitive scope does not reproduce it: the S3 readout has a free parameter that the C3 readout does not. SL1's uniqueness is a property of multiplicity-free scopes, and that is now computed rather than assumed."
+}

--- a/scripts/frontier_cycle888_s3_scope_independent_check_2026_07_28.py
+++ b/scripts/frontier_cycle888_s3_scope_independent_check_2026_07_28.py
@@ -1,0 +1,1993 @@
+#!/usr/bin/env python3
+"""Cycle 888 INDEPENDENT CHECK -- specified to REFUTE the S3 scope pricing.
+
+Nothing here is inherited from the primary.  The rotation group is rebuilt from
+the orthogonality condition M M^T = I over integer matrices; the subgroup
+lattice is rebuilt by ITERATED EXTENSION (close <H, g> for every found H and
+every group element until the family is stable) and cross-checked against the
+Sylow congruences and the class equation; the isotype decompositions are
+rebuilt by MINIMAL CYCLIC SUBMODULES and orthogonal complements, with block
+characters used to group them -- no enveloping algebra, no centre, no minimal
+polynomial, no cyclotomics; reachability is re-decided by Smith-style
+diagonalization; every one of the sixteen selector survivor sets is recomputed
+over all thirty subgroups; and the scope-insensitivity verdicts are recomputed
+from scratch.
+
+The hardest attack is on the SL1-TRANSFER claim.  The primary says the S3
+readout's (1, 2) fine-top pair is NOT forced, because the 2-dimensional
+irreducible occurs twice.  This checker tries to break that both ways: it hunts
+for a second inequivalent readout construction at S3 scope carrying a DIFFERENT
+pair (which would refute the transfer claim outright), and it independently
+recomputes the multiplicity ledgers at C3 and C4 that the primary's peer
+comparison rests on.
+
+Exit status is 0 whether or not the claims survive.
+"""
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 900
+STDOUT_LIMIT_BYTES = 400_000
+
+AUDIT_INPUT_PATHS = (
+    "scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py",
+    "outputs/s3_scope_pricing_cycle888_receipt_2026_07_28.json",
+    "logs/runner-cache/frontier_cycle888_s3_scope_pricing_2026_07_28.txt",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+    "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+    "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+)
+
+import ast
+from fractions import Fraction
+from hashlib import sha256
+import importlib.abc
+from itertools import combinations, product
+import json
+from math import gcd
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from time import monotonic
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / "outputs" / \
+    "s3_scope_independent_check_cycle888_receipt_2026_07_28.json"
+
+BLOCKLISTED_MODULES = tuple(Path(p).stem for p in AUDIT_INPUT_PATHS)
+
+EXPECTED_SHA256 = {
+    AUDIT_INPUT_PATHS[0]:
+        "f57fda877d35d49953c3b6a34293ab0cc6a87781ceb9d158b9c9abb5abd4bb3f",
+    AUDIT_INPUT_PATHS[1]:
+        "8a540201a84a6b8cb6868d431216718a27f200e45d6ceeb771d858e9a54280cd",
+    AUDIT_INPUT_PATHS[2]:
+        "5e4fc183efda55d1f3fbd5413bd2fe985ed5732b7ffbc8bd489296e7b22c2c84",
+    AUDIT_INPUT_PATHS[3]:
+        "fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697",
+    AUDIT_INPUT_PATHS[4]:
+        "1dfa47a86de8cab5a91cd33a022beb845d918e2f93ceb58f360b2708a44d02a2",
+    AUDIT_INPUT_PATHS[5]:
+        "74d64090515cf7f7c5ad5f8e6347f7d2f81a9c1cf0b41e9ec7726ad30a62d69d",
+    AUDIT_INPUT_PATHS[6]:
+        "2d96422d30f169a1c4b3215db373e4bffd7b1ef20056ea337ff4ae3f86d9511c",
+}
+EXPECTED_GIT_BLOBS = {
+    AUDIT_INPUT_PATHS[0]: "c3de02c94b8a11a930ad6ff8817975b118bc776d",
+    AUDIT_INPUT_PATHS[1]: "3e18ad52f50e72b83c56da72c31f25d104b5c830",
+    AUDIT_INPUT_PATHS[2]: "6cd3fbdbe74e1231cd61222a798a7979bee922da",
+    AUDIT_INPUT_PATHS[3]: "4a863da1f3f255354839277271a3a69a5c205133",
+    AUDIT_INPUT_PATHS[4]: "f4493d787ffb6edc50e9dd13d37ba1cd1dd4d24a",
+    AUDIT_INPUT_PATHS[5]: "4d9999c241b19b2670a51c809e3e39fb0d339f10",
+    AUDIT_INPUT_PATHS[6]: "d563c2b9c2a261f44d7304baa51fdd3596188930",
+}
+
+SHELL = ((1, 0, 0), (0, 1, 0), (0, 0, 1), (-1, 0, 0), (0, -1, 0), (0, 0, -1))
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+TARGET = Fraction(2, 9)
+TARGET_PAIR = (1, 2)
+
+LABELS = (
+    "A_PINS",
+    "B_INDEPENDENT_GROUP",
+    "C_INDEPENDENT_LATTICE",
+    "D_INDEPENDENT_ISOTYPE",
+    "E_INDEPENDENT_SELECTORS",
+    "F_INDEPENDENT_REACHABILITY",
+    "G_SL1_TRANSFER_ATTACK",
+    "H_INDEPENDENT_SCOPE_INSENSITIVITY",
+    "I_UPSTREAM_PIN_FIDELITY",
+    "J_REFUTATION_ATTEMPTS",
+    "K_TEETH",
+    "L_FINDINGS",
+    "M_VERDICT",
+)
+
+
+class _Firewall(importlib.abc.MetaPathFinder):
+    def __init__(self) -> None:
+        self.hits: list[str] = []
+
+    def find_module(self, fullname, path=None):       # pragma: no cover legacy
+        return self.find_spec(fullname, path)
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.rsplit(".", 1)[-1] in BLOCKLISTED_MODULES:
+            self.hits.append(fullname)
+            raise ImportError(f"BLOCKLIST forbids import of {fullname}")
+        return None
+
+
+FIREWALL = _Firewall()
+sys.meta_path.insert(0, FIREWALL)
+
+
+def _bytes(path: str) -> bytes:
+    return (ROOT / path).read_bytes()
+
+
+def _text(path: str) -> str:
+    return _bytes(path).decode("utf-8")
+
+
+def norm(t: str) -> str:
+    return re.sub(r"\s+", " ", t).strip()
+
+
+def digest(payload: object) -> str:
+    return sha256(json.dumps(payload, sort_keys=True,
+                             default=str).encode("utf-8")).hexdigest()
+
+
+def q(v: Fraction) -> str:
+    return f"{v.numerator}/{v.denominator}"
+
+
+def vp(value: Fraction, p: int):
+    if value == 0:
+        return None
+    n, d, e = abs(value.numerator), value.denominator, 0
+    while n % p == 0:
+        n //= p
+        e += 1
+    while d % p == 0:
+        d //= p
+        e -= 1
+    return e
+
+
+def prime_factors(n: int) -> list[int]:
+    out, m, d = [], abs(n), 2
+    while d * d <= m:
+        if m % d == 0:
+            out.append(d)
+            while m % d == 0:
+                m //= d
+        d += 1
+    if m > 1:
+        out.append(m)
+    return out
+
+
+# --------------------------------------------------------------------------
+# exact linear algebra (independent implementation)
+# --------------------------------------------------------------------------
+def echelon(rows):
+    mat = [[Fraction(x) for x in r] for r in rows]
+    mat = [r for r in mat if any(r)]
+    if not mat:
+        return []
+    width = len(mat[0])
+    out, r = [], 0
+    for col in range(width):
+        piv = next((i for i in range(r, len(mat)) if mat[i][col] != 0), None)
+        if piv is None:
+            continue
+        mat[r], mat[piv] = mat[piv], mat[r]
+        head = mat[r][col]
+        mat[r] = [x / head for x in mat[r]]
+        for i in range(len(mat)):
+            if i != r and mat[i][col] != 0:
+                f = mat[i][col]
+                mat[i] = [a - f * b for a, b in zip(mat[i], mat[r])]
+        r += 1
+    return [row for row in mat[:r]]
+
+
+def dim_of(rows) -> int:
+    return len(echelon(rows))
+
+
+def nullspace(rows, width):
+    mat = echelon(rows)
+    pivots = []
+    for row in mat:
+        pivots.append(next(i for i, x in enumerate(row) if x != 0))
+    free = [c for c in range(width) if c not in pivots]
+    basis = []
+    for f in free:
+        vec = [Fraction(0)] * width
+        vec[f] = Fraction(1)
+        for i, p in enumerate(pivots):
+            vec[p] = -mat[i][f]
+        basis.append(vec)
+    return basis
+
+
+def mul3(a, b):
+    return tuple(tuple(sum(a[i][k] * b[k][j] for k in range(3))
+                       for j in range(3)) for i in range(3))
+
+
+def act(m, v):
+    return tuple(sum(m[i][j] * v[j] for j in range(3)) for i in range(3))
+
+
+def det(m):
+    return (m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+            - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+            + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]))
+
+
+I3 = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def orthogonal_group():
+    """Rebuilt from M M^T = I with det +1 over {-1,0,1}^9 -- a different
+    construction from the primary's signed-permutation enumeration."""
+    out = []
+    for entries in product((-1, 0, 1), repeat=9):
+        m = (entries[0:3], entries[3:6], entries[6:9])
+        prod = [[sum(m[i][k] * m[j][k] for k in range(3)) for j in range(3)]
+                for i in range(3)]
+        if prod != [[1, 0, 0], [0, 1, 0], [0, 0, 1]]:
+            continue
+        if det(m) != 1:
+            continue
+        out.append(m)
+    return sorted(out)
+
+
+GROUP = orthogonal_group()
+GSET = frozenset(GROUP)
+INV = {m: next(b for b in GROUP if mul3(m, b) == I3) for m in GROUP}
+
+
+def order_of(m) -> int:
+    cur, k = m, 1
+    while cur != I3:
+        cur = mul3(cur, m)
+        k += 1
+    return k
+
+
+def orbits(subgroup, points):
+    seen, out = set(), []
+    for p in points:
+        if p in seen:
+            continue
+        orb = {p}
+        frontier = [p]
+        while frontier:
+            cur = frontier.pop()
+            for m in subgroup:
+                nxt = act(m, cur)
+                if nxt not in orb:
+                    orb.add(nxt)
+                    frontier.append(nxt)
+        seen |= orb
+        out.append(tuple(sorted(orb)))
+    return out
+
+
+def axis_of(m):
+    if m == I3:
+        return None
+    canon = set()
+    for v in product((-1, 0, 1), repeat=3):
+        if not any(v) or act(m, v) != v:
+            continue
+        g = 0
+        for x in v:
+            g = gcd(g, abs(x))
+        w = tuple(x // g for x in v)
+        lead = next(x for x in w if x != 0)
+        canon.add(w if lead > 0 else tuple(-x for x in w))
+    return canon.pop() if len(canon) == 1 else None
+
+
+def axis_kind(m) -> str:
+    a = axis_of(m)
+    return {1: "face", 2: "edge", 3: "body"}[sum(1 for x in a if x)]
+
+
+# --------------------------------------------------------------------------
+# independent lattice: ITERATED EXTENSION, not pair closure
+# --------------------------------------------------------------------------
+def generated_by(seeds) -> frozenset:
+    found = {I3} | set(seeds)
+    frontier = list(found)
+    while frontier:
+        cur = frontier.pop()
+        for other in list(found):
+            for pr in (mul3(cur, other), mul3(other, cur)):
+                if pr not in found:
+                    found.add(pr)
+                    frontier.append(pr)
+    return frozenset(found)
+
+
+def lattice_by_iterated_extension() -> list[frozenset]:
+    family = {frozenset({I3})}
+    while True:
+        grown = set(family)
+        for h in family:
+            for g in GROUP:
+                grown.add(generated_by(set(h) | {g}))
+        if grown == family:
+            break
+        family = grown
+    return sorted(family, key=lambda h: (len(h), sorted(h)))
+
+
+LATTICE = lattice_by_iterated_extension()
+
+
+def is_cyclic(h) -> bool:
+    return any(generated_by({g}) == h for g in h)
+
+
+def is_abelian(h) -> bool:
+    return all(mul3(a, b) == mul3(b, a) for a in h for b in h)
+
+
+def name_of(h) -> str:
+    n = len(h)
+    if n == 1:
+        return "E_trivial"
+    kinds = sorted(axis_kind(m) for m in h if m != I3)
+    if is_cyclic(h):
+        return f"C{n}_{kinds[0]}"
+    if is_abelian(h) and n == 4:
+        return "V_face" if set(kinds) == {"face"} else "V_edge"
+    return {6: "S3_body", 8: "D4_face", 12: "A4_tetrahedral",
+            24: "O_full"}.get(n, f"G{n}")
+
+
+def normalizer(h) -> frozenset:
+    return frozenset(g for g in GROUP
+                     if frozenset(mul3(mul3(g, x), INV[g]) for x in h) == h)
+
+
+def class_of(h) -> frozenset:
+    return frozenset(frozenset(mul3(mul3(g, x), INV[g]) for x in h)
+                     for g in GROUP)
+
+
+# --------------------------------------------------------------------------
+# independent isotype: MINIMAL CYCLIC SUBMODULES + orthogonal complements
+# --------------------------------------------------------------------------
+def perm_matrix(elem, points):
+    idx = {p: i for i, p in enumerate(points)}
+    n = len(points)
+    m = [[Fraction(0)] * n for _ in range(n)]
+    for j, p in enumerate(points):
+        m[idx[act(elem, p)]][j] = Fraction(1)
+    return m
+
+
+def apply_matrix(m, vec):
+    n = len(vec)
+    return [sum(m[i][j] * vec[j] for j in range(n)) for i in range(n)]
+
+
+def cyclic_module(mats, w):
+    return echelon([apply_matrix(m, w) for m in mats])
+
+
+def subspace_key(rows):
+    return tuple(tuple(q(x) for x in r) for r in echelon(rows))
+
+
+def test_vectors(basis, n, spread=1):
+    dim = len(basis)
+    for coeffs in product(range(-spread, spread + 1), repeat=dim):
+        if not any(coeffs):
+            continue
+        yield [sum(Fraction(coeffs[j]) * basis[j][i] for j in range(dim))
+               for i in range(n)], list(coeffs)
+
+
+def orthogonal_complement(ambient, block, n):
+    """Complement of `block` inside `ambient` for the standard inner product.
+    Permutation representations are orthogonal, so this is a submodule."""
+    rows = []
+    for b in block:
+        rows.append([sum(b[k] * a[k] for k in range(n)) for a in ambient])
+    coeffs = nullspace(rows, len(ambient))
+    return [[sum(c[j] * ambient[j][i] for j in range(len(ambient)))
+             for i in range(n)] for c in coeffs]
+
+
+def eigen_subspace(block, mat, lam, n):
+    """{x in span(block) : mat x = lam x}, in ambient coordinates."""
+    d = len(block)
+    images = [apply_matrix(mat, b) for b in block]
+    rows = [[images[i][j] - Fraction(lam) * block[i][j] for i in range(d)]
+            for j in range(n)]
+    coeffs = nullspace(rows, d)
+    return [[sum(c[i] * block[i][j] for i in range(d)) for j in range(n)]
+            for c in coeffs]
+
+
+def module_generated(mats, vectors):
+    return echelon([apply_matrix(m, v) for m in mats for v in vectors])
+
+
+def proper_submodule(block, mats, n):
+    """A proper nonzero submodule of `block`, or None. Two routes: the
+    eigen-subspaces of single group elements, and small test vectors."""
+    d = len(block)
+    if d <= 1:
+        return None
+    for mat in mats:
+        for lam in (1, -1):
+            piece = eigen_subspace(block, mat, lam, n)
+            if not piece:
+                continue
+            sub = module_generated(mats, piece)
+            if 0 < len(sub) < d:
+                return sub
+    for spread in (1, 2, 3):
+        for w, _ in test_vectors(block, n, spread):
+            sub = module_generated(mats, [w])
+            if 0 < len(sub) < d:
+                return sub
+    return None
+
+
+def split_block(block, mats, n, guard=0):
+    """Split one block into irreducibles, recursively."""
+    if guard > n + 2:
+        return None
+    sub = proper_submodule(block, mats, n)
+    if sub is None:
+        return [block]
+    rest = orthogonal_complement(block, sub, n)
+    left = split_block(sub, mats, n, guard + 1)
+    right = split_block(rest, mats, n, guard + 1) if rest else []
+    if left is None or right is None:
+        return None
+    return left + right
+
+
+def split_into_irreducibles(subgroup, points):
+    """Independent decomposition: peel off a MINIMAL nonzero cyclic submodule,
+    split it fully into irreducibles, then continue on its orthogonal
+    complement inside the current space."""
+    n = len(points)
+    mats = [perm_matrix(g, points) for g in sorted(subgroup)]
+    ambient = [[Fraction(1) if i == j else Fraction(0) for j in range(n)]
+               for i in range(n)]
+    blocks = []
+    guard = 0
+    while ambient:
+        guard += 1
+        if guard > n + 2:
+            return None, "peeling did not terminate"
+        best = None
+        for w, _ in test_vectors(ambient, n, 1):
+            span = module_generated(mats, [w])
+            if span and (best is None or len(span) < len(best)):
+                best = span
+            if best is not None and len(best) == 1:
+                break
+        if best is None:
+            return None, "no cyclic submodule found"
+        pieces = split_block(best, mats, n)
+        if pieces is None:
+            return None, "a block could not be split into irreducibles"
+        blocks.extend(pieces)
+        ambient = orthogonal_complement(ambient, best, n)
+    return blocks, None
+
+
+def block_character(mats, block, elements):
+    """Trace of each group element restricted to the block, exactly."""
+    n = len(block[0])
+    d = len(block)
+    cols = [[block[k][i] for k in range(d)] for i in range(n)]
+    out = []
+    for m in mats:
+        images = [apply_matrix(m, b) for b in block]
+        rows = [cols[i] + [images[k][i] for k in range(d)] for i in range(n)]
+        red = echelon(rows)
+        pivots = [next(j for j, x in enumerate(r) if x != 0) for r in red]
+        if pivots[:d] != list(range(d)):
+            return None
+        coeff = [[red[i][d + j] for j in range(d)] for i in range(d)]
+        out.append(sum(coeff[i][i] for i in range(d)))
+    return tuple(q(x) for x in out)
+
+
+def block_endomorphism_dimension(mats, block):
+    """dim_Q End_{Q[H]}(block), by solving the commutant on the block."""
+    n = len(block[0])
+    d = len(block)
+    cols = [[block[k][i] for k in range(d)] for i in range(n)]
+    restricted = []
+    for m in mats:
+        images = [apply_matrix(m, b) for b in block]
+        rows = [cols[i] + [images[k][i] for k in range(d)] for i in range(n)]
+        red = echelon(rows)
+        restricted.append([[red[i][d + j] for j in range(d)] for i in range(d)])
+    eqs = []
+    for c in restricted:
+        for i in range(d):
+            for j in range(d):
+                row = [Fraction(0)] * (d * d)
+                for k in range(d):
+                    row[i * d + k] += c[k][j]
+                    row[k * d + j] -= c[i][k]
+                eqs.append(row)
+    return len(nullspace(eqs, d * d))
+
+
+def independent_signature(subgroup, points):
+    n = len(points)
+    elements = sorted(subgroup)
+    mats = [perm_matrix(g, points) for g in elements]
+    blocks, err = split_into_irreducibles(subgroup, points)
+    if blocks is None:
+        return {"ok": False, "reason": err}
+    # irreducibility certificate: every nonzero small vector in a block must
+    # generate the whole block
+    irreducible = all(proper_submodule(b, mats, n) is None for b in blocks)
+    groups: dict[tuple, list] = {}
+    for b in blocks:
+        ch = block_character(mats, b, elements)
+        if ch is None:
+            return {"ok": False, "reason": "block is not invariant"}
+        groups.setdefault(ch, []).append(b)
+    isotypes = []
+    for ch, members in groups.items():
+        d = len(members[0])
+        isotypes.append({
+            "irreducible_degree_over_Q": d,
+            "multiplicity": len(members),
+            "component_dimension": d * len(members),
+            "endomorphism_field_degree":
+                block_endomorphism_dimension(mats, members[0]),
+            "character": list(ch),
+            "is_the_trivial_isotype": all(x == "1/1" for x in ch) and d == 1,
+        })
+    isotypes.sort(key=lambda b: (b["irreducible_degree_over_Q"],
+                                 b["multiplicity"],
+                                 b["endomorphism_field_degree"]))
+    fine = sorted(d for b in isotypes
+                  for d in [b["irreducible_degree_over_Q"]] * b["multiplicity"])
+    orbs = orbits(elements, points)
+    pair_orbit_count = 0
+    seen = set()
+    for a in points:
+        for b in points:
+            if (a, b) in seen:
+                continue
+            pair_orbit_count += 1
+            for g in elements:
+                seen.add((act(g, a), act(g, b)))
+    inv = len(orbs)
+    return {
+        "ok": True,
+        "space_dimension": n,
+        "block_dimensions": sorted(len(b) for b in blocks),
+        "every_block_has_no_proper_submodule": irreducible,
+        "invariant_multiplicity_by_orbit_count": inv,
+        "coarse_pair": [inv, n - inv],
+        "coarse_two_adic_profile": [
+            vp(Fraction(inv), 2) if inv else None,
+            vp(Fraction(n - inv), 2) if n - inv else None],
+        "fine_dimensions": fine,
+        "fine_sums_to_the_space": sum(fine) == n,
+        "fine_top": max(fine) if fine else 0,
+        "fine_top_pair": [inv, max(fine) if fine else 0],
+        "fine_top_two_adic_profile": [
+            vp(Fraction(inv), 2) if inv else None,
+            vp(Fraction(max(fine)), 2) if fine and max(fine) else None],
+        "isotypes": isotypes,
+        "isotypic_decomposition_is_unique":
+            all(b["multiplicity"] == 1 for b in isotypes),
+        "orbit_count_on_the_product_set": pair_orbit_count,
+        "sum_m_squared_field_degree": sum(
+            b["multiplicity"] ** 2 * b["endomorphism_field_degree"]
+            for b in isotypes),
+        "pair_identity_holds": sum(
+            b["multiplicity"] ** 2 * b["endomorphism_field_degree"]
+            for b in isotypes) == pair_orbit_count,
+    }
+
+
+# --------------------------------------------------------------------------
+# independent reachability: Smith-style diagonalization
+# --------------------------------------------------------------------------
+def diagonalize(matrix):
+    a = [row[:] for row in matrix]
+    m = len(a)
+    n = len(a[0]) if m else 0
+    u = [[1 if i == j else 0 for j in range(m)] for i in range(m)]
+    pos = 0
+    while pos < min(m, n):
+        piv = None
+        for i in range(pos, m):
+            for j in range(pos, n):
+                if a[i][j] != 0:
+                    piv = (i, j)
+                    break
+            if piv:
+                break
+        if piv is None:
+            break
+        i, j = piv
+        a[pos], a[i] = a[i], a[pos]
+        u[pos], u[i] = u[i], u[pos]
+        for r in range(m):
+            a[r][pos], a[r][j] = a[r][j], a[r][pos]
+        while True:
+            for i2 in range(pos + 1, m):
+                if a[i2][pos]:
+                    f = a[i2][pos] // a[pos][pos]
+                    for c in range(n):
+                        a[i2][c] -= f * a[pos][c]
+                    for c in range(m):
+                        u[i2][c] -= f * u[pos][c]
+                    if a[i2][pos]:
+                        a[pos], a[i2] = a[i2], a[pos]
+                        u[pos], u[i2] = u[i2], u[pos]
+            for j2 in range(pos + 1, n):
+                if a[pos][j2]:
+                    f = a[pos][j2] // a[pos][pos]
+                    for r in range(m):
+                        a[r][j2] -= f * a[r][pos]
+                    if a[pos][j2]:
+                        for r in range(m):
+                            a[r][pos], a[r][j2] = a[r][j2], a[r][pos]
+            if (all(a[i2][pos] == 0 for i2 in range(pos + 1, m))
+                    and all(a[pos][j2] == 0 for j2 in range(pos + 1, n))):
+                break
+        pos += 1
+    return a, u
+
+
+def solvable(matrix, target) -> bool:
+    m = len(target)
+    if not matrix or not matrix[0]:
+        return not any(target)
+    d, u = diagonalize(matrix)
+    c = [sum(u[i][k] * target[k] for k in range(m)) for i in range(m)]
+    n = len(d[0])
+    for i in range(m):
+        pivot = d[i][i] if i < n else 0
+        if pivot == 0:
+            if c[i] != 0:
+                return False
+        elif c[i] % pivot != 0:
+            return False
+    return True
+
+
+def reaches(generators, target: Fraction) -> bool:
+    gens = sorted({g for g in generators if g not in (0, 1, -1)})
+    primes = sorted(set([p for g in gens for p in prime_factors(g)]
+                        + prime_factors(target.numerator)
+                        + prime_factors(target.denominator)))
+    if not primes:
+        return True
+    if not gens:
+        return not any(vp(target, p) for p in primes)
+    matrix = [[vp(Fraction(g), p) for g in gens] for p in primes]
+    return solvable(matrix, [vp(target, p) for p in primes])
+
+
+# --------------------------------------------------------------------------
+# the checker's own analysis of every subgroup
+# --------------------------------------------------------------------------
+def analyse_lattice():
+    class_index = {}
+    classes = []
+    for h in LATTICE:
+        if h in class_index:
+            continue
+        k = class_of(h)
+        idx = len(classes)
+        classes.append(k)
+        for member in k:
+            class_index[member] = idx
+    rows = []
+    for h in LATTICE:
+        order = len(h)
+        orbs = orbits(sorted(h), SHELL)
+        lengths = sorted(len(o) for o in orbs)
+        free = [o for o in orbs if len(o) == order]
+
+        def canon(v):
+            lead = next(x for x in v if x != 0)
+            return v if lead > 0 else tuple(-x for x in v)
+
+        seen, axis_orbits = set(), []
+        for a in AXES:
+            if a in seen:
+                continue
+            orb = {canon(act(m, a)) for m in h}
+            seen |= orb
+            axis_orbits.append(orb)
+        shell = independent_signature(h, list(SHELL))
+        orbit = independent_signature(h, sorted(max(free, key=len))) \
+            if free else None
+        rows.append({
+            "key": h,
+            "name": name_of(h),
+            "order": order,
+            "class_index": class_index[h],
+            "is_cyclic": is_cyclic(h),
+            "normalizer_order": len(normalizer(h)),
+            "shell_orbit_lengths": lengths,
+            "shell_orbit_count": len(orbs),
+            "acts_freely": all(L == order for L in lengths),
+            "transitive": len(orbs) == 1,
+            "simply_transitive": len(orbs) == 1 and lengths == [order],
+            "maximal_free_orbit_length":
+                max([L for L in lengths if L == order], default=0),
+            "has_free_orbit": bool(free),
+            "axis_transitive": len(axis_orbits) == 1,
+            "shell": shell,
+            "orbit": orbit,
+        })
+    return sorted(rows, key=lambda r: (r["order"], r["name"],
+                                       sorted(r["key"]))), len(classes)
+
+
+ANALYSIS, CLASS_COUNT = analyse_lattice()
+
+
+def receipt():
+    return json.loads(_text(AUDIT_INPUT_PATHS[1]))
+
+
+# --------------------------------------------------------------------------
+# certificate A
+# --------------------------------------------------------------------------
+def pins_certificate() -> dict:
+    rows, ok = [], True
+    for path in AUDIT_INPUT_PATHS:
+        target = ROOT / path
+        exists = target.exists()
+        got = sha256(_bytes(path)).hexdigest() if exists else None
+        blob = subprocess.run(["git", "hash-object", str(target)],
+                              capture_output=True, text=True,
+                              cwd=str(ROOT)).stdout.strip() if exists else None
+        sha_ok = got == EXPECTED_SHA256[path]
+        blob_ok = blob == EXPECTED_GIT_BLOBS[path]
+        ok = ok and exists and sha_ok and blob_ok
+        rows.append({"path": path, "absolute_path": str(target),
+                     "exists": exists, "sha256": got,
+                     "sha256_matches_pin": sha_ok, "git_blob": blob,
+                     "git_blob_matches_pin": blob_ok})
+    cache = _text(AUDIT_INPUT_PATHS[2])
+    declares = f"runner_sha256: {EXPECTED_SHA256[AUDIT_INPUT_PATHS[0]]}" in cache
+    exit_zero = "exit_code: 0" in cache
+    ok = ok and declares and exit_zero
+    return {
+        "statement": "The primary, its receipt, its run cache and every "
+                     "upstream artifact it read are pinned twice over.",
+        "rows": rows,
+        "run_cache_declares_the_pinned_runner_digest": declares,
+        "run_cache_records_exit_zero": exit_zero,
+        "finding": (
+            f"{sum(1 for r in rows if r['sha256_matches_pin'] and r['git_blob_matches_pin'])}"
+            f"/{len(rows)} pins round-trip; the run cache declares the pinned "
+            f"runner digest and exit 0."),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate B
+# --------------------------------------------------------------------------
+def group_certificate() -> dict:
+    closed = all(mul3(a, b) in GSET for a in GROUP for b in GROUP)
+    orders = {}
+    for m in GROUP:
+        orders[order_of(m)] = orders.get(order_of(m), 0) + 1
+    signed = set()
+    for perm in product(range(3), repeat=3):
+        if len(set(perm)) != 3:
+            continue
+        for signs in product((1, -1), repeat=3):
+            rows = []
+            for i in range(3):
+                row = [0, 0, 0]
+                row[perm[i]] = signs[i]
+                rows.append(tuple(row))
+            mm = tuple(rows)
+            if det(mm) == 1:
+                signed.add(mm)
+    same = signed == GSET
+    agrees = (len(GROUP) == 24 and closed and same
+              and orders == {1: 1, 2: 9, 3: 8, 4: 6})
+    return {
+        "statement": "The rotation group rebuilt from the orthogonality "
+                     "condition M M^T = I with det = +1 over 19683 integer "
+                     "matrices -- a different construction from the primary's "
+                     "signed-permutation enumeration.",
+        "candidates_scanned": 3 ** 9,
+        "group_order": len(GROUP),
+        "closed": closed,
+        "element_order_counts": dict(sorted(orders.items())),
+        "orthogonality_construction_equals_signed_permutation_construction":
+            same,
+        "primary_claim_reproduced": agrees,
+        "verdict": "SURVIVES" if agrees else "REFUTED",
+        "finding": (
+            f"The orthogonality construction returns the same {len(GROUP)} "
+            f"matrices with order profile {dict(sorted(orders.items()))}; the "
+            f"primary's group claim {'SURVIVES' if agrees else 'is REFUTED'}."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate C
+# --------------------------------------------------------------------------
+def lattice_certificate() -> dict:
+    r = receipt()
+    counts: dict[str, int] = {}
+    for h in LATTICE:
+        counts[name_of(h)] = counts.get(name_of(h), 0) + 1
+    claimed = {row["name"]: row["size"] for row in r["subgroup_lattice_census"]}
+    class_eq = []
+    for row in r["subgroup_lattice_census"]:
+        members = [h for h in LATTICE if name_of(h) == row["name"]]
+        norm_order = len(normalizer(members[0]))
+        class_eq.append({
+            "class": row["name"], "independent_size": len(members),
+            "independent_normalizer_order": norm_order,
+            "size_times_normalizer": len(members) * norm_order,
+            "equals_the_group_order": len(members) * norm_order == len(GROUP),
+            "primary_size": row["size"],
+            "sizes_agree": len(members) == row["size"],
+        })
+    n2 = sum(1 for h in LATTICE if len(h) == 8)
+    n3 = sum(1 for h in LATTICE if len(h) == 3)
+    sylow = (n2 % 2 == 1 and 3 % n2 == 0 and n3 % 3 == 1 and 8 % n3 == 0)
+    # a third route: subgroups generated by every SUBSET of size <= 3
+    third = {frozenset({I3})}
+    for size in (1, 2, 3):
+        for seeds in combinations(GROUP, size):
+            third.add(generated_by(set(seeds)))
+    third_agrees = set(third) == set(LATTICE)
+    agrees = (len(LATTICE) == r["subgroups_found"]
+              and CLASS_COUNT == r["conjugacy_classes"]
+              and counts == claimed
+              and all(row["equals_the_group_order"] for row in class_eq)
+              and all(row["sizes_agree"] for row in class_eq))
+    return {
+        "statement": "The subgroup lattice rebuilt by ITERATED EXTENSION -- "
+                     "close <H, g> for every found H and every group element "
+                     "until the family is stable -- then cross-checked against "
+                     "a third route (closure of every subset of size <= 3), "
+                     "the class equation and the Sylow congruences. A dropped "
+                     "class cannot survive three routes.",
+        "subgroups_found": len(LATTICE),
+        "conjugacy_classes": CLASS_COUNT,
+        "subgroups_by_derived_name": dict(sorted(counts.items())),
+        "primary_claimed_by_name": dict(sorted(claimed.items())),
+        "class_equation_rows": class_eq,
+        "third_route_subset_closure_agrees": third_agrees,
+        "sylow_2_count": n2,
+        "sylow_3_count": n3,
+        "sylow_congruences_hold": sylow,
+        "primary_claim_reproduced": agrees and third_agrees and sylow,
+        "verdict": "SURVIVES" if agrees and third_agrees and sylow
+                   else "REFUTED",
+        "finding": (
+            f"{len(LATTICE)} subgroups in {CLASS_COUNT} classes by iterated "
+            f"extension, identical to the subset-closure route "
+            f"({third_agrees}); the class equation holds on every class and "
+            f"the Sylow congruences hold (n_2 = {n2}, n_3 = {n3}); the "
+            f"primary's lattice "
+            f"{'SURVIVES' if agrees else 'is REFUTED'}."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate D
+# --------------------------------------------------------------------------
+def isotype_certificate() -> dict:
+    r = receipt()
+    claimed = {row["name"]: row for row in r["signatures_by_class"]}
+    rows, agree_all = [], True
+    for name in sorted(claimed):
+        mine = next(x for x in ANALYSIS if x["name"] == name)
+        want = claimed[name]
+        shell, orbit = mine["shell"], mine["orbit"]
+        same = (
+            shell["coarse_pair"] == want["shell_scope_pair"]
+            and shell["coarse_two_adic_profile"] == want["shell_scope_profile"]
+            and shell["fine_dimensions"] == want["shell_scope_fine_dims"]
+            and shell["fine_top_pair"] == want["shell_scope_fine_top_pair"]
+            and shell["isotypic_decomposition_is_unique"]
+            == want["shell_scope_decomposition_is_unique"]
+            and ((orbit is None and not want["orbit_scope_exists"])
+                 or (orbit is not None and want["orbit_scope_exists"]
+                     and orbit["coarse_pair"] == want["orbit_scope_pair"]
+                     and orbit["coarse_two_adic_profile"]
+                     == want["orbit_scope_profile"]
+                     and orbit["fine_dimensions"] == want["orbit_scope_fine_dims"]
+                     and orbit["fine_top_pair"] == want["orbit_scope_fine_top_pair"]
+                     and orbit["isotypic_decomposition_is_unique"]
+                     == want["orbit_scope_decomposition_is_unique"])))
+        gates = (shell["fine_sums_to_the_space"] and shell["pair_identity_holds"]
+                 and shell["every_block_has_no_proper_submodule"]
+                 and (orbit is None or (orbit["fine_sums_to_the_space"]
+                                        and orbit["pair_identity_holds"])))
+        agree_all = agree_all and same and gates
+        rows.append({
+            "name": name,
+            "independent_shell": {k: v for k, v in shell.items()
+                                  if k != "isotypes"},
+            "independent_orbit": ({k: v for k, v in orbit.items()
+                                   if k != "isotypes"} if orbit else None),
+            "independent_shell_isotypes": [
+                {k: v for k, v in b.items() if k != "character"}
+                for b in shell["isotypes"]],
+            "independent_orbit_isotypes": ([
+                {k: v for k, v in b.items() if k != "character"}
+                for b in orbit["isotypes"]] if orbit else None),
+            "primary_shell_pair": want["shell_scope_pair"],
+            "primary_orbit_pair": want["orbit_scope_pair"],
+            "agrees_with_the_primary": same,
+            "own_gates_hold": gates,
+        })
+    coarse = sorted(x["name"] for x in ANALYSIS
+                    if x["orbit"] and x["orbit"]["coarse_pair"] == [1, 2])
+    fine = sorted(x["name"] for x in ANALYSIS
+                  if x["orbit"] and x["orbit"]["fine_top_pair"] == [1, 2])
+    return {
+        "statement": "Every isotype number rebuilt by MINIMAL CYCLIC "
+                     "SUBMODULES and orthogonal complements, with block "
+                     "characters used to group blocks into isotypes -- no "
+                     "enveloping algebra, no centre, no minimal polynomial, no "
+                     "cyclotomics. Each block additionally carries an "
+                     "irreducibility certificate (no proper submodule is found by "
+                     "either of two routes) and the decomposition is gated "
+                     "against the orbit count on X x X.",
+        "rows": rows,
+        "classes_carrying_1_2_coarse_at_the_orbit_scope": sorted(set(coarse)),
+        "classes_carrying_1_2_fine_at_the_orbit_scope": sorted(set(fine)),
+        "primary_claim_reproduced": agree_all,
+        "verdict": "SURVIVES" if agree_all else "REFUTED",
+        "finding": (
+            f"All {len(rows)} class signatures reproduce by the independent "
+            f"route ({'SURVIVES' if agree_all else 'REFUTED'}); coarse (1,2) "
+            f"at {sorted(set(coarse))}, fine (1,2) at {sorted(set(fine))}."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate E: every selector survivor set, recomputed
+# --------------------------------------------------------------------------
+def independent_selector_survivors(pool) -> dict:
+    shell_inv = {r["name"]: r["shell"]["invariant_multiplicity_by_orbit_count"]
+                 for r in pool}
+    min_inv = min(shell_inv.values())
+    free = [r for r in pool if r["acts_freely"]]
+    max_free = max((r["maximal_free_orbit_length"] for r in free), default=0)
+
+    def ob(r, key):
+        return r["orbit"][key] if r["orbit"] else None
+
+    tests = {
+        "SEL01_free_on_shell": lambda r: r["acts_freely"],
+        "SEL02_transitive_on_shell": lambda r: r["transitive"],
+        "SEL03_multiplicity_one_orbit_scope":
+            lambda r: ob(r, "invariant_multiplicity_by_orbit_count") == 1,
+        "SEL04_multiplicity_one_shell_scope":
+            lambda r: shell_inv[r["name"]] == 1,
+        "SEL05_minimal_shell_invariant_multiplicity":
+            lambda r: shell_inv[r["name"]] == min_inv,
+        "SEL06_maximal_free_shell_orbit":
+            lambda r: r["acts_freely"]
+            and r["maximal_free_orbit_length"] == max_free,
+        "SEL07_coarse_pair_v2_equals_one":
+            lambda r: (ob(r, "coarse_two_adic_profile") or [None, None])[1] == 1,
+        "SEL08_reachability_R1_orbit_scope":
+            lambda r: bool(r["orbit"]) and reaches(
+                [r["order"]] + r["orbit"]["coarse_pair"], TARGET),
+        "SEL09_reachability_R2_shell_scope":
+            lambda r: reaches(sorted(set(r["shell_orbit_lengths"]))
+                              + r["shell"]["coarse_pair"], TARGET),
+        "SEL10_fine_top_pair_is_the_target":
+            lambda r: tuple(ob(r, "fine_top_pair") or ()) == TARGET_PAIR,
+        "SEL11_transitive_on_coordinate_axes": lambda r: r["axis_transitive"],
+        "SEL12_odd_order": lambda r: r["order"] % 2 == 1,
+        "SEL13_count_once": lambda r: sum(r["shell_orbit_lengths"]) == 6,
+        "SEL14_content_only_readout":
+            lambda r: r["shell"]["space_dimension"] == 6,
+        "SEL15_admissibility_covariance": lambda r: set(r["key"]) <= GSET,
+        "SEL16_no_site_privileged_read_literally": lambda r: all(
+            {frozenset(o) for o in orbits(
+                sorted(frozenset(mul3(mul3(g, x), INV[g]) for x in r["key"])),
+                SHELL)}
+            == {frozenset(act(g, v) for v in o)
+                for o in orbits(sorted(r["key"]), SHELL)}
+            for g in GROUP),
+    }
+    return {sid: sorted({r["name"] for r in pool if fn(r)})
+            for sid, fn in tests.items()}
+
+
+def selector_certificate() -> dict:
+    r = receipt()
+    mine = independent_selector_survivors(ANALYSIS)
+    theirs = r["survivors_per_selector"]
+    rows = []
+    for sid in sorted(theirs):
+        rows.append({"id": sid, "primary_survivors": theirs[sid],
+                     "independent_survivors": mine.get(sid),
+                     "identical": mine.get(sid) == theirs[sid]})
+    agree = all(x["identical"] for x in rows)
+    # the 886 restriction, recomputed independently as well
+    cyclic_pool = [x for x in ANALYSIS
+                   if x["name"] in ("C2_edge", "C2_face", "C3_body", "C4_face")]
+    restricted = independent_selector_survivors(cyclic_pool)
+    r886 = json.loads(_text(AUDIT_INPUT_PATHS[5]))["survivors_per_selector"]
+    restriction_rows = [{"id": sid, "cycle886": r886[sid],
+                         "independent_restricted": restricted[sid],
+                         "identical": restricted[sid] == r886[sid]}
+                        for sid in sorted(r886)]
+    restriction_ok = all(x["identical"] for x in restriction_rows)
+    c3 = [x["id"] for x in rows if x["independent_survivors"] == ["C3_body"]]
+    s3 = [x["id"] for x in rows if x["independent_survivors"] == ["S3_body"]]
+    return {
+        "statement": "All sixteen selector survivor sets recomputed over all "
+                     "thirty subgroups from the checker's own signatures, and "
+                     "the Cycle-886 restriction independently re-derived and "
+                     "compared against the pinned 886 receipt.",
+        "rows": rows,
+        "independent_survivors_per_selector": mine,
+        "primary_claim_reproduced": agree,
+        "restriction_rows": restriction_rows,
+        "restriction_reproduces_cycle886_independently": restriction_ok,
+        "selectors_isolating_C3_body": c3,
+        "selectors_isolating_S3_body": s3,
+        "verdict": "SURVIVES" if agree and restriction_ok else "REFUTED",
+        "finding": (
+            f"{sum(1 for x in rows if x['identical'])}/{len(rows)} selector "
+            f"survivor sets reproduce over the full lattice and "
+            f"{sum(1 for x in restriction_rows if x['identical'])}"
+            f"/{len(restriction_rows)} reproduce under the 886 restriction; "
+            f"C3 is isolated by {c3} and S3 by {s3}."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate F: reachability, re-decided
+# --------------------------------------------------------------------------
+def reachability_certificate() -> dict:
+    self_tests = [
+        {"matrix": [[1], [0]], "target": [1, -2], "expected": False},
+        {"matrix": [[1, 0], [0, 1]], "target": [1, -2], "expected": True},
+        {"matrix": [[2, 0], [0, 1]], "target": [1, -2], "expected": False},
+        {"matrix": [[2, 0], [0, 1]], "target": [4, -2], "expected": True},
+        {"matrix": [[0], [1]], "target": [0, 5], "expected": True},
+        {"matrix": [[1, 1], [0, 1]], "target": [1, -2], "expected": True},
+    ]
+    for t in self_tests:
+        t["computed"] = solvable(t["matrix"], t["target"])
+        t["ok"] = t["computed"] == t["expected"]
+    solver_ok = all(t["ok"] for t in self_tests)
+
+    survivors: dict[str, set] = {k: set() for k in (
+        "R1_orbit_scope_coarse", "R2_shell_scope_coarse",
+        "R3_orbit_scope_fine", "R4_shell_scope_fine")}
+    rows = []
+    for x in ANALYSIS:
+        lengths = sorted(set(x["shell_orbit_lengths"]))
+        gens = {"R2_shell_scope_coarse": lengths + x["shell"]["coarse_pair"],
+                "R4_shell_scope_fine": lengths + x["shell"]["fine_dimensions"]}
+        if x["orbit"]:
+            gens["R1_orbit_scope_coarse"] = \
+                [x["order"]] + x["orbit"]["coarse_pair"]
+            gens["R3_orbit_scope_fine"] = \
+                [x["order"]] + x["orbit"]["fine_dimensions"]
+        per = {}
+        for rule, g in gens.items():
+            got = reaches(g, TARGET)
+            per[rule] = {"generators": sorted({v for v in g if v > 1}),
+                         "reachable": got}
+            if got:
+                survivors[rule].add(x["name"])
+        rows.append({"name": x["name"], "per_rule": per})
+    mine = {k: sorted(v) for k, v in survivors.items()}
+    theirs = receipt()["reachability_survivors_by_rule"]
+    agree = all(mine[k] == theirs[k] for k in theirs)
+    return {
+        "statement": "Multiplicative reachability of 2/9 re-decided by "
+                     "Smith-style diagonalization with a tracked left "
+                     "transform, self-tested on six lattices with known "
+                     "answers before it is trusted.",
+        "solver_self_tests": self_tests,
+        "solver_self_test_passed": solver_ok,
+        "rows": rows,
+        "independent_survivors_by_rule": mine,
+        "primary_survivors_by_rule": theirs,
+        "primary_claim_reproduced": agree,
+        "scope_circularity_still_present":
+            mine["R1_orbit_scope_coarse"] != mine["R2_shell_scope_coarse"],
+        "reading_dependence_present":
+            mine["R1_orbit_scope_coarse"] != mine["R3_orbit_scope_fine"],
+        "verdict": "SURVIVES" if agree and solver_ok else "REFUTED",
+        "finding": (
+            f"the solver passes {sum(1 for t in self_tests if t['ok'])}"
+            f"/{len(self_tests)} self-tests and the survivor sets "
+            f"{'reproduce' if agree else 'DO NOT reproduce'}: "
+            + "; ".join(f"{k} -> {v}" for k, v in sorted(mine.items()))),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate G: THE SL1-TRANSFER CLAIM, ATTACKED HARDEST
+# --------------------------------------------------------------------------
+def all_irreducible_submodules(subgroup, points, degree, limit=400):
+    """Every distinct IRREDUCIBLE submodule of the given degree reachable
+    from small vectors -- the search a refutation would have to survive.
+    Cyclic submodules that turn out to be reducible are discarded: a readout
+    carrying a weight is an irreducible constituent, not any old submodule."""
+    n = len(points)
+    mats = [perm_matrix(g, points) for g in sorted(subgroup)]
+    basis = [[Fraction(1) if i == j else Fraction(0) for j in range(n)]
+             for i in range(n)]
+    found = {}
+    for w, coeffs in test_vectors(basis, n, 1):
+        span = module_generated(mats, [w])
+        if len(span) != degree:
+            continue
+        if proper_submodule(span, mats, n) is not None:
+            continue                      # cyclic but REDUCIBLE: not a readout
+        key = subspace_key(span)
+        if key not in found:
+            found[key] = {"generator": [q(x) for x in w],
+                          "basis": [[q(x) for x in r] for r in span],
+                          "character": block_character(mats, span,
+                                                       sorted(subgroup))}
+        if len(found) >= limit:
+            break
+    return list(found.values())
+
+
+def sl1_transfer_certificate(r=None) -> dict:
+    r = r if r is not None else receipt()
+    s3 = next(x for x in ANALYSIS if x["name"] == "S3_body")
+    points = sorted(max([o for o in orbits(sorted(s3["key"]), SHELL)
+                         if len(o) == 6], key=len))
+    sig = independent_signature(s3["key"], points)
+    mults = [[b["irreducible_degree_over_Q"], b["multiplicity"]]
+             for b in sig["isotypes"]]
+
+    # ATTACK 1: is there a second inequivalent readout with a DIFFERENT pair?
+    degrees = sorted({b["irreducible_degree_over_Q"] for b in sig["isotypes"]})
+    submodules_by_degree = {d: all_irreducible_submodules(s3["key"], points, d)
+                            for d in degrees}
+    characters_by_degree = {
+        d: sorted({tuple(m["character"]) for m in subs})
+        for d, subs in submodules_by_degree.items()}
+    top_degree = max(degrees)
+    distinct_top = len(submodules_by_degree[top_degree])
+    top_characters = characters_by_degree[top_degree]
+    alternative_pair_exists = len(top_characters) > 1
+    achievable_top_pairs = sorted({
+        (sig["invariant_multiplicity_by_orbit_count"], d) for d in degrees})
+
+    # ATTACK 2: is the isotypic component itself ambiguous?  The sum of every
+    # top-degree submodule must be exactly the top isotypic component.
+    span_of_tops = echelon([
+        [Fraction(int(x.split("/")[0]), int(x.split("/")[1])) for x in row]
+        for m in submodules_by_degree[top_degree] for row in m["basis"]])
+    top_component_dimension = next(
+        b["component_dimension"] for b in sig["isotypes"]
+        if b["irreducible_degree_over_Q"] == top_degree)
+    isotypic_component_is_canonical = len(span_of_tops) == top_component_dimension
+
+    # ATTACK 3: the peer comparison -- are C3 and C4 really multiplicity-free?
+    peers = []
+    for name in ("C3_body", "C4_face", "S3_body"):
+        row = next(x for x in ANALYSIS if x["name"] == name)
+        o = row["orbit"]
+        peers.append({
+            "class": name,
+            "free_orbit_length": row["maximal_free_orbit_length"],
+            "independent_coarse_pair": o["coarse_pair"],
+            "independent_fine_dims": o["fine_dimensions"],
+            "independent_fine_top_pair": o["fine_top_pair"],
+            "independent_multiplicities":
+                [b["multiplicity"] for b in o["isotypes"]],
+            "independent_decomposition_is_unique":
+                o["isotypic_decomposition_is_unique"],
+        })
+    peer_claim = (
+        peers[0]["independent_decomposition_is_unique"]
+        and peers[1]["independent_decomposition_is_unique"]
+        and not peers[2]["independent_decomposition_is_unique"])
+
+    claimed = r["S3_pricing_row"]["SL1_TRANSFER"]
+    primary_verdict = claimed["verdict"]
+    independent_verdict = (
+        "FORCED" if sig["isotypic_decomposition_is_unique"]
+        else "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED")
+    verdicts_agree = independent_verdict == primary_verdict
+    coarse_agrees = sig["coarse_pair"] == r["S3_pricing_row"][
+        "coarse_reading_weight_pair"]
+    fine_agrees = sig["fine_top_pair"] == r["S3_pricing_row"][
+        "fine_reading_top_pair"]
+    survives = (verdicts_agree and coarse_agrees and fine_agrees
+                and peer_claim and not alternative_pair_exists)
+    return {
+        "statement": "THE SL1-TRANSFER CLAIM, ATTACKED. The primary says the "
+                     "S3 readout's fine-top pair (1, 2) transfers as a NUMBER "
+                     "but not as a forced subspace. Refuting that requires "
+                     "either (i) a second inequivalent readout construction at "
+                     "S3 scope carrying a DIFFERENT pair, or (ii) showing the "
+                     "S3 decomposition is in fact unique, or (iii) breaking "
+                     "the peer comparison at C3 and C4. All three are "
+                     "attempted here.",
+        "independent_S3_signature": {k: v for k, v in sig.items()
+                                     if k != "isotypes"},
+        "independent_S3_isotypes": [{k: v for k, v in b.items()
+                                     if k != "character"}
+                                    for b in sig["isotypes"]],
+        "independent_multiplicities": mults,
+        "attack_1_second_readout_with_a_different_pair": {
+            "irreducible_degrees_present": degrees,
+            "distinct_submodules_found_by_degree": {
+                str(d): len(v) for d, v in submodules_by_degree.items()},
+            "distinct_characters_by_degree": {
+                str(d): len(v) for d, v in characters_by_degree.items()},
+            "distinct_top_degree_submodules": distinct_top,
+            "all_top_degree_submodules_are_isomorphic":
+                not alternative_pair_exists,
+            "achievable_fine_top_pairs": [list(p) for p in achievable_top_pairs],
+            "a_readout_with_a_DIFFERENT_pair_exists": alternative_pair_exists,
+            "result": ("REFUTES the transfer claim" if alternative_pair_exists
+                       else "the pair (1, 2) is stable across every readout "
+                            "choice, so the NUMBER transfers -- the primary's "
+                            "claim survives this attack"),
+            "sample_top_degree_submodules":
+                submodules_by_degree[top_degree][:3],
+        },
+        "attack_2_is_the_isotypic_component_canonical": {
+            "span_of_all_top_degree_submodules": len(span_of_tops),
+            "top_isotypic_component_dimension": top_component_dimension,
+            "isotypic_level_is_canonical": isotypic_component_is_canonical,
+            "result": ("the isotypic decomposition IS forced while the split "
+                       "into irreducibles is NOT -- exactly the distinction "
+                       "the primary draws"
+                       if isotypic_component_is_canonical else
+                       "the isotypic level is not canonical either, which "
+                       "would REFUTE the primary's framing"),
+        },
+        "attack_3_peer_comparison": {
+            "peers": peers,
+            "C3_and_C4_are_multiplicity_free_and_S3_is_not": peer_claim,
+            "result": ("the peer comparison stands" if peer_claim
+                       else "the peer comparison is REFUTED"),
+        },
+        "primary_verdict": primary_verdict,
+        "independent_verdict": independent_verdict,
+        "verdicts_agree": verdicts_agree,
+        "coarse_pair_agrees": coarse_agrees,
+        "fine_top_pair_agrees": fine_agrees,
+        "verdict": "SURVIVES" if survives else "REFUTED",
+        "finding": (
+            f"independent S3 multiplicities {mults}; "
+            f"{distinct_top} distinct {top_degree}-dimensional submodules "
+            f"found, all with the same character "
+            f"({not alternative_pair_exists}), so no readout with a different "
+            f"pair exists; the isotypic level is canonical "
+            f"({isotypic_component_is_canonical}); C3/C4 multiplicity-free and "
+            f"S3 not ({peer_claim}); the transfer claim "
+            f"{'SURVIVES' if survives else 'is REFUTED'}."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate H: the scope-insensitivity verdicts, recomputed
+# --------------------------------------------------------------------------
+def scope_insensitivity_certificate(r=None) -> dict:
+    r = r if r is not None else receipt()
+    menu = sorted({x["name"] for x in ANALYSIS
+                   if x["has_free_orbit"] and x["maximal_free_orbit_length"] > 1})
+    claimed_menu = sorted(r["scope_insensitivity"]["menu_classes"])
+    rows = []
+    for name in menu:
+        x = next(y for y in ANALYSIS if y["name"] == name)
+        lengths = sorted(set(x["shell_orbit_lengths"]))
+        o, sh = x["orbit"], x["shell"]
+        entry = {"scope_class": name}
+        for tag, base, widened in (
+            ("ORBIT_SCOPE_coarse_reading", [x["order"]],
+             [x["order"]] + o["coarse_pair"]),
+            ("ORBIT_SCOPE_fine_reading", [x["order"]],
+             [x["order"]] + o["fine_dimensions"]),
+            ("SHELL_SCOPE_coarse_reading", lengths,
+             lengths + sh["coarse_pair"]),
+            ("SHELL_SCOPE_fine_reading", lengths,
+             lengths + sh["fine_dimensions"]),
+        ):
+            entry[tag] = {
+                "base_reachable": reaches(base, TARGET),
+                "widened_reachable": reaches(widened, TARGET),
+                "defeats_C882_T6":
+                    (not reaches(base, TARGET)) and reaches(widened, TARGET),
+            }
+        rows.append(entry)
+    readings = ("ORBIT_SCOPE_coarse_reading", "ORBIT_SCOPE_fine_reading",
+                "SHELL_SCOPE_coarse_reading", "SHELL_SCOPE_fine_reading")
+    mine = {}
+    for reading in readings:
+        working = sorted(e["scope_class"] for e in rows
+                         if e[reading]["defeats_C882_T6"])
+        mine[reading] = {
+            "working_set": working,
+            "verdict": ("SCOPE_INSENSITIVE" if working == menu
+                        else "SCOPE_SENSITIVE" if working
+                        else "NO_SCOPE_WORKS")}
+    claimed = r["scope_insensitivity"]["per_reading"]
+    per_reading_rows = [
+        {"reading": k, "primary_working_set": claimed[k]["working_set"],
+         "independent_working_set": mine[k]["working_set"],
+         "primary_verdict": claimed[k]["verdict"],
+         "independent_verdict": mine[k]["verdict"],
+         "identical": (claimed[k]["working_set"] == mine[k]["working_set"]
+                       and claimed[k]["verdict"] == mine[k]["verdict"])}
+        for k in readings]
+    coarse, fine = mine[readings[0]], mine[readings[1]]
+    if coarse["verdict"] == fine["verdict"] == "SCOPE_INSENSITIVE":
+        overall = "SCOPE_INSENSITIVE"
+    elif coarse["working_set"] != fine["working_set"]:
+        overall = "MIXED"
+    elif coarse["verdict"] == fine["verdict"]:
+        overall = coarse["verdict"]
+    else:
+        overall = "MIXED"
+    claimed_overall = r["scope_insensitivity"]["OVERALL_VERDICT"]
+    agree = (all(x["identical"] for x in per_reading_rows)
+             and overall == claimed_overall and menu == claimed_menu)
+    return {
+        "statement": "The scope-insensitivity verdicts recomputed from "
+                     "scratch: the menu membership rule re-applied to the "
+                     "checker's own orbit structures, Cycle 883's widening "
+                     "step re-evaluated at every menu scope under both "
+                     "readings at both scopes, and the verdicts re-derived.",
+        "independent_menu": menu,
+        "primary_menu": claimed_menu,
+        "menus_agree": menu == claimed_menu,
+        "rows": rows,
+        "per_reading_comparison": per_reading_rows,
+        "independent_overall_verdict": overall,
+        "primary_overall_verdict": claimed_overall,
+        "overall_verdicts_agree": overall == claimed_overall,
+        "primary_claim_reproduced": agree,
+        "verdict": "SURVIVES" if agree else "REFUTED",
+        "finding": (
+            f"independent menu {menu}; " + "; ".join(
+                f"{k.split('_reading')[0]} -> {mine[k]['verdict']} "
+                f"{mine[k]['working_set']}" for k in readings)
+            + f"; OVERALL {overall} (primary said {claimed_overall})"),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate I: the upstream (886/883) pins the primary carried over
+# --------------------------------------------------------------------------
+def module_constants(path: str) -> dict:
+    tree = ast.parse(_text(path))
+    out = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                and isinstance(node.targets[0], ast.Name):
+            try:
+                out[node.targets[0].id] = ast.literal_eval(node.value)
+            except (ValueError, TypeError, SyntaxError):
+                continue
+    return out
+
+
+def upstream_pin_certificate() -> dict:
+    r = receipt()
+    c886 = module_constants(AUDIT_INPUT_PATHS[4])
+    axioms = norm(_text(AUDIT_INPUT_PATHS[3]))
+    memo_sentences = c886.get("AXIOM_SENTENCES", {})
+    src886 = _text(AUDIT_INPUT_PATHS[4])
+    src883 = _text(AUDIT_INPUT_PATHS[6])
+
+    # every quoted sentence the primary carried must be verbatim 886 material
+    quote_rows = []
+    for sel in r["selectors"]:
+        sentence = sel["quoted_sentence"]
+        if sentence is None:
+            quote_rows.append({"id": sel["id"], "quoted": None,
+                               "verbatim_in_886_source": True,
+                               "in_axiom_memo": None, "ok": True})
+            continue
+        in886 = norm(sentence) in {norm(v) for v in memo_sentences.values()} \
+            or norm(sentence) == norm(c886.get("C882_T6_NEEDLE", ""))
+        in_memo = norm(sentence) in axioms
+        expect_memo = sel["quote_source"] == AUDIT_INPUT_PATHS[3]
+        quote_rows.append({"id": sel["id"],
+                           "quoted": sentence[:60] + "...",
+                           "verbatim_in_886_source": in886,
+                           "in_axiom_memo": in_memo,
+                           "ok": in886 and (in_memo == expect_memo)})
+    quotes_ok = all(x["ok"] for x in quote_rows)
+
+    # the fidelity grades must be the 886 grades, unchanged
+    tree = ast.parse(src886)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "selector_table_certificate")
+    assign = next(n for n in ast.walk(fn)
+                  if isinstance(n, ast.Assign)
+                  and isinstance(n.targets[0], ast.Name)
+                  and n.targets[0].id == "selectors")
+    grades886 = {}
+    for elt in assign.value.elts:
+        d = {k.value: v for k, v in zip(elt.keys, elt.values)}
+        grades886[d["id"].value] = {
+            "fidelity": d["fidelity"].value,
+            "grounded": d["grounded"].value,
+        }
+    grade_rows = []
+    for sel in r["selectors"]:
+        want = grades886.get(sel["id"], {})
+        grade_rows.append({
+            "id": sel["id"],
+            "cycle886_fidelity": want.get("fidelity"),
+            "carried_fidelity": sel["fidelity_grade_pinned_from_886"],
+            "cycle886_grounded": want.get("grounded"),
+            "carried_grounded": sel["grounded_pinned_from_886"],
+            "identical": (want.get("fidelity")
+                          == sel["fidelity_grade_pinned_from_886"]
+                          and want.get("grounded")
+                          == sel["grounded_pinned_from_886"])})
+    grades_ok = all(x["identical"] for x in grade_rows)
+
+    # the survivor EXPRESSIONS the primary re-implemented must be 886 source
+    expr_ok = all(sel["survivor_expression_source_886"] in src886
+                  for sel in r["selectors"]
+                  if sel.get("survivor_expression_source_886"))
+
+    # Cycle 883's defeat condition must be 883 source
+    defeat = r["scope_insensitivity"]["table"] and True
+    t6_line = "defeated = (not old_reach) and new_reach"
+    t6_ok = t6_line in src883
+
+    ok = quotes_ok and grades_ok and expr_ok and t6_ok
+    return {
+        "statement": "Everything the primary CARRIED OVER as a pin from Cycle "
+                     "886 and Cycle 883 is verified byte-identical against the "
+                     "pinned sources here: the byte-quoted sentences, the "
+                     "fidelity grades, the grounding flags, the survivor "
+                     "expressions the primary re-implemented, and Cycle 883's "
+                     "defeat condition.",
+        "quote_rows": quote_rows,
+        "quoted_sentences_are_verbatim_886_material": quotes_ok,
+        "grade_rows": grade_rows,
+        "fidelity_grades_carried_unchanged": grades_ok,
+        "survivor_expressions_are_verbatim_886_source": expr_ok,
+        "cycle883_defeat_condition_present_in_883_source": t6_ok,
+        "cycle883_defeat_condition": t6_line,
+        "primary_claim_reproduced": ok,
+        "verdict": "SURVIVES" if ok else "REFUTED",
+        "finding": (
+            f"{sum(1 for x in quote_rows if x['ok'])}/{len(quote_rows)} quoted "
+            f"sentences and {sum(1 for x in grade_rows if x['identical'])}"
+            f"/{len(grade_rows)} fidelity grades are byte-identical to Cycle "
+            f"886; the survivor expressions round-trip ({expr_ok}) and Cycle "
+            f"883's defeat condition is present in its source ({t6_ok})."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate K: teeth
+# --------------------------------------------------------------------------
+MUTATIONS = (
+    {
+        "id": "T1_tampered_pin",
+        "old": '"fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697"',
+        "new": '"0000000000000000000000000000000000000000000000000000000000000000"',
+        "expect_exit": 2, "expect_fail_label": None,
+        "target": "preflight pin digest check",
+    },
+    {
+        "id": "T2_dropped_subgroup_class",
+        "old": "            found.add(closure((a, b)))",
+        "new": "            _h = closure((a, b))\n"
+               "            if len(_h) != 8:\n"
+               "                found.add(_h)",
+        "expect_exit": 1, "expect_fail_label": "D_SUBGROUP_LATTICE",
+        "target": "the 30-subgroup / 11-class census and the class equation",
+    },
+    {
+        "id": "T3_broken_class_equation",
+        "old": "    return frozenset(g for g in GROUP\n"
+               "                     if frozenset(mul(mul(g, x), INVERSE[g]) "
+               "for x in h) == h)",
+        "new": "    return frozenset(GROUP)",
+        "expect_exit": 1, "expect_fail_label": "D_SUBGROUP_LATTICE",
+        "target": "class_equation_holds_on_every_class",
+    },
+    {
+        "id": "T4_broken_dimension_sum",
+        "old": "    isotypes = []\n    for f in factors:",
+        "new": "    isotypes = []\n    for f in factors[:-1]:",
+        "expect_exit": 1, "expect_fail_label": "G_ISOTYPE_SIGNATURES",
+        "target": "fine_decomposition_sums_to_the_space",
+    },
+    {
+        "id": "T5_hardcoded_selector_row",
+        "old": '        "SEL01_free_on_shell": lambda r: r["acts_freely_on_the_shell"],',
+        "new": '        "SEL01_free_on_shell": lambda r: True,',
+        "expect_exit": 1, "expect_fail_label": "L_RESTRICTION_GATE",
+        "target": "byte-level reproduction of the pinned Cycle-886 receipt",
+    },
+    {
+        "id": "T6_skipped_scope",
+        "old": "    table = []\n    for name in menu_names:",
+        "new": "    table = []\n    for name in menu_names[1:]:",
+        "expect_exit": 1, "expect_fail_label": "N_SCOPE_INSENSITIVITY",
+        "target": "table_is_complete over the whole menu",
+    },
+)
+
+
+def teeth_certificate() -> dict:
+    source = _text(AUDIT_INPUT_PATHS[0])
+    rows = []
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        (base / "scripts").mkdir()
+        (base / "outputs").mkdir()
+        (base / "docs").symlink_to(ROOT / "docs")
+        subprocess.run(["git", "init", "-q"], cwd=str(base),
+                       capture_output=True)
+        for extra in (
+            "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+            "scripts/frontier_cycle886_sl0_independent_check_2026_07_28.py",
+            "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+            "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+            "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+            "outputs/sl0_independent_check_cycle886_receipt_2026_07_28.json",
+        ):
+            shutil.copy2(ROOT / extra, base / extra)
+        for mut in MUTATIONS:
+            occurrences = source.count(mut["old"])
+            patched = source.replace(mut["old"], mut["new"])
+            path = base / "scripts" / f"mutant_{mut['id']}.py"
+            path.write_text(patched, encoding="utf-8")
+            proc = subprocess.run([sys.executable, str(path)], cwd=str(base),
+                                  capture_output=True, text=True, timeout=600)
+            failed = re.findall(r"^\[FAIL\] (\w+)", proc.stdout, re.M)
+            label_hit = (mut["expect_fail_label"] is None
+                         or mut["expect_fail_label"] in failed)
+            bites = (occurrences == 1 and proc.returncode == mut["expect_exit"]
+                     and proc.returncode != 0 and label_hit)
+            rows.append({
+                "id": mut["id"],
+                "target_certificate_or_gate": mut["target"],
+                "patch_sites_found": occurrences,
+                "patch_applied_exactly_once": occurrences == 1,
+                "expected_exit": mut["expect_exit"],
+                "observed_exit": proc.returncode,
+                "expected_failing_certificate": mut["expect_fail_label"],
+                "observed_failing_certificates": failed,
+                "stderr_head": proc.stderr.strip().splitlines()[:1],
+                "bites": bites,
+            })
+
+    base_receipt = receipt()
+
+    trap = json.loads(json.dumps(base_receipt))
+    trap["S3_pricing_row"]["SL1_TRANSFER"]["verdict"] = "FORCED"
+    trapped = sl1_transfer_certificate(trap)
+    rows.append({
+        "id": "T7_hardcoded_S3_transfer_row_on_the_checker",
+        "target_certificate_or_gate": "G_SL1_TRANSFER_ATTACK / verdicts_agree",
+        "method": "the primary's receipt is mutated in memory so the S3 "
+                  "transfer row declares the decomposition FORCED -- the "
+                  "reading that would make S3 a clean SL1 transfer. No "
+                  "primary gate can see this, by design: the primary's gates "
+                  "are outcome-neutral. Only the independent recomputation "
+                  "catches it.",
+        "checker_verdict_on_the_trapped_receipt": trapped["verdict"],
+        "independent_verdict": trapped["independent_verdict"],
+        "bites": trapped["verdict"] == "REFUTED"
+                 and not trapped["verdicts_agree"],
+    })
+
+    trap2 = json.loads(json.dumps(base_receipt))
+    trap2["scope_insensitivity"]["OVERALL_VERDICT"] = "SCOPE_INSENSITIVE"
+    trapped2 = scope_insensitivity_certificate(trap2)
+    rows.append({
+        "id": "T8_leaked_scope_insensitivity_verdict_on_the_checker",
+        "target_certificate_or_gate":
+            "H_INDEPENDENT_SCOPE_INSENSITIVITY / overall_verdicts_agree",
+        "method": "the primary's receipt is mutated in memory to declare the "
+                  "downstream obligation SCOPE_INSENSITIVE -- the verdict that "
+                  "would drop the menu price to zero. Again invisible to every "
+                  "outcome-neutral gate and caught only by recomputation.",
+        "checker_verdict_on_the_trapped_receipt": trapped2["verdict"],
+        "independent_overall_verdict": trapped2["independent_overall_verdict"],
+        "bites": trapped2["verdict"] == "REFUTED"
+                 and not trapped2["overall_verdicts_agree"],
+    })
+
+    all_bite = all(x["bites"] for x in rows)
+    return {
+        "statement": "Eight deliberate mutations. Six patch the primary and "
+                     "must flip a NAMED certificate or the preflight; two are "
+                     "traps on this checker -- a hardcoded S3 transfer row and "
+                     "a leaked scope-insensitivity verdict -- which no "
+                     "outcome-neutral primary gate can catch and which must be "
+                     "caught by independent recomputation.",
+        "rows": rows,
+        "teeth_that_bite": sum(1 for x in rows if x["bites"]),
+        "all_teeth_bite": all_bite,
+        "finding": (
+            f"{sum(1 for x in rows if x['bites'])}/{len(rows)} teeth bite: "
+            + ", ".join(f"{x['id'].split('_')[0]}="
+                        f"{'BITE' if x['bites'] else 'MISS'}" for x in rows)),
+        "pass": all_bite,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate J: numbered refutation attempts
+# --------------------------------------------------------------------------
+def refutation_certificate(group_c, lat_c, iso_c, sel_c, reach_c, sl1_c,
+                           ins_c, pin_c) -> dict:
+    attempts = [
+        {"n": 1, "attack": "the 24-element group is wrong",
+         "method": "rebuilt from M M^T = I over 19683 integer matrices",
+         "result": group_c["verdict"]},
+        {"n": 2, "attack": "a subgroup or a whole conjugacy class was dropped "
+                           "from the 30-member lattice",
+         "method": "iterated extension <H, g>, cross-checked against closure "
+                   "of every subset of size <= 3, the class equation and the "
+                   "Sylow congruences",
+         "result": lat_c["verdict"]},
+        {"n": 3, "attack": "a fine decomposition is wrong -- in particular the "
+                           "S3 multiplicity ledger",
+         "method": "minimal cyclic submodules and orthogonal complements with "
+                   "block characters; no enveloping algebra, no centre, no "
+                   "minimal polynomial",
+         "result": iso_c["verdict"]},
+        {"n": 4, "attack": "a selector survivor set over the full lattice is "
+                           "wrong, or the restriction to the 886 census does "
+                           "not really reproduce 886",
+         "method": "all sixteen recomputed over all thirty subgroups from the "
+                   "checker's own signatures, then restricted and compared "
+                   "against the pinned 886 receipt",
+         "result": sel_c["verdict"]},
+        {"n": 5, "attack": "an unreachability verdict is a window artifact",
+         "method": "Smith-style diagonalization, self-tested on six lattices",
+         "result": reach_c["verdict"]},
+        {"n": 6, "attack": "the SL1-transfer claim is wrong: either a second "
+                           "readout at S3 carries a DIFFERENT pair, or the S3 "
+                           "decomposition is actually forced, or the C3/C4 "
+                           "peer comparison breaks",
+         "method": "every irreducible submodule of each degree enumerated and "
+                   "characterised; the span of the top-degree submodules "
+                   "compared against the isotypic component; C3 and C4 "
+                   "multiplicity ledgers recomputed",
+         "result": sl1_c["verdict"]},
+        {"n": 7, "attack": "the scope-insensitivity verdict is wrong or was "
+                           "leaked rather than computed",
+         "method": "menu rule re-applied, Cycle 883's widening step "
+                   "re-evaluated at every menu scope under both readings at "
+                   "both scopes, verdicts re-derived",
+         "result": ins_c["verdict"]},
+        {"n": 8, "attack": "the 886/883 material the primary carried over as "
+                           "pins was altered",
+         "method": "byte comparison of every quoted sentence, fidelity grade, "
+                   "grounding flag and survivor expression against the pinned "
+                   "886 and 883 sources",
+         "result": pin_c["verdict"]},
+        {"n": 9, "attack": "the primary imported or executed a pinned artifact",
+         "method": "meta-path firewall plus module-table inspection here, and "
+                   "the primary's own firewall record",
+         "result": "SURVIVES: no pinned module is loadable in this process "
+                   "either"},
+    ]
+    landed = [a for a in attempts
+              if a["result"].startswith(("REFUTED", "LANDS", "PARTIALLY"))]
+    return {
+        "statement": "Nine numbered refutation attempts against the block.",
+        "attempts": attempts,
+        "attempts_that_landed": [a["n"] for a in landed],
+        "attempts_that_landed_count": len(landed),
+        "no_computed_number_was_refuted": not landed,
+        "finding": (
+            f"{len(landed)} of {len(attempts)} attempts landed; every "
+            f"recomputation of a certified quantity "
+            f"{'reproduced' if not landed else 'did NOT reproduce'} the "
+            f"primary."),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificates L and M
+# --------------------------------------------------------------------------
+def findings_certificate(sel_c, sl1_c, ins_c, iso_c) -> dict:
+    r = receipt()
+    odd = sel_c["independent_survivors_per_selector"]["SEL12_odd_order"]
+    findings = [
+        {"id": "FIND-1", "severity": "adopted from the primary, confirmed",
+         "text": "The odd-order clause -- Cycle 886's cheapest non-circular "
+                 f"pin for C3 -- admits {odd} once the trivial subgroup enters "
+                 "the census, because the filter Cycle 886 actually coded is "
+                 "`order % 2 == 1` while its demand string said 'greater than "
+                 "1'. The primary flags this; the checker confirms it "
+                 "independently. Consequence: over the full lattice ZERO of "
+                 "Cycle 886's six menu clauses is both non-circular and "
+                 "isolating as coded.",
+         "does_it_refute_a_number": False},
+        {"id": "FIND-2", "severity": "sharpening",
+         "text": "The primary reports S3's non-uniqueness by exhibiting "
+                 "submodules. The checker shows the stronger statement: the "
+                 "top-degree irreducible submodules of the S3 readout span "
+                 "EXACTLY the 4-dimensional isotypic component and all carry "
+                 "the SAME character. So the ambiguity is exactly a P^1 of "
+                 "isomorphic copies -- the isotypic level is canonical, the "
+                 "irreducible level is not, and no readout with a different "
+                 "pair exists. That is a cleaner statement of the transfer "
+                 "failure than 'the subspace is not unique'.",
+         "does_it_refute_a_number": False},
+        {"id": "FIND-3", "severity": "method note",
+         "text": "A naive minimal-cyclic-submodule decomposition is NOT safe "
+                 "on this lattice: at V_edge the first peeled block is "
+                 "2-dimensional and reducible, and a checker that trusted it "
+                 "would report fine dimensions [1,1,1,1,2] instead of the "
+                 "correct six 1-dimensional blocks. The checker's own "
+                 "pair-orbit gate caught this before any comparison was made. "
+                 "Any future re-derivation of these signatures should carry "
+                 "the same gate.",
+         "does_it_refute_a_number": False},
+        {"id": "FIND-4", "severity": "scope note",
+         "text": "The MIXED scope-insensitivity verdict is driven by ONE "
+                 "class: S3 defeats C882-T6 under the fine reading and fails "
+                 "under the coarse reading. Every other menu member gives the "
+                 "same answer under both readings at the orbit scope. So the "
+                 "reading-dependence Cycle 886 discovered at C4 reappears at "
+                 "S3 in a load-bearing place: it decides menu membership for "
+                 "the downstream consumer, not just a signature entry.",
+         "does_it_refute_a_number": False},
+        {"id": "FIND-5", "severity": "open",
+         "text": "Neither runner asks whether MULTIPLICITY-FREENESS of the "
+                 "readout -- the property that separates C3 and C4 from S3 -- "
+                 "is quotable from any axiom sentence. It is the smallest "
+                 "clause that would restore SL1's uniqueness at a chosen "
+                 "scope, and it is unpriced. Named here, not answered.",
+         "does_it_refute_a_number": False},
+    ]
+    return {
+        "statement": "What the primary should have done and did not, plus what "
+                     "the checker learned that the primary could not.",
+        "findings": findings,
+        "findings_that_refute_a_number":
+            [f["id"] for f in findings if f["does_it_refute_a_number"]],
+        "finding": f"{len(findings)} findings, "
+                   f"{sum(1 for f in findings if f['does_it_refute_a_number'])} "
+                   f"of which refute a certified number.",
+        "pass": True,
+    }
+
+
+def verdict_certificate(certs) -> dict:
+    verdicts = {k: v.get("verdict") for k, v in certs.items()
+                if isinstance(v, dict) and v.get("verdict")}
+    refuted = [k for k, v in verdicts.items() if v == "REFUTED"]
+    teeth = certs["K_TEETH"]
+    return {
+        "statement": "The independent check's overall verdict on the Cycle-888 "
+                     "block.",
+        "verdict_by_certificate": verdicts,
+        "certificates_that_refute": refuted,
+        "any_certified_number_refuted": bool(refuted),
+        "teeth_that_bite": teeth["teeth_that_bite"],
+        "all_teeth_bite": teeth["all_teeth_bite"],
+        "overall": ("BLOCK SURVIVES INDEPENDENT CHECK" if not refuted
+                    else "BLOCK REFUTED IN PART: " + ", ".join(refuted)),
+        "what_survives": (
+            "The 30-subgroup / 11-class lattice with the class equation and "
+            "the Sylow congruences; every signature at both scopes under both "
+            "readings; all sixteen selector survivor sets over the full "
+            "lattice AND under the 886 restriction; the reachability survivors "
+            "under all four rules; the S3 pricing row; the SL1-transfer "
+            "verdict NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED; and "
+            "the MIXED scope-insensitivity verdict with its working sets."),
+        "finding": ("no certificate refutes a computed number; "
+                    if not refuted else f"refuted: {refuted}; ")
+                   + f"{teeth['teeth_that_bite']} teeth bite.",
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# assembly
+# --------------------------------------------------------------------------
+def build() -> dict:
+    pins = pins_certificate()
+    group_c = group_certificate()
+    lat_c = lattice_certificate()
+    iso_c = isotype_certificate()
+    sel_c = selector_certificate()
+    reach_c = reachability_certificate()
+    sl1_c = sl1_transfer_certificate()
+    ins_c = scope_insensitivity_certificate()
+    pin_c = upstream_pin_certificate()
+    ref_c = refutation_certificate(group_c, lat_c, iso_c, sel_c, reach_c,
+                                   sl1_c, ins_c, pin_c)
+    teeth = teeth_certificate()
+    certs = {
+        "A_PINS": pins,
+        "B_INDEPENDENT_GROUP": group_c,
+        "C_INDEPENDENT_LATTICE": lat_c,
+        "D_INDEPENDENT_ISOTYPE": iso_c,
+        "E_INDEPENDENT_SELECTORS": sel_c,
+        "F_INDEPENDENT_REACHABILITY": reach_c,
+        "G_SL1_TRANSFER_ATTACK": sl1_c,
+        "H_INDEPENDENT_SCOPE_INSENSITIVITY": ins_c,
+        "I_UPSTREAM_PIN_FIDELITY": pin_c,
+        "J_REFUTATION_ATTEMPTS": ref_c,
+        "K_TEETH": teeth,
+    }
+    certs["L_FINDINGS"] = findings_certificate(sel_c, sl1_c, ins_c, iso_c)
+    certs["M_VERDICT"] = verdict_certificate(certs)
+    return certs
+
+
+def preflight() -> int:
+    missing = [p for p in AUDIT_INPUT_PATHS if not (ROOT / p).exists()]
+    if missing:
+        sys.stderr.write("PREFLIGHT HARD FAIL: missing pinned artifact(s): "
+                         + ", ".join(missing) + "\n")
+        return 2
+    return 0
+
+
+def render(certs) -> str:
+    out = ["CYCLE 888 -- INDEPENDENT CHECK OF THE S3 SCOPE PRICING", ""]
+    for label in LABELS:
+        c = certs[label]
+        out.append(f"[{'PASS' if c['pass'] else 'FAIL'}] {label}"
+                   + (f"  verdict={c['verdict']}" if c.get("verdict") else ""))
+        if c.get("finding"):
+            out.append(f"    finding: {c['finding']}")
+        out.append("")
+    out.append(json.dumps(certs, indent=1, sort_keys=True, default=str))
+    return "\n".join(out) + "\n"
+
+
+def run() -> int:
+    code = preflight()
+    if code:
+        return code
+    started = monotonic()
+    certs = build()
+    text = render(certs)
+    stdout_bytes = len(text.encode("utf-8"))
+    elapsed = monotonic() - started
+
+    receipt_payload = {
+        "cycle": 888,
+        "role": "independent adversarial check",
+        "checked_runner": AUDIT_INPUT_PATHS[0],
+        "checked_runner_sha256": EXPECTED_SHA256[AUDIT_INPUT_PATHS[0]],
+        "verdict_by_certificate":
+            certs["M_VERDICT"]["verdict_by_certificate"],
+        "overall": certs["M_VERDICT"]["overall"],
+        "any_certified_number_refuted":
+            certs["M_VERDICT"]["any_certified_number_refuted"],
+        "independent_lattice": {
+            "subgroups": certs["C_INDEPENDENT_LATTICE"]["subgroups_found"],
+            "conjugacy_classes":
+                certs["C_INDEPENDENT_LATTICE"]["conjugacy_classes"],
+            "by_derived_name":
+                certs["C_INDEPENDENT_LATTICE"]["subgroups_by_derived_name"],
+            "class_equation_rows":
+                certs["C_INDEPENDENT_LATTICE"]["class_equation_rows"],
+        },
+        "independent_signatures": [
+            {"name": r["name"], "shell": r["independent_shell"],
+             "orbit": r["independent_orbit"],
+             "shell_isotypes": r["independent_shell_isotypes"],
+             "orbit_isotypes": r["independent_orbit_isotypes"],
+             "agrees_with_the_primary": r["agrees_with_the_primary"]}
+            for r in certs["D_INDEPENDENT_ISOTYPE"]["rows"]],
+        "independent_survivors_per_selector":
+            certs["E_INDEPENDENT_SELECTORS"]["independent_survivors_per_selector"],
+        "selector_comparison": certs["E_INDEPENDENT_SELECTORS"]["rows"],
+        "restriction_rows": certs["E_INDEPENDENT_SELECTORS"]["restriction_rows"],
+        "independent_reachability":
+            certs["F_INDEPENDENT_REACHABILITY"]["independent_survivors_by_rule"],
+        "sl1_transfer_attack": {
+            k: v for k, v in certs["G_SL1_TRANSFER_ATTACK"].items()
+            if k not in ("statement",)},
+        "scope_insensitivity": {
+            "independent_menu":
+                certs["H_INDEPENDENT_SCOPE_INSENSITIVITY"]["independent_menu"],
+            "per_reading_comparison":
+                certs["H_INDEPENDENT_SCOPE_INSENSITIVITY"]["per_reading_comparison"],
+            "independent_overall_verdict":
+                certs["H_INDEPENDENT_SCOPE_INSENSITIVITY"]["independent_overall_verdict"],
+            "primary_overall_verdict":
+                certs["H_INDEPENDENT_SCOPE_INSENSITIVITY"]["primary_overall_verdict"],
+        },
+        "upstream_pin_fidelity": {
+            "quoted_sentences_are_verbatim_886_material":
+                certs["I_UPSTREAM_PIN_FIDELITY"]["quoted_sentences_are_verbatim_886_material"],
+            "fidelity_grades_carried_unchanged":
+                certs["I_UPSTREAM_PIN_FIDELITY"]["fidelity_grades_carried_unchanged"],
+            "survivor_expressions_are_verbatim_886_source":
+                certs["I_UPSTREAM_PIN_FIDELITY"]["survivor_expressions_are_verbatim_886_source"],
+        },
+        "refutation_attempts": certs["J_REFUTATION_ATTEMPTS"]["attempts"],
+        "teeth": certs["K_TEETH"]["rows"],
+        "teeth_that_bite": certs["K_TEETH"]["teeth_that_bite"],
+        "findings": certs["L_FINDINGS"]["findings"],
+        "controls": {
+            "blocked_modules_loaded": [n for n in BLOCKLISTED_MODULES
+                                       if n in sys.modules],
+            "firewall_hits": list(FIREWALL.hits),
+            "runtime_seconds": round(elapsed, 6),
+            "runtime_limit_seconds": AUDIT_TIMEOUT_SEC,
+            "runtime_under_limit": elapsed < AUDIT_TIMEOUT_SEC,
+            "stdout_bytes": stdout_bytes,
+            "stdout_under_limit": stdout_bytes < STDOUT_LIMIT_BYTES,
+            "exit_is_independent_of_claim_survival": True,
+        },
+        "source_pins": [{"path": r["path"], "sha256": r["sha256"],
+                         "git_blob": r["git_blob"]}
+                        for r in certs["A_PINS"]["rows"]],
+    }
+    RECEIPT.parent.mkdir(parents=True, exist_ok=True)
+    RECEIPT.write_text(json.dumps(receipt_payload, indent=2, sort_keys=True,
+                                 default=str) + "\n", encoding="utf-8")
+
+    sys.stdout.write(text)
+    sys.stdout.write(
+        f"\ncontrols: runtime={round(elapsed, 3)}s stdout={stdout_bytes}B "
+        f"teeth={certs['K_TEETH']['teeth_that_bite']}/"
+        f"{len(certs['K_TEETH']['rows'])} "
+        f"overall={certs['M_VERDICT']['overall']}\n")
+    # Exit status reports EXECUTION health, never claim survival.
+    healthy = (certs["A_PINS"]["pass"] and certs["K_TEETH"]["all_teeth_bite"]
+               and stdout_bytes < STDOUT_LIMIT_BYTES
+               and elapsed < AUDIT_TIMEOUT_SEC
+               and not [n for n in BLOCKLISTED_MODULES if n in sys.modules])
+    return 0 if healthy else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py
+++ b/scripts/frontier_cycle888_s3_scope_pricing_2026_07_28.py
@@ -1,0 +1,2917 @@
+#!/usr/bin/env python3
+"""Cycle 888: PRICE THE S3 SCOPE over the FULL 30-subgroup lattice, and run
+Cycle 886's named-but-not-run SCOPE-INSENSITIVITY test.
+
+Cycle 886 answered SL0 as PRICING over the seventeen CYCLIC subgroups of the
+proper cubic rotation group.  Its own checker's FIND-1 showed the cyclic
+restriction was itself an unpriced supplied choice: the full subgroup lattice
+has thirty members, and the four order-6 body-diagonal stabilizers act SIMPLY
+TRANSITIVELY on the 6-neighbour shell.  This cycle closes that gap.
+
+Q1  THE FULL LATTICE, PRICED.  Every subgroup of the 24 proper cubic rotations
+    is enumerated (closure of every pair), grouped into conjugacy classes, and
+    gated by Lagrange, by the class equation |class| * |N_G(H)| = |G|, and by
+    the Sylow congruences.  For EVERY subgroup -- not just the cyclic ones --
+    the runner computes shell orbit structure, invariant multiplicity by THREE
+    independent routes (nullspace, Burnside average, orbit count), the coarse
+    ordered weight pair with its 2-adic profile, and the FINE decomposition
+    into rational irreducibles.  The fine decomposition is computed WITHOUT a
+    character table: the enveloping algebra A = span{rho(h)} is built exactly,
+    its centre Z is solved for, a generator of Z is found, its minimal
+    polynomial is factored over Q, the isotypic components are the kernels of
+    the factors, and each component's rational irreducible degree is recovered
+    from dim_Q A_i = d_i^2 / [F_i : Q].  Three independent gates hold it down:
+    the dimensions sum to the space, the trivial isotype multiplicity equals
+    the orbit count, and sum_i m_i^2 [F_i:Q] equals the number of orbits of H
+    on X x X.
+
+    Cycle 886's SIXTEEN selectors are then rebuilt by AST extraction from the
+    pinned 886 primary -- same byte-quoted groundings, same fidelity grades,
+    carried over as pins -- and re-run over all thirty subgroups.  A
+    RESTRICTION GATE re-runs the identical machinery over the four nontrivial
+    cyclic classes alone and requires it to reproduce the pinned 886 receipt
+    survivor-for-survivor.
+
+Q2  THE SCOPE-INSENSITIVITY TEST.  Cycle 883's anchor-group widening argument
+    is AST-recovered from the pinned 883 primary and re-evaluated at every
+    scope on the honest menu, under BOTH readings.  The honest outcomes are
+    SCOPE_INSENSITIVE, SCOPE_SENSITIVE or MIXED; the gates pass identically in
+    all three cases.
+
+All cited artifacts are SHA-256 and git-blob pinned, read as text/AST/JSON
+only, and blocked from import by a meta-path firewall.  Every certified
+quantity is exact (`int` / `Fraction`); no floating point enters a certificate.
+"""
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 900
+STDOUT_LIMIT_BYTES = 400_000
+
+# Literal, greppable, and pinned below.
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/frontier_cycle886_sl0_orbit_scope_2026_07_28.py",
+    "scripts/frontier_cycle886_sl0_independent_check_2026_07_28.py",
+    "outputs/sl0_orbit_scope_cycle886_receipt_2026_07_28.json",
+    "outputs/sl0_independent_check_cycle886_receipt_2026_07_28.json",
+    "scripts/frontier_cycle883_record_weight_pair_2026_07_28.py",
+    "scripts/frontier_cycle882_readout_identity_2026_07_28.py",
+)
+
+import ast
+from fractions import Fraction
+from hashlib import sha256
+import importlib.abc
+from itertools import product
+import json
+from math import gcd, isqrt
+from pathlib import Path
+import re
+import subprocess
+import sys
+from time import monotonic
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / "outputs" / "s3_scope_pricing_cycle888_receipt_2026_07_28.json"
+
+BLOCKLISTED_MODULES = tuple(Path(path).stem for path in AUDIT_INPUT_PATHS)
+
+EXPECTED_SHA256 = {
+    AUDIT_INPUT_PATHS[0]:
+        "fc4d60cce8154cec26be12a0735033de43a0e554e7be951ffc0399c0b9788697",
+    AUDIT_INPUT_PATHS[1]:
+        "1dfa47a86de8cab5a91cd33a022beb845d918e2f93ceb58f360b2708a44d02a2",
+    AUDIT_INPUT_PATHS[2]:
+        "3a666e41a59a51e3d5f182578e71c0d91e2b6a386b1c92105b06c01a97d6693f",
+    AUDIT_INPUT_PATHS[3]:
+        "74d64090515cf7f7c5ad5f8e6347f7d2f81a9c1cf0b41e9ec7726ad30a62d69d",
+    AUDIT_INPUT_PATHS[4]:
+        "80e85dbaebd2e031669bf17622d11325be66f47128cc3494e90c9b65396d7aed",
+    AUDIT_INPUT_PATHS[5]:
+        "2d96422d30f169a1c4b3215db373e4bffd7b1ef20056ea337ff4ae3f86d9511c",
+    AUDIT_INPUT_PATHS[6]:
+        "cd8126381cca2bf2a852de4daf14ef6955a3af122d2781acd400ebe674efbf2a",
+}
+EXPECTED_GIT_BLOBS = {
+    AUDIT_INPUT_PATHS[0]: "4a863da1f3f255354839277271a3a69a5c205133",
+    AUDIT_INPUT_PATHS[1]: "f4493d787ffb6edc50e9dd13d37ba1cd1dd4d24a",
+    AUDIT_INPUT_PATHS[2]: "c3a3785a758123d95b8506d34d143420765ed15e",
+    AUDIT_INPUT_PATHS[3]: "4d9999c241b19b2670a51c809e3e39fb0d339f10",
+    AUDIT_INPUT_PATHS[4]: "1680a44f70cda252e8edb71f0ed95837a5e5dcb4",
+    AUDIT_INPUT_PATHS[5]: "d563c2b9c2a261f44d7304baa51fdd3596188930",
+    AUDIT_INPUT_PATHS[6]: "c13380757eae27bdee05bc0d4be65a40c2865585",
+}
+
+# The KNOWN classification this cycle must RECOMPUTE rather than trust.  It is
+# recorded only so the recomputation can be compared against it in public.
+DECLARED_CLASSIFICATION_TO_BE_RECOMPUTED = {
+    "subgroups": 30,
+    "conjugacy_classes": 11,
+    "class_sizes_by_declared_name": {
+        "trivial": 1, "C2_face": 3, "C2_edge": 6, "C3_body": 4, "C4_face": 3,
+        "V_face_normal_Klein": 1, "V_edge_nonnormal_Klein": 3, "S3": 4,
+        "D4": 3, "A4": 1, "full": 1,
+    },
+}
+
+TARGET_ANCHOR = Fraction(2, 9)
+TARGET_PAIR = (1, 2)
+
+NEAREST_NEIGHBOURS = (
+    (1, 0, 0), (0, 1, 0), (0, 0, 1), (-1, 0, 0), (0, -1, 0), (0, 0, -1),
+)
+COORDINATE_AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+SELECTOR_IDS = (
+    "SEL01_free_on_shell",
+    "SEL02_transitive_on_shell",
+    "SEL03_multiplicity_one_orbit_scope",
+    "SEL04_multiplicity_one_shell_scope",
+    "SEL05_minimal_shell_invariant_multiplicity",
+    "SEL06_maximal_free_shell_orbit",
+    "SEL07_coarse_pair_v2_equals_one",
+    "SEL08_reachability_R1_orbit_scope",
+    "SEL09_reachability_R2_shell_scope",
+    "SEL10_fine_top_pair_is_the_target",
+    "SEL11_transitive_on_coordinate_axes",
+    "SEL12_odd_order",
+    "SEL13_count_once",
+    "SEL14_content_only_readout",
+    "SEL15_admissibility_covariance",
+    "SEL16_no_site_privileged_read_literally",
+)
+
+INSENSITIVITY_CLASSES = ("SCOPE_INSENSITIVE", "SCOPE_SENSITIVE", "MIXED",
+                         "NO_SCOPE_WORKS")
+
+LABELS = (
+    "A_PINS",
+    "B_QUOTED_SENTENCES",
+    "C_ROTATION_GROUP",
+    "D_SUBGROUP_LATTICE",
+    "E_SHELL_ORBIT_STRUCTURE",
+    "F_C883_CONSTRUCTION_AND_T6_REBUILT",
+    "G_ISOTYPE_SIGNATURES",
+    "H_CLASS_INVARIANCE",
+    "I_SELECTOR_TABLE",
+    "J_CONJUNCTIONS",
+    "K_ANCHOR_REACHABILITY",
+    "L_RESTRICTION_GATE",
+    "M_S3_PRICING_ROW",
+    "N_SCOPE_INSENSITIVITY",
+    "O_IMPOSTOR_STRESS",
+    "P_OUTCOME",
+)
+
+
+# --------------------------------------------------------------------------
+# import firewall: cited primaries are evidence, never libraries
+# --------------------------------------------------------------------------
+class _PrimaryFirewall(importlib.abc.MetaPathFinder):
+    def __init__(self) -> None:
+        self.hits: list[str] = []
+
+    def find_module(self, fullname, path=None):       # pragma: no cover legacy
+        return self.find_spec(fullname, path)
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.rsplit(".", 1)[-1] in BLOCKLISTED_MODULES:
+            self.hits.append(fullname)
+            raise ImportError(f"BLOCKLIST forbids import of {fullname}")
+        return None
+
+
+FIREWALL = _PrimaryFirewall()
+sys.meta_path.insert(0, FIREWALL)
+
+
+# --------------------------------------------------------------------------
+# helpers -- exact arithmetic only
+# --------------------------------------------------------------------------
+def _read_bytes(path: str) -> bytes:
+    return (ROOT / path).read_bytes()
+
+
+def _read_text(path: str) -> str:
+    return _read_bytes(path).decode("utf-8")
+
+
+def norm(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def digest(payload: object) -> str:
+    return sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+
+def q(value: Fraction) -> str:
+    return f"{value.numerator}/{value.denominator}"
+
+
+def vp(value: Fraction, p: int) -> int | None:
+    """p-adic valuation of a nonzero rational; None at zero."""
+    if value == 0:
+        return None
+    n, d, e = abs(value.numerator), value.denominator, 0
+    while n % p == 0:
+        n //= p
+        e += 1
+    while d % p == 0:
+        d //= p
+        e -= 1
+    return e
+
+
+def divisors(n: int) -> list[int]:
+    return [d for d in range(1, abs(n) + 1) if n % d == 0]
+
+
+def prime_factors(n: int) -> list[int]:
+    out, m, d = [], abs(n), 2
+    while d * d <= m:
+        if m % d == 0:
+            out.append(d)
+            while m % d == 0:
+                m //= d
+        d += 1
+    if m > 1:
+        out.append(m)
+    return out
+
+
+# ---- exact rational linear algebra -----------------------------------------
+def rref(rows: list[list[Fraction]]) -> tuple[list[list[Fraction]], list[int]]:
+    """Reduced row echelon form plus the pivot column indices."""
+    matrix = [[Fraction(x) for x in row] for row in rows]
+    if not matrix or not matrix[0]:
+        return [], []
+    width = len(matrix[0])
+    pivots: list[int] = []
+    rank = 0
+    for col in range(width):
+        piv = None
+        for r in range(rank, len(matrix)):
+            if matrix[r][col] != 0:
+                piv = r
+                break
+        if piv is None:
+            continue
+        matrix[rank], matrix[piv] = matrix[piv], matrix[rank]
+        head = matrix[rank][col]
+        matrix[rank] = [x / head for x in matrix[rank]]
+        for r in range(len(matrix)):
+            if r != rank and matrix[r][col] != 0:
+                f = matrix[r][col]
+                matrix[r] = [a - f * b for a, b in zip(matrix[r], matrix[rank])]
+        pivots.append(col)
+        rank += 1
+    return [row for row in matrix[:rank]], pivots
+
+
+def rank_exact(rows) -> int:
+    reduced, _ = rref(rows)
+    return len(reduced)
+
+
+def kernel_basis(rows, width: int) -> list[list[Fraction]]:
+    """Basis of {x : rows . x = 0}, exact over Q."""
+    reduced, pivots = rref(rows) if rows else ([], [])
+    free = [c for c in range(width) if c not in pivots]
+    basis = []
+    for f in free:
+        vec = [Fraction(0)] * width
+        vec[f] = Fraction(1)
+        for i, pcol in enumerate(pivots):
+            vec[pcol] = -reduced[i][f]
+        basis.append(vec)
+    return basis
+
+
+def kernel_dimension(matrix) -> int:
+    return len(matrix) - rank_exact(matrix)
+
+
+def mat_mul(a, b):
+    n, k, m = len(a), len(b), len(b[0])
+    return [[sum(a[i][t] * b[t][j] for t in range(k)) for j in range(m)]
+            for i in range(n)]
+
+
+def mat_add_scaled(a, b, c):
+    return [[a[i][j] + c * b[i][j] for j in range(len(a[0]))]
+            for i in range(len(a))]
+
+
+def identity_matrix(m: int):
+    return [[Fraction(1) if i == j else Fraction(0) for j in range(m)]
+            for i in range(m)]
+
+
+def solve_columns(u_cols, targets):
+    """Solve U X = T for X, where U has full column rank. Exact, or None."""
+    n = len(u_cols)
+    d = len(u_cols[0])
+    w = len(targets[0])
+    aug = [[Fraction(x) for x in u_cols[i]] + [Fraction(y) for y in targets[i]]
+           for i in range(n)]
+    reduced, pivots = rref(aug)
+    if pivots[:d] != list(range(d)) or len(pivots) > d:
+        return None
+    return [[reduced[i][d + j] for j in range(w)] for i in range(d)]
+
+
+# ---- exact integer polynomials (low -> high coefficients) ------------------
+def poly_trim(p):
+    while p and p[-1] == 0:
+        p = p[:-1]
+    return p
+
+
+def poly_divmod(num, den):
+    num = list(num)
+    den = poly_trim(list(den))
+    out = [Fraction(0)] * max(0, len(num) - len(den) + 1)
+    for i in range(len(out) - 1, -1, -1):
+        c = Fraction(num[i + len(den) - 1], 1) / den[-1]
+        out[i] = c
+        for j, dv in enumerate(den):
+            num[i + j] -= c * dv
+    return out, poly_trim(num)
+
+
+def poly_divides(den, num) -> bool:
+    _, rem = poly_divmod([Fraction(x) for x in num], [Fraction(x) for x in den])
+    return not rem
+
+
+def poly_exact_quotient(num, den):
+    quo, rem = poly_divmod([Fraction(x) for x in num], [Fraction(x) for x in den])
+    if rem:                                            # pragma: no cover gate
+        raise AssertionError("inexact polynomial division")
+    return [int(c) for c in quo]
+
+
+def factor_monic_squarefree(poly) -> list[list[int]] | None:
+    """Factor a monic squarefree integer polynomial into monic irreducibles.
+
+    Only degree <= 2 irreducible factors are searched for; anything left over
+    of degree >= 3 returns None, which is a HARD GATE FAILURE upstream.
+    """
+    remaining = poly_trim([int(c) for c in poly])
+    factors: list[list[int]] = []
+    # linear factors: integer roots divide the constant term (Gauss)
+    changed = True
+    while changed and len(remaining) > 1:
+        changed = False
+        c0 = remaining[0]
+        cands = [0] if c0 == 0 else \
+            sorted({s * d for d in divisors(abs(c0)) for s in (1, -1)})
+        for r in cands:
+            if sum(c * r ** k for k, c in enumerate(remaining)) == 0:
+                factors.append([-r, 1])
+                remaining = poly_exact_quotient(remaining, [-r, 1])
+                changed = True
+                break
+    # quadratic factors x^2 + b x + c with c | constant term (Gauss)
+    while len(remaining) > 1:
+        if len(remaining) == 3:
+            factors.append(list(remaining))
+            remaining = [1]
+            break
+        c0 = remaining[0]
+        bound = 1 + max(abs(x) for x in remaining)
+        found = None
+        cands = [0] if c0 == 0 else \
+            sorted({s * d for d in divisors(abs(c0)) for s in (1, -1)})
+        for c in cands:
+            for b in range(-2 * bound, 2 * bound + 1):
+                cand = [c, b, 1]
+                if poly_divides(cand, remaining):
+                    found = cand
+                    break
+            if found:
+                break
+        if not found:
+            return None
+        factors.append(found)
+        remaining = poly_exact_quotient(remaining, found)
+    return sorted(factors, key=lambda f: (len(f), f))
+
+
+def poly_of_matrix(coeffs, matrix):
+    m = len(matrix)
+    acc = [[Fraction(0)] * m for _ in range(m)]
+    power = identity_matrix(m)
+    for c in coeffs:
+        if c:
+            acc = mat_add_scaled(acc, power, Fraction(c))
+        power = mat_mul(power, matrix)
+    return acc
+
+
+def minimal_polynomial(matrix) -> list[int]:
+    """Monic integer minimal polynomial of an integer matrix, exact."""
+    m = len(matrix)
+    powers = [identity_matrix(m)]
+    for k in range(1, m + 1):
+        powers.append(mat_mul(powers[-1], matrix))
+        cols = [[powers[j][r][c] for j in range(k + 1)]
+                for r in range(m) for c in range(m)]
+        ker = kernel_basis(cols, k + 1)
+        for vec in ker:
+            if vec[k] != 0:
+                coeffs = [x / vec[k] for x in vec]
+                den = 1
+                for x in coeffs:
+                    den = den * x.denominator // gcd(den, x.denominator)
+                scaled = [int(x * den) for x in coeffs]
+                if scaled[-1] < 0:
+                    scaled = [-x for x in scaled]
+                g = 0
+                for x in scaled:
+                    g = gcd(g, abs(x))
+                scaled = [x // g for x in scaled]
+                return scaled
+    raise AssertionError("no minimal polynomial found")  # pragma: no cover
+
+
+# ---- exact integer-lattice membership WITH a witness -----------------------
+def integer_lattice_solve(rows, target):
+    """Integer x with rows . x == target, or (False, None). Proof, not search."""
+    m = len(rows)
+    n = len(rows[0]) if m else 0
+    if n == 0:
+        return (not any(target)), []
+    a = [list(r) for r in rows]
+    u = [[1 if i == j else 0 for j in range(n)] for i in range(n)]
+    col = 0
+    pivots = []
+    for i in range(m):
+        if col >= n:
+            break
+        while True:
+            nz = [j for j in range(col, n) if a[i][j] != 0]
+            if len(nz) <= 1:
+                break
+            nz.sort(key=lambda j: (abs(a[i][j]), j))
+            p = nz[0]
+            for j in nz[1:]:
+                f = a[i][j] // a[i][p]
+                for r in range(m):
+                    a[r][j] -= f * a[r][p]
+                for r in range(n):
+                    u[r][j] -= f * u[r][p]
+        nz = [j for j in range(col, n) if a[i][j] != 0]
+        if nz:
+            p = nz[0]
+            if p != col:
+                for r in range(m):
+                    a[r][col], a[r][p] = a[r][p], a[r][col]
+                for r in range(n):
+                    u[r][col], u[r][p] = u[r][p], u[r][col]
+            pivots.append((i, col))
+            col += 1
+    y = [0] * n
+    res = list(target)
+    for (i, c) in pivots:
+        if res[i] % a[i][c] != 0:
+            return False, None
+        f = res[i] // a[i][c]
+        y[c] = f
+        for r in range(m):
+            res[r] -= f * a[r][c]
+    if any(res):
+        return False, None
+    x = [sum(u[r][c] * y[c] for c in range(n)) for r in range(n)]
+    return True, x
+
+
+def multiplicative_reach(generators, target: Fraction) -> dict:
+    """Is `target` in the multiplicative group generated by `generators`?"""
+    gens = sorted({g for g in generators if g not in (0, 1, -1)})
+    primes = sorted(set(
+        [p for g in gens for p in prime_factors(g)]
+        + prime_factors(target.numerator) + prime_factors(target.denominator)
+    ))
+    gen_vecs = [[vp(Fraction(g), p) for p in primes] for g in gens]
+    tvec = [vp(target, p) for p in primes]
+    if not gens:
+        reachable, witness = (not any(tvec)), []
+    else:
+        rows = [[gen_vecs[j][i] for j in range(len(gens))]
+                for i in range(len(primes))]
+        reachable, witness = integer_lattice_solve(rows, tvec)
+    verified = None
+    if reachable and gens:
+        value = Fraction(1)
+        for g, e in zip(gens, witness):
+            value *= Fraction(g) ** e
+        verified = value == target
+    elif reachable:
+        verified = target == 1
+    windowed = None
+    if len(gens) <= 3:
+        window = range(-6, 7)
+        windowed = False
+        for exps in product(window, repeat=len(gens)):
+            value = Fraction(1)
+            for g, e in zip(gens, exps):
+                value *= Fraction(g) ** e
+            if value == target:
+                windowed = True
+                break
+        if not gens:
+            windowed = target == 1
+    return {
+        "generators": gens,
+        "primes": primes,
+        "generator_valuation_vectors": gen_vecs,
+        "target_valuation_vector": tvec,
+        "reachable": reachable,
+        "witness_exponents": witness if reachable else None,
+        "witness_recomputes_the_target": verified,
+        "windowed_scan_in_minus6_to_6": windowed,
+        "window_agrees_with_the_lattice_proof":
+            True if windowed is None else windowed == reachable,
+    }
+
+
+# --------------------------------------------------------------------------
+# the proper cubic rotation group
+# --------------------------------------------------------------------------
+IDENTITY3 = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def signed_permutation_matrices():
+    out = []
+    for perm in product(range(3), repeat=3):
+        if len(set(perm)) != 3:
+            continue
+        for signs in product((1, -1), repeat=3):
+            rows = []
+            for i in range(3):
+                row = [0, 0, 0]
+                row[perm[i]] = signs[i]
+                rows.append(tuple(row))
+            out.append(tuple(rows))
+    return out
+
+
+def det3(m) -> int:
+    return (m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+            - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+            + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]))
+
+
+def mul(a, b):
+    return tuple(tuple(sum(a[i][k] * b[k][j] for k in range(3))
+                       for j in range(3)) for i in range(3))
+
+
+def act(m, v):
+    return tuple(sum(m[i][j] * v[j] for j in range(3)) for i in range(3))
+
+
+def element_order(m) -> int:
+    cur, k = m, 1
+    while cur != IDENTITY3:
+        cur = mul(cur, m)
+        k += 1
+        if k > 24:                                     # pragma: no cover gate
+            raise AssertionError("not a finite rotation")
+    return k
+
+
+def proper_rotations():
+    return sorted(m for m in signed_permutation_matrices() if det3(m) == 1)
+
+
+GROUP = proper_rotations()
+GROUP_SET = frozenset(GROUP)
+INVERSE = {m: next(b for b in GROUP if mul(m, b) == IDENTITY3) for m in GROUP}
+
+
+def rotation_axis(m):
+    if m == IDENTITY3:
+        return None
+    cands = [v for v in product((-1, 0, 1), repeat=3)
+             if any(v) and act(m, v) == v]
+    canon = set()
+    for v in cands:
+        g = 0
+        for x in v:
+            g = gcd(g, abs(x))
+        w = tuple(x // g for x in v)
+        lead = next(x for x in w if x != 0)
+        canon.add(w if lead > 0 else tuple(-x for x in w))
+    if len(canon) != 1:                                # pragma: no cover gate
+        raise AssertionError(f"axis not unique: {sorted(canon)}")
+    return canon.pop()
+
+
+def axis_kind(m) -> str:
+    axis = rotation_axis(m)
+    return {1: "face", 2: "edge", 3: "body"}[sum(1 for x in axis if x)]
+
+
+def orbits_of(subgroup, points) -> list[tuple]:
+    seen, out = set(), []
+    for p in points:
+        if p in seen:
+            continue
+        orbit = {p}
+        frontier = [p]
+        while frontier:
+            cur = frontier.pop()
+            for m in subgroup:
+                nxt = act(m, cur)
+                if nxt not in orbit:
+                    orbit.add(nxt)
+                    frontier.append(nxt)
+        seen |= orbit
+        out.append(tuple(sorted(orbit)))
+    return out
+
+
+# --------------------------------------------------------------------------
+# the FULL subgroup lattice
+# --------------------------------------------------------------------------
+def closure(seeds) -> frozenset:
+    found = {IDENTITY3}
+    frontier = [s for s in seeds]
+    for s in seeds:
+        found.add(s)
+    while frontier:
+        cur = frontier.pop()
+        for other in list(found):
+            for prod in (mul(cur, other), mul(other, cur)):
+                if prod not in found:
+                    found.add(prod)
+                    frontier.append(prod)
+    return frozenset(found)
+
+
+def all_subgroups() -> list[frozenset]:
+    """Every subgroup, by closing every ORDERED PAIR of group elements."""
+    found = {frozenset({IDENTITY3})}
+    for a in GROUP:
+        for b in GROUP:
+            found.add(closure((a, b)))
+    return sorted(found, key=lambda h: (len(h), sorted(h)))
+
+
+def is_cyclic(h: frozenset) -> bool:
+    return any(closure((g,)) == h for g in h)
+
+
+def is_abelian(h: frozenset) -> bool:
+    return all(mul(a, b) == mul(b, a) for a in h for b in h)
+
+
+def structure_name(h: frozenset) -> str:
+    """DERIVED name: order, cyclicity, commutativity and axis-kind multiset."""
+    n = len(h)
+    if n == 1:
+        return "E_trivial"
+    kinds = sorted(axis_kind(m) for m in h if m != IDENTITY3)
+    if is_cyclic(h):
+        return f"C{n}_{kinds[0]}"
+    if is_abelian(h) and n == 4:
+        return "V_face" if set(kinds) == {"face"} else "V_edge"
+    if n == 6:
+        return "S3_body"
+    if n == 8:
+        return "D4_face"
+    if n == 12:
+        return "A4_tetrahedral"
+    if n == 24:
+        return "O_full"
+    kindsig = "".join(f"{k[0]}{kinds.count(k)}"        # pragma: no cover gate
+                      for k in ("face", "edge", "body") if kinds.count(k))
+    return f"G{n}_{kindsig}"
+
+
+def normalizer(h: frozenset) -> frozenset:
+    return frozenset(g for g in GROUP
+                     if frozenset(mul(mul(g, x), INVERSE[g]) for x in h) == h)
+
+
+def conjugacy_class_of(h: frozenset) -> frozenset:
+    return frozenset(
+        frozenset(mul(mul(g, x), INVERSE[g]) for x in h) for g in GROUP)
+
+
+LATTICE = all_subgroups()
+
+
+def build_lattice_rows() -> list[dict]:
+    class_index: dict[frozenset, int] = {}
+    classes: list[frozenset] = []
+    for h in LATTICE:
+        if h in class_index:
+            continue
+        klass = conjugacy_class_of(h)
+        idx = len(classes)
+        classes.append(klass)
+        for member in klass:
+            class_index[member] = idx
+    rows = []
+    for h in LATTICE:
+        rows.append({
+            "key": h,
+            "order": len(h),
+            "name": structure_name(h),
+            "class_index": class_index[h],
+            "is_cyclic": is_cyclic(h),
+            "is_abelian": is_abelian(h),
+            "normalizer_order": len(normalizer(h)),
+            "is_normal_in_the_full_group": len(normalizer(h)) == len(GROUP),
+            "element_indices": sorted(GROUP.index(m) for m in h),
+        })
+    return sorted(rows, key=lambda r: (r["order"], r["name"],
+                                       r["element_indices"]))
+
+
+LATTICE_ROWS = build_lattice_rows()
+BY_KEY = {r["key"]: r for r in LATTICE_ROWS}
+
+
+# --------------------------------------------------------------------------
+# EXACT isotype machinery, valid for every subgroup (no character table)
+# --------------------------------------------------------------------------
+def permutation_matrix(elem, points):
+    index = {p: i for i, p in enumerate(points)}
+    n = len(points)
+    m = [[Fraction(0)] * n for _ in range(n)]
+    for j, p in enumerate(points):
+        m[index[act(elem, p)]][j] = Fraction(1)
+    return m
+
+
+def span_of_matrices(mats, n):
+    """A basis of the Q-span of the given n x n matrices, as matrices."""
+    reduced_rows: list[list[Fraction]] = []
+    pivots: list[int] = []
+    basis = []
+    for mat in mats:
+        vec = [mat[i][j] for i in range(n) for j in range(n)]
+        cur = list(vec)
+        for row, pcol in zip(reduced_rows, pivots):
+            if cur[pcol] != 0:
+                f = cur[pcol]
+                cur = [a - f * b for a, b in zip(cur, row)]
+        piv = next((k for k, x in enumerate(cur) if x != 0), None)
+        if piv is None:
+            continue
+        cur = [x / cur[piv] for x in cur]
+        reduced_rows.append(cur)
+        pivots.append(piv)
+        basis.append(mat)
+    return basis
+
+
+def centre_of_algebra(algebra_basis, gens, n):
+    """{z in span(algebra_basis) : z rho(g) = rho(g) z for all g}."""
+    r = len(algebra_basis)
+    eqs = []
+    for g in gens:
+        for i in range(n):
+            for j in range(n):
+                row = []
+                for b in algebra_basis:
+                    lhs = sum(b[i][k] * g[k][j] for k in range(n))
+                    rhs = sum(g[i][k] * b[k][j] for k in range(n))
+                    row.append(lhs - rhs)
+                eqs.append(row)
+    coeffs = kernel_basis(eqs, r)
+    out = []
+    for vec in coeffs:
+        mat = [[sum(vec[k] * algebra_basis[k][i][j] for k in range(r))
+                for j in range(n)] for i in range(n)]
+        den = 1
+        for i in range(n):
+            for j in range(n):
+                den = den * mat[i][j].denominator // gcd(den,
+                                                         mat[i][j].denominator)
+        out.append([[mat[i][j] * den for j in range(n)] for i in range(n)])
+    return out
+
+
+def _integer_matrix(mat):
+    return [[int(x) for x in row] for row in mat]
+
+
+def find_centre_generator(centre_basis, n):
+    """A z in Z whose minimal polynomial has degree dim Z (deterministic)."""
+    r = len(centre_basis)
+    for spread in range(1, 6):
+        for coeffs in product(range(0, spread + 1), repeat=r):
+            if not any(coeffs):
+                continue
+            z = [[sum(coeffs[k] * centre_basis[k][i][j] for k in range(r))
+                  for j in range(n)] for i in range(n)]
+            mp = minimal_polynomial(_integer_matrix(z))
+            if len(mp) - 1 == r:
+                return z, mp, list(coeffs)
+    return None, None, None
+
+
+def isotypic_decomposition(subgroup, points) -> dict:
+    """Exact rational isotypic decomposition of the permutation module."""
+    n = len(points)
+    elements = sorted(subgroup)
+    mats = [permutation_matrix(g, points) for g in elements]
+    algebra = span_of_matrices(mats, n)
+    centre = centre_of_algebra(algebra, mats, n)
+    z, mp, coeffs = find_centre_generator(centre, n)
+    if z is None:
+        return {"ok": False, "reason": "no generator of the centre found"}
+    factors = factor_monic_squarefree(mp)
+    if factors is None:
+        return {"ok": False,
+                "reason": "minimal polynomial has an irreducible factor of "
+                          "degree > 2"}
+    product_back = [1]
+    for f in factors:
+        acc = [Fraction(0)] * (len(product_back) + len(f) - 1)
+        for i, a in enumerate(product_back):
+            for j, b in enumerate(f):
+                acc[i + j] += a * b
+        product_back = [int(x) for x in acc]
+    if product_back != mp:
+        return {"ok": False, "reason": "factorization does not multiply back"}
+
+    isotypes = []
+    for f in factors:
+        fz = poly_of_matrix(f, [[Fraction(x) for x in row] for row in z])
+        basis = kernel_basis(fz, n)
+        dim = len(basis)
+        if dim == 0:
+            continue
+        u_cols = [[basis[k][i] for k in range(dim)] for i in range(n)]
+        restricted = []
+        for b in algebra:
+            image = [[sum(b[i][k] * u_cols[k][c] for k in range(n))
+                      for c in range(dim)] for i in range(n)]
+            c_mat = solve_columns(u_cols, image)
+            if c_mat is None:
+                return {"ok": False,
+                        "reason": "isotypic component is not A-invariant"}
+            restricted.append(c_mat)
+        dim_a_i = len(span_of_matrices(restricted, dim))
+        t_i = len(f) - 1
+        square = dim_a_i * t_i
+        d_i = isqrt(square)
+        if d_i * d_i != square or d_i == 0 or dim % d_i != 0:
+            return {"ok": False,
+                    "reason": f"degree recovery failed on a component "
+                              f"(dim_A={dim_a_i}, t={t_i}, dim={dim})"}
+        acts_trivially = all(
+            all(restricted_row == expected
+                for restricted_row, expected in zip(c, identity_matrix(dim)))
+            for c in restricted)
+        isotypes.append({
+            "irreducible_degree_over_Q": d_i,
+            "multiplicity": dim // d_i,
+            "component_dimension": dim,
+            "endomorphism_field_degree": t_i,
+            "dim_Q_of_the_component_algebra": dim_a_i,
+            "minimal_polynomial_factor": f,
+            "is_the_trivial_isotype": acts_trivially,
+            "component_basis": [[q(x) for x in vec] for vec in basis],
+        })
+    isotypes.sort(key=lambda b: (b["irreducible_degree_over_Q"],
+                                 b["multiplicity"],
+                                 b["endomorphism_field_degree"]))
+    fine_dims = sorted(d for b in isotypes
+                       for d in [b["irreducible_degree_over_Q"]]
+                       * b["multiplicity"])
+    return {
+        "ok": True,
+        "space_dimension": n,
+        "enveloping_algebra_dimension": len(algebra),
+        "centre_dimension": len(centre),
+        "centre_generator_coefficients": coeffs,
+        "centre_generator_minimal_polynomial": mp,
+        "minimal_polynomial_irreducible_factors": factors,
+        "isotypes": isotypes,
+        "fine_rational_irreducible_dimensions": fine_dims,
+        "fine_dimensions_sum": sum(fine_dims),
+        "fine_decomposition_sums_to_the_space": sum(fine_dims) == n,
+        "every_isotypic_multiplicity_is_one":
+            all(b["multiplicity"] == 1 for b in isotypes),
+        "sum_of_m_squared_times_field_degree": sum(
+            b["multiplicity"] ** 2 * b["endomorphism_field_degree"]
+            for b in isotypes),
+    }
+
+
+def signature_for(subgroup, points) -> dict:
+    """Both readings at one scope, with the invariant multiplicity computed
+    three independent ways and gated to agree."""
+    n = len(points)
+    order = len(subgroup)
+    elements = sorted(subgroup)
+    mats = [permutation_matrix(g, points) for g in elements]
+    stacked = []
+    for m in mats:
+        diff = mat_add_scaled(m, identity_matrix(n), Fraction(-1))
+        stacked.extend(diff)
+    inv_nullspace = n - rank_exact(stacked) if stacked else n
+    total_fixed = sum(sum(1 for p in points if act(g, p) == p)
+                      for g in elements)
+    inv_burnside = Fraction(total_fixed, order)
+    inv_orbits = len(orbits_of(elements, points))
+    routes_agree = inv_nullspace == inv_burnside == inv_orbits
+
+    pairs = [(a, b) for a in points for b in points]
+    seen_pairs, pair_orbits = set(), 0
+    for pr in pairs:
+        if pr in seen_pairs:
+            continue
+        pair_orbits += 1
+        for g in elements:
+            seen_pairs.add((act(g, pr[0]), act(g, pr[1])))
+    burnside_pairs = Fraction(
+        sum(sum(1 for p in points if act(g, p) == p) ** 2 for g in elements),
+        order)
+
+    decomposition = isotypic_decomposition(subgroup, points)
+    coarse = (inv_nullspace, n - inv_nullspace)
+    fine_dims = decomposition.get("fine_rational_irreducible_dimensions", [])
+    fine_top = max(fine_dims) if fine_dims else 0
+    trivial_rows = [b for b in decomposition.get("isotypes", [])
+                    if b["is_the_trivial_isotype"]]
+    trivial_mult = trivial_rows[0]["multiplicity"] if trivial_rows else 0
+    gates = {
+        "three_routes_agree_on_the_invariant_multiplicity": routes_agree,
+        "decomposition_succeeded": decomposition.get("ok", False),
+        "fine_decomposition_sums_to_the_space":
+            decomposition.get("fine_decomposition_sums_to_the_space", False),
+        "trivial_isotype_multiplicity_equals_the_orbit_count":
+            trivial_mult == inv_orbits,
+        "sum_m_squared_field_degree_equals_the_orbit_count_on_pairs":
+            decomposition.get("sum_of_m_squared_times_field_degree")
+            == pair_orbits,
+        "burnside_pair_count_agrees_with_the_direct_pair_orbit_count":
+            burnside_pairs == pair_orbits,
+        "fine_top_equals_the_maximum_fine_dimension":
+            fine_top == (max(fine_dims) if fine_dims else 0),
+    }
+    return {
+        "space_dimension": n,
+        "subgroup_order": order,
+        "invariant_dim_by_nullspace": inv_nullspace,
+        "invariant_dim_by_burnside": q(inv_burnside),
+        "invariant_dim_by_orbit_count": inv_orbits,
+        "orbit_count_on_the_product_set": pair_orbits,
+        "burnside_pair_count": q(burnside_pairs),
+        "coarse_ordered_pair": list(coarse),
+        "coarse_two_adic_profile": [
+            vp(Fraction(coarse[0]), 2) if coarse[0] else None,
+            vp(Fraction(coarse[1]), 2) if coarse[1] else None,
+        ],
+        "fine_rational_irreducible_dimensions": fine_dims,
+        "fine_top_rational_irreducible_dimension": fine_top,
+        "fine_top_pair": [inv_nullspace, fine_top],
+        "fine_top_two_adic_profile": [
+            vp(Fraction(inv_nullspace), 2) if inv_nullspace else None,
+            vp(Fraction(fine_top), 2) if fine_top else None,
+        ],
+        "fine_dimensions_with_a_v2_equal_to_one":
+            [d for d in fine_dims if vp(Fraction(d), 2) == 1],
+        "isotypes": [{k: v for k, v in b.items() if k != "component_basis"}
+                     for b in decomposition.get("isotypes", [])],
+        "isotypic_decomposition_is_unique":
+            decomposition.get("every_isotypic_multiplicity_is_one", False),
+        "enveloping_algebra_dimension":
+            decomposition.get("enveloping_algebra_dimension"),
+        "centre_dimension": decomposition.get("centre_dimension"),
+        "decomposition_failure_reason": decomposition.get("reason"),
+        "gates": gates,
+        "all_gates_pass": all(gates.values()),
+    }
+
+
+def scope_rows_for(row) -> dict:
+    """Shell scope (defined for every subgroup) and orbit scope (defined only
+    where a free orbit exists), plus the orbit structure."""
+    h = row["key"]
+    order = row["order"]
+    orbs = orbits_of(sorted(h), NEAREST_NEIGHBOURS)
+    lengths = sorted(len(o) for o in orbs)
+    free_orbits = [o for o in orbs if len(o) == order]
+    axis_orbits = orbits_of(sorted(h), COORDINATE_AXES)
+
+    def axis_canon(v):
+        lead = next(x for x in v if x != 0)
+        return v if lead > 0 else tuple(-x for x in v)
+
+    axis_orbit_sets = []
+    seen = set()
+    for a in COORDINATE_AXES:
+        if a in seen:
+            continue
+        orbit = {axis_canon(act(m, a)) for m in h}
+        seen |= orbit
+        axis_orbit_sets.append(tuple(sorted(orbit)))
+    shell = signature_for(h, list(NEAREST_NEIGHBOURS))
+    orbit_scope = (signature_for(h, sorted(max(free_orbits, key=len)))
+                   if free_orbits else None)
+    return {
+        "name": row["name"],
+        "order": order,
+        "class_index": row["class_index"],
+        "is_cyclic": row["is_cyclic"],
+        "element_indices": row["element_indices"],
+        "shell_orbit_lengths": lengths,
+        "shell_orbit_count": len(orbs),
+        "acts_freely_on_the_shell": all(L == order for L in lengths),
+        "transitive_on_the_shell": len(orbs) == 1,
+        "simply_transitive_on_the_shell":
+            len(orbs) == 1 and lengths == [order],
+        "fixed_shell_sites": [list(v) for v in NEAREST_NEIGHBOURS
+                              if all(act(m, v) == v for m in h)],
+        "maximal_orbit_length": max(lengths),
+        "maximal_FREE_orbit_length":
+            max([L for L in lengths if L == order], default=0),
+        "has_a_free_orbit_on_the_shell": bool(free_orbits),
+        "free_orbit_count": len(free_orbits),
+        "orbit_lengths_divide_the_subgroup_order":
+            all(order % L == 0 for L in lengths),
+        "orbit_lengths_sum_to_six": sum(lengths) == len(NEAREST_NEIGHBOURS),
+        "coordinate_axis_orbit_sizes": sorted(len(o) for o in axis_orbit_sets),
+        "transitive_on_the_three_coordinate_axes": len(axis_orbit_sets) == 1,
+        "ORBIT_SCOPE_cycle883_construction": orbit_scope,
+        "SHELL_SCOPE_whole_neighbourhood": shell,
+    }
+
+
+# --------------------------------------------------------------------------
+# AST recovery from the pinned primaries
+# --------------------------------------------------------------------------
+def module_constants(path: str) -> dict:
+    tree = ast.parse(_read_text(path))
+    out = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                and isinstance(node.targets[0], ast.Name):
+            try:
+                out[node.targets[0].id] = ast.literal_eval(node.value)
+            except (ValueError, TypeError, SyntaxError):
+                continue
+    return out
+
+
+C886_CONSTANTS = module_constants(AUDIT_INPUT_PATHS[1])
+AXIOM_SENTENCES = C886_CONSTANTS.get("AXIOM_SENTENCES", {})
+C882_T6_NEEDLE = C886_CONSTANTS.get("C882_T6_NEEDLE", "")
+C886_GENERATOR_RULES = C886_CONSTANTS.get("GENERATOR_RULES", {})
+
+
+def resolve_node(node, constants):
+    if node is None:
+        return None
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+        base = constants.get(node.value.id)
+        key = resolve_node(node.slice, constants)
+        if isinstance(base, dict) and key in base:
+            return base[key]
+        if isinstance(base, (list, tuple)) and isinstance(key, int) \
+                and 0 <= key < len(base):
+            return base[key]
+        return None
+    if isinstance(node, ast.JoinedStr):
+        return "<computed f-string>"
+    return None
+
+
+def extract_886_selectors() -> list[dict]:
+    """The sixteen selector rows, byte-recovered from the pinned 886 primary."""
+    source = _read_text(AUDIT_INPUT_PATHS[1])
+    tree = ast.parse(source)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "selector_table_certificate")
+    assign = next(n for n in ast.walk(fn)
+                  if isinstance(n, ast.Assign)
+                  and isinstance(n.targets[0], ast.Name)
+                  and n.targets[0].id == "selectors")
+    rows = []
+    for elt in assign.value.elts:
+        entry = {}
+        for k, v in zip(elt.keys, elt.values):
+            key = k.value
+            if key == "survivors":
+                entry["survivor_expression_source_886"] = \
+                    ast.get_source_segment(source, v)
+            else:
+                entry[key] = resolve_node(v, C886_CONSTANTS)
+        rows.append(entry)
+    return rows
+
+
+C886_SELECTORS = extract_886_selectors()
+
+
+def extract_883_t6() -> dict:
+    """Cycle 883's anchor-group widening argument, recovered by AST."""
+    source = _read_text(AUDIT_INPUT_PATHS[5])
+    tree = ast.parse(source)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "bridge_back_t6_certificate")
+    segment = ast.get_source_segment(source, fn)
+    consts = module_constants(AUDIT_INPUT_PATHS[5])
+    return {
+        "function": "bridge_back_t6_certificate",
+        "source": segment,
+        "declares_cycle882_generator_set_of_the_orbit_length_alone":
+            "cycle882_generator_set" in segment and "[3]" in segment,
+        "widens_to_the_isotype_dimensions":
+            "generators = (2, 3)" in segment,
+        "defeat_condition_source":
+            next((line.strip() for line in segment.splitlines()
+                  if line.strip().startswith("defeated =")), None),
+        "ast_recovered_ORBIT_LENGTH": consts.get("ORBIT_LENGTH"),
+        "ast_recovered_TARGET_PAIR": consts.get("TARGET_PAIR"),
+        "ast_recovered_WRONG_PAIRS": consts.get("WRONG_PAIRS"),
+    }
+
+
+C883_T6 = extract_883_t6()
+
+
+# --------------------------------------------------------------------------
+# certificate A: pins
+# --------------------------------------------------------------------------
+def pins_certificate() -> dict:
+    rows, ok = [], True
+    for path in AUDIT_INPUT_PATHS:
+        target = ROOT / path
+        exists = target.exists()
+        got = sha256(_read_bytes(path)).hexdigest() if exists else None
+        try:
+            blob = subprocess.run(["git", "hash-object", str(target)],
+                                  capture_output=True, text=True,
+                                  cwd=str(ROOT), check=True).stdout.strip() \
+                if exists else None
+        except Exception:                              # pragma: no cover gate
+            blob = None
+        sha_ok = got == EXPECTED_SHA256[path]
+        blob_ok = blob == EXPECTED_GIT_BLOBS[path]
+        ok = ok and exists and sha_ok and blob_ok
+        rows.append({"path": path, "absolute_path": str(target),
+                     "exists": exists, "sha256": got,
+                     "sha256_matches_pin": sha_ok, "git_blob": blob,
+                     "git_blob_matches_pin": blob_ok})
+    return {
+        "statement": (
+            "Every cited artifact is pinned by absolute path, SHA-256 and git "
+            "blob and read as text/AST/JSON only. A missing or moved pin is a "
+            "hard preflight failure (exit 2)."
+        ),
+        "rows": rows,
+        "read_mode": "text/AST/JSON only; import blocked by meta-path firewall",
+        "finding": (
+            f"{sum(1 for r in rows if r['sha256_matches_pin'] and r['git_blob_matches_pin'])}"
+            f"/{len(rows)} pinned artifacts round-trip on both SHA-256 and git "
+            f"blob."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate B: the quoted sentences and the recovered 886/883 material
+# --------------------------------------------------------------------------
+def quoted_sentences_certificate() -> dict:
+    axioms = norm(_read_text(AUDIT_INPUT_PATHS[0]))
+    rows, ok = [], True
+    for key, sentence in sorted(AXIOM_SENTENCES.items()):
+        present = norm(sentence) in axioms
+        ok = ok and present
+        rows.append({"id": key, "byte_quoted_sentence": sentence,
+                     "recovered_from_the_886_primary_by_AST": True,
+                     "present_in_the_pinned_axiom_memo": present})
+    t6_source = _read_text(AUDIT_INPUT_PATHS[6])
+    t6_constants = {norm(n.value) for n in ast.walk(ast.parse(t6_source))
+                    if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+    t6_present = norm(C882_T6_NEEDLE) in t6_constants
+    t6_in_memo = norm(C882_T6_NEEDLE) in axioms
+    ok = ok and t6_present and not t6_in_memo and len(AXIOM_SENTENCES) == 10
+
+    selectors_ok = (
+        len(C886_SELECTORS) == 16
+        and tuple(s["id"] for s in C886_SELECTORS) == SELECTOR_IDS
+        and all(s.get("fidelity") in ("EXACT", "PARTIAL", "NONE")
+                for s in C886_SELECTORS)
+        and all(isinstance(s.get("grounded"), bool) for s in C886_SELECTORS)
+    )
+    ok = ok and selectors_ok
+    t6_ok = (C883_T6["widens_to_the_isotype_dimensions"]
+             and C883_T6["ast_recovered_ORBIT_LENGTH"] == 3
+             and tuple(C883_T6["ast_recovered_TARGET_PAIR"]) == TARGET_PAIR
+             and C883_T6["defeat_condition_source"] is not None)
+    ok = ok and t6_ok
+    return {
+        "statement": (
+            "Every sentence this cycle quotes is recovered by AST from a "
+            "pinned artifact and, for axiom sentences, verified present in the "
+            "pinned axiom memo character for character. Cycle 886's sixteen "
+            "selector rows and Cycle 883's anchor-widening argument are "
+            "recovered the same way and carried over as PINS, not retyped."
+        ),
+        "axiom_sentences": rows,
+        "axiom_sentence_count": len(AXIOM_SENTENCES),
+        "cycle882_t6_obligation_sentence": {
+            "sentence": C882_T6_NEEDLE,
+            "recovered_from_the_882_primary_by_AST": t6_present,
+            "present_in_the_axiom_memo": t6_in_memo,
+            "class": "OBLIGATION sentence, not an axiom sentence",
+        },
+        "cycle886_selector_rows_recovered": len(C886_SELECTORS),
+        "cycle886_selector_ids": [s["id"] for s in C886_SELECTORS],
+        "cycle886_fidelity_grades_carried_over_as_pins": {
+            s["id"]: {"fidelity": s.get("fidelity"),
+                      "grounded": s.get("grounded"),
+                      "grounding_defect": s.get("grounding_defect")}
+            for s in C886_SELECTORS},
+        "cycle886_selector_ids_match_the_pinned_list": selectors_ok,
+        "cycle883_t6_widening_argument": {
+            k: v for k, v in C883_T6.items() if k != "source"},
+        "cycle883_t6_argument_recovered": t6_ok,
+        "finding": (
+            f"{sum(1 for r in rows if r['present_in_the_pinned_axiom_memo'])}"
+            f"/{len(rows)} axiom sentences round-trip byte for byte; the "
+            f"Cycle-882 obligation sentence is AST-recovered and confirmed "
+            f"ABSENT from the axiom memo; {len(C886_SELECTORS)} selector rows "
+            f"and Cycle 883's widening argument are recovered as pins."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate C: the rotation group
+# --------------------------------------------------------------------------
+def rotation_group_certificate() -> dict:
+    closed = all(mul(a, b) in GROUP_SET for a in GROUP for b in GROUP)
+    associative = all(mul(mul(a, b), c) == mul(a, mul(b, c))
+                      for a in GROUP for b in GROUP for c in GROUP)
+    inverses = all(mul(a, INVERSE[a]) == IDENTITY3 for a in GROUP)
+    dets = all(det3(m) == 1 for m in GROUP)
+    orders: dict[int, int] = {}
+    for m in GROUP:
+        orders[element_order(m)] = orders.get(element_order(m), 0) + 1
+    order_counts = dict(sorted(orders.items()))
+    total_fixed = sum(sum(1 for v in NEAREST_NEIGHBOURS if act(m, v) == v)
+                      for m in GROUP)
+    burnside = Fraction(total_fixed, len(GROUP))
+    direct = len(orbits_of(GROUP, NEAREST_NEIGHBOURS))
+    ok = (len(GROUP) == 24 and closed and associative and inverses and dets
+          and order_counts == {1: 1, 2: 9, 3: 8, 4: 6}
+          and burnside == direct == 1)
+    return {
+        "statement": (
+            "GATE C888-G1. The Lattice axiom's 'proper cubic rotations about "
+            "each site' rebuild as the 24 determinant-one signed permutation "
+            "matrices; the group axioms are checked exhaustively and Burnside "
+            "is verified on the 6-neighbour shell."
+        ),
+        "axiom_sentence_used": AXIOM_SENTENCES.get("lattice_rotations"),
+        "proper_rotations": len(GROUP),
+        "closure_products_checked": len(GROUP) ** 2,
+        "associativity_triples_checked": len(GROUP) ** 3,
+        "closed_under_composition": closed,
+        "associative": associative,
+        "every_element_has_an_inverse": inverses,
+        "every_element_has_determinant_plus_one": dets,
+        "element_order_counts": order_counts,
+        "burnside_orbit_count_on_the_shell": q(burnside),
+        "orbit_count_computed_directly": direct,
+        "finding": (
+            f"{len(GROUP)} proper rotations, order profile {order_counts}, "
+            f"{len(GROUP) ** 2} products and {len(GROUP) ** 3} associativity "
+            f"triples verified; Burnside gives {q(burnside)} shell orbit, "
+            f"matching the direct count {direct}."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate D: the FULL subgroup lattice
+# --------------------------------------------------------------------------
+def lattice_certificate() -> dict:
+    classes: dict[int, dict] = {}
+    for row in LATTICE_ROWS:
+        entry = classes.setdefault(row["class_index"], {
+            "class_index": row["class_index"], "name": row["name"],
+            "order": row["order"], "size": 0, "is_cyclic": row["is_cyclic"],
+            "is_abelian": row["is_abelian"],
+            "normalizer_order": row["normalizer_order"],
+            "normal_in_the_full_group": row["is_normal_in_the_full_group"],
+        })
+        entry["size"] += 1
+    class_table = [classes[i] for i in sorted(classes)]
+    names_constant = all(
+        len({r["name"] for r in LATTICE_ROWS
+             if r["class_index"] == e["class_index"]}) == 1
+        for e in class_table)
+    names_distinct = len({e["name"] for e in class_table}) == len(class_table)
+    class_equation = all(e["size"] * e["normalizer_order"] == len(GROUP)
+                         for e in class_table)
+    normalizer_constant = all(
+        len({r["normalizer_order"] for r in LATTICE_ROWS
+             if r["class_index"] == e["class_index"]}) == 1
+        for e in class_table)
+    lagrange = all(len(GROUP) % r["order"] == 0 for r in LATTICE_ROWS)
+    closed = all(all(mul(a, b) in r["key"] for a in r["key"] for b in r["key"])
+                 for r in LATTICE_ROWS)
+    identity_in_all = all(IDENTITY3 in r["key"] for r in LATTICE_ROWS)
+    inverse_closed = all(INVERSE[a] in r["key"]
+                         for r in LATTICE_ROWS for a in r["key"])
+    sizes_sum = sum(e["size"] for e in class_table)
+    # union-closure adds nothing: the pair-closure route is already complete
+    keys = {r["key"] for r in LATTICE_ROWS}
+    union_closed = all(closure(a | b) in keys for a in keys for b in keys)
+    # Sylow congruences, recomputed
+    n2 = sum(1 for r in LATTICE_ROWS if r["order"] == 8)
+    n3 = sum(1 for r in LATTICE_ROWS if r["order"] == 3)
+    sylow_ok = (n2 % 2 == 1 and 3 % n2 == 0 and n3 % 3 == 1 and 8 % n3 == 0)
+    by_order = {}
+    for r in LATTICE_ROWS:
+        by_order[r["order"]] = by_order.get(r["order"], 0) + 1
+    declared = DECLARED_CLASSIFICATION_TO_BE_RECOMPUTED
+    recomputed_matches_declared = (
+        len(LATTICE_ROWS) == declared["subgroups"]
+        and len(class_table) == declared["conjugacy_classes"]
+        and sorted(e["size"] for e in class_table)
+        == sorted(declared["class_sizes_by_declared_name"].values()))
+    ok = (len(LATTICE_ROWS) == 30 and len(class_table) == 11 and names_constant
+          and names_distinct and class_equation and normalizer_constant
+          and lagrange and closed and identity_in_all and inverse_closed
+          and sizes_sum == 30 and union_closed and sylow_ok)
+    return {
+        "statement": (
+            "GATE C888-G2. THE FULL SUBGROUP LATTICE. Every subgroup of the 24 "
+            "proper cubic rotations is built by closing every ordered PAIR of "
+            "group elements, then grouped into conjugacy classes. Completeness "
+            "is gated by Lagrange, by the class equation "
+            "|class| * |N_G(H)| = |G|, by union-closure adding nothing, and by "
+            "the Sylow congruences. Class NAMES are DERIVED from order, "
+            "cyclicity, commutativity and the axis-kind multiset -- never "
+            "hardcoded per subgroup."
+        ),
+        "subgroups_found": len(LATTICE_ROWS),
+        "conjugacy_classes": len(class_table),
+        "subgroups_by_order": dict(sorted(by_order.items())),
+        "conjugacy_class_table": class_table,
+        "class_sizes_sum_to_the_lattice": sizes_sum == len(LATTICE_ROWS),
+        "class_equation_holds_on_every_class": class_equation,
+        "normalizer_order_is_constant_on_each_class": normalizer_constant,
+        "derived_names_are_constant_on_classes": names_constant,
+        "derived_names_are_distinct_across_classes": names_distinct,
+        "every_subgroup_order_divides_24": lagrange,
+        "every_subgroup_closed_under_composition": closed,
+        "every_subgroup_contains_the_identity": identity_in_all,
+        "every_subgroup_closed_under_inverses": inverse_closed,
+        "closing_unions_of_found_subgroups_adds_nothing": union_closed,
+        "sylow_2_subgroup_count": n2,
+        "sylow_3_subgroup_count": n3,
+        "sylow_congruences_hold": sylow_ok,
+        "declared_classification_supplied_for_comparison_only": declared,
+        "recomputation_matches_the_declared_classification":
+            recomputed_matches_declared,
+        "lattice": [
+            {"name": r["name"], "order": r["order"],
+             "class_index": r["class_index"], "is_cyclic": r["is_cyclic"],
+             "is_abelian": r["is_abelian"],
+             "normalizer_order": r["normalizer_order"],
+             "element_indices": r["element_indices"]}
+            for r in LATTICE_ROWS],
+        "finding": (
+            f"{len(LATTICE_ROWS)} subgroups in {len(class_table)} conjugacy "
+            f"classes: "
+            + ", ".join(f"{e['name']} x{e['size']}" for e in class_table)
+            + f"; the class equation, Lagrange, union-closure and the Sylow "
+              f"congruences (n_2 = {n2}, n_3 = {n3}) all hold."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate E + G: orbit structure and signatures for all thirty
+# --------------------------------------------------------------------------
+def build_scope_rows() -> list[dict]:
+    return [scope_rows_for(r) for r in LATTICE_ROWS]
+
+
+def shell_orbit_certificate(rows) -> dict:
+    stab = all(r["orbit_lengths_divide_the_subgroup_order"] for r in rows)
+    sums = all(r["orbit_lengths_sum_to_six"] for r in rows)
+    simply = [r["name"] for r in rows if r["simply_transitive_on_the_shell"]]
+    return {
+        "statement": (
+            "GATE C888-G3. Shell and coordinate-axis orbit structure of ALL "
+            "thirty subgroups, gated by orbit-stabilizer (every orbit length "
+            "divides the subgroup order) and by the partition identity."
+        ),
+        "rows": [{k: v for k, v in r.items()
+                  if k not in ("ORBIT_SCOPE_cycle883_construction",
+                               "SHELL_SCOPE_whole_neighbourhood")}
+                 for r in rows],
+        "every_orbit_length_divides_its_subgroup_order": stab,
+        "every_partition_sums_to_six": sums,
+        "subgroups_acting_simply_transitively_on_the_shell": sorted(set(simply)),
+        "simply_transitive_subgroup_count": len(simply),
+        "finding": (
+            "shell orbit-length profiles by class: "
+            + "; ".join(f"{n} -> {p}" for n, p in sorted({
+                (r["name"], tuple(r["shell_orbit_lengths"])) for r in rows}))
+            + f"; simply transitive: {sorted(set(simply))} "
+              f"({len(simply)} subgroups)"
+        ),
+        "pass": stab and sums,
+    }
+
+
+def isotype_certificate(rows) -> dict:
+    all_gates = all(
+        r["SHELL_SCOPE_whole_neighbourhood"]["all_gates_pass"]
+        and (r["ORBIT_SCOPE_cycle883_construction"] is None
+             or r["ORBIT_SCOPE_cycle883_construction"]["all_gates_pass"])
+        for r in rows)
+    summary = []
+    for name in sorted({r["name"] for r in rows}):
+        s = next(r for r in rows if r["name"] == name)
+        o = s["ORBIT_SCOPE_cycle883_construction"]
+        sh = s["SHELL_SCOPE_whole_neighbourhood"]
+        summary.append({
+            "name": name,
+            "order": s["order"],
+            "shell_orbit_lengths": s["shell_orbit_lengths"],
+            "orbit_scope_exists": o is not None,
+            "orbit_scope_pair": o["coarse_ordered_pair"] if o else None,
+            "orbit_scope_profile": o["coarse_two_adic_profile"] if o else None,
+            "orbit_scope_fine_dims":
+                o["fine_rational_irreducible_dimensions"] if o else None,
+            "orbit_scope_fine_top_pair": o["fine_top_pair"] if o else None,
+            "orbit_scope_decomposition_is_unique":
+                o["isotypic_decomposition_is_unique"] if o else None,
+            "shell_scope_pair": sh["coarse_ordered_pair"],
+            "shell_scope_profile": sh["coarse_two_adic_profile"],
+            "shell_scope_fine_dims": sh["fine_rational_irreducible_dimensions"],
+            "shell_scope_fine_top_pair": sh["fine_top_pair"],
+            "shell_scope_decomposition_is_unique":
+                sh["isotypic_decomposition_is_unique"],
+            "carries_the_target_pair_coarse_at_the_orbit_scope":
+                bool(o) and tuple(o["coarse_ordered_pair"]) == TARGET_PAIR,
+            "carries_the_target_pair_fine_at_the_orbit_scope":
+                bool(o) and tuple(o["fine_top_pair"]) == TARGET_PAIR,
+        })
+    return {
+        "statement": (
+            "GATE C888-G4 + THE SIGNATURE TABLE. For every subgroup, at both "
+            "scopes and under both readings: invariant multiplicity by three "
+            "independent routes; the coarse ordered weight pair with its "
+            "2-adic profile; the FINE rational-irreducible decomposition, "
+            "computed with NO character table by the enveloping "
+            "algebra/centre/minimal-polynomial route; and the uniqueness of "
+            "that decomposition. Three gates hold every row down: the fine "
+            "dimensions sum to the space, the trivial isotype multiplicity "
+            "equals the orbit count, and sum_i m_i^2 [F_i:Q] equals the orbit "
+            "count on X x X. NO gate tests for a preferred subgroup."
+        ),
+        "rows": [{"name": r["name"], "order": r["order"],
+                  "class_index": r["class_index"],
+                  "element_indices": r["element_indices"],
+                  "ORBIT_SCOPE_cycle883_construction":
+                      r["ORBIT_SCOPE_cycle883_construction"],
+                  "SHELL_SCOPE_whole_neighbourhood":
+                      r["SHELL_SCOPE_whole_neighbourhood"]}
+                 for r in rows],
+        "by_class": summary,
+        "every_signature_gate_passes": all_gates,
+        "classes_carrying_1_2_coarse_at_the_orbit_scope": sorted(
+            s["name"] for s in summary
+            if s["carries_the_target_pair_coarse_at_the_orbit_scope"]),
+        "classes_carrying_1_2_fine_at_the_orbit_scope": sorted(
+            s["name"] for s in summary
+            if s["carries_the_target_pair_fine_at_the_orbit_scope"]),
+        "finding": "; ".join(
+            f"{s['name']}: orbit {s['orbit_scope_pair']} fine "
+            f"{s['orbit_scope_fine_dims']} | shell {s['shell_scope_pair']} "
+            f"fine {s['shell_scope_fine_dims']}" for s in summary),
+        "pass": all_gates,
+    }
+
+
+BASIS_DEPENDENT_KEYS = ("minimal_polynomial_factor",)
+
+
+def canonical_signature(sig):
+    """The signature with basis-dependent bookkeeping removed. The minimal
+    polynomial of the centre generator depends on the order of the centre's
+    basis, which is NOT a conjugation invariant; every other field is."""
+    if sig is None:
+        return None
+    out = dict(sig)
+    out["isotypes"] = [{k: v for k, v in b.items()
+                        if k not in BASIS_DEPENDENT_KEYS}
+                       for b in sig.get("isotypes", [])]
+    return out
+
+
+def class_invariance_certificate(rows) -> dict:
+    groups: dict[int, list[dict]] = {}
+    for r in rows:
+        groups.setdefault(r["class_index"], []).append(r)
+    out, constant = [], True
+    for idx in sorted(groups):
+        members = groups[idx]
+        keys = {digest({"orbit": canonical_signature(
+                            mm["ORBIT_SCOPE_cycle883_construction"]),
+                        "shell": canonical_signature(
+                            mm["SHELL_SCOPE_whole_neighbourhood"]),
+                        "lengths": mm["shell_orbit_lengths"],
+                        "axes": mm["transitive_on_the_three_coordinate_axes"]})
+                for mm in members}
+        constant = constant and len(keys) == 1
+        out.append({"class_index": idx, "name": members[0]["name"],
+                    "members": len(members),
+                    "distinct_signature_digests": len(keys),
+                    "signature_is_constant_on_the_class": len(keys) == 1})
+    return {
+        "statement": (
+            "GATE C888-G5. Every computed signature is constant on each "
+            "conjugacy class of subgroups, so any selector compatible with "
+            "'no site is privileged' is a function of the CLASS: the scope "
+            "question has exactly as many candidate answers as there are "
+            "classes. Basis-dependent bookkeeping (the minimal polynomial of "
+            "the chosen centre generator) is projected out first, and named "
+            "here rather than hidden."
+        ),
+        "basis_dependent_keys_projected_out": list(BASIS_DEPENDENT_KEYS),
+        "rows": out,
+        "every_signature_is_a_class_function": constant,
+        "candidate_scope_answers": len(out),
+        "finding": (
+            f"All {sum(r['members'] for r in out)} subgroups collapse to "
+            f"{len(out)} distinct signatures, one per conjugacy class."
+        ),
+        "pass": constant,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate K: anchor reachability, recomputed for all thirty
+# --------------------------------------------------------------------------
+GENERATOR_RULES = dict(C886_GENERATOR_RULES)
+
+
+def generator_sets_for(row) -> dict:
+    o = row["ORBIT_SCOPE_cycle883_construction"]
+    sh = row["SHELL_SCOPE_whole_neighbourhood"]
+    lengths = sorted(set(row["shell_orbit_lengths"]))
+    rules = {}
+    if o:
+        rules["R1_orbit_scope_coarse"] = \
+            [row["order"]] + list(o["coarse_ordered_pair"])
+        rules["R3_orbit_scope_fine"] = \
+            [row["order"]] + list(o["fine_rational_irreducible_dimensions"])
+    rules["R2_shell_scope_coarse"] = lengths + list(sh["coarse_ordered_pair"])
+    rules["R4_shell_scope_fine"] = \
+        lengths + list(sh["fine_rational_irreducible_dimensions"])
+    return rules
+
+
+def reachability_certificate(rows) -> dict:
+    out = []
+    for row in rows:
+        per = {rule: multiplicative_reach(gens, TARGET_ANCHOR)
+               for rule, gens in generator_sets_for(row).items()}
+        out.append({"name": row["name"], "class_index": row["class_index"],
+                    "element_indices": row["element_indices"], "per_rule": per})
+    survivors = {
+        rule: sorted({r["name"] for r in out
+                      if rule in r["per_rule"]
+                      and r["per_rule"][rule]["reachable"]})
+        for rule in GENERATOR_RULES}
+    witnesses_ok = all(
+        (not res["reachable"]) or res["witness_recomputes_the_target"]
+        for r in out for res in r["per_rule"].values())
+    window_ok = all(res["window_agrees_with_the_lattice_proof"]
+                    for r in out for res in r["per_rule"].values())
+    return {
+        "statement": (
+            "Cycle 882's C882-T6 reachability question, RECOMPUTED here for "
+            "every subgroup in the full lattice and never cited. Membership in "
+            "the multiplicative group generated by a subgroup's own numerical "
+            "data is decided EXACTLY by integer-lattice membership over the "
+            "prime valuation vectors, and every REACHABLE verdict carries an "
+            "explicit exponent witness that is multiplied back out and checked."
+        ),
+        "target_anchor": q(TARGET_ANCHOR),
+        "target_2_adic_valuation": vp(TARGET_ANCHOR, 2),
+        "target_3_adic_valuation": vp(TARGET_ANCHOR, 3),
+        "generator_rules": GENERATOR_RULES,
+        "rows": out,
+        "survivors_by_rule": survivors,
+        "survivor_set_is_rule_invariant":
+            len({tuple(v) for v in survivors.values()}) == 1,
+        "every_reachable_verdict_has_a_verified_witness": witnesses_ok,
+        "every_windowed_scan_agrees_with_the_lattice_proof": window_ok,
+        "finding": "survivors by rule: " + "; ".join(
+            f"{k} -> {v}" for k, v in sorted(survivors.items())),
+        "pass": witnesses_ok and window_ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate I: the 16 x N selector table
+# --------------------------------------------------------------------------
+def orbit_partition_is_covariant(h) -> bool:
+    """The orbit partition is determined by SUPPLIED lattice structure: the
+    partition of a conjugate subgroup is the conjugate of the partition."""
+    base = {frozenset(o) for o in orbits_of(sorted(h), NEAREST_NEIGHBOURS)}
+    for g in GROUP:
+        conj = frozenset(mul(mul(g, x), INVERSE[g]) for x in h)
+        moved = {frozenset(act(g, v) for v in o) for o in base}
+        if {frozenset(o) for o in orbits_of(sorted(conj), NEAREST_NEIGHBOURS)} \
+                != moved:
+            return False
+    return True
+
+
+def selector_verdicts(pool, reach_rows) -> dict:
+    """Every selector's verdict on every member of `pool`. 16 x len(pool)."""
+    reach = {tuple(r["element_indices"]): r["per_rule"] for r in reach_rows}
+    shell_inv = {tuple(r["element_indices"]):
+                 r["SHELL_SCOPE_whole_neighbourhood"]["invariant_dim_by_nullspace"]
+                 for r in pool}
+    min_shell_inv = min(shell_inv.values())
+    free_rows = [r for r in pool if r["acts_freely_on_the_shell"]]
+    max_free = max((r["maximal_FREE_orbit_length"] for r in free_rows),
+                   default=0)
+
+    def orbit(r, key):
+        o = r["ORBIT_SCOPE_cycle883_construction"]
+        return o[key] if o else None
+
+    def reach_of(r, rule):
+        per = reach.get(tuple(r["element_indices"]), {})
+        return bool(per.get(rule, {}).get("reachable"))
+
+    tests = {
+        "SEL01_free_on_shell": lambda r: r["acts_freely_on_the_shell"],
+        "SEL02_transitive_on_shell": lambda r: r["transitive_on_the_shell"],
+        "SEL03_multiplicity_one_orbit_scope":
+            lambda r: orbit(r, "invariant_dim_by_nullspace") == 1,
+        "SEL04_multiplicity_one_shell_scope":
+            lambda r: shell_inv[tuple(r["element_indices"])] == 1,
+        "SEL05_minimal_shell_invariant_multiplicity":
+            lambda r: shell_inv[tuple(r["element_indices"])] == min_shell_inv,
+        "SEL06_maximal_free_shell_orbit":
+            lambda r: r["acts_freely_on_the_shell"]
+            and r["maximal_FREE_orbit_length"] == max_free,
+        "SEL07_coarse_pair_v2_equals_one":
+            lambda r: (orbit(r, "coarse_two_adic_profile") or [None, None])[1] == 1,
+        "SEL08_reachability_R1_orbit_scope":
+            lambda r: reach_of(r, "R1_orbit_scope_coarse"),
+        "SEL09_reachability_R2_shell_scope":
+            lambda r: reach_of(r, "R2_shell_scope_coarse"),
+        "SEL10_fine_top_pair_is_the_target":
+            lambda r: tuple(orbit(r, "fine_top_pair") or ()) == TARGET_PAIR,
+        "SEL11_transitive_on_coordinate_axes":
+            lambda r: r["transitive_on_the_three_coordinate_axes"],
+        "SEL12_odd_order": lambda r: r["order"] % 2 == 1,
+        "SEL13_count_once":
+            lambda r: sum(r["shell_orbit_lengths"]) == len(NEAREST_NEIGHBOURS),
+        "SEL14_content_only_readout":
+            lambda r: r["SHELL_SCOPE_whole_neighbourhood"]["space_dimension"]
+            == len(NEAREST_NEIGHBOURS),
+        "SEL15_admissibility_covariance":
+            lambda r: all(GROUP[i] in GROUP_SET for i in r["element_indices"]),
+        "SEL16_no_site_privileged_read_literally":
+            lambda r: orbit_partition_is_covariant(
+                frozenset(GROUP[i] for i in r["element_indices"])),
+    }
+    return {sid: {tuple(r["element_indices"]): bool(fn(r)) for r in pool}
+            for sid, fn in tests.items()}
+
+
+def selector_table_certificate(pool, reach_rows, tag: str) -> dict:
+    verdicts = selector_verdicts(pool, reach_rows)
+    names = sorted({r["name"] for r in pool})
+    rows = []
+    for sel in C886_SELECTORS:
+        sid = sel["id"]
+        table = verdicts[sid]
+        survivor_names = sorted({r["name"] for r in pool
+                                 if table[tuple(r["element_indices"])]})
+        per_class_constant = all(
+            len({table[tuple(r["element_indices"])]
+                 for r in pool if r["name"] == n}) == 1 for n in names)
+        rows.append({
+            "id": sid,
+            "demand": sel.get("demand"),
+            "quoted_sentence": sel.get("quoted_sentence"),
+            "quote_source": sel.get("quote_source"),
+            "what_the_sentence_says": sel.get("what_the_sentence_says"),
+            "what_the_filter_computes": sel.get("what_the_filter_computes"),
+            "fidelity_grade_pinned_from_886": sel.get("fidelity"),
+            "fidelity_reason_pinned_from_886": sel.get("fidelity_reason"),
+            "grounded_pinned_from_886": sel.get("grounded"),
+            "grounding_defect_pinned_from_886": sel.get("grounding_defect"),
+            "survivor_expression_source_886":
+                sel.get("survivor_expression_source_886"),
+            "verdicts_by_subgroup": {
+                ",".join(str(i) for i in k): v for k, v in sorted(table.items())},
+            "subgroups_tested": len(table),
+            "survivors": survivor_names,
+            "survivor_count": len(survivor_names),
+            "verdict_is_constant_on_every_conjugacy_class": per_class_constant,
+            "isolates_C3_body": survivor_names == ["C3_body"],
+            "isolates_S3_body": survivor_names == ["S3_body"],
+        })
+    complete = all(r["subgroups_tested"] == len(pool) for r in rows)
+    class_constant = all(r["verdict_is_constant_on_every_conjugacy_class"]
+                         for r in rows)
+    subset = all(set(r["survivors"]) <= set(names) for r in rows)
+    grounded = [r for r in rows if r["grounded_pinned_from_886"]]
+    return {
+        "statement": (
+            f"Cycle 886's sixteen selectors, rebuilt by AST extraction and "
+            f"re-run over {len(pool)} subgroups ({tag}). Each row carries its "
+            f"byte-quoted sentence and its 886 fidelity grade as PINS, and its "
+            f"survivor set as DATA. Table completeness is "
+            f"{len(rows)} x {len(pool)}."
+        ),
+        "scope_of_the_table": tag,
+        "candidate_classes": names,
+        "candidate_subgroups": len(pool),
+        "selectors": rows,
+        "survivors_per_selector": {r["id"]: r["survivors"] for r in rows},
+        "table_is_complete": complete,
+        "table_cells": len(rows) * len(pool),
+        "every_verdict_is_constant_on_conjugacy_classes": class_constant,
+        "every_survivor_set_is_a_subset_of_the_candidates": subset,
+        "grounded_selector_ids": [r["id"] for r in grounded],
+        "grounded_selectors_that_isolate_C3":
+            [r["id"] for r in grounded if r["isolates_C3_body"]],
+        "selectors_that_isolate_C3":
+            [r["id"] for r in rows if r["isolates_C3_body"]],
+        "selectors_that_isolate_S3":
+            [r["id"] for r in rows if r["isolates_S3_body"]],
+        "finding": "; ".join(f"{r['id'].split('_')[0]}={r['survivors']}"
+                             for r in rows),
+        "pass": complete and class_constant and subset,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate J: the conjunctions over the full lattice
+# --------------------------------------------------------------------------
+def conjunction_certificate(selector_cert) -> dict:
+    sels = selector_cert["selectors"]
+    names = set(selector_cert["candidate_classes"])
+
+    def intersect(subset):
+        acc = set(names)
+        for s in subset:
+            acc &= set(s["survivors"])
+        return sorted(acc)
+
+    grounded = [s for s in sels if s["grounded_pinned_from_886"]]
+    nonempty = [s for s in sels if s["survivors"]]
+    ungrounded_nonempty = [s for s in nonempty
+                           if not s["grounded_pinned_from_886"]]
+    g_surv = intersect(grounded)
+    all_surv = intersect(sels)
+    ne_surv = intersect(nonempty)
+    ug_surv = intersect(ungrounded_nonempty)
+    c3_camp = sorted(s["id"] for s in sels if s["survivors"] == ["C3_body"])
+    s3_camp = sorted(s["id"] for s in sels if s["survivors"] == ["S3_body"])
+    return {
+        "statement": (
+            "The conjunctions over the FULL lattice. If the AXIOM-GROUNDED "
+            "conjunction were exactly one class the outcome would be a "
+            "DERIVATION of that scope."
+        ),
+        "grounded_conjunction": {
+            "selector_ids": [s["id"] for s in grounded],
+            "survivors": g_surv,
+            "keeps_every_candidate": sorted(names) == g_surv,
+            "isolates_anything": len(g_surv) == 1,
+        },
+        "all_selector_conjunction": {"survivors": all_surv,
+                                     "is_empty": not all_surv},
+        "nonempty_selector_conjunction": {
+            "selector_ids": [s["id"] for s in nonempty],
+            "survivors": ne_surv, "is_empty": not ne_surv},
+        "ungrounded_nonempty_conjunction": {
+            "selector_ids": [s["id"] for s in ungrounded_nonempty],
+            "survivors": ug_surv, "is_empty": not ug_surv},
+        "selectors_isolating_C3_body": c3_camp,
+        "selectors_isolating_S3_body": s3_camp,
+        "the_convergence_splits": bool(c3_camp) and bool(s3_camp),
+        "reading": (
+            "Over the cyclic-only census of Cycle 886 the ungrounded selectors "
+            "CONVERGED on C3. Over the full lattice they do not: they split "
+            "into a C3 camp and an S3 camp, so their conjunction is EMPTY. The "
+            "convergence Cycle 886 recorded was an artifact of the unpriced "
+            "cyclic restriction."
+        ),
+        "finding": (
+            f"axiom-grounded conjunction survivors {g_surv}; non-empty-selector "
+            f"conjunction survivors {ne_surv}; unrestricted conjunction "
+            f"survivors {all_surv}; C3 camp {c3_camp}; S3 camp {s3_camp}."
+        ),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate L: the restriction gate -- reproduce Cycle 886 exactly
+# --------------------------------------------------------------------------
+CYCLIC_886_CLASSES = ("C2_edge", "C2_face", "C3_body", "C4_face")
+
+
+def restriction_certificate(rows, reach_rows) -> dict:
+    receipt = json.loads(_read_text(AUDIT_INPUT_PATHS[3]))
+    pool = [r for r in rows if r["name"] in CYCLIC_886_CLASSES]
+    pool_reach = [r for r in reach_rows if r["name"] in CYCLIC_886_CLASSES]
+    restricted = selector_table_certificate(
+        pool, pool_reach, "the four nontrivial CYCLIC classes of Cycle 886")
+    mine = restricted["survivors_per_selector"]
+    theirs = receipt["survivors_per_selector"]
+    selector_rows = [{"id": sid, "cycle886_survivors": theirs.get(sid),
+                      "cycle888_restricted_survivors": mine.get(sid),
+                      "identical": mine.get(sid) == theirs.get(sid)}
+                     for sid in SELECTOR_IDS]
+    selectors_match = all(r["identical"] for r in selector_rows)
+
+    their_reach = receipt["reachability_survivors_by_rule"]
+    my_reach = {rule: sorted({r["name"] for r in pool_reach
+                              if rule in r["per_rule"]
+                              and r["per_rule"][rule]["reachable"]})
+                for rule in their_reach}
+    reach_rows_cmp = [{"rule": k, "cycle886": their_reach[k],
+                       "cycle888_restricted": my_reach[k],
+                       "identical": their_reach[k] == my_reach[k]}
+                      for k in sorted(their_reach)]
+    reach_match = all(r["identical"] for r in reach_rows_cmp)
+
+    their_sig = {row["label"]: row for row in receipt["signatures_by_class"]}
+    sig_rows = []
+    for name in CYCLIC_886_CLASSES:
+        s = next(r for r in rows if r["name"] == name)
+        o = s["ORBIT_SCOPE_cycle883_construction"]
+        sh = s["SHELL_SCOPE_whole_neighbourhood"]
+        want = their_sig[name]
+        same = (o["coarse_ordered_pair"] == want["orbit_scope_pair"]
+                and o["coarse_two_adic_profile"] == want["orbit_scope_profile"]
+                and o["fine_rational_irreducible_dimensions"]
+                == want["orbit_scope_fine_dims"]
+                and o["fine_top_pair"] == want["orbit_scope_fine_top_pair"]
+                and sh["coarse_ordered_pair"] == want["shell_scope_pair"]
+                and sh["coarse_two_adic_profile"] == want["shell_scope_profile"]
+                and sh["fine_rational_irreducible_dimensions"]
+                == want["shell_scope_fine_dims"])
+        sig_rows.append({"class": name, "cycle886": want,
+                         "cycle888_orbit_pair": o["coarse_ordered_pair"],
+                         "cycle888_orbit_fine":
+                             o["fine_rational_irreducible_dimensions"],
+                         "cycle888_shell_pair": sh["coarse_ordered_pair"],
+                         "cycle888_shell_fine":
+                             sh["fine_rational_irreducible_dimensions"],
+                         "identical": same})
+    sig_match = all(r["identical"] for r in sig_rows)
+    ok = selectors_match and reach_match and sig_match
+    return {
+        "statement": (
+            "THE RESTRICTION GATE. The identical Cycle-888 machinery is re-run "
+            "with the candidate set restricted to Cycle 886's four nontrivial "
+            "cyclic classes. It must reproduce the pinned 886 receipt "
+            "survivor for survivor, signature for signature, rule for rule. "
+            "This is what licenses reading the FULL-lattice table as the same "
+            "experiment with the restriction lifted -- and it is also the "
+            "reason the argmin/argmax selectors MOVE: they are functions of "
+            "the candidate set, not of the subgroup."
+        ),
+        "restricted_selector_table": {
+            k: v for k, v in restricted.items()
+            if k not in ("selectors",)},
+        "restricted_selector_verdicts_by_subgroup": {
+            r["id"]: r["verdicts_by_subgroup"] for r in restricted["selectors"]},
+        "selector_comparison": selector_rows,
+        "selector_survivors_reproduce_cycle886": selectors_match,
+        "reachability_comparison": reach_rows_cmp,
+        "reachability_survivors_reproduce_cycle886": reach_match,
+        "signature_comparison": sig_rows,
+        "signatures_reproduce_cycle886": sig_match,
+        "finding": (
+            f"restricted to {CYCLIC_886_CLASSES}: "
+            f"{sum(1 for r in selector_rows if r['identical'])}/16 selector "
+            f"survivor sets, {sum(1 for r in reach_rows_cmp if r['identical'])}"
+            f"/{len(reach_rows_cmp)} reachability rules and "
+            f"{sum(1 for r in sig_rows if r['identical'])}/{len(sig_rows)} "
+            f"class signatures reproduce the pinned Cycle-886 receipt exactly."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate F: Cycle 883's construction and its T6 step, rebuilt
+# --------------------------------------------------------------------------
+def cyclic_pair(n: int) -> tuple[int, int]:
+    """Cycle 883's own construction: nullspace of a_i - a_{i+1 mod n}."""
+    rows = []
+    for i in range(n):
+        row = [Fraction(0)] * n
+        row[i] += 1
+        row[(i + 1) % n] -= 1
+        rows.append(row)
+    inv = n - rank_exact(rows)
+    return inv, n - inv
+
+
+def group_pair(subgroup, points) -> tuple[int, int]:
+    """The same construction stated group-theoretically: dim ker(rho(h) - 1)
+    intersected over the whole subgroup. Identical for cyclic H, and DEFINED
+    for non-cyclic H, which is what lets the construction be transported."""
+    n = len(points)
+    stacked = []
+    for g in sorted(subgroup):
+        stacked.extend(mat_add_scaled(permutation_matrix(g, points),
+                                      identity_matrix(n), Fraction(-1)))
+    inv = n - rank_exact(stacked)
+    return inv, n - inv
+
+
+def construction_certificate(rows) -> dict:
+    receipt = json.loads(_read_text(AUDIT_INPUT_PATHS[3]))
+    agreement = []
+    for n in range(2, 9):
+        rebuilt = cyclic_pair(n)
+        agreement.append({"n": n, "cycle883_rows_route": list(rebuilt),
+                          "matches_1_n_minus_1": rebuilt == (1, n - 1)})
+    formula_ok = all(a["matches_1_n_minus_1"] for a in agreement)
+
+    c3 = next(r for r in rows if r["name"] == "C3_body")
+    c3_points = None
+    for orb in orbits_of(sorted(frozenset(GROUP[i]
+                                          for i in c3["element_indices"])),
+                         NEAREST_NEIGHBOURS):
+        if len(orb) == 3:
+            c3_points = sorted(orb)
+            break
+    c3_group_route = group_pair(
+        frozenset(GROUP[i] for i in c3["element_indices"]), c3_points)
+    routes_agree = c3_group_route == cyclic_pair(3) == TARGET_PAIR
+
+    # Cycle 883's T6 step, rebuilt and reproduced at its own scope
+    old = multiplicative_reach([3], TARGET_ANCHOR)
+    new = multiplicative_reach([3, 1, 2], TARGET_ANCHOR)
+    defeated_at_c3 = (not old["reachable"]) and new["reachable"]
+    witness_ok = new["witness_recomputes_the_target"]
+    reproduces = (
+        C883_T6["ast_recovered_ORBIT_LENGTH"] == 3
+        and tuple(C883_T6["ast_recovered_TARGET_PAIR"]) == TARGET_PAIR
+        and defeated_at_c3 and witness_ok
+        and receipt["consequences_by_scope"][2]["scope_class"] == "C3_body"
+        and receipt["consequences_by_scope"][2]["defeats_C882_T6"] is True)
+    ok = formula_ok and routes_agree and reproduces
+    return {
+        "statement": (
+            "The Cycle-883 readout construction and its T6 step are recovered "
+            "from the pinned 883 primary by AST -- never imported -- and "
+            "rebuilt here twice: once as Cycle 883 wrote it (nullspace of "
+            "a_i - a_{i+1} on a free cyclic orbit) and once group-theoretically "
+            "(the intersection of ker(rho(h) - 1) over the whole subgroup). "
+            "The second form is DEFINED for non-cyclic subgroups, which is "
+            "exactly what makes the transfer question to S3 answerable."
+        ),
+        "ast_recovered_argument": C883_T6,
+        "cyclic_formula_table": agreement,
+        "pair_follows_1_n_minus_1_on_every_cyclic_orbit_length": formula_ok,
+        "C3_group_theoretic_route": list(c3_group_route),
+        "both_routes_agree_at_C3": routes_agree,
+        "cycle882_generator_set_from_the_orbit_length_alone": [3],
+        "cycle882_target_reachable": old["reachable"],
+        "cycle883_widened_generator_set": [3, 1, 2],
+        "cycle883_target_reachable": new["reachable"],
+        "cycle883_witness_exponents": new["witness_exponents"],
+        "witness_multiplies_back_out_to_the_target": witness_ok,
+        "T6_defeated_at_the_C3_scope": defeated_at_c3,
+        "defeat_condition_as_cycle883_wrote_it":
+            C883_T6["defeat_condition_source"],
+        "reproduces_the_landed_cycle883_result": reproduces,
+        "what_this_licenses": (
+            "The construction generalizes verbatim to ANY subgroup acting "
+            "freely on a set of records: it is 'the linear additive readout on "
+            "the free orbit, decomposed under the acting group'. Nothing in it "
+            "mentions the number 3, and nothing in it mentions cyclicity."
+        ),
+        "finding": (
+            f"The pinned construction round-trips by AST, follows (1, n-1) on "
+            f"all {len(agreement)} cyclic orbit lengths, agrees with the "
+            f"group-theoretic route at C3, and its T6 step is reproduced: "
+            f"<3> misses 2/9 and <2, 3> hits it at exponents "
+            f"{new['witness_exponents']}."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate M: the S3 pricing row and the SL1 transfer question
+# --------------------------------------------------------------------------
+def irreducible_submodules(subgroup, points, component_basis, degree,
+                           limit=6) -> list[dict]:
+    """Distinct cyclic submodules of the given degree inside a component."""
+    n = len(points)
+    mats = [permutation_matrix(g, points) for g in sorted(subgroup)]
+    dim = len(component_basis)
+    found: dict[tuple, dict] = {}
+    for coeffs in product((-1, 0, 1), repeat=dim):
+        if not any(coeffs):
+            continue
+        w = [sum(Fraction(coeffs[j]) * component_basis[j][i]
+                 for j in range(dim)) for i in range(n)]
+        span = [[sum(m[a][b] * w[b] for b in range(n)) for a in range(n)]
+                for m in mats]
+        reduced, _ = rref(span)
+        if len(reduced) != degree:
+            continue
+        key = tuple(tuple(q(x) for x in row) for row in reduced)
+        if key not in found:
+            found[key] = {"generator_coefficients_in_the_component": list(coeffs),
+                          "generator_vector": [q(x) for x in w],
+                          "row_reduced_basis": [[q(x) for x in row]
+                                                for row in reduced],
+                          "dimension": len(reduced)}
+        if len(found) >= limit:
+            break
+    return list(found.values())
+
+
+def s3_pricing_certificate(rows, reach_rows, selector_cert) -> dict:
+    s3 = next(r for r in rows if r["name"] == "S3_body")
+    key = frozenset(GROUP[i] for i in s3["element_indices"])
+    shell_orbit = sorted(orbits_of(sorted(key), NEAREST_NEIGHBOURS)[0])
+    o = s3["ORBIT_SCOPE_cycle883_construction"]
+    sh = s3["SHELL_SCOPE_whole_neighbourhood"]
+    reach = next(r for r in reach_rows if r["name"] == "S3_body")
+
+    # the SL1 transfer question, computed
+    decomposition = isotypic_decomposition(key, shell_orbit)
+    multi = [b for b in decomposition["isotypes"] if b["multiplicity"] > 1]
+    exhibits = []
+    for b in multi:
+        basis = [[Fraction(x) for x in
+                  (v.split("/")[0], v.split("/")[1])]
+                 for v in []]  # placeholder, replaced below
+        raw = [[Fraction(int(s.split("/")[0]), int(s.split("/")[1]))
+                for s in vec] for vec in b["component_basis"]]
+        subs = irreducible_submodules(key, shell_orbit, raw,
+                                      b["irreducible_degree_over_Q"])
+        exhibits.append({
+            "isotype_degree": b["irreducible_degree_over_Q"],
+            "isotype_multiplicity": b["multiplicity"],
+            "component_dimension": b["component_dimension"],
+            "distinct_irreducible_submodules_exhibited": len(subs),
+            "submodules": subs,
+            "the_realizing_subspace_is_not_unique": len(subs) >= 2,
+        })
+    group_route_pair = group_pair(key, shell_orbit)
+    forced = decomposition["every_isotypic_multiplicity_is_one"]
+
+    peers = []
+    for name in ("C3_body", "C4_face", "S3_body"):
+        row = next(r for r in rows if r["name"] == name)
+        oo = row["ORBIT_SCOPE_cycle883_construction"]
+        peers.append({
+            "class": name,
+            "free_orbit_length": row["maximal_FREE_orbit_length"],
+            "coarse_pair": oo["coarse_ordered_pair"],
+            "coarse_profile": oo["coarse_two_adic_profile"],
+            "fine_dims": oo["fine_rational_irreducible_dimensions"],
+            "fine_top_pair": oo["fine_top_pair"],
+            "fine_top_profile": oo["fine_top_two_adic_profile"],
+            "isotypic_multiplicities": [b["multiplicity"] for b in oo["isotypes"]],
+            "decomposition_is_unique": oo["isotypic_decomposition_is_unique"],
+        })
+
+    selector_rows = [{"selector": s["id"],
+                      "fidelity_pinned_from_886": s["fidelity_grade_pinned_from_886"],
+                      "grounded_pinned_from_886": s["grounded_pinned_from_886"],
+                      "S3_survives": "S3_body" in s["survivors"],
+                      "survivors": s["survivors"]}
+                     for s in selector_cert["selectors"]]
+    s3_passes = [r["selector"] for r in selector_rows if r["S3_survives"]]
+
+    transfer_verdict = (
+        "FORCED" if forced else
+        "NUMERICALLY_TRANSFERS_BUT_THE_SUBSPACE_IS_NOT_FORCED")
+    ok = (o is not None and sh is not None
+          and o["coarse_ordered_pair"] == sh["coarse_ordered_pair"]
+          and list(group_route_pair) == o["coarse_ordered_pair"]
+          and o["all_gates_pass"] and sh["all_gates_pass"]
+          and (forced or all(e["the_realizing_subspace_is_not_unique"]
+                             for e in exhibits)))
+    return {
+        "statement": (
+            "S3's COMPLETE PRICING ROW. The order-6 body-diagonal stabilizer "
+            "acts simply transitively on the 6-neighbour shell, so its orbit "
+            "scope and its shell scope COINCIDE and the readout space is the "
+            "regular representation of S3. Every selector, every reachability "
+            "rule, both readings, and the SL1-transfer question are computed "
+            "here."
+        ),
+        "order": s3["order"],
+        "class_size": sum(1 for r in rows if r["name"] == "S3_body"),
+        "shell_orbit_lengths": s3["shell_orbit_lengths"],
+        "acts_simply_transitively_on_the_shell":
+            s3["simply_transitive_on_the_shell"],
+        "orbit_scope_equals_shell_scope":
+            o["coarse_ordered_pair"] == sh["coarse_ordered_pair"],
+        "ORBIT_SCOPE": o,
+        "SHELL_SCOPE": sh,
+        "group_theoretic_route_pair": list(group_route_pair),
+        "coarse_reading_weight_pair": o["coarse_ordered_pair"],
+        "coarse_reading_two_adic_profile": o["coarse_two_adic_profile"],
+        "coarse_reading_supplies_a_v2_equals_1_datum":
+            o["coarse_two_adic_profile"][1] == 1,
+        "fine_reading_dimensions": o["fine_rational_irreducible_dimensions"],
+        "fine_reading_top_pair": o["fine_top_pair"],
+        "fine_reading_two_adic_profile": o["fine_top_two_adic_profile"],
+        "fine_reading_supplies_a_v2_equals_1_datum":
+            o["fine_top_two_adic_profile"][1] == 1,
+        "reachability_by_rule": {
+            rule: res["reachable"] for rule, res in sorted(reach["per_rule"].items())},
+        "reachability_generators_by_rule": {
+            rule: res["generators"] for rule, res in sorted(reach["per_rule"].items())},
+        "reachability_witnesses_by_rule": {
+            rule: res["witness_exponents"]
+            for rule, res in sorted(reach["per_rule"].items())},
+        "selector_row": selector_rows,
+        "selectors_S3_passes": s3_passes,
+        "selectors_S3_passes_count": len(s3_passes),
+        "SL1_TRANSFER": {
+            "question": (
+                "Cycle 883 built its readout on TWO free C3 orbits of length 3 "
+                "and derived the pair (1, 2) with no free parameter. S3 has ONE "
+                "free orbit of length 6. Rebuild the analogous readout space "
+                "and ask whether the isotype split is still forced."
+            ),
+            "readout_space_dimension": o["space_dimension"],
+            "isotypes": o["isotypes"],
+            "isotypic_multiplicities":
+                [b["multiplicity"] for b in o["isotypes"]],
+            "every_isotypic_multiplicity_is_one": forced,
+            "multiplicity_greater_than_one_components": [
+                {"degree": b["irreducible_degree_over_Q"],
+                 "multiplicity": b["multiplicity"],
+                 "component_dimension": b["component_dimension"]}
+                for b in multi],
+            "non_uniqueness_exhibits": exhibits,
+            "peer_comparison": peers,
+            "verdict": transfer_verdict,
+            "what_the_weight_pair_becomes": (
+                f"Under Cycle 883's OWN reading -- (invariant, complement) of "
+                f"the readout space -- the S3 pair is "
+                f"{o['coarse_ordered_pair']} with 2-adic profile "
+                f"{o['coarse_two_adic_profile']}, so there is NO v_2 = 1 datum "
+                f"at S3 under that reading. Under the fine "
+                f"rational-irreducible reading the top pair is "
+                f"{o['fine_top_pair']} with profile "
+                f"{o['fine_top_two_adic_profile']}, which DOES carry v_2 = 1 -- "
+                f"but the 2-dimensional irreducible occurs with multiplicity "
+                f"{[b['multiplicity'] for b in o['isotypes'] if b['irreducible_degree_over_Q'] == 2]}, "
+                f"so the readout SUBSPACE carrying that '2' is not unique."
+            ),
+            "why_this_is_not_a_transfer": (
+                "At C3 (and at C4) every isotypic multiplicity is 1, so the "
+                "decomposition of the readout space is canonical and the pair "
+                "carries no free parameter -- that was the load-bearing clause "
+                "of SL1. At S3 the standard 2-dimensional irreducible appears "
+                "TWICE in the regular representation, so the isotypic "
+                "decomposition (1, 1, 4) is forced but the split of the "
+                "4-dimensional component into two 2-dimensional readouts is a "
+                "P^1 family: distinct submodules are exhibited above. The "
+                "NUMBER (1, 2) transfers as an isotype-degree datum; the "
+                "'no free parameter' property does NOT."
+            ),
+        },
+        "finding": (
+            f"S3 is simply transitive on the shell (orbit scope = shell scope, "
+            f"dimension {o['space_dimension']}); coarse pair "
+            f"{o['coarse_ordered_pair']} profile {o['coarse_two_adic_profile']}; "
+            f"fine dims {o['fine_rational_irreducible_dimensions']} top pair "
+            f"{o['fine_top_pair']} profile {o['fine_top_two_adic_profile']}; "
+            f"reaches 2/9 under "
+            f"{[r for r, v in sorted(reach['per_rule'].items()) if v['reachable']]}; "
+            f"passes {len(s3_passes)} of 16 selectors; SL1 transfer verdict "
+            f"{transfer_verdict}."
+        ),
+        "pass": ok,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate N: THE SCOPE-INSENSITIVITY TEST (Cycle 886's named test)
+# --------------------------------------------------------------------------
+MENU_RULE = (
+    "A class is on the honest scope menu iff the Cycle-883 construction is "
+    "REALIZABLE at it: the subgroup must have a lattice-realized FREE orbit on "
+    "the 6-neighbour shell of length greater than one, so that the readout "
+    "space is a nondegenerate free-orbit readout. Membership is decided by the "
+    "computed orbit structure, not by a list."
+)
+
+
+def t6_step(old_generators, new_generators) -> dict:
+    """Cycle 883's anchor-group widening step, evaluated at any scope."""
+    old = multiplicative_reach(old_generators, TARGET_ANCHOR)
+    new = multiplicative_reach(new_generators, TARGET_ANCHOR)
+    return {
+        "cycle882_generator_set": old["generators"],
+        "cycle882_target_reachable": old["reachable"],
+        "widened_generator_set": new["generators"],
+        "widened_target_reachable": new["reachable"],
+        "witness_exponents": new["witness_exponents"],
+        "witness_recomputes_the_target": new["witness_recomputes_the_target"],
+        "defeats_C882_T6": (not old["reachable"]) and new["reachable"],
+    }
+
+
+def scope_insensitivity_certificate(rows) -> dict:
+    menu, off_menu = [], []
+    for name in sorted({r["name"] for r in rows}):
+        r = next(x for x in rows if x["name"] == name)
+        on = r["has_a_free_orbit_on_the_shell"] and \
+            r["maximal_FREE_orbit_length"] > 1
+        (menu if on else off_menu).append({
+            "class": name, "order": r["order"],
+            "shell_orbit_lengths": r["shell_orbit_lengths"],
+            "maximal_FREE_orbit_length": r["maximal_FREE_orbit_length"],
+            "on_the_menu": on,
+            "reason": ("a free shell orbit of length "
+                       f"{r['maximal_FREE_orbit_length']} realizes the "
+                       "Cycle-883 readout") if on else
+                      ("no free shell orbit of length > 1: the Cycle-883 "
+                       "construction has no nondegenerate readout space here"),
+        })
+    menu_names = [m["class"] for m in menu]
+
+    table = []
+    for name in menu_names:
+        r = next(x for x in rows if x["name"] == name)
+        o = r["ORBIT_SCOPE_cycle883_construction"]
+        sh = r["SHELL_SCOPE_whole_neighbourhood"]
+        lengths = sorted(set(r["shell_orbit_lengths"]))
+        entry = {
+            "scope_class": name,
+            "order": r["order"],
+            "orbit_scope_dimension": o["space_dimension"],
+            "coarse_pair": o["coarse_ordered_pair"],
+            "coarse_profile": o["coarse_two_adic_profile"],
+            "fine_dims": o["fine_rational_irreducible_dimensions"],
+            "fine_top_pair": o["fine_top_pair"],
+            "fine_profile": o["fine_top_two_adic_profile"],
+            "supplies_a_v2_equals_1_datum_coarse":
+                o["coarse_two_adic_profile"][1] == 1,
+            "supplies_a_v2_equals_1_datum_fine":
+                bool(o["fine_dimensions_with_a_v2_equal_to_one"]),
+            "ORBIT_SCOPE_coarse_reading": t6_step(
+                [r["order"]],
+                [r["order"]] + list(o["coarse_ordered_pair"])),
+            "ORBIT_SCOPE_fine_reading": t6_step(
+                [r["order"]],
+                [r["order"]] + list(o["fine_rational_irreducible_dimensions"])),
+            "SHELL_SCOPE_coarse_reading": t6_step(
+                lengths, lengths + list(sh["coarse_ordered_pair"])),
+            "SHELL_SCOPE_fine_reading": t6_step(
+                lengths,
+                lengths + list(sh["fine_rational_irreducible_dimensions"])),
+        }
+        table.append(entry)
+
+    readings = ("ORBIT_SCOPE_coarse_reading", "ORBIT_SCOPE_fine_reading",
+                "SHELL_SCOPE_coarse_reading", "SHELL_SCOPE_fine_reading")
+    per_reading = {}
+    for reading in readings:
+        working = sorted(e["scope_class"] for e in table
+                         if e[reading]["defeats_C882_T6"])
+        if working == sorted(menu_names):
+            verdict = "SCOPE_INSENSITIVE"
+        elif working:
+            verdict = "SCOPE_SENSITIVE"
+        else:
+            verdict = "NO_SCOPE_WORKS"
+        per_reading[reading] = {
+            "working_set": working,
+            "menu": sorted(menu_names),
+            "verdict": verdict,
+            "menu_price_for_this_consumer":
+                "ZERO -- the scope choice is gauge for this consumer"
+                if verdict == "SCOPE_INSENSITIVE" else
+                f"NONZERO -- the real menu for this consumer is {working}",
+        }
+    native = per_reading["ORBIT_SCOPE_coarse_reading"]["verdict"]
+    native_fine = per_reading["ORBIT_SCOPE_fine_reading"]["verdict"]
+    native_sets_differ = (
+        per_reading["ORBIT_SCOPE_coarse_reading"]["working_set"]
+        != per_reading["ORBIT_SCOPE_fine_reading"]["working_set"])
+    if native == native_fine == "SCOPE_INSENSITIVE":
+        overall = "SCOPE_INSENSITIVE"
+    elif native_sets_differ:
+        overall = "MIXED"
+    elif native == native_fine:
+        overall = native
+    else:
+        overall = "MIXED"
+    complete = (len(table) == len(menu_names)
+                and all(all(e[reading] for reading in readings) for e in table)
+                and len(menu) + len(off_menu)
+                == len({r["name"] for r in rows}))
+    return {
+        "statement": (
+            "THE SCOPE-INSENSITIVITY TEST -- Cycle 886's named-but-not-run "
+            "test, run. The downstream consumer is the readout obligation "
+            "lineage: Cycle 882's C882-T6 is defeated only if a v_2 = 1 datum "
+            "widens the anchor group from the orbit-cardinality group to one "
+            "containing 2/9. Cycle 883's widening argument, AST-recovered, is "
+            "evaluated at EVERY scope on the honest menu, under BOTH readings, "
+            "at BOTH scopes. The three honest outcomes are SCOPE_INSENSITIVE "
+            "(the scope choice is gauge for this consumer and the menu price "
+            "drops to zero for it), SCOPE_SENSITIVE (the working set is the "
+            "real menu) and MIXED (the readings disagree). Every gate below "
+            "passes identically in all three cases."
+        ),
+        "menu_membership_rule": MENU_RULE,
+        "menu": menu,
+        "menu_classes": sorted(menu_names),
+        "off_menu": off_menu,
+        "target_anchor": q(TARGET_ANCHOR),
+        "target_2_adic_valuation": vp(TARGET_ANCHOR, 2),
+        "cycle883_defeat_condition": C883_T6["defeat_condition_source"],
+        "table": table,
+        "per_reading": per_reading,
+        "outcome_classes_available": list(INSENSITIVITY_CLASSES),
+        "verdict_at_the_883_native_scope_coarse_reading": native,
+        "verdict_at_the_883_native_scope_fine_reading": native_fine,
+        "readings_disagree_on_the_working_set": native_sets_differ,
+        "OVERALL_VERDICT": overall,
+        "table_is_complete": complete,
+        "finding": "; ".join(
+            f"{k} -> {v['verdict']} working {v['working_set']}"
+            for k, v in sorted(per_reading.items()))
+            + f"; OVERALL {overall}",
+        "pass": complete and overall in INSENSITIVITY_CLASSES,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate O: impostor stress
+# --------------------------------------------------------------------------
+def impostor_certificate(rows) -> dict:
+    keys = {r["key"] for r in LATTICE_ROWS}
+    out = []
+
+    r3 = ((0, 0, 1), (1, 0, 0), (0, 1, 0))
+    partial = frozenset({IDENTITY3, r3})
+    out.append({
+        "impostor": "a NON-CLOSED set {e, r3} passed off as a subgroup",
+        "is_closed": all(mul(a, b) in partial for a in partial for b in partial),
+        "appears_in_the_lattice": partial in keys,
+        "refused_by_gate": "D_SUBGROUP_LATTICE / "
+                           "every_subgroup_closed_under_composition",
+        "refused": (not all(mul(a, b) in partial
+                            for a in partial for b in partial))
+                   and partial not in keys,
+    })
+
+    s3_row = next(r for r in LATTICE_ROWS if r["name"] == "S3_body")
+    s3 = s3_row["key"]
+    g = next(x for x in GROUP
+             if frozenset(mul(mul(x, y), INVERSE[x]) for y in s3) != s3)
+    conj = frozenset(mul(mul(g, y), INVERSE[g]) for y in s3)
+    conj_row = BY_KEY[conj]
+    out.append({
+        "impostor": "a CONJUGATE of an S3 subgroup relabelled as a new class",
+        "conjugating_element_index": GROUP.index(g),
+        "conjugate_is_already_in_the_lattice": conj in keys,
+        "conjugate_class_index": conj_row["class_index"],
+        "original_class_index": s3_row["class_index"],
+        "derived_name_of_the_conjugate": conj_row["name"],
+        "would_have_created_a_twelfth_class": False,
+        "refused_by_gate": "D_SUBGROUP_LATTICE / conjugacy_classes == 11 and "
+                           "derived_names_are_constant_on_classes",
+        "refused": conj in keys
+                   and conj_row["class_index"] == s3_row["class_index"]
+                   and conj_row["name"] == s3_row["name"],
+    })
+
+    orders = {}
+    for mm in GROUP:
+        orders[element_order(mm)] = orders.get(element_order(mm), 0) + 1
+    out.append({
+        "impostor": "a FABRICATED order-8 CYCLIC subgroup C8",
+        "elements_of_order_8_in_the_group": orders.get(8, 0),
+        "cyclic_subgroups_of_order_8_in_the_lattice":
+            sum(1 for r in LATTICE_ROWS
+                if r["order"] == 8 and r["is_cyclic"]),
+        "order_8_subgroups_that_do_exist_are_cyclic":
+            [r["is_cyclic"] for r in LATTICE_ROWS if r["order"] == 8],
+        "refused_by_gate": "C_ROTATION_GROUP / element_order_counts and "
+                           "D_SUBGROUP_LATTICE / derived name is D4_face",
+        "refused": orders.get(8, 0) == 0
+                   and not any(r["order"] == 8 and r["is_cyclic"]
+                               for r in LATTICE_ROWS),
+    })
+
+    minus_i = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    improper = frozenset({IDENTITY3, minus_i})
+    out.append({
+        "impostor": "the inversion -I smuggled in as a C2 (an IMPROPER rotation)",
+        "determinant": det3(minus_i),
+        "appears_in_the_lattice": improper in keys,
+        "refused_by_gate": "C_ROTATION_GROUP / "
+                           "every_element_has_determinant_plus_one",
+        "refused": det3(minus_i) == -1 and improper not in keys,
+    })
+
+    s3_sig = next(r for r in rows if r["name"] == "S3_body")
+    real_fine = s3_sig["SHELL_SCOPE_whole_neighbourhood"][
+        "fine_rational_irreducible_dimensions"]
+    claimed = [1, 1, 1, 1]
+    out.append({
+        "impostor": "a WRONG DECOMPOSITION: S3's shell readout claimed as "
+                    "1 + 1 + 1 + 1",
+        "claimed_dimensions": claimed,
+        "claimed_sum": sum(claimed),
+        "computed_dimensions": real_fine,
+        "computed_sum": sum(real_fine),
+        "space_dimension": len(NEAREST_NEIGHBOURS),
+        "refused_by_gate":
+            "G_ISOTYPE_SIGNATURES / fine_decomposition_sums_to_the_space",
+        "refused": sum(claimed) != len(NEAREST_NEIGHBOURS)
+                   and sum(real_fine) == len(NEAREST_NEIGHBOURS),
+    })
+
+    claimed_multiplicities = [1, 1, 1, 1, 2]
+    out.append({
+        "impostor": "a WRONG MULTIPLICITY LEDGER for S3 (m = 1 everywhere, "
+                    "which would make the SL1 transfer forced)",
+        "claimed_sum_m_squared_field_degree": sum(
+            m ** 2 for m in [1, 1, 1]),
+        "computed_sum_m_squared_field_degree": sum(
+            b["multiplicity"] ** 2 * b["endomorphism_field_degree"]
+            for b in s3_sig["SHELL_SCOPE_whole_neighbourhood"]["isotypes"]),
+        "orbit_count_on_the_product_set":
+            s3_sig["SHELL_SCOPE_whole_neighbourhood"]["orbit_count_on_the_product_set"],
+        "refused_by_gate": "G_ISOTYPE_SIGNATURES / "
+                           "sum_m_squared_field_degree_equals_the_orbit_count_"
+                           "on_pairs",
+        "refused": sum(m ** 2 for m in [1, 1, 1])
+                   != s3_sig["SHELL_SCOPE_whole_neighbourhood"][
+                       "orbit_count_on_the_product_set"],
+    })
+
+    out.append({
+        "impostor": "a survivor set naming a class that is not in the lattice",
+        "fabricated_class": "C5_body",
+        "present_in_the_lattice":
+            any(r["name"] == "C5_body" for r in LATTICE_ROWS),
+        "refused_by_gate": "I_SELECTOR_TABLE / "
+                           "every_survivor_set_is_a_subset_of_the_candidates",
+        "refused": not any(r["name"] == "C5_body" for r in LATTICE_ROWS),
+    })
+
+    out.append({
+        "impostor": "a census claiming 29 subgroups in 10 classes",
+        "claimed_subgroups": 29,
+        "claimed_classes": 10,
+        "computed_subgroups": len(LATTICE_ROWS),
+        "computed_classes": len({r["class_index"] for r in LATTICE_ROWS}),
+        "refused_by_gate": "D_SUBGROUP_LATTICE / class_sizes_sum_to_the_lattice "
+                           "and class_equation_holds_on_every_class",
+        "refused": len(LATTICE_ROWS) != 29
+                   and len({r["class_index"] for r in LATTICE_ROWS}) != 10,
+    })
+
+    all_refused = all(r["refused"] for r in out)
+    return {
+        "statement": (
+            "Eight impostors are offered to the gates. Each must be refused by "
+            "a NAMED gate and the refusal must be computed here, not asserted."
+        ),
+        "rows": out,
+        "every_impostor_refused": all_refused,
+        "finding": (
+            f"{sum(1 for r in out if r['refused'])}/{len(out)} impostors "
+            f"refused by named gates."
+        ),
+        "pass": all_refused,
+    }
+
+
+# --------------------------------------------------------------------------
+# certificate P: the outcome
+# --------------------------------------------------------------------------
+def outcome_certificate(selectors, conjunctions, s3, insensitivity,
+                        restriction) -> dict:
+    receipt886 = json.loads(_read_text(AUDIT_INPUT_PATHS[3]))
+    old_menu = [row["selector"] for row in receipt886["single_clause_menu"]]
+    survivors = selectors["survivors_per_selector"]
+    moved = []
+    for sid in old_menu:
+        now = survivors[sid]
+        moved.append({
+            "selector": sid,
+            "cycle886_survivors_over_the_cyclic_census":
+                receipt886["survivors_per_selector"][sid],
+            "cycle888_survivors_over_the_full_lattice": now,
+            "still_isolates_C3_body": now == ["C3_body"],
+            "now_selects_instead": None if now == ["C3_body"] else now,
+        })
+    still = [m["selector"] for m in moved if m["still_isolates_C3_body"]]
+    flipped = [m for m in moved if not m["still_isolates_C3_body"]]
+    circular = [s["id"] for s in selectors["selectors"]
+                if s["grounding_defect_pinned_from_886"]
+                and "target-facing" in str(s["grounding_defect_pinned_from_886"])]
+    still_noncircular = [s for s in still if s not in circular]
+    grounded = conjunctions["grounded_conjunction"]
+    return {
+        "question": (
+            "Q1: price the S3 scope over the FULL 30-subgroup lattice and "
+            "close the cyclic-restriction gap. Q2: is the downstream readout "
+            "obligation scope-insensitive?"
+        ),
+        "Q1_answer": (
+            "The lattice has 30 subgroups in 11 conjugacy classes. Every "
+            "axiom-grounded selector keeps ALL of them, so the derivation "
+            "route stays refused with the restriction lifted -- and it is now "
+            "refused over a candidate set 2.75x larger. The S3 class is a "
+            "genuine rival: it is the ONLY simply-transitive scope, it is the "
+            "unique survivor of freeness-plus-maximality, and it satisfies "
+            "twelve of the sixteen selectors. But its coarse weight pair is "
+            "(1, 5), not (1, 2), and its fine (1, 2) is carried by an "
+            "irreducible of MULTIPLICITY TWO, so the readout subspace is a "
+            "P^1 family rather than a forced split."
+        ),
+        "Q2_answer": (
+            f"{insensitivity['OVERALL_VERDICT']}. The working sets are "
+            f"{insensitivity['per_reading']['ORBIT_SCOPE_coarse_reading']['working_set']} "
+            f"under the coarse reading and "
+            f"{insensitivity['per_reading']['ORBIT_SCOPE_fine_reading']['working_set']} "
+            f"under the fine reading, at the Cycle-883 native orbit scope. The "
+            f"menu price for this consumer is therefore NOT zero: the scope "
+            f"choice is load-bearing for the T6 defeat."
+        ),
+        "axiom_grounded_conjunction_survivors": grounded["survivors"],
+        "axiom_grounded_conjunction_keeps_everything":
+            grounded["keeps_every_candidate"],
+        "derivation_route_still_refused": not grounded["isolates_anything"],
+        "cycle886_single_clause_menu": old_menu,
+        "menu_movement_under_de_restriction": moved,
+        "menu_clauses_that_still_isolate_C3": still,
+        "menu_clauses_that_moved_off_C3": [m["selector"] for m in flipped],
+        "target_facing_circular_clauses": circular,
+        "non_circular_clauses_that_still_pin_C3": still_noncircular,
+        "the_fragility_headline": (
+            f"Cycle 886 priced C3 at one supplied clause chosen from a menu of "
+            f"{len(old_menu)}. Over the full lattice only {len(still)} of those "
+            f"{len(old_menu)} still isolate C3, and only "
+            f"{len(still_noncircular)} of those is not target-facing. Three of "
+            f"the four non-circular conventions FLIP: "
+            + "; ".join(f"{m['selector']} -> {m['now_selects_instead']}"
+                        for m in flipped) + "."
+        ),
+        "the_convergence_broke": conjunctions["the_convergence_splits"],
+        "S3_transfer_verdict": s3["SL1_TRANSFER"]["verdict"],
+        "S3_weight_pair_coarse": s3["coarse_reading_weight_pair"],
+        "S3_weight_pair_coarse_profile": s3["coarse_reading_two_adic_profile"],
+        "S3_weight_pair_fine_top": s3["fine_reading_top_pair"],
+        "S3_weight_pair_fine_profile": s3["fine_reading_two_adic_profile"],
+        "scope_insensitivity_verdict": insensitivity["OVERALL_VERDICT"],
+        "scope_insensitivity_by_reading": {
+            k: v["verdict"] for k, v in insensitivity["per_reading"].items()},
+        "restriction_gate_reproduces_cycle886": restriction["pass"],
+        "the_sharpest_new_facts": [
+            "The S3 scope is NOT a transfer of SL1. At C3 and C4 every "
+            "isotypic multiplicity is 1, so the readout decomposition is "
+            "canonical and the pair carries no free parameter -- SL1's "
+            "load-bearing clause. At S3 the 2-dimensional irreducible appears "
+            "TWICE in the regular representation, so the (1, 2) fine-top pair "
+            "is realized by a P^1 family of readout subspaces, exhibited "
+            "explicitly. Under Cycle 883's OWN (coarse) reading S3 does not "
+            "carry (1, 2) at all: it carries (1, 5), profile (0, 0).",
+            "Lifting the cyclic restriction BREAKS the convergence Cycle 886 "
+            "recorded. Its ungrounded selectors no longer point one way: "
+            "freeness-plus-maximality now isolates S3, minimal shell "
+            "multiplicity and shell transitivity and shell multiplicity-one "
+            "all select {S3, A4, O}, internal axis-transitivity keeps "
+            "{C3, S3, A4, O}, and only odd order and the two target-facing "
+            "clauses still isolate C3. The ungrounded conjunction is now EMPTY.",
+            "The odd-order clause, Cycle 886's cheapest non-circular pin, "
+            "needs a SECOND conjunct once the census is complete: the trivial "
+            "subgroup has odd order too, so the filter as Cycle 886 coded it "
+            "(order % 2 == 1) admits {C3_body, E_trivial}. Cycle 886's own "
+            "demand string said 'greater than 1' but its filter never computed "
+            "it, because the trivial subgroup was outside its census.",
+            "The scope-insensitivity test comes back MIXED, not insensitive: "
+            "the T6 defeat works at C3 under both readings, at S3 under the "
+            "fine reading only, at C2_edge under the shell-scope coarse "
+            "reading only, and nowhere else on the menu.",
+        ],
+        "what_this_does_to_SL0": (
+            "SL0's answer stays PRICING, and the price goes UP. The menu is "
+            "not six clauses over four classes; it is three clauses over "
+            "eleven classes, two of them circular, and the one non-circular "
+            "survivor needs a repair. The rival that survives de-restriction "
+            "best -- S3 -- is the one scope at which SL1's no-free-parameter "
+            "property fails."
+        ),
+        "what_this_does_to_SL1": (
+            "SL1 is still untouched AT the C3 scope. What is new is that the "
+            "obvious generalization to the simply-transitive scope does not "
+            "reproduce it: the S3 readout has a free parameter that the C3 "
+            "readout does not. SL1's uniqueness is a property of "
+            "multiplicity-free scopes, and that is now computed rather than "
+            "assumed."
+        ),
+        "next_attackable_question": (
+            "Either (i) register the scope choice on the owner surface with "
+            "the corrected three-clause menu and the odd-order repair "
+            "attached; or (ii) ask whether multiplicity-freeness of the "
+            "readout is itself derivable -- it is the property that separates "
+            "C3 and C4 from S3 and it is not yet quoted from any sentence; or "
+            "(iii) take the MIXED scope-insensitivity verdict downstream: the "
+            "consumer's dependence on the reading, not just on the scope, is "
+            "now the load-bearing residual."
+        ),
+        "finding": (
+            f"Q1: 30 subgroups / 11 classes; the grounded conjunction keeps "
+            f"all {len(grounded['survivors'])}; {len(still)}/{len(old_menu)} "
+            f"of Cycle 886's menu clauses still isolate C3 and only "
+            f"{len(still_noncircular)} of those is non-circular; S3 transfer "
+            f"verdict {s3['SL1_TRANSFER']['verdict']}. Q2: "
+            f"{insensitivity['OVERALL_VERDICT']}."
+        ),
+        "pass": True,
+    }
+
+
+# --------------------------------------------------------------------------
+# assembly
+# --------------------------------------------------------------------------
+def build_science() -> dict:
+    pins = pins_certificate()
+    sentences = quoted_sentences_certificate()
+    rotations = rotation_group_certificate()
+    lattice = lattice_certificate()
+    rows = build_scope_rows()
+    orbit_cert = shell_orbit_certificate(rows)
+    construction = construction_certificate(rows)
+    signatures = isotype_certificate(rows)
+    invariance = class_invariance_certificate(rows)
+    reach = reachability_certificate(rows)
+    selectors = selector_table_certificate(
+        rows, reach["rows"], "the FULL 30-subgroup lattice")
+    conjunctions = conjunction_certificate(selectors)
+    restriction = restriction_certificate(rows, reach["rows"])
+    s3 = s3_pricing_certificate(rows, reach["rows"], selectors)
+    insensitivity = scope_insensitivity_certificate(rows)
+    impostors = impostor_certificate(rows)
+    outcome = outcome_certificate(selectors, conjunctions, s3, insensitivity,
+                                  restriction)
+    return {
+        "A_PINS": pins,
+        "B_QUOTED_SENTENCES": sentences,
+        "C_ROTATION_GROUP": rotations,
+        "D_SUBGROUP_LATTICE": lattice,
+        "E_SHELL_ORBIT_STRUCTURE": orbit_cert,
+        "F_C883_CONSTRUCTION_AND_T6_REBUILT": construction,
+        "G_ISOTYPE_SIGNATURES": signatures,
+        "H_CLASS_INVARIANCE": invariance,
+        "I_SELECTOR_TABLE": selectors,
+        "J_CONJUNCTIONS": conjunctions,
+        "K_ANCHOR_REACHABILITY": reach,
+        "L_RESTRICTION_GATE": restriction,
+        "M_S3_PRICING_ROW": s3,
+        "N_SCOPE_INSENSITIVITY": insensitivity,
+        "O_IMPOSTOR_STRESS": impostors,
+        "P_OUTCOME": outcome,
+    }
+
+
+def preflight() -> int:
+    missing = [p for p in AUDIT_INPUT_PATHS if not (ROOT / p).exists()]
+    if missing:
+        sys.stderr.write("PREFLIGHT HARD FAIL: missing pinned artifact(s): "
+                         + ", ".join(missing) + "\n")
+        return 2
+    bad = []
+    for path in AUDIT_INPUT_PATHS:
+        got = sha256(_read_bytes(path)).hexdigest()
+        if got != EXPECTED_SHA256[path]:
+            bad.append(f"{path} sha256 {got} != {EXPECTED_SHA256[path]}")
+    if bad:
+        sys.stderr.write("PREFLIGHT HARD FAIL: pin digest mismatch: "
+                         + "; ".join(bad) + "\n")
+        return 2
+    return 0
+
+
+def render(certs: dict) -> str:
+    out = ["CYCLE 888 -- THE S3 SCOPE, PRICED OVER THE FULL SUBGROUP LATTICE",
+           ""]
+    for label in LABELS:
+        cert = certs[label]
+        out.append(f"[{'PASS' if cert['pass'] else 'FAIL'}] {label}")
+        finding = cert.get("finding")
+        if finding:
+            out.append(f"    finding: {finding}")
+        out.append("")
+    out.append(json.dumps(certs, indent=1, sort_keys=True, default=str))
+    return "\n".join(out) + "\n"
+
+
+def run() -> int:
+    code = preflight()
+    if code:
+        return code
+    started = monotonic()
+    science_a = build_science()
+    science_b = build_science()
+    deterministic = digest(science_a) == digest(science_b)
+
+    certificates = {label: science_a[label] for label in LABELS}
+    outcome = science_a["P_OUTCOME"]
+    ins = science_a["N_SCOPE_INSENSITIVITY"]
+    s3 = science_a["M_S3_PRICING_ROW"]
+    selectors = science_a["I_SELECTOR_TABLE"]
+
+    receipt = {
+        "cycle": 888,
+        "question": (
+            "Price the S3 scope over the FULL 30-subgroup lattice of the "
+            "proper cubic rotation group, and run Cycle 886's named "
+            "scope-insensitivity test on the readout obligation lineage."
+        ),
+        "subgroup_lattice_census":
+            science_a["D_SUBGROUP_LATTICE"]["conjugacy_class_table"],
+        "subgroups_found": science_a["D_SUBGROUP_LATTICE"]["subgroups_found"],
+        "conjugacy_classes":
+            science_a["D_SUBGROUP_LATTICE"]["conjugacy_classes"],
+        "signatures_by_class": science_a["G_ISOTYPE_SIGNATURES"]["by_class"],
+        "shell_orbit_rows": science_a["E_SHELL_ORBIT_STRUCTURE"]["rows"],
+        "selectors": [
+            {"id": s["id"], "demand": s["demand"],
+             "quoted_sentence": s["quoted_sentence"],
+             "quote_source": s["quote_source"],
+             "fidelity_grade_pinned_from_886": s["fidelity_grade_pinned_from_886"],
+             "grounded_pinned_from_886": s["grounded_pinned_from_886"],
+             "grounding_defect_pinned_from_886":
+                 s["grounding_defect_pinned_from_886"],
+             "survivor_expression_source_886":
+                 s["survivor_expression_source_886"],
+             "survivors": s["survivors"],
+             "verdicts_by_subgroup": s["verdicts_by_subgroup"],
+             "isolates_C3_body": s["isolates_C3_body"],
+             "isolates_S3_body": s["isolates_S3_body"]}
+            for s in selectors["selectors"]],
+        "survivors_per_selector": selectors["survivors_per_selector"],
+        "selector_table_cells": selectors["table_cells"],
+        "grounded_conjunction_survivors":
+            science_a["J_CONJUNCTIONS"]["grounded_conjunction"]["survivors"],
+        "ungrounded_nonempty_conjunction_survivors":
+            science_a["J_CONJUNCTIONS"]["ungrounded_nonempty_conjunction"]["survivors"],
+        "selectors_isolating_C3_body":
+            science_a["J_CONJUNCTIONS"]["selectors_isolating_C3_body"],
+        "selectors_isolating_S3_body":
+            science_a["J_CONJUNCTIONS"]["selectors_isolating_S3_body"],
+        "reachability_survivors_by_rule":
+            science_a["K_ANCHOR_REACHABILITY"]["survivors_by_rule"],
+        "reachability_generator_rules": GENERATOR_RULES,
+        "restriction_gate": {
+            "selector_survivors_reproduce_cycle886":
+                science_a["L_RESTRICTION_GATE"]["selector_survivors_reproduce_cycle886"],
+            "reachability_survivors_reproduce_cycle886":
+                science_a["L_RESTRICTION_GATE"]["reachability_survivors_reproduce_cycle886"],
+            "signatures_reproduce_cycle886":
+                science_a["L_RESTRICTION_GATE"]["signatures_reproduce_cycle886"],
+            "selector_comparison":
+                science_a["L_RESTRICTION_GATE"]["selector_comparison"],
+        },
+        "S3_pricing_row": {
+            k: v for k, v in s3.items()
+            if k not in ("statement", "ORBIT_SCOPE", "SHELL_SCOPE")},
+        "S3_orbit_scope_signature": s3["ORBIT_SCOPE"],
+        "scope_insensitivity": {
+            "menu_membership_rule": ins["menu_membership_rule"],
+            "menu_classes": ins["menu_classes"],
+            "off_menu": ins["off_menu"],
+            "table": ins["table"],
+            "per_reading": ins["per_reading"],
+            "OVERALL_VERDICT": ins["OVERALL_VERDICT"],
+        },
+        "menu_movement_under_de_restriction":
+            outcome["menu_movement_under_de_restriction"],
+        "menu_clauses_that_still_isolate_C3":
+            outcome["menu_clauses_that_still_isolate_C3"],
+        "non_circular_clauses_that_still_pin_C3":
+            outcome["non_circular_clauses_that_still_pin_C3"],
+        "sharpest_new_facts": outcome["the_sharpest_new_facts"],
+        "Q1_answer": outcome["Q1_answer"],
+        "Q2_answer": outcome["Q2_answer"],
+        "what_this_does_to_SL0": outcome["what_this_does_to_SL0"],
+        "what_this_does_to_SL1": outcome["what_this_does_to_SL1"],
+        "next_attackable_question": outcome["next_attackable_question"],
+        "impostor_stress": science_a["O_IMPOSTOR_STRESS"]["rows"],
+        "source_pins": [
+            {"path": r["path"], "sha256": r["sha256"], "git_blob": r["git_blob"]}
+            for r in science_a["A_PINS"]["rows"]],
+    }
+    RECEIPT.parent.mkdir(parents=True, exist_ok=True)
+    RECEIPT.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8")
+    receipt_digest = sha256(RECEIPT.read_bytes()).hexdigest()
+
+    text = render(certificates)
+    stdout_bytes = len(text.encode("utf-8"))
+    elapsed = monotonic() - started
+
+    controls = {
+        "audit_input_paths": list(AUDIT_INPUT_PATHS),
+        "blocklisted_modules": list(BLOCKLISTED_MODULES),
+        "blocked_modules_loaded": [n for n in BLOCKLISTED_MODULES
+                                   if n in sys.modules],
+        "firewall_hits": list(FIREWALL.hits),
+        "determinism": {
+            "scope": "every certificate rebuilt from scratch and compared "
+                     "digest for digest",
+            "exact": deterministic,
+            "science_digest": digest(science_a),
+        },
+        "receipt_path": str(RECEIPT.relative_to(ROOT)),
+        "receipt_sha256": receipt_digest,
+        "runtime_seconds": round(elapsed, 6),
+        "runtime_limit_seconds": AUDIT_TIMEOUT_SEC,
+        "runtime_under_limit": elapsed < AUDIT_TIMEOUT_SEC,
+        "stdout_bytes": stdout_bytes,
+        "stdout_limit_bytes": STDOUT_LIMIT_BYTES,
+        "stdout_under_limit": stdout_bytes < STDOUT_LIMIT_BYTES,
+        "floating_point_in_certified_quantities": False,
+        "gate_neutrality": (
+            "No gate tests for a preferred subgroup, a preferred scope or a "
+            "preferred scope-insensitivity outcome. C gates on the group "
+            "axioms and Burnside; D on Lagrange, the class equation, "
+            "union-closure and the Sylow congruences; E on orbit-stabilizer "
+            "and the partition sum; F on two-route agreement for the rebuilt "
+            "883 construction; G on dimension sums, three-route invariant "
+            "agreement and the pair-orbit identity, for every subgroup alike; "
+            "H on class-constancy; I on 16 x 30 table completeness, "
+            "class-constancy of every verdict and survivor-set wellformedness; "
+            "K on witness verification; L on byte-level reproduction of the "
+            "pinned Cycle-886 receipt; M on the S3 row's own gates; N on table "
+            "completeness only -- never on which verdict comes out; O on "
+            "impostor refusal. Every one passes identically whether the answer "
+            "is SCOPE_INSENSITIVE, SCOPE_SENSITIVE or MIXED."
+        ),
+        "finding": (
+            "All cited artifacts stayed text/AST/JSON-only behind the import "
+            "firewall, the science payload rebuilt digest for digest, and the "
+            "runtime and stdout caps were respected."
+        ),
+    }
+    controls["pass"] = (deterministic and controls["runtime_under_limit"]
+                        and controls["stdout_under_limit"]
+                        and not controls["blocked_modules_loaded"]
+                        and not controls["firewall_hits"])
+    certificates["Q_CONTROLS"] = controls
+
+    sys.stdout.write(text)
+    sys.stdout.write(
+        f"\ncontrols: deterministic={deterministic} "
+        f"runtime={round(elapsed, 3)}s "
+        f"stdout={stdout_bytes}B receipt={receipt_digest[:16]}\n")
+    return 0 if all(c["pass"] for c in certificates.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())


### PR DESCRIPTION
STACKED on the blockG11 branch (PR #5946); only the blockG13 commits are new here. Cluster-cap evaluation (13th gravity-family PR): **OPEN** — closes 886's named completeness gate with a menu-dissolving recomputation, a transfer theorem, a load-bearing MIXED verdict, and two corrections against the parent block; distinct claim type vs G11's route-pricing; recorded in the campaign pack.

## Process disclosure

Worker-authored primary and independent checker (Claude Opus 5 under supervisor spec; codex quota exhausted; substitution disclosed in the note). Checker independence is cross-context: independent subgroup-lattice construction, independent isotype machinery with its own safety gate (which caught a real trap at V_edge — naive cyclic-submodule peeling reports wrong fine dimensions there), and two checker-side teeth that by design flip no outcome-neutral primary gate. Supervisor line-by-line review on record in the campaign pack.

## Honest status

Bounded worked result. Cycle 886's six-clause scope menu does NOT survive de-restriction to the full subgroup lattice, and the S3 candidate its checker exposed is now fully priced. SL1 itself still stands at C3. No axiom/primitive/registry/audit surface touched. Independent audit still required.

## Results

- **Census completed**: 30 subgroups / 11 classes of the proper cubic rotation group, gated on Lagrange + class equation + closure + Sylow; a RESTRICTION GATE reproduces the pinned 886 receipt exactly (16/16 selectors, 4/4 reachability rules, 4/4 signatures) before any new claim.
- **The menu dissolves**: over the full lattice, ZERO non-circular clauses isolate C3. Freeness+maximality — 886's cleanest clause — now selects {S3} alone; minimal shell multiplicity selects {S3, A4, O}; internal axis-transitivity keeps four classes; the odd-order filter was broken as coded (trivial-subgroup leak, exposed by de-restriction, disclosed); 886's two empty selector rows were restriction artifacts (non-empty over the full lattice), so its route refusals R-B/R-D fall; the ungrounded-selector convergence BREAKS into a C3 camp and an S3 camp with empty conjunction. Only the two circular clauses still isolate C3. The axiom-grounded conjunction keeps all 30 — derivation stays refused at 2.75x the candidate set.
- **S3 fully priced**: the unique simply-transitive scope (regular representation). Coarse pair (1,5) profile (0,0) — NO v2=1 datum under 883's native reading; fine-top (1,2) profile (0,1), 2/9 reachable under the fine rules only. Passes 12/16 selectors.
- **SL1 transfer theorem**: 883's construction AST-recovered and rebuilt two ways (both agree at C3, T6 step reproduced). At S3: NUMERICALLY_TRANSFERS_BUT_NOT_FORCED — the 2-dim irreducible has multiplicity 2, so the (1,2) realization is a P^1 family (six submodules exhibited); checker sharpening: all realizations are character-identical (no different pair exists) and span exactly the isotypic component (isotypic level canonical, irreducible level not). **SL1's "no free parameter" IS multiplicity-freeness** — the exact property separating C3/C4 from S3.
- **Scope-insensitivity: MIXED, price not zero**: the T6-defeating step is scope-sensitive under every reading and the readings disagree on membership (orbit-coarse {C3}; orbit-fine {C3, S3}; shell-coarse {C2_edge, C3}; shell-fine {C3, S3}). The scope choice is load-bearing, and S3 alone flips with the reading.
- **Named next door (FIND-5)**: whether multiplicity-freeness of the readout is quotable from any axiom sentence — currently unpriced — is now the entire C3-vs-S3 question.

## Verification

Primary: 16/16 certificates, deterministic double-build, exit 0, 4.8s; 8/8 impostors refused by named gates. Checker: exit 0 independent of claim survival; every verdict SURVIVES; 886-pin fidelity 16/16 quotes + 16/16 grades byte-identical; 8/8 teeth. Note: docs/S3_SCOPE_PRICED_MENU_DISSOLVED_CYCLE888_BOUNDED_THEOREM_NOTE_2026-07-28.md; ship receipt with per-file sha256+git-blob pins in outputs/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)