### PR TITLE
AXIOM (owner-approved): Admissibility determines the local probability distribution from nearest neighbors

### DIFF
--- a/docs/MINIMAL_AXIOMS_2026-06-29.md
+++ b/docs/MINIMAL_AXIOMS_2026-06-29.md
@@ -57,8 +57,18 @@ algebraic structure alone.
 There is one fixed nearest-neighbor admissibility rule, covariant under lattice
 translations and proper cubic rotations.
 
-For each site, the available possibilities are determined by, and vary with,
-the nearest-neighbor conditions.
+For each site, the likelihood of each possibility is determined by, and varies
+with, the nearest-neighbor conditions.
+
+*Reading notes (interpretive, non-governing).* (1) The likelihood is
+law-level: the general substrate is the weighted-branching realization, with
+deterministic substrates as boundary realizations -- the law supplies the
+odds; the realized state supplies the pick. (2) Read with Record, a
+possibility's likelihood concerns its being locked; the conditional and joint
+readings coincide whenever formation rate is itself
+nearest-neighbor-determined. (3) Zero likelihood is unavailability:
+"available"/"admissible" denotes the likelihood's support. For any future
+rule assigning continuous spread, likelihood reads as density.
 
 ### Record / Fixed Reality
 
@@ -102,11 +112,11 @@ scientific dependency must be retained-derived or remain conditional/open.
 
 ## Relation To Dynamics And Kinetic Branch Selection
 
-Admissibility is not a dynamics axiom. It determines availability by a
-nearest-neighbor rule: for each site, the available possibilities are
-determined by, and vary with, the nearest-neighbor conditions. It does not
-choose a Hamiltonian or transfer operator, supply transition probabilities or
-weights, select a scalar or nonzero kinetic branch, assert a Dirac-square
+Admissibility is not a dynamics axiom. It determines local likelihood by a
+nearest-neighbor rule: for each site, the likelihood of each possibility is
+determined by, and varies with, the nearest-neighbor conditions. It does not
+choose a Hamiltonian or transfer operator, supply transition-probability or
+weight values, select a scalar or nonzero kinetic branch, assert a Dirac-square
 carrier, define a time metric, or provide a record-production process or
 physical persistence dynamics.
 
@@ -144,7 +154,7 @@ readout structure:
 - Qubit names the domain of local possibilities and its full one-site algebraic
   presentation.
 - Admissibility names the nearest-neighbor rule by which, for each site, the
-  available possibilities are determined by, and vary with, the
+  likelihood of each possibility is determined by, and varies with, the
   nearest-neighbor conditions.
 - Record names the fixed locking of one admissible local possibility,
   one-record-per-site uniqueness, permanence, and finite scalar readout
@@ -161,10 +171,10 @@ gates. In particular, the following remain outside axiom content:
 - the staggered-Dirac/finite-Grassmann realization and `AC_phi_lambda`;
 - the strong-CP theta gauge and mass-side derivation obligations;
 - P2/modulus/phase-blindness and any log-det readout theorem;
-- context selection, measurement basis selection, Born weights, probability
-  rules, update laws, decoherence mechanisms, and formation rules (which
-  admissible possibility a new record locks, at which site, with what weight,
-  or at what rate);
+- context selection, measurement basis selection, Born weight values,
+  probability rules beyond the likelihood clause, update laws, decoherence
+  mechanisms, and the remaining formation rules (the likelihood function's
+  form and values, at which site, and at what rate);
 - arrow, record-production dynamics, physical persistence dynamics, time metric,
   and local observability of records;
 - source/action and physical-observable identification;
@@ -185,9 +195,20 @@ formation rule (which admissible possibility, at which site, with what weight,
 at what rate) remained downstream supplier content. The file path was kept
 unchanged so existing runner needles and links continue to resolve.
 
+The 2026-08-05 owner-approved revision replaced Admissibility's availability
+sentence with the likelihood sentence: for each site, the likelihood of each
+possibility is determined by, and varies with, the nearest-neighbor
+conditions. The determination of likelihood became named axiom content;
+availability became the likelihood's support (zero likelihood is
+unavailability); the likelihood function's form and values, the site
+question, and the rate question remain downstream supplier content. The file
+path was again kept unchanged so existing runner needles and links continue
+to resolve.
+
 This memo exposes the remaining minimal ontology needed by the blocked audit
 lanes: records are not arbitrary mosaics. The admissibility rule determines the
-available possibilities at each site from the nearest-neighbor conditions, and
-those available possibilities vary with those conditions, before a record can
-lock one available local possibility. Probability, dynamics, readout contexts,
-and physical observable bridges remain downstream.
+likelihood of each possibility at each site from the nearest-neighbor
+conditions, and those likelihoods vary with those conditions, before a record
+can lock one available local possibility. The likelihood function's form and
+values, dynamics, readout contexts, and physical observable bridges remain
+downstream.

--- a/docs/MINIMAL_AXIOMS_2026-06-29.md
+++ b/docs/MINIMAL_AXIOMS_2026-06-29.md
@@ -57,18 +57,19 @@ algebraic structure alone.
 There is one fixed nearest-neighbor admissibility rule, covariant under lattice
 translations and proper cubic rotations.
 
-For each site, the likelihood of each possibility is determined by, and varies
-with, the nearest-neighbor conditions.
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
 
-*Reading notes (interpretive, non-governing).* (1) The likelihood is
+*Reading notes (interpretive, non-governing).* (1) The distribution is
 law-level: the general substrate is the weighted-branching realization, with
 deterministic substrates as boundary realizations -- the law supplies the
-odds; the realized state supplies the pick. (2) Read with Record, a
-possibility's likelihood concerns its being locked; the conditional and joint
-readings coincide whenever formation rate is itself
-nearest-neighbor-determined. (3) Zero likelihood is unavailability:
-"available"/"admissible" denotes the likelihood's support. For any future
-rule assigning continuous spread, likelihood reads as density.
+odds; the realized state supplies the pick. (2) Read with Record, the
+distribution concerns which possibility a forming record locks; the
+conditional and joint readings coincide whenever formation rate is itself
+nearest-neighbor-determined. (3) The distribution is a probability measure on
+the local possibility domain; "available"/"admissible" denotes its support --
+on finite menus, exactly the possibilities of nonzero probability
+(probability zero is unavailable); Record locks a supported realization.
 
 ### Record / Fixed Reality
 
@@ -112,9 +113,10 @@ scientific dependency must be retained-derived or remain conditional/open.
 
 ## Relation To Dynamics And Kinetic Branch Selection
 
-Admissibility is not a dynamics axiom. It determines local likelihood by a
-nearest-neighbor rule: for each site, the likelihood of each possibility is
-determined by, and varies with, the nearest-neighbor conditions. It does not
+Admissibility is not a dynamics axiom. It determines the local probability
+distribution by a nearest-neighbor rule: for each site, the probability
+distribution over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions. It does not
 choose a Hamiltonian or transfer operator, supply transition-probability or
 weight values, select a scalar or nonzero kinetic branch, assert a Dirac-square
 carrier, define a time metric, or provide a record-production process or
@@ -154,8 +156,8 @@ readout structure:
 - Qubit names the domain of local possibilities and its full one-site algebraic
   presentation.
 - Admissibility names the nearest-neighbor rule by which, for each site, the
-  likelihood of each possibility is determined by, and varies with, the
-  nearest-neighbor conditions.
+  probability distribution over the possibilities is determined by, and
+  varies with, the nearest-neighbor conditions.
 - Record names the fixed locking of one admissible local possibility,
   one-record-per-site uniqueness, permanence, and finite scalar readout
   additivity over disjoint record collections.
@@ -172,9 +174,9 @@ gates. In particular, the following remain outside axiom content:
 - the strong-CP theta gauge and mass-side derivation obligations;
 - P2/modulus/phase-blindness and any log-det readout theorem;
 - context selection, measurement basis selection, Born weight values,
-  probability rules beyond the likelihood clause, update laws, decoherence
-  mechanisms, and the remaining formation rules (the likelihood function's
-  form and values, at which site, and at what rate);
+  probability rules beyond the distribution clause, update laws, decoherence
+  mechanisms, and the remaining formation rules (the distribution's form and
+  values, at which site, and at what rate);
 - arrow, record-production dynamics, physical persistence dynamics, time metric,
   and local observability of records;
 - source/action and physical-observable identification;
@@ -196,19 +198,22 @@ at what rate) remained downstream supplier content. The file path was kept
 unchanged so existing runner needles and links continue to resolve.
 
 The 2026-08-05 owner-approved revision replaced Admissibility's availability
-sentence with the likelihood sentence: for each site, the likelihood of each
-possibility is determined by, and varies with, the nearest-neighbor
-conditions. The determination of likelihood became named axiom content;
-availability became the likelihood's support (zero likelihood is
-unavailability); the likelihood function's form and values, the site
-question, and the rate question remain downstream supplier content. The file
+sentence with the distribution sentence: for each site, the probability
+distribution over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions. The determination of the distribution became
+named axiom content; availability became the distribution's support (on
+finite menus, probability zero is unavailable); the distribution's form and
+values, the site question, and the rate question remain downstream supplier
+content. The measure/support formulation was adopted on independent review
+(per-point likelihood under-specifies an atomless law on the continuous
+one-site domain). The file
 path was again kept unchanged so existing runner needles and links continue
 to resolve.
 
 This memo exposes the remaining minimal ontology needed by the blocked audit
 lanes: records are not arbitrary mosaics. The admissibility rule determines the
-likelihood of each possibility at each site from the nearest-neighbor
-conditions, and those likelihoods vary with those conditions, before a record
-can lock one available local possibility. The likelihood function's form and
-values, dynamics, readout contexts, and physical observable bridges remain
-downstream.
+probability distribution over the possibilities at each site from the
+nearest-neighbor conditions, and that distribution varies with those
+conditions, before a record can lock one available local possibility. The
+distribution's form and values, dynamics, readout contexts, and physical
+observable bridges remain downstream.

--- a/docs/audit/AXIOM_MINIMALITY_POLICY.md
+++ b/docs/audit/AXIOM_MINIMALITY_POLICY.md
@@ -776,15 +776,20 @@ delta; not a discharge):
     landing PR thread; the record does not land without it.
 
 - **2026-08-05 -- Admissibility second sentence: availability replaced by
-  likelihood (owner-approved, 2026-08-05).** The Admissibility axiom's second
-  sentence is edited in place to: "For each site, the likelihood of each
-  possibility is determined by, and varies with, the nearest-neighbor
-  conditions." Content notes: the determination of likelihood becomes named
-  axiom content; availability/admissibility becomes the likelihood's support
-  (zero likelihood is unavailability -- forced by composition with Record, no
-  stipulation needed); site normalization follows from Record's "locks
-  exactly one"; the likelihood function's form and values, the site question,
-  and the rate question remain downstream supplier content. Owner reading
+  the probability distribution (owner-approved, 2026-08-05).** The
+  Admissibility axiom's second sentence is edited in place to: "For each
+  site, the probability distribution over the possibilities is determined
+  by, and varies with, the nearest-neighbor conditions." Content notes: the
+  determination of the distribution becomes named axiom content;
+  availability/admissibility becomes the distribution's support (on finite
+  menus, exactly nonzero probability -- probability zero is unavailable --
+  forced by composition with Record, no stipulation needed; the
+  measure/support formulation adopted on independent review, since per-point
+  likelihood under-specifies an atomless law on the continuous one-site
+  domain); site normalization is carried by the term "probability
+  distribution" and by Record's "locks exactly one"; the distribution's form
+  and values, the site question, and the rate question remain downstream
+  supplier content. Owner reading
   ruling on the section-1 fence and the memo's dynamics fence: "define
   probabilities / assign weights / supply transition probabilities" means
   supplying values or selections; establishing that likelihoods are

--- a/docs/audit/AXIOM_MINIMALITY_POLICY.md
+++ b/docs/audit/AXIOM_MINIMALITY_POLICY.md
@@ -774,3 +774,20 @@ delta; not a discharge):
     proposes no retirement.
   - **Approval.** Owner approval for adding this record is recorded in the
     landing PR thread; the record does not land without it.
+
+- **2026-08-05 -- Admissibility second sentence: availability replaced by
+  likelihood (owner-approved, 2026-08-05).** The Admissibility axiom's second
+  sentence is edited in place to: "For each site, the likelihood of each
+  possibility is determined by, and varies with, the nearest-neighbor
+  conditions." Content notes: the determination of likelihood becomes named
+  axiom content; availability/admissibility becomes the likelihood's support
+  (zero likelihood is unavailability -- forced by composition with Record, no
+  stipulation needed); site normalization follows from Record's "locks
+  exactly one"; the likelihood function's form and values, the site question,
+  and the rate question remain downstream supplier content. Owner reading
+  ruling on the section-1 fence and the memo's dynamics fence: "define
+  probabilities / assign weights / supply transition probabilities" means
+  supplying values or selections; establishing that likelihoods are
+  nearest-neighbor-determined is structural and does not breach the fence.
+  The memo's reading notes are interpretive and non-governing. Historical
+  record of the approval only.


### PR DESCRIPTION
Owner-approved constitutional wording change, 2026-08-05. The file path is unchanged so existing links and runner references remain stable.

## Governing change

Admissibility second sentence changes from:

> For each site, the available possibilities are determined by, and vary with, the nearest-neighbor conditions.

to exactly:

> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.

This remains one Admissibility rule, not a new axiom.

## Forced reading with Qubit and Record

- The distribution ranges over the full Qubit one-site possibility domain.
- Available/admissible denotes the support of that distribution. On a finite atomic menu, support is exactly the nonzero-probability possibilities. On a continuous domain, a supported exact point may have zero singleton measure.
- Probability distribution carries normalization. Record locks exactly one supported realization, conditional on formation at that site.
- The memo does not specify the distribution form or values, realized draw, formation site, formation probability/rate, context selection, update law, or Born bridge.

These are interpretive consequences of the existing Qubit and Record axioms; no additional governing support sentence is added.

## Landing package

Stacked PR #6013 repairs every changed semantic consumer, strengthens the memo/registry guard, refreshes the canonical evidence caches, and removes stale campaign artifacts. The validation pipeline correctly invalidates 887 prior judgments on the changed framework-premise epoch, produces a 3,600-row re-audit queue, and leaves zero retained-grade rows until the independent audit lane re-ratifies them. Those generated audit/status outputs are validation-only and are not part of the landing.

Generated with Claude Code; independently reviewed and repaired through the repository review-loop.
