### PR TITLE
[CLOSED — novelty below the bar] Sector-independent dial exclusion

### DIFF
--- a/docs/SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md
+++ b/docs/SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md
@@ -1,4 +1,4 @@
-# No Sector-Independent Value of `r` Agrees With the Registered Dials, Subject to Three Named Walls (Bounded Theorem)
+# No Sector-Independent Value of `r` Agrees With the Common-Scale Dial Comparators, Subject to Four Named Walls (Bounded Theorem)
 
 **Date:** 2026-08-07
 **Type:** bounded_theorem
@@ -11,6 +11,15 @@ set, predict, or apply an audit outcome, and edits no registry.
 **Cached runner output:**
 [`logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt`](../logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt)
 
+> **Unlanded dependency — read before anything else.** Every number in T1 and
+> T2 is consumed from
+> `SECTOR_DIAL_SCALE_INVARIANCE_AND_COMMON_SCALE_COMPARATOR_BOUNDED_THEOREM_NOTE_2026-08-07.md`,
+> which is **in flight and unaudited** and is **not present in this repository
+> yet**. The link to it below **does not resolve on this branch**, so the
+> citation graph cannot seed that edge and the comparators cannot be checked
+> against their source here. This note must not be landed or audited before that
+> companion note lands. If its comparators move, T1 and T2 must be re-run.
+
 ## This is not a no_go
 
 It was drafted as one — "no sector-blind supply of the occupancy grain is
@@ -20,9 +29,12 @@ convincing steelman using either. Per the gate's own instruction, the claim is
 demoted rather than shipped in its original framing.
 
 What ships is the narrow, honest version: a **bounded exclusion of one named
-class of candidate supplies, with three walls stated as load-bearing
+class of candidate supplies, with four walls stated as load-bearing
 conditions rather than as caveats.** The full N1–N8 checklist is in the PR
 body.
+
+A fourth wall (W4) and the prior-art section below were added in review; the
+PR body's N1 route table and its "three walls" count predate them.
 
 ## Claim
 
@@ -30,14 +42,20 @@ Let a *candidate sector-independent supply* be any axiom, primitive, or
 theorem whose output is **one numerical value** `r*` of the C₃ dial
 coordinate, the same for every fermion sector.
 
-**T1 (exact).** No such `r*` exists within 5σ of all three registered
-common-scale dials. The three 5σ intervals are pairwise disjoint and their
-triple intersection is empty. The best possible single value — the `r*`
-minimising the largest pull over the three sectors — still sits **149.5σ**
-from at least one sector, because the charged-lepton dial is pinned to
-`1.0 × 10⁻⁵`.
+**T1 (exact).** No such `r*` exists within 5σ of all three common-scale dial
+comparators. The three 5σ intervals are pairwise disjoint and their triple
+intersection is empty. The **exact** minimax — the `r*` minimising the largest
+pull over the three sectors, computed by envelope-breakpoint enumeration, not
+by a grid scan — still sits **149.4807σ** from at least one sector. So T1 does
+not depend on the choice of `K`: it holds for every `K < 149.48`.
 
-Registered inputs (comparators, frozen as exact rationals in the runner):
+Two honesty notes on that σ figure. It is large mainly because the
+charged-lepton dial is pinned to `1.0 × 10⁻⁵`, three orders of magnitude
+tighter than the quark dials; the *physical* separation at the minimax is
+`Δr ≈ 0.33`, not something 149 times any physical width. And a σ-distance is
+only as good as the σ — see "Robustness" below.
+
+Comparator inputs (frozen as exact rationals in the runner):
 
 ```text
 charged lepton   r = 0.499990767 ± 0.0000102     (0.9σ from exactly 1/2)
@@ -52,7 +70,7 @@ atoms has singlet weight `w = 1/n`, hence `r = (n−1)/2` — the ladder
 from its nearest rung, up-type 76.7σ. So no uniform count of atoms, of any
 `n`, reaches either quark sector.
 
-## The three walls
+## The four walls
 
 These are load-bearing conditions, not caveats. Any one of them failing voids
 the corresponding part of the claim.
@@ -80,10 +98,30 @@ claimed. T1 holds only if the supplied `r` is the registered `r`.
 ([`ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16.md`](ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16.md),
 T3) but that note states the coordinate is "supplied only through the
 relocation theorem's explicitly unadopted energy dictionary (Residual Atom
-2)." T2 therefore consumes an **unadopted** dictionary. **T1 does not depend
-on W3** and stands if T2 falls.
+2)." That quote is verbatim and in context. The same note also labels its T3
+"support-only arithmetic, not a bijection of physical grains," and is itself an
+unaudited `bounded_theorem`. T2 therefore consumes an **unadopted, support-only**
+dictionary. **T1 does not depend on W3** — but see W4 before reading that as
+"T1 is dictionary-free."
 
-W1, W2 and W3 are pairwise independent: closing any one closes neither other.
+**W4 — mass-to-dial dictionary (T1 and T2).** The comparators are not measured
+values of `r`. They are computed from PDG masses through the C₃-circulant
+(Brannen) ansatz `H = aI + bC + b̄C²` together with the identification of its
+eigenvalues as one-leg amplitudes `√m` rather than masses.
+[`QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md`](QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28.md)
+records both as **non-retained inputs** — the Frobenius/equal-block-energy
+selection and the one-leg-amplitude reading of the eigenvalues — and
+[`KOIDE_BAE_PROBE_HW_SECTOR_IDENTIFICATION_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe27.md`](KOIDE_BAE_PROBE_HW_SECTOR_IDENTIFICATION_BOUNDED_OBSTRUCTION_NOTE_2026-05-09_probe27.md)
+treats the circulant ansatz as an ansatz, not retained content. If that
+dictionary is not the framework's, T1 excludes values of a quantity the
+framework never computes.
+
+W4 matters for how W3 is read. T1 escaping W3 does **not** make T1 free of
+dictionary dependence — it means T1 rides a *different* non-retained dictionary
+of the same kind. The earlier framing "T1 stands if T2 falls" is true only in
+the narrow sense that T1 does not use the weight-to-dial coordinate.
+
+W1, W2, W3 and W4 are pairwise independent: closing any one closes no other.
 
 ## What the exclusion does not reach
 
@@ -101,6 +139,80 @@ This narrowing came out of the gate's N5 rhetoric audit and is load-bearing on
 the claim's wording. The broader phrase "no sector-blind supply" was tested
 only at the resolution of *values* and is over-broad at the resolution of
 *rules*; it does not appear in this note.
+
+## Prior art — what is actually new here
+
+T1's *qualitative* content is already in the repo. This note does not claim it
+as new.
+
+- [`FOURTH_AXIOM_RG_SCALE_DYNAMICS_SCOPING_2026-06-05.md`](FOURTH_AXIOM_RG_SCALE_DYNAMICS_SCOPING_2026-06-05.md)
+  §2.1 already states it and already does the minimax in absolute units: "The
+  best single universal value (mid-range `r* = 0.637`) still misses a sector by
+  `0.137`… a single scale-invariant fixed point gives one number and is
+  falsified by the quark sectors." Its §5 already states T1's forward
+  constraint: the distinct sector values "argue that whatever selects `r` is
+  sector-structured by a non-color label — a constraint on any future selection
+  principle, scale-based or otherwise." That note is `Type: meta`, explicitly
+  historical/provenance banking and a **non-claim source**, so the content is
+  present in the repo but not as a claim.
+- [`FLAVOR_MAX_RECORD_ENTROPY_IS_SECTOR_BLIND_CANNOT_DERIVE_THE_KOIDE_DIAL_NARROW_NO_GO_NOTE_2026-06-15.md`](FLAVOR_MAX_RECORD_ENTROPY_IS_SECTOR_BLIND_CANNOT_DERIVE_THE_KOIDE_DIAL_NARROW_NO_GO_NOTE_2026-06-15.md)
+  states the `r* = 1/2` special case: a universal selector "would weight-leak to
+  a universal Koide `Q = 2/3` and miss the registered quark comparators."
+- [`FLAVOR_GAUGE_REPRESENTATION_CHANNEL_CANNOT_SOURCE_THE_SECTOR_R_SPREAD_NARROW_NO_GO_NOTE_2026-06-15.md`](FLAVOR_GAUGE_REPRESENTATION_CHANNEL_CANNOT_SOURCE_THE_SECTOR_R_SPREAD_NARROW_NO_GO_NOTE_2026-06-15.md)
+  uses the same non-coincidence (`r_up ≠ r_down` at equal colour) as its
+  load-bearing step.
+
+**What is new is only the quantification, and it is narrow:** exact 5σ interval
+arithmetic instead of a bare distance, an exact minimax instead of a midpoint,
+the statement that the result is `K`-independent below 149.48σ, and the use of
+the common-scale comparators rather than mixed-scale ones. A reader should size
+this note as *putting error bars on an already-recorded observation*, not as
+establishing the observation.
+
+## The comparators moved, and in the direction that helps
+
+The prior-art notes above register the down-type and up-type dials as
+`r ≈ 0.597` and `r ≈ 0.773`–`0.774`. This note uses `0.621090` and `0.830971`.
+That is not a re-selection of friendlier numbers: the older values mix mass
+conventions (light quarks quoted at 2 GeV, `m_b` at `m_b`, `m_t` at `m_t`), and
+the companion note removes the mixing by bringing each sector to one scale.
+The Koide ratio `Q = Σm / (Σ√m)²` is homogeneous of degree zero, so a *common*
+rescaling of a sector's three masses cannot move the dial at all; the entire
+shift is therefore the mixed-convention artifact, and nothing in it is physics.
+This is the mass-scheme/mixed-convention route in the PR body's alternative-route
+table.
+
+It must be said plainly that the corrected comparators sit **further apart**
+than the ones they replace, which makes T1 stronger than it would have been on
+the previously registered values. On the old values T1 still holds, but with
+less margin. Until the companion note lands, four landed notes continue to
+carry `0.597` / `0.773`; reconciling them is downstream work this note does not
+do and does not claim to have done.
+
+## Robustness — the uncertainties are symmetrised, and that needs a number
+
+The 5σ intervals use symmetric, Gaussian, linearly-propagated uncertainties.
+Several PDG inputs behind them (`m_u`, `m_d`, `m_s`) have strongly asymmetric
+published errors, so symmetrisation is a real modelling choice and could
+flatter the result. The runner therefore reports the exact factor by which the
+quoted σ would have to grow before each conclusion fails:
+
+```text
+charged lepton / down-type   disjoint up to  sigma x 3.30
+charged lepton / up-type     disjoint up to  sigma x 29.90
+down-type / up-type          disjoint up to  sigma x 4.40
+down-type off-rung (T2)      holds    up to  sigma x 3.30
+up-type   off-rung (T2)      holds    up to  sigma x 15.34
+```
+
+The binding case is the down-type sector, at **3.3×**. Published asymmetries on
+`m_d` and `m_s` are at the tens-of-percent level between the two arms, so the
+worst-arm σ is well under 3.3× the symmetrised σ, and the down-type conclusion
+survives. But the margin is 3.3×, not a hundred-fold, so the symmetrisation is
+a stated condition of T1 and T2 rather than a harmless convenience. A reader
+who rejects the symmetrisation should re-run with an asymmetric propagation
+before relying on the down-type numbers; the σ-counts (16.5σ, 149.48σ) would
+move, though the sign of the conclusion would not.
 
 ## Relation to the standing non-supply no-go
 
@@ -124,12 +236,17 @@ such theorem must yield a sector-dependent answer, or fail W1 or W2.
 
 - **This is not a no_go**, does not assert that any route is structurally
   closed, and does not claim a new axiom is required. It excludes one named
-  class of candidate supplies subject to three named walls.
+  class of candidate supplies subject to four named walls.
 - No `r`, `Q`, `δ`, mass, mass scale, mixing angle, probability rule, Born
   weight, species map, or sector weight is derived. Every number in T1 and T2
   is an external comparator.
-- The registered dial values are consumed from a companion note that is
-  **in flight and unaudited**. If those comparators move, T1 must be re-run.
+- The dial values are consumed from a companion note that is **in flight,
+  unaudited, and absent from this branch**; its link here does not resolve. See
+  the banner at the top.
+- **The observation is not new.** T1 quantifies a fact already recorded in the
+  repo (see "Prior art"). Only the error bars, the exact minimax, the
+  `K`-independence, and the common-scale comparators are new.
+- T1 is not dictionary-free. It escapes W3 and rides W4.
 - No claim is made about *why* the sectors differ, or that Admissibility
   supplies the difference.
 - No axiom, approved primitive, registry entry, or audit verdict is added,
@@ -142,13 +259,19 @@ such theorem must yield a sector-dependent answer, or fail W1 or W2.
 
 ## Scope boundary
 
-Three-generation fermion sectors of the Standard Model as registered.
-Real-valued dials. Gaussian, symmetric, linearly-propagated input
-uncertainties as published by the companion note; `K = 5σ` intervals. The
-exactness claim is downstream of the comparator declaration: the interval
-construction, disjointness, intersection emptiness, and ladder distances are
-all exact `Fraction` arithmetic, and the frozen input rationals are the only
-external numbers.
+Three-generation charged fermion sectors of the Standard Model as registered
+(neutrinos carry no registered dial and are out of scope). Real-valued dials.
+Gaussian, symmetric, linearly-propagated input uncertainties as published by
+the companion note; `K = 5σ` intervals, with T1 shown `K`-independent below
+149.48σ. The comparators are mass-derived through the non-retained dictionary
+named in W4.
+
+The exactness claim is downstream of the comparator declaration: the interval
+construction, disjointness, intersection emptiness, the minimax, the σ-inflation
+break-even factors, and the ladder distances are all exact `Fraction`
+arithmetic, and the frozen input rationals are the only external numbers. No
+float reaches any load-bearing comparison; floats appear only inside `print`
+formatting.
 
 ## Reproduce
 

--- a/docs/SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md
+++ b/docs/SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md
@@ -1,0 +1,160 @@
+# No Sector-Independent Value of `r` Agrees With the Registered Dials, Subject to Three Named Walls (Bounded Theorem)
+
+**Date:** 2026-08-07
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem (with named walls)
+**Status:** proposed_retained
+**Status authority:** independent audit lane only. This source note does not
+set, predict, or apply an audit outcome, and edits no registry.
+**Primary runner:**
+[`scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py`](../scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py)
+**Cached runner output:**
+[`logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt`](../logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt)
+
+## This is not a no_go
+
+It was drafted as one — "no sector-blind supply of the occupancy grain is
+admissible" — and it failed the `/no-go-gate` N1–N8 stress test at N1, N5 and
+N7. Two attack routes against it are open, and a hostile reviewer can write a
+convincing steelman using either. Per the gate's own instruction, the claim is
+demoted rather than shipped in its original framing.
+
+What ships is the narrow, honest version: a **bounded exclusion of one named
+class of candidate supplies, with three walls stated as load-bearing
+conditions rather than as caveats.** The full N1–N8 checklist is in the PR
+body.
+
+## Claim
+
+Let a *candidate sector-independent supply* be any axiom, primitive, or
+theorem whose output is **one numerical value** `r*` of the C₃ dial
+coordinate, the same for every fermion sector.
+
+**T1 (exact).** No such `r*` exists within 5σ of all three registered
+common-scale dials. The three 5σ intervals are pairwise disjoint and their
+triple intersection is empty. The best possible single value — the `r*`
+minimising the largest pull over the three sectors — still sits **149.5σ**
+from at least one sector, because the charged-lepton dial is pinned to
+`1.0 × 10⁻⁵`.
+
+Registered inputs (comparators, frozen as exact rationals in the runner):
+
+```text
+charged lepton   r = 0.499990767 ± 0.0000102     (0.9σ from exactly 1/2)
+down-type quark  r = 0.621090   ± 0.007335
+up-type quark    r = 0.830971   ± 0.002204
+```
+
+**T2 (exact, but conditional on wall W3).** Uniform occupancy over `n` counted
+atoms has singlet weight `w = 1/n`, hence `r = (n−1)/2` — the ladder
+`{0, 1/2, 1, 3/2, …}`. The charged-lepton dial sits **on** the `n = 2` rung
+(0.9σ). Both quark dials sit **strictly between** rungs: down-type is 16.5σ
+from its nearest rung, up-type 76.7σ. So no uniform count of atoms, of any
+`n`, reaches either quark sector.
+
+## The three walls
+
+These are load-bearing conditions, not caveats. Any one of them failing voids
+the corresponding part of the claim.
+
+**W1 — carrier universality.** T1 compares three dials as if they were the
+same observable evaluated on three sectors. That all three sectors register
+the *same* C₃ `hw=1` carrier is **not derived**.
+[`SPECIES_BRIDGE_MINIMUM_DECOMPOSITION_BOUNDED_THEOREM_NOTE_2026-06-13.md`](SPECIES_BRIDGE_MINIMUM_DECOMPOSITION_BOUNDED_THEOREM_NOTE_2026-06-13.md)
+derives the carrier *structure* for the `hw=1` triplet but explicitly excludes
+"a claim about across-fermion-type alignment," and lists that alignment as an
+open residual. If the quark sectors do not carry the same C₃ object, `r` is
+not one observable across sectors and T1 compares unlike things.
+
+**W2 — registration scale.** The companion invariance theorem
+([`SECTOR_DIAL_SCALE_INVARIANCE_AND_COMMON_SCALE_COMPARATOR_BOUNDED_THEOREM_NOTE_2026-08-07.md`](SECTOR_DIAL_SCALE_INVARIANCE_AND_COMMON_SCALE_COMPARATOR_BOUNDED_THEOREM_NOTE_2026-08-07.md),
+in flight, unaudited) makes the dial scale-independent **under
+flavour-universal QCD running only**. Standard-Model Yukawa contributions to
+the mass anomalous dimension are flavour-*dependent*. So a dial supplied at
+some other scale — a lattice or unification scale — need not equal the
+registered one, and T1 would then be excluding a value the framework never
+claimed. T1 holds only if the supplied `r` is the registered `r`.
+
+**W3 — energy dictionary (T2 only).** T2's weight-to-dial coordinate
+`r = (1 − w)/(2w)` is prior art
+([`ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16.md`](ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16.md),
+T3) but that note states the coordinate is "supplied only through the
+relocation theorem's explicitly unadopted energy dictionary (Residual Atom
+2)." T2 therefore consumes an **unadopted** dictionary. **T1 does not depend
+on W3** and stands if T2 falls.
+
+W1, W2 and W3 are pairwise independent: closing any one closes neither other.
+
+## What the exclusion does not reach
+
+The excluded class is candidate supplies yielding one sector-independent
+**numerical value**. It is *not* a claim about sector-blind **rules**.
+
+A universal rule whose input is sector-dependent registered content is
+untouched, and the runner gives the two-line existence proof: inverting
+`r = (1 − w)/(2w)` on each sector's registered dial reproduces all three from
+one rule and three inputs. Admissibility — the axiom whose content is that the
+one-site distribution varies with the nearest-neighbour conditions — is
+exactly a rule of that shape. Nothing here bears against it.
+
+This narrowing came out of the gate's N5 rhetoric audit and is load-bearing on
+the claim's wording. The broader phrase "no sector-blind supply" was tested
+only at the resolution of *values* and is over-broad at the resolution of
+*rules*; it does not appear in this note.
+
+## Relation to the standing non-supply no-go
+
+[`ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md`](ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04.md)
+shows the axiom surface does not *entail* a determinant-power grain. That is a
+non-entailment result about what the axioms settle.
+
+This note is **not** a witness for it and does not cite it as one: the
+residuals differ. That note's residual is "the axioms do not select between
+`F_C` and `F_R`"; this note's is "no single numerical `r` fits three
+registered sectors." The two are complementary — the first says the axioms are
+silent, the second constrains what a future theorem could say — and neither
+supports the other. The gate's N4 residual-matching step is why this is spelled
+out rather than assumed.
+
+That no-go explicitly leaves open "a future physical CAR/action theorem that
+derives a specific Gaussian measure." T1 adds a condition to that opening: any
+such theorem must yield a sector-dependent answer, or fail W1 or W2.
+
+## Non-claims
+
+- **This is not a no_go**, does not assert that any route is structurally
+  closed, and does not claim a new axiom is required. It excludes one named
+  class of candidate supplies subject to three named walls.
+- No `r`, `Q`, `δ`, mass, mass scale, mixing angle, probability rule, Born
+  weight, species map, or sector weight is derived. Every number in T1 and T2
+  is an external comparator.
+- The registered dial values are consumed from a companion note that is
+  **in flight and unaudited**. If those comparators move, T1 must be re-run.
+- No claim is made about *why* the sectors differ, or that Admissibility
+  supplies the difference.
+- No axiom, approved primitive, registry entry, or audit verdict is added,
+  edited, retired, or predicted. The primitive registry check was run: the
+  three approved primitives (`scale_reference`, `kinetic_isotropy`,
+  `realized_state`) are each declared not to supply any dimensionless
+  quantity, weighting rule, or probability rule, so no wall language of the
+  form "no retained primitive supplies this" is used here. The Tier-A count is
+  unchanged.
+
+## Scope boundary
+
+Three-generation fermion sectors of the Standard Model as registered.
+Real-valued dials. Gaussian, symmetric, linearly-propagated input
+uncertainties as published by the companion note; `K = 5σ` intervals. The
+exactness claim is downstream of the comparator declaration: the interval
+construction, disjointness, intersection emptiness, and ladder distances are
+all exact `Fraction` arithmetic, and the frozen input rationals are the only
+external numbers.
+
+## Reproduce
+
+```bash
+python3 scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
+```
+
+Standard library only. No floating point and no randomness after the comparator
+input declaration.

--- a/logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt
+++ b/logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
-runner_sha256: 4328dcd3a809621a99e0d8009cd9e546110d68bfb62eadb606325781c2b0a064
-input_fingerprint_sha256: f25c7b3101357dc923be65bd0d2537835984b702866f2cdd9f6299d3095954e3
+runner_sha256: 8f6328b5a0136f444115ff0f8782005bc650a754a21e59b92b2bafb84ae49edc
+input_fingerprint_sha256: 7ebea71807013cd5dcfe7cfb20f76e31d3e3f83babfe98e3049f9cac8410db54
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.17
+elapsed_sec: 0.06
 status: ok
 ----- stdout -----
 
@@ -34,7 +34,14 @@ A. EXACT: the K-sigma registered dial intervals are pairwise disjoint
     up-type quark    vs r* = 0.621090:     95.2 sigma
 
   Best-case single r*: minimise the largest pull over the three sectors.
-  [PASS] even the best single r* is excluded by at least one sector  (argmin r* = 0.5015, largest pull there = 149.5 sigma)
+  Exact minimax over all real r* (envelope-breakpoint enumeration).
+  [PASS] even the best single r* is excluded by at least one sector  (exact argmin r* = 0.5015155, largest pull there = 149.4807 sigma)
+  [PASS] the exclusion does not depend on the choice of K  (T1 holds for every K < 149.4807; K = 5 is far inside that range)
+
+  Robustness of T1 to inflated (e.g. asymmetric-error) uncertainties:
+  [PASS] charged lepton / down-type quark stay disjoint under uniform sigma inflation up to x3.30  (exact break-even inflation factor = 3.297)
+  [PASS] charged lepton / up-type quark stay disjoint under uniform sigma inflation up to x29.90  (exact break-even inflation factor = 29.896)
+  [PASS] down-type quark / up-type quark stay disjoint under uniform sigma inflation up to x4.40  (exact break-even inflation factor = 4.400)
 
 B. EXACT but WALL-CONDITIONAL: the uniform-count ladder
 -------------------------------------------------------
@@ -59,6 +66,10 @@ B. EXACT but WALL-CONDITIONAL: the uniform-count ladder
   [PASS] up-type quark: strictly between rungs  (nearest rung 1, exact distance 0.169029 = 76.7 sigma)
   [PASS] charged lepton: ON the n = 2 rung, within 1 sigma  (distance from r = 1/2 is 0.9 sigma)
 
+  Robustness of the 'strictly between rungs' finding to inflated sigma:
+  [PASS] down-type quark stays off-rung under sigma inflation up to x3.30  (exact break-even inflation factor = 3.302)
+  [PASS] up-type quark stays off-rung under sigma inflation up to x15.34  (exact break-even inflation factor = 15.338)
+
 C. EXACT: what the exclusion does NOT reach
 -------------------------------------------
   The excluded class is: candidate supplies that yield ONE numerical
@@ -69,7 +80,7 @@ C. EXACT: what the exclusion does NOT reach
   [PASS] charged lepton: one rule reproduces the registered dial from w = 0.500005  (exact inverse; shows the rule-level route is untouched by Part A)
   [PASS] down-type quark: one rule reproduces the registered dial from w = 0.445995  (exact inverse; shows the rule-level route is untouched by Part A)
   [PASS] up-type quark: one rule reproduces the registered dial from w = 0.375666  (exact inverse; shows the rule-level route is untouched by Part A)
-  [PASS] so Part A excludes sector-independent VALUES, not sector-blind rules  (this is the N5 narrowing and is load-bearing on the claim's wording)
+  [PASS] the surviving rule-level route needs three DISTINCT sector inputs  (so it is genuinely outside the class Part A excludes, not a disguised single value; this is the N5 narrowing and is load-bearing on the wording)
 
 D. Named walls, echoed from the note
 ------------------------------------
@@ -77,11 +88,16 @@ D. Named walls, echoed from the note
   [PASS] wall stated in the source note: W1
   W2 registration scale: the companion invariance theorem covers flavour-universal QCD running only; SM Yukawa contributions to the mass anomalous dimension are flavour-DEPENDENT, so a dial supplied at a different scale need not equal the registered one
   [PASS] wall stated in the source note: W2
-  W3 energy dictionary: Part B's weight-to-dial coordinate rides on an explicitly unadopted energy dictionary; Part A is independent of it
+  W3 energy dictionary (Part B only): Part B's weight-to-dial coordinate rides on an explicitly unadopted energy dictionary; Part A is independent of THIS dictionary
   [PASS] wall stated in the source note: W3
+  W4 mass-to-dial dictionary (Part A too): the comparators are not measured r; they are computed from PDG masses through the C_3-circulant (Brannen) ansatz and the sqrt(m) one-leg amplitude identification, which the quark circulant source-law boundary note records as NON-RETAINED inputs.  Part A escapes W3 but rides W4, which is a dictionary of the same kind
+  [PASS] wall stated in the source note: W4
 
-  [PASS] Part A is independent of walls W3  (Part A uses no weight-to-dial coordinate at all)
-  [PASS] Part A is NOT independent of walls W1 and W2  (both are stated as load-bearing conditions of the claim, not as caveats)
+  Part A is independent of W3 (it uses no weight-to-dial coordinate at
+  all), but is NOT independent of W1, W2 or W4.  All three are stated in
+  the note as load-bearing conditions of the claim, not as caveats.
+  'T1 survives if T2 falls' therefore means only that T1 escapes W3 --
+  it does NOT mean T1 is free of dictionary dependence.
 
 E. Scope guards
 ---------------
@@ -91,11 +107,14 @@ E. Scope guards
   [PASS] note contains discipline marker: 'comparator'  (note marks its numerics as comparators)
   [PASS] note contains discipline marker: 'prior art'  (note defers the ladder arithmetic to prior art)
   [PASS] note contains discipline marker: 'proposed_retained'  (note uses author-side status vocabulary only)
+  [PASS] note contains discipline marker: 'FOURTH_AXIOM_RG_SCALE_DYNAMICS_SCOPING_2026-06-05'  (note credits the prior art that already states Part A qualitatively)
+  [PASS] note contains discipline marker: 'W4'  (note names the mass-to-dial dictionary wall that Part A rides)
+  [PASS] note contains discipline marker: 'does not resolve on this branch'  (note is explicit that its comparator source is not present yet)
   [PASS] note does not set 'effective_status'  (status authority stays with the independent audit lane)
   [PASS] note does not set 'audit_status'  (status authority stays with the independent audit lane)
 
 ================================================================
-TOTAL: PASS=29, FAIL=0
+TOTAL: PASS=37, FAIL=0
 ================================================================
 
 ----- stderr -----

--- a/logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt
+++ b/logs/runner-cache/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.txt
@@ -1,0 +1,102 @@
+===== runner cache v1 =====
+runner: scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
+runner_sha256: 4328dcd3a809621a99e0d8009cd9e546110d68bfb62eadb606325781c2b0a064
+input_fingerprint_sha256: f25c7b3101357dc923be65bd0d2537835984b702866f2cdd9f6299d3095954e3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.17
+status: ok
+----- stdout -----
+
+A. EXACT: the K-sigma registered dial intervals are pairwise disjoint
+---------------------------------------------------------------------
+  Comparator inputs, frozen as exact rationals (see header):
+    charged lepton   r = 0.499990767 +- 0.000010
+    down-type quark  r = 0.621090000 +- 0.007335
+    up-type quark    r = 0.830971000 +- 0.002204
+  Interval half-width K = 5 sigma.  All arithmetic below is exact.
+
+    charged lepton   [0.499940, 0.500042]
+    down-type quark  [0.584415, 0.657765]
+    up-type quark    [0.819951, 0.841991]
+
+  [PASS] charged lepton and down-type quark intervals are disjoint  (exact gap = 84373233/1000000000 = 0.084373)
+  [PASS] charged lepton and up-type quark intervals are disjoint  (exact gap = 319909233/1000000000 = 0.319909)
+  [PASS] down-type quark and up-type quark intervals are disjoint  (exact gap = 81093/500000 = 0.162186)
+  [PASS] the triple intersection is empty: no single r* lies in all three  (max(lower) = 0.819951 > min(upper) = 0.500042)
+
+  Pulls of each sector against the other sectors' central values:
+    charged lepton   vs r* = 0.621090:  11872.5 sigma
+    charged lepton   vs r* = 0.830971:  32449.0 sigma
+    down-type quark  vs r* = 0.499991:     16.5 sigma
+    down-type quark  vs r* = 0.830971:     28.6 sigma
+    up-type quark    vs r* = 0.499991:    150.2 sigma
+    up-type quark    vs r* = 0.621090:     95.2 sigma
+
+  Best-case single r*: minimise the largest pull over the three sectors.
+  [PASS] even the best single r* is excluded by at least one sector  (argmin r* = 0.5015, largest pull there = 149.5 sigma)
+
+B. EXACT but WALL-CONDITIONAL: the uniform-count ladder
+-------------------------------------------------------
+  CONDITIONAL ON WALL W3.  The weight-to-dial coordinate
+      r = (1 - w) / (2 w)
+  is prior art -- ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_
+  DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16, T3 --
+  but that note states it is 'supplied only through the relocation
+  theorem's explicitly unadopted energy dictionary (Residual Atom 2)'.
+  Part B therefore consumes an UNADOPTED dictionary and is conditional.
+  Part A does not depend on Part B.
+
+  Uniform count on n atoms: w = 1/n, so r = (n-1)/2.
+    n=1: r=0,  n=2: r=1/2,  n=3: r=1,  n=4: r=3/2,  n=5: r=2,  n=6: r=5/2,  n=7: r=3,  n=8: r=7/2
+
+  [PASS] menu-note arithmetic reproduced: w = 1/2 -> r = 1/2  (all four pairs are quoted in the cited note; none is fitted here)
+  [PASS] menu-note arithmetic reproduced: w = 1/3 -> r = 1  (all four pairs are quoted in the cited note; none is fitted here)
+  [PASS] menu-note arithmetic reproduced: w = 2/3 -> r = 1/4  (all four pairs are quoted in the cited note; none is fitted here)
+  [PASS] menu-note arithmetic reproduced: w = 1/4 -> r = 3/2  (all four pairs are quoted in the cited note; none is fitted here)
+
+  [PASS] down-type quark: strictly between rungs  (nearest rung 1/2, exact distance 0.121090 = 16.5 sigma)
+  [PASS] up-type quark: strictly between rungs  (nearest rung 1, exact distance 0.169029 = 76.7 sigma)
+  [PASS] charged lepton: ON the n = 2 rung, within 1 sigma  (distance from r = 1/2 is 0.9 sigma)
+
+C. EXACT: what the exclusion does NOT reach
+-------------------------------------------
+  The excluded class is: candidate supplies that yield ONE numerical
+  value of r shared by every sector.  A universal RULE whose input is
+  sector-dependent registered content is NOT in that class and is NOT
+  excluded.  The witness below is a two-line existence proof.
+
+  [PASS] charged lepton: one rule reproduces the registered dial from w = 0.500005  (exact inverse; shows the rule-level route is untouched by Part A)
+  [PASS] down-type quark: one rule reproduces the registered dial from w = 0.445995  (exact inverse; shows the rule-level route is untouched by Part A)
+  [PASS] up-type quark: one rule reproduces the registered dial from w = 0.375666  (exact inverse; shows the rule-level route is untouched by Part A)
+  [PASS] so Part A excludes sector-independent VALUES, not sector-blind rules  (this is the N5 narrowing and is load-bearing on the claim's wording)
+
+D. Named walls, echoed from the note
+------------------------------------
+  W1 carrier universality: that all three sectors register the SAME C_3 hw=1 carrier is not derived; the species bridge's across-fermion-type alignment residual is explicitly open
+  [PASS] wall stated in the source note: W1
+  W2 registration scale: the companion invariance theorem covers flavour-universal QCD running only; SM Yukawa contributions to the mass anomalous dimension are flavour-DEPENDENT, so a dial supplied at a different scale need not equal the registered one
+  [PASS] wall stated in the source note: W2
+  W3 energy dictionary: Part B's weight-to-dial coordinate rides on an explicitly unadopted energy dictionary; Part A is independent of it
+  [PASS] wall stated in the source note: W3
+
+  [PASS] Part A is independent of walls W3  (Part A uses no weight-to-dial coordinate at all)
+  [PASS] Part A is NOT independent of walls W1 and W2  (both are stated as load-bearing conditions of the claim, not as caveats)
+
+E. Scope guards
+---------------
+  [PASS] source note is present on the branch  (SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md)
+  [PASS] note contains discipline marker: 'This is not a no_go'  (note refuses no_go classification)
+  [PASS] note contains discipline marker: 'sector-independent'  (note states the narrow excluded class)
+  [PASS] note contains discipline marker: 'comparator'  (note marks its numerics as comparators)
+  [PASS] note contains discipline marker: 'prior art'  (note defers the ladder arithmetic to prior art)
+  [PASS] note contains discipline marker: 'proposed_retained'  (note uses author-side status vocabulary only)
+  [PASS] note does not set 'effective_status'  (status authority stays with the independent audit lane)
+  [PASS] note does not set 'audit_status'  (status authority stays with the independent audit lane)
+
+================================================================
+TOTAL: PASS=29, FAIL=0
+================================================================
+
+----- stderr -----
+

--- a/scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
+++ b/scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Exact interval arithmetic for the sector-independent-dial exclusion.
+
+Companion runner for
+docs/SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md
+
+The note asks whether any candidate supply that yields ONE numerical value of
+the C_3 dial coordinate r, the same for every fermion sector, can agree with
+the registered common-scale dials.
+
+Structure of the exactness claim.  The registered dial values and their
+uncertainties are COMPARATORS -- external PDG-derived floating-point inputs,
+declared below and frozen as exact rationals at the top of Part A.  Everything
+downstream of that declaration is exact `fractions.Fraction` arithmetic: the
+interval construction, the pairwise-disjointness test, the emptiness of the
+triple intersection, and the ladder distances.  No floating point and no
+randomness appears after the input declaration.
+
+This runner derives no dial value, asserts no no-go, and closes no obligation.
+It excludes one named class of candidate supplies, subject to three walls that
+are stated in the note and echoed in Part D.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import combinations
+from pathlib import Path
+
+AUDIT_INPUT_PATHS = (
+    "docs/SECTOR_INDEPENDENT_DIAL_EXCLUSION_WITH_NAMED_WALLS_BOUNDED_THEOREM_NOTE_2026-08-07.md",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / AUDIT_INPUT_PATHS[0]
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, ok: bool, detail: object = "") -> None:
+    global PASS, FAIL
+    if bool(ok):
+        PASS += 1
+        tag = "PASS"
+    else:
+        FAIL += 1
+        tag = "FAIL"
+    suffix = f"  ({detail})" if detail != "" else ""
+    print(f"  [{tag}] {label}{suffix}")
+
+
+def section(title: str) -> None:
+    print()
+    print(title)
+    print("-" * len(title))
+
+
+# ---------------------------------------------------------------------------
+# COMPARATOR INPUT DECLARATION.  These are the only external numbers in this
+# runner.  They are the registered common-scale dials and their propagated
+# uncertainties, produced by the companion note
+#   docs/SECTOR_DIAL_SCALE_INVARIANCE_AND_COMMON_SCALE_COMPARATOR_BOUNDED_THEOREM_NOTE_2026-08-07.md
+# and its runner.  They are frozen here as exact rationals with the digits as
+# published; every check below is exact in those rationals.
+#
+# DEPENDENCY: that note is in flight and unaudited at the time of writing.  If
+# its comparator values move, Part A must be re-run.  Status authority for
+# either note is the independent audit lane.
+# ---------------------------------------------------------------------------
+SECTORS = {
+    "charged lepton": (Fraction(499990767, 10 ** 9), Fraction(102, 10 ** 7)),
+    "down-type quark": (Fraction(621090, 10 ** 6), Fraction(7335, 10 ** 6)),
+    "up-type quark": (Fraction(830971, 10 ** 6), Fraction(2204, 10 ** 6)),
+}
+
+K = 5  # interval half-width in standard deviations
+
+
+section("A. EXACT: the K-sigma registered dial intervals are pairwise disjoint")
+
+print("  Comparator inputs, frozen as exact rationals (see header):")
+for name, (c, s) in SECTORS.items():
+    print(f"    {name:16s} r = {float(c):.9f} +- {float(s):.6f}")
+print(f"  Interval half-width K = {K} sigma.  All arithmetic below is exact.")
+print()
+
+INTERVALS = {name: (c - K * s, c + K * s) for name, (c, s) in SECTORS.items()}
+for name, (lo, hi) in INTERVALS.items():
+    print(f"    {name:16s} [{float(lo):.6f}, {float(hi):.6f}]")
+print()
+
+for (n1, i1), (n2, i2) in combinations(INTERVALS.items(), 2):
+    lo = max(i1[0], i2[0])
+    hi = min(i1[1], i2[1])
+    disjoint = lo > hi
+    gap = lo - hi
+    check(
+        f"{n1} and {n2} intervals are disjoint",
+        disjoint,
+        f"exact gap = {gap} = {float(gap):.6f}",
+    )
+
+lo = max(i[0] for i in INTERVALS.values())
+hi = min(i[1] for i in INTERVALS.values())
+check(
+    "the triple intersection is empty: no single r* lies in all three",
+    lo > hi,
+    f"max(lower) = {float(lo):.6f} > min(upper) = {float(hi):.6f}",
+)
+
+print()
+print("  Pulls of each sector against the other sectors' central values:")
+for a, (ca, sa) in SECTORS.items():
+    for b, (cb, _) in SECTORS.items():
+        if a == b:
+            continue
+        pull = abs(ca - cb) / sa
+        print(f"    {a:16s} vs r* = {float(cb):.6f}: {float(pull):8.1f} sigma")
+
+# the weakest possible single value: the one minimising the largest pull
+print()
+print("  Best-case single r*: minimise the largest pull over the three sectors.")
+best = None
+# exact scan on a rational grid fine enough to bracket the optimum, then report
+# the bound.  The bound is what matters, not the optimiser's precision.
+GRID = [Fraction(i, 2000) for i in range(1000, 1801)]
+for rstar in GRID:
+    worst = max(abs(c - rstar) / s for c, s in SECTORS.values())
+    if best is None or worst < best[1]:
+        best = (rstar, worst)
+check(
+    "even the best single r* is excluded by at least one sector",
+    best[1] > K,
+    f"argmin r* = {float(best[0]):.4f}, largest pull there = {float(best[1]):.1f} sigma",
+)
+
+
+section("B. EXACT but WALL-CONDITIONAL: the uniform-count ladder")
+
+print("  CONDITIONAL ON WALL W3.  The weight-to-dial coordinate")
+print("      r = (1 - w) / (2 w)")
+print("  is prior art -- ACPHILAMBDA_OCCUPANCY_GRAIN_MENU_COUNTING_MEASURE_")
+print("  DYNAMICAL_STATIC_CORRESPONDENCE_BOUNDED_THEOREM_NOTE_2026-07-16, T3 --")
+print("  but that note states it is 'supplied only through the relocation")
+print("  theorem's explicitly unadopted energy dictionary (Residual Atom 2)'.")
+print("  Part B therefore consumes an UNADOPTED dictionary and is conditional.")
+print("  Part A does not depend on Part B.")
+print()
+
+# uniform occupancy over n counted atoms gives singlet weight w = 1/n
+RUNGS = {n: (1 - Fraction(1, n)) / (2 * Fraction(1, n)) for n in range(1, 9)}
+print("  Uniform count on n atoms: w = 1/n, so r = (n-1)/2.")
+print("    " + ",  ".join(f"n={n}: r={v}" for n, v in RUNGS.items()))
+print()
+
+# reproduce the menu note's own stated pairs, exactly
+for w, r_expected in [(Fraction(1, 2), Fraction(1, 2)),
+                      (Fraction(1, 3), Fraction(1)),
+                      (Fraction(2, 3), Fraction(1, 4)),
+                      (Fraction(1, 4), Fraction(3, 2))]:
+    check(
+        f"menu-note arithmetic reproduced: w = {w} -> r = {r_expected}",
+        (1 - w) / (2 * w) == r_expected,
+        "all four pairs are quoted in the cited note; none is fitted here",
+    )
+
+print()
+for name in ("down-type quark", "up-type quark"):
+    c, s = SECTORS[name]
+    nearest = min(RUNGS.values(), key=lambda v: abs(v - c))
+    d = abs(c - nearest)
+    check(
+        f"{name}: strictly between rungs",
+        d / s > K,
+        f"nearest rung {nearest}, exact distance {float(d):.6f} = {float(d/s):.1f} sigma",
+    )
+
+c, s = SECTORS["charged lepton"]
+check(
+    "charged lepton: ON the n = 2 rung, within 1 sigma",
+    abs(c - Fraction(1, 2)) / s < 1,
+    f"distance from r = 1/2 is {float(abs(c-Fraction(1,2))/s):.1f} sigma",
+)
+
+
+section("C. EXACT: what the exclusion does NOT reach")
+
+print("  The excluded class is: candidate supplies that yield ONE numerical")
+print("  value of r shared by every sector.  A universal RULE whose input is")
+print("  sector-dependent registered content is NOT in that class and is NOT")
+print("  excluded.  The witness below is a two-line existence proof.")
+print()
+
+# a universal rule with sector-dependent input reproduces all three dials
+def universal_rule(w):
+    """One rule, applied to a per-sector registered weight w."""
+    return (1 - w) / (2 * w)
+
+
+for name, (c, _) in SECTORS.items():
+    w_needed = 1 / (1 + 2 * c)          # invert r = (1-w)/(2w)
+    check(
+        f"{name}: one rule reproduces the registered dial from w = {float(w_needed):.6f}",
+        universal_rule(w_needed) == c,
+        "exact inverse; shows the rule-level route is untouched by Part A",
+    )
+
+check(
+    "so Part A excludes sector-independent VALUES, not sector-blind rules",
+    True,
+    "this is the N5 narrowing and is load-bearing on the claim's wording",
+)
+
+
+section("D. Named walls, echoed from the note")
+
+WALLS = {
+    "W1 carrier universality":
+        "that all three sectors register the SAME C_3 hw=1 carrier is not "
+        "derived; the species bridge's across-fermion-type alignment residual "
+        "is explicitly open",
+    "W2 registration scale":
+        "the companion invariance theorem covers flavour-universal QCD running "
+        "only; SM Yukawa contributions to the mass anomalous dimension are "
+        "flavour-DEPENDENT, so a dial supplied at a different scale need not "
+        "equal the registered one",
+    "W3 energy dictionary":
+        "Part B's weight-to-dial coordinate rides on an explicitly unadopted "
+        "energy dictionary; Part A is independent of it",
+}
+for k, v in WALLS.items():
+    print(f"  {k}: {v}")
+    check(f"wall stated in the source note: {k.split()[0]}",
+          NOTE.exists() and k.split()[0] in NOTE.read_text(encoding="utf-8"))
+
+print()
+check("Part A is independent of walls W3", True,
+      "Part A uses no weight-to-dial coordinate at all")
+check("Part A is NOT independent of walls W1 and W2", True,
+      "both are stated as load-bearing conditions of the claim, not as caveats")
+
+
+section("E. Scope guards")
+
+if NOTE.exists():
+    text = NOTE.read_text(encoding="utf-8")
+    check("source note is present on the branch", True, NOTE.name)
+    for needle, why in [
+        ("This is not a no_go", "note refuses no_go classification"),
+        ("sector-independent", "note states the narrow excluded class"),
+        ("comparator", "note marks its numerics as comparators"),
+        ("prior art", "note defers the ladder arithmetic to prior art"),
+        ("proposed_retained", "note uses author-side status vocabulary only"),
+    ]:
+        check(f"note contains discipline marker: {needle!r}", needle in text, why)
+    for forbidden in ["effective_status", "audit_status"]:
+        check(f"note does not set {forbidden!r}", forbidden not in text,
+              "status authority stays with the independent audit lane")
+else:
+    check("source note is present on the branch", False, f"missing: {NOTE}")
+
+
+print()
+print("=" * 64)
+print(f"TOTAL: PASS={PASS}, FAIL={FAIL}")
+print("=" * 64)

--- a/scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
+++ b/scripts/frontier_sector_independent_dial_exclusion_bounded_2026_08_07.py
@@ -17,8 +17,16 @@ triple intersection, and the ladder distances.  No floating point and no
 randomness appears after the input declaration.
 
 This runner derives no dial value, asserts no no-go, and closes no obligation.
-It excludes one named class of candidate supplies, subject to three walls that
+It excludes one named class of candidate supplies, subject to FOUR walls that
 are stated in the note and echoed in Part D.
+
+Novelty boundary.  The qualitative content of Part A -- that one universal value
+of r cannot reproduce the distinct sector dials -- is PRIOR ART in this repo
+(FOURTH_AXIOM_RG_SCALE_DYNAMICS_SCOPING_2026-06-05, section 2.1, which already
+computes a best single universal value and reports that it misses a sector).
+What is new here is only the quantification: exact 5-sigma interval arithmetic,
+an exact minimax, and the common-scale comparators.  See the note's "Prior art"
+section.
 """
 
 from __future__ import annotations
@@ -118,22 +126,55 @@ for a, (ca, sa) in SECTORS.items():
         pull = abs(ca - cb) / sa
         print(f"    {a:16s} vs r* = {float(cb):.6f}: {float(pull):8.1f} sigma")
 
-# the weakest possible single value: the one minimising the largest pull
+# the weakest possible single value: the one minimising the largest pull.
+#
+# EXACT MINIMAX, not a grid scan.  P(r) = max_i |c_i - r| / s_i is a maximum of
+# V-shaped piecewise-linear functions, hence convex and piecewise linear, so its
+# minimum is attained at a breakpoint of the upper envelope.  Every breakpoint is
+# a crossing of a rising branch of one sector with a falling branch of another:
+#     (r - c_i)/s_i = (c_j - r)/s_j   =>   r = (s_i*c_j + s_j*c_i)/(s_i + s_j).
+# Enumerating all such crossings and taking the least value of P is therefore the
+# exact minimax, not an upper bound on it.  (A grid scan would only ever give an
+# UPPER bound, which is the wrong direction for an exclusion claim.)
 print()
 print("  Best-case single r*: minimise the largest pull over the three sectors.")
+print("  Exact minimax over all real r* (envelope-breakpoint enumeration).")
 best = None
-# exact scan on a rational grid fine enough to bracket the optimum, then report
-# the bound.  The bound is what matters, not the optimiser's precision.
-GRID = [Fraction(i, 2000) for i in range(1000, 1801)]
-for rstar in GRID:
+for (ca, sa), (cb, sb) in combinations(SECTORS.values(), 2):
+    rstar = (sa * cb + sb * ca) / (sa + sb)
     worst = max(abs(c - rstar) / s for c, s in SECTORS.values())
     if best is None or worst < best[1]:
         best = (rstar, worst)
 check(
     "even the best single r* is excluded by at least one sector",
     best[1] > K,
-    f"argmin r* = {float(best[0]):.4f}, largest pull there = {float(best[1]):.1f} sigma",
+    f"exact argmin r* = {float(best[0]):.7f}, largest pull there = "
+    f"{float(best[1]):.4f} sigma",
 )
+check(
+    "the exclusion does not depend on the choice of K",
+    best[1] > K,
+    f"T1 holds for every K < {float(best[1]):.4f}; K = {K} is far inside that range",
+)
+
+# ---------------------------------------------------------------------------
+# ROBUSTNESS: the input uncertainties are SYMMETRIC Gaussian linear propagations
+# of PDG inputs, several of which (m_u, m_d, m_s) have strongly ASYMMETRIC
+# published errors.  Symmetrising is only safe if the conclusion has margin
+# against inflating sigma.  These checks report the exact factor by which the
+# quoted sigmas would have to grow before T1 fails, so a reader can compare that
+# factor against the published asymmetry directly instead of trusting the
+# symmetrisation.
+# ---------------------------------------------------------------------------
+print()
+print("  Robustness of T1 to inflated (e.g. asymmetric-error) uncertainties:")
+for (n1, (c1, s1)), (n2, (c2, s2)) in combinations(SECTORS.items(), 2):
+    factor = abs(c1 - c2) / (K * (s1 + s2))
+    check(
+        f"{n1} / {n2} stay disjoint under uniform sigma inflation up to x{float(factor):.2f}",
+        factor > 1,
+        f"exact break-even inflation factor = {float(factor):.3f}",
+    )
 
 
 section("B. EXACT but WALL-CONDITIONAL: the uniform-count ladder")
@@ -183,6 +224,19 @@ check(
     f"distance from r = 1/2 is {float(abs(c-Fraction(1,2))/s):.1f} sigma",
 )
 
+# same asymmetric-error robustness question as Part A, for the ladder distances
+print()
+print("  Robustness of the 'strictly between rungs' finding to inflated sigma:")
+for name in ("down-type quark", "up-type quark"):
+    c, s = SECTORS[name]
+    nearest = min(RUNGS.values(), key=lambda v: abs(v - c))
+    factor = abs(c - nearest) / (K * s)
+    check(
+        f"{name} stays off-rung under sigma inflation up to x{float(factor):.2f}",
+        factor > 1,
+        f"exact break-even inflation factor = {float(factor):.3f}",
+    )
+
 
 section("C. EXACT: what the exclusion does NOT reach")
 
@@ -206,10 +260,15 @@ for name, (c, _) in SECTORS.items():
         "exact inverse; shows the rule-level route is untouched by Part A",
     )
 
+# The existence proof is only meaningful if the one rule genuinely needs THREE
+# DIFFERENT inputs; if the three required weights coincided, the "rule" would be
+# a disguised sector-independent value and Part A would exclude it after all.
+w_required = [1 / (1 + 2 * c) for c, _ in SECTORS.values()]
 check(
-    "so Part A excludes sector-independent VALUES, not sector-blind rules",
-    True,
-    "this is the N5 narrowing and is load-bearing on the claim's wording",
+    "the surviving rule-level route needs three DISTINCT sector inputs",
+    len(set(w_required)) == 3,
+    "so it is genuinely outside the class Part A excludes, not a disguised "
+    "single value; this is the N5 narrowing and is load-bearing on the wording",
 )
 
 
@@ -225,9 +284,15 @@ WALLS = {
         "only; SM Yukawa contributions to the mass anomalous dimension are "
         "flavour-DEPENDENT, so a dial supplied at a different scale need not "
         "equal the registered one",
-    "W3 energy dictionary":
+    "W3 energy dictionary (Part B only)":
         "Part B's weight-to-dial coordinate rides on an explicitly unadopted "
-        "energy dictionary; Part A is independent of it",
+        "energy dictionary; Part A is independent of THIS dictionary",
+    "W4 mass-to-dial dictionary (Part A too)":
+        "the comparators are not measured r; they are computed from PDG masses "
+        "through the C_3-circulant (Brannen) ansatz and the sqrt(m) one-leg "
+        "amplitude identification, which the quark circulant source-law "
+        "boundary note records as NON-RETAINED inputs.  Part A escapes W3 but "
+        "rides W4, which is a dictionary of the same kind",
 }
 for k, v in WALLS.items():
     print(f"  {k}: {v}")
@@ -235,10 +300,11 @@ for k, v in WALLS.items():
           NOTE.exists() and k.split()[0] in NOTE.read_text(encoding="utf-8"))
 
 print()
-check("Part A is independent of walls W3", True,
-      "Part A uses no weight-to-dial coordinate at all")
-check("Part A is NOT independent of walls W1 and W2", True,
-      "both are stated as load-bearing conditions of the claim, not as caveats")
+print("  Part A is independent of W3 (it uses no weight-to-dial coordinate at")
+print("  all), but is NOT independent of W1, W2 or W4.  All three are stated in")
+print("  the note as load-bearing conditions of the claim, not as caveats.")
+print("  'T1 survives if T2 falls' therefore means only that T1 escapes W3 --")
+print("  it does NOT mean T1 is free of dictionary dependence.")
 
 
 section("E. Scope guards")
@@ -252,6 +318,11 @@ if NOTE.exists():
         ("comparator", "note marks its numerics as comparators"),
         ("prior art", "note defers the ladder arithmetic to prior art"),
         ("proposed_retained", "note uses author-side status vocabulary only"),
+        ("FOURTH_AXIOM_RG_SCALE_DYNAMICS_SCOPING_2026-06-05",
+         "note credits the prior art that already states Part A qualitatively"),
+        ("W4", "note names the mass-to-dial dictionary wall that Part A rides"),
+        ("does not resolve on this branch",
+         "note is explicit that its comparator source is not present yet"),
     ]:
         check(f"note contains discipline marker: {needle!r}", needle in text, why)
     for forbidden in ["effective_status", "audit_status"]:


### PR DESCRIPTION
> **BLOCKED ON #6020 — do not land or audit this first.** Every number in T1 and
> T2 is consumed from the common-scale comparator note produced there. That file
> is **not present in this branch**, so the markdown link to it **does not
> resolve** and the citation graph cannot seed the edge that carries all of this
> note's inputs. **Land #6020 first.** If those comparators move, T1 and T2 must
> be re-run.

## Review pass (2026-08-07) changed the claim — read this before the checklist below

A review pass added a fourth wall, credited prior art, and narrowed the novelty
claim. **The N1–N8 checklist further down predates that pass**; where they
disagree, the note is authoritative. Deltas:

| # | Finding | Disposition |
|---|---|---|
| 1 | **The observation is prior art.** `FOURTH_AXIOM_RG_SCALE_DYNAMICS_SCOPING_2026-06-05` §2.1 already states T1 qualitatively ("the best single universal value … still misses a sector by `0.137`; a single scale-invariant fixed point gives one number and is falsified by the quark sectors") and §5 already states T1's forward constraint. The max-record-entropy and gauge-representation-channel no-gos carry the `r = 1/2` special case. **N1's route table and N3's hidden-wall scan were run without a prior-art sweep.** | Fixed: prior-art section added, all three cited, novelty narrowed to *the quantification only*. The prior note is `Type: meta` / non-claim, so this is a promotion-with-error-bars, not a duplication — but it must not be read as a new observation. |
| 2 | **A fourth wall was missing.** The comparators are computed from PDG masses through the C₃-circulant (Brannen) ansatz and the `√m` one-leg-amplitude identification, both recorded as **non-retained** by `QUARK_C3_CIRCULANT_SOURCE_LAW_BOUNDARY_NOTE_2026-04-28`. | Fixed: **W4 (mass-to-dial dictionary)** added. T1 escapes W3 but rides W4. "T1 stands if T2 falls" no longer implies T1 is dictionary-free. Wall count 3 → 4. |
| 3 | **Comparators silently superseded four landed notes** (`0.597`/`0.773` → `0.621090`/`0.830971`), and moved in the direction that *strengthens* T1. | Fixed and stated plainly. `Q = Σm/(Σ√m)²` is homogeneous of degree zero, so a common rescaling cannot move the dial; the whole shift is the mixed-mass-convention artifact. Downstream reconciliation of the four notes is **not** done here. |
| 4 | **The 149.5σ minimax was a rational grid scan**, which gives an *upper* bound on the minimax — the wrong direction for an exclusion claim. | Fixed: exact convex piecewise-linear envelope-breakpoint enumeration. Exact value **149.4807σ**. T1 additionally shown **K-independent** for every `K < 149.48`. |
| 5 | **Symmetrised errors were an unquantified modelling choice** (`m_u`, `m_d`, `m_s` have strongly asymmetric PDG errors). | Fixed: exact σ-inflation break-even factors now computed. Binding case is **down-type at 3.30×**; published arm asymmetries are far below that, so the down-type conclusion survives — but 3.3× is a stated condition, not a harmless convenience. |
| 6 | Three of the 29 checks were `check(..., True, ...)` fiat assertions. | Fixed: replaced by a real distinctness test or demoted to prose. |
| 7 | **Comparator firewall verified clean.** Every load-bearing comparison is `Fraction`; floats appear only inside `print` formatting. | No change needed. |
| 8 | **N4 residual-matching judgement verified correct.** `ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04`'s residual really is the `F_C`/`F_R` non-selection; it is rightly not cited as a witness. The W3 quote is verbatim and in context. | No change needed. |

Runner **37/37** (was 29/29), exact `Fraction` arithmetic downstream of the
comparator input declaration; cache regenerated and fresh.

## Claim (as reviewed)

**T1 (exact).** A *candidate sector-independent supply* is one whose output is a
single numerical `r` shared by every fermion sector. No such value exists within
5σ of all three common-scale dial comparators — the intervals are pairwise
disjoint, the triple intersection is empty, and the exact minimax still sits
**149.4807σ** from at least one sector. The σ figure is large mainly because the
charged-lepton dial is pinned to `1.0e-5`; the *physical* separation at the
minimax is `Δr ≈ 0.33`.

| sector | comparator `r` |
|---|---|
| charged lepton | 0.499990767 ± 0.0000102 (0.9σ from exactly 1/2) |
| down-type quark | 0.621090 ± 0.007335 |
| up-type quark | 0.830971 ± 0.002204 |

**T2 (exact, conditional on W3 and W4).** Uniform occupancy over `n` atoms gives
`w = 1/n`, hence the ladder `r = (n−1)/2`. Leptons sit **on** the `n = 2` rung
(0.9σ); both quark dials sit **strictly between** rungs, 16.5σ and 76.7σ from
the nearest.

## The four walls

- **W1 — carrier universality.** That all three sectors register the same C₃ `hw=1` carrier is not derived; the species bridge lists across-fermion-type alignment as an open residual.
- **W2 — registration scale.** The companion invariance theorem covers flavour-universal QCD running only; SM Yukawa contributions to the mass anomalous dimension are flavour-*dependent*.
- **W3 — energy dictionary (T2 only).** The weight-to-dial coordinate is supplied only through an explicitly unadopted, support-only energy dictionary.
- **W4 — mass-to-dial dictionary (T1 and T2).** The comparators ride the non-retained C₃-circulant ansatz and `√m` one-leg-amplitude reading.

All four are pairwise independent. T1 carries W1, W2, W4; T2 carries all four.

## N1–N8 gate checklist (as originally drafted — superseded where it conflicts with the table above)

**N1 — alternative routes (6 named, ≥5 required).**

| # | route | outcome |
|---|---|---|
| R1 | The spread is a mass-scheme/mixed-convention artifact | **ATTEMPTED, closed** by the common-rescaling invariance theorem (#6020): dial stable to 2.4e-12 across six common scales |
| R2 | Quarks don't register the same C₃ carrier, so `r` isn't one observable | **OPEN → wall W1**; `SPECIES_BRIDGE_MINIMUM_DECOMPOSITION_..._2026-06-13` explicitly excludes across-fermion-type alignment |
| R3 | The framework supplies `r` at another scale; SM Yukawa running is flavour-*dependent* | **OPEN → wall W2**; #6020 covers QCD running only |
| R4 | A universal rule with sector-dependent registered input | **OUT OF SCOPE by construction** — see N5 |
| R5 | A different C₃ coordinatization makes the dials agree | ~~ATTEMPTED, closed~~ — **superseded by review: this is now wall W4.** The original closure argument (that changing the `√m` coordinate breaks the leptonic `Q = 2/3` that motivates the lane) is motivational, not a closure |
| R6 | `r` isn't a count, so "between rungs" proves nothing | **PARTIAL → wall W3**; T1 does not depend on it |

*(Missing from this table, added by review: the route "this is already recorded in the repo." It is — see the review table, item 1.)*

**N2 — wall independence.** All pairs independent. Wall count is now **4**, of which T1 carries 3 and T2 carries 4.

**N3 — hidden-wall scan.** Hits on "registered" → wall W2. Hit on "standard" for QCD flavour-universality → explicitly supplied condition in #6020. PDG inputs annotated as external comparators. **Review found one hidden wall this scan missed: the mass-to-dial dictionary, now W4.**

**N4 — residual matching.** `ACPHILAMBDA_RECORD_OUTCOME_ORBIT_OCCUPANCY_NON_SUPPLY_NO_GO_NOTE_2026-07-04` attacks the residual "the axioms do not select `F_C` vs `F_R`"; this note's residual is "no single numerical `r` fits three sectors." **Residuals differ → citation dropped as a witness**, retained only as complementary context. Witness count after dropping: 0. *Review verified this against the cited note: correct.*

**N5 — rhetoric audit.** "No sector-blind supply" tested at resolutions *value* / *rule* / *input*. Verified only at **value**; the broader phrase does not appear in the note. Runner Part C gives the existence proof that rule-level supplies survive — *and, after review, additionally checks that the surviving rule genuinely needs three distinct inputs, so it is not a disguised single value.*

**N6 — partial-closure path scan.** A convention-level reframe *does* dissolve this wall: declaring the grain to be per-sector registered data rather than axiom content. Reported rather than suppressed; the note does **not** say "a new axiom is required." Primitive registry check run — the three approved primitives each declare they supply no dimensionless quantity, weighting rule, or probability rule, so no "no retained primitive supplies this" language is used.

**N7 — steelman (this is why it's demoted).** *"Your comparison presupposes the quark sectors register the same C₃ object as the leptons — precisely the across-fermion-type alignment the species bridge note lists as an open residual. Grant that, and you still assume the framework's `r` is the low-scale registered one; your own invariance theorem only covers QCD, and SM Yukawa contributions to `γ_m` are flavour-dependent, so a substrate-scale `r` could be universal and run apart. You have excluded a value nobody claimed, at a scale you did not establish, for an observable you did not show is the same across sectors."* **Review extends the steelman: "…and computed through a mass-to-dial dictionary your own repo records as non-retained."** That is why this ships bounded-with-named-walls.

**N8 — cross-cycle echo.** Structurally similar walls here have been retired by **reframe** (moving a residual from physics to convention). That mechanism applies and is named in the note as the route the claim does not reach.

**Verdict: demoted, then PASS at the narrowed scope — with novelty reduced to quantification and a fourth wall added in review.**

## Non-claims

Not a no_go. Asserts no route is structurally closed. Derives no `r`, `Q`, `δ`,
mass, scale, mixing angle, probability rule, species map, or sector weight —
every number is an external comparator. **The observation is not new**; only the
error bars, the exact minimax, the K-independence, and the common-scale
comparators are. **T1 is not dictionary-free** — it escapes W3 and rides W4.
Makes no claim about *why* the sectors differ, or that Admissibility supplies
the difference. Does not reconcile the four landed notes that still carry the
superseded `0.597`/`0.773` values. No axiom, primitive, registry entry, or audit
verdict added, edited, retired, or predicted; status authority is the
independent audit lane alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEnGMUdwTHWaaAH43odZqx)_