### PR TITLE
docs: add AGENTS.md executor guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — executor guardrails
+
+Baseline for all automated executors (codex, subagents) working in this
+repository. Per-dispatch spec text adds to this file; it never overrides it.
+
+## Anti-fabrication (mandatory)
+
+- Never fabricate a numeric result, a runner output, or a PASS line. If a
+  computation did not run, say so.
+- Never fit a scalar prefactor to force a match with a target value; derive it
+  or report the honest residual.
+- Derive, don't hard-code: a runner must compute the claimed value, never embed
+  the expected constant and compare it to itself.
+- Report failures verbatim. A FAIL honestly reported is good work; a masked
+  FAIL is fabrication.
+
+## Runner discipline
+
+- Runner stdout stays under 6000 characters.
+- Print a final summary line `TOTAL: PASS=<n> FAIL=<n>`; a green claim requires
+  FAIL=0.
+- Check bounds at pass tolerances; do not print platform-dependent noise digits
+  (1e-13…1e-19 tails) as if they were results.
+
+## Scope limits
+
+- No `git commit`, `git push`, or network access in analysis dispatches; edit
+  only where the dispatch says.
+- Never edit audit or ledger surfaces (effective-status data, queues, shards,
+  grade fields). Audit status is set only by the independent audit lane.
+- Use framework terms in prose and notes; no ad-hoc coinages or internal
+  shorthand indices.
+
+## Canonical sources
+
+- Axioms: `git show origin/main:docs/MINIMAL_AXIOMS_2026-06-29.md` — a working
+  tree can be stale; origin/main is the only status authority.
+- Terminology: `docs/KEY_TERMINOLOGY.md` (same rule: read it from origin/main).


### PR DESCRIPTION
## Summary
- Adds a repo-root `AGENTS.md` — the baseline guardrail file automated executors (codex reads `AGENTS.md` from the worktree root automatically) pick up on every dispatch.
- Today the anti-fabrication and runner-discipline rules ride only on per-dispatch spec text — a single point of failure. This makes them defense-in-depth: the file holds the floor, dispatch text adds to it.

## Changes
- `AGENTS.md` (new, 38 lines): anti-fabrication (no fabricated results/PASS lines, no fitted scalar prefactors, derive-don't-hardcode, report FAILs verbatim); runner discipline (stdout <6000 chars, `TOTAL: PASS=n FAIL=0` summary, pass-tolerance bounds not noise digits); scope limits (no commit/push/network in analysis dispatches, never edit audit/ledger surfaces, framework terms only); canonical sources read via `git show origin/main:` (a working tree can be stale).

## Test Plan
- Docs-only; no runners, notes, or audit surfaces touched. Content distilled from the standing dispatch rules in `.claude/commands/workhorse.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)