### PR TITLE
docs: point root agent docs at the standing ai/execution branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — pointer
+
+Agent instructions for this repository live on the standing `ai/execution`
+branch (an orphan branch that never merges into `main`), alongside the other
+AI planning surfaces. Read them from any checkout without touching your
+working tree:
+
+```bash
+git fetch origin ai/execution --quiet
+git show origin/ai/execution:AGENTS.md
+```
+
+`origin/main` remains the sole authority for science content and audit
+status; the `ai/execution` branch holds planning and instruction material
+only. Do not check its files out into a `main` working tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
 # Repository AI Model Policy
 
 Use the best available model for all AI-assisted tasks in this repository.
+
+AI planning surfaces (agent instructions, TOE closure scorecard) live on the
+standing `ai/execution` branch, which never merges into `main`:
+`git fetch origin ai/execution --quiet && git show origin/ai/execution:README.md`.


### PR DESCRIPTION
## Summary
- Adds a pointer-only `AGENTS.md` at the repo root: agent instructions live on the standing `ai/execution` branch (orphan; never merges into `main`), read via `git show origin/ai/execution:AGENTS.md`.
- Adds the matching two-line pointer to `CLAUDE.md` so sessions discover the branch.

## Why
- Keeps `main` the sole authority for science content and audit status while giving instruction/planning material a versioned home that stays out of the citation surface.
- Supersedes #6023 (its guardrail content landed on `ai/execution` instead of `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)