### PR TITLE
science-fix-loop: land the packet with the PR, recover archived defect reports, surface the backlog

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -128,6 +128,7 @@ jobs:
             python3 docs/audit/scripts/repair_missing_dependency_edges.py --apply
             bash docs/audit/scripts/run_pipeline.sh
             python3 docs/audit/scripts/generate_conditional_prompts.py
+            python3 docs/audit/scripts/compute_science_fix_backlog.py
             commit_if_needed || exit 0
           done
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -75,6 +75,15 @@ jobs:
         # been re-audited.
         run: python3 docs/audit/scripts/generate_conditional_prompts.py
 
+      - name: Compute science-fix backlog surface
+        # science_fix_backlog.json is the durable summary of every surface
+        # the science-fix-loop can drain: applied non-clean verdicts,
+        # archived-advisory defect reports that survive ledger-wide
+        # invalidations, and evidence-repair rows grouped by gate family.
+        # Runs after the pipeline so audit_queue.json exists. Summary only:
+        # no verdict, no premise, no audit authority.
+        run: python3 docs/audit/scripts/compute_science_fix_backlog.py
+
       - name: Commit refreshed ledger / queue
         run: |
           set -e
@@ -129,6 +138,7 @@ jobs:
           name: audit-queue-${{ github.run_id }}
           path: |
             docs/audit/data/audit_queue.json
+            docs/audit/data/science_fix_backlog.json
             docs/audit/data/effective_status_summary.json
             docs/audit/data/cycle_inventory.json
             docs/publication/ci3_z3/PUBLICATION_AUDIT_DIVERGENCE.md

--- a/docs/ai_methodology/skills/no-go-discipline/SKILL.md
+++ b/docs/ai_methodology/skills/no-go-discipline/SKILL.md
@@ -49,8 +49,9 @@ Skills that must invoke this gate before approving negative-claim output:
 
 Each item must be answered IN WRITING in the cycle's `CLAIM_STATUS_CERTIFICATE.md`
 (or in a dedicated `NO_GO_DISCIPLINE_CHECKLIST.md`) before the negative claim
-can ship. The checklist must be visible in the PR body or review verdict so
-the audit lane and reviewers can see exactly what was tested.
+can ship. The checklist must LAND as a committed artifact (see Output below)
+so the audit lane and reviewers can see exactly what was tested. Copying it
+into the PR body or review verdict as well is a courtesy, not the record.
 
 ### N1 — Alternative route enumeration
 
@@ -267,8 +268,10 @@ If the gate produces `FAIL`:
 
 If the gate produces `PASS`:
 
-- ship the negative claim with the checklist visible in the PR body or
-  review verdict;
+- ship the negative claim with both Output artifacts LANDING in the same PR:
+  the N1-N8 checklist as a committed artifact, and the N5 execution
+  certificate in the primary runner's cached stdout. A PR-body-only copy
+  does not satisfy this;
 - the independent audit lane and other reviewers can then see exactly what
   was tested and what alternative routes were closed.
 

--- a/docs/ai_methodology/skills/no-go-discipline/SKILL.md
+++ b/docs/ai_methodology/skills/no-go-discipline/SKILL.md
@@ -225,7 +225,29 @@ the no-go is premature.
 
 A `NO_GO_DISCIPLINE_CHECKLIST.md` (or a `## No-Go Discipline Gate` section
 in `CLAIM_STATUS_CERTIFICATE.md`) recording the answers to N1-N8 verbatim.
-The output must be present in the PR body or review verdict.
+
+**The packet must LAND with the PR — a PR body is not a landing surface.**
+The single largest audit-invalidation class in this repo's history is the
+no-go-discipline packet family (1,560 voided verdicts, 799 of them in one
+day for `no_go_discipline_packet_missing`): packets that existed at review
+time but did not land as evidence the audit could bind. Two artifacts are
+therefore required to land IN the PR, not merely appear in its body:
+
+1. **The N1-N8 checklist as a committed artifact** — a `## No-Go Discipline
+   Gate` section in the source note itself, or a committed sidecar
+   `NO_GO_DISCIPLINE_CHECKLIST.md` the note links. Copying it into the PR
+   body as well is fine, but the PR body copy is a courtesy, not the record.
+2. **The N5 execution certificate in the primary runner's cached stdout** —
+   one line per resolution class (`per_element:`, `per_site:`, `per_mode:`,
+   `per_block:`, `lattice_wide:`), each an honest, substantive (>= 40 char)
+   statement of what the runner actually resolves at that granularity,
+   using the form "checked and not executed — <reason>" where a class is
+   genuinely not exercised. `docs/audit/scripts/forensic_evidence_readiness.py`
+   is the validator; `docs/audit/scripts/check_changed_audit_evidence.py`
+   checks it at review time against the staged changes.
+
+A negative-claim PR whose packet artifacts are not landing with it fails
+this gate even when the checklist is complete and correct.
 
 Status: `PASS` if all 8 checks have answers and no failure conditions are
 hit. `FAIL` if any failure condition is hit.

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -1098,6 +1098,37 @@ labels, draft-branch vocabulary, campaign names, and noncanonical theory
 phrases must be rewritten into repo-native language or explicitly deferred in
 `docs/repo/ACTIVE_REVIEW_QUEUE.md`; do not land them silently.
 
+13. **Landed-evidence PASS gate (hard).** Audit evidence must LAND with the
+PR, not live in its body. For every branch-changed note or runner whose row
+the audit lane will consume, run
+
+```bash
+python3 docs/audit/scripts/check_changed_audit_evidence.py
+```
+
+and treat any reported `forensic_evidence_ready: false` on an affected row as
+a blocking finding. In particular, for negative-claim-shaped changes (notes
+whose rhetoric trips the N5 scan phrases in
+`docs/audit/scripts/no_go_discipline_gate.py`):
+
+- the primary runner's cached stdout must carry the five-line N5 execution
+  certificate (`per_element:`, `per_site:`, `per_mode:`, `per_block:`,
+  `lattice_wide:` — each honest and substantive, using "checked and not
+  executed — <reason>" where a class is genuinely not exercised); and
+- the N1-N8 checklist required by the no-go-discipline gate must be a
+  committed artifact (a `## No-Go Discipline Gate` section in the note or a
+  committed sidecar), not only PR-body text.
+
+Rationale: packets that existed at review time but did not land are the
+largest audit-invalidation class in repo history (1,560 voided verdicts;
+799 in one day for `no_go_discipline_packet_missing`). A PASS with
+un-landed evidence recreates that failure mode. Repairing the evidence
+(adding honest certificate lines, landing the checklist) is in scope for
+the review; fabricating resolution coverage is not — a runner that
+genuinely cannot certify a resolution class states so honestly, and if the
+claim's rhetoric then over-reaches the certificate, the claim is narrowed,
+not the certificate padded.
+
 The review loop must not run `docs/audit/scripts/apply_audit.py` and must not
 write `audit_status`, `audited_clean`, or other audit verdicts. If the branch
 introduces retained-grade `claim_type` rows, report those claim IDs in the

--- a/docs/ai_methodology/skills/science-fix-loop/SKILL.md
+++ b/docs/ai_methodology/skills/science-fix-loop/SKILL.md
@@ -82,8 +82,9 @@ Only complete, applied `audited_conditional`, `audited_renaming`,
 
 After a ledger-wide invalidation (premise-epoch reset, packet-requirement
 change), zero applied verdicts exist and lane 1 is empty — but the archived
-non-clean rationales in `previous_audits[]` still name source defects the
-invalidating event did not repair. Recover them as ADVISORY candidates:
+non-clean rationales and canonical repair instructions
+(`notes_for_re_audit_if_any`) in `previous_audits[]` still name source defects
+the invalidating event did not repair. Recover them as ADVISORY candidates:
 
 ```bash
 python3 scripts/science_fix_loop.py --from-archived --dry-run

--- a/docs/ai_methodology/skills/science-fix-loop/SKILL.md
+++ b/docs/ai_methodology/skills/science-fix-loop/SKILL.md
@@ -78,6 +78,32 @@ python3 scripts/science_fix_loop.py --dry-run
 Only complete, applied `audited_conditional`, `audited_renaming`,
 `audited_failed`, and `audited_numerical_match` records enter this lane.
 
+### 1b. Archived advisories (post-invalidation recovery)
+
+After a ledger-wide invalidation (premise-epoch reset, packet-requirement
+change), zero applied verdicts exist and lane 1 is empty — but the archived
+non-clean rationales in `previous_audits[]` still name source defects the
+invalidating event did not repair. Recover them as ADVISORY candidates:
+
+```bash
+python3 scripts/science_fix_loop.py --from-archived --dry-run
+```
+
+Selection is conservative: only rows whose LAST archived verdict is
+non-clean qualify (a trailing clean means the defect was repaired and
+re-audited before the reset, so plain re-audit is the right next step).
+Archived verdicts are VOID and authorize nothing: every worker prompt binds
+reproduce-first discipline — verify the named defect on current
+`origin/main`, make no edit when it is already settled, and report
+"settled on main" with evidence. The independent audit lane re-decides
+everything.
+
+The consolidated backlog across all lanes (applied, archived-advisory,
+evidence-repair by gate family) is generated nightly to
+`docs/audit/data/science_fix_backlog.json` by
+`docs/audit/scripts/compute_science_fix_backlog.py`; read it first when
+deciding where to drain.
+
 ### 2. Campaign quarantines
 
 Render the typed recovery plan first:

--- a/docs/audit/data/dependency_policy_epoch.json
+++ b/docs/audit/data/dependency_policy_epoch.json
@@ -9,7 +9,7 @@
     "docs/audit/data/source_path_aliases.json": "f99befd84da12bba9a39659fcb30fd98e4065873f80de19942110a8249297638",
     "docs/audit/data/tier_a_admissions.json": null,
     "docs/audit/scripts/audit_science_fingerprint.py": "23ca0c90aff6cc0f3f53e63d2930a8751e1d5dfffa3357debed0a1d9906f5348",
-    "docs/audit/scripts/build_citation_graph.py": "e09dbee45c074c5f62f0133fa1261bee95b8671adae9147584febb3b658a541e",
+    "docs/audit/scripts/build_citation_graph.py": "20698263cbf6ad82569f15ceee0642525f18c9c093d329be1149253217d33415",
     "docs/audit/scripts/classify_runner_passes.py": "00bbc8c1dadef177542b0a98c75ead2e15c13c94c4b5595406d9818ec9129289",
     "docs/audit/scripts/compute_audit_queue.py": "9cfe60140554ac19c38bfd8637d3a5348b665beae6059d61e127af1b9cba1ff6",
     "docs/audit/scripts/compute_effective_status.py": "f0a78fd0679b6c94684224af74938a6b6f108f64b32bbb713470827eac4ac422",

--- a/docs/audit/data/science_fix_backlog.json
+++ b/docs/audit/data/science_fix_backlog.json
@@ -1,0 +1,33 @@
+{
+ "schema": "science_fix_backlog_v1",
+ "authority": "generated summary only; no verdict, no premise, no audit authority; archived_advisory entries are VOID verdicts whose defect reports must be re-verified on current main before any edit",
+ "applied_non_clean": {
+  "total": 0,
+  "by_verdict": {}
+ },
+ "archived_advisory": {
+  "total": 233,
+  "by_verdict": {
+   "audited_failed": 121,
+   "audited_numerical_match": 34,
+   "audited_renaming": 78
+  },
+  "unmapped_category_records": 1024
+ },
+ "evidence_repair": {
+  "queue_available": true,
+  "total": 481,
+  "by_gate_family": {
+   "forensic_n5_execution_certificate_incomplete": 448,
+   "forensic_runner_cache_not_fresh": 20,
+   "runner_declared_inputs_invalid": 8,
+   "forensic_n5_runner_missing": 5
+  },
+  "note": ""
+ },
+ "drain_commands": {
+  "applied_non_clean": "python3 scripts/science_fix_loop.py --dry-run",
+  "archived_advisory": "python3 scripts/science_fix_loop.py --from-archived --dry-run",
+  "evidence_repair": "see docs/audit/data/audit_queue.json rows with audit_work_kind=evidence_repair_required"
+ }
+}

--- a/docs/audit/data/science_fix_backlog.json
+++ b/docs/audit/data/science_fix_backlog.json
@@ -6,13 +6,15 @@
   "by_verdict": {}
  },
  "archived_advisory": {
-  "total": 233,
+  "total": 954,
   "by_verdict": {
+   "audited_conditional": 721,
    "audited_failed": 121,
    "audited_numerical_match": 34,
    "audited_renaming": 78
   },
-  "unmapped_category_records": 1024
+  "unmapped_category_records": 302,
+  "incomplete_records": 1
  },
  "evidence_repair": {
   "queue_available": true,

--- a/docs/audit/scripts/compute_science_fix_backlog.py
+++ b/docs/audit/scripts/compute_science_fix_backlog.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Compute the consolidated science-fix backlog surface.
+
+Writes ``docs/audit/data/science_fix_backlog.json``: a generated, read-only
+summary of every surface the science-fix-loop can drain, so the repair lane
+survives ledger-wide invalidations and the nightly workflow can show the true
+repair backlog even when zero applied verdicts exist.
+
+Surfaces summarized:
+
+1. ``applied_non_clean`` — live applied non-clean verdicts (the fix-loop's
+   primary lane; empty immediately after any mass invalidation).
+2. ``archived_advisory`` — rows whose LAST archived audit in
+   ``previous_audits[]`` carries a non-clean scientific verdict while the live
+   row is ``unaudited``.  These are ADVISORY: the archived verdict is void and
+   authorizes nothing; the count exists so recorded defect-finding stays
+   visible across resets.  ``archived_advisory_unmapped`` counts archived
+   non-clean records whose repair target predates the category-prefix
+   convention and therefore cannot be routed automatically.
+3. ``evidence_repair`` — rows the audit queue marks ``evidence_repair_required``,
+   grouped by gate family (e.g. the forensic N5 execution certificate).
+
+This script writes a generated data surface only.  It mints no verdict, edits
+no ledger row, and carries no audit authority.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LEDGER_DIR = REPO_ROOT / "docs" / "audit" / "data" / "ledger"
+QUEUE_PATH = REPO_ROOT / "docs" / "audit" / "data" / "audit_queue.json"
+OUT_PATH = REPO_ROOT / "docs" / "audit" / "data" / "science_fix_backlog.json"
+
+APPLIED_NON_CLEAN = (
+    "audited_conditional",
+    "audited_failed",
+    "audited_renaming",
+    "audited_numerical_match",
+)
+
+CONDITIONAL_PREFIXES = (
+    "runner_artifact_issue",
+    "scope_too_broad",
+    "missing_dependency_edge",
+    "missing_bridge_theorem",
+)
+
+
+def _mapped_category(verdict: str, repair_target: str) -> bool:
+    """Mirror of scripts/science_fix_loop.py:audit_repair_category coverage."""
+    if verdict in ("audited_renaming", "audited_failed", "audited_numerical_match"):
+        return True
+    if verdict == "audited_conditional":
+        prefix = repair_target.split("—", 1)[0].split(":", 1)[0].strip().lower()
+        return prefix in CONDITIONAL_PREFIXES
+    return False
+
+
+def _gate_family(issue: str) -> str:
+    """Collapse a readiness-issue string to its stable gate-family prefix."""
+    return issue.split(":", 1)[0].strip() or "unknown"
+
+
+def main() -> int:
+    applied = Counter()
+    applied_rows: list[str] = []
+    advisory = Counter()
+    advisory_rows: list[str] = []
+    advisory_unmapped = 0
+
+    for shard in sorted(LEDGER_DIR.glob("*/*.json")):
+        try:
+            row = json.loads(shard.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(row, dict):
+            continue
+        claim_id = str(row.get("claim_id") or shard.stem)
+        status = row.get("audit_status")
+        if status in APPLIED_NON_CLEAN:
+            applied[status] += 1
+            applied_rows.append(claim_id)
+            continue
+        if status != "unaudited":
+            continue
+        archived = row.get("previous_audits") or []
+        if not isinstance(archived, list) or not archived:
+            continue
+        last = archived[-1]
+        if not isinstance(last, dict):
+            continue
+        verdict = last.get("audit_status")
+        if verdict not in APPLIED_NON_CLEAN:
+            continue
+        if _mapped_category(str(verdict), str(last.get("repair_target") or "")):
+            advisory[str(verdict)] += 1
+            advisory_rows.append(claim_id)
+        else:
+            advisory_unmapped += 1
+
+    evidence = Counter()
+    evidence_total = 0
+    queue_available = QUEUE_PATH.exists()
+    if queue_available:
+        try:
+            queue = json.loads(QUEUE_PATH.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            queue = {}
+            queue_available = False
+        rows = (
+            queue.get("queue") if isinstance(queue, dict) else None
+        ) or (queue.get("rows") if isinstance(queue, dict) else None)
+        for entry in rows if isinstance(rows, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            issue = entry.get("forensic_evidence_readiness_issue")
+            if entry.get("audit_work_kind") != "evidence_repair_required" and not issue:
+                continue
+            issue = issue or entry.get("audit_work_reason") or "unknown"
+            evidence[_gate_family(str(issue))] += 1
+            evidence_total += 1
+
+    payload = {
+        "schema": "science_fix_backlog_v1",
+        "authority": (
+            "generated summary only; no verdict, no premise, no audit "
+            "authority; archived_advisory entries are VOID verdicts whose "
+            "defect reports must be re-verified on current main before any "
+            "edit"
+        ),
+        "applied_non_clean": {
+            "total": sum(applied.values()),
+            "by_verdict": dict(sorted(applied.items())),
+        },
+        "archived_advisory": {
+            "total": sum(advisory.values()),
+            "by_verdict": dict(sorted(advisory.items())),
+            "unmapped_category_records": advisory_unmapped,
+        },
+        "evidence_repair": {
+            "queue_available": queue_available,
+            "total": evidence_total if queue_available else None,
+            "by_gate_family": dict(evidence.most_common()),
+            "note": (
+                "" if queue_available else
+                "audit_queue.json absent (generated per pipeline run); run "
+                "docs/audit/scripts/run_pipeline.sh first"
+            ),
+        },
+        "drain_commands": {
+            "applied_non_clean": "python3 scripts/science_fix_loop.py --dry-run",
+            "archived_advisory": (
+                "python3 scripts/science_fix_loop.py --from-archived --dry-run"
+            ),
+            "evidence_repair": (
+                "see docs/audit/data/audit_queue.json rows with "
+                "audit_work_kind=evidence_repair_required"
+            ),
+        },
+    }
+    OUT_PATH.write_text(
+        json.dumps(payload, indent=1, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    print(
+        f"science_fix_backlog: applied={payload['applied_non_clean']['total']} "
+        f"archived_advisory={payload['archived_advisory']['total']} "
+        f"(+{advisory_unmapped} unmapped) "
+        f"evidence_repair={evidence_total if queue_available else 'unavailable'} "
+        f"-> {OUT_PATH.relative_to(REPO_ROOT)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/audit/scripts/compute_science_fix_backlog.py
+++ b/docs/audit/scripts/compute_science_fix_backlog.py
@@ -14,9 +14,10 @@ Surfaces summarized:
    ``previous_audits[]`` carries a non-clean scientific verdict while the live
    row is ``unaudited``.  These are ADVISORY: the archived verdict is void and
    authorizes nothing; the count exists so recorded defect-finding stays
-   visible across resets.  ``archived_advisory_unmapped`` counts archived
-   non-clean records whose repair target predates the category-prefix
-   convention and therefore cannot be routed automatically.
+   visible across resets.  ``unmapped_category_records`` counts complete
+   archived non-clean records whose repair instruction cannot be routed
+   automatically; ``incomplete_records`` counts records without the minimum
+   rationale/path metadata needed to create an advisory candidate.
 3. ``evidence_repair`` — rows the audit queue marks ``evidence_repair_required``,
    grouped by gate family (e.g. the forensic N5 execution certificate).
 
@@ -61,6 +62,15 @@ def _mapped_category(verdict: str, repair_target: str) -> bool:
     return False
 
 
+def _archived_repair_target(archived: dict) -> str:
+    """Mirror science_fix_loop.archived_repair_target without importing it."""
+    return str(
+        archived.get("notes_for_re_audit_if_any")
+        or archived.get("repair_target")
+        or ""
+    ).strip()
+
+
 def _gate_family(issue: str) -> str:
     """Collapse a readiness-issue string to its stable gate-family prefix."""
     return issue.split(":", 1)[0].strip() or "unknown"
@@ -72,6 +82,7 @@ def main() -> int:
     advisory = Counter()
     advisory_rows: list[str] = []
     advisory_unmapped = 0
+    advisory_incomplete = 0
 
     for shard in sorted(LEDGER_DIR.glob("*/*.json")):
         try:
@@ -80,7 +91,8 @@ def main() -> int:
             continue
         if not isinstance(row, dict):
             continue
-        claim_id = str(row.get("claim_id") or shard.stem)
+        raw_claim_id = row.get("claim_id")
+        claim_id = str(raw_claim_id or shard.stem)
         status = row.get("audit_status")
         if status in APPLIED_NON_CLEAN:
             applied[status] += 1
@@ -97,7 +109,15 @@ def main() -> int:
         verdict = last.get("audit_status")
         if verdict not in APPLIED_NON_CLEAN:
             continue
-        if _mapped_category(str(verdict), str(last.get("repair_target") or "")):
+        rationale = str(last.get("verdict_rationale") or "").strip()
+        if not rationale:
+            advisory_incomplete += 1
+            continue
+        repair_target = _archived_repair_target(last)
+        if _mapped_category(str(verdict), repair_target):
+            if not raw_claim_id or not row.get("note_path"):
+                advisory_incomplete += 1
+                continue
             advisory[str(verdict)] += 1
             advisory_rows.append(claim_id)
         else:
@@ -141,6 +161,7 @@ def main() -> int:
             "total": sum(advisory.values()),
             "by_verdict": dict(sorted(advisory.items())),
             "unmapped_category_records": advisory_unmapped,
+            "incomplete_records": advisory_incomplete,
         },
         "evidence_repair": {
             "queue_available": queue_available,
@@ -169,7 +190,8 @@ def main() -> int:
     print(
         f"science_fix_backlog: applied={payload['applied_non_clean']['total']} "
         f"archived_advisory={payload['archived_advisory']['total']} "
-        f"(+{advisory_unmapped} unmapped) "
+        f"(+{advisory_unmapped} unmapped, "
+        f"+{advisory_incomplete} incomplete) "
         f"evidence_repair={evidence_total if queue_available else 'unavailable'} "
         f"-> {OUT_PATH.relative_to(REPO_ROOT)}"
     )

--- a/docs/audit/scripts/tests/test_science_fix_priority.py
+++ b/docs/audit/scripts/tests/test_science_fix_priority.py
@@ -1,8 +1,10 @@
 """Science-fix scheduling: lane priority, category ranks, cross-clone dedupe."""
 from __future__ import annotations
 
+import io
 import json
 import sys
+import tarfile
 import tempfile
 import types
 import unittest
@@ -11,7 +13,9 @@ from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "docs" / "audit" / "scripts"))
 
+import compute_science_fix_backlog as backlog
 import science_fix_loop as sfl
 
 
@@ -208,6 +212,109 @@ class AuditHandoffTest(unittest.TestCase):
                         self._write(payload),
                         ledger_loader=lambda claim_id: self._ledger_row(),
                     )
+
+
+class ArchivedAdvisoryTest(unittest.TestCase):
+    @staticmethod
+    def _archive_bytes(rows):
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w") as archive:
+            for index, row in enumerate(rows):
+                data = (json.dumps(row) + "\n").encode("utf-8")
+                info = tarfile.TarInfo(
+                    f"docs/audit/data/ledger/aa/row-{index}.json"
+                )
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+        return buffer.getvalue()
+
+    @staticmethod
+    def _conditional_row(claim_id="claim_x"):
+        return {
+            "claim_id": claim_id,
+            "note_path": f"docs/{claim_id}.md",
+            "audit_status": "unaudited",
+            "previous_audits": [
+                {
+                    "audit_status": "audited_conditional",
+                    "claim_type": "bounded_theorem",
+                    "claim_scope": "A bounded claim.",
+                    "verdict_rationale": "The bridge remains unproved.",
+                    "notes_for_re_audit_if_any": (
+                        "missing_bridge_theorem: prove the bridge."
+                    ),
+                    "invalidation_reason": "science_changed:test",
+                    "archived_at": "2026-08-01T00:00:00+00:00",
+                }
+            ],
+        }
+
+    def test_canonical_archived_repair_field_drives_routing(self):
+        archived = {
+            "notes_for_re_audit_if_any": "missing_bridge_theorem: canonical",
+            "repair_target": "scope_too_broad: legacy fallback",
+        }
+        self.assertEqual(
+            sfl.archived_repair_target(archived),
+            "missing_bridge_theorem: canonical",
+        )
+
+        trailing_clean = self._conditional_row("claim_repaired")
+        trailing_clean["previous_audits"].append(
+            {
+                "audit_status": "audited_clean",
+                "verdict_rationale": "The bridge was repaired and rechecked.",
+            }
+        )
+        result = mock.Mock(
+            returncode=0,
+            stdout=self._archive_bytes(
+                [self._conditional_row(), trailing_clean]
+            ),
+            stderr=b"",
+        )
+        with mock.patch.object(sfl, "refresh_origin_main_for_handoff"), \
+             mock.patch.object(sfl.subprocess, "run", return_value=result):
+            rows = sfl.parse_archived_advisories()
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["category"], "conditional_missing_bridge_theorem"
+        )
+        self.assertIn("prove the bridge", rows[0]["prompt_body"])
+        self.assertIn("VOID", rows[0]["prompt_body"])
+        self.assertIn("verify against CURRENT origin/main", rows[0]["prompt_body"])
+
+    def test_backlog_mirrors_archived_selector_and_missing_queue_state(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        ledger_dir = root / "ledger"
+        shard_dir = ledger_dir / "aa"
+        shard_dir.mkdir(parents=True)
+        (shard_dir / "claim_x.json").write_text(
+            json.dumps(self._conditional_row()), encoding="utf-8"
+        )
+        out_path = root / "science_fix_backlog.json"
+
+        with mock.patch.object(backlog, "REPO_ROOT", root), \
+             mock.patch.object(backlog, "LEDGER_DIR", ledger_dir), \
+             mock.patch.object(backlog, "QUEUE_PATH", root / "audit_queue.json"), \
+             mock.patch.object(backlog, "OUT_PATH", out_path):
+            self.assertEqual(backlog.main(), 0)
+
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["archived_advisory"]["total"], 1)
+        self.assertEqual(
+            payload["archived_advisory"]["by_verdict"],
+            {"audited_conditional": 1},
+        )
+        self.assertEqual(
+            payload["archived_advisory"]["unmapped_category_records"], 0
+        )
+        self.assertEqual(payload["archived_advisory"]["incomplete_records"], 0)
+        self.assertFalse(payload["evidence_repair"]["queue_available"])
+        self.assertIsNone(payload["evidence_repair"]["total"])
 
 
 class CampaignRepairIntakeTest(unittest.TestCase):

--- a/docs/repo/FRONT_DOOR_STATUS.md
+++ b/docs/repo/FRONT_DOOR_STATUS.md
@@ -100,43 +100,9 @@ the local pipeline cache `docs/audit/data/audit_queue.json` (gitignored).
 | Live conditional/failed rows that would park | 0 |
 | Live rows fail-open (legacy/unversioned snapshot) | 0 |
 | Lane rows already in actual ready top-10 | 2 |
-| Lane rows added since prior pass | 32 |
+| Lane rows added since prior pass | 0 |
 | Lane rows removed since prior pass | 0 |
 | Non-lane rows deferred by simulated interleave | 187 |
-
-Named lane membership churn since the prior pass:
-- added: `ckm_five_sixths_bridge_support_note`
-- added: `cl3_taste_generation_theorem`
-- added: `cpt_exact_note`
-- added: `dm_full_closure_same_surface_numerator_selector_boundary_note_2026-04-16`
-- added: `dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15`
-- added: `dm_wilson_direct_descendant_schur_feshbach_boundary_variational_theorem_note_2026-04-25`
-- added: `ew_higgs_gauge_mass_diagonalization_theorem_note_2026-04-26`
-- added: `g_bare_rigidity_theorem_note`
-- added: `gauge_vacuum_plaquette_connected_hierarchy_theorem_note`
-- added: `gauge_vacuum_plaquette_framework_point_underdetermination_note`
-- added: `gauge_vacuum_plaquette_reduction_existence_theorem_note`
-- added: `gauge_vacuum_plaquette_source_sector_matrix_element_factorization_note`
-- added: `gauge_vacuum_plaquette_susceptibility_flow_theorem_note`
-- added: `gauge_vacuum_plaquette_transfer_operator_character_recurrence_note`
-- added: `gravitomagnetic_note`
-- added: `hierarchy_matsubara_decomposition_note`
-- added: `hierarchy_matsubara_determinant_narrow_theorem_note_2026-05-02`
-- added: `higgs_mechanism_note`
-- added: `koide_aps_block_by_block_forcing_note_2026-04-21`
-- added: `koide_kappa_spectrum_operator_bridge_theorem_note_2026-04-19`
-- added: `matter_inertial_closure_note`
-- added: `plaquette_self_consistency_note`
-- added: `q_integer_spectrum_theorem_note_2026-05-02`
-- added: `quark_cp_carrier_completion_note_2026-04-18`
-- added: `shapiro_static_discriminator_note`
-- added: `single_axiom_hilbert_note`
-- added: `teleportation_native_axioms_theory_note`
-- added: `universal_gr_casimir_block_localization_note`
-- added: `universal_gr_lorentzian_global_atlas_closure_note`
-- added: `work_history.ckm.cabibbo_bound_note`
-- added: `z2_hw1_mass_matrix_parametrization_note`
-- added: `z3_conjugate_support_trichotomy_narrow_theorem_note_2026-05-02`
 
 Unmanifested candidates (visible gaming surface; need review-landed pending entries before admission):
 - `affine_imaginary_slot_invariance_narrow_theorem_note_2026-05-02`

--- a/docs/repo/FRONT_DOOR_STATUS.md
+++ b/docs/repo/FRONT_DOOR_STATUS.md
@@ -100,9 +100,43 @@ the local pipeline cache `docs/audit/data/audit_queue.json` (gitignored).
 | Live conditional/failed rows that would park | 0 |
 | Live rows fail-open (legacy/unversioned snapshot) | 0 |
 | Lane rows already in actual ready top-10 | 2 |
-| Lane rows added since prior pass | 0 |
+| Lane rows added since prior pass | 32 |
 | Lane rows removed since prior pass | 0 |
 | Non-lane rows deferred by simulated interleave | 187 |
+
+Named lane membership churn since the prior pass:
+- added: `ckm_five_sixths_bridge_support_note`
+- added: `cl3_taste_generation_theorem`
+- added: `cpt_exact_note`
+- added: `dm_full_closure_same_surface_numerator_selector_boundary_note_2026-04-16`
+- added: `dm_neutrino_odd_circulant_z2_slot_theorem_note_2026-04-15`
+- added: `dm_wilson_direct_descendant_schur_feshbach_boundary_variational_theorem_note_2026-04-25`
+- added: `ew_higgs_gauge_mass_diagonalization_theorem_note_2026-04-26`
+- added: `g_bare_rigidity_theorem_note`
+- added: `gauge_vacuum_plaquette_connected_hierarchy_theorem_note`
+- added: `gauge_vacuum_plaquette_framework_point_underdetermination_note`
+- added: `gauge_vacuum_plaquette_reduction_existence_theorem_note`
+- added: `gauge_vacuum_plaquette_source_sector_matrix_element_factorization_note`
+- added: `gauge_vacuum_plaquette_susceptibility_flow_theorem_note`
+- added: `gauge_vacuum_plaquette_transfer_operator_character_recurrence_note`
+- added: `gravitomagnetic_note`
+- added: `hierarchy_matsubara_decomposition_note`
+- added: `hierarchy_matsubara_determinant_narrow_theorem_note_2026-05-02`
+- added: `higgs_mechanism_note`
+- added: `koide_aps_block_by_block_forcing_note_2026-04-21`
+- added: `koide_kappa_spectrum_operator_bridge_theorem_note_2026-04-19`
+- added: `matter_inertial_closure_note`
+- added: `plaquette_self_consistency_note`
+- added: `q_integer_spectrum_theorem_note_2026-05-02`
+- added: `quark_cp_carrier_completion_note_2026-04-18`
+- added: `shapiro_static_discriminator_note`
+- added: `single_axiom_hilbert_note`
+- added: `teleportation_native_axioms_theory_note`
+- added: `universal_gr_casimir_block_localization_note`
+- added: `universal_gr_lorentzian_global_atlas_closure_note`
+- added: `work_history.ckm.cabibbo_bound_note`
+- added: `z2_hw1_mass_matrix_parametrization_note`
+- added: `z3_conjugate_support_trichotomy_narrow_theorem_note_2026-05-02`
 
 Unmanifested candidates (visible gaming surface; need review-landed pending entries before admission):
 - `affine_imaginary_slot_invariance_narrow_theorem_note_2026-05-02`

--- a/scripts/science_fix_loop.py
+++ b/scripts/science_fix_loop.py
@@ -89,7 +89,9 @@ import os
 import re
 import shutil
 import signal
+import io
 import subprocess
+import tarfile
 import sys
 import tempfile
 import time
@@ -550,6 +552,167 @@ CAMPAIGN_REASON_CATEGORY = {
     "blocked_row_reentry_quarantined": "campaign_blocked_reentry",
     "claim_transaction_quarantined": "campaign_claim_transaction",
 }
+
+
+ARCHIVED_NON_CLEAN_VERDICTS = (
+    "audited_conditional",
+    "audited_failed",
+    "audited_renaming",
+    "audited_numerical_match",
+)
+
+
+def advisory_handoff_prompt(row: dict) -> str:
+    """Worker prompt for an ADVISORY candidate from an archived audit.
+
+    The archived verdict is void and confers no authority.  The prompt binds
+    the worker to reproduce-first discipline so a defect that current main has
+    already settled produces no edit.
+    """
+    return f"""Use the physics-loop skill to evaluate and, only if it still reproduces, repair a defect named by an ARCHIVED audit of {row['note_path']}.
+
+ADVISORY PROVENANCE — READ FIRST. The audit verdict quoted below was
+invalidated by a ledger-wide event ({row['invalidation_reason']},
+archived {row['archived_at']}). It is VOID and carries no audit authority.
+It is supplied only because a non-clean rationale usually names a real
+source defect that the invalidating event (for example an axiom wording
+change) did not repair. The independent audit lane re-decides everything.
+
+Claim id: {row['claim_id']}
+Archived verdict (void): {row['audit_verdict']}
+Claim type: {row['claim_type']}
+Load-bearing step class: {row['cls']}
+Claim scope: {row['claim_scope']}
+
+Archived auditor rationale (advisory only):
+{row['verdict_rationale']}
+
+Archived auditor repair target (advisory only):
+{row['repair_target']}
+
+Required first step: verify against CURRENT origin/main that the named
+defect still exists — read the note, run the runner, check the cited
+lines. If current main already settles it, STOP: make no edit and report
+"settled on main" with the evidence. Only a still-reproducing defect
+authorizes the narrowest honest source or runner edit. Open no new axiom
+or primitive. Do not edit audit-ledger or generated audit-status
+surfaces. The goal is a reviewable PR whose merged result can be
+independently re-audited.
+""".strip()
+
+
+def parse_archived_advisories() -> list[dict]:
+    """ADVISORY repair candidates from archived (invalidated) audits.
+
+    A mass invalidation — a premise-epoch reset, a packet-requirement change —
+    archives every live verdict into ``previous_audits[]`` and resets rows to
+    ``unaudited``.  The verdicts are void, but a non-clean rationale usually
+    names a source defect that the invalidating event did not repair.  This
+    lane resurfaces that knowledge so months of defect-finding survive a
+    reset, without granting the archived verdict any authority.
+
+    Conservative selection rule, per row on current ``origin/main``:
+
+    - live ``audit_status`` is ``unaudited``;
+    - ``previous_audits`` is non-empty and its LAST archived record carries a
+      non-clean scientific verdict.  If the last archived verdict is clean,
+      the defect was repaired and re-audited clean before the invalidation,
+      so re-audit alone is the right next step and no candidate is emitted.
+
+    Candidates are read from ``origin/main`` (single ``git archive``
+    snapshot), never from the possibly-stale local ledger.
+    """
+    refresh_origin_main_for_handoff()
+    try:
+        result = subprocess.run(
+            ["git", "archive", "origin/main", "docs/audit/data/ledger"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"cannot snapshot origin/main ledger: {exc}") from exc
+    if result.returncode != 0:
+        raise ValueError(
+            "cannot snapshot origin/main ledger: "
+            + result.stderr.decode("utf-8", "replace").strip()
+        )
+
+    rows: list[dict] = []
+    skipped_unmapped = 0
+    skipped_incomplete = 0
+    with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+        for member in tar.getmembers():
+            if not member.name.endswith(".json"):
+                continue
+            fh = tar.extractfile(member)
+            if fh is None:
+                continue
+            try:
+                row = json.loads(fh.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(row, dict):
+                continue
+            if row.get("audit_status") != "unaudited":
+                continue
+            archived = row.get("previous_audits") or []
+            if not isinstance(archived, list) or not archived:
+                continue
+            last = archived[-1]
+            if not isinstance(last, dict):
+                continue
+            verdict = last.get("audit_status")
+            if verdict not in ARCHIVED_NON_CLEAN_VERDICTS:
+                continue
+            repair_target = str(last.get("repair_target") or "").strip()
+            rationale = str(last.get("verdict_rationale") or "").strip()
+            if not rationale:
+                skipped_incomplete += 1
+                continue
+            category = audit_repair_category(verdict, repair_target)
+            if category is None:
+                skipped_unmapped += 1
+                continue
+            claim_id = row.get("claim_id")
+            note_path = row.get("note_path")
+            if not claim_id or not note_path:
+                skipped_incomplete += 1
+                continue
+            candidate = {
+                "category": category,
+                "claim_id": claim_id,
+                "note_path": note_path,
+                "descendants": int(row.get("transitive_descendants") or 0),
+                "cls": str(
+                    last.get("load_bearing_step_class")
+                    or row.get("load_bearing_step_class")
+                    or "unknown"
+                ),
+                "claim_type": str(
+                    last.get("claim_type") or row.get("claim_type") or "unknown"
+                ),
+                "claim_scope": str(
+                    last.get("claim_scope") or row.get("claim_scope") or ""
+                ),
+                "audit_verdict": verdict,
+                "verdict_rationale": rationale,
+                "repair_target": repair_target or "(none recorded)",
+                "invalidation_reason": str(
+                    last.get("invalidation_reason") or "unrecorded"
+                ),
+                "archived_at": str(last.get("archived_at") or "unrecorded"),
+                "advisory": True,
+                "prompt_source": "archived_previous_audits(origin/main)",
+            }
+            candidate["prompt_body"] = advisory_handoff_prompt(candidate)
+            rows.append(candidate)
+    if skipped_unmapped or skipped_incomplete:
+        print(
+            f"from-archived: skipped {skipped_unmapped} unmapped-category and "
+            f"{skipped_incomplete} incomplete archived records"
+        )
+    return rows
 
 
 def origin_main_blob_oid(path: str | None) -> str | None:
@@ -1414,6 +1577,19 @@ def main() -> int:
         ),
     )
     p.add_argument(
+        "--from-archived",
+        action="store_true",
+        help=(
+            "Build ADVISORY repair candidates from archived (invalidated) "
+            "non-clean audits in previous_audits[] on origin/main. Archived "
+            "verdicts carry no authority: each worker must reproduce the "
+            "named defect on current main before editing, and settled "
+            "defects produce no edit. Use after a mass invalidation (e.g. a "
+            "premise-epoch reset) so recorded defect-finding survives the "
+            "reset."
+        ),
+    )
+    p.add_argument(
         "--campaign-workdir",
         type=Path,
         default=None,
@@ -1454,6 +1630,8 @@ def main() -> int:
         p.error("--difficulty must include at least one bucket")
     if args.handoff_file is not None and args.campaign_workdir is not None:
         p.error("--handoff-file and --campaign-workdir are mutually exclusive")
+    if args.from_archived and (args.handoff_file or args.campaign_workdir):
+        p.error("--from-archived is mutually exclusive with --handoff-file/--campaign-workdir")
 
     RUNTIME["model"] = args.model
     RUNTIME["reasoning"] = args.reasoning
@@ -1469,6 +1647,8 @@ def main() -> int:
     try:
         if args.handoff_file is not None:
             rows = parse_audit_handoff(args.handoff_file)
+        elif args.from_archived:
+            rows = parse_archived_advisories()
         elif args.campaign_workdir is not None:
             rows = parse_campaign_workdir(args.campaign_workdir)
         else:
@@ -1480,7 +1660,8 @@ def main() -> int:
         source = (
             args.handoff_file
             or args.campaign_workdir
-            or PROMPTS_FILE.relative_to(REPO_ROOT)
+            or ("archived previous_audits on origin/main" if args.from_archived
+                else PROMPTS_FILE.relative_to(REPO_ROOT))
         )
         print(f"No actionable repair candidates found in {source}")
         return 0

--- a/scripts/science_fix_loop.py
+++ b/scripts/science_fix_loop.py
@@ -352,6 +352,21 @@ def audit_repair_category(audit_verdict: str, repair_target: str) -> str | None:
     return category
 
 
+def archived_repair_target(archived: dict) -> str:
+    """Return the canonical repair instruction from one archived audit.
+
+    Applied ledger rows expose the instruction as
+    ``notes_for_re_audit_if_any`` and that is the field preserved by
+    ``previous_audits[]``.  ``repair_target`` is accepted only as a legacy or
+    handoff-shaped fallback; it is not the archived-ledger field.
+    """
+    return str(
+        archived.get("notes_for_re_audit_if_any")
+        or archived.get("repair_target")
+        or ""
+    ).strip()
+
+
 def audit_handoff_prompt(row: dict) -> str:
     """Reconstruct the worker prompt from ledger-verified audit fields."""
     return f"""Use the physics-loop skill to repair the validated non-clean audit on {row['note_path']}.
@@ -665,7 +680,7 @@ def parse_archived_advisories() -> list[dict]:
             verdict = last.get("audit_status")
             if verdict not in ARCHIVED_NON_CLEAN_VERDICTS:
                 continue
-            repair_target = str(last.get("repair_target") or "").strip()
+            repair_target = archived_repair_target(last)
             rationale = str(last.get("verdict_rationale") or "").strip()
             if not rationale:
                 skipped_incomplete += 1


### PR DESCRIPTION
Control-plane repairs to the audit-cleaning loop, each motivated by measured history rather than taste. Timed deliberately: the premise-epoch reset already zeroed all live audits (all 3,972 ledger rows are `unaudited`), so governed-surface edits currently invalidate nothing.

## Why

- The **no-go-discipline packet family is the largest audit-invalidation class in repo history**: 1,560 voided verdicts, 799 of them in one day (2026-07-11, `no_go_discipline_packet_missing`). Packets existed at review time — in PR bodies — but never landed as evidence the audit could bind.
- The 2026-08-07 premise-epoch reset zeroed all live verdicts **and emptied the fix-loop's input**: the loop only eats *applied* non-clean verdicts, while the non-clean rationales naming real source defects sit unreadable in `previous_audits[]`.
- No single surface shows the full repair backlog; after a reset it reads as "nothing to fix" when the exact current-main landing pipeline finds 482 evidence-repair rows ready for work.

## What

**1. Packets must land with the PR.**
- `no-go-discipline/SKILL.md` Output section: the N1–N8 checklist must be a **committed artifact** (a `## No-Go Discipline Gate` section in the note, or a committed sidecar), and the primary runner's cached stdout must carry the five-line **N5 execution certificate**. A PR body is not a landing surface.
- The two older passages that still said the checklist "must be visible in the PR body or review verdict" (the N1–N8 preamble and the gate's PASS branch) now point at the landed artifact and demote the PR-body copy to a courtesy. Left as-is they would have re-authorized the exact failure mode this change closes.
- `review-loop/SKILL.md`: new hard gate 13 — run `docs/audit/scripts/check_changed_audit_evidence.py` against affected rows and block PASS on unready evidence. Explicit anti-gaming clause: an over-reaching claim gets **narrowed**, its certificate never padded.

**2. Archived defect reports survive resets (advisory only).**
- `scripts/science_fix_loop.py --from-archived`: ADVISORY candidates from `previous_audits[]` on `origin/main`, only where the live row is `unaudited` and the **last** archived verdict is non-clean (a trailing clean means it was repaired and re-ratified before the reset — skip). Verdicts are VOID and authorize nothing; every worker prompt binds reproduce-first discipline. Dry-run today: **954 candidates**; 302 older records have no routable category and one is incomplete, all counted rather than silently dropped.
- **Sol-found schema fix during cross-family review:** archived ledger records store the canonical repair instruction in `notes_for_re_audit_if_any`, not `repair_target`. Both the worker selector and backlog reader now prefer the canonical field (with `repair_target` only as a legacy fallback), recovering 721 routable conditional advisories that the original branch incorrectly classified as unmapped. Focused regression tests bind canonical-field precedence, trailing-clean suppression, VOID/reproduce-first prompts, selector/backlog agreement, and honest missing-queue output.
- **Exact-integration manifest acknowledgment:** the landing pipeline exposed a pre-existing current-main mismatch between the reviewed `build_citation_graph.py` source (`20698263...`, landed earlier in `43c6682bc`) and the controlled `dependency_policy_epoch.json` entry (`e09dbee4...`). This PR does not change that governed source; it refreshes only the stale source identity so the already-reviewed policy source is acknowledged. The policy epoch is not bumped, `legacy_science_epoch_baseline.json` remains immutable, and no audit verdict is authored.

**3. The backlog is visible nightly.**
- New `docs/audit/scripts/compute_science_fix_backlog.py` → `docs/audit/data/science_fix_backlog.json`. The reviewed branch snapshot records applied **0**, archived-advisory **954** (+302 unmapped, +1 incomplete), and evidence-repair **481**. The exact current-main landing pipeline seeds 12 already-present main notes and now observes **482** evidence repairs (448 `forensic_n5_execution_certificate_incomplete`, 20 stale-cache, 9 invalid-inputs, 5 missing-runner); gate 7 strips that dynamic regeneration, and the nightly audit lane will refresh it after landing. The script degrades honestly when the gitignored `audit_queue.json` is absent (`queue_available: false`, `total: null`, explanatory note).
- `audit.yml` runs it after the pipeline; surface ships in the nightly artifact. The push-race retry block regenerates it too, so a retry cannot commit a refreshed ledger next to a stale backlog.

## Authority boundaries held

No verdict, premise, ledger row, registry, or audit authority is touched. The advisory lane never writes status; the backlog surface is generated summary only and says so in its own `authority` field. Auditor selection and verdict application stay entirely with audit-loop.

## Verification

- `--from-archived --dry-run` produces the 954-candidate inventory without invoking any worker: 721 conditional, 121 failed, 78 renaming, and 34 numerical-match advisories; 302 records remain unmapped and one is incomplete.
- Backlog script tested with and without `audit_queue.json` present; byte-identical on rerun; evidence counts match the independent pipeline survey exactly. Queue key (`queue`), readiness-issue key (`forensic_evidence_readiness_issue`), and the `_mapped_category` mirror of `audit_repair_category` all verified against `compute_audit_queue.py` / `science_fix_loop.py`.
- The 1,560 / 799 history figures re-derived from `previous_audits[]`: `no_go_discipline*` = 1,529 plus `cross_confirmation_first_audit_no_go_packet_invalid*` = 31 → **1,560**; 799 archived on 2026-07-11.
- Gate numbering checked: `review-loop/SKILL.md` runs 6a, 7, 8, 9, 10, 11, 12, 13 with no section asserting a fixed gate count.
- `vocab_lint` clean; `audit_lint.py --strict` reports `OK: no errors` (pre-existing notices only). Workflow YAML parses; backlog step ordered after the pipeline and before the commit step.
- Audit-script test suite: **46 failures, identical with and without this change** (`test_fingerprint_v1_stamping.py`, `test_runner_pin_gate.py`); none import the changed files. `test_science_fix_priority.py`, which *does* import `science_fix_loop`, passes 24/24 including the two schema-regression tests. Pre-existing broad-suite failures are not addressed here.
- `docs/repo/FRONT_DOOR_STATUS.md` was dropped from this branch during review: it is stage 17 of `run_pipeline.sh`, is only ever authored by `audit:` commits on main, and gate 7 forbids framework PRs shipping pipeline-regenerated surfaces. The diff was a validation-run leftover.

## Known rough edge

`science_fix_backlog.json` is tracked but its `evidence_repair` block derives from the gitignored `audit_queue.json`. A contributor who runs the script locally without a pipeline cache will produce a degraded (honestly labelled) diff. CI always has the queue, so the nightly value is the authoritative one.

## Related finding, deliberately not fixed here

The N5 pilot drain (separate PR) found that **runner-cache freshness is decoupled from correctness**: `declared_input_paths` does not cover the doc/registry files many runners grep, so upstream content drift (e.g. the probability-semantics rename) never invalidates their caches — a share of N5-blocked runners fail live while their caches read fresh and green. That is a `runner_cache` design issue needing its own change; flagged here so it isn't lost.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEnGMUdwTHWaaAH43odZqx)_
