### PR TITLE
ci(audit): unblock nightly auto-commit push and raise job timeout

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,13 +34,13 @@ concurrency:
 jobs:
   audit_pipeline:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0    # full history so the citation graph builder can resolve all paths
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.AUDIT_DEPLOY_KEY }}  # deploy key on the ruleset bypass list; GITHUB_TOKEN pushes are blocked by the main-branch PR gate
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## What

Two-line repair to the nightly audit-lane workflow (`.github/workflows/audit.yml`):

1. `timeout-minutes: 20` → `45`
2. Checkout credential: `token: ${{ secrets.GITHUB_TOKEN }}` → `ssh-key: ${{ secrets.AUDIT_DEPLOY_KEY }}`

## Why

The lane has not landed a nightly refresh since 2026-07-30.

- Runs 2026-07-31 → 2026-08-07 were killed at the 20-minute job timeout (all "cancelled" at ~20m20s; last success 2026-07-30 at 11m59s).
- Run 31243986633 (2026-08-08) completed the pipeline in 19m44s — within seconds of the ceiling — then had its auto-commit rejected on push: GH013 "Changes must be made through a pull request" from the main-branch "trusted-contributor PR gate" ruleset (created 2026-07-30). The workflow pushes as the GITHUB_TOKEN app actor, which is not on the ruleset bypass list, and GitHub rejects adding the Actions app as a bypass actor on user-owned repos (API 422).

## Owner-side changes already applied (owner-approved, 2026-08-08)

- Ruleset 20039967 bypass list now includes actor type `DeployKey` (mode: always), alongside the two existing user bypasses; the `pull_request` rule and active enforcement are unchanged.
- A dedicated write deploy key "audit-lane nightly push (ruleset DeployKey bypass)" was added; its private key is stored as the `AUDIT_DEPLOY_KEY` Actions secret. Local key copies were deleted after upload.

With `ssh-key:` on `actions/checkout`, the checkout persists the SSH credential and rewrites the origin remote, so the existing plain `git push` in the auto-commit step authenticates as the deploy key and bypasses the PR gate. The auto-commit message already carries `[skip ci]`, so no workflow recursion. The workflow's only credential reference and only push path are the two lines this PR touches.

## Scope

No science notes, runners, ledger, or generated audit surfaces are touched — CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)