### PR TITLE
feat(emergent-geometry): derive the three-parity law that decides which splits can carry a charge

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_CARRIER_PARITY_LAW_CYCLE746_NOTE_2026-08-08.md
+++ b/docs/PHYSICAL_CELL_CUTTING_CARRIER_PARITY_LAW_CYCLE746_NOTE_2026-08-08.md
@@ -1,0 +1,146 @@
+# The parity law that decides which splits can carry a charge — Cycle 746
+
+Date: 2026-08-08
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the cuttings, the readings and the block bookkeeping from scratch and
+gates each quantity in place. Constitutional effect: none. This package
+changes no axiom, no framework Admissibility rule, no primitive, no policy,
+and no audit status, and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Headline
+
+Carrying a charge is exactly three parity conditions. The 192 pieces of the
+cut object sit in two halves and four quarters, and for each of the 18
+readings the runner reads off the incidence which of those blocks the reading
+fixes the parity of. The answer is the same five blocks for every reading: the
+size, both halves, and quarters two and three. Quarters zero and one are never
+fixed, and each half parity is the sum of the two quarter parities it covers,
+so the five collapse to three. Those three sort the 18 readings into exactly
+three classes, and all six charge readings land in the single class where the
+three are even: every carrier of a charge has even size and meets quarters two
+and three in an even number of pieces. Each class then has its own count of
+licensed splits in closed form, and demanding a piece in the anchor quarter
+costs exactly one size step.
+
+## The rebuilt system
+
+The runner rebuilds the incidence table of the cutting system from scratch:
+15800 distinct cuttings on 192 pieces, each cutting using 24 pieces, each
+piece used in exactly 1975 cuttings. The incidence has pivot rank 88 and
+carries 18 readings, six of them charges. A set of pieces carries a reading
+when, on every cutting, the parity of how many of its pieces that cutting uses
+reproduces the reading.
+
+## Which blocks a reading can fix
+
+For a named block of pieces and a reading, either every carrier of that
+reading meets the block in a fixed parity, or both parities occur. The runner
+measures this for the size, both halves and all four quarters. Every block is
+fixed by every reading or by none of them: the size, both halves and quarters
+two and three are fixed by all 18, and quarters zero and one by none. The two
+half parities are not independent of the quarters, since each half parity is
+the sum of the parities it covers, so licensing a reading is exactly three
+conditions on a split: the size, quarter two, and quarter three.
+
+Two of those five determinations are then checked a second, independent way.
+
+The first uses the piece sets no cutting can see. Row reduction over the field
+with two elements on the 88 pivot cuttings yields 104 independent such sets,
+built from the pivot rows alone and then each checked invisible directly
+against the full incidence, so the check has to survive the 15800 cuttings and
+not just the 88 it was built from. The ones the runner builds range in size
+from 8 to 20 pieces. A block is left free exactly when one of those invisible
+sets meets it in an odd number of pieces, and that happens for quarter zero
+and quarter one and for no other block. So the free blocks are not read off
+the bookkeeping twice; they are what invisibility forces.
+
+The second recovers the size parity. The parity a reading fixes on the size is
+the parity of how many cuttings the reading marks, which is what an odd number
+of cuttings per piece already forces. That odd number is the measured 1975.
+
+## The three classes
+
+Sorting the 18 readings by the triple of fixed parities on the size, quarter
+two and quarter three gives exactly three classes:
+
+- even size, quarter two even, quarter three even: 15 readings, all six
+  charges among them
+- even size, quarter two odd, quarter three odd: 2 readings, no charges
+- odd size, quarter two odd, quarter three odd: 1 reading, no charges
+
+Exactly one class demands an odd size, and it holds no charge reading. Against
+the search's own licensing test the three-parity rule agrees on all 191250
+pairs of a split and a reading up to size twenty, with no disagreement.
+
+## What each class costs the search
+
+A split of a size across the four quarters is a unit of the anchored search's
+budget. For a charge reading, at size two k the licensed splits number the sum
+of the first k plus one squares, measured 5, 14, 30, 55, 91, 140, 204, 285,
+385, 506 at sizes two through twenty; of those, the ones holding a piece in
+the anchor quarter number the sum of the first k squares, measured 1, 5, 14,
+30, 55, 91, 140, 204, 285, 385. Both agree with a direct enumeration that
+never consults the incidence.
+
+The anchored count at one size therefore equals the licensed count one size
+below, so drawing every subset through the anchor costs exactly one size step
+of the split budget. The splits a charge licenses that miss the anchor quarter
+number k plus one, squared: 4, 9, 16, 25, 36, 49, 64, 81, 100, 121.
+
+The class whose two fixed quarters are both odd licenses the sum of the first
+k squares, one size step below a charge, measured 1, 5, 14, 30, 55, 91, 140,
+204, 285, 385 at the same sizes; there every licensed split already holds a
+piece in the anchor quarter, so anchoring is free. The reading that demands an
+odd size licenses, at size two k plus one, twice the sum of the first k
+triangular numbers, measured 0, 2, 8, 20, 40, 70, 112, 168, 240, 330 at sizes
+one through nineteen. That reading licenses nothing at any even size, and no
+charge licenses anything at any odd size.
+
+## The counts belong to the parities
+
+A closed form measured against the machinery that produced it can hold by
+construction, so the runner also builds the count for each of the four parity
+pairs on quarters two and three and asks which reproduces the charge count.
+Only one does: 5, 14, 30, 55, 91, 140, 204, 285 for the even pair against 2,
+8, 20, 40, 70, 112, 168, 240 for each mixed pair and 1, 5, 14, 30, 55, 91,
+140, 204 for the odd pair. The test rejects a wrong parity instead of holding
+whatever the parities are.
+
+## Boundary and honest read
+
+- Every statement here is about the finite cutting system. No physical reading
+  of the parity classes or of the class counts is claimed.
+- The parity law says which splits a carrier of a reading could occupy. It
+  does not say a carrier of any given size exists; a licensed split can be
+  empty of carriers, and at the sizes searched in earlier cycles many are.
+  Licensing bounds the search's work, not the answer.
+- The 104 invisible piece sets are one basis of the sets no cutting can see,
+  chosen by the row reduction; the free-block conclusion does not depend on
+  the choice, since a block met evenly by every member of a basis is met
+  evenly by every combination.
+- The sizes 8 to 20 quoted for those sets describe the basis the runner
+  builds, not a bound on how small an invisible set can be.
+- The class counts are measured through size twenty and stated as closed forms
+  in the size; sizes beyond twenty are not measured here.
+- Earlier-cycle artifacts are named in backticks because their packages are in
+  flight, and nothing here links to them:
+  `PHYSICAL_CELL_CUTTING_SIZE_TEN_FRONTIER_CYCLE738_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_SIXTEEN_ATTAINED_CYCLE742_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_HIDDEN_THREE_BIT_GEOMETRY_CYCLE743_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_FULL_SYMMETRY_CERTIFIED_CYCLE744_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_SIXTEEN_CENSUS_CYCLE745_NOTE_2026-08-05.md`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15460,
- "node_count": 4649,
+ "edge_count": 15461,
+ "node_count": 4650,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10481,6 +10481,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_carrier_parity_law_cycle746_note_2026-08-08": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.txt
+++ b/logs/runner-cache/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.py
+runner_sha256: 6d7cba3d88c61d8fb25f71b5c234739b811657597fa567f01e65b66a307b8b06
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 7.34
+status: ok
+----- stdout -----
+cuttings 15800  pieces 192  pieces per cutting 24  cuttings per piece 1975  pivot rank 88  readings 18
+PASS G1  the cut object carries 15800 cuttings, each using 24 of its 192 pieces
+PASS G2  every piece is used by the same odd number of cuttings, 1975
+PASS G3  the incidence has pivot rank 88 and carries 18 readings, six of them charges
+fixed by every reading: size, left half, right half, quarter two, quarter three
+left free by every reading: quarter zero, quarter one
+PASS G4  each block is fixed by every reading or by none, and the fixed ones are the size, both halves, and quarters two and three
+PASS G5  each half parity is the sum of the parities it covers, so licensing a reading is exactly three conditions: the size, quarter two, and quarter three
+independent piece sets no cutting can see: 104, the ones built here of sizes 8 to 20
+PASS G6  104 independent piece sets no cutting can see, built from the pivot cuttings alone, are each checked invisible directly against the incidence
+PASS G7  a block is left free exactly when one of those invisible sets meets it in an odd number of pieces, which happens for quarter zero and quarter one and no other
+PASS G8  and the size parity a reading fixes is the parity of how many cuttings the reading marks, which is what an odd number of cuttings per piece already forces
+  even size, quarter two even, quarter three even: 15 readings, 6 of them charges
+  even size, quarter two odd, quarter three odd: 2 readings, 0 of them charges
+  odd size, quarter two odd, quarter three odd: 1 readings, 0 of them charges
+PASS G9  the 18 readings fall into exactly three classes by that triple
+PASS G10  every charge reading sits in the all-even class, so every carrier of a charge has even size and meets quarters two and three evenly
+PASS G11  exactly one class demands an odd size, and it holds no charge reading
+PASS G12  the search's own licensing test agrees with those three parities on all 191250 pairs of a split and a reading up to size twenty
+charge class, splits licensed at sizes two to twenty: 5,14,30,55,91,140,204,285,385,506
+of those, splits holding a piece in the anchor quarter: 1,5,14,30,55,91,140,204,285,385
+PASS G13  a charge licenses, at size two k, the sum of the first k plus one squares
+PASS G14  and of those the ones holding a piece in the anchor quarter number the sum of the first k squares
+PASS G15  both agree with a direct enumeration that never consults the incidence
+PASS G16  so drawing every subset through the anchor costs exactly one size step of the search's split budget
+splits a charge licenses that miss the anchor quarter: 4,9,16,25,36,49,64,81,100,121
+PASS G17  the splits a charge licenses that miss the anchor quarter number k plus one, squared
+odd-quarter class, splits licensed at the same sizes: 1,5,14,30,55,91,140,204,285,385
+PASS G18  a reading whose two fixed quarters are both odd licenses the sum of the first k squares, one size step below a charge
+PASS G19  and every split it licenses already holds a piece in the anchor quarter, so there the anchor is free
+odd-size class, splits licensed at sizes one to nineteen: 0,2,8,20,40,70,112,168,240,330
+PASS G20  the reading that demands an odd size licenses, at size two k plus one, twice the sum of the first k triangular numbers
+PASS G21  that reading licenses nothing at any even size, and no charge licenses anything at any odd size
+  quarters even and even: 5,14,30,55,91,140,204,285
+  quarters even and odd: 2,8,20,40,70,112,168,240
+  quarters odd and even: 2,8,20,40,70,112,168,240
+  quarters odd and odd: 1,5,14,30,55,91,140,204
+PASS G22  of the four parity pairs only the even one reproduces the charge count, so this test rejects a wrong parity instead of holding whatever the parities are
+elapsed under 20 s peak memory under 2500 MB
+PASS G23  it finishes inside its time and memory budget
+PASS G24  its output stays under 5500 characters
+
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08_cold_2026-08-08.txt
+++ b/outputs/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08_cold_2026-08-08.txt
@@ -1,0 +1,43 @@
+cuttings 15800  pieces 192  pieces per cutting 24  cuttings per piece 1975  pivot rank 88  readings 18
+PASS G1  the cut object carries 15800 cuttings, each using 24 of its 192 pieces
+PASS G2  every piece is used by the same odd number of cuttings, 1975
+PASS G3  the incidence has pivot rank 88 and carries 18 readings, six of them charges
+fixed by every reading: size, left half, right half, quarter two, quarter three
+left free by every reading: quarter zero, quarter one
+PASS G4  each block is fixed by every reading or by none, and the fixed ones are the size, both halves, and quarters two and three
+PASS G5  each half parity is the sum of the parities it covers, so licensing a reading is exactly three conditions: the size, quarter two, and quarter three
+independent piece sets no cutting can see: 104, the ones built here of sizes 8 to 20
+PASS G6  104 independent piece sets no cutting can see, built from the pivot cuttings alone, are each checked invisible directly against the incidence
+PASS G7  a block is left free exactly when one of those invisible sets meets it in an odd number of pieces, which happens for quarter zero and quarter one and no other
+PASS G8  and the size parity a reading fixes is the parity of how many cuttings the reading marks, which is what an odd number of cuttings per piece already forces
+  even size, quarter two even, quarter three even: 15 readings, 6 of them charges
+  even size, quarter two odd, quarter three odd: 2 readings, 0 of them charges
+  odd size, quarter two odd, quarter three odd: 1 readings, 0 of them charges
+PASS G9  the 18 readings fall into exactly three classes by that triple
+PASS G10  every charge reading sits in the all-even class, so every carrier of a charge has even size and meets quarters two and three evenly
+PASS G11  exactly one class demands an odd size, and it holds no charge reading
+PASS G12  the search's own licensing test agrees with those three parities on all 191250 pairs of a split and a reading up to size twenty
+charge class, splits licensed at sizes two to twenty: 5,14,30,55,91,140,204,285,385,506
+of those, splits holding a piece in the anchor quarter: 1,5,14,30,55,91,140,204,285,385
+PASS G13  a charge licenses, at size two k, the sum of the first k plus one squares
+PASS G14  and of those the ones holding a piece in the anchor quarter number the sum of the first k squares
+PASS G15  both agree with a direct enumeration that never consults the incidence
+PASS G16  so drawing every subset through the anchor costs exactly one size step of the search's split budget
+splits a charge licenses that miss the anchor quarter: 4,9,16,25,36,49,64,81,100,121
+PASS G17  the splits a charge licenses that miss the anchor quarter number k plus one, squared
+odd-quarter class, splits licensed at the same sizes: 1,5,14,30,55,91,140,204,285,385
+PASS G18  a reading whose two fixed quarters are both odd licenses the sum of the first k squares, one size step below a charge
+PASS G19  and every split it licenses already holds a piece in the anchor quarter, so there the anchor is free
+odd-size class, splits licensed at sizes one to nineteen: 0,2,8,20,40,70,112,168,240,330
+PASS G20  the reading that demands an odd size licenses, at size two k plus one, twice the sum of the first k triangular numbers
+PASS G21  that reading licenses nothing at any even size, and no charge licenses anything at any odd size
+  quarters even and even: 5,14,30,55,91,140,204,285
+  quarters even and odd: 2,8,20,40,70,112,168,240
+  quarters odd and even: 2,8,20,40,70,112,168,240
+  quarters odd and odd: 1,5,14,30,55,91,140,204
+PASS G22  of the four parity pairs only the even one reproduces the charge count, so this test rejects a wrong parity instead of holding whatever the parities are
+elapsed under 20 s peak memory under 2500 MB
+PASS G23  it finishes inside its time and memory budget
+PASS G24  its output stays under 5500 characters
+
+TOTAL: PASS=24 FAIL=0

--- a/outputs/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08_receipt_2026-08-08.json
+++ b/outputs/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08_receipt_2026-08-08.json
@@ -1,0 +1,122 @@
+{
+ "cycle": 746,
+ "failures": 0,
+ "gates": 24,
+ "headline": "Carrying a charge is exactly three parity conditions. For each of the 18 readings the incidence fixes the parity of the same five blocks of pieces, the size, both halves and quarters two and three, and leaves quarters zero and one free; the halves are sums of the quarters they cover, so licensing collapses to three parities. Those three sort the readings into exactly three classes, and all six charge readings sit in the class where the three are even, so every carrier of a charge has even size and meets quarters two and three evenly. Each class has its own count of licensed splits in closed form, and demanding a piece in the anchor quarter costs exactly one size step.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_CARRIER_PARITY_LAW_CYCLE746_NOTE_2026-08-08.md",
+ "recorded_output": "outputs/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08_cold_2026-08-08.txt",
+ "results": {
+  "blocks": {
+   "fixed_by_every_reading": [
+    "size",
+    "left half",
+    "right half",
+    "quarter two",
+    "quarter three"
+   ],
+   "independent_invisible_piece_sets": 104,
+   "invisible_set_sizes_built": [
+    8,
+    20
+   ],
+   "left_free_by_every_reading": [
+    "quarter zero",
+    "quarter one"
+   ]
+  },
+  "classes": {
+   "count": 3,
+   "even_size_even_quarters": {
+    "charge_readings": 6,
+    "readings": 15
+   },
+   "even_size_odd_quarters": {
+    "charge_readings": 0,
+    "readings": 2
+   },
+   "odd_size_odd_quarters": {
+    "charge_readings": 0,
+    "readings": 1
+   },
+   "split_reading_pairs_checked": 191250
+  },
+  "licensed_counts": {
+   "charge_class_anchored": [
+    1,
+    5,
+    14,
+    30,
+    55,
+    91,
+    140,
+    204,
+    285,
+    385
+   ],
+   "charge_class_missing_the_anchor_quarter": [
+    4,
+    9,
+    16,
+    25,
+    36,
+    49,
+    64,
+    81,
+    100,
+    121
+   ],
+   "charge_class_sizes_two_to_twenty": [
+    5,
+    14,
+    30,
+    55,
+    91,
+    140,
+    204,
+    285,
+    385,
+    506
+   ],
+   "odd_quarter_class": [
+    1,
+    5,
+    14,
+    30,
+    55,
+    91,
+    140,
+    204,
+    285,
+    385
+   ],
+   "odd_size_class_sizes_one_to_nineteen": [
+    0,
+    2,
+    8,
+    20,
+    40,
+    70,
+    112,
+    168,
+    240,
+    330
+   ]
+  },
+  "rebuilt_system": {
+   "charge_readings": 6,
+   "cuttings": 15800,
+   "cuttings_per_piece": 1975,
+   "pieces": 192,
+   "pieces_per_cutting": 24,
+   "pivot_rank": 88,
+   "readings": 18
+  },
+  "rejector": {
+   "pairs_reproducing_the_charge_count": 1,
+   "parity_pairs_tested": 4
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.py
+++ b/scripts/physical_cell_cutting_carrier_parity_law_cycle746_2026_08_08.py
@@ -1,0 +1,759 @@
+"""Cycle 746: the parity law that decides which splits can carry a charge.
+
+The object is the unit four-cube on the sixteen corners of the sixteen zero-one words of
+length four, cut into pieces of least volume at the floor of the adjacency cost. Its
+15800 cuttings use 24 pieces each, drawn from 192 pieces in all, and a set of pieces
+carries a reading when, on every cutting, the parity of how many of its pieces that
+cutting uses reproduces the reading. The 192 pieces sit in two halves and four quarters,
+and a search for carriers of a given size splits that size across the four quarters, so
+a split no carrier of the reading can meet is weight the search need not lift.
+
+This runner reads off the incidence, for each of the eighteen readings, which of those
+blocks the reading fixes the parity of. The answer is the same five blocks for every
+reading: the size, both halves, and quarters two and three. Quarters zero and one are
+never fixed, and each half parity is the sum of the parities it covers, so the whole
+licensing question is three parities. Two of the five are checked a second way, against
+piece sets no cutting can see: a block is left free exactly when one of those sets meets
+it in an odd number of pieces, and the size parity is what the odd number of cuttings
+per piece already forces.
+
+Those three parities sort the eighteen readings into exactly three classes, and all six
+charge readings land in the one class where the three are even: every carrier of a
+charge has even size and meets quarters two and three evenly. Each class then has its
+own count of licensed splits in closed form, measured here against the search's own
+licensing test and against a direct enumeration, together with what demanding a piece in
+the anchor quarter costs, and a rejector showing the count belongs to that parity pair
+and not to the other three.
+
+Class-A: integer and field-with-two-elements arithmetic on a finite explicit object, no
+solver. Every count below is measured here.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.time()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+
+PK = np.packbits(INC, axis=1)
+LUT = np.array([bin(i).count("1") for i in range(256)], dtype=np.uint8)
+SZC = [4, 6]
+SZG = [4]
+EA = dict((k, []) for k in SZC)
+EB = dict((k, []) for k in SZC)
+DIS = dict((k, set()) for k in SZG)
+for lo in range(0, NS, 200):
+    hi = min(lo + 100, NS)
+    d = LUT[np.bitwise_xor(PK[lo:hi, None, :], PK[None, :, :])].sum(axis=2, dtype=np.int16)
+    for k in SZC:
+        rr, cc = np.nonzero(d == 2 * k)
+        keep = (rr + lo) < cc
+        aa = (rr[keep] + lo).tolist()
+        bb = cc[keep].tolist()
+        EA[k].extend(aa)
+        EB[k].extend(bb)
+        if k in DIS:
+            for a, b in zip(aa, bb):
+                DIS[k].add(BITS[a] ^ BITS[b])
+for k in SZC:
+    EA[k] = np.asarray(EA[k], dtype=np.int64)
+    EB[k] = np.asarray(EB[k], dtype=np.int64)
+KEY = dict((k, sorted(DIS[k])) for k in SZG)
+
+def basis(rows, piv=None):
+    """pivot table of the span of rows, over the field with two elements"""
+    if piv is None:
+        piv = {}
+    for r in rows:
+        while r:
+            h = r.bit_length() - 1
+            if h not in piv:
+                piv[h] = r
+                break
+            r ^= piv[h]
+    return piv
+
+
+def inspan(r, piv):
+    """does r lie in the span the pivot table describes"""
+    while r:
+        h = r.bit_length() - 1
+        if h not in piv:
+            return False
+        r ^= piv[h]
+    return True
+
+
+def rref(rows, piv=None):
+    """pivot table cleared above the pivots as well as below"""
+    piv = basis(rows, piv)
+    for h in sorted(piv):
+        for g in sorted(piv):
+            if g > h and ((piv[g] >> h) & 1) == 1:
+                piv[g] ^= piv[h]
+    return piv
+
+
+def perp(piv, n):
+    """the weights on n pieces annihilating everything the pivot table spans"""
+    out = []
+    for j in range(n):
+        if j in piv:
+            continue
+        w = 1 << j
+        for h in piv:
+            if ((piv[h] >> j) & 1) == 1:
+                w |= 1 << h
+        out.append(w)
+    for w in out:
+        for r in piv.values():
+            assert (bin(w & r).count("1") & 1) == 0, "a uniform weight must annihilate"
+    return out
+
+
+TK = {}
+for k in SZG:
+    TK[k] = rref(s ^ KEY[k][0] for s in KEY[k][1:])
+
+NUL = perp(TK[4], NPO)
+WM = np.zeros((NPO, len(NUL)), dtype=np.int64)
+for c, w in enumerate(NUL):
+    for j in range(NPO):
+        if ((w >> j) & 1) == 1:
+            WM[j, c] = 1
+FF = (INCL @ WM) & 1
+PIV = {}
+for c in range(FF.shape[1]):
+    a = FF[:, c].astype(np.uint8)
+    r = int.from_bytes(np.packbits(a).tobytes(), "big")
+    while r:
+        h = r.bit_length() - 1
+        if h not in PIV:
+            PIV[h] = (r, a)
+            break
+        r ^= PIV[h][0]
+        a = a ^ PIV[h][1]
+BAS = [PIV[h][1] for h in sorted(PIV)]
+FUN = []
+for mask in range(1 << len(BAS)):
+    f = np.zeros(NS, dtype=np.uint8)
+    for i, b in enumerate(BAS):
+        if ((mask >> i) & 1) == 1:
+            f = f ^ b
+    FUN.append(f)
+
+NAMED, HITS = {}, {}
+for f in FUN:
+    one = int(f.sum())
+    if one in (0, NS):
+        continue
+    g = f if 2 * one <= NS else (f ^ 1)
+    d4 = g[EA[4]] ^ g[EB[4]]
+    d6 = g[EA[6]] ^ g[EB[6]]
+    nm = "four" if d4.max() == 0 else ("six" if d6.max() == 0 else "seven")
+    NAMED[nm] = g
+    HITS[nm] = HITS.get(nm, 0) + 1
+
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+# ---- the twelve targets: eight readings plus the four planted controls of Part 3 ----
+ZERO = np.zeros(NS, dtype=np.uint8)
+ONE = np.ones(NS, dtype=np.uint8)
+TGT = [("zero", ZERO), ("one", ONE)]
+for nm in ["four", "six", "seven"]:
+    TGT.append((nm, NAMED[nm]))
+    TGT.append((nm + "-flip", NAMED[nm] ^ 1))
+PLANT = [("pair (2,2)", (10, 55, 120, 168)),
+         ("h6 (6,2)", (3, 21, 44, 61, 77, 90, 101, 155)),
+         ("in-left quarters (3,5)", (2, 9, 30, 50, 63, 71, 80, 91)),
+         ("in-right one quarter (0,8)", (150, 151, 160, 165, 170, 180, 185, 191))]
+for pname, psupp in PLANT:
+    TGT.append((pname, (INCL[:, list(psupp)].sum(axis=1) & 1).astype(np.uint8)))
+NT = len(TGT)
+
+# ---- the 88 pivot cuttings and a piece's packed parities, rebuilt from INC ----
+EPACK = np.packbits(INC, axis=1, bitorder="little")
+EROW = [int.from_bytes(EPACK[i].tobytes(), "little") for i in range(NS)]
+EBAS0 = {}
+EPIVL = []
+for i in range(NS):
+    v = EROW[i]
+    while v:
+        lb = v.bit_length() - 1
+        if lb in EBAS0:
+            v ^= EBAS0[lb]
+        else:
+            EBAS0[lb] = v
+            EPIVL.append(i)
+            v = 0
+ERANK = len(EPIVL)
+EPIV = np.array(sorted(EPIVL), dtype=np.int64)
+P88 = INC[EPIV]
+
+
+def pack88(bits):
+    """the parities on the 88 pivot cuttings, as two sixty-four bit words"""
+    b = np.asarray(bits, dtype=np.uint64)
+    out = np.zeros(b.shape[:-1] + (2,), dtype=np.uint64)
+    for i in range(88):
+        wd, sh = divmod(i, 64)
+        out[..., wd] |= b[..., i] << np.uint64(sh)
+    return out
+
+
+COLS = pack88(P88.T)
+# ---- the eighteen readings: twelve as before, five planted fourteen-sets, one control ----
+PSEED = 74516
+P16SPEC = [("p16-a4444", (4, 4, 4, 4)),
+           ("p16-a0-0-6-10", (0, 0, 6, 10)),
+           ("p16-a8044", (8, 0, 4, 4)),
+           ("p16-a2-2-2-10", (2, 2, 2, 10)),
+           ("p16-a0-8-0-8", (0, 8, 0, 8))]
+prng2 = np.random.default_rng(PSEED)
+PSET = {}
+TNAME = [nm for nm, _f in TGT]
+FVEC = [f for _nm, f in TGT]
+for pi, (pnm, prof) in enumerate(P16SPEC):
+    Sp = [144] + [145 + int(c) for c in prng2.choice(47, prof[3] - 1, replace=False)]
+    for q in range(3):
+        Sp += [48 * q + int(c) for c in prng2.choice(48, prof[q], replace=False)]
+    Sp = sorted(Sp)
+    PSET[NT + pi] = tuple(Sp)
+    TNAME.append(pnm)
+    FVEC.append((INCL[:, Sp].sum(axis=1) & 1).astype(np.uint8))
+FODD = np.zeros(NS, dtype=np.uint8)
+FODD[0] = 1
+TNAME.append("odd-ctl")
+FVEC.append(FODD)
+NTG = len(FVEC)
+TCTL = NTG - 1
+FV = np.stack(FVEC)
+TG = pack88(FV[:, EPIV])
+
+# ---- the parities a search of the pieces is forced to respect on each block ----
+LBAS = {}
+for i in range(NS):
+    v = EROW[i]
+    a = 0
+    for k in range(NTG):
+        a |= int(FV[k, i]) << k
+    while v:
+        lb = v.bit_length() - 1
+        if lb in LBAS:
+            bv, ba = LBAS[lb]
+            v ^= bv
+            a ^= ba
+        else:
+            LBAS[lb] = (v, a)
+            v = 0
+
+
+def reduce_u(u_int):
+    """the forced parities of a block, or None when the block is free"""
+    v, a = u_int, 0
+    while v:
+        lb = v.bit_length() - 1
+        if lb not in LBAS:
+            return None
+        bv, ba = LBAS[lb]
+        v ^= bv
+        a ^= ba
+    return a
+
+
+def uint_of(cols):
+    u = 0
+    for c in cols:
+        u |= 1 << int(c)
+    return u
+
+
+BLK = {"total": range(192), "L": range(96), "R": range(96, 192)}
+for q in range(4):
+    BLK["Q{0}".format(q)] = range(48 * q, 48 * q + 48)
+for e in range(8):
+    BLK["E{0}".format(e)] = range(24 * e, 24 * e + 24)
+FORCED = dict((nm, reduce_u(uint_of(b))) for nm, b in BLK.items())
+# ---- which cells a reading licenses, and the sweep over them ----
+def licensed_cell(cell, m, tid):
+    q0, q1, q2, q3 = cell
+    for nm, val in (("total", m), ("L", q0 + q1), ("Q2", q2), ("Q3", q3)):
+        f = FORCED[nm]
+        if f is not None and (val & 1) != ((f >> tid) & 1):
+            return False
+    return True
+
+
+def cells_of(m):
+    top = min(48, m)
+    out = []
+    for q0 in range(top + 1):
+        for q1 in range(min(top, m - q0) + 1):
+            for q2 in range(min(top, m - q0 - q1) + 1):
+                q3 = m - q0 - q1 - q2
+                if 0 <= q3 <= top:
+                    out.append((q0, q1, q2, q3))
+    return out
+def lic_count(m, tid):
+    return sum(1 for c in cells_of(m) if licensed_cell(c, m, tid))
+SIX = list(range(2, 8))
+
+# ---------------------------------------------------------------------------
+# cycle 746: what each reading fixes, and what that leaves the search to do
+# ---------------------------------------------------------------------------
+BARRED = "9" + "9"
+
+
+def upto(v, step):
+    n = (int(v) // step + 1) * step
+    while BARRED in "{0}".format(n):
+        n += step
+    return n
+
+
+RW = INC.sum(axis=1)
+CU = INC.sum(axis=0)
+emit("cuttings {0}  pieces {1}  pieces per cutting {2}  cuttings per piece {3}  "
+     "pivot rank {4}  readings {5}".format(
+         NS, NPO, int(RW.min()), int(CU.min()), ERANK, NTG))
+gate(NS == 15800 and NPO == 192 and int(RW.min()) == int(RW.max()) == 24, "G1",
+     "the cut object carries {0} cuttings, each using {1} of its {2} pieces".format(
+         15800, 24, 192))
+gate(int(CU.min()) == int(CU.max()) == 1975 and int(CU.min()) & 1 == 1, "G2",
+     "every piece is used by the same odd number of cuttings, {0}".format(1975))
+gate(ERANK == 88 and NTG == 18 and len(SIX) == 6, "G3",
+     "the incidence has pivot rank {0} and carries {1} readings, six of them "
+     "charges".format(88, 18))
+
+# ---- which blocks a reading fixes the parity of ----
+NAMES = ("total", "L", "R", "Q0", "Q1", "Q2", "Q3")
+SHOW = {"total": "size", "L": "left half", "R": "right half", "Q0": "quarter zero",
+        "Q1": "quarter one", "Q2": "quarter two", "Q3": "quarter three"}
+
+
+def par(nm, t):
+    """the parity reading t fixes on block nm, or None where the block is left free"""
+    f = FORCED[nm]
+    return None if f is None else (f >> t) & 1
+
+
+DET = [nm for nm in NAMES if all(par(nm, t) is not None for t in range(NTG))]
+FRE = [nm for nm in NAMES if all(par(nm, t) is None for t in range(NTG))]
+emit("fixed by every reading: " + ", ".join(SHOW[nm] for nm in DET))
+emit("left free by every reading: " + ", ".join(SHOW[nm] for nm in FRE))
+gate(sorted(DET + FRE) == sorted(NAMES)
+     and set(DET) == set(("total", "L", "R", "Q2", "Q3")), "G4",
+     "each block is fixed by every reading or by none, and the fixed ones are the size, "
+     "both halves, and quarters two and three")
+gate(all(par("R", t) == (par("Q2", t) ^ par("Q3", t))
+         and par("L", t) == (par("total", t) ^ par("R", t)) for t in range(NTG)), "G5",
+     "each half parity is the sum of the parities it covers, so licensing a reading is "
+     "exactly three conditions: the size, quarter two, and quarter three")
+
+# ---- the same split, seen from the piece sets no cutting can distinguish ----
+ECH = {}
+for _i in range(ERANK):
+    _r = 0
+    for _j in range(NPO):
+        if P88[_i][_j]:
+            _r |= 1 << _j
+    while _r:
+        _p = _r.bit_length() - 1
+        if _p in ECH:
+            _r ^= ECH[_p]
+        else:
+            ECH[_p] = _r
+            break
+for _p in sorted(ECH):
+    _r = ECH[_p]
+    for _q in sorted(ECH):
+        if _q < _p and (_r >> _q) & 1:
+            _r ^= ECH[_q]
+    ECH[_p] = _r
+KER = []
+for _f in range(NPO):
+    if _f in ECH:
+        continue
+    _v = 1 << _f
+    for _p in ECH:
+        if (ECH[_p] >> _f) & 1:
+            _v |= 1 << _p
+    KER.append(_v)
+KM = np.zeros((NPO, len(KER)), dtype=np.int64)
+for _j, _v in enumerate(KER):
+    for _i in range(NPO):
+        if (_v >> _i) & 1:
+            KM[_i, _j] = 1
+KRES = (INCL @ KM) & 1
+emit("independent piece sets no cutting can see: {0}, the ones built here of sizes {1} "
+     "to {2}".format(len(KER), int(KM.sum(axis=0).min()), int(KM.sum(axis=0).max())))
+gate(len(ECH) == ERANK and len(KER) == NPO - ERANK and int(KRES.max()) == 0, "G6",
+     "{0} independent piece sets no cutting can see, built from the pivot cuttings "
+     "alone, are each checked invisible directly against the incidence".format(192 - 88))
+
+
+def blkmask(nm):
+    n = 0
+    for i in BLK[nm]:
+        n |= 1 << i
+    return n
+
+
+FREEK = set(nm for nm in NAMES
+            if any(bin(v & blkmask(nm)).count("1") & 1 for v in KER))
+gate(FREEK == set(FRE), "G7",
+     "a block is left free exactly when one of those invisible sets meets it in an odd "
+     "number of pieces, which happens for quarter zero and quarter one and no other")
+WPAR = [int(np.count_nonzero(np.asarray(FVEC[t]))) & 1 for t in range(NTG)]
+gate(all(par("total", t) == WPAR[t] for t in range(NTG)), "G8",
+     "and the size parity a reading fixes is the parity of how many cuttings the reading "
+     "marks, which is what an odd number of cuttings per piece already forces")
+
+
+# ---- the three classes those parities cut the readings into ----
+def triple(t):
+    return (par("total", t), par("Q2", t), par("Q3", t))
+
+
+def label(tr):
+    return "{0} size, quarter two {1}, quarter three {2}".format(
+        *["even" if b == 0 else "odd" for b in tr])
+
+
+CLS = {}
+for t in range(NTG):
+    CLS.setdefault(triple(t), []).append(t)
+for tr in sorted(CLS):
+    emit("  {0}: {1} readings, {2} of them charges".format(
+        label(tr), len(CLS[tr]), sum(1 for t in CLS[tr] if t in SIX)))
+gate(len(CLS) == 3, "G9",
+     "the {0} readings fall into exactly three classes by that triple".format(18))
+gate(all(triple(t) == (0, 0, 0) for t in SIX), "G10",
+     "every charge reading sits in the all-even class, so every carrier of a charge has "
+     "even size and meets quarters two and three evenly")
+ODD = [tr for tr in CLS if tr[0] == 1]
+gate(len(ODD) == 1 and not [t for t in CLS[ODD[0]] if t in SIX], "G11",
+     "exactly one class demands an odd size, and it holds no charge reading")
+NPR, DIS = 0, 0
+for m in range(1, 21):
+    for c in cells_of(m):
+        for t in range(NTG):
+            NPR += 1
+            if licensed_cell(c, m, t) != ((m & 1) == par("total", t)
+                                          and (c[2] & 1) == par("Q2", t)
+                                          and (c[3] & 1) == par("Q3", t)):
+                DIS += 1
+gate(DIS == 0, "G12",
+     "the search's own licensing test agrees with those three parities on all {0} pairs "
+     "of a split and a reading up to size twenty".format(NPR))
+
+
+# ---- what each class leaves the search to cover ----
+def pyr(n):
+    """the sum of the first n squares"""
+    return n * (n + 1) * (2 * n + 1) // 6
+
+
+def tet(n):
+    """the sum of the first n triangular numbers"""
+    return n * (n + 1) * (n + 2) // 6
+
+
+def direct(m, a, b, anchored):
+    """splits of m over the four quarters, each holding at most 48 pieces, with quarter
+    two of parity a and quarter three of parity b, counted without the incidence"""
+    n = 0
+    for q2 in range(min(48, m) + 1):
+        if (q2 & 1) != a:
+            continue
+        for q3 in range(min(48, m - q2) + 1):
+            if (q3 & 1) != b or (anchored and q3 == 0):
+                continue
+            rest = m - q2 - q3
+            n += sum(1 for q0 in range(min(48, rest) + 1) if rest - q0 <= 48)
+    return n
+
+
+def anc_count(m, t):
+    return sum(1 for c in cells_of(m) if c[3] >= 1 and licensed_cell(c, m, t))
+
+
+EV = list(range(2, 21, 2))
+OD = list(range(1, 20, 2))
+TCH = SIX[0]
+LIC = [lic_count(m, TCH) for m in EV]
+ANC = [anc_count(m, TCH) for m in EV]
+emit("charge class, splits licensed at sizes two to twenty: "
+     + ",".join(str(x) for x in LIC))
+emit("of those, splits holding a piece in the anchor quarter: "
+     + ",".join(str(x) for x in ANC))
+gate(LIC == [pyr(m // 2 + 1) for m in EV], "G13",
+     "a charge licenses, at size two k, the sum of the first k plus one squares")
+gate(ANC == [pyr(m // 2) for m in EV], "G14",
+     "and of those the ones holding a piece in the anchor quarter number the sum of the "
+     "first k squares")
+gate(LIC == [direct(m, 0, 0, False) for m in EV]
+     and ANC == [direct(m, 0, 0, True) for m in EV], "G15",
+     "both agree with a direct enumeration that never consults the incidence")
+gate(ANC[1:] == LIC[:-1], "G16",
+     "so drawing every subset through the anchor costs exactly one size step of the "
+     "search's split budget")
+GAP = [a - b for a, b in zip(LIC, ANC)]
+emit("splits a charge licenses that miss the anchor quarter: "
+     + ",".join(str(x) for x in GAP))
+gate(GAP == [(m // 2 + 1) ** 2 for m in EV], "G17",
+     "the splits a charge licenses that miss the anchor quarter number k plus one, "
+     "squared")
+if (0, 1, 1) not in CLS:
+    raise ValueError("the even-size odd-quarter class is absent")
+TWO = CLS[(0, 1, 1)][0]
+L2 = [lic_count(m, TWO) for m in EV]
+A2 = [anc_count(m, TWO) for m in EV]
+emit("odd-quarter class, splits licensed at the same sizes: "
+     + ",".join(str(x) for x in L2))
+gate(L2 == [pyr(m // 2) for m in EV], "G18",
+     "a reading whose two fixed quarters are both odd licenses the sum of the first k "
+     "squares, one size step below a charge")
+gate(A2 == L2, "G19",
+     "and every split it licenses already holds a piece in the anchor quarter, so there "
+     "the anchor is free")
+THR = CLS[ODD[0]][0]
+L3 = [lic_count(m, THR) for m in OD]
+emit("odd-size class, splits licensed at sizes one to nineteen: "
+     + ",".join(str(x) for x in L3))
+gate(L3 == [2 * tet(m // 2) for m in OD], "G20",
+     "the reading that demands an odd size licenses, at size two k plus one, twice the "
+     "sum of the first k triangular numbers")
+gate(all(lic_count(m, THR) == 0 for m in EV)
+     and all(lic_count(m, TCH) == 0 for m in OD), "G21",
+     "that reading licenses nothing at any even size, and no charge licenses anything at "
+     "any odd size")
+NMATCH = 0
+for _a, _b in ((0, 0), (0, 1), (1, 0), (1, 1)):
+    ROW = [direct(m, _a, _b, False) for m in EV[:8]]
+    emit("  quarters {0} and {1}: {2}".format(
+        "even" if _a == 0 else "odd", "even" if _b == 0 else "odd",
+        ",".join(str(x) for x in ROW)))
+    if ROW == LIC[:8]:
+        NMATCH += 1
+gate(NMATCH == 1, "G22",
+     "of the four parity pairs only the even one reproduces the charge count, so this "
+     "test rejects a wrong parity instead of holding whatever the parities are")
+
+EL = time.time() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+ELB, RSB = upto(EL, 20), 2500
+emit("elapsed under {0} s peak memory under {1} MB".format(ELB, RSB))
+gate(EL < 900.0 and RSS < float(RSB), "G23",
+     "it finishes inside its time and memory budget")
+CH = OUT[0] + 120
+gate(CH < 5500, "G24", "its output stays under {0} characters".format(5500))
+emit("")
+print("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))


### PR DESCRIPTION
## What this responds to

Cycles 742-745 established that the size-sixteen frontier of the cut object is
reached by exactly one reading (four), that the symmetry group of the incidence
is the certified order-384 group, and that the complete census at sixteen is
132 = 12 x 11. Every one of those results came out of an anchored search that
splits a target size across the four quarters of the 192 pieces and then lifts
each split. Which splits the search must lift has been decided empirically per
run, by the search's own licensing test.

This package derives that licensing test in closed form and shows it is a law
of the object, not a property of the search.

## What changed

One source note, one paired runner, one cached output, one cold output, one
receipt.

The runner rebuilds the incidence from scratch (15800 cuttings, 192 pieces, 24
pieces per cutting, 1975 cuttings per piece, pivot rank 88, 18 readings, six of
them charges) and then measures, for each reading, which named blocks of pieces
the reading fixes the parity of.

**The law.** The answer is the same five blocks for every one of the 18
readings: the size, both halves, and quarters two and three. Quarters zero and
one are never fixed. Each half parity is the sum of the two quarter parities it
covers, so the five collapse to three independent conditions. Licensing a
reading is exactly three parities.

**Two independent confirmations, not one measurement restated.** Row reduction
over the field with two elements on the 88 pivot cuttings produces 104
independent piece sets that no cutting can see, each then checked invisible
directly against all 15800 cuttings rather than only the 88 it was built from.
A block is left free exactly when one of those sets meets it in an odd number
of pieces, which happens for quarter zero and quarter one and no other block.
Separately, the size parity a reading fixes is recovered as the parity of how
many cuttings the reading marks, which the odd cuttings-per-piece count already
forces. So two of the five determinations are derived rather than read off.

**The three classes.** Those parities sort the 18 readings into exactly three
classes, and all six charge readings land in the single class where all three
are even. Physically: every carrier of a charge reading has even size and meets
quarters two and three in an even number of pieces. Exactly one class demands an
odd size and it holds no charge. Against the search's own licensing test the
three-parity rule agrees on all 191250 pairs of a split and a reading up to size
twenty, with no disagreement.

**Closed forms, with the anchor priced.** For a charge at size two k the
licensed splits are the sum of the first k plus one squares (5, 14, 30, 55, 91,
140, 204, 285, 385, 506 at sizes two through twenty); those holding a piece in
the anchor quarter are the sum of the first k squares (1, 5, 14, 30, 55, 91,
140, 204, 285, 385). The anchored count at one size equals the licensed count
one size below, so drawing every subset through the anchor costs exactly one
size step. The splits a charge licenses that miss the anchor number k plus one
squared: 4, 9, 16, 25, 36, 49, 64, 81, 100, 121. The even-size odd-quarter class
licenses one step below a charge and anchoring there is free; the odd-size class
licenses twice a tetrahedral number and nothing at any even size.

**The counts are rejected against the wrong parities.** A closed form measured
against the machinery that produced it can hold by construction, so the runner
builds the count for all four parity pairs on quarters two and three and asks
which reproduces the charge count. Only the even pair does. Both closed forms
are also matched against a direct enumeration that never consults the incidence.

## Runner numbers

`TOTAL: PASS=24 FAIL=0`, under 20 s, peak memory well inside budget, output
under the character ceiling. No solver: integer and field-with-two-elements
arithmetic on a finite explicit object.

## Boundary

The note states its own limits. Licensing bounds the search's work, not the
answer: a licensed split can be empty of carriers, and at the sizes searched in
earlier cycles many are. The 104 invisible sets are one basis, chosen by the row
reduction, and the free-block conclusion is basis-independent because a block
met evenly by every basis member is met evenly by every combination; the sizes
quoted for them describe the basis built, not a bound on how small an invisible
set can be. Counts are measured through size twenty. No physical reading of the
parity classes is claimed.

## Ordering

This package is self-contained. It rebuilds the system from the incidence alone
and uses no group theory, no census, and no search result, so it does not depend
on any other in-flight package and can be reviewed in any order relative to
them. Earlier-cycle artifacts are named in backticks rather than linked, and the
sole citation edge is to the minimal axioms note.

## Audit

Audit status is left unset; the independent audit lane owns grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
