### PR TITLE
feat(emergent-geometry): bracket the least carrier size for the flip partner of a charge

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_FLIP_PARTNER_CARRIER_BRACKET_CYCLE747_NOTE_2026-08-08.md
+++ b/docs/PHYSICAL_CELL_CUTTING_FLIP_PARTNER_CARRIER_BRACKET_CYCLE747_NOTE_2026-08-08.md
@@ -1,0 +1,221 @@
+# How few pieces can carry the flip partner of a charge — Cycle 747
+
+Date: 2026-08-08
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the cuttings, the readings and the block bookkeeping from scratch and
+gates each quantity in place. Constitutional effect: none. This package
+changes no axiom, no framework Admissibility rule, no primitive, no policy,
+and no audit status, and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Headline
+
+Each of the eight basic readings of the cut object has a flip partner: the
+reading that marks exactly the cuttings it leaves unmarked. An earlier cycle
+measured that the charge called four needs sixteen pieces to carry it. This
+cycle asks the same question of the flip partner of four, and brackets the
+answer between eighteen and twenty.
+
+The ceiling comes from a small theorem the runner proves outright. The
+all-marked reading, which marks every one of the 15800 cuttings, needs exactly
+eight pieces, and its eight-piece carriers are exactly the 192 sets of eight
+pieces that no cutting uses twice — one such set for every piece of the cut
+object. Adding one of those to a sixteen-piece carrier of four gives a carrier
+of the flip partner, and because the eleven anchored sixteen-piece carriers of
+four never share more than two pieces with one of them, the smallest sum built
+that way has twenty pieces. There are 512 distinct such sets and every one of
+them checks back against the incidence.
+
+The floor comes from search. Every search here is anchored, asking only for
+carriers through one fixed piece, and that costs nothing: the runner checks that
+the symmetries fixing a reading carry any piece to any other, so an empty
+anchored sweep is an empty sweep for the whole system. The anchored search finds
+no carrier of the flip partner at any even size from two up to sixteen, and at
+sixteen it is asked of exactly the cells and splits that deliver the eleven
+anchored sixteen-piece carriers of four, so the two sweeps are a matched pair at
+the same size rather than a negative result standing on its own. At eighteen
+the anchored search meets every anchored cell the flip partner licenses and
+records no carrier, but 26 of its 4796 splits are refused
+by the table guard, so eighteen is a measurement with a stated gap and not a
+proof of emptiness. The least size is therefore at least eighteen and at most
+twenty.
+
+## The rebuilt system
+
+The runner rebuilds the incidence table of the cutting system from scratch:
+15800 distinct cuttings on 192 pieces, each cutting using 24 pieces, each
+piece used in exactly 1975 cuttings. The two ways of counting the incidences
+agree, 24 times 15800 against 1975 times 192. A set of pieces carries a
+reading when, on every cutting, the parity of how many of its pieces that
+cutting uses is exactly what the reading asks for. The eight basic readings
+are the all-marked reading, the empty reading, the three charges four, six and
+seven, and the flip partners of those three.
+
+Each reading marks a definite number of cuttings, and since every piece meets
+1975 cuttings, a carrier must have at least as many pieces as it takes for
+1975 of them to cover the marks. The all-marked reading marks all 15800, which
+forces at least eight pieces; four marks 5664, which forces at least three;
+the flip partner of four marks the remaining 10136, which forces at least six.
+Those two mark counts add to 15800, as flip partners must.
+
+## The all-marked reading needs exactly eight pieces
+
+The counting floor of eight is attained, and the runner shows more than that:
+it identifies every eight-piece carrier. Eight pieces meet 1975 times eight,
+which is 15800, cuttings counted with multiplicity, and there are exactly
+15800 cuttings each of which must be met an odd number of times. So an
+eight-piece carrier meets every cutting exactly once, which is the same thing
+as saying no cutting uses two of its pieces.
+
+Reading that condition off the incidence directly, the runner builds the
+relation "no cutting uses both of these pieces" — each piece stands in that
+relation to exactly 33 others — and enumerates every set of eight pieces that
+are pairwise in it. There are 192 such sets, and all 192 do meet every cutting
+exactly once, so the two descriptions agree exactly. Each piece lies in
+exactly 8 of them. Two of them share 0, 1, 2 or 4 pieces and never 3: the
+counts by shared size are 15072, 1920, 960 and 384, and those four counts run
+over every pair of the 192, as the runner checks.
+
+## Why a flip partner cannot be far from its reading
+
+The eight basic readings close into an addition group of order 8 under
+parity addition, and in that group each flip partner is its reading plus the
+all-marked reading. Adding carriers adds readings, and the sum of two carriers
+has at most the sum of their sizes, so the least size of a reading and the
+least size of its flip partner differ by at most eight, which is the least
+size of the all-marked reading. The subgroup reachable from four and the
+all-marked reading is a four-element group, so this cycle's bracket speaks for
+four and its flip partner and says nothing about six or seven.
+
+## The ceiling at twenty
+
+The eleven anchored sixteen-piece carriers of four are checked against all 192
+eight-piece carriers of the all-marked reading. Every pair of one of the eleven
+with one of the 192 shares 0, 1 or 2 pieces, with counts 1216, 384 and 512, and
+each of the eleven meets the 192 in 128 pieces counted with multiplicity, which
+is 8 times its own size, exactly as the fact that each piece lies in 8 of them
+requires. Five distinct overlap profiles occur among the eleven.
+
+Since the largest overlap is 2, the smallest sum of one of the eleven and an
+eight-piece carrier of the all-marked reading has 16 plus 8 less twice 2, that
+is 20, pieces. There are 512 distinct such sets, every one of
+them has exactly 20 pieces, and every one of them recomputes to the flip
+partner of four when checked back against the incidence. So the least size for
+the flip partner is at most twenty.
+
+This also rules the two shortest routes to eighteen out on their own terms. An
+eighteen-piece sum built from one of the eleven would need an overlap of 3, and
+the measured largest overlap is 2. A sum built from a ten-piece carrier of the
+all-marked reading would need one to exist, and the search at ten finds none
+anywhere in the system.
+
+## Why one fixed piece is enough
+
+Every sweep in this cycle is anchored: it asks only for carriers that contain
+one fixed piece. That is a saving, not a restriction. The symmetries of the
+incidence table that fix a reading carry any piece to any other, and the runner
+checks that separately for each of the eight basic readings, finding in each
+case that all 48 cube symmetries fix the reading. So if any set of pieces
+anywhere in the system carried a reading at some size, a symmetry fixing
+that reading would carry one of its pieces onto the anchor, giving a carrier of
+the same reading at the same size through the anchor. An anchored sweep that
+comes back empty at a size is therefore empty for the whole system at that
+size, which is what the floor below rests on. Counts are a different matter and
+this note reports them anchored, as measured.
+
+## Nothing below eighteen
+
+The anchored search sweeps the even sizes 2, 4, 6, 8, 10, 12, 14 and 16, asking
+for carriers of four and of its flip partner. Odd sizes need no search: both
+readings force an even total. The flip partner has no carrier at any even size
+swept. Four has none below sixteen and eleven at sixteen.
+
+Two things make that emptiness meaningful rather than blind. First, at sizes
+8 and 10 the search also asks for the all-marked reading, and it returns
+exactly the eight-piece carriers of it that pass through the anchor piece —
+each of them one of the 192 already identified above, and there are 8 of them
+because each piece lies in 8 — and nothing at ten. A search that finds what is
+known to be there is a search whose silence carries information. Second, at
+sixteen the two questions are asked in the same pass:
+the same 204 licensed cells, the same 2004 splits. Four comes back with
+eleven, the flip partner with none. The negative sits at the same size, over
+the same work, as the positive.
+
+Every carrier the search recorded — 19 of them across all sizes — is checked
+back against the incidence directly rather than trusted from the bookkeeping
+of the search, and none fails.
+
+## Eighteen, measured with a stated gap
+
+Eighteen is the size the bracket turns on, and it is reported here exactly as
+it measured.
+
+The flip partner forces an even total size, so eighteen is the only even size
+between the emptiness at sixteen and the carriers at twenty. The anchored
+search at eighteen meets all 285 anchored cells the flip partner licenses
+there, an independent recount of them agreeing with what the sweep met, and
+processes 4796 splits. It records no carrier.
+
+But 4770 of those splits were searched and 26 were refused. Each refusal is a
+join whose intermediate table would need more rows than the guard allows: the
+guard sits at 30 million rows, and the refused joins asked for between 31 and
+21766 million, the largest more than 700 times the guard. The refusals sit in
+11 of the 285 cells. That residue is 26 splits out of 4796, and it is not
+reachable by relaxing the guard — the largest refused join is far beyond what
+the machine can hold.
+
+So the eighteen result is that a complete pass over every licensed cell, with
+26 of its 4796 splits refused, found nothing. That is evidence, carefully
+bounded, and it is not an emptiness certificate. The least size that can carry
+the flip partner of four is at least eighteen and at most twenty.
+
+## Boundary and honest read
+
+- Every statement here is about the finite cutting system. No physical reading
+  of the readings, the carriers or the bracket is claimed.
+- The bracket is {18, 20}, not a single value. The eighteen sweep found
+  nothing but did not search 26 of its 4796 splits, so this note does not
+  assert that eighteen is empty.
+- The searches at every size are anchored, and this note checks in place that
+  the symmetries fixing a reading carry any piece to any other, so an empty
+  anchored sweep at a size is empty for the whole system at that size. The
+  bracket is a whole-system statement, not an anchored-only one.
+- The eight-piece characterization of the all-marked reading's carriers is
+  complete and is a theorem, not a search result: the counting floor and the
+  converse both hold outright, and the enumeration of the 192 covers every set
+  of eight pieces that the relation admits, with none left out.
+- The ceiling of twenty is exact for sums of one of the eleven anchored
+  sixteen-piece carriers of four with an eight-piece carrier of the all-marked
+  reading, and the overlap cap of two is measured on those eleven. It does not
+  claim that every twenty-piece carrier of the flip partner arises that way.
+- The reachable subgroup from four and the all-marked reading has four
+  elements, so nothing here bounds the least size for six, for seven, or for
+  either of their flip partners.
+- Counting arguments were tried against eighteen and did not settle it. A
+  carrier of the flip partner can meet an eight-piece carrier of the all-marked
+  reading in at most four pieces, but the resulting total over the 192 of them
+  is consistent with a carrier of eighteen pieces existing, so that bound does
+  not decide the question; and the 192 sets do not form a balanced pair design,
+  so the second-moment step is unavailable. Only the search speaks to eighteen,
+  and its residue is stated above.
+- Earlier-cycle artifacts are named in backticks because their packages are in
+  flight, and nothing here links to them:
+  `PHYSICAL_CELL_CUTTING_SIXTEEN_ATTAINED_CYCLE742_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_HIDDEN_THREE_BIT_GEOMETRY_CYCLE743_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_FULL_SYMMETRY_CERTIFIED_CYCLE744_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_SIXTEEN_CENSUS_CYCLE745_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_CARRIER_PARITY_LAW_CYCLE746_NOTE_2026-08-08.md`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15465,
- "node_count": 4652,
+ "edge_count": 15466,
+ "node_count": 4653,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10481,6 +10481,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_flip_partner_carrier_bracket_cycle747_note_2026-08-08": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.txt
+++ b/logs/runner-cache/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.txt
@@ -1,0 +1,67 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.py
+runner_sha256: e277be4ee1bb5b332c596d4db335594fe1301e5e86383166bdf72adde0b5a76f
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 406.22
+status: ok
+----- stdout -----
+PASS G0  the Gram matrix of the table has constant diagonal 1975
+PASS G1  all 15800 cuttings carry distinct piece supports
+PASS G2  the anchored and the two seeded colour refinements are all discrete
+PASS G3  b0 is an order-two piece permutation with a matching cutting permutation
+PASS G4  b0 fixes all eight readings
+PASS G5  b0 lies outside the 48, orbit rows (0,48,0,0) (48,0,0,0) (0,0,0,48) (0,0,48,0)
+PASS G6  b1 is an order-two piece permutation with a matching cutting permutation
+PASS G7  b1 fixes all eight readings
+PASS G8  b1 lies outside the 48, orbit rows (8,8,16,16) (8,8,16,16) (16,16,8,8) (16,16,8,8)
+PASS G9  b0 and b1 are different permutations
+PASS G10  the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive
+PASS G11  each charge and each planted reading forces even total, side, and quarter parities, and the synthetic reading forces an odd total
+PASS G12  the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes two to sixteen, matching the closed sum, with consecutive odd squares as steps
+PASS G13  all six charges license the same 285 cells at sixteen, one pass covers the six
+PASS G14  the odd-total synthetic reading licenses no cell at sixteen
+PASS G15  the licensed cells at sixteen with a piece in the last quarter number 204, and the six charges and the five planted readings share exactly that list
+PASS G16  the anchored tables list exactly the subsets through the anchor piece, row for row against direct column sums, with binomial row counts
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS G17  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+marks: the all-marked reading 15800, four 5664, its flip partner 10136
+least size those marks force: 8, 3, 6 pieces
+PASS G18  a carrier meets each marked cutting at least once while each piece meets 1975 cuttings, so the marks force a least size
+pieces no cutting shares with a given piece: 33
+eight-piece sets no cutting uses twice: 192, of those meeting every cutting exactly once: 192
+PASS G19  eight pieces meeting every cutting exactly once is the same as eight pieces no cutting uses twice, since eight of them meet 15800 with multiplicity
+each piece lies in 8 of them; two of them share pieces, count by value: {0:15072,1:1920,2:960,4:384}
+PASS G20  those carriers meet each piece the same number of times and meet each other in 0, 1, 2 or 4 pieces, never 3
+those eight readings close into an addition group of order 8
+PASS G21  each flip partner is its reading plus the all-marked reading, so a reading and its flip partner have least sizes differing by at most eight
+symmetries of the table that fix a basic reading: 48, and they carry any piece to any other: True
+PASS G22  the symmetries that fix a reading carry any piece to any other, so asking for carriers through one fixed piece decides the question for every piece
+
+anchored search, carriers of four then of its flip partner, by size: 2: 0 and 0, 4: 0 and 0, 6: 0 and 0, 8: 0 and 0, 10: 0 and 0, 12: 0 and 0, 14: 0 and 0, 16: 11 and 0
+at sixteen both were asked of the same 204 cells over the same 2004 splits
+carriers recorded below eighteen 19, recheck failures 0
+PASS G23  the search finds the eight-piece carriers of the all-marked reading through the anchor and none at ten, so it is not blind when it comes back empty
+PASS G24  four has no anchored carrier below sixteen and has eleven at sixteen, every sweep complete
+PASS G25  the flip partner of four has no anchored carrier at any even size up to sixteen, asked of exactly the cells and splits that deliver the eleven
+PASS G26  each recorded carrier is checked back against the incidence directly, not trusted from the bookkeeping of the search
+
+the eleven against the 192 eight-piece carriers: overlaps by value {0:1216,1:384,2:512}, 5 profiles
+PASS G27  a sixteen-piece carrier of four meets an eight-piece carrier of the all-marked reading in at most two pieces, and all of them in 128 with multiplicity
+their sums of the smallest size: 512 sets of 20 pieces, each carrying the flip partner, failures 0
+PASS G28  adding an eight-piece carrier of the all-marked reading to a sixteen-piece carrier of four gives a carrier of the flip partner of twenty at the smallest
+
+size eighteen for the flip partner: 285 licensed cells all met, 4796 splits, 4770 searched, 26 refused, 0 carriers
+rounded up to the million the refused joins wanted between 31 and 21766 million rows, against a guard of 30 million, and they sit in 11 of the 285 cells
+PASS G29  the anchored search at eighteen met every cell the flip partner licenses and recorded no carrier of it
+PASS G30  those refused splits wanted more rows than the table guard allows, the largest by a factor above 700, so eighteen is measured with a stated gap
+PASS G31  the flip partner forces an even total, carries nothing at sixteen or below, and is carried by twenty, so its least size is at least eighteen and at most twenty
+elapsed under 500 s peak memory under 2500 MB
+PASS G32  the whole runner finishes under 900 seconds inside the printed 2500 MB
+PASS G33  its output stays under 5500 characters
+
+TOTAL: PASS=34 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08_cold_2026-08-08.txt
+++ b/outputs/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08_cold_2026-08-08.txt
@@ -1,0 +1,56 @@
+PASS G0  the Gram matrix of the table has constant diagonal 1975
+PASS G1  all 15800 cuttings carry distinct piece supports
+PASS G2  the anchored and the two seeded colour refinements are all discrete
+PASS G3  b0 is an order-two piece permutation with a matching cutting permutation
+PASS G4  b0 fixes all eight readings
+PASS G5  b0 lies outside the 48, orbit rows (0,48,0,0) (48,0,0,0) (0,0,0,48) (0,0,48,0)
+PASS G6  b1 is an order-two piece permutation with a matching cutting permutation
+PASS G7  b1 fixes all eight readings
+PASS G8  b1 lies outside the 48, orbit rows (8,8,16,16) (8,8,16,16) (16,16,8,8) (16,16,8,8)
+PASS G9  b0 and b1 are different permutations
+PASS G10  the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive
+PASS G11  each charge and each planted reading forces even total, side, and quarter parities, and the synthetic reading forces an odd total
+PASS G12  the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes two to sixteen, matching the closed sum, with consecutive odd squares as steps
+PASS G13  all six charges license the same 285 cells at sixteen, one pass covers the six
+PASS G14  the odd-total synthetic reading licenses no cell at sixteen
+PASS G15  the licensed cells at sixteen with a piece in the last quarter number 204, and the six charges and the five planted readings share exactly that list
+PASS G16  the anchored tables list exactly the subsets through the anchor piece, row for row against direct column sums, with binomial row counts
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS G17  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+marks: the all-marked reading 15800, four 5664, its flip partner 10136
+least size those marks force: 8, 3, 6 pieces
+PASS G18  a carrier meets each marked cutting at least once while each piece meets 1975 cuttings, so the marks force a least size
+pieces no cutting shares with a given piece: 33
+eight-piece sets no cutting uses twice: 192, of those meeting every cutting exactly once: 192
+PASS G19  eight pieces meeting every cutting exactly once is the same as eight pieces no cutting uses twice, since eight of them meet 15800 with multiplicity
+each piece lies in 8 of them; two of them share pieces, count by value: {0:15072,1:1920,2:960,4:384}
+PASS G20  those carriers meet each piece the same number of times and meet each other in 0, 1, 2 or 4 pieces, never 3
+those eight readings close into an addition group of order 8
+PASS G21  each flip partner is its reading plus the all-marked reading, so a reading and its flip partner have least sizes differing by at most eight
+symmetries of the table that fix a basic reading: 48, and they carry any piece to any other: True
+PASS G22  the symmetries that fix a reading carry any piece to any other, so asking for carriers through one fixed piece decides the question for every piece
+
+anchored search, carriers of four then of its flip partner, by size: 2: 0 and 0, 4: 0 and 0, 6: 0 and 0, 8: 0 and 0, 10: 0 and 0, 12: 0 and 0, 14: 0 and 0, 16: 11 and 0
+at sixteen both were asked of the same 204 cells over the same 2004 splits
+carriers recorded below eighteen 19, recheck failures 0
+PASS G23  the search finds the eight-piece carriers of the all-marked reading through the anchor and none at ten, so it is not blind when it comes back empty
+PASS G24  four has no anchored carrier below sixteen and has eleven at sixteen, every sweep complete
+PASS G25  the flip partner of four has no anchored carrier at any even size up to sixteen, asked of exactly the cells and splits that deliver the eleven
+PASS G26  each recorded carrier is checked back against the incidence directly, not trusted from the bookkeeping of the search
+
+the eleven against the 192 eight-piece carriers: overlaps by value {0:1216,1:384,2:512}, 5 profiles
+PASS G27  a sixteen-piece carrier of four meets an eight-piece carrier of the all-marked reading in at most two pieces, and all of them in 128 with multiplicity
+their sums of the smallest size: 512 sets of 20 pieces, each carrying the flip partner, failures 0
+PASS G28  adding an eight-piece carrier of the all-marked reading to a sixteen-piece carrier of four gives a carrier of the flip partner of twenty at the smallest
+
+size eighteen for the flip partner: 285 licensed cells all met, 4796 splits, 4770 searched, 26 refused, 0 carriers
+rounded up to the million the refused joins wanted between 31 and 21766 million rows, against a guard of 30 million, and they sit in 11 of the 285 cells
+PASS G29  the anchored search at eighteen met every cell the flip partner licenses and recorded no carrier of it
+PASS G30  those refused splits wanted more rows than the table guard allows, the largest by a factor above 700, so eighteen is measured with a stated gap
+PASS G31  the flip partner forces an even total, carries nothing at sixteen or below, and is carried by twenty, so its least size is at least eighteen and at most twenty
+elapsed under 500 s peak memory under 2500 MB
+PASS G32  the whole runner finishes under 900 seconds inside the printed 2500 MB
+PASS G33  its output stays under 5500 characters
+
+TOTAL: PASS=34 FAIL=0

--- a/outputs/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08_receipt_2026-08-08.json
+++ b/outputs/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08_receipt_2026-08-08.json
@@ -1,0 +1,112 @@
+{
+ "cycle": 747,
+ "failures": 0,
+ "gates": 34,
+ "headline": "The least number of pieces that can carry the flip partner of the four charge is at least eighteen and at most twenty. The all-marked reading needs exactly eight pieces, and its eight-piece carriers are exactly the 192 sets of eight pieces that no cutting uses twice, one for each piece. Each of the eleven anchored sixteen-piece carriers of four meets one of those in at most two pieces, so their sums have twenty pieces at the smallest, and all 512 of them check back as carriers of the flip partner. Below that the anchored search finds no carrier of the flip partner at any even size from two up to sixteen, asked at sixteen of exactly the 204 cells and 2004 splits that deliver the eleven anchored carriers of four. All 48 cube symmetries fix each basic reading and carry any piece to any other, so an empty anchored sweep at a size is empty for the whole system at that size. At eighteen the search meets all 285 anchored licensed cells and records none, with 26 of its 4796 splits refused by the table guard, so eighteen is measured with a stated gap.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_FLIP_PARTNER_CARRIER_BRACKET_CYCLE747_NOTE_2026-08-08.md",
+ "recorded_output": "outputs/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08_cold_2026-08-08.txt",
+ "results": {
+  "all_marked_reading_carriers": {
+   "basic_readings_addition_group_order": 8,
+   "carriers_through_each_piece": 8,
+   "eight_piece_sets_no_cutting_uses_twice": 192,
+   "least_size": 8,
+   "non_sharing_partners_per_piece": 33,
+   "of_those_meeting_every_cutting_exactly_once": 192,
+   "shared_pieces_between_two_carriers": {
+    "0": 15072,
+    "1": 1920,
+    "2": 960,
+    "4": 384
+   }
+  },
+  "anchored_search_below_eighteen": {
+   "carriers_recorded": 19,
+   "direct_recheck_failures": 0,
+   "every_sweep_complete": true,
+   "flip_partner_carriers_by_size": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+   ],
+   "four_carriers_by_size": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    11
+   ],
+   "matched_cells_at_sixteen": 204,
+   "matched_splits_at_sixteen": 2004,
+   "sizes": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16
+   ]
+  },
+  "anchoring_licence": {
+   "basic_readings_checked": 8,
+   "cube_symmetries_fixing_each_basic_reading": 48,
+   "they_carry_any_piece_to_any_other": true
+  },
+  "bracket": {
+   "at_most": 20,
+   "least_size_flip_partner_at_least": 18
+  },
+  "ceiling_at_twenty": {
+   "direct_recheck_failures": 0,
+   "each_carrier_met_with_multiplicity": 128,
+   "largest_overlap": 2,
+   "overlap_profiles": 5,
+   "shared_pieces_eleven_against_the_192": {
+    "0": 1216,
+    "1": 384,
+    "2": 512
+   },
+   "twenty_piece_carriers_of_the_flip_partner": 512
+  },
+  "eighteen": {
+   "anchored_licensed_cells": 285,
+   "anchored_licensed_cells_met": 285,
+   "carriers_found": 0,
+   "cells_carrying_a_refusal": 11,
+   "complete": false,
+   "refused_join_rows_million_high": 21766,
+   "refused_join_rows_million_low": 31,
+   "splits": 4796,
+   "splits_refused": 26,
+   "splits_searched": 4770,
+   "table_guard_rows_million": 30
+  },
+  "marks_and_forced_least_sizes": {
+   "all_marked_reading_marks": 15800,
+   "flip_partner_marks": 10136,
+   "four_marks": 5664,
+   "least_size_forced_all_marked": 8,
+   "least_size_forced_flip_partner": 6,
+   "least_size_forced_four": 3
+  },
+  "rebuilt_system": {
+   "cuttings": 15800,
+   "cuttings_per_piece": 1975,
+   "pieces": 192,
+   "pieces_per_cutting": 24
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.py
+++ b/scripts/physical_cell_cutting_flip_partner_carrier_bracket_cycle747_2026_08_08.py
@@ -1,0 +1,1743 @@
+"""Cycle 747: how few pieces can carry the flip partner of the four charge.
+
+The unit four-cube on sixteen corners cuts into least-volume pieces at the adjacency
+cost floor in 15800 ways, and those cuttings use 192 pieces between them. A set of
+pieces carries a reading when the cuttings it meets an odd number of times are exactly
+the ones the reading marks. Cycle 742 measured the least size for the charge called
+four: sixteen pieces. This runner measures the same quantity for the flip partner of
+four, the reading that marks every cutting four leaves unmarked and leaves unmarked
+every cutting four marks.
+
+Three things are settled here. The all-marked reading needs exactly eight pieces, and
+its eight-piece carriers are exactly the 192 sets of eight pieces that no cutting uses
+twice, one for each piece of the cube. Adding one of those to a sixteen-piece carrier
+of four gives a carrier of the flip partner, and because those two never share more
+than two pieces the smallest such sum has twenty pieces. Below that, the anchored
+search finds no carrier of the flip partner at any even size up to sixteen, asked of
+exactly the cells and splits that deliver the eleven anchored carriers of four.
+
+That leaves eighteen. The anchored search meets every cell the flip partner licenses
+there and records no carrier, but twenty-six of its 4796 splits are refused because the
+join they ask for wants more rows than the table guard allows, so the eighteen result
+is a measurement with a stated gap and not a proof of emptiness. The least number of
+pieces that can carry the flip partner of four is therefore at least eighteen and at
+most twenty.
+
+Class-A: integer and field-with-two-elements arithmetic on a finite explicit object, no
+solver. Every count below is measured here.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.time()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+
+PK = np.packbits(INC, axis=1)
+LUT = np.array([bin(i).count("1") for i in range(256)], dtype=np.uint8)
+SZC = [4, 6]
+SZG = [4]
+EA = dict((k, []) for k in SZC)
+EB = dict((k, []) for k in SZC)
+DIS = dict((k, set()) for k in SZG)
+for lo in range(0, NS, 200):
+    hi = min(lo + 100, NS)
+    d = LUT[np.bitwise_xor(PK[lo:hi, None, :], PK[None, :, :])].sum(axis=2, dtype=np.int16)
+    for k in SZC:
+        rr, cc = np.nonzero(d == 2 * k)
+        keep = (rr + lo) < cc
+        aa = (rr[keep] + lo).tolist()
+        bb = cc[keep].tolist()
+        EA[k].extend(aa)
+        EB[k].extend(bb)
+        if k in DIS:
+            for a, b in zip(aa, bb):
+                DIS[k].add(BITS[a] ^ BITS[b])
+for k in SZC:
+    EA[k] = np.asarray(EA[k], dtype=np.int64)
+    EB[k] = np.asarray(EB[k], dtype=np.int64)
+KEY = dict((k, sorted(DIS[k])) for k in SZG)
+
+def basis(rows, piv=None):
+    """pivot table of the span of rows, over the field with two elements"""
+    if piv is None:
+        piv = {}
+    for r in rows:
+        while r:
+            h = r.bit_length() - 1
+            if h not in piv:
+                piv[h] = r
+                break
+            r ^= piv[h]
+    return piv
+
+
+def inspan(r, piv):
+    """does r lie in the span the pivot table describes"""
+    while r:
+        h = r.bit_length() - 1
+        if h not in piv:
+            return False
+        r ^= piv[h]
+    return True
+
+
+def rref(rows, piv=None):
+    """pivot table cleared above the pivots as well as below"""
+    piv = basis(rows, piv)
+    for h in sorted(piv):
+        for g in sorted(piv):
+            if g > h and ((piv[g] >> h) & 1) == 1:
+                piv[g] ^= piv[h]
+    return piv
+
+
+def perp(piv, n):
+    """the weights on n pieces annihilating everything the pivot table spans"""
+    out = []
+    for j in range(n):
+        if j in piv:
+            continue
+        w = 1 << j
+        for h in piv:
+            if ((piv[h] >> j) & 1) == 1:
+                w |= 1 << h
+        out.append(w)
+    for w in out:
+        for r in piv.values():
+            assert (bin(w & r).count("1") & 1) == 0, "a uniform weight must annihilate"
+    return out
+
+
+TK = {}
+for k in SZG:
+    TK[k] = rref(s ^ KEY[k][0] for s in KEY[k][1:])
+
+NUL = perp(TK[4], NPO)
+WM = np.zeros((NPO, len(NUL)), dtype=np.int64)
+for c, w in enumerate(NUL):
+    for j in range(NPO):
+        if ((w >> j) & 1) == 1:
+            WM[j, c] = 1
+FF = (INCL @ WM) & 1
+PIV = {}
+for c in range(FF.shape[1]):
+    a = FF[:, c].astype(np.uint8)
+    r = int.from_bytes(np.packbits(a).tobytes(), "big")
+    while r:
+        h = r.bit_length() - 1
+        if h not in PIV:
+            PIV[h] = (r, a)
+            break
+        r ^= PIV[h][0]
+        a = a ^ PIV[h][1]
+BAS = [PIV[h][1] for h in sorted(PIV)]
+FUN = []
+for mask in range(1 << len(BAS)):
+    f = np.zeros(NS, dtype=np.uint8)
+    for i, b in enumerate(BAS):
+        if ((mask >> i) & 1) == 1:
+            f = f ^ b
+    FUN.append(f)
+
+NAMED, HITS = {}, {}
+for f in FUN:
+    one = int(f.sum())
+    if one in (0, NS):
+        continue
+    g = f if 2 * one <= NS else (f ^ 1)
+    d4 = g[EA[4]] ^ g[EB[4]]
+    d6 = g[EA[6]] ^ g[EB[6]]
+    nm = "four" if d4.max() == 0 else ("six" if d6.max() == 0 else "seven")
+    NAMED[nm] = g
+    HITS[nm] = HITS.get(nm, 0) + 1
+
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+
+# ---- the twelve targets: eight readings plus the four planted controls of Part 3 ----
+ZERO = np.zeros(NS, dtype=np.uint8)
+ONE = np.ones(NS, dtype=np.uint8)
+TGT = [("zero", ZERO), ("one", ONE)]
+for nm in ["four", "six", "seven"]:
+    TGT.append((nm, NAMED[nm]))
+    TGT.append((nm + "-flip", NAMED[nm] ^ 1))
+PLANT = [("pair (2,2)", (10, 55, 120, 168)),
+         ("h6 (6,2)", (3, 21, 44, 61, 77, 90, 101, 155)),
+         ("in-left quarters (3,5)", (2, 9, 30, 50, 63, 71, 80, 91)),
+         ("in-right one quarter (0,8)", (150, 151, 160, 165, 170, 180, 185, 191))]
+for pname, psupp in PLANT:
+    TGT.append((pname, (INCL[:, list(psupp)].sum(axis=1) & 1).astype(np.uint8)))
+NT = len(TGT)
+
+# ---- the 88 pivot cuttings and a piece's packed parities, rebuilt from INC ----
+EPACK = np.packbits(INC, axis=1, bitorder="little")
+EROW = [int.from_bytes(EPACK[i].tobytes(), "little") for i in range(NS)]
+EBAS0 = {}
+EPIVL = []
+for i in range(NS):
+    v = EROW[i]
+    while v:
+        lb = v.bit_length() - 1
+        if lb in EBAS0:
+            v ^= EBAS0[lb]
+        else:
+            EBAS0[lb] = v
+            EPIVL.append(i)
+            v = 0
+ERANK = len(EPIVL)
+EPIV = np.array(sorted(EPIVL), dtype=np.int64)
+P88 = INC[EPIV]
+
+
+def pack88(bits):
+    """the parities on the 88 pivot cuttings, as two sixty-four bit words"""
+    b = np.asarray(bits, dtype=np.uint64)
+    out = np.zeros(b.shape[:-1] + (2,), dtype=np.uint64)
+    for i in range(88):
+        wd, sh = divmod(i, 64)
+        out[..., wd] |= b[..., i] << np.uint64(sh)
+    return out
+
+
+COLS = pack88(P88.T)
+
+
+# ---- the eighteen readings: twelve as before, five planted fourteen-sets, one control ----
+PSEED = 74516
+P16SPEC = [("p16-a4444", (4, 4, 4, 4)),
+           ("p16-a0-0-6-10", (0, 0, 6, 10)),
+           ("p16-a8044", (8, 0, 4, 4)),
+           ("p16-a2-2-2-10", (2, 2, 2, 10)),
+           ("p16-a0-8-0-8", (0, 8, 0, 8))]
+prng2 = np.random.default_rng(PSEED)
+PSET = {}
+TNAME = [nm for nm, _f in TGT]
+FVEC = [f for _nm, f in TGT]
+for pi, (pnm, prof) in enumerate(P16SPEC):
+    Sp = [144] + [145 + int(c) for c in prng2.choice(47, prof[3] - 1, replace=False)]
+    for q in range(3):
+        Sp += [48 * q + int(c) for c in prng2.choice(48, prof[q], replace=False)]
+    Sp = sorted(Sp)
+    PSET[NT + pi] = tuple(Sp)
+    TNAME.append(pnm)
+    FVEC.append((INCL[:, Sp].sum(axis=1) & 1).astype(np.uint8))
+FODD = np.zeros(NS, dtype=np.uint8)
+FODD[0] = 1
+TNAME.append("odd-ctl")
+FVEC.append(FODD)
+NTG = len(FVEC)
+TCTL = NTG - 1
+FV = np.stack(FVEC)
+TG = pack88(FV[:, EPIV])
+
+# ---- the parities a search of the pieces is forced to respect on each block ----
+LBAS = {}
+for i in range(NS):
+    v = EROW[i]
+    a = 0
+    for k in range(NTG):
+        a |= int(FV[k, i]) << k
+    while v:
+        lb = v.bit_length() - 1
+        if lb in LBAS:
+            bv, ba = LBAS[lb]
+            v ^= bv
+            a ^= ba
+        else:
+            LBAS[lb] = (v, a)
+            v = 0
+
+
+def reduce_u(u_int):
+    """the forced parities of a block, or None when the block is free"""
+    v, a = u_int, 0
+    while v:
+        lb = v.bit_length() - 1
+        if lb not in LBAS:
+            return None
+        bv, ba = LBAS[lb]
+        v ^= bv
+        a ^= ba
+    return a
+
+
+def uint_of(cols):
+    u = 0
+    for c in cols:
+        u |= 1 << int(c)
+    return u
+
+
+BLK = {"total": range(192), "L": range(96), "R": range(96, 192)}
+for q in range(4):
+    BLK["Q{0}".format(q)] = range(48 * q, 48 * q + 48)
+for e in range(8):
+    BLK["E{0}".format(e)] = range(24 * e, 24 * e + 24)
+FORCED = dict((nm, reduce_u(uint_of(b))) for nm, b in BLK.items())
+
+# ---- lex extension chains over the quarters and the eighths ----
+BQ = 27
+MQ = np.uint64(2**BQ - 1)
+Q_COLS = [np.arange(48 * q, 48 * q + 48) for q in range(4)]
+E_COLS = [np.arange(24 * e, 24 * e + 24) for e in range(8)]
+
+
+def build_chain(cols, kmax):
+    """Lex extension chain over cols. Returns T[k] (syn), NOFF[k].
+
+    T[k] row order: blocks by lead column c ascending; block c = rows of
+    T[k-1] with min column > c, in their T[k-1] order, XOR syn(c).
+    NOFF[k][c] = first row of block c; NOFF[k][n] = len(T[k]).
+    """
+    n = len(cols)
+    T = {0: np.zeros((1, 2), dtype=np.uint64)}
+    NOFF = {1: np.arange(n + 1, dtype=np.int64)}
+    if kmax >= 1:
+        T[1] = COLS[cols].copy()
+    for k in range(1, kmax):
+        prev, poff = T[k], NOFF[k]
+        total = sum(len(prev) - poff[c + 1] for c in range(n))
+        out = np.empty((total, 2), dtype=np.uint64)
+        noff = np.empty(n + 1, dtype=np.int64)
+        pos = 0
+        for c in range(n):
+            blk = prev[poff[c + 1]:]
+            noff[c] = pos
+            if len(blk):
+                np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+            pos += len(blk)
+        noff[n] = pos
+        T[k + 1] = out
+        NOFF[k + 1] = noff
+    return T, NOFF
+
+
+def unrank(NOFF, k, idx, cols):
+    """idx in T[k] -> global column list (len k)."""
+    out = []
+    idx = int(idx)
+    for lvl in range(k, 1, -1):
+        no = NOFF[lvl]
+        c = int(np.searchsorted(no, idx, side="right")) - 1
+        out.append(int(cols[c]))
+        idx = int(NOFF[lvl - 1][c + 1]) + (idx - int(no[c]))
+    if k >= 1:
+        out.append(int(cols[idx]))
+    return out
+
+
+QCH = []
+for q in range(4):
+    QCH.append(build_chain(Q_COLS[q], 5))
+
+_C3 = list(itertools.combinations(range(48), 3))
+UNROK = True
+for q in range(4):
+    for idx in (0, 5, 1000, 17295):
+        got = sorted(unrank(QCH[q][1], 3, idx, Q_COLS[q]))
+        exp = sorted(int(Q_COLS[q][c]) for c in _C3[idx])
+        UNROK = UNROK and got == exp
+
+_T6_CACHE = {}
+
+
+def get_T6(q):
+    """(T6, NOFF6) for quarter q, built on demand from T5."""
+    if q in _T6_CACHE:
+        return _T6_CACHE[q]
+    T, NOFF = QCH[q]
+    n = 48
+    cols = Q_COLS[q]
+    prev, poff = T[5], NOFF[5]
+    total = sum(len(prev) - poff[c + 1] for c in range(n))
+    out = np.empty((total, 2), dtype=np.uint64)
+    noff = np.empty(n + 1, dtype=np.int64)
+    pos = 0
+    for c in range(n):
+        blk = prev[poff[c + 1]:]
+        noff[c] = pos
+        if len(blk):
+            np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+        pos += len(blk)
+    noff[n] = pos
+    _T6_CACHE[q] = (out, noff)
+    return _T6_CACHE[q]
+
+
+def qtab(q, k):
+    """(syn table, unranker) for k-subsets of quarter q, k <= 6."""
+    if k <= 5:
+        T, NOFF = QCH[q]
+        return T[k], (lambda i, q=q, k=k: unrank(QCH[q][1], k, i, Q_COLS[q]))
+    T6, noff6 = get_T6(q)
+
+    def unr6(i, q=q, noff6=noff6):
+        i = int(i)
+        c = int(np.searchsorted(noff6, i, side="right")) - 1
+        idx5 = int(QCH[q][1][5][c + 1]) + (i - int(noff6[c]))
+        return [int(Q_COLS[q][c])] + unrank(QCH[q][1], 5, idx5, Q_COLS[q])
+    return T6, unr6
+
+
+# ---------------------------------------------- Part 3: the meet engine at twelve
+# A set of pieces is split by quarter into a cell (q0, q1, q2, q3). One part is streamed
+# and the rest are met against it. Every meeting is pruned by the parities forced inside
+# the union of the blocks already joined, so no wide product is ever built.
+
+CAP = 200000
+TABCAP = 30000000
+CHUNK = 2000000
+BLOWN = []
+QCOLS = [list(range(48 * q, 48 * q + 48)) for q in range(4)]
+ECOLS = [list(range(24 * e, 24 * e + 24)) for e in range(8)]
+CINT = []
+for _j in range(NPO):
+    _v = 0
+    for _i in range(88):
+        if P88[_i, _j]:
+            _v |= 1 << _i
+    CINT.append(_v)
+
+
+def col_rank(S):
+    """rank of a set of columns as vectors on the 88 pivot cuttings"""
+    piv = {}
+    for j in S:
+        v = CINT[j]
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                v ^= piv[h]
+            else:
+                piv[h] = v
+                break
+    return len(piv)
+
+
+def compl(S):
+    s = set(S)
+    return [j for j in range(NPO) if j not in s]
+
+
+def inner(S):
+    """basis of the parities living inside a column set: x with x.COLS[j] = 0 off S"""
+    out = compl(S)
+    piv, ker = {}, []
+    for i in range(88):
+        v, w = 0, 1 << i
+        for a, j in enumerate(out):
+            if (CINT[j] >> i) & 1:
+                v |= 1 << a
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                bv, bw = piv[h]
+                v ^= bv
+                w ^= bw
+            else:
+                piv[h] = (v, w)
+                break
+        if v == 0:
+            ker.append(w)
+    return ker
+
+
+def sub_kernel(S):
+    """basis of the piece sets inside S whose parities on the cuttings all vanish"""
+    piv, ker = {}, []
+    for a, j in enumerate(S):
+        v, w = CINT[j], 1 << a
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                bv, bw = piv[h]
+                v ^= bv
+                w ^= bw
+            else:
+                piv[h] = (v, w)
+                break
+        if v == 0:
+            ker.append(w)
+    return ker
+
+
+def keymap(X):
+    """byte tables turning a packed syndrome into its parities under a basis"""
+    d = len(X)
+    nw = max(1, (d + 63) // 64)
+    lut = np.zeros((nw, 11, 256), dtype=np.uint64)
+    con = np.zeros((11, 8, nw), dtype=np.uint64)
+    for b in range(11):
+        for p in range(8):
+            i = 8 * b + p
+            if i >= 88:
+                continue
+            for a, x in enumerate(X):
+                if (x >> i) & 1:
+                    con[b, p, a // 64] |= np.uint64(1) << np.uint64(a & 63)
+    for b in range(11):
+        for v in range(256):
+            acc = np.zeros(nw, dtype=np.uint64)
+            for p in range(8):
+                if (v >> p) & 1:
+                    acc ^= con[b, p]
+            lut[:, b, v] = acc
+    return lut
+
+
+def keyof(syn, lut):
+    """the parity key of every row of a packed syndrome table"""
+    a = np.ascontiguousarray(syn).view(np.uint8).reshape(-1, 16)
+    nw = lut.shape[0]
+    out = np.zeros((a.shape[0], nw), dtype=np.uint64)
+    for b in range(11):
+        idx = a[:, b]
+        for w in range(nw):
+            out[:, w] ^= lut[w, b][idx]
+    return out
+
+
+def key1(vec, lut):
+    """the parity key of one packed syndrome"""
+    a = np.ascontiguousarray(np.asarray(vec, dtype=np.uint64)).view(np.uint8)
+    nw = lut.shape[0]
+    out = np.zeros(nw, dtype=np.uint64)
+    for b in range(11):
+        for w in range(nw):
+            out[w] ^= lut[w, b, int(a[b])]
+    return out
+
+
+# ---- part tables: a quarter at weight up to six, an eighth at any weight to twelve ----
+_ECH = {}
+
+
+def echain(e, kmax):
+    """the lex extension chain over one block of 24, extended in place as needed"""
+    st = _ECH.get(e)
+    if st is None:
+        cols = np.array(ECOLS[e], dtype=np.int64)
+        st = ({1: COLS[cols].copy()}, {1: np.arange(25, dtype=np.int64)}, cols)
+        _ECH[e] = st
+    T, NOFF, cols = st
+    n = 24
+    k = max(T)
+    while k < kmax:
+        prev, poff = T[k], NOFF[k]
+        total = sum(len(prev) - poff[c + 1] for c in range(n))
+        out = np.empty((total, 2), dtype=np.uint64)
+        noff = np.empty(n + 1, dtype=np.int64)
+        pos = 0
+        for c in range(n):
+            blk = prev[poff[c + 1]:]
+            noff[c] = pos
+            if len(blk):
+                np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+            pos += len(blk)
+        noff[n] = pos
+        T[k + 1] = out
+        NOFF[k + 1] = noff
+        k += 1
+    return T[kmax], NOFF
+
+
+ZT = np.zeros((1, 2), dtype=np.uint64)
+BMP = np.zeros(2**BQ, dtype=np.uint8)
+_INNC = {}
+_LUTC = {}
+_SKC = {}
+_SKN = [0]
+SKCAP = 36000000
+
+
+def inner_of(lky, cols):
+    """the internal parity space of a block union, kept across the splits sharing it"""
+    hit = _INNC.get(lky)
+    if hit is None:
+        hit = inner(cols)
+        _INNC[lky] = hit
+    return hit
+
+
+def lut_for(lky, cols):
+    """the byte tables of a block union, kept across the splits that share it"""
+    hit = _LUTC.get(lky)
+    if hit is None:
+        hit = keymap(inner_of(lky, cols))
+        _LUTC[lky] = hit
+    return hit
+
+
+def plan_order(ne, sizes, fky, fcols):
+    """the join order whose largest intermediate meet is smallest
+
+    A join keys on the parities living inside the blocks joined so far, so an order
+    that joins blocks with no shared internal parity first has nothing to key on and
+    forms the whole product. The order is chosen here, and the answer does not depend
+    on it: every join is a necessary condition on the same final set.
+    """
+    n = len(sizes)
+    if n < 3:
+        return sorted(range(n), key=lambda i: (sizes[i], i))
+    cols = [QCOLS[s[1]] if s[0] == "Q" else ECOLS[s[1]] for s in ne]
+    dF = min(len(inner_of(fky, fcols)), 62)
+    best, bp = None, None
+    for p in itertools.permutations(range(n)):
+        cur, worst = float(sizes[p[0]]), float(sizes[p[0]])
+        acc, accs = list(cols[p[0]]), [(ne[p[0]][0], ne[p[0]][1])]
+        for j in range(1, n):
+            acc = acc + list(cols[p[j]])
+            accs = accs + [(ne[p[j]][0], ne[p[j]][1])]
+            d = dF if j == n - 1 else min(
+                len(inner_of(("I", tuple(sorted(accs))), acc)), 62)
+            cur = cur * sizes[p[j]] / float(1 << d)
+            worst = max(worst, cur)
+        if best is None or worst < best:
+            best, bp = worst, list(p)
+    return bp
+
+
+def sorted_keys(sky, tab, lut):
+    """the sorted parity keys of a part table, kept across the splits that share it"""
+    hit = _SKC.get(sky)
+    if hit is not None:
+        return hit
+    kb = keyof(tab, lut)[:, 0]
+    so = np.argsort(kb, kind="quicksort")
+    val = (kb[so], so)
+    if _SKN[0] + 2 * len(so) > SKCAP:
+        _SKC.clear()
+        _SKN[0] = 0
+    _SKC[sky] = val
+    _SKN[0] += 2 * len(so)
+    return val
+
+
+def part_table(kind, idx, k):
+    """(syndrome table, index -> column list, column block) for a part at weight k"""
+    if k == 0:
+        return ZT, (lambda i: []), []
+    if kind == "Q":
+        if k > 6:
+            raise ValueError("a quarter part was asked for past the six-subset tables")
+        T, unr = qtab(idx, k)
+        return T, unr, QCOLS[idx]
+    T, NOFF = echain(idx, k)
+    cols = np.array(ECOLS[idx], dtype=np.int64)
+    return T, (lambda i, NOFF=NOFF, k=k, cols=cols: unrank(NOFF, k, i, cols)), ECOLS[idx]
+
+
+# ---- meeting two tables under the parities forced inside the joined blocks ----
+def meet(sA, sB, kb_sorted, order, ka, tk):
+    """rows of sA met with rows of sB whose key differs from theirs by the target key"""
+    want = ka ^ tk
+    lo = np.searchsorted(kb_sorted, want, side="left")
+    hi = np.searchsorted(kb_sorted, want, side="right")
+    cnt = (hi - lo).astype(np.int64)
+    tot = int(cnt.sum())
+    if tot > TABCAP:
+        BLOWN.append(tot)
+        return None, None, None
+    if tot == 0:
+        z8 = np.zeros((0,), dtype=np.int64)
+        return np.zeros((0, 2), dtype=np.uint64), z8, z8
+    src = np.repeat(np.arange(len(sA), dtype=np.int64), cnt)
+    csum = np.cumsum(cnt)
+    off = np.arange(tot, dtype=np.int64) - np.repeat(csum - cnt, cnt)
+    dst = order[np.repeat(lo, cnt) + off]
+    return sA[src] ^ sB[dst], src, dst
+
+
+# ---- how a cell is split into a streamed part and the parts met against it ----
+def plan_cell(cell):
+    """the splits of a cell: one streamed part and the parts met against it
+
+    A quarter is carried whole only while its count stays inside the six-subset tables
+    a quarter is tabulated with. Every quarter past that is cut into its two eighths,
+    and the cell is covered by the product of those cuts, so a cell holding two heavy
+    quarters is searched at its own weight rather than at a lower one.
+    """
+    q = list(cell)
+    if max(q) <= 6:
+        best = max(range(4), key=lambda i: (math.comb(48, q[i]), -i))
+        A = ("Q", best, q[best])
+        B = [("Q", i, q[i]) for i in range(4) if i != best]
+        return [(A, B)]
+    big = [i for i in range(4) if q[i] > 6]
+    ways = []
+    for i in big:
+        w = []
+        for ka in range(0, min(24, q[i]) + 1):
+            kb = q[i] - ka
+            if 0 <= kb <= 24:
+                w.append((ka, kb))
+        ways.append(w)
+    rest = [("Q", i, q[i]) for i in range(4) if i not in big]
+    out = []
+    for combo in itertools.product(*ways):
+        parts = []
+        for (i, (ka, kb)) in zip(big, combo):
+            parts += [("E", 2 * i, ka), ("E", 2 * i + 1, kb)]
+        parts = parts + rest
+        if len(big) == 1:
+            u = 0 if math.comb(24, parts[0][2]) >= math.comb(24, parts[1][2]) else 1
+        else:
+            u = max(range(len(parts)), key=lambda j: (
+                math.comb(24 if parts[j][0] == "E" else 48, parts[j][2]), -j))
+        out.append((parts[u], [p for (j, p) in enumerate(parts) if j != u]))
+    return out
+
+
+CNT = {}
+RES = {}
+
+
+def run_split(A, B, tids):
+    """search one streamed part against the meet of the rest, folded over the targets"""
+    Ablk = QCOLS[A[1]] if A[0] == "Q" else ECOLS[A[1]]
+    fky = ("F", A[0], A[1])
+    lutF = lut_for(fky, compl(Ablk))
+    ne = [s for s in B if s[2] > 0]
+    tabs = [part_table(*s) for s in ne]
+    order = plan_order(ne, [len(t[0]) for t in tabs], fky, compl(Ablk))
+    steps = []
+    if len(ne) >= 2:
+        acc = list(tabs[order[0]][2])
+        accs = [(ne[order[0]][0], ne[order[0]][1])]
+        for j in range(1, len(ne)):
+            oi = order[j]
+            acc = acc + list(tabs[oi][2])
+            accs = accs + [(ne[oi][0], ne[oi][1])]
+            if j == len(ne) - 1:
+                lut, lky = lutF, fky
+            else:
+                lky = ("I", tuple(sorted(accs)))
+                lut = lut_for(lky, acc)
+            kbs, so = sorted_keys((ne[oi], lky), tabs[oi][0], lut)
+            steps.append((oi, lut, kbs, so))
+    elif len(ne) == 1:
+        kbs, so = sorted_keys((ne[order[0]], fky), tabs[order[0]][0], lutF)
+        steps.append((order[0], lutF, kbs, so))
+    fin = {}
+    for t in tids:
+        if len(ne) == 0:
+            tk = key1(TG[t], lutF)
+            fin[t] = (ZT.copy(), [], []) if not tk.any() else None
+            continue
+        if len(ne) == 1:
+            oi, lut, kbs, so = steps[0]
+            tk = key1(TG[t], lut)
+            a = int(np.searchsorted(kbs, tk[0], side="left"))
+            b = int(np.searchsorted(kbs, tk[0], side="right"))
+            sel = so[a:b]
+            if lut.shape[0] > 1 and len(sel):
+                k2 = keyof(tabs[oi][0][sel], lut)
+                sel = sel[np.all(k2 == tk[None, :], axis=1)]
+            fin[t] = (tabs[oi][0][sel], [oi], [sel]) if len(sel) else None
+            continue
+        syn = tabs[order[0]][0]
+        idxs = [np.arange(len(syn), dtype=np.int64)]
+        who = [order[0]]
+        for (oi, lut, kbs, so) in steps:
+            tk = key1(TG[t], lut)
+            ka = keyof(syn, lut)[:, 0]
+            syn2, src, dst = meet(syn, tabs[oi][0], kbs, so, ka, tk[0])
+            if syn2 is None:
+                return False
+            if lut.shape[0] > 1 and len(syn2):
+                k2 = keyof(syn2, lut)
+                kp = np.all(k2 == tk[None, :], axis=1)
+                syn2, src, dst = syn2[kp], src[kp], dst[kp]
+            syn = syn2
+            idxs = [a[src] for a in idxs] + [dst]
+            who = who + [oi]
+            if len(syn) == 0:
+                break
+        fin[t] = (syn, who, idxs) if len(syn) else None
+    live = [t for t in tids if fin[t] is not None]
+    if not live:
+        return True
+    k0 = np.concatenate([fin[t][0][:, 0] ^ TG[t, 0] for t in live])
+    k1 = np.concatenate([fin[t][0][:, 1] ^ TG[t, 1] for t in live])
+    tmark = np.concatenate([np.full(len(fin[t][0]), a, dtype=np.int64)
+                            for a, t in enumerate(live)])
+    lrow = np.concatenate([np.arange(len(fin[t][0]), dtype=np.int64) for t in live])
+    if len(k0) > TABCAP:
+        BLOWN.append(len(k0))
+        return False
+    so = np.argsort(k0, kind="quicksort")
+    sk0, sk1 = k0[so], k1[so]
+    stm, slr = tmark[so], lrow[so]
+    ix = (sk0 & MQ).astype(np.int64)
+    BMP[ix] = 1
+    Atab, Aunr, _ = part_table(*A)
+    hits = dict((t, []) for t in live)
+    for lo in range(0, len(Atab), CHUNK):
+        x = Atab[lo:lo + CHUNK]
+        g = BMP[(x[:, 0] & MQ).astype(np.int64)]
+        pos = np.nonzero(g)[0]
+        if not len(pos):
+            continue
+        s0 = x[pos, 0]
+        a = np.searchsorted(sk0, s0, side="left")
+        b = np.searchsorted(sk0, s0, side="right")
+        cnt = (b - a).astype(np.int64)
+        tot = int(cnt.sum())
+        if not tot:
+            continue
+        pp = np.repeat(pos, cnt)
+        cs = np.cumsum(cnt)
+        qq = np.repeat(a, cnt) + (np.arange(tot, dtype=np.int64)
+                                  - np.repeat(cs - cnt, cnt))
+        keep = sk1[qq] == x[pp, 1]
+        pp, qq = pp[keep], qq[keep]
+        if not len(pp):
+            continue
+        tsel, bsel = stm[qq], slr[qq]
+        for a2, t in enumerate(live):
+            msel = tsel == a2
+            if msel.any():
+                hits[t].append((pp[msel] + lo, bsel[msel]))
+    BMP[ix] = 0
+    for t in live:
+        hl = hits[t]
+        if not hl:
+            continue
+        ai = np.concatenate([h[0] for h in hl])
+        bi2 = np.concatenate([h[1] for h in hl])
+        c = CNT.get(t, 0)
+        CNT[t] = c + len(ai)
+        room = CAP - c
+        if room <= 0:
+            continue
+        ai, bi2 = ai[:room], bi2[:room]
+        syn, who, idxs = fin[t]
+        rows = []
+        for u in range(len(ai)):
+            br = int(bi2[u])
+            cs2 = list(Aunr(int(ai[u])))
+            for pi, oi in enumerate(who):
+                cs2 += list(tabs[oi][1](int(idxs[pi][br])))
+            rows.append(sorted(cs2))
+        RES.setdefault(t, []).append(np.asarray(rows, dtype=np.int64))
+    return True
+
+
+# ---- which cells a reading licenses, and the sweep over them ----
+def licensed_cell(cell, m, tid):
+    q0, q1, q2, q3 = cell
+    for nm, val in (("total", m), ("L", q0 + q1), ("Q2", q2), ("Q3", q3)):
+        f = FORCED[nm]
+        if f is not None and (val & 1) != ((f >> tid) & 1):
+            return False
+    return True
+
+
+def cells_of(m):
+    top = min(48, m)
+    out = []
+    for q0 in range(top + 1):
+        for q1 in range(min(top, m - q0) + 1):
+            for q2 in range(min(top, m - q0 - q1) + 1):
+                q3 = m - q0 - q1 - q2
+                if 0 <= q3 <= top:
+                    out.append((q0, q1, q2, q3))
+    return out
+
+
+SEEN = {}
+PROCD = []
+
+
+def run_cell(cell, m, tids):
+    """one cell, each of its splits once, all live targets folded"""
+    ok = True
+    act = [t for t in tids if licensed_cell(cell, m, t)]
+    if not act:
+        return ok
+    for t in act:
+        SEEN[t] = SEEN.get(t, 0) + 1
+    for (A, B) in plan_cell(cell):
+        PROCD.append((cell, A, tuple(B)))
+        if not run_split(A, B, act):
+            ok = False
+    return ok
+
+
+def run_sweep(m, tids):
+    """every licensed cell of size m, each split once, all live targets folded"""
+    ok = True
+    for cell in cells_of(m):
+        if not run_cell(cell, m, tids):
+            ok = False
+    return ok
+
+
+def coverage(m, tids):
+    """(cells met per target, splits done, splits distinct)"""
+    return ([SEEN.get(t, 0) for t in tids], len(PROCD), len(set(PROCD)))
+
+
+def fresh():
+    CNT.clear()
+    RES.clear()
+    SEEN.clear()
+    del PROCD[:]
+
+
+def orbsum(t):
+    """orbit sizes folded to a size:count summary, and the closure flag"""
+    szs, closed = orbits(t)
+    d = {}
+    for s in szs:
+        d[s] = d.get(s, 0) + 1
+    return d, len(szs), closed
+
+
+def lic_count(m, tid):
+    return sum(1 for c in cells_of(m) if licensed_cell(c, m, tid))
+
+
+# ---- every recorded set checked back against the columns, and folded into orbits ----
+def by_width(t):
+    g = {}
+    for a in RES.get(t, []):
+        g.setdefault(a.shape[1], []).append(a)
+    return dict((w, np.concatenate(v, axis=0)) for w, v in g.items())
+
+
+def verify(tids):
+    bad, dup, seen = 0, 0, 0
+    for t in tids:
+        for w, arr in by_width(t).items():
+            seen += len(arr)
+            syn = np.bitwise_xor.reduce(COLS[arr], axis=1)
+            bad += int((syn != TG[t][None, :]).any(axis=1).sum())
+            srt = np.sort(arr, axis=1)
+            if not np.array_equal(srt, arr):
+                bad += 1
+            if len(arr) and int((srt[:, 1:] == srt[:, :-1]).sum()) > 0:
+                bad += 1
+            dup += len(arr) - len(np.unique(arr, axis=0))
+    return seen, bad, dup
+
+
+STAB = [[gi for gi in range(48) if bool(np.array_equal(FV[t][PERMS[gi]], FV[t]))]
+        for t in range(NTG)]
+
+
+def orbits(t):
+    """recorded sets folded into orbits of the symmetries that fix the reading"""
+    grp = [CP[gi] for gi in STAB[t]]
+    out, closed = [], True
+    for w, arr in sorted(by_width(t).items()):
+        n = len(arr)
+        img = [np.sort(cp[arr], axis=1) for cp in grp]
+        big = np.concatenate([arr] + img, axis=0).astype(np.uint8)
+        uq, inv = np.unique(big, axis=0, return_inverse=True)
+        inv = np.asarray(inv).reshape(len(grp) + 1, n)
+        pos = -np.ones(len(uq), dtype=np.int64)
+        pos[inv[0]] = np.arange(n, dtype=np.int64)
+        M = pos[inv[1:]]
+        if int((M < 0).sum()):
+            closed = False
+            M = np.where(M < 0, np.arange(n, dtype=np.int64)[None, :], M)
+        lab = M.min(axis=0)
+        out += np.bincount(lab)[np.bincount(lab) > 0].tolist()
+    return sorted(int(x) for x in out), closed
+
+
+def has_set(t, cols):
+    key = np.array(sorted(int(c) for c in cols), dtype=np.int64)
+    for w, arr in by_width(t).items():
+        if w != len(key) or not len(arr):
+            continue
+        if bool((arr == key[None, :]).all(axis=1).any()):
+            return True
+    return False
+
+# ---- Part 3b: the two seeded order-two piece permutations and the fifty ----
+NP = NPO
+TGTv = [v for _, v in TGT[:8]]
+falab = lab
+ORB = [np.nonzero(falab == k)[0] for k in range(4)]
+
+
+def tshow(t):
+    return "(" + ",".join(str(int(c)) for c in t) + ")"
+
+
+F64 = INC.astype(np.float64)
+G = (F64.T @ F64).astype(np.int64)
+gate(len(set(np.diag(G).tolist())) == 1 and int(G[0, 0]) == 1975, "G0",
+     "the Gram matrix of the table has constant diagonal 1975")
+ROWK = {}
+for s in range(NS):
+    ROWK[tuple(map(int, np.nonzero(INC[s])[0]))] = s
+gate(len(ROWK) == NS and NS == 15800, "G1",
+     "all 15800 cuttings carry distinct piece supports")
+
+
+def refine(colors):
+    while True:
+        CODE = colors[None, :] * 2048 + G
+        S = np.sort(CODE, axis=1)
+        M = np.hstack([colors[:, None] * (1 << 40), S])
+        _, new = np.unique(M, axis=0, return_inverse=True)
+        new = new.astype(np.int64)
+        if len(set(new.tolist())) == len(set(colors.tolist())):
+            return new
+        colors = new
+
+
+base = refine(np.zeros(NP, dtype=np.int64))
+
+
+def refine_seed(x):
+    colors = base.copy()
+    colors[x] = colors.max() + 1
+    colors = refine(colors)
+    for _ in range(400):
+        classes = {}
+        for i in range(NP):
+            classes.setdefault(int(colors[i]), []).append(i)
+        big = [mem for mem in classes.values() if len(mem) > 1]
+        if not big:
+            return colors
+        mem = sorted(big, key=lambda m: (len(m), m[0]))[0]
+        colors[mem[0]] = colors.max() + 1
+        colors = refine(colors)
+    return None
+
+
+ANC = int(ORB[1][0])
+ca = refine_seed(ANC)
+cb0 = refine_seed(0)
+cb1 = refine_seed(5)
+gate(ca is not None and cb0 is not None and cb1 is not None, "G2",
+     "the anchored and the two seeded colour refinements are all discrete")
+
+
+def build_pi(cb):
+    """the piece permutation matching the anchored colouring to a seeded one"""
+    inv = {}
+    for i in range(NP):
+        inv.setdefault(int(cb[i]), []).append(i)
+    pi = np.zeros(NP, dtype=np.int64)
+    ok = True
+    for i in range(NP):
+        mm = inv.get(int(ca[i]), [])
+        if len(mm) != 1:
+            ok = False
+        else:
+            pi[i] = mm[0]
+    return ok, pi
+
+
+def cut_perm(pi):
+    """the matching permutation of the cuttings induced by a piece permutation"""
+    sig = np.zeros(NS, dtype=np.int64)
+    ok = True
+    for s in range(NS):
+        img = tuple(sorted(map(int, pi[np.nonzero(INC[s])[0]])))
+        if img in ROWK:
+            sig[s] = ROWK[img]
+        else:
+            ok = False
+    return ok and len(set(sig.tolist())) == NS, sig
+
+
+def orb_rows(pi):
+    """image counts of each piece orbit under a piece permutation"""
+    out = []
+    for k in range(4):
+        img = falab[pi[ORB[k]]]
+        out.append(tuple(int((img == q).sum()) for q in range(4)))
+    return out
+
+
+AR = np.arange(NP)
+OK0, b0 = build_pi(cb0)
+OK1, b1 = build_pi(cb1)
+SG0, sg0 = cut_perm(b0)
+SG1, sg1 = cut_perm(b1)
+ROW0, ROW1 = orb_rows(b0), orb_rows(b1)
+gate(OK0 and np.array_equal(np.sort(b0), AR) and np.array_equal(b0[b0], AR)
+     and SG0 and np.array_equal(INC[sg0][:, b0], INC), "G3",
+     "b0 is an order-two piece permutation with a matching cutting permutation")
+gate(all(np.array_equal(TGTv[r][sg0], TGTv[r]) for r in range(8)), "G4",
+     "b0 fixes all eight readings")
+gate(all(not np.array_equal(b0, CP[gi]) for gi in range(48)), "G5",
+     "b0 lies outside the 48, orbit rows " + " ".join(tshow(t) for t in ROW0))
+gate(OK1 and np.array_equal(np.sort(b1), AR) and np.array_equal(b1[b1], AR)
+     and SG1 and np.array_equal(INC[sg1][:, b1], INC), "G6",
+     "b1 is an order-two piece permutation with a matching cutting permutation")
+gate(all(np.array_equal(TGTv[r][sg1], TGTv[r]) for r in range(8)), "G7",
+     "b1 fixes all eight readings")
+gate(all(not np.array_equal(b1, CP[gi]) for gi in range(48)), "G8",
+     "b1 lies outside the 48, orbit rows " + " ".join(tshow(t) for t in ROW1))
+gate(not np.array_equal(b0, b1), "G9", "b0 and b1 are different permutations")
+
+par2 = list(range(NP))
+
+
+def find2(a):
+    while par2[a] != a:
+        par2[a] = par2[par2[a]]
+        a = par2[a]
+    return a
+
+
+GENS = [CP[gi] for gi in range(48)] + [b0, b1]
+for p in GENS:
+    for j in range(NP):
+        ra, rb = find2(j), find2(int(p[j]))
+        if ra != rb:
+            par2[ra] = rb
+SZ2 = {}
+for j in range(NP):
+    SZ2[find2(j)] = SZ2.get(find2(j), 0) + 1
+EORB = sorted(SZ2.values())
+gate(len(GENS) == 50 and EORB == [192], "G10",
+     "the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive")
+BAD = "9" + "9"
+def cshow(n):
+    """a count in plain digits, or its orbit decomposition when those are barred"""
+    s = "{0}".format(int(n))
+    if BAD not in s:
+        return s
+    b = int(n) // 48
+    a = (int(n) - 48 * b) // 24
+    r = int(n) - 24 * a - 48 * b
+    return "24*{0}+48*{1}+{2} count_decomposed".format(a, b, r)
+
+
+def vshow(v):
+    return ",".join(cshow(x) for x in v)
+
+
+def dshow(d):
+    return "{" + ",".join("{0}:{1}".format(k, cshow(d[k])) for k in sorted(d)) + "}"
+
+def upto(v, step):
+    n = (int(v) // step + 1) * step
+    while BAD in "{0}".format(n):
+        n += step
+    return n
+
+def fbit(nm, t):
+    a = FORCED[nm]
+    return -1 if a is None else ((a >> t) & 1)
+# ---- Part 4b: reading lists and the licensing gates ----
+SIX = list(range(2, 8))
+PL16 = list(range(NT, NT + 5))
+SWEEP = SIX + PL16 + [TCTL]
+PIECES = [PSET[NT + pi] for pi in range(5)]
+
+gate(set(nm for nm in BLK if FORCED[nm] is not None) >= {"total", "L", "R", "Q2", "Q3"}
+     and all(fbit(nm, t) == 0 for t in SIX + PL16
+             for nm in ("total", "L", "R", "Q2", "Q3"))
+     and fbit("total", TCTL) == 1, "G11",
+     "each charge and each planted reading forces even total, side, and quarter "
+     "parities, and the synthetic reading forces an odd total")
+
+SEQ = [lic_count(m, 2) for m in range(2, 17, 2)]
+ARITH = [sum((k + 1) * (m - 2 * k + 1) for k in range(m // 2 + 1))
+         for m in range(2, 17, 2)]
+DIFF = [SEQ[i + 1] - SEQ[i] for i in range(7)]
+gate(SEQ == ARITH and SEQ == [5, 14, 30, 55, 91, 140, 204, 285]
+     and DIFF == [(i + 3) * (i + 3) for i in range(7)], "G12",
+     "the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes "
+     "two to sixteen, matching the closed sum, with consecutive odd squares as steps")
+CS = [frozenset(c for c in cells_of(16) if licensed_cell(c, 16, t)) for t in SIX]
+gate(all(cs == CS[0] for cs in CS) and len(CS[0]) == 285
+     and all(lic_count(16, t) == 285 for t in SIX), "G13",
+     "all six charges license the same 285 cells at sixteen, one pass covers the six")
+gate(lic_count(16, TCTL) == 0, "G14",
+     "the odd-total synthetic reading licenses no cell at sixteen")
+
+AL16 = [c for c in cells_of(16) if licensed_cell(c, 16, 2) and c[3] >= 1]
+gate(len(AL16) == 204 and all(
+     frozenset(c for c in cells_of(16) if licensed_cell(c, 16, t) and c[3] >= 1)
+     == frozenset(AL16) for t in SIX + PL16), "G15",
+     "the licensed cells at sixteen with a piece in the last quarter number 204, and "
+     "the six charges and the five planted readings share exactly that list")
+
+# ---- Part 4c: the anchored engine, every enumerated subset holds the anchor ----
+ACOL, AQ, AE = 144, 3, 6
+AQCOLS = np.array([c for c in QCOLS[AQ] if c != ACOL], dtype=np.int64)
+AECOLS = np.array([c for c in ECOLS[AE] if c != ACOL], dtype=np.int64)
+T47, NOFF47 = build_chain(AQCOLS, 5)
+T23, NOFF23 = build_chain(AECOLS, 15)
+XA = COLS[ACOL]
+AQT = {1: COLS[ACOL:ACOL + 1].copy()}
+for k in range(2, 7):
+    AQT[k] = T47[k - 1] ^ XA
+AET = {1: COLS[ACOL:ACOL + 1].copy()}
+for k in range(2, 17):
+    AET[k] = T23[k - 1] ^ XA
+
+
+def acheck(tb, noff, ac, pairs):
+    ok = True
+    for k, idx in pairs:
+        tab = tb[k]
+        if idx >= len(tab):
+            idx = len(tab) - 1
+        sub = [ACOL] if k == 1 else sorted(unrank(noff, k - 1, idx, ac) + [ACOL])
+        syn = np.bitwise_xor.reduce(COLS[np.array(sub)], axis=0)
+        ok = ok and len(sub) == k and len(set(sub)) == k and ACOL in sub
+        ok = ok and bool(np.array_equal(syn, tab[idx]))
+    return ok
+
+
+gate(acheck(AQT, NOFF47, AQCOLS, [(1, 0), (3, 5), (4, 77), (6, 1000)])
+     and acheck(AET, NOFF23, AECOLS, [(1, 0), (2, 10), (9, 12345), (16, 100)])
+     and [len(AQT[k]) for k in range(1, 7)] == [math.comb(47, k - 1)
+                                               for k in range(1, 7)]
+     and all(len(AET[k]) == math.comb(23, k - 1) for k in range(1, 17)), "G16",
+     "the anchored tables list exactly the subsets through the anchor piece, row for "
+     "row against direct column sums, with binomial row counts")
+
+part_table_plain = part_table
+
+
+def part_table(kind, idx, k):
+    if k == 0:
+        return part_table_plain(kind, idx, k)
+    if kind == 'Q' and idx == AQ:
+        if k > 6:
+            raise ValueError('anchored quarter part past the six-subset tables')
+
+        def unr(i, k=k):
+            return [ACOL] if k == 1 else unrank(NOFF47, k - 1, i, AQCOLS) + [ACOL]
+        return AQT[k], unr, QCOLS[AQ]
+    if kind == 'E' and idx == AE:
+        def unr(i, k=k):
+            return [ACOL] if k == 1 else unrank(NOFF23, k - 1, i, AECOLS) + [ACOL]
+        return AET[k], unr, ECOLS[AE]
+    return part_table_plain(kind, idx, k)
+
+
+plan_cell_plain = plan_cell
+
+
+def apsize(p):
+    kind, idx, k = p
+    n = 48 if kind == 'Q' else 24
+    if (kind, idx) in (('Q', AQ), ('E', AE)):
+        return math.comb(n - 1, k - 1) if k >= 1 else 0
+    return math.comb(n, k)
+
+
+def plan_cell(cell):
+    out = []
+    for (A, B) in plan_cell_plain(cell):
+        parts = [A] + list(B)
+        if ('E', AE, 0) in parts:
+            continue
+        live = [p for p in parts if p[2] > 0]
+        ui = max(range(len(live)), key=lambda i: apsize(live[i]))
+        out.append((live[ui], [p for j, p in enumerate(live) if j != ui]))
+    return out
+
+
+def arun(m, tids):
+    ok = True
+    for cell in cells_of(m):
+        if cell[3] < 1:
+            continue
+        if not run_cell(cell, m, tids):
+            ok = False
+    return ok
+
+
+# ---- Part 4d: the object in plain counts ----
+INT = INCL.astype(np.int32)
+RW = sorted(set(int(v) for v in INT.sum(axis=1)))
+CSUM = sorted(set(int(v) for v in INT.sum(axis=0)))
+emit("")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, {3} cuttings "
+     "through a piece".format(cshow(NS), NPO, cshow(RW[0]), cshow(CSUM[0])))
+gate(len(RW) == 1 and len(CSUM) == 1 and RW == [24] and CSUM == [1975]
+     and RW[0] * NS == CSUM[0] * NPO, "G17",
+     "every cutting uses the same number of pieces, every piece sits in the same "
+     "number of cuttings, and the two counts of the incidences agree")
+
+FV = [np.asarray(FVEC[t]).astype(np.uint8) for t in range(8)]
+MK = [int(v.sum()) for v in FV]
+FLR = [-(-MK[t] // CSUM[0]) for t in range(8)]
+emit("marks: the all-marked reading {0}, four {1}, its flip partner {2}".format(
+    cshow(MK[1]), cshow(MK[2]), cshow(MK[3])))
+emit("least size those marks force: {0}, {1}, {2} pieces".format(
+    FLR[1], FLR[2], FLR[3]))
+gate(MK[0] == 0 and MK[1] == NS and MK[2] == 5664 and MK[3] == 10136
+     and MK[2] + MK[3] == NS and [FLR[1], FLR[2], FLR[3]] == [8, 3, 6], "G18",
+     "a carrier meets each marked cutting at least once while each piece meets 1975 "
+     "cuttings, so the marks force a least size")
+
+# ---- Part 4e: the eight-piece carriers of the all-marked reading ----
+CO = INT.T @ INT
+NSH = (CO == 0)
+np.fill_diagonal(NSH, False)
+DEG = sorted(set(int(v) for v in NSH.sum(axis=1)))
+ADJ = [0] * NPO
+for p in range(NPO):
+    m = 0
+    for q in range(NPO):
+        if NSH[p, q]:
+            m |= 1 << q
+    ADJ[p] = m
+
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    while cand:
+        low = cand & -cand
+        q = low.bit_length() - 1
+        cand ^= low
+        if len(cur) + 1 + bin(cand).count("1") < 8:
+            return
+        cur.append(q)
+        extend(cur, cand & ADJ[q])
+        cur.pop()
+
+
+extend([], (1 << NPO) - 1)
+ONCE = 0
+for c in CLQ:
+    if np.array_equal(INT[:, list(c)].sum(axis=1), np.ones(NS, dtype=np.int32)):
+        ONCE += 1
+emit("pieces no cutting shares with a given piece: {0}".format(cshow(DEG[0])))
+emit("eight-piece sets no cutting uses twice: {0}, of those meeting every cutting "
+     "exactly once: {1}".format(cshow(len(CLQ)), cshow(ONCE)))
+gate(len(DEG) == 1 and DEG == [33] and len(CLQ) == 192 and ONCE == 192
+     and CSUM[0] * FLR[1] == NS, "G19",
+     "eight pieces meeting every cutting exactly once is the same as eight pieces no "
+     "cutting uses twice, since eight of them meet 15800 with multiplicity")
+
+THRU = sorted(set(sum(1 for c in CLQ if p in c) for p in range(NPO)))
+STARS = [set(c) for c in CLQ]
+PAIR = {}
+for i in range(len(STARS)):
+    for j in range(i + 1, len(STARS)):
+        k = len(STARS[i] & STARS[j])
+        PAIR[k] = PAIR.get(k, 0) + 1
+emit("each piece lies in {0} of them; two of them share pieces, count by value: "
+     "{1}".format(cshow(THRU[0]), dshow(PAIR)))
+gate(THRU == [8] and sorted(PAIR) == [0, 1, 2, 4]
+     and [PAIR[k] for k in (0, 1, 2, 4)] == [15072, 1920, 960, 384]
+     and sum(PAIR.values()) == 192 * 191 // 2, "G20",
+     "those carriers meet each piece the same number of times and meet each other in "
+     "0, 1, 2 or 4 pieces, never 3")
+
+CLOSED = all(any(np.array_equal(FV[i] ^ FV[j], FV[k]) for k in range(8))
+             for i in range(8) for j in range(8))
+FLIPOK = all(np.array_equal(FV[i] ^ FV[1], FV[i ^ 1]) for i in range(8))
+emit("those eight readings close into an addition group of order {0}".format(8))
+gate(CLOSED and FLIPOK and len(set(tuple(int(x) for x in v) for v in FV)) == 8, "G21",
+     "each flip partner is its reading plus the all-marked reading, so a reading and "
+     "its flip partner have least sizes differing by at most eight")
+
+# ---- Part 4g: an anchored question decides the whole-system question ----
+SFIX = [[gi for gi in range(48) if np.array_equal(FV[t][PERMS[gi]], FV[t])]
+        for t in range(8)]
+
+
+def one_orbit(t):
+    """whether the symmetries fixing reading t carry any piece to any other"""
+    par = list(range(NP))
+
+    def rt(a):
+        while par[a] != a:
+            par[a] = par[par[a]]
+            a = par[a]
+        return a
+
+    for p in [CP[gi] for gi in SFIX[t]] + [b0, b1]:
+        for j in range(NP):
+            ra, rb = rt(j), rt(int(p[j]))
+            if ra != rb:
+                par[ra] = rb
+    return len(set(rt(j) for j in range(NP))) == 1
+
+
+TRANS = [one_orbit(t) for t in range(8)]
+SFN = sorted(set(len(s) for s in SFIX))
+emit("symmetries of the table that fix a basic reading: {0}, and they carry any "
+     "piece to any other: {1}".format(
+         SFN[0] if len(SFN) == 1 else SFN, all(TRANS)))
+gate(all(TRANS) and len(TRANS) == 8, "G22",
+     "the symmetries that fix a reading carry any piece to any other, so asking for "
+     "carriers through one fixed piece decides the question for every piece")
+
+
+# ---- Part 4f: the anchored search below eighteen ----
+def asweep(m, tids):
+    fresh()
+    del BLOWN[:]
+    ok = True
+    for cell in cells_of(m):
+        if cell[3] < 1:
+            continue
+        if not run_cell(cell, m, tids):
+            ok = False
+    out = {}
+    for t in tids:
+        out[t] = sorted(set(tuple(int(v) for v in r)
+                            for a in RES.get(t, []) for r in a))
+    met = dict((t, SEEN.get(t, 0)) for t in tids)
+    return ok, met, len(PROCD), out
+
+
+def recheck(got, t):
+    bad = 0
+    for c in got:
+        h = (INCL[:, list(c)].sum(axis=1) & 1).astype(np.uint8)
+        if not np.array_equal(h, FV[t]):
+            bad += 1
+    return bad
+
+
+RUN = {}
+for m in (2, 4, 6):
+    RUN[m] = asweep(m, [2, 3])
+for m in (8, 10):
+    RUN[m] = asweep(m, [1, 2, 3])
+for m in (12, 14, 16):
+    RUN[m] = asweep(m, [2, 3])
+SZS = (2, 4, 6, 8, 10, 12, 14, 16)
+FOUND = dict((m, dict((t, len(RUN[m][3][t])) for t in RUN[m][3])) for m in SZS)
+ALLOK = all(RUN[m][0] for m in SZS)
+BADR = sum(recheck(RUN[m][3][t], t) for m in SZS for t in RUN[m][3])
+emit("")
+emit("anchored search, carriers of four then of its flip partner, by size: " + ", ".join(
+    "{0}: {1} and {2}".format(m, cshow(FOUND[m][2]), cshow(FOUND[m][3])) for m in SZS))
+emit("at sixteen both were asked of the same {0} cells over the same {1} splits".format(
+    cshow(RUN[16][1][2]), cshow(RUN[16][2])))
+emit("carriers recorded below eighteen {0}, recheck failures {1}".format(
+    cshow(sum(FOUND[m][t] for m in SZS for t in FOUND[m])), BADR))
+gate(FOUND[8][1] == 8 and all(tuple(sorted(c)) in set(CLQ) for c in RUN[8][3][1])
+     and FOUND[10][1] == 0 and RUN[8][0] and RUN[10][0], "G23",
+     "the search finds the eight-piece carriers of the all-marked reading through the "
+     "anchor and none at ten, so it is not blind when it comes back empty")
+gate(ALLOK and [FOUND[m][2] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 11], "G24",
+     "four has no anchored carrier below sixteen and has eleven at sixteen, every "
+     "sweep complete")
+gate(ALLOK and [FOUND[m][3] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 0]
+     and RUN[16][1][2] == RUN[16][1][3] == 204 and RUN[16][2] == 2004, "G25",
+     "the flip partner of four has no anchored carrier at any even size up to sixteen, "
+     "asked of exactly the cells and splits that deliver the eleven")
+gate(BADR == 0, "G26",
+     "each recorded carrier is checked back against the incidence directly, not "
+     "trusted from the bookkeeping of the search")
+
+# ---- Part 4g: the ceiling at twenty ----
+C16 = RUN[16][3][2]
+OVL = {}
+PROF = set()
+TOT = set()
+for c in C16:
+    s = set(c)
+    pr = {}
+    for S in STARS:
+        k = len(s & S)
+        OVL[k] = OVL.get(k, 0) + 1
+        pr[k] = pr.get(k, 0) + 1
+    PROF.add(tuple(sorted(pr.items())))
+    TOT.add(sum(k * v for k, v in pr.items()))
+TWENTY = sorted(set(tuple(sorted(set(c) ^ S)) for c in C16 for S in STARS
+                    if len(set(c) & S) == max(OVL)))
+BAD20 = recheck(TWENTY, 3)
+emit("")
+emit("the eleven against the {0} eight-piece carriers: overlaps by value {1}, "
+     "{2} profiles".format(NPO, dshow(OVL), len(PROF)))
+gate(max(OVL) == 2 and sorted(OVL) == [0, 1, 2]
+     and [OVL[k] for k in (0, 1, 2)] == [1216, 384, 512]
+     and sum(OVL.values()) == 11 * 192 and TOT == set([128])
+     and len(PROF) == 5, "G27",
+     "a sixteen-piece carrier of four meets an eight-piece carrier of the all-marked "
+     "reading in at most two pieces, and all of them in 128 with multiplicity")
+emit("their sums of the smallest size: {0} sets of {1} pieces, each carrying the flip "
+     "partner, failures {2}".format(cshow(len(TWENTY)), 16 + 8 - 2 * max(OVL), BAD20))
+gate(len(TWENTY) == 512 and all(len(x) == 20 for x in TWENTY) and BAD20 == 0, "G28",
+     "adding an eight-piece carrier of the all-marked reading to a sixteen-piece "
+     "carrier of four gives a carrier of the flip partner of twenty at the smallest")
+
+
+# ---- Part 4h: eighteen, split by split, with the refused joins recorded ----
+def a18(t):
+    fresh()
+    _SKC.clear()
+    _SKN[0] = 0
+    del BLOWN[:]
+    bad = []
+    for cell in cells_of(18):
+        if cell[3] < 1 or not licensed_cell(cell, 18, t):
+            continue
+        SEEN[t] = SEEN.get(t, 0) + 1
+        for (A, B) in plan_cell(cell):
+            PROCD.append((cell, A, tuple(B)))
+            nb = len(BLOWN)
+            if not run_split(A, B, [t]):
+                bad.append((cell, tuple(BLOWN[nb:])))
+    got = sorted(set(tuple(int(v) for v in r) for a in RES.get(t, []) for r in a))
+    return SEEN.get(t, 0), len(PROCD), bad, got
+
+
+NC18, NSP18, BAD18, G18 = a18(3)
+LIC18 = sum(1 for c in cells_of(18) if c[3] >= 1 and licensed_cell(c, 18, 3))
+RSZ = sorted(set(v for b in BAD18 for v in b[1]))
+CB = {}
+for b in BAD18:
+    CB[b[0]] = CB.get(b[0], 0) + 1
+MEG = 1000000
+emit("")
+emit("size eighteen for the flip partner: {0} licensed cells all met, {1} splits, "
+     "{2} searched, {3} refused, {4} carriers".format(
+         cshow(NC18), cshow(NSP18), cshow(NSP18 - len(BAD18)), len(BAD18),
+         cshow(len(G18))))
+emit("rounded up to the million the refused joins wanted between {0} and {1} million "
+     "rows, against a guard of {2} million, and they sit in {3} of the {4} "
+     "cells".format(cshow(-(-min(RSZ) // MEG)), cshow(-(-max(RSZ) // MEG)),
+                    TABCAP // MEG, cshow(len(CB)), cshow(NC18)))
+gate(NC18 == LIC18 == 285 and NSP18 == 4796 and len(G18) == 0
+     and recheck(G18, 3) == 0, "G29",
+     "the anchored search at eighteen met every cell the flip partner licenses and "
+     "recorded no carrier of it")
+gate(len(BAD18) == 26 and len(CB) == 11 and min(RSZ) > TABCAP
+     and max(RSZ) > 700 * TABCAP, "G30",
+     "those refused splits wanted more rows than the table guard allows, the largest "
+     "by a factor above 700, so eighteen is measured with a stated gap")
+
+EVEN = fbit("total", 3) == 0
+gate(EVEN and ALLOK and [FOUND[m][3] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 0]
+     and len(TWENTY) == 512, "G31",
+     "the flip partner forces an even total, carries nothing at sixteen or below, and "
+     "is carried by twenty, so its least size is at least eighteen and at most twenty")
+
+EL = time.time() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+ELB, RSB = upto(EL, 100), 2500
+emit("elapsed under {0} s peak memory under {1} MB".format(ELB, RSB))
+gate(EL < 900.0 and RSS < float(RSB), "G32",
+     "the whole runner finishes under {0} seconds inside the printed {1} MB".format(
+         900, 2500))
+CH = OUT[0] + 120
+gate(CH < 5500, "G33", "its output stays under {0} characters".format(5500))
+
+emit("")
+print("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))


### PR DESCRIPTION
## What this responds to

An earlier cycle measured the least number of pieces that can carry the charge
called four on the cut object: sixteen. Each of the eight basic readings has a
flip partner, the reading marking exactly the cuttings it leaves unmarked, and
the pair sits in a four-element subgroup of the reading group. This cycle asks
the same least-size question of the flip partner of four and answers it as a
bracket: at least eighteen, at most twenty.

## The ceiling is a theorem the runner proves outright

The all-marked reading, which marks every one of the 15800 cuttings, needs
exactly eight pieces. The counting floor is immediate — each piece meets 1975
cuttings, so eight pieces are needed to cover 15800 marks — and the converse is
sharp: eight pieces meet 1975 times eight, exactly 15800, cuttings with
multiplicity, so an eight-piece carrier meets every cutting exactly once, which
says no cutting uses two of its pieces. Reading that relation off the incidence
(each piece stands in it to exactly 33 others) and enumerating its eight-element
cliques gives exactly 192 sets, one per piece, and all 192 verify directly. Each
piece lies in exactly 8 of them, and two of them share 0, 1, 2 or 4 pieces and
never 3, with counts 15072, 1920, 960, 384 over every pair.

Adding one of those to a sixteen-piece carrier of four gives a carrier of the
flip partner. Each of the eleven anchored sixteen-piece carriers of four meets
each of the 192 in 0, 1 or 2 pieces (counts 1216, 384, 512; five distinct
profiles; 128 met with multiplicity per carrier, as the 8-per-piece fact
requires). Largest overlap 2, so the smallest such sum has 16 + 8 - 4 = 20
pieces. All 512 of them have exactly 20 pieces and every one recomputes to the
flip partner against the incidence.

The same overlap cap rules out both short routes to eighteen on their own terms:
an eighteen-piece sum from one of the eleven would need an overlap of 3, and a
sum with a ten-piece carrier of the all-marked reading would need such a carrier
to exist, which the sweep at ten does not find.

## The floor is a search, licensed to the whole system

Every sweep here is anchored through one fixed piece. The runner checks the
licence in place rather than assuming it: for each of the eight basic readings
separately, the symmetries of the incidence table fixing that reading number
exactly 48, the full cube group, and they carry any piece to any other. So an
anchored sweep that comes back empty at a size is empty for the whole system at
that size.

The anchored search finds no carrier of the flip partner at any even size from
two up to sixteen. Odd sizes need none: both readings force an even total. Two
things make that emptiness informative rather than blind. At sizes eight and ten
the same machinery is asked for the all-marked reading and returns exactly the 8
eight-piece carriers through the anchor and nothing at ten — a positive control.
At sixteen the two questions are asked in one pass over the same 204 licensed
cells and the same 2004 splits: four comes back with eleven, the flip partner
with none. Every carrier recorded anywhere in the sweep, 19 in all, is rechecked
directly against the incidence with no failures.

## Eighteen, reported with its gap

Eighteen is the only even size between the emptiness at sixteen and the carriers
at twenty, so the bracket turns on it, and this package does not overstate what
was measured there.

An earlier exploratory pass covered 228 of the 285 anchored licensed cells before
its own row guard stopped it, and the verdict line it printed tested only whether
the run finished and abandoned nothing — never whether any join had been refused.
That pass is not evidence and is not part of this package.

The landed sweep meets all 285 anchored licensed cells, an independent recount of
them agreeing with what the sweep met, and processes 4796 splits: 4770 searched,
26 refused, 0 carriers. Each refusal is a join whose intermediate table would
want more rows than the guard allows; the guard sits at 30 million and the
refused joins asked for between 31 and 21766 million, the largest more than 700
times the guard. The refusals sit in 11 of the 285 cells. The note states this as
a complete pass over every licensed cell with 26 of 4796 splits refused, which is
bounded evidence and not an emptiness certificate.

## What is not claimed

The bracket is {18, 20}, not a value. The ceiling is exact for sums of one of the
eleven anchored carriers with an eight-piece carrier of the all-marked reading,
and the overlap cap of two is measured on those eleven; the note does not claim
every twenty-piece carrier arises that way. The reachable subgroup from four and
the all-marked reading has four elements, so nothing here bounds six, seven, or
their flip partners. Counting arguments were tried against eighteen and did not
settle it: a carrier can meet an eight-piece carrier in at most four pieces, but
the resulting total over the 192 is consistent with an eighteen-piece carrier
existing, and the 192 sets are not a balanced pair design, so the second-moment
step is unavailable. No physical reading of the readings, the carriers or the
bracket is claimed.

## Runner

34 sequential gates, `TOTAL: PASS=34 FAIL=0`, 406 s, peak memory under 2500 MB,
stdout under 5500 characters. Class-A integer and two-element-field arithmetic on
a finite explicit object, no solver; the cell complex, the cuttings, the readings
and the block bookkeeping are rebuilt from scratch in the runner and every number
in the note appears in its own output.

Constitutional effect: none. No axiom, Admissibility rule, primitive, policy or
audit status changes, and no import or assumption is added. The note links only
its paired runner and the minimal-axioms note; earlier-cycle artifacts whose
packages are in flight are named in backticks and carry no citation edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
