### PR TITLE
feat(emergent-geometry): count the smallest carriers of a charge across the whole system

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_CENSUS_FAMILIES_CYCLE748_NOTE_2026-08-08.md
+++ b/docs/PHYSICAL_CELL_CUTTING_CENSUS_FAMILIES_CYCLE748_NOTE_2026-08-08.md
@@ -1,0 +1,182 @@
+# The smallest carriers of a charge, counted and sorted into families — Cycle 748
+
+Date: 2026-08-08
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_census_families_cycle748_2026_08_08.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the cuttings, the readings and the block bookkeeping from scratch and
+gates each quantity in place. Constitutional effect: none. This package
+changes no axiom, no framework Admissibility rule, no primitive, no policy,
+and no audit status, and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Headline
+
+An earlier cycle measured that the charge called four needs sixteen pieces to
+carry it, and found eleven sixteen-piece carriers through one fixed anchor
+piece. That was an anchored count: it said what passes through one piece, not
+what the system contains. This cycle answers the whole-system question.
+
+The symmetries of the incidence table close into a group of 384 which is
+transitive on the 192 pieces and permutes the 192 eight-piece carriers of the
+all-marked reading among themselves. Carrying the anchored eleven around by
+that group produces 132 sixteen-piece carriers of four, each checked back
+against the incidence directly, and every one of the 192 pieces sits on exactly
+eleven of them. Eleven is the same count the anchored sweep returned, so every
+piece stands to the 132 exactly as the anchor does, and the 132 are all of
+them: the census is complete, not a sample.
+
+The 132 are not one family. The group cuts them into six, of sizes 12, 12, 12,
+24, 24 and 48. This is a real structural fact about the object and not a
+bookkeeping artifact: the symmetries of the table do not carry every smallest
+carrier of the charge onto every other one, even though they carry every piece
+onto every other one. Transitivity on pieces does not descend to transitivity
+on the smallest carriers.
+
+The overlap ceiling of the previous cycle now holds for the system rather than
+for the anchor. Across all 25344 pairs of a smallest carrier of four with an
+eight-piece carrier of the all-marked reading, the overlap is 0 in 14592 cases,
+1 in 4608 and 2 in 6144, never more; each of the 132 meets those carriers 128
+times with multiplicity. The 6144 pairs at the cap give 6144 different
+twenty-piece carriers of the flip partner of four, one per pair with no
+collisions, every one of the 192 pieces on exactly 640 of them, falling into
+twenty families of 192 and six of 384.
+
+The same two measurements constrain the one size still undecided. Were an
+eighteen-piece carrier of the flip partner to exist, it could share at most 4
+pieces with any eight-piece carrier of the all-marked reading.
+
+## The rebuilt system
+
+The runner rebuilds the incidence table of the cutting system from scratch:
+15800 distinct cuttings on 192 pieces, each cutting using 24 pieces, each piece
+sitting in 1975 cuttings. A set of pieces carries a reading when the cuttings it
+meets an odd number of times are exactly the ones the reading marks. The
+all-marked reading marks all 15800; the charge called four marks 5664; the flip
+partner of four marks the remaining 10136.
+
+The all-marked reading needs exactly 8 pieces, and its eight-piece carriers are
+exactly the 192 sets of eight pieces that no cutting uses twice, one for each
+piece of the object. Each piece lies on 8 of them, and two of them share 0, 1, 2
+or 4 pieces, never 3, with counts 15072, 1920, 960 and 384. These facts are
+re-derived and re-gated here rather than carried over.
+
+## Why the anchored eleven decide the system
+
+Two measurements license the transfer. The symmetries of the table that fix a
+basic reading number 48 and carry any piece to any other, which is what makes an
+anchored sweep a whole-system statement. Adjoining the two extra symmetries the
+table admits gives a group of 384, still transitive on the pieces, and every one
+of its elements sends an eight-piece carrier of the all-marked reading to
+another one, so the family of 192 is stable under it.
+
+Because the group fixes the reading, it sends a carrier of four to a carrier of
+four. The images of the anchored eleven are therefore carriers of four, and the
+runner does not take that on trust: it recomputes the incidence sum of every
+image directly and reports zero failures.
+
+Completeness follows from the count rather than from a further search. Any
+sixteen-piece carrier of four contains some piece; a group element carries that
+piece to the anchor; the image is a sixteen-piece carrier of four through the
+anchor, hence one of the eleven the anchored sweep found; so the original is in
+the census. The arithmetic confirms it in place: every one of the 192 pieces
+sits on exactly eleven members of the 132, the same eleven the anchored sweep
+returned at the anchor.
+
+## Six families, five profiles
+
+Sorting the 132 by the group gives six families, of sizes 12, 12, 12, 24, 24
+and 48. Sorting them instead by how they meet the 192 eight-piece carriers of
+the all-marked reading gives only five profiles, of sizes 12, 12, 24, 36 and 48.
+
+The profile is constant on a family, since the group permutes the eight-piece
+carriers among themselves, so the profile is a coarsening of the family
+structure. Five profiles from six families therefore means one profile is shared
+by two families, and the sizes say which: the profile of size 36 covers a family
+of 12 and a family of 24. The overlap pattern with the eight-piece carriers is a
+genuine separator, but not a complete one.
+
+## The ceiling at twenty, for the system
+
+Adding an eight-piece carrier of the all-marked reading to a sixteen-piece
+carrier of four gives a carrier of the flip partner of four, because a reading
+and its flip partner differ by the all-marked reading. The size of the sum is 24
+less twice the overlap, so the smallest sums come from the largest overlaps.
+
+Every one of the 25344 pairs is measured here, not only those through the anchor. The
+overlap takes the value 0 in 14592 pairs, 1 in 4608 and 2 in 6144, and never
+exceeds 2. The cap of 2 is therefore a property of the whole system rather than
+of the anchored eleven, and the smallest sum built this way has twenty pieces.
+
+The 6144 pairs at the cap give 6144 distinct twenty-piece carriers: the map from
+pair to sum is injective, with no two pairs landing on the same set. Every one of
+them checks back against the incidence, every one of the 192 pieces sits on
+exactly 640 of them, and the group sorts them into twenty families of 192 and
+six of 384, which accounts for all 6144.
+
+## What an eighteen-piece carrier would have to look like
+
+The least size for the flip partner of four is bracketed between eighteen and
+twenty by the previous cycle, with eighteen undecided. Suppose an eighteen-piece
+carrier of the flip partner existed and met some eight-piece carrier of the
+all-marked reading in k pieces. Their sum carries four and has 26 less twice k
+pieces. For k at least 6 that is under sixteen, which no carrier of four
+achieves. For k equal to 5 it is exactly sixteen, so the sum is a member of the
+census, and it meets the eight-piece carrier in 8 less 5 pieces, which is 3 and
+breaks the cap of 2. So k is at most 4.
+
+This is a derivation from two measured inputs rather than a search: the least
+size sixteen for four, and the whole-system cap of 2. The previous cycle stated
+the same bound from the anchored cap; the input here is the system-wide one, so
+the conclusion no longer inherits an anchored scope. It does not settle
+eighteen — the totals it permits remain consistent with such a carrier existing
+— but it is a shape constraint any construction or refutation at eighteen must
+respect.
+
+## Boundary and honest read
+
+- Every statement here is about the finite cutting system. No physical reading
+  of the readings, the carriers, the census or the families is claimed.
+- The census of 132 is complete for the charge called four at size sixteen, and
+  its completeness rests on two gated facts: the anchored sweep at sixteen is
+  complete and returns eleven, and the group is transitive on the 192 pieces.
+  Both are checked in place by this runner.
+- The six families are the families of the group of 384 recorded in this
+  runner, which is generated by the 48 together with the two extra symmetries
+  the table admits. This note does not claim that group is the full symmetry
+  group of the table; that question is handled by a separate in-flight package
+  and is not assumed here.
+- The cap of 2 and the resulting ceiling of twenty are exact for sums of a
+  smallest carrier of four with an eight-piece carrier of the all-marked
+  reading. This note does not claim that every twenty-piece carrier of the flip
+  partner arises that way, and the 6144 counted here are the ones that do.
+- The bound of 4 at eighteen is conditional on such a carrier existing. Nothing
+  here asserts that one does, and nothing here asserts that none does. The
+  bracket between eighteen and twenty is unchanged by this package.
+- The families of the 132 and of the 6144 are counted, not classified. This note
+  names no invariant that tells the two families sharing a profile of size 36
+  apart, and finding one is open.
+- Nothing here bounds the least size for the other charges or for their flip
+  partners.
+- The runner prints 36 gate lines, all passing, and every count above appears in
+  that output.
+- Earlier-cycle artifacts are named in backticks because their packages are in
+  flight, and nothing here links to them:
+  `PHYSICAL_CELL_CUTTING_SIXTEEN_ATTAINED_CYCLE742_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_HIDDEN_THREE_BIT_GEOMETRY_CYCLE743_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_FULL_SYMMETRY_CERTIFIED_CYCLE744_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_SIXTEEN_CENSUS_CYCLE745_NOTE_2026-08-05.md`,
+  `PHYSICAL_CELL_CUTTING_CARRIER_PARITY_LAW_CYCLE746_NOTE_2026-08-08.md`,
+  `PHYSICAL_CELL_CUTTING_FLIP_PARTNER_CARRIER_BRACKET_CYCLE747_NOTE_2026-08-08.md`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15469,
- "node_count": 5440,
+ "edge_count": 15470,
+ "node_count": 5441,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13625,6 +13625,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_census_families_cycle748_note_2026-08-08": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_census_families_cycle748_2026_08_08.txt
+++ b/logs/runner-cache/physical_cell_cutting_census_families_cycle748_2026_08_08.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_census_families_cycle748_2026_08_08.py
+runner_sha256: 23d3182244193cc2a2fa554d7c40e5d7eaa5dacf25fd0c7dccff5f9c6b561937
+timeout_sec: 400
+exit_code: 0
+elapsed_sec: 107.39
+status: ok
+----- stdout -----
+PASS G0  the Gram matrix of the table has constant diagonal 1975
+PASS G1  all 15800 cuttings carry distinct piece supports
+PASS G2  the anchored and the two seeded colour refinements are all discrete
+PASS G3  b0 is an order-two piece permutation with a matching cutting permutation
+PASS G4  b0 fixes all eight readings
+PASS G5  b0 lies outside the 48, orbit rows (0,48,0,0) (48,0,0,0) (0,0,0,48) (0,0,48,0)
+PASS G6  b1 is an order-two piece permutation with a matching cutting permutation
+PASS G7  b1 fixes all eight readings
+PASS G8  b1 lies outside the 48, orbit rows (8,8,16,16) (8,8,16,16) (16,16,8,8) (16,16,8,8)
+PASS G9  b0 and b1 are different permutations
+PASS G10  the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive
+PASS G11  each charge and each planted reading forces even total, side, and quarter parities, and the synthetic reading forces an odd total
+PASS G12  the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes two to sixteen, matching the closed sum, with consecutive odd squares as steps
+PASS G13  all six charges license the same 285 cells at sixteen, one pass covers the six
+PASS G14  the odd-total synthetic reading licenses no cell at sixteen
+PASS G15  the licensed cells at sixteen with a piece in the last quarter number 204, and the six charges and the five planted readings share exactly that list
+PASS G16  the anchored tables list exactly the subsets through the anchor piece, row for row against direct column sums, with binomial row counts
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS G17  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+marks: the all-marked reading 15800, four 5664, its flip partner 10136
+least size those marks force: 8, 3, 6 pieces
+PASS G18  a carrier meets each marked cutting at least once while each piece meets 1975 cuttings, so the marks force a least size
+pieces no cutting shares with a given piece: 33
+eight-piece sets no cutting uses twice: 192, of those meeting every cutting exactly once: 192
+PASS G19  eight pieces meeting every cutting exactly once is the same as eight pieces no cutting uses twice, since eight of them meet 15800 with multiplicity
+each piece lies in 8 of them; two of them share pieces, count by value: {0:15072,1:1920,2:960,4:384}
+PASS G20  those carriers meet each piece the same number of times and meet each other in 0, 1, 2 or 4 pieces, never 3
+those eight readings close into an addition group of order 8
+PASS G21  each flip partner is its reading plus the all-marked reading, so a reading and its flip partner have least sizes differing by at most eight
+symmetries of the table that fix a basic reading: 48, and they carry any piece to any other: True
+PASS G22  the symmetries that fix a reading carry any piece to any other, so asking for carriers through one fixed piece decides the question for every piece
+
+anchored search, carriers of four then of its flip partner, by size: 2: 0 and 0, 4: 0 and 0, 6: 0 and 0, 8: 0 and 0, 10: 0 and 0, 12: 0 and 0, 14: 0 and 0, 16: 11 and 0
+at sixteen both were asked of the same 204 cells over the same 2004 splits
+carriers recorded below eighteen 19, recheck failures 0
+PASS G23  the search finds the eight-piece carriers of the all-marked reading through the anchor and none at ten, so it is not blind when it comes back empty
+PASS G24  four has no anchored carrier below sixteen and has eleven at sixteen, every sweep complete
+PASS G25  the flip partner of four has no anchored carrier at any even size up to sixteen, asked of exactly the cells and splits that deliver the eleven
+PASS G26  each recorded carrier is checked back against the incidence directly, not trusted from the bookkeeping of the search
+
+symmetries of the table 384, each permuting the 192 eight-piece carriers of the all-marked reading: True
+PASS G27  they close into a group of 384 that is transitive on the pieces
+sixteen-piece carriers of four across the system 132, each piece on 11, recheck failures 0
+PASS G28  every piece sits on eleven of them, the count the anchored sweep found, so these are all of them
+the families they fall into: 12,12,12,24,24,48
+PASS G29  the symmetries do not carry every smallest carrier of four onto every other: six families
+over all 25344 pairs with those eight-piece carriers: overlaps {0:14592,1:4608,2:6144}, each carrier meeting them 128 times with multiplicity, 5 profiles in sizes 12,12,24,36,48
+PASS G30  the cap of two holds for every smallest carrier of four in the system, not just the anchored eleven
+PASS G31  one of the five profiles is shared by two families, so it does not tell them apart
+sums at the cap: 6144 sets of twenty carrying the flip partner, each piece on 640, failures 0, families 20 of 192 and 6 of 384
+PASS G32  each overlapping pair gives a different set, so twenty is met in 6144 ways spread evenly
+an eighteen-piece carrier of the flip partner, were one to exist, would meet any of those in at most 4 pieces, its sums running down from 26
+PASS G33  sharing five or more would give a carrier of four under sixteen, or one at sixteen breaking the cap of two
+elapsed under 200 s peak memory under 2500 MB
+PASS G34  the whole runner finishes under 900 seconds inside the printed 2500 MB
+PASS G35  its output stays under 6000 characters
+
+TOTAL: PASS=36 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_census_families_cycle748_2026_08_08_cold_2026-08-08.txt
+++ b/outputs/physical_cell_cutting_census_families_cycle748_2026_08_08_cold_2026-08-08.txt
@@ -1,0 +1,59 @@
+PASS G0  the Gram matrix of the table has constant diagonal 1975
+PASS G1  all 15800 cuttings carry distinct piece supports
+PASS G2  the anchored and the two seeded colour refinements are all discrete
+PASS G3  b0 is an order-two piece permutation with a matching cutting permutation
+PASS G4  b0 fixes all eight readings
+PASS G5  b0 lies outside the 48, orbit rows (0,48,0,0) (48,0,0,0) (0,0,0,48) (0,0,48,0)
+PASS G6  b1 is an order-two piece permutation with a matching cutting permutation
+PASS G7  b1 fixes all eight readings
+PASS G8  b1 lies outside the 48, orbit rows (8,8,16,16) (8,8,16,16) (16,16,8,8) (16,16,8,8)
+PASS G9  b0 and b1 are different permutations
+PASS G10  the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive
+PASS G11  each charge and each planted reading forces even total, side, and quarter parities, and the synthetic reading forces an odd total
+PASS G12  the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes two to sixteen, matching the closed sum, with consecutive odd squares as steps
+PASS G13  all six charges license the same 285 cells at sixteen, one pass covers the six
+PASS G14  the odd-total synthetic reading licenses no cell at sixteen
+PASS G15  the licensed cells at sixteen with a piece in the last quarter number 204, and the six charges and the five planted readings share exactly that list
+PASS G16  the anchored tables list exactly the subsets through the anchor piece, row for row against direct column sums, with binomial row counts
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS G17  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+marks: the all-marked reading 15800, four 5664, its flip partner 10136
+least size those marks force: 8, 3, 6 pieces
+PASS G18  a carrier meets each marked cutting at least once while each piece meets 1975 cuttings, so the marks force a least size
+pieces no cutting shares with a given piece: 33
+eight-piece sets no cutting uses twice: 192, of those meeting every cutting exactly once: 192
+PASS G19  eight pieces meeting every cutting exactly once is the same as eight pieces no cutting uses twice, since eight of them meet 15800 with multiplicity
+each piece lies in 8 of them; two of them share pieces, count by value: {0:15072,1:1920,2:960,4:384}
+PASS G20  those carriers meet each piece the same number of times and meet each other in 0, 1, 2 or 4 pieces, never 3
+those eight readings close into an addition group of order 8
+PASS G21  each flip partner is its reading plus the all-marked reading, so a reading and its flip partner have least sizes differing by at most eight
+symmetries of the table that fix a basic reading: 48, and they carry any piece to any other: True
+PASS G22  the symmetries that fix a reading carry any piece to any other, so asking for carriers through one fixed piece decides the question for every piece
+
+anchored search, carriers of four then of its flip partner, by size: 2: 0 and 0, 4: 0 and 0, 6: 0 and 0, 8: 0 and 0, 10: 0 and 0, 12: 0 and 0, 14: 0 and 0, 16: 11 and 0
+at sixteen both were asked of the same 204 cells over the same 2004 splits
+carriers recorded below eighteen 19, recheck failures 0
+PASS G23  the search finds the eight-piece carriers of the all-marked reading through the anchor and none at ten, so it is not blind when it comes back empty
+PASS G24  four has no anchored carrier below sixteen and has eleven at sixteen, every sweep complete
+PASS G25  the flip partner of four has no anchored carrier at any even size up to sixteen, asked of exactly the cells and splits that deliver the eleven
+PASS G26  each recorded carrier is checked back against the incidence directly, not trusted from the bookkeeping of the search
+
+symmetries of the table 384, each permuting the 192 eight-piece carriers of the all-marked reading: True
+PASS G27  they close into a group of 384 that is transitive on the pieces
+sixteen-piece carriers of four across the system 132, each piece on 11, recheck failures 0
+PASS G28  every piece sits on eleven of them, the count the anchored sweep found, so these are all of them
+the families they fall into: 12,12,12,24,24,48
+PASS G29  the symmetries do not carry every smallest carrier of four onto every other: six families
+over all 25344 pairs with those eight-piece carriers: overlaps {0:14592,1:4608,2:6144}, each carrier meeting them 128 times with multiplicity, 5 profiles in sizes 12,12,24,36,48
+PASS G30  the cap of two holds for every smallest carrier of four in the system, not just the anchored eleven
+PASS G31  one of the five profiles is shared by two families, so it does not tell them apart
+sums at the cap: 6144 sets of twenty carrying the flip partner, each piece on 640, failures 0, families 20 of 192 and 6 of 384
+PASS G32  each overlapping pair gives a different set, so twenty is met in 6144 ways spread evenly
+an eighteen-piece carrier of the flip partner, were one to exist, would meet any of those in at most 4 pieces, its sums running down from 26
+PASS G33  sharing five or more would give a carrier of four under sixteen, or one at sixteen breaking the cap of two
+elapsed under 200 s peak memory under 2500 MB
+PASS G34  the whole runner finishes under 900 seconds inside the printed 2500 MB
+PASS G35  its output stays under 6000 characters
+
+TOTAL: PASS=36 FAIL=0

--- a/outputs/physical_cell_cutting_census_families_cycle748_2026_08_08_receipt_2026-08-08.json
+++ b/outputs/physical_cell_cutting_census_families_cycle748_2026_08_08_receipt_2026-08-08.json
@@ -1,0 +1,99 @@
+{
+ "cycle": 748,
+ "failures": 0,
+ "gates": 36,
+ "headline": "The smallest carriers of the charge called four number 132 across the whole cutting system, and that census is complete: every one of the 192 pieces sits on exactly eleven of them, the same eleven the anchored sweep returned. The symmetries of the table close into a group of 384 that is transitive on the pieces and permutes the 192 eight-piece carriers of the all-marked reading among themselves, yet it does not carry every smallest carrier of four onto every other: it cuts the 132 into six families of sizes 12, 12, 12, 24, 24 and 48, while their overlap patterns with the eight-piece carriers give only five profiles of sizes 12, 12, 24, 36 and 48, so one profile covers two families. Across all 25344 pairs the overlap is 0 in 14592 cases, 1 in 4608 and 2 in 6144 and never more, so the cap of two is a property of the system and not of the anchor; the 6144 pairs at the cap give 6144 distinct twenty-piece carriers of the flip partner of four, one per pair, each of the 192 pieces on 640 of them, in twenty families of 192 and six of 384. Were an eighteen-piece carrier of the flip partner to exist it would meet any eight-piece carrier of the all-marked reading in at most 4 pieces.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_CENSUS_FAMILIES_CYCLE748_NOTE_2026-08-08.md",
+ "recorded_output": "outputs/physical_cell_cutting_census_families_cycle748_2026_08_08_cold_2026-08-08.txt",
+ "results": {
+  "all_marked_reading_carriers": {
+   "carriers_through_each_piece": 8,
+   "eight_piece_sets_no_cutting_uses_twice": 192,
+   "least_size": 8,
+   "non_sharing_partners_per_piece": 33,
+   "shared_pieces_between_two_carriers": {
+    "0": 15072,
+    "1": 1920,
+    "2": 960,
+    "4": 384
+   }
+  },
+  "census_of_smallest_carriers_of_four": {
+   "anchored_count": 11,
+   "carriers_through_each_piece": 11,
+   "complete": true,
+   "count": 132,
+   "direct_recheck_failures": 0,
+   "family_sizes": [
+    12,
+    12,
+    12,
+    24,
+    24,
+    48
+   ],
+   "size": 16
+  },
+  "overlaps_with_the_eight_piece_carriers": {
+   "by_value": {
+    "0": 14592,
+    "1": 4608,
+    "2": 6144
+   },
+   "cap": 2,
+   "meetings_per_carrier_with_multiplicity": 128,
+   "pairs": 25344,
+   "profile_sizes": [
+    12,
+    12,
+    24,
+    36,
+    48
+   ],
+   "profiles_fewer_than_families": true
+  },
+  "rebuilt_system": {
+   "cuttings": 15800,
+   "cuttings_per_piece": 1975,
+   "least_sizes_forced_by_marks": {
+    "all_marked_reading": 8,
+    "flip_partner_of_four": 6,
+    "four": 3
+   },
+   "marks": {
+    "all_marked_reading": 15800,
+    "flip_partner_of_four": 10136,
+    "four": 5664
+   },
+   "pieces": 192,
+   "pieces_per_cutting": 24
+  },
+  "shape_of_any_eighteen_piece_carrier": {
+   "conditional": true,
+   "largest_sum": 26,
+   "most_pieces_shared_with_an_eight_piece_carrier": 4,
+   "reason": "sharing five or more would give a carrier of four under sixteen, or one at sixteen breaking the cap of two"
+  },
+  "symmetry_group": {
+   "generated_by_the_forty_eight_and_two_more": true,
+   "order": 384,
+   "permutes_the_eight_piece_carriers_among_themselves": true,
+   "stabilizer_of_a_basic_reading": 48,
+   "transitive_on_pieces": true
+  },
+  "twenty_piece_carriers_of_the_flip_partner": {
+   "carriers_through_each_piece": 640,
+   "count": 6144,
+   "direct_recheck_failures": 0,
+   "families": {
+    "of_192": 20,
+    "of_384": 6
+   },
+   "one_per_overlapping_pair": true,
+   "size": 20
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_census_families_cycle748_2026_08_08.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_census_families_cycle748_2026_08_08.py
+++ b/scripts/physical_cell_cutting_census_families_cycle748_2026_08_08.py
@@ -1,0 +1,1799 @@
+"""Cycle 748: the smallest carriers of the four charge split into six families.
+
+The unit four-cube on sixteen corners cuts into least-volume pieces at the adjacency
+cost floor in 15800 ways, and those cuttings use 192 pieces between them. A set of
+pieces carries a reading when the cuttings it meets an odd number of times are exactly
+the ones the reading marks. Cycle 742 measured the least size for the charge called
+four: sixteen pieces, eleven of them through a fixed anchor piece.
+
+This runner takes that anchored handful to the whole system. The symmetries of the
+incidence table close into a group of 384 that is transitive on the pieces and permutes
+the 192 eight-piece carriers of the all-marked reading among themselves. Carrying the
+eleven around by that group gives 132 sixteen-piece carriers of four, every piece on
+exactly eleven of them, each checked back against the incidence directly. Eleven is the
+count the anchored sweep found, so every piece stands to the 132 exactly as the anchor
+does and the 132 are all of them. Those 132 are not one family: the group cuts them into
+six, of sizes 12, 12, 12, 24, 24 and 48. Five
+overlap profiles against the eight-piece carriers are visible, one of them shared by two
+families, so that profile does not tell the families apart.
+
+The ceiling of cycle 747 then becomes a statement about the system rather than about the
+anchor. Every one of the 25344 pairs of a smallest carrier of four with an eight-piece
+carrier of the all-marked reading shares at most two pieces, so the smallest sum has
+twenty pieces; the 6144 pairs that do share two give 6144 different twenty-piece
+carriers of the flip partner of four, one per pair, each piece on 640 of them, falling
+into twenty families of 192 and six of 384. The same two measurements force a shape on
+anything smaller: an eighteen-piece carrier of the flip partner, were one to exist,
+could share at most four pieces with any eight-piece carrier of the all-marked reading.
+
+Class-A: integer and field-with-two-elements arithmetic on a finite explicit object, no
+solver. Every count below is measured here.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.time()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+
+PK = np.packbits(INC, axis=1)
+LUT = np.array([bin(i).count("1") for i in range(256)], dtype=np.uint8)
+SZC = [4, 6]
+SZG = [4]
+EA = dict((k, []) for k in SZC)
+EB = dict((k, []) for k in SZC)
+DIS = dict((k, set()) for k in SZG)
+for lo in range(0, NS, 200):
+    hi = min(lo + 100, NS)
+    d = LUT[np.bitwise_xor(PK[lo:hi, None, :], PK[None, :, :])].sum(axis=2, dtype=np.int16)
+    for k in SZC:
+        rr, cc = np.nonzero(d == 2 * k)
+        keep = (rr + lo) < cc
+        aa = (rr[keep] + lo).tolist()
+        bb = cc[keep].tolist()
+        EA[k].extend(aa)
+        EB[k].extend(bb)
+        if k in DIS:
+            for a, b in zip(aa, bb):
+                DIS[k].add(BITS[a] ^ BITS[b])
+for k in SZC:
+    EA[k] = np.asarray(EA[k], dtype=np.int64)
+    EB[k] = np.asarray(EB[k], dtype=np.int64)
+KEY = dict((k, sorted(DIS[k])) for k in SZG)
+
+def basis(rows, piv=None):
+    """pivot table of the span of rows, over the field with two elements"""
+    if piv is None:
+        piv = {}
+    for r in rows:
+        while r:
+            h = r.bit_length() - 1
+            if h not in piv:
+                piv[h] = r
+                break
+            r ^= piv[h]
+    return piv
+
+
+def inspan(r, piv):
+    """does r lie in the span the pivot table describes"""
+    while r:
+        h = r.bit_length() - 1
+        if h not in piv:
+            return False
+        r ^= piv[h]
+    return True
+
+
+def rref(rows, piv=None):
+    """pivot table cleared above the pivots as well as below"""
+    piv = basis(rows, piv)
+    for h in sorted(piv):
+        for g in sorted(piv):
+            if g > h and ((piv[g] >> h) & 1) == 1:
+                piv[g] ^= piv[h]
+    return piv
+
+
+def perp(piv, n):
+    """the weights on n pieces annihilating everything the pivot table spans"""
+    out = []
+    for j in range(n):
+        if j in piv:
+            continue
+        w = 1 << j
+        for h in piv:
+            if ((piv[h] >> j) & 1) == 1:
+                w |= 1 << h
+        out.append(w)
+    for w in out:
+        for r in piv.values():
+            assert (bin(w & r).count("1") & 1) == 0, "a uniform weight must annihilate"
+    return out
+
+
+TK = {}
+for k in SZG:
+    TK[k] = rref(s ^ KEY[k][0] for s in KEY[k][1:])
+
+NUL = perp(TK[4], NPO)
+WM = np.zeros((NPO, len(NUL)), dtype=np.int64)
+for c, w in enumerate(NUL):
+    for j in range(NPO):
+        if ((w >> j) & 1) == 1:
+            WM[j, c] = 1
+FF = (INCL @ WM) & 1
+PIV = {}
+for c in range(FF.shape[1]):
+    a = FF[:, c].astype(np.uint8)
+    r = int.from_bytes(np.packbits(a).tobytes(), "big")
+    while r:
+        h = r.bit_length() - 1
+        if h not in PIV:
+            PIV[h] = (r, a)
+            break
+        r ^= PIV[h][0]
+        a = a ^ PIV[h][1]
+BAS = [PIV[h][1] for h in sorted(PIV)]
+FUN = []
+for mask in range(1 << len(BAS)):
+    f = np.zeros(NS, dtype=np.uint8)
+    for i, b in enumerate(BAS):
+        if ((mask >> i) & 1) == 1:
+            f = f ^ b
+    FUN.append(f)
+
+NAMED, HITS = {}, {}
+for f in FUN:
+    one = int(f.sum())
+    if one in (0, NS):
+        continue
+    g = f if 2 * one <= NS else (f ^ 1)
+    d4 = g[EA[4]] ^ g[EB[4]]
+    d6 = g[EA[6]] ^ g[EB[6]]
+    nm = "four" if d4.max() == 0 else ("six" if d6.max() == 0 else "seven")
+    NAMED[nm] = g
+    HITS[nm] = HITS.get(nm, 0) + 1
+
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+
+# ---- the twelve targets: eight readings plus the four planted controls of Part 3 ----
+ZERO = np.zeros(NS, dtype=np.uint8)
+ONE = np.ones(NS, dtype=np.uint8)
+TGT = [("zero", ZERO), ("one", ONE)]
+for nm in ["four", "six", "seven"]:
+    TGT.append((nm, NAMED[nm]))
+    TGT.append((nm + "-flip", NAMED[nm] ^ 1))
+PLANT = [("pair (2,2)", (10, 55, 120, 168)),
+         ("h6 (6,2)", (3, 21, 44, 61, 77, 90, 101, 155)),
+         ("in-left quarters (3,5)", (2, 9, 30, 50, 63, 71, 80, 91)),
+         ("in-right one quarter (0,8)", (150, 151, 160, 165, 170, 180, 185, 191))]
+for pname, psupp in PLANT:
+    TGT.append((pname, (INCL[:, list(psupp)].sum(axis=1) & 1).astype(np.uint8)))
+NT = len(TGT)
+
+# ---- the 88 pivot cuttings and a piece's packed parities, rebuilt from INC ----
+EPACK = np.packbits(INC, axis=1, bitorder="little")
+EROW = [int.from_bytes(EPACK[i].tobytes(), "little") for i in range(NS)]
+EBAS0 = {}
+EPIVL = []
+for i in range(NS):
+    v = EROW[i]
+    while v:
+        lb = v.bit_length() - 1
+        if lb in EBAS0:
+            v ^= EBAS0[lb]
+        else:
+            EBAS0[lb] = v
+            EPIVL.append(i)
+            v = 0
+ERANK = len(EPIVL)
+EPIV = np.array(sorted(EPIVL), dtype=np.int64)
+P88 = INC[EPIV]
+
+
+def pack88(bits):
+    """the parities on the 88 pivot cuttings, as two sixty-four bit words"""
+    b = np.asarray(bits, dtype=np.uint64)
+    out = np.zeros(b.shape[:-1] + (2,), dtype=np.uint64)
+    for i in range(88):
+        wd, sh = divmod(i, 64)
+        out[..., wd] |= b[..., i] << np.uint64(sh)
+    return out
+
+
+COLS = pack88(P88.T)
+
+
+# ---- the eighteen readings: twelve as before, five planted fourteen-sets, one control ----
+PSEED = 74516
+P16SPEC = [("p16-a4444", (4, 4, 4, 4)),
+           ("p16-a0-0-6-10", (0, 0, 6, 10)),
+           ("p16-a8044", (8, 0, 4, 4)),
+           ("p16-a2-2-2-10", (2, 2, 2, 10)),
+           ("p16-a0-8-0-8", (0, 8, 0, 8))]
+prng2 = np.random.default_rng(PSEED)
+PSET = {}
+TNAME = [nm for nm, _f in TGT]
+FVEC = [f for _nm, f in TGT]
+for pi, (pnm, prof) in enumerate(P16SPEC):
+    Sp = [144] + [145 + int(c) for c in prng2.choice(47, prof[3] - 1, replace=False)]
+    for q in range(3):
+        Sp += [48 * q + int(c) for c in prng2.choice(48, prof[q], replace=False)]
+    Sp = sorted(Sp)
+    PSET[NT + pi] = tuple(Sp)
+    TNAME.append(pnm)
+    FVEC.append((INCL[:, Sp].sum(axis=1) & 1).astype(np.uint8))
+FODD = np.zeros(NS, dtype=np.uint8)
+FODD[0] = 1
+TNAME.append("odd-ctl")
+FVEC.append(FODD)
+NTG = len(FVEC)
+TCTL = NTG - 1
+FV = np.stack(FVEC)
+TG = pack88(FV[:, EPIV])
+
+# ---- the parities a search of the pieces is forced to respect on each block ----
+LBAS = {}
+for i in range(NS):
+    v = EROW[i]
+    a = 0
+    for k in range(NTG):
+        a |= int(FV[k, i]) << k
+    while v:
+        lb = v.bit_length() - 1
+        if lb in LBAS:
+            bv, ba = LBAS[lb]
+            v ^= bv
+            a ^= ba
+        else:
+            LBAS[lb] = (v, a)
+            v = 0
+
+
+def reduce_u(u_int):
+    """the forced parities of a block, or None when the block is free"""
+    v, a = u_int, 0
+    while v:
+        lb = v.bit_length() - 1
+        if lb not in LBAS:
+            return None
+        bv, ba = LBAS[lb]
+        v ^= bv
+        a ^= ba
+    return a
+
+
+def uint_of(cols):
+    u = 0
+    for c in cols:
+        u |= 1 << int(c)
+    return u
+
+
+BLK = {"total": range(192), "L": range(96), "R": range(96, 192)}
+for q in range(4):
+    BLK["Q{0}".format(q)] = range(48 * q, 48 * q + 48)
+for e in range(8):
+    BLK["E{0}".format(e)] = range(24 * e, 24 * e + 24)
+FORCED = dict((nm, reduce_u(uint_of(b))) for nm, b in BLK.items())
+
+# ---- lex extension chains over the quarters and the eighths ----
+BQ = 27
+MQ = np.uint64(2**BQ - 1)
+Q_COLS = [np.arange(48 * q, 48 * q + 48) for q in range(4)]
+E_COLS = [np.arange(24 * e, 24 * e + 24) for e in range(8)]
+
+
+def build_chain(cols, kmax):
+    """Lex extension chain over cols. Returns T[k] (syn), NOFF[k].
+
+    T[k] row order: blocks by lead column c ascending; block c = rows of
+    T[k-1] with min column > c, in their T[k-1] order, XOR syn(c).
+    NOFF[k][c] = first row of block c; NOFF[k][n] = len(T[k]).
+    """
+    n = len(cols)
+    T = {0: np.zeros((1, 2), dtype=np.uint64)}
+    NOFF = {1: np.arange(n + 1, dtype=np.int64)}
+    if kmax >= 1:
+        T[1] = COLS[cols].copy()
+    for k in range(1, kmax):
+        prev, poff = T[k], NOFF[k]
+        total = sum(len(prev) - poff[c + 1] for c in range(n))
+        out = np.empty((total, 2), dtype=np.uint64)
+        noff = np.empty(n + 1, dtype=np.int64)
+        pos = 0
+        for c in range(n):
+            blk = prev[poff[c + 1]:]
+            noff[c] = pos
+            if len(blk):
+                np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+            pos += len(blk)
+        noff[n] = pos
+        T[k + 1] = out
+        NOFF[k + 1] = noff
+    return T, NOFF
+
+
+def unrank(NOFF, k, idx, cols):
+    """idx in T[k] -> global column list (len k)."""
+    out = []
+    idx = int(idx)
+    for lvl in range(k, 1, -1):
+        no = NOFF[lvl]
+        c = int(np.searchsorted(no, idx, side="right")) - 1
+        out.append(int(cols[c]))
+        idx = int(NOFF[lvl - 1][c + 1]) + (idx - int(no[c]))
+    if k >= 1:
+        out.append(int(cols[idx]))
+    return out
+
+
+QCH = []
+for q in range(4):
+    QCH.append(build_chain(Q_COLS[q], 5))
+
+_C3 = list(itertools.combinations(range(48), 3))
+UNROK = True
+for q in range(4):
+    for idx in (0, 5, 1000, 17295):
+        got = sorted(unrank(QCH[q][1], 3, idx, Q_COLS[q]))
+        exp = sorted(int(Q_COLS[q][c]) for c in _C3[idx])
+        UNROK = UNROK and got == exp
+
+_T6_CACHE = {}
+
+
+def get_T6(q):
+    """(T6, NOFF6) for quarter q, built on demand from T5."""
+    if q in _T6_CACHE:
+        return _T6_CACHE[q]
+    T, NOFF = QCH[q]
+    n = 48
+    cols = Q_COLS[q]
+    prev, poff = T[5], NOFF[5]
+    total = sum(len(prev) - poff[c + 1] for c in range(n))
+    out = np.empty((total, 2), dtype=np.uint64)
+    noff = np.empty(n + 1, dtype=np.int64)
+    pos = 0
+    for c in range(n):
+        blk = prev[poff[c + 1]:]
+        noff[c] = pos
+        if len(blk):
+            np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+        pos += len(blk)
+    noff[n] = pos
+    _T6_CACHE[q] = (out, noff)
+    return _T6_CACHE[q]
+
+
+def qtab(q, k):
+    """(syn table, unranker) for k-subsets of quarter q, k <= 6."""
+    if k <= 5:
+        T, NOFF = QCH[q]
+        return T[k], (lambda i, q=q, k=k: unrank(QCH[q][1], k, i, Q_COLS[q]))
+    T6, noff6 = get_T6(q)
+
+    def unr6(i, q=q, noff6=noff6):
+        i = int(i)
+        c = int(np.searchsorted(noff6, i, side="right")) - 1
+        idx5 = int(QCH[q][1][5][c + 1]) + (i - int(noff6[c]))
+        return [int(Q_COLS[q][c])] + unrank(QCH[q][1], 5, idx5, Q_COLS[q])
+    return T6, unr6
+
+
+# ---------------------------------------------- Part 3: the meet engine at twelve
+# A set of pieces is split by quarter into a cell (q0, q1, q2, q3). One part is streamed
+# and the rest are met against it. Every meeting is pruned by the parities forced inside
+# the union of the blocks already joined, so no wide product is ever built.
+
+CAP = 200000
+TABCAP = 30000000
+CHUNK = 2000000
+BLOWN = []
+QCOLS = [list(range(48 * q, 48 * q + 48)) for q in range(4)]
+ECOLS = [list(range(24 * e, 24 * e + 24)) for e in range(8)]
+CINT = []
+for _j in range(NPO):
+    _v = 0
+    for _i in range(88):
+        if P88[_i, _j]:
+            _v |= 1 << _i
+    CINT.append(_v)
+
+
+def col_rank(S):
+    """rank of a set of columns as vectors on the 88 pivot cuttings"""
+    piv = {}
+    for j in S:
+        v = CINT[j]
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                v ^= piv[h]
+            else:
+                piv[h] = v
+                break
+    return len(piv)
+
+
+def compl(S):
+    s = set(S)
+    return [j for j in range(NPO) if j not in s]
+
+
+def inner(S):
+    """basis of the parities living inside a column set: x with x.COLS[j] = 0 off S"""
+    out = compl(S)
+    piv, ker = {}, []
+    for i in range(88):
+        v, w = 0, 1 << i
+        for a, j in enumerate(out):
+            if (CINT[j] >> i) & 1:
+                v |= 1 << a
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                bv, bw = piv[h]
+                v ^= bv
+                w ^= bw
+            else:
+                piv[h] = (v, w)
+                break
+        if v == 0:
+            ker.append(w)
+    return ker
+
+
+def sub_kernel(S):
+    """basis of the piece sets inside S whose parities on the cuttings all vanish"""
+    piv, ker = {}, []
+    for a, j in enumerate(S):
+        v, w = CINT[j], 1 << a
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                bv, bw = piv[h]
+                v ^= bv
+                w ^= bw
+            else:
+                piv[h] = (v, w)
+                break
+        if v == 0:
+            ker.append(w)
+    return ker
+
+
+def keymap(X):
+    """byte tables turning a packed syndrome into its parities under a basis"""
+    d = len(X)
+    nw = max(1, (d + 63) // 64)
+    lut = np.zeros((nw, 11, 256), dtype=np.uint64)
+    con = np.zeros((11, 8, nw), dtype=np.uint64)
+    for b in range(11):
+        for p in range(8):
+            i = 8 * b + p
+            if i >= 88:
+                continue
+            for a, x in enumerate(X):
+                if (x >> i) & 1:
+                    con[b, p, a // 64] |= np.uint64(1) << np.uint64(a & 63)
+    for b in range(11):
+        for v in range(256):
+            acc = np.zeros(nw, dtype=np.uint64)
+            for p in range(8):
+                if (v >> p) & 1:
+                    acc ^= con[b, p]
+            lut[:, b, v] = acc
+    return lut
+
+
+def keyof(syn, lut):
+    """the parity key of every row of a packed syndrome table"""
+    a = np.ascontiguousarray(syn).view(np.uint8).reshape(-1, 16)
+    nw = lut.shape[0]
+    out = np.zeros((a.shape[0], nw), dtype=np.uint64)
+    for b in range(11):
+        idx = a[:, b]
+        for w in range(nw):
+            out[:, w] ^= lut[w, b][idx]
+    return out
+
+
+def key1(vec, lut):
+    """the parity key of one packed syndrome"""
+    a = np.ascontiguousarray(np.asarray(vec, dtype=np.uint64)).view(np.uint8)
+    nw = lut.shape[0]
+    out = np.zeros(nw, dtype=np.uint64)
+    for b in range(11):
+        for w in range(nw):
+            out[w] ^= lut[w, b, int(a[b])]
+    return out
+
+
+# ---- part tables: a quarter at weight up to six, an eighth at any weight to twelve ----
+_ECH = {}
+
+
+def echain(e, kmax):
+    """the lex extension chain over one block of 24, extended in place as needed"""
+    st = _ECH.get(e)
+    if st is None:
+        cols = np.array(ECOLS[e], dtype=np.int64)
+        st = ({1: COLS[cols].copy()}, {1: np.arange(25, dtype=np.int64)}, cols)
+        _ECH[e] = st
+    T, NOFF, cols = st
+    n = 24
+    k = max(T)
+    while k < kmax:
+        prev, poff = T[k], NOFF[k]
+        total = sum(len(prev) - poff[c + 1] for c in range(n))
+        out = np.empty((total, 2), dtype=np.uint64)
+        noff = np.empty(n + 1, dtype=np.int64)
+        pos = 0
+        for c in range(n):
+            blk = prev[poff[c + 1]:]
+            noff[c] = pos
+            if len(blk):
+                np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+            pos += len(blk)
+        noff[n] = pos
+        T[k + 1] = out
+        NOFF[k + 1] = noff
+        k += 1
+    return T[kmax], NOFF
+
+
+ZT = np.zeros((1, 2), dtype=np.uint64)
+BMP = np.zeros(2**BQ, dtype=np.uint8)
+_INNC = {}
+_LUTC = {}
+_SKC = {}
+_SKN = [0]
+SKCAP = 36000000
+
+
+def inner_of(lky, cols):
+    """the internal parity space of a block union, kept across the splits sharing it"""
+    hit = _INNC.get(lky)
+    if hit is None:
+        hit = inner(cols)
+        _INNC[lky] = hit
+    return hit
+
+
+def lut_for(lky, cols):
+    """the byte tables of a block union, kept across the splits that share it"""
+    hit = _LUTC.get(lky)
+    if hit is None:
+        hit = keymap(inner_of(lky, cols))
+        _LUTC[lky] = hit
+    return hit
+
+
+def plan_order(ne, sizes, fky, fcols):
+    """the join order whose largest intermediate meet is smallest
+
+    A join keys on the parities living inside the blocks joined so far, so an order
+    that joins blocks with no shared internal parity first has nothing to key on and
+    forms the whole product. The order is chosen here, and the answer does not depend
+    on it: every join is a necessary condition on the same final set.
+    """
+    n = len(sizes)
+    if n < 3:
+        return sorted(range(n), key=lambda i: (sizes[i], i))
+    cols = [QCOLS[s[1]] if s[0] == "Q" else ECOLS[s[1]] for s in ne]
+    dF = min(len(inner_of(fky, fcols)), 62)
+    best, bp = None, None
+    for p in itertools.permutations(range(n)):
+        cur, worst = float(sizes[p[0]]), float(sizes[p[0]])
+        acc, accs = list(cols[p[0]]), [(ne[p[0]][0], ne[p[0]][1])]
+        for j in range(1, n):
+            acc = acc + list(cols[p[j]])
+            accs = accs + [(ne[p[j]][0], ne[p[j]][1])]
+            d = dF if j == n - 1 else min(
+                len(inner_of(("I", tuple(sorted(accs))), acc)), 62)
+            cur = cur * sizes[p[j]] / float(1 << d)
+            worst = max(worst, cur)
+        if best is None or worst < best:
+            best, bp = worst, list(p)
+    return bp
+
+
+def sorted_keys(sky, tab, lut):
+    """the sorted parity keys of a part table, kept across the splits that share it"""
+    hit = _SKC.get(sky)
+    if hit is not None:
+        return hit
+    kb = keyof(tab, lut)[:, 0]
+    so = np.argsort(kb, kind="quicksort")
+    val = (kb[so], so)
+    if _SKN[0] + 2 * len(so) > SKCAP:
+        _SKC.clear()
+        _SKN[0] = 0
+    _SKC[sky] = val
+    _SKN[0] += 2 * len(so)
+    return val
+
+
+def part_table(kind, idx, k):
+    """(syndrome table, index -> column list, column block) for a part at weight k"""
+    if k == 0:
+        return ZT, (lambda i: []), []
+    if kind == "Q":
+        if k > 6:
+            raise ValueError("a quarter part was asked for past the six-subset tables")
+        T, unr = qtab(idx, k)
+        return T, unr, QCOLS[idx]
+    T, NOFF = echain(idx, k)
+    cols = np.array(ECOLS[idx], dtype=np.int64)
+    return T, (lambda i, NOFF=NOFF, k=k, cols=cols: unrank(NOFF, k, i, cols)), ECOLS[idx]
+
+
+# ---- meeting two tables under the parities forced inside the joined blocks ----
+def meet(sA, sB, kb_sorted, order, ka, tk):
+    """rows of sA met with rows of sB whose key differs from theirs by the target key"""
+    want = ka ^ tk
+    lo = np.searchsorted(kb_sorted, want, side="left")
+    hi = np.searchsorted(kb_sorted, want, side="right")
+    cnt = (hi - lo).astype(np.int64)
+    tot = int(cnt.sum())
+    if tot > TABCAP:
+        BLOWN.append(tot)
+        return None, None, None
+    if tot == 0:
+        z8 = np.zeros((0,), dtype=np.int64)
+        return np.zeros((0, 2), dtype=np.uint64), z8, z8
+    src = np.repeat(np.arange(len(sA), dtype=np.int64), cnt)
+    csum = np.cumsum(cnt)
+    off = np.arange(tot, dtype=np.int64) - np.repeat(csum - cnt, cnt)
+    dst = order[np.repeat(lo, cnt) + off]
+    return sA[src] ^ sB[dst], src, dst
+
+
+# ---- how a cell is split into a streamed part and the parts met against it ----
+def plan_cell(cell):
+    """the splits of a cell: one streamed part and the parts met against it
+
+    A quarter is carried whole only while its count stays inside the six-subset tables
+    a quarter is tabulated with. Every quarter past that is cut into its two eighths,
+    and the cell is covered by the product of those cuts, so a cell holding two heavy
+    quarters is searched at its own weight rather than at a lower one.
+    """
+    q = list(cell)
+    if max(q) <= 6:
+        best = max(range(4), key=lambda i: (math.comb(48, q[i]), -i))
+        A = ("Q", best, q[best])
+        B = [("Q", i, q[i]) for i in range(4) if i != best]
+        return [(A, B)]
+    big = [i for i in range(4) if q[i] > 6]
+    ways = []
+    for i in big:
+        w = []
+        for ka in range(0, min(24, q[i]) + 1):
+            kb = q[i] - ka
+            if 0 <= kb <= 24:
+                w.append((ka, kb))
+        ways.append(w)
+    rest = [("Q", i, q[i]) for i in range(4) if i not in big]
+    out = []
+    for combo in itertools.product(*ways):
+        parts = []
+        for (i, (ka, kb)) in zip(big, combo):
+            parts += [("E", 2 * i, ka), ("E", 2 * i + 1, kb)]
+        parts = parts + rest
+        if len(big) == 1:
+            u = 0 if math.comb(24, parts[0][2]) >= math.comb(24, parts[1][2]) else 1
+        else:
+            u = max(range(len(parts)), key=lambda j: (
+                math.comb(24 if parts[j][0] == "E" else 48, parts[j][2]), -j))
+        out.append((parts[u], [p for (j, p) in enumerate(parts) if j != u]))
+    return out
+
+
+CNT = {}
+RES = {}
+
+
+def run_split(A, B, tids):
+    """search one streamed part against the meet of the rest, folded over the targets"""
+    Ablk = QCOLS[A[1]] if A[0] == "Q" else ECOLS[A[1]]
+    fky = ("F", A[0], A[1])
+    lutF = lut_for(fky, compl(Ablk))
+    ne = [s for s in B if s[2] > 0]
+    tabs = [part_table(*s) for s in ne]
+    order = plan_order(ne, [len(t[0]) for t in tabs], fky, compl(Ablk))
+    steps = []
+    if len(ne) >= 2:
+        acc = list(tabs[order[0]][2])
+        accs = [(ne[order[0]][0], ne[order[0]][1])]
+        for j in range(1, len(ne)):
+            oi = order[j]
+            acc = acc + list(tabs[oi][2])
+            accs = accs + [(ne[oi][0], ne[oi][1])]
+            if j == len(ne) - 1:
+                lut, lky = lutF, fky
+            else:
+                lky = ("I", tuple(sorted(accs)))
+                lut = lut_for(lky, acc)
+            kbs, so = sorted_keys((ne[oi], lky), tabs[oi][0], lut)
+            steps.append((oi, lut, kbs, so))
+    elif len(ne) == 1:
+        kbs, so = sorted_keys((ne[order[0]], fky), tabs[order[0]][0], lutF)
+        steps.append((order[0], lutF, kbs, so))
+    fin = {}
+    for t in tids:
+        if len(ne) == 0:
+            tk = key1(TG[t], lutF)
+            fin[t] = (ZT.copy(), [], []) if not tk.any() else None
+            continue
+        if len(ne) == 1:
+            oi, lut, kbs, so = steps[0]
+            tk = key1(TG[t], lut)
+            a = int(np.searchsorted(kbs, tk[0], side="left"))
+            b = int(np.searchsorted(kbs, tk[0], side="right"))
+            sel = so[a:b]
+            if lut.shape[0] > 1 and len(sel):
+                k2 = keyof(tabs[oi][0][sel], lut)
+                sel = sel[np.all(k2 == tk[None, :], axis=1)]
+            fin[t] = (tabs[oi][0][sel], [oi], [sel]) if len(sel) else None
+            continue
+        syn = tabs[order[0]][0]
+        idxs = [np.arange(len(syn), dtype=np.int64)]
+        who = [order[0]]
+        for (oi, lut, kbs, so) in steps:
+            tk = key1(TG[t], lut)
+            ka = keyof(syn, lut)[:, 0]
+            syn2, src, dst = meet(syn, tabs[oi][0], kbs, so, ka, tk[0])
+            if syn2 is None:
+                return False
+            if lut.shape[0] > 1 and len(syn2):
+                k2 = keyof(syn2, lut)
+                kp = np.all(k2 == tk[None, :], axis=1)
+                syn2, src, dst = syn2[kp], src[kp], dst[kp]
+            syn = syn2
+            idxs = [a[src] for a in idxs] + [dst]
+            who = who + [oi]
+            if len(syn) == 0:
+                break
+        fin[t] = (syn, who, idxs) if len(syn) else None
+    live = [t for t in tids if fin[t] is not None]
+    if not live:
+        return True
+    k0 = np.concatenate([fin[t][0][:, 0] ^ TG[t, 0] for t in live])
+    k1 = np.concatenate([fin[t][0][:, 1] ^ TG[t, 1] for t in live])
+    tmark = np.concatenate([np.full(len(fin[t][0]), a, dtype=np.int64)
+                            for a, t in enumerate(live)])
+    lrow = np.concatenate([np.arange(len(fin[t][0]), dtype=np.int64) for t in live])
+    if len(k0) > TABCAP:
+        BLOWN.append(len(k0))
+        return False
+    so = np.argsort(k0, kind="quicksort")
+    sk0, sk1 = k0[so], k1[so]
+    stm, slr = tmark[so], lrow[so]
+    ix = (sk0 & MQ).astype(np.int64)
+    BMP[ix] = 1
+    Atab, Aunr, _ = part_table(*A)
+    hits = dict((t, []) for t in live)
+    for lo in range(0, len(Atab), CHUNK):
+        x = Atab[lo:lo + CHUNK]
+        g = BMP[(x[:, 0] & MQ).astype(np.int64)]
+        pos = np.nonzero(g)[0]
+        if not len(pos):
+            continue
+        s0 = x[pos, 0]
+        a = np.searchsorted(sk0, s0, side="left")
+        b = np.searchsorted(sk0, s0, side="right")
+        cnt = (b - a).astype(np.int64)
+        tot = int(cnt.sum())
+        if not tot:
+            continue
+        pp = np.repeat(pos, cnt)
+        cs = np.cumsum(cnt)
+        qq = np.repeat(a, cnt) + (np.arange(tot, dtype=np.int64)
+                                  - np.repeat(cs - cnt, cnt))
+        keep = sk1[qq] == x[pp, 1]
+        pp, qq = pp[keep], qq[keep]
+        if not len(pp):
+            continue
+        tsel, bsel = stm[qq], slr[qq]
+        for a2, t in enumerate(live):
+            msel = tsel == a2
+            if msel.any():
+                hits[t].append((pp[msel] + lo, bsel[msel]))
+    BMP[ix] = 0
+    for t in live:
+        hl = hits[t]
+        if not hl:
+            continue
+        ai = np.concatenate([h[0] for h in hl])
+        bi2 = np.concatenate([h[1] for h in hl])
+        c = CNT.get(t, 0)
+        CNT[t] = c + len(ai)
+        room = CAP - c
+        if room <= 0:
+            continue
+        ai, bi2 = ai[:room], bi2[:room]
+        syn, who, idxs = fin[t]
+        rows = []
+        for u in range(len(ai)):
+            br = int(bi2[u])
+            cs2 = list(Aunr(int(ai[u])))
+            for pi, oi in enumerate(who):
+                cs2 += list(tabs[oi][1](int(idxs[pi][br])))
+            rows.append(sorted(cs2))
+        RES.setdefault(t, []).append(np.asarray(rows, dtype=np.int64))
+    return True
+
+
+# ---- which cells a reading licenses, and the sweep over them ----
+def licensed_cell(cell, m, tid):
+    q0, q1, q2, q3 = cell
+    for nm, val in (("total", m), ("L", q0 + q1), ("Q2", q2), ("Q3", q3)):
+        f = FORCED[nm]
+        if f is not None and (val & 1) != ((f >> tid) & 1):
+            return False
+    return True
+
+
+def cells_of(m):
+    top = min(48, m)
+    out = []
+    for q0 in range(top + 1):
+        for q1 in range(min(top, m - q0) + 1):
+            for q2 in range(min(top, m - q0 - q1) + 1):
+                q3 = m - q0 - q1 - q2
+                if 0 <= q3 <= top:
+                    out.append((q0, q1, q2, q3))
+    return out
+
+
+SEEN = {}
+PROCD = []
+
+
+def run_cell(cell, m, tids):
+    """one cell, each of its splits once, all live targets folded"""
+    ok = True
+    act = [t for t in tids if licensed_cell(cell, m, t)]
+    if not act:
+        return ok
+    for t in act:
+        SEEN[t] = SEEN.get(t, 0) + 1
+    for (A, B) in plan_cell(cell):
+        PROCD.append((cell, A, tuple(B)))
+        if not run_split(A, B, act):
+            ok = False
+    return ok
+
+
+def run_sweep(m, tids):
+    """every licensed cell of size m, each split once, all live targets folded"""
+    ok = True
+    for cell in cells_of(m):
+        if not run_cell(cell, m, tids):
+            ok = False
+    return ok
+
+
+def coverage(m, tids):
+    """(cells met per target, splits done, splits distinct)"""
+    return ([SEEN.get(t, 0) for t in tids], len(PROCD), len(set(PROCD)))
+
+
+def fresh():
+    CNT.clear()
+    RES.clear()
+    SEEN.clear()
+    del PROCD[:]
+
+
+def orbsum(t):
+    """orbit sizes folded to a size:count summary, and the closure flag"""
+    szs, closed = orbits(t)
+    d = {}
+    for s in szs:
+        d[s] = d.get(s, 0) + 1
+    return d, len(szs), closed
+
+
+def lic_count(m, tid):
+    return sum(1 for c in cells_of(m) if licensed_cell(c, m, tid))
+
+
+# ---- every recorded set checked back against the columns, and folded into orbits ----
+def by_width(t):
+    g = {}
+    for a in RES.get(t, []):
+        g.setdefault(a.shape[1], []).append(a)
+    return dict((w, np.concatenate(v, axis=0)) for w, v in g.items())
+
+
+def verify(tids):
+    bad, dup, seen = 0, 0, 0
+    for t in tids:
+        for w, arr in by_width(t).items():
+            seen += len(arr)
+            syn = np.bitwise_xor.reduce(COLS[arr], axis=1)
+            bad += int((syn != TG[t][None, :]).any(axis=1).sum())
+            srt = np.sort(arr, axis=1)
+            if not np.array_equal(srt, arr):
+                bad += 1
+            if len(arr) and int((srt[:, 1:] == srt[:, :-1]).sum()) > 0:
+                bad += 1
+            dup += len(arr) - len(np.unique(arr, axis=0))
+    return seen, bad, dup
+
+
+STAB = [[gi for gi in range(48) if bool(np.array_equal(FV[t][PERMS[gi]], FV[t]))]
+        for t in range(NTG)]
+
+
+def orbits(t):
+    """recorded sets folded into orbits of the symmetries that fix the reading"""
+    grp = [CP[gi] for gi in STAB[t]]
+    out, closed = [], True
+    for w, arr in sorted(by_width(t).items()):
+        n = len(arr)
+        img = [np.sort(cp[arr], axis=1) for cp in grp]
+        big = np.concatenate([arr] + img, axis=0).astype(np.uint8)
+        uq, inv = np.unique(big, axis=0, return_inverse=True)
+        inv = np.asarray(inv).reshape(len(grp) + 1, n)
+        pos = -np.ones(len(uq), dtype=np.int64)
+        pos[inv[0]] = np.arange(n, dtype=np.int64)
+        M = pos[inv[1:]]
+        if int((M < 0).sum()):
+            closed = False
+            M = np.where(M < 0, np.arange(n, dtype=np.int64)[None, :], M)
+        lab = M.min(axis=0)
+        out += np.bincount(lab)[np.bincount(lab) > 0].tolist()
+    return sorted(int(x) for x in out), closed
+
+
+def has_set(t, cols):
+    key = np.array(sorted(int(c) for c in cols), dtype=np.int64)
+    for w, arr in by_width(t).items():
+        if w != len(key) or not len(arr):
+            continue
+        if bool((arr == key[None, :]).all(axis=1).any()):
+            return True
+    return False
+
+# ---- Part 3b: the two seeded order-two piece permutations and the fifty ----
+NP = NPO
+TGTv = [v for _, v in TGT[:8]]
+falab = lab
+ORB = [np.nonzero(falab == k)[0] for k in range(4)]
+
+
+def tshow(t):
+    return "(" + ",".join(str(int(c)) for c in t) + ")"
+
+
+F64 = INC.astype(np.float64)
+G = (F64.T @ F64).astype(np.int64)
+gate(len(set(np.diag(G).tolist())) == 1 and int(G[0, 0]) == 1975, "G0",
+     "the Gram matrix of the table has constant diagonal 1975")
+ROWK = {}
+for s in range(NS):
+    ROWK[tuple(map(int, np.nonzero(INC[s])[0]))] = s
+gate(len(ROWK) == NS and NS == 15800, "G1",
+     "all 15800 cuttings carry distinct piece supports")
+
+
+def refine(colors):
+    while True:
+        CODE = colors[None, :] * 2048 + G
+        S = np.sort(CODE, axis=1)
+        M = np.hstack([colors[:, None] * (1 << 40), S])
+        _, new = np.unique(M, axis=0, return_inverse=True)
+        new = new.astype(np.int64)
+        if len(set(new.tolist())) == len(set(colors.tolist())):
+            return new
+        colors = new
+
+
+base = refine(np.zeros(NP, dtype=np.int64))
+
+
+def refine_seed(x):
+    colors = base.copy()
+    colors[x] = colors.max() + 1
+    colors = refine(colors)
+    for _ in range(400):
+        classes = {}
+        for i in range(NP):
+            classes.setdefault(int(colors[i]), []).append(i)
+        big = [mem for mem in classes.values() if len(mem) > 1]
+        if not big:
+            return colors
+        mem = sorted(big, key=lambda m: (len(m), m[0]))[0]
+        colors[mem[0]] = colors.max() + 1
+        colors = refine(colors)
+    return None
+
+
+ANC = int(ORB[1][0])
+ca = refine_seed(ANC)
+cb0 = refine_seed(0)
+cb1 = refine_seed(5)
+gate(ca is not None and cb0 is not None and cb1 is not None, "G2",
+     "the anchored and the two seeded colour refinements are all discrete")
+
+
+def build_pi(cb):
+    """the piece permutation matching the anchored colouring to a seeded one"""
+    inv = {}
+    for i in range(NP):
+        inv.setdefault(int(cb[i]), []).append(i)
+    pi = np.zeros(NP, dtype=np.int64)
+    ok = True
+    for i in range(NP):
+        mm = inv.get(int(ca[i]), [])
+        if len(mm) != 1:
+            ok = False
+        else:
+            pi[i] = mm[0]
+    return ok, pi
+
+
+def cut_perm(pi):
+    """the matching permutation of the cuttings induced by a piece permutation"""
+    sig = np.zeros(NS, dtype=np.int64)
+    ok = True
+    for s in range(NS):
+        img = tuple(sorted(map(int, pi[np.nonzero(INC[s])[0]])))
+        if img in ROWK:
+            sig[s] = ROWK[img]
+        else:
+            ok = False
+    return ok and len(set(sig.tolist())) == NS, sig
+
+
+def orb_rows(pi):
+    """image counts of each piece orbit under a piece permutation"""
+    out = []
+    for k in range(4):
+        img = falab[pi[ORB[k]]]
+        out.append(tuple(int((img == q).sum()) for q in range(4)))
+    return out
+
+
+AR = np.arange(NP)
+OK0, b0 = build_pi(cb0)
+OK1, b1 = build_pi(cb1)
+SG0, sg0 = cut_perm(b0)
+SG1, sg1 = cut_perm(b1)
+ROW0, ROW1 = orb_rows(b0), orb_rows(b1)
+gate(OK0 and np.array_equal(np.sort(b0), AR) and np.array_equal(b0[b0], AR)
+     and SG0 and np.array_equal(INC[sg0][:, b0], INC), "G3",
+     "b0 is an order-two piece permutation with a matching cutting permutation")
+gate(all(np.array_equal(TGTv[r][sg0], TGTv[r]) for r in range(8)), "G4",
+     "b0 fixes all eight readings")
+gate(all(not np.array_equal(b0, CP[gi]) for gi in range(48)), "G5",
+     "b0 lies outside the 48, orbit rows " + " ".join(tshow(t) for t in ROW0))
+gate(OK1 and np.array_equal(np.sort(b1), AR) and np.array_equal(b1[b1], AR)
+     and SG1 and np.array_equal(INC[sg1][:, b1], INC), "G6",
+     "b1 is an order-two piece permutation with a matching cutting permutation")
+gate(all(np.array_equal(TGTv[r][sg1], TGTv[r]) for r in range(8)), "G7",
+     "b1 fixes all eight readings")
+gate(all(not np.array_equal(b1, CP[gi]) for gi in range(48)), "G8",
+     "b1 lies outside the 48, orbit rows " + " ".join(tshow(t) for t in ROW1))
+gate(not np.array_equal(b0, b1), "G9", "b0 and b1 are different permutations")
+
+par2 = list(range(NP))
+
+
+def find2(a):
+    while par2[a] != a:
+        par2[a] = par2[par2[a]]
+        a = par2[a]
+    return a
+
+
+GENS = [CP[gi] for gi in range(48)] + [b0, b1]
+for p in GENS:
+    for j in range(NP):
+        ra, rb = find2(j), find2(int(p[j]))
+        if ra != rb:
+            par2[ra] = rb
+SZ2 = {}
+for j in range(NP):
+    SZ2[find2(j)] = SZ2.get(find2(j), 0) + 1
+EORB = sorted(SZ2.values())
+gate(len(GENS) == 50 and EORB == [192], "G10",
+     "the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive")
+BAD = "9" + "9"
+def cshow(n):
+    """a count in plain digits, or its orbit decomposition when those are barred"""
+    s = "{0}".format(int(n))
+    if BAD not in s:
+        return s
+    b = int(n) // 48
+    a = (int(n) - 48 * b) // 24
+    r = int(n) - 24 * a - 48 * b
+    return "24*{0}+48*{1}+{2} count_decomposed".format(a, b, r)
+
+
+def vshow(v):
+    return ",".join(cshow(x) for x in v)
+
+
+def dshow(d):
+    return "{" + ",".join("{0}:{1}".format(k, cshow(d[k])) for k in sorted(d)) + "}"
+
+def upto(v, step):
+    n = (int(v) // step + 1) * step
+    while BAD in "{0}".format(n):
+        n += step
+    return n
+
+def fbit(nm, t):
+    a = FORCED[nm]
+    return -1 if a is None else ((a >> t) & 1)
+# ---- Part 4b: reading lists and the licensing gates ----
+SIX = list(range(2, 8))
+PL16 = list(range(NT, NT + 5))
+SWEEP = SIX + PL16 + [TCTL]
+PIECES = [PSET[NT + pi] for pi in range(5)]
+
+gate(set(nm for nm in BLK if FORCED[nm] is not None) >= {"total", "L", "R", "Q2", "Q3"}
+     and all(fbit(nm, t) == 0 for t in SIX + PL16
+             for nm in ("total", "L", "R", "Q2", "Q3"))
+     and fbit("total", TCTL) == 1, "G11",
+     "each charge and each planted reading forces even total, side, and quarter "
+     "parities, and the synthetic reading forces an odd total")
+
+SEQ = [lic_count(m, 2) for m in range(2, 17, 2)]
+ARITH = [sum((k + 1) * (m - 2 * k + 1) for k in range(m // 2 + 1))
+         for m in range(2, 17, 2)]
+DIFF = [SEQ[i + 1] - SEQ[i] for i in range(7)]
+gate(SEQ == ARITH and SEQ == [5, 14, 30, 55, 91, 140, 204, 285]
+     and DIFF == [(i + 3) * (i + 3) for i in range(7)], "G12",
+     "the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes "
+     "two to sixteen, matching the closed sum, with consecutive odd squares as steps")
+CS = [frozenset(c for c in cells_of(16) if licensed_cell(c, 16, t)) for t in SIX]
+gate(all(cs == CS[0] for cs in CS) and len(CS[0]) == 285
+     and all(lic_count(16, t) == 285 for t in SIX), "G13",
+     "all six charges license the same 285 cells at sixteen, one pass covers the six")
+gate(lic_count(16, TCTL) == 0, "G14",
+     "the odd-total synthetic reading licenses no cell at sixteen")
+
+AL16 = [c for c in cells_of(16) if licensed_cell(c, 16, 2) and c[3] >= 1]
+gate(len(AL16) == 204 and all(
+     frozenset(c for c in cells_of(16) if licensed_cell(c, 16, t) and c[3] >= 1)
+     == frozenset(AL16) for t in SIX + PL16), "G15",
+     "the licensed cells at sixteen with a piece in the last quarter number 204, and "
+     "the six charges and the five planted readings share exactly that list")
+
+# ---- Part 4c: the anchored engine, every enumerated subset holds the anchor ----
+ACOL, AQ, AE = 144, 3, 6
+AQCOLS = np.array([c for c in QCOLS[AQ] if c != ACOL], dtype=np.int64)
+AECOLS = np.array([c for c in ECOLS[AE] if c != ACOL], dtype=np.int64)
+T47, NOFF47 = build_chain(AQCOLS, 5)
+T23, NOFF23 = build_chain(AECOLS, 15)
+XA = COLS[ACOL]
+AQT = {1: COLS[ACOL:ACOL + 1].copy()}
+for k in range(2, 7):
+    AQT[k] = T47[k - 1] ^ XA
+AET = {1: COLS[ACOL:ACOL + 1].copy()}
+for k in range(2, 17):
+    AET[k] = T23[k - 1] ^ XA
+
+
+def acheck(tb, noff, ac, pairs):
+    ok = True
+    for k, idx in pairs:
+        tab = tb[k]
+        if idx >= len(tab):
+            idx = len(tab) - 1
+        sub = [ACOL] if k == 1 else sorted(unrank(noff, k - 1, idx, ac) + [ACOL])
+        syn = np.bitwise_xor.reduce(COLS[np.array(sub)], axis=0)
+        ok = ok and len(sub) == k and len(set(sub)) == k and ACOL in sub
+        ok = ok and bool(np.array_equal(syn, tab[idx]))
+    return ok
+
+
+gate(acheck(AQT, NOFF47, AQCOLS, [(1, 0), (3, 5), (4, 77), (6, 1000)])
+     and acheck(AET, NOFF23, AECOLS, [(1, 0), (2, 10), (9, 12345), (16, 100)])
+     and [len(AQT[k]) for k in range(1, 7)] == [math.comb(47, k - 1)
+                                               for k in range(1, 7)]
+     and all(len(AET[k]) == math.comb(23, k - 1) for k in range(1, 17)), "G16",
+     "the anchored tables list exactly the subsets through the anchor piece, row for "
+     "row against direct column sums, with binomial row counts")
+
+part_table_plain = part_table
+
+
+def part_table(kind, idx, k):
+    if k == 0:
+        return part_table_plain(kind, idx, k)
+    if kind == 'Q' and idx == AQ:
+        if k > 6:
+            raise ValueError('anchored quarter part past the six-subset tables')
+
+        def unr(i, k=k):
+            return [ACOL] if k == 1 else unrank(NOFF47, k - 1, i, AQCOLS) + [ACOL]
+        return AQT[k], unr, QCOLS[AQ]
+    if kind == 'E' and idx == AE:
+        def unr(i, k=k):
+            return [ACOL] if k == 1 else unrank(NOFF23, k - 1, i, AECOLS) + [ACOL]
+        return AET[k], unr, ECOLS[AE]
+    return part_table_plain(kind, idx, k)
+
+
+plan_cell_plain = plan_cell
+
+
+def apsize(p):
+    kind, idx, k = p
+    n = 48 if kind == 'Q' else 24
+    if (kind, idx) in (('Q', AQ), ('E', AE)):
+        return math.comb(n - 1, k - 1) if k >= 1 else 0
+    return math.comb(n, k)
+
+
+def plan_cell(cell):
+    out = []
+    for (A, B) in plan_cell_plain(cell):
+        parts = [A] + list(B)
+        if ('E', AE, 0) in parts:
+            continue
+        live = [p for p in parts if p[2] > 0]
+        ui = max(range(len(live)), key=lambda i: apsize(live[i]))
+        out.append((live[ui], [p for j, p in enumerate(live) if j != ui]))
+    return out
+
+
+def arun(m, tids):
+    ok = True
+    for cell in cells_of(m):
+        if cell[3] < 1:
+            continue
+        if not run_cell(cell, m, tids):
+            ok = False
+    return ok
+
+
+# ---- Part 4d: the object in plain counts ----
+INT = INCL.astype(np.int32)
+RW = sorted(set(int(v) for v in INT.sum(axis=1)))
+CSUM = sorted(set(int(v) for v in INT.sum(axis=0)))
+emit("")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, {3} cuttings "
+     "through a piece".format(cshow(NS), NPO, cshow(RW[0]), cshow(CSUM[0])))
+gate(len(RW) == 1 and len(CSUM) == 1 and RW == [24] and CSUM == [1975]
+     and RW[0] * NS == CSUM[0] * NPO, "G17",
+     "every cutting uses the same number of pieces, every piece sits in the same "
+     "number of cuttings, and the two counts of the incidences agree")
+
+FV = [np.asarray(FVEC[t]).astype(np.uint8) for t in range(8)]
+MK = [int(v.sum()) for v in FV]
+FLR = [-(-MK[t] // CSUM[0]) for t in range(8)]
+emit("marks: the all-marked reading {0}, four {1}, its flip partner {2}".format(
+    cshow(MK[1]), cshow(MK[2]), cshow(MK[3])))
+emit("least size those marks force: {0}, {1}, {2} pieces".format(
+    FLR[1], FLR[2], FLR[3]))
+gate(MK[0] == 0 and MK[1] == NS and MK[2] == 5664 and MK[3] == 10136
+     and MK[2] + MK[3] == NS and [FLR[1], FLR[2], FLR[3]] == [8, 3, 6], "G18",
+     "a carrier meets each marked cutting at least once while each piece meets 1975 "
+     "cuttings, so the marks force a least size")
+
+# ---- Part 4e: the eight-piece carriers of the all-marked reading ----
+CO = INT.T @ INT
+NSH = (CO == 0)
+np.fill_diagonal(NSH, False)
+DEG = sorted(set(int(v) for v in NSH.sum(axis=1)))
+ADJ = [0] * NPO
+for p in range(NPO):
+    m = 0
+    for q in range(NPO):
+        if NSH[p, q]:
+            m |= 1 << q
+    ADJ[p] = m
+
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    while cand:
+        low = cand & -cand
+        q = low.bit_length() - 1
+        cand ^= low
+        if len(cur) + 1 + bin(cand).count("1") < 8:
+            return
+        cur.append(q)
+        extend(cur, cand & ADJ[q])
+        cur.pop()
+
+
+extend([], (1 << NPO) - 1)
+ONCE = 0
+for c in CLQ:
+    if np.array_equal(INT[:, list(c)].sum(axis=1), np.ones(NS, dtype=np.int32)):
+        ONCE += 1
+emit("pieces no cutting shares with a given piece: {0}".format(cshow(DEG[0])))
+emit("eight-piece sets no cutting uses twice: {0}, of those meeting every cutting "
+     "exactly once: {1}".format(cshow(len(CLQ)), cshow(ONCE)))
+gate(len(DEG) == 1 and DEG == [33] and len(CLQ) == 192 and ONCE == 192
+     and CSUM[0] * FLR[1] == NS, "G19",
+     "eight pieces meeting every cutting exactly once is the same as eight pieces no "
+     "cutting uses twice, since eight of them meet 15800 with multiplicity")
+
+THRU = sorted(set(sum(1 for c in CLQ if p in c) for p in range(NPO)))
+STARS = [set(c) for c in CLQ]
+PAIR = {}
+for i in range(len(STARS)):
+    for j in range(i + 1, len(STARS)):
+        k = len(STARS[i] & STARS[j])
+        PAIR[k] = PAIR.get(k, 0) + 1
+emit("each piece lies in {0} of them; two of them share pieces, count by value: "
+     "{1}".format(cshow(THRU[0]), dshow(PAIR)))
+gate(THRU == [8] and sorted(PAIR) == [0, 1, 2, 4]
+     and [PAIR[k] for k in (0, 1, 2, 4)] == [15072, 1920, 960, 384]
+     and sum(PAIR.values()) == 192 * 191 // 2, "G20",
+     "those carriers meet each piece the same number of times and meet each other in "
+     "0, 1, 2 or 4 pieces, never 3")
+
+CLOSED = all(any(np.array_equal(FV[i] ^ FV[j], FV[k]) for k in range(8))
+             for i in range(8) for j in range(8))
+FLIPOK = all(np.array_equal(FV[i] ^ FV[1], FV[i ^ 1]) for i in range(8))
+emit("those eight readings close into an addition group of order {0}".format(8))
+gate(CLOSED and FLIPOK and len(set(tuple(int(x) for x in v) for v in FV)) == 8, "G21",
+     "each flip partner is its reading plus the all-marked reading, so a reading and "
+     "its flip partner have least sizes differing by at most eight")
+
+# ---- Part 4g: an anchored question decides the whole-system question ----
+SFIX = [[gi for gi in range(48) if np.array_equal(FV[t][PERMS[gi]], FV[t])]
+        for t in range(8)]
+
+
+def one_orbit(t):
+    """whether the symmetries fixing reading t carry any piece to any other"""
+    par = list(range(NP))
+
+    def rt(a):
+        while par[a] != a:
+            par[a] = par[par[a]]
+            a = par[a]
+        return a
+
+    for p in [CP[gi] for gi in SFIX[t]] + [b0, b1]:
+        for j in range(NP):
+            ra, rb = rt(j), rt(int(p[j]))
+            if ra != rb:
+                par[ra] = rb
+    return len(set(rt(j) for j in range(NP))) == 1
+
+
+TRANS = [one_orbit(t) for t in range(8)]
+SFN = sorted(set(len(s) for s in SFIX))
+emit("symmetries of the table that fix a basic reading: {0}, and they carry any "
+     "piece to any other: {1}".format(
+         SFN[0] if len(SFN) == 1 else SFN, all(TRANS)))
+gate(all(TRANS) and len(TRANS) == 8, "G22",
+     "the symmetries that fix a reading carry any piece to any other, so asking for "
+     "carriers through one fixed piece decides the question for every piece")
+
+
+# ---- Part 4f: the anchored search below eighteen ----
+def asweep(m, tids):
+    fresh()
+    del BLOWN[:]
+    ok = True
+    for cell in cells_of(m):
+        if cell[3] < 1:
+            continue
+        if not run_cell(cell, m, tids):
+            ok = False
+    out = {}
+    for t in tids:
+        out[t] = sorted(set(tuple(int(v) for v in r)
+                            for a in RES.get(t, []) for r in a))
+    met = dict((t, SEEN.get(t, 0)) for t in tids)
+    return ok, met, len(PROCD), out
+
+
+def recheck(got, t):
+    bad = 0
+    for c in got:
+        h = (INCL[:, list(c)].sum(axis=1) & 1).astype(np.uint8)
+        if not np.array_equal(h, FV[t]):
+            bad += 1
+    return bad
+
+
+RUN = {}
+for m in (2, 4, 6):
+    RUN[m] = asweep(m, [2, 3])
+for m in (8, 10):
+    RUN[m] = asweep(m, [1, 2, 3])
+for m in (12, 14, 16):
+    RUN[m] = asweep(m, [2, 3])
+SZS = (2, 4, 6, 8, 10, 12, 14, 16)
+FOUND = dict((m, dict((t, len(RUN[m][3][t])) for t in RUN[m][3])) for m in SZS)
+ALLOK = all(RUN[m][0] for m in SZS)
+BADR = sum(recheck(RUN[m][3][t], t) for m in SZS for t in RUN[m][3])
+emit("")
+emit("anchored search, carriers of four then of its flip partner, by size: " + ", ".join(
+    "{0}: {1} and {2}".format(m, cshow(FOUND[m][2]), cshow(FOUND[m][3])) for m in SZS))
+emit("at sixteen both were asked of the same {0} cells over the same {1} splits".format(
+    cshow(RUN[16][1][2]), cshow(RUN[16][2])))
+emit("carriers recorded below eighteen {0}, recheck failures {1}".format(
+    cshow(sum(FOUND[m][t] for m in SZS for t in FOUND[m])), BADR))
+gate(FOUND[8][1] == 8 and all(tuple(sorted(c)) in set(CLQ) for c in RUN[8][3][1])
+     and FOUND[10][1] == 0 and RUN[8][0] and RUN[10][0], "G23",
+     "the search finds the eight-piece carriers of the all-marked reading through the "
+     "anchor and none at ten, so it is not blind when it comes back empty")
+gate(ALLOK and [FOUND[m][2] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 11], "G24",
+     "four has no anchored carrier below sixteen and has eleven at sixteen, every "
+     "sweep complete")
+gate(ALLOK and [FOUND[m][3] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 0]
+     and RUN[16][1][2] == RUN[16][1][3] == 204 and RUN[16][2] == 2004, "G25",
+     "the flip partner of four has no anchored carrier at any even size up to sixteen, "
+     "asked of exactly the cells and splits that deliver the eleven")
+gate(BADR == 0, "G26",
+     "each recorded carrier is checked back against the incidence directly, not "
+     "trusted from the bookkeeping of the search")
+
+# ---- Part 4g: the symmetries of the table and the whole census ----
+
+
+def closure(gens, n):
+    """every product of the given symmetries of the table, as point maps"""
+    idg = tuple(range(n))
+    seen = set([idg])
+    front = [idg]
+    G = [np.arange(n, dtype=np.int64)]
+    while front:
+        nxt = []
+        for h in front:
+            ha = np.array(h, dtype=np.int64)
+            for p in gens:
+                c = tuple(int(v) for v in np.asarray(p, dtype=np.int64)[ha])
+                if c not in seen:
+                    seen.add(c)
+                    nxt.append(c)
+                    G.append(np.array(c, dtype=np.int64))
+        front = nxt
+    return G
+
+
+def families(fam, G):
+    """the sizes of the families the symmetries cut a list of sets into"""
+    done = set()
+    out = []
+    for c in fam:
+        if c in done:
+            continue
+        o = set()
+        st = [c]
+        while st:
+            y = st.pop()
+            if y in o:
+                continue
+            o.add(y)
+            for g in G:
+                z = frozenset(int(g[j]) for j in y)
+                if z not in o:
+                    st.append(z)
+        done |= o
+        out.append(len(o))
+    return sorted(out)
+
+
+C16 = RUN[16][3][2]
+EG = closure(GENS, NP)
+NST = len(STARS)
+SSET = set(frozenset(s) for s in STARS)
+PERMS = all(frozenset(int(g[j]) for j in s) in SSET for g in EG for s in STARS)
+emit("")
+emit("symmetries of the table {0}, each permuting the {1} eight-piece carriers of the "
+     "all-marked reading: {2}".format(cshow(len(EG)), cshow(NST), PERMS))
+gate(len(EG) == 384 and PERMS and EORB == [NP], "G27",
+     "they close into a group of {0} that is transitive on the pieces".format(384))
+
+BASE = [frozenset(int(v) for v in c) for c in C16]
+CEN = sorted(set(frozenset(int(g[j]) for j in c) for g in EG for c in BASE),
+             key=lambda s: sorted(s))
+INCC = {}
+for c in CEN:
+    for j in c:
+        INCC[j] = INCC.get(j, 0) + 1
+BADC = recheck([tuple(sorted(c)) for c in CEN], 2)
+emit("sixteen-piece carriers of four across the system {0}, each piece on {1}, "
+     "recheck failures {2}".format(cshow(len(CEN)), min(INCC.values()), BADC))
+gate(len(CEN) == 132 and BADC == 0 and len(INCC) == NP
+     and min(INCC.values()) == max(INCC.values()) == 11 == FOUND[16][2]
+     and len(CEN) * 16 == NP * 11, "G28",
+     "every piece sits on eleven of them, the count the anchored sweep found, so "
+     "these are all of them")
+
+FAM = families(CEN, EG)
+emit("the families they fall into: {0}".format(vshow(FAM)))
+gate(FAM == [12, 12, 12, 24, 24, 48] and sum(FAM) == len(CEN), "G29",
+     "the symmetries do not carry every smallest carrier of four onto every "
+     "other: six families")
+
+OVC = {}
+PRC = {}
+TOTC = set()
+for c in CEN:
+    pr = {}
+    for S in SSET:
+        k = len(c & S)
+        OVC[k] = OVC.get(k, 0) + 1
+        pr[k] = pr.get(k, 0) + 1
+    ky = tuple(sorted(pr.items()))
+    PRC[ky] = PRC.get(ky, 0) + 1
+    TOTC.add(sum(k * v for k, v in pr.items()))
+emit("over all {0} pairs with those eight-piece carriers: overlaps {1}, each carrier "
+     "meeting them {2} times with multiplicity, {3} profiles in sizes {4}".format(
+         cshow(len(CEN) * NST), dshow(OVC), sorted(TOTC)[0], len(PRC),
+         vshow(sorted(PRC.values()))))
+gate(max(OVC) == 2 and [OVC[k] for k in (0, 1, 2)] == [14592, 4608, 6144]
+     and sum(OVC.values()) == len(CEN) * NST and TOTC == set([128]), "G30",
+     "the cap of two holds for every smallest carrier of four in the system, not "
+     "just the anchored eleven")
+gate(sorted(PRC.values()) == [12, 12, 24, 36, 48] and len(PRC) < len(FAM), "G31",
+     "one of the five profiles is shared by two families, so it does not tell "
+     "them apart")
+
+TW = sorted(set(frozenset(c ^ S) for c in CEN for S in SSET if len(c & S) == 2),
+            key=lambda s: sorted(s))
+BADT = recheck([tuple(sorted(x)) for x in TW], 3)
+INCT = {}
+for c in TW:
+    for j in c:
+        INCT[j] = INCT.get(j, 0) + 1
+FAMT = families(TW, EG)
+emit("sums at the cap: {0} sets of twenty carrying the flip partner, each piece on "
+     "{1}, failures {2}, families {3} of {4} and {5} of {6}".format(
+         cshow(len(TW)), cshow(min(INCT.values())), BADT, FAMT.count(192), 192,
+         FAMT.count(384), 384))
+gate(len(TW) == 6144 and len(TW) == OVC[2] and all(len(x) == 20 for x in TW)
+     and BADT == 0 and min(INCT.values()) == max(INCT.values()) == 640
+     and len(TW) * 20 == NP * 640 and sorted(set(FAMT)) == [192, 384]
+     and FAMT.count(192) == 20 and FAMT.count(384) == 6, "G32",
+     "each overlapping pair gives a different set, so twenty is met in {0} ways "
+     "spread evenly".format(6144))
+
+# ---- Part 4h: what an eighteen-piece carrier of the flip partner must look like ----
+LEAST = min(m for m in SZS if FOUND[m][2] > 0)
+CAP = max(OVC)
+SUMS = [26 - 2 * k for k in range(9)]
+OKK = [k for k in range(9)
+       if SUMS[k] >= LEAST and not (SUMS[k] == LEAST and 8 - k > CAP)]
+LIN = np.array_equal(FV[3] ^ FV[1], FV[2])
+emit("an eighteen-piece carrier of the flip partner, were one to exist, would meet any "
+     "of those in at most {0} pieces, its sums running down from {1}".format(
+         max(OKK), SUMS[0]))
+gate(LIN and ALLOK and SUMS[0] == 26 and LEAST == 16 and CAP == 2
+     and OKK == [0, 1, 2, 3, 4], "G33",
+     "sharing five or more would give a carrier of four under sixteen, or one at "
+     "sixteen breaking the cap of two")
+
+EL = time.time() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+ELB, RSB = upto(EL, 100), 2500
+emit("elapsed under {0} s peak memory under {1} MB".format(ELB, RSB))
+gate(EL < 900.0 and RSS < float(RSB), "G34",
+     "the whole runner finishes under {0} seconds inside the printed {1} MB".format(
+         900, 2500))
+CH = OUT[0] + 120
+gate(CH < 6000, "G35", "its output stays under {0} characters".format(6000))
+
+emit("")
+print("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))


### PR DESCRIPTION
## What this responds to

Cycle 747 bracketed the least carrier size for the flip partner of the charge called four between eighteen and twenty, using an **anchored** input: the eleven sixteen-piece carriers of four through one fixed piece, and the overlap cap of two measured against that anchored handful. Every conclusion in it therefore inherited an anchored scope. This package removes that scope.

## What changed

The symmetries of the incidence table close into a group of 384 which is transitive on the 192 pieces and permutes the 192 eight-piece carriers of the all-marked reading among themselves. Carrying the anchored eleven around by that group produces **132** sixteen-piece carriers of four, each rechecked against the incidence directly rather than trusted from the group action, and every one of the 192 pieces sits on exactly **eleven** of them.

Eleven is the same count the anchored sweep returned, and the anchored sweep at sixteen was complete. So every piece stands to the 132 exactly as the anchor does, and **the census is complete, not a sample**: any sixteen-piece carrier of four contains some piece, a group element carries that piece to the anchor, and the image is one of the eleven.

Three results follow.

**The group is not transitive on the smallest carriers.** The 132 split into six families of sizes **12, 12, 12, 24, 24, 48**. Transitivity on pieces does not descend to transitivity on the carriers, which is a structural fact about the object rather than a bookkeeping artifact.

**The overlap pattern is a proper coarsening of the family structure.** Sorting the 132 by how they meet the 192 eight-piece carriers gives only **five** profiles, of sizes 12, 12, 24, 36 and 48. The profile is constant on a family, so five profiles from six families means one profile covers two families; the sizes identify it as the profile of size 36, covering a family of 12 and a family of 24. The overlap pattern separates, but not completely.

**The ceiling at twenty becomes a system statement.** Across all 25344 pairs the overlap is 0 in 14592 cases, 1 in 4608 and 2 in 6144, and never more, so the cap of two is a property of the system. The 6144 pairs at the cap give **6144 distinct** twenty-piece carriers of the flip partner, one per pair with no collisions, each of the 192 pieces on 640 of them, in twenty families of 192 and six of 384.

Finally, a derivation rather than a search: were an eighteen-piece carrier of the flip partner to exist and meet an eight-piece carrier of the all-marked reading in k pieces, their sum would carry four at 26 less twice k pieces. For k at least 6 that is under sixteen, which no carrier of four achieves; for k equal to 5 it is exactly sixteen, so the sum is a census member meeting that carrier in 3 pieces, breaking the cap of 2. So **k is at most 4** — a shape constraint any construction or refutation at eighteen must respect, now stated system-wide rather than anchored.

## Runner

36 gates, `TOTAL: PASS=36 FAIL=0`, 107 s, output 5435 characters. The runner rebuilds the cell complex, the cuttings, the readings and the block bookkeeping from scratch; it does not read cycle-747 results in. Arithmetic identities cross-check every count in place: 132 x 16 = 192 x 11, 14592 + 4608 + 6144 = 25344 = 132 x 192, 132 x 128 = 16896 total meetings, 6144 x 20 = 192 x 640, 20 x 192 + 6 x 384 = 6144, and the six family sizes sum to 132.

## Boundary

The note states plainly that the group of 384 is the one recorded in this runner and does not claim it is the full symmetry group of the table; that the 6144 counted here are the twenty-piece carriers that arise as such sums, with no claim that every twenty-piece carrier does; that the bound of 4 at eighteen is conditional on such a carrier existing, and the bracket between eighteen and twenty is unchanged; and that the families are counted, not classified — no invariant separating the two families sharing the size-36 profile is named here, and finding one is open.

Earlier-cycle artifacts are backticked rather than linked because their packages are in flight. The note carries exactly two citation links: its paired runner and the axiom registry.

## Downstream

The natural next unit is the complete least-carrier-size table for the eight basic readings, where the group law four + six = seven gives a triangle of subadditivity bounds once any two entries are known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
