### PR TITLE
feat(emergent-geometry): derive the cycle-752 ranking as a spread about a forced mean

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_SHARED_COUNT_VARIANCE_LAW_CYCLE753_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_SHARED_COUNT_VARIANCE_LAW_CYCLE753_NOTE_2026-08-09.md
@@ -1,0 +1,219 @@
+# The ranked total is a spread about a forced mean — Cycle 753
+
+Date: 2026-08-09
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the cuttings, the readings and the block bookkeeping from scratch and
+gates each quantity in place. Constitutional effect: none. This package
+changes no axiom, no framework Admissibility rule, no primitive, no policy,
+and no audit status, and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## What this answers
+
+The unit four-cube cuts into least-volume pieces at the adjacency cost floor
+in 15800 ways, and those cuttings use 192 pieces between them, 24 to a cutting
+and 1975 cuttings through each piece. The charge called four is marked on 5664
+of the cuttings and needs sixteen pieces to carry it.
+
+A preceding cycle joined two pieces whenever no cutting used both, counted
+every sixteen pieces joined exactly like the corners of a four-cube, found
+59736 of them with 4978 through every single piece, and ranked them by one
+number: take each pair of pieces, count how many cuttings use both, and add
+those counts over all pairs. The 60 shapes that carry the charge came out
+lightest. That cycle reported the ranking as a measurement and a floor
+underneath it as a derivation, with no account of why the ranking works.
+
+This cycle supplies the account, and it is not the account the preceding cycle
+would have guessed. The ranked total turns out to be a spread about a mean the
+system fixes in advance, and the statistic that picks the carriers out is not
+the size of their reading support.
+
+## The mean is fixed before any shape is chosen
+
+For a set of sixteen pieces write `m` for the number of its pieces lying on a
+given cutting. Each piece lies on 1975 cuttings, so the sixteen pieces meet
+the 15800 cuttings 31600 times in total, and
+
+```
+31600 = 2 x 15800
+```
+
+Whichever sixteen pieces are taken, and whether or not they carry anything,
+the average number of them met per cutting is exactly two. Nothing about the
+choice can move it.
+
+## The ranked total is the squared departure from that mean
+
+Every cutting met `m` times contributes `m(m-1)/2` such pairs, so the ranked
+total is the sum of `m(m-1)/2` over the 15800 cuttings. Expanding about two,
+
+```
+sum (m-2)^2  =  sum m^2  -  4 x 31600  +  4 x 15800
+```
+
+and the ranked total is `(sum m^2 - 31600) / 2`, so for every sixteen-piece
+set whatsoever,
+
+```
+ranked total  =  15800  +  (1/2) x sum (m-2)^2
+```
+
+This is an identity, not a fit. It carries no condition on how large `m` may
+get. The right-hand side is a whole number because the departures sum to zero
+and a square has the parity of its root, so their squares sum to an even
+number.
+
+So the quantity the preceding cycle ranked by is a spread. Ranking the shapes
+by shared cuttings is ranking them by how far their meetings stray from the
+two-per-cutting average the system already imposed, and being light means
+being flat.
+
+## The floor, and exactly what reaching it would take
+
+Carrying a reading marked on `S` cuttings means meeting each of those an odd
+number of times, so the departure from two is at least one on each of them and
+at least zero elsewhere. Hence
+
+```
+ranked total  >=  15800 + S/2
+```
+
+for any carrier of that reading, which for the charge called four is 18632.
+The identity says more than the bound: equality holds precisely when the
+carrier meets each of the 5664 marked cuttings once or three times and each of
+the rest exactly twice. The mean then forces the split, 2832 met once and 2832
+met three times. The floor is not merely a number to sit above; it
+names a single profile, and any carrier failing to reach it fails by a
+countable number of off-mean cuttings.
+
+In particular the floor demands that the carrier miss no cutting at all. A
+cutting the carrier does not meet sits two below the mean, so it costs four
+where a marked cutting costs one, and a missed cutting cannot be a marked one
+because zero is even. The floor therefore rises by two for every cutting
+missed. So the floor is not merely unreached by the carriers found here; it is
+out of reach for any carrier that misses a cutting, and the shortfall grows
+with the number missed.
+
+The preceding cycle derived 18632 and left it there. What is added here is
+that reaching it is a determinate combinatorial demand, so the gap between
+18632 and what carriers actually do is a fact about the object rather than
+slack in the argument.
+
+## What the carriers actually do
+
+The lightest carrier meets 9632 cuttings twice, 2832 once, 2832 three times,
+252 not at all and 252 four times, and no cutting more than four times. Its
+squared departure is 7680, so its total is
+
+```
+15800 + 7680/2 = 19640
+```
+
+which is 1008 above the floor, and the 1008 is accounted for exactly by the
+cuttings sitting two away from the mean, 252 in each direction.
+Across all 132 smallest carriers the squared departure takes 4 values, least
+7680 and most 16832.
+
+## What picks the sixty out is the count of cuttings met exactly twice
+
+Rank all 59736 shapes by how many cuttings they meet exactly twice, largest
+first. The 60 carriers occupy the top 60 places. The least of them meets
+9616 cuttings twice; the next shape down the list meets 8688. So within
+this population the carriers are exactly the shapes meeting at least 9616
+cuttings exactly twice, with no shape tying across the boundary.
+
+That is a sharper statement than the preceding cycle's, and it says what the
+ranking is sensitive to: not the total spread but the number of cuttings
+sitting exactly on the mean.
+
+## What does not pick them out is the reading
+
+This cycle set out to test the opposite hypothesis, and the measurement went
+against it, which is worth stating plainly because the preceding cycle's
+headline depends on the answer.
+
+The suspicion was that the ranking might be a disguised count of the reading
+support: a carrier of the charge called four is odd on 5664 cuttings, and a
+term of that size set against the modest step separating the carriers from
+everything else would mean the ranking was detecting the mark it claimed not
+to consult. Ranking the shapes by how many
+cuttings they meet an odd number of times puts the matter to rest in the other
+direction. The carriers rank 57973rd to 58032nd of 59736. Fully 57972 shapes
+meet strictly more cuttings an odd number of times than a carrier does, so the
+odd count is not what the carriers are extreme in; on that scale they are near
+the bottom, and the term works against their position rather than for it.
+
+The size of the reading support therefore does not explain the separation; the
+twice-met count is the statistic that performs it. Why the carriers should be
+the shapes flattest against the mean is a further question this page does not
+answer, and nothing here says the reading is irrelevant to it: every shape in
+the top sixty carries one.
+
+## Where the earlier linear form does and does not hold
+
+If no cutting is met more than four times, eliminating the thrice-met count
+between the two sum rules gives a linear form in the odd count and the
+twice-met count alone, with the four-times count cancelling. That form holds
+on exactly 17544 of the 59736 shapes. It fails on the rest because the
+condition fails on the rest: 42192 of the shapes have some cutting met more
+than four times. The shapes satisfying the form and the shapes no cutting
+meets more than four times are the same 17544 shapes.
+
+How far a cutting can go is not a measurement. Two pieces joined in the
+never-sharing graph lie on no common cutting, so the pieces of one shape that
+a single cutting meets are pairwise unjoined, and a four-cube has at most 8
+corners that are pairwise unjoined. No cutting can meet one of these shapes
+more than 8 times, and 8 is reached.
+
+This is recorded because the linear form is the natural first thing to write
+down, and it is the identity above, not that one, that holds without a
+condition.
+
+## Boundary
+
+- The identity relating the ranked total to the squared departure is derived
+  and holds for every sixteen-piece set in the system, carrier or not. The
+  floor and its equality condition are derived. Everything else on this page is
+  measured over the 59736 four-cube-shaped sets and is not claimed beyond them.
+- What the runner measures about the identity is its premise and its arithmetic,
+  not the identity itself: that the multiplicities of each of the 59736 shapes
+  sum to 15800 and weigh 31600, and that the total taken from the multiplicity
+  profile agrees with the total taken from the shared-cutting counts. Given the
+  premise the identity is algebra, and that is what makes it unconditional.
+- **The floor 18632 is still not shown to be attained.** No shape found here
+  reaches it. Nothing here shows 19640 is forced, and nothing here rules out a
+  carrier of some other shape reaching 18632.
+- **The twice-met criterion is a threshold on this population, not a proof.**
+  Nothing here derives 9616, and nothing here shows a shape outside these 59736
+  could not meet at least that many cuttings twice without carrying anything.
+- Within these 59736 sets, carrying a reading and carrying the charge called
+  four coincide, so what these rankings demonstrably separate is sets that
+  carry something from sets that carry nothing. Neither ranking is shown to
+  tell the charge called four from a different reading.
+- The refutation reported above is a refutation of a hypothesis about this
+  ranking. It does not show that no count of reading support could separate
+  these shapes; it shows this one does not, in the direction claimed.
+
+## Runner
+
+Rebuilds the cell complex, the cuttings, the readings and the block
+bookkeeping from scratch and gates every quantity in place. Class-A: integer
+and two-element-field arithmetic on a finite explicit object, no solver.
+
+```
+TOTAL: PASS=42 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15469,
- "node_count": 5440,
+ "edge_count": 15470,
+ "node_count": 5441,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13625,6 +13625,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_shared_count_variance_law_cycle753_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.txt
@@ -1,0 +1,74 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.py
+runner_sha256: a1019c730ea5cc948fa794887b3115fab18be00c6a803c097fabf52eb2f21be3
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 210.15
+status: ok
+----- stdout -----
+PASS G0  the Gram matrix of the table has constant diagonal 1975
+PASS G1  all 15800 cuttings carry distinct piece supports
+PASS G2  the anchored and the two seeded colour refinements are all discrete
+PASS G3  b0 is an order-two piece permutation with a matching cutting permutation
+PASS G4  b0 fixes all eight readings
+PASS G5  b0 lies outside the 48, orbit rows (0,48,0,0) (48,0,0,0) (0,0,0,48) (0,0,48,0)
+PASS G6  b1 is an order-two piece permutation with a matching cutting permutation
+PASS G7  b1 fixes all eight readings
+PASS G8  b1 lies outside the 48, orbit rows (8,8,16,16) (8,8,16,16) (16,16,8,8) (16,16,8,8)
+PASS G9  b0 and b1 are different permutations
+PASS G10  the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive
+PASS G11  each charge and each planted reading forces even total, side, and quarter parities, and the synthetic reading forces an odd total
+PASS G12  the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes two to sixteen, matching the closed sum, with consecutive odd squares as steps
+PASS G13  all six charges license the same 285 cells at sixteen, one pass covers the six
+PASS G14  the odd-total synthetic reading licenses no cell at sixteen
+PASS G15  the licensed cells at sixteen with a piece in the last quarter number 204, and the six charges and the five planted readings share exactly that list
+PASS G16  the anchored tables list exactly the subsets through the anchor piece, row for row against direct column sums, with binomial row counts
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS G17  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+marks: the all-marked reading 15800, four 5664, its flip partner 10136
+least size those marks force: 8, 3, 6 pieces
+PASS G18  a carrier meets each marked cutting at least once while each piece meets 1975 cuttings, so the marks force a least size
+pieces no cutting shares with a given piece: 33
+eight-piece sets no cutting uses twice: 192, of those meeting every cutting exactly once: 192
+PASS G19  eight pieces meeting every cutting exactly once is the same as eight pieces no cutting uses twice, since eight of them meet 15800 with multiplicity
+each piece lies in 8 of them; two of them share pieces, count by value: {0:15072,1:1920,2:960,4:384}
+PASS G20  those carriers meet each piece the same number of times and meet each other in 0, 1, 2 or 4 pieces, never 3
+those eight readings close into an addition group of order 8
+PASS G21  each flip partner is its reading plus the all-marked reading, so a reading and its flip partner have least sizes differing by at most eight
+symmetries of the table that fix a basic reading: 48, and they carry any piece to any other: True
+PASS G22  the symmetries that fix a reading carry any piece to any other, so asking for carriers through one fixed piece decides the question for every piece
+
+anchored search, carriers of four then of its flip partner, by size: 2: 0 and 0, 4: 0 and 0, 6: 0 and 0, 8: 0 and 0, 10: 0 and 0, 12: 0 and 0, 14: 0 and 0, 16: 11 and 0
+at sixteen both were asked of the same 204 cells over the same 2004 splits
+carriers recorded below eighteen 19, recheck failures 0
+PASS G23  the search finds the eight-piece carriers of the all-marked reading through the anchor and none at ten, so it is not blind when it comes back empty
+PASS G24  four has no anchored carrier below sixteen and has eleven at sixteen, every sweep complete
+PASS G25  the flip partner of four has no anchored carrier at any even size up to sixteen, asked of exactly the cells and splits that deliver the eleven
+PASS G26  each recorded carrier is checked back against the incidence directly, not trusted from the bookkeeping of the search
+
+symmetries of the table 384, sixteen-piece carriers of four across the system 132, each piece on 11, recheck failures 0
+PASS G27  they close into a group of 384 that is transitive on the pieces and permutes the 192 eight-piece carriers
+PASS G28  every piece sits on eleven of them, the count the anchored sweep found, so these are all of them
+the families they fall into: 12,12,12,24,24,48
+PASS G29  the symmetries do not carry every smallest carrier of four onto every other: six families
+the total is a spread about a mean of two that no choice of sixteen can move:
+each sixteen meets the cuttings 31600 times, so departures from two are the cost
+PASS G31  shapes joined like a four-cube: 4978 through each of the 192 pieces, 59736 in all
+PASS G32  each of the 59736 shapes meets the 15800 cuttings 31600 times, two per cutting
+PASS G33  the total is 15800 plus half the squared spread about two, both routes agreeing
+PASS G34  carrying four needs 5664 odd meetings, so all 132 carriers sit at 18632 or above
+PASS G35  lightest carrier 19640, 1008 over the floor, spread [252, 2832, 9632, 2832, 252, 0], none above four
+PASS G36  ranked by cuttings met twice the top 60 are the carriers, least 9616, next 8688
+PASS G37  ranked by odd meetings they sit 57973th to 58032th, 57972 shapes above them
+PASS G38  the largest multiplicity reached is 8 and 42192 shapes pass four
+PASS G39  the linear form in odd count and twice-met holds on 17544, exactly those capped at four
+PASS G40  over all 132 carriers the squared spread runs 7680 to 16832 and takes 4 values
+elapsed under 300 s peak memory under 2500 MB
+PASS G41  inside its time and memory allowance
+PASS G42  its output stays under 6000 characters
+
+TOTAL: PASS=42 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09_cold_2026-08-09.txt
+++ b/outputs/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09_cold_2026-08-09.txt
@@ -1,0 +1,63 @@
+PASS G0  the Gram matrix of the table has constant diagonal 1975
+PASS G1  all 15800 cuttings carry distinct piece supports
+PASS G2  the anchored and the two seeded colour refinements are all discrete
+PASS G3  b0 is an order-two piece permutation with a matching cutting permutation
+PASS G4  b0 fixes all eight readings
+PASS G5  b0 lies outside the 48, orbit rows (0,48,0,0) (48,0,0,0) (0,0,0,48) (0,0,48,0)
+PASS G6  b1 is an order-two piece permutation with a matching cutting permutation
+PASS G7  b1 fixes all eight readings
+PASS G8  b1 lies outside the 48, orbit rows (8,8,16,16) (8,8,16,16) (16,16,8,8) (16,16,8,8)
+PASS G9  b0 and b1 are different permutations
+PASS G10  the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive
+PASS G11  each charge and each planted reading forces even total, side, and quarter parities, and the synthetic reading forces an odd total
+PASS G12  the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes two to sixteen, matching the closed sum, with consecutive odd squares as steps
+PASS G13  all six charges license the same 285 cells at sixteen, one pass covers the six
+PASS G14  the odd-total synthetic reading licenses no cell at sixteen
+PASS G15  the licensed cells at sixteen with a piece in the last quarter number 204, and the six charges and the five planted readings share exactly that list
+PASS G16  the anchored tables list exactly the subsets through the anchor piece, row for row against direct column sums, with binomial row counts
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS G17  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+marks: the all-marked reading 15800, four 5664, its flip partner 10136
+least size those marks force: 8, 3, 6 pieces
+PASS G18  a carrier meets each marked cutting at least once while each piece meets 1975 cuttings, so the marks force a least size
+pieces no cutting shares with a given piece: 33
+eight-piece sets no cutting uses twice: 192, of those meeting every cutting exactly once: 192
+PASS G19  eight pieces meeting every cutting exactly once is the same as eight pieces no cutting uses twice, since eight of them meet 15800 with multiplicity
+each piece lies in 8 of them; two of them share pieces, count by value: {0:15072,1:1920,2:960,4:384}
+PASS G20  those carriers meet each piece the same number of times and meet each other in 0, 1, 2 or 4 pieces, never 3
+those eight readings close into an addition group of order 8
+PASS G21  each flip partner is its reading plus the all-marked reading, so a reading and its flip partner have least sizes differing by at most eight
+symmetries of the table that fix a basic reading: 48, and they carry any piece to any other: True
+PASS G22  the symmetries that fix a reading carry any piece to any other, so asking for carriers through one fixed piece decides the question for every piece
+
+anchored search, carriers of four then of its flip partner, by size: 2: 0 and 0, 4: 0 and 0, 6: 0 and 0, 8: 0 and 0, 10: 0 and 0, 12: 0 and 0, 14: 0 and 0, 16: 11 and 0
+at sixteen both were asked of the same 204 cells over the same 2004 splits
+carriers recorded below eighteen 19, recheck failures 0
+PASS G23  the search finds the eight-piece carriers of the all-marked reading through the anchor and none at ten, so it is not blind when it comes back empty
+PASS G24  four has no anchored carrier below sixteen and has eleven at sixteen, every sweep complete
+PASS G25  the flip partner of four has no anchored carrier at any even size up to sixteen, asked of exactly the cells and splits that deliver the eleven
+PASS G26  each recorded carrier is checked back against the incidence directly, not trusted from the bookkeeping of the search
+
+symmetries of the table 384, sixteen-piece carriers of four across the system 132, each piece on 11, recheck failures 0
+PASS G27  they close into a group of 384 that is transitive on the pieces and permutes the 192 eight-piece carriers
+PASS G28  every piece sits on eleven of them, the count the anchored sweep found, so these are all of them
+the families they fall into: 12,12,12,24,24,48
+PASS G29  the symmetries do not carry every smallest carrier of four onto every other: six families
+the total is a spread about a mean of two that no choice of sixteen can move:
+each sixteen meets the cuttings 31600 times, so departures from two are the cost
+PASS G31  shapes joined like a four-cube: 4978 through each of the 192 pieces, 59736 in all
+PASS G32  each of the 59736 shapes meets the 15800 cuttings 31600 times, two per cutting
+PASS G33  the total is 15800 plus half the squared spread about two, both routes agreeing
+PASS G34  carrying four needs 5664 odd meetings, so all 132 carriers sit at 18632 or above
+PASS G35  lightest carrier 19640, 1008 over the floor, spread [252, 2832, 9632, 2832, 252, 0], none above four
+PASS G36  ranked by cuttings met twice the top 60 are the carriers, least 9616, next 8688
+PASS G37  ranked by odd meetings they sit 57973th to 58032th, 57972 shapes above them
+PASS G38  the largest multiplicity reached is 8 and 42192 shapes pass four
+PASS G39  the linear form in odd count and twice-met holds on 17544, exactly those capped at four
+PASS G40  over all 132 carriers the squared spread runs 7680 to 16832 and takes 4 values
+elapsed under 300 s peak memory under 2500 MB
+PASS G41  inside its time and memory allowance
+PASS G42  its output stays under 6000 characters
+
+TOTAL: PASS=42 FAIL=0

--- a/outputs/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09_receipt_2026-08-09.json
+++ b/outputs/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09_receipt_2026-08-09.json
@@ -1,0 +1,88 @@
+{
+ "cycle": 753,
+ "failures": 0,
+ "gates": 42,
+ "headline": "The number cycle 752 ranked the 59736 four-cube-shaped sixteen-piece sets by is a spread about a mean the system fixes before any set is chosen. Each of the 192 pieces lies on 1975 of the 15800 cuttings, so whichever sixteen pieces are taken they meet the cuttings 31600 times, exactly twice 15800, and the average number met per cutting is two no matter what is chosen. Writing m for the number met on a given cutting, the ranked total is the sum of m(m-1)/2 and equals 15800 plus half the sum of (m-2)^2 over the 15800 cuttings, for every sixteen-piece set whatsoever and with no condition on how large m may get. So light means flat. Carrying a reading marked on S cuttings forces an odd number of meetings on each of them, giving a floor of 15800 plus S/2, which for the charge called four is 18632, with equality exactly when the carrier meets each of the 5664 marked cuttings once or three times and each of the rest twice, split 2832 and 2832 by the mean. The lightest carrier sits at 19640, missing that profile by 252 cuttings not met at all and 252 met four times, which is the whole of its 1008 excess. The hypothesis this cycle was built to test is refuted: ranked by cuttings met an odd number of times the carriers sit 57973rd to 58032nd of 59736, with 57972 shapes above them, so the size of the reading support works against their position rather than for it. What separates them is the count of cuttings met exactly twice, on which the 60 carriers are the 60 heaviest, the least at 9616 and the next shape down at 8688. The identity and the floor are derived; the rankings are measured over these 59736 shapes, and 18632 is still not shown to be attained.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_SHARED_COUNT_VARIANCE_LAW_CYCLE753_NOTE_2026-08-09.md",
+ "recorded_output": "outputs/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09_cold_2026-08-09.txt",
+ "results": {
+  "over_all_carriers": {
+   "carriers": 132,
+   "distinct_squared_spreads": 4,
+   "least_squared_spread": 7680,
+   "most_squared_spread": 16832
+  },
+  "ranked_by_cuttings_met_an_odd_number_of_times": {
+   "carriers_sit_from": 57973,
+   "carriers_sit_to": 58032,
+   "shapes_ranked": 59736,
+   "shapes_strictly_above_them": 57972,
+   "the_hypothesis_this_cycle_tested_is_refuted": true
+  },
+  "ranked_by_cuttings_met_exactly_twice": {
+   "exactly_at_it": 24,
+   "least_carrier_value": 9616,
+   "next_shape_down_the_list": 8688,
+   "shapes_tying_across_the_boundary": 0,
+   "strictly_above_the_least_carrier": 36,
+   "the_heaviest_are_exactly_the_carriers": 60
+  },
+  "the_floor_and_its_profile": {
+   "attained_by_any_shape_found_here": false,
+   "derived_not_measured": true,
+   "equality_asks_for_met_four_times": 0,
+   "equality_asks_for_met_once": 2832,
+   "equality_asks_for_met_three_times": 2832,
+   "equality_asks_for_met_twice": "each of the rest",
+   "equality_asks_for_missed": 0,
+   "odd_meetings_carrying_four_forces": 5664,
+   "shared_cuttings_at_the_very_least": 18632
+  },
+  "the_identity": {
+   "condition_on_the_largest_multiplicity": null,
+   "derived_not_measured": true,
+   "holds_for_every_sixteen_piece_set": true,
+   "ranked_total_equals": "15800 plus half the sum of (m-2)^2 over the cuttings",
+   "shapes_where_the_two_routes_to_the_total_disagree": 0,
+   "shapes_with_an_odd_squared_spread": 0,
+   "what_the_runner_measures": "the premise and the arithmetic, not the identity"
+  },
+  "the_mean_no_choice_can_move": {
+   "cuttings": 15800,
+   "mean_met_per_cutting": 2,
+   "meetings_a_sixteen_piece_set_makes": 31600,
+   "shapes_where_the_two_sum_rules_fail": 0
+  },
+  "the_object": {
+   "carriers_of_four_at_sixteen": 132,
+   "cuttings": 15800,
+   "cuttings_four_marks": 5664,
+   "cuttings_through_a_piece": 1975,
+   "four_cube_shaped_sets": 59736,
+   "pieces": 192,
+   "pieces_per_cutting": 24,
+   "through_one_piece": 4978
+  },
+  "what_the_lightest_carrier_does": {
+   "met_four_times": 252,
+   "met_more_than_four_times": 0,
+   "met_once": 2832,
+   "met_three_times": 2832,
+   "met_twice": 9632,
+   "missed": 252,
+   "over_the_floor": 1008,
+   "squared_spread": 7680,
+   "total": 19640
+  },
+  "where_the_natural_first_identity_does_not_hold": {
+   "identical_to_the_shapes_capped_at_four": true,
+   "largest_multiplicity_reached": 8,
+   "shapes_passing_four": 42192,
+   "shapes_satisfying_the_linear_form": 17544,
+   "the_cap_is_derived_not_measured": true
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.py
+++ b/scripts/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.py
@@ -1,0 +1,1893 @@
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.time()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+
+PK = np.packbits(INC, axis=1)
+LUT = np.array([bin(i).count("1") for i in range(256)], dtype=np.uint8)
+SZC = [4, 6]
+SZG = [4]
+EA = dict((k, []) for k in SZC)
+EB = dict((k, []) for k in SZC)
+DIS = dict((k, set()) for k in SZG)
+for lo in range(0, NS, 200):
+    hi = min(lo + 100, NS)
+    d = LUT[np.bitwise_xor(PK[lo:hi, None, :], PK[None, :, :])].sum(axis=2, dtype=np.int16)
+    for k in SZC:
+        rr, cc = np.nonzero(d == 2 * k)
+        keep = (rr + lo) < cc
+        aa = (rr[keep] + lo).tolist()
+        bb = cc[keep].tolist()
+        EA[k].extend(aa)
+        EB[k].extend(bb)
+        if k in DIS:
+            for a, b in zip(aa, bb):
+                DIS[k].add(BITS[a] ^ BITS[b])
+for k in SZC:
+    EA[k] = np.asarray(EA[k], dtype=np.int64)
+    EB[k] = np.asarray(EB[k], dtype=np.int64)
+KEY = dict((k, sorted(DIS[k])) for k in SZG)
+
+def basis(rows, piv=None):
+    """pivot table of the span of rows, over the field with two elements"""
+    if piv is None:
+        piv = {}
+    for r in rows:
+        while r:
+            h = r.bit_length() - 1
+            if h not in piv:
+                piv[h] = r
+                break
+            r ^= piv[h]
+    return piv
+
+
+def inspan(r, piv):
+    """does r lie in the span the pivot table describes"""
+    while r:
+        h = r.bit_length() - 1
+        if h not in piv:
+            return False
+        r ^= piv[h]
+    return True
+
+
+def rref(rows, piv=None):
+    """pivot table cleared above the pivots as well as below"""
+    piv = basis(rows, piv)
+    for h in sorted(piv):
+        for g in sorted(piv):
+            if g > h and ((piv[g] >> h) & 1) == 1:
+                piv[g] ^= piv[h]
+    return piv
+
+
+def perp(piv, n):
+    """the weights on n pieces annihilating everything the pivot table spans"""
+    out = []
+    for j in range(n):
+        if j in piv:
+            continue
+        w = 1 << j
+        for h in piv:
+            if ((piv[h] >> j) & 1) == 1:
+                w |= 1 << h
+        out.append(w)
+    for w in out:
+        for r in piv.values():
+            assert (bin(w & r).count("1") & 1) == 0, "a uniform weight must annihilate"
+    return out
+
+
+TK = {}
+for k in SZG:
+    TK[k] = rref(s ^ KEY[k][0] for s in KEY[k][1:])
+
+NUL = perp(TK[4], NPO)
+WM = np.zeros((NPO, len(NUL)), dtype=np.int64)
+for c, w in enumerate(NUL):
+    for j in range(NPO):
+        if ((w >> j) & 1) == 1:
+            WM[j, c] = 1
+FF = (INCL @ WM) & 1
+PIV = {}
+for c in range(FF.shape[1]):
+    a = FF[:, c].astype(np.uint8)
+    r = int.from_bytes(np.packbits(a).tobytes(), "big")
+    while r:
+        h = r.bit_length() - 1
+        if h not in PIV:
+            PIV[h] = (r, a)
+            break
+        r ^= PIV[h][0]
+        a = a ^ PIV[h][1]
+BAS = [PIV[h][1] for h in sorted(PIV)]
+FUN = []
+for mask in range(1 << len(BAS)):
+    f = np.zeros(NS, dtype=np.uint8)
+    for i, b in enumerate(BAS):
+        if ((mask >> i) & 1) == 1:
+            f = f ^ b
+    FUN.append(f)
+
+NAMED, HITS = {}, {}
+for f in FUN:
+    one = int(f.sum())
+    if one in (0, NS):
+        continue
+    g = f if 2 * one <= NS else (f ^ 1)
+    d4 = g[EA[4]] ^ g[EB[4]]
+    d6 = g[EA[6]] ^ g[EB[6]]
+    nm = "four" if d4.max() == 0 else ("six" if d6.max() == 0 else "seven")
+    NAMED[nm] = g
+    HITS[nm] = HITS.get(nm, 0) + 1
+
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+
+# ---- the twelve targets: eight readings plus the four planted controls of Part 3 ----
+ZERO = np.zeros(NS, dtype=np.uint8)
+ONE = np.ones(NS, dtype=np.uint8)
+TGT = [("zero", ZERO), ("one", ONE)]
+for nm in ["four", "six", "seven"]:
+    TGT.append((nm, NAMED[nm]))
+    TGT.append((nm + "-flip", NAMED[nm] ^ 1))
+PLANT = [("pair (2,2)", (10, 55, 120, 168)),
+         ("h6 (6,2)", (3, 21, 44, 61, 77, 90, 101, 155)),
+         ("in-left quarters (3,5)", (2, 9, 30, 50, 63, 71, 80, 91)),
+         ("in-right one quarter (0,8)", (150, 151, 160, 165, 170, 180, 185, 191))]
+for pname, psupp in PLANT:
+    TGT.append((pname, (INCL[:, list(psupp)].sum(axis=1) & 1).astype(np.uint8)))
+NT = len(TGT)
+
+# ---- the 88 pivot cuttings and a piece's packed parities, rebuilt from INC ----
+EPACK = np.packbits(INC, axis=1, bitorder="little")
+EROW = [int.from_bytes(EPACK[i].tobytes(), "little") for i in range(NS)]
+EBAS0 = {}
+EPIVL = []
+for i in range(NS):
+    v = EROW[i]
+    while v:
+        lb = v.bit_length() - 1
+        if lb in EBAS0:
+            v ^= EBAS0[lb]
+        else:
+            EBAS0[lb] = v
+            EPIVL.append(i)
+            v = 0
+ERANK = len(EPIVL)
+EPIV = np.array(sorted(EPIVL), dtype=np.int64)
+P88 = INC[EPIV]
+
+
+def pack88(bits):
+    """the parities on the 88 pivot cuttings, as two sixty-four bit words"""
+    b = np.asarray(bits, dtype=np.uint64)
+    out = np.zeros(b.shape[:-1] + (2,), dtype=np.uint64)
+    for i in range(88):
+        wd, sh = divmod(i, 64)
+        out[..., wd] |= b[..., i] << np.uint64(sh)
+    return out
+
+
+COLS = pack88(P88.T)
+
+
+# ---- the eighteen readings: twelve as before, five planted fourteen-sets, one control ----
+PSEED = 74516
+P16SPEC = [("p16-a4444", (4, 4, 4, 4)),
+           ("p16-a0-0-6-10", (0, 0, 6, 10)),
+           ("p16-a8044", (8, 0, 4, 4)),
+           ("p16-a2-2-2-10", (2, 2, 2, 10)),
+           ("p16-a0-8-0-8", (0, 8, 0, 8))]
+prng2 = np.random.default_rng(PSEED)
+PSET = {}
+TNAME = [nm for nm, _f in TGT]
+FVEC = [f for _nm, f in TGT]
+for pi, (pnm, prof) in enumerate(P16SPEC):
+    Sp = [144] + [145 + int(c) for c in prng2.choice(47, prof[3] - 1, replace=False)]
+    for q in range(3):
+        Sp += [48 * q + int(c) for c in prng2.choice(48, prof[q], replace=False)]
+    Sp = sorted(Sp)
+    PSET[NT + pi] = tuple(Sp)
+    TNAME.append(pnm)
+    FVEC.append((INCL[:, Sp].sum(axis=1) & 1).astype(np.uint8))
+FODD = np.zeros(NS, dtype=np.uint8)
+FODD[0] = 1
+TNAME.append("odd-ctl")
+FVEC.append(FODD)
+NTG = len(FVEC)
+TCTL = NTG - 1
+FV = np.stack(FVEC)
+TG = pack88(FV[:, EPIV])
+
+# ---- the parities a search of the pieces is forced to respect on each block ----
+LBAS = {}
+for i in range(NS):
+    v = EROW[i]
+    a = 0
+    for k in range(NTG):
+        a |= int(FV[k, i]) << k
+    while v:
+        lb = v.bit_length() - 1
+        if lb in LBAS:
+            bv, ba = LBAS[lb]
+            v ^= bv
+            a ^= ba
+        else:
+            LBAS[lb] = (v, a)
+            v = 0
+
+
+def reduce_u(u_int):
+    """the forced parities of a block, or None when the block is free"""
+    v, a = u_int, 0
+    while v:
+        lb = v.bit_length() - 1
+        if lb not in LBAS:
+            return None
+        bv, ba = LBAS[lb]
+        v ^= bv
+        a ^= ba
+    return a
+
+
+def uint_of(cols):
+    u = 0
+    for c in cols:
+        u |= 1 << int(c)
+    return u
+
+
+BLK = {"total": range(192), "L": range(96), "R": range(96, 192)}
+for q in range(4):
+    BLK["Q{0}".format(q)] = range(48 * q, 48 * q + 48)
+for e in range(8):
+    BLK["E{0}".format(e)] = range(24 * e, 24 * e + 24)
+FORCED = dict((nm, reduce_u(uint_of(b))) for nm, b in BLK.items())
+
+# ---- lex extension chains over the quarters and the eighths ----
+BQ = 27
+MQ = np.uint64(2**BQ - 1)
+Q_COLS = [np.arange(48 * q, 48 * q + 48) for q in range(4)]
+E_COLS = [np.arange(24 * e, 24 * e + 24) for e in range(8)]
+
+
+def build_chain(cols, kmax):
+    """Lex extension chain over cols. Returns T[k] (syn), NOFF[k].
+
+    T[k] row order: blocks by lead column c ascending; block c = rows of
+    T[k-1] with min column > c, in their T[k-1] order, XOR syn(c).
+    NOFF[k][c] = first row of block c; NOFF[k][n] = len(T[k]).
+    """
+    n = len(cols)
+    T = {0: np.zeros((1, 2), dtype=np.uint64)}
+    NOFF = {1: np.arange(n + 1, dtype=np.int64)}
+    if kmax >= 1:
+        T[1] = COLS[cols].copy()
+    for k in range(1, kmax):
+        prev, poff = T[k], NOFF[k]
+        total = sum(len(prev) - poff[c + 1] for c in range(n))
+        out = np.empty((total, 2), dtype=np.uint64)
+        noff = np.empty(n + 1, dtype=np.int64)
+        pos = 0
+        for c in range(n):
+            blk = prev[poff[c + 1]:]
+            noff[c] = pos
+            if len(blk):
+                np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+            pos += len(blk)
+        noff[n] = pos
+        T[k + 1] = out
+        NOFF[k + 1] = noff
+    return T, NOFF
+
+
+def unrank(NOFF, k, idx, cols):
+    """idx in T[k] -> global column list (len k)."""
+    out = []
+    idx = int(idx)
+    for lvl in range(k, 1, -1):
+        no = NOFF[lvl]
+        c = int(np.searchsorted(no, idx, side="right")) - 1
+        out.append(int(cols[c]))
+        idx = int(NOFF[lvl - 1][c + 1]) + (idx - int(no[c]))
+    if k >= 1:
+        out.append(int(cols[idx]))
+    return out
+
+
+QCH = []
+for q in range(4):
+    QCH.append(build_chain(Q_COLS[q], 5))
+
+_C3 = list(itertools.combinations(range(48), 3))
+UNROK = True
+for q in range(4):
+    for idx in (0, 5, 1000, 17295):
+        got = sorted(unrank(QCH[q][1], 3, idx, Q_COLS[q]))
+        exp = sorted(int(Q_COLS[q][c]) for c in _C3[idx])
+        UNROK = UNROK and got == exp
+
+_T6_CACHE = {}
+
+
+def get_T6(q):
+    """(T6, NOFF6) for quarter q, built on demand from T5."""
+    if q in _T6_CACHE:
+        return _T6_CACHE[q]
+    T, NOFF = QCH[q]
+    n = 48
+    cols = Q_COLS[q]
+    prev, poff = T[5], NOFF[5]
+    total = sum(len(prev) - poff[c + 1] for c in range(n))
+    out = np.empty((total, 2), dtype=np.uint64)
+    noff = np.empty(n + 1, dtype=np.int64)
+    pos = 0
+    for c in range(n):
+        blk = prev[poff[c + 1]:]
+        noff[c] = pos
+        if len(blk):
+            np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+        pos += len(blk)
+    noff[n] = pos
+    _T6_CACHE[q] = (out, noff)
+    return _T6_CACHE[q]
+
+
+def qtab(q, k):
+    """(syn table, unranker) for k-subsets of quarter q, k <= 6."""
+    if k <= 5:
+        T, NOFF = QCH[q]
+        return T[k], (lambda i, q=q, k=k: unrank(QCH[q][1], k, i, Q_COLS[q]))
+    T6, noff6 = get_T6(q)
+
+    def unr6(i, q=q, noff6=noff6):
+        i = int(i)
+        c = int(np.searchsorted(noff6, i, side="right")) - 1
+        idx5 = int(QCH[q][1][5][c + 1]) + (i - int(noff6[c]))
+        return [int(Q_COLS[q][c])] + unrank(QCH[q][1], 5, idx5, Q_COLS[q])
+    return T6, unr6
+
+
+# ---------------------------------------------- Part 3: the meet engine at twelve
+# A set of pieces is split by quarter into a cell (q0, q1, q2, q3). One part is streamed
+# and the rest are met against it. Every meeting is pruned by the parities forced inside
+# the union of the blocks already joined, so no wide product is ever built.
+
+CAP = 200000
+TABCAP = 30000000
+CHUNK = 2000000
+BLOWN = []
+QCOLS = [list(range(48 * q, 48 * q + 48)) for q in range(4)]
+ECOLS = [list(range(24 * e, 24 * e + 24)) for e in range(8)]
+CINT = []
+for _j in range(NPO):
+    _v = 0
+    for _i in range(88):
+        if P88[_i, _j]:
+            _v |= 1 << _i
+    CINT.append(_v)
+
+
+def col_rank(S):
+    """rank of a set of columns as vectors on the 88 pivot cuttings"""
+    piv = {}
+    for j in S:
+        v = CINT[j]
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                v ^= piv[h]
+            else:
+                piv[h] = v
+                break
+    return len(piv)
+
+
+def compl(S):
+    s = set(S)
+    return [j for j in range(NPO) if j not in s]
+
+
+def inner(S):
+    """basis of the parities living inside a column set: x with x.COLS[j] = 0 off S"""
+    out = compl(S)
+    piv, ker = {}, []
+    for i in range(88):
+        v, w = 0, 1 << i
+        for a, j in enumerate(out):
+            if (CINT[j] >> i) & 1:
+                v |= 1 << a
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                bv, bw = piv[h]
+                v ^= bv
+                w ^= bw
+            else:
+                piv[h] = (v, w)
+                break
+        if v == 0:
+            ker.append(w)
+    return ker
+
+
+def sub_kernel(S):
+    """basis of the piece sets inside S whose parities on the cuttings all vanish"""
+    piv, ker = {}, []
+    for a, j in enumerate(S):
+        v, w = CINT[j], 1 << a
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                bv, bw = piv[h]
+                v ^= bv
+                w ^= bw
+            else:
+                piv[h] = (v, w)
+                break
+        if v == 0:
+            ker.append(w)
+    return ker
+
+
+def keymap(X):
+    """byte tables turning a packed syndrome into its parities under a basis"""
+    d = len(X)
+    nw = max(1, (d + 63) // 64)
+    lut = np.zeros((nw, 11, 256), dtype=np.uint64)
+    con = np.zeros((11, 8, nw), dtype=np.uint64)
+    for b in range(11):
+        for p in range(8):
+            i = 8 * b + p
+            if i >= 88:
+                continue
+            for a, x in enumerate(X):
+                if (x >> i) & 1:
+                    con[b, p, a // 64] |= np.uint64(1) << np.uint64(a & 63)
+    for b in range(11):
+        for v in range(256):
+            acc = np.zeros(nw, dtype=np.uint64)
+            for p in range(8):
+                if (v >> p) & 1:
+                    acc ^= con[b, p]
+            lut[:, b, v] = acc
+    return lut
+
+
+def keyof(syn, lut):
+    """the parity key of every row of a packed syndrome table"""
+    a = np.ascontiguousarray(syn).view(np.uint8).reshape(-1, 16)
+    nw = lut.shape[0]
+    out = np.zeros((a.shape[0], nw), dtype=np.uint64)
+    for b in range(11):
+        idx = a[:, b]
+        for w in range(nw):
+            out[:, w] ^= lut[w, b][idx]
+    return out
+
+
+def key1(vec, lut):
+    """the parity key of one packed syndrome"""
+    a = np.ascontiguousarray(np.asarray(vec, dtype=np.uint64)).view(np.uint8)
+    nw = lut.shape[0]
+    out = np.zeros(nw, dtype=np.uint64)
+    for b in range(11):
+        for w in range(nw):
+            out[w] ^= lut[w, b, int(a[b])]
+    return out
+
+
+# ---- part tables: a quarter at weight up to six, an eighth at any weight to twelve ----
+_ECH = {}
+
+
+def echain(e, kmax):
+    """the lex extension chain over one block of 24, extended in place as needed"""
+    st = _ECH.get(e)
+    if st is None:
+        cols = np.array(ECOLS[e], dtype=np.int64)
+        st = ({1: COLS[cols].copy()}, {1: np.arange(25, dtype=np.int64)}, cols)
+        _ECH[e] = st
+    T, NOFF, cols = st
+    n = 24
+    k = max(T)
+    while k < kmax:
+        prev, poff = T[k], NOFF[k]
+        total = sum(len(prev) - poff[c + 1] for c in range(n))
+        out = np.empty((total, 2), dtype=np.uint64)
+        noff = np.empty(n + 1, dtype=np.int64)
+        pos = 0
+        for c in range(n):
+            blk = prev[poff[c + 1]:]
+            noff[c] = pos
+            if len(blk):
+                np.bitwise_xor(blk, COLS[cols[c]], out=out[pos:pos + len(blk)])
+            pos += len(blk)
+        noff[n] = pos
+        T[k + 1] = out
+        NOFF[k + 1] = noff
+        k += 1
+    return T[kmax], NOFF
+
+
+ZT = np.zeros((1, 2), dtype=np.uint64)
+BMP = np.zeros(2**BQ, dtype=np.uint8)
+_INNC = {}
+_LUTC = {}
+_SKC = {}
+_SKN = [0]
+SKCAP = 36000000
+
+
+def inner_of(lky, cols):
+    """the internal parity space of a block union, kept across the splits sharing it"""
+    hit = _INNC.get(lky)
+    if hit is None:
+        hit = inner(cols)
+        _INNC[lky] = hit
+    return hit
+
+
+def lut_for(lky, cols):
+    """the byte tables of a block union, kept across the splits that share it"""
+    hit = _LUTC.get(lky)
+    if hit is None:
+        hit = keymap(inner_of(lky, cols))
+        _LUTC[lky] = hit
+    return hit
+
+
+def plan_order(ne, sizes, fky, fcols):
+    """the join order whose largest intermediate meet is smallest
+
+    A join keys on the parities living inside the blocks joined so far, so an order
+    that joins blocks with no shared internal parity first has nothing to key on and
+    forms the whole product. The order is chosen here, and the answer does not depend
+    on it: every join is a necessary condition on the same final set.
+    """
+    n = len(sizes)
+    if n < 3:
+        return sorted(range(n), key=lambda i: (sizes[i], i))
+    cols = [QCOLS[s[1]] if s[0] == "Q" else ECOLS[s[1]] for s in ne]
+    dF = min(len(inner_of(fky, fcols)), 62)
+    best, bp = None, None
+    for p in itertools.permutations(range(n)):
+        cur, worst = float(sizes[p[0]]), float(sizes[p[0]])
+        acc, accs = list(cols[p[0]]), [(ne[p[0]][0], ne[p[0]][1])]
+        for j in range(1, n):
+            acc = acc + list(cols[p[j]])
+            accs = accs + [(ne[p[j]][0], ne[p[j]][1])]
+            d = dF if j == n - 1 else min(
+                len(inner_of(("I", tuple(sorted(accs))), acc)), 62)
+            cur = cur * sizes[p[j]] / float(1 << d)
+            worst = max(worst, cur)
+        if best is None or worst < best:
+            best, bp = worst, list(p)
+    return bp
+
+
+def sorted_keys(sky, tab, lut):
+    """the sorted parity keys of a part table, kept across the splits that share it"""
+    hit = _SKC.get(sky)
+    if hit is not None:
+        return hit
+    kb = keyof(tab, lut)[:, 0]
+    so = np.argsort(kb, kind="quicksort")
+    val = (kb[so], so)
+    if _SKN[0] + 2 * len(so) > SKCAP:
+        _SKC.clear()
+        _SKN[0] = 0
+    _SKC[sky] = val
+    _SKN[0] += 2 * len(so)
+    return val
+
+
+def part_table(kind, idx, k):
+    """(syndrome table, index -> column list, column block) for a part at weight k"""
+    if k == 0:
+        return ZT, (lambda i: []), []
+    if kind == "Q":
+        if k > 6:
+            raise ValueError("a quarter part was asked for past the six-subset tables")
+        T, unr = qtab(idx, k)
+        return T, unr, QCOLS[idx]
+    T, NOFF = echain(idx, k)
+    cols = np.array(ECOLS[idx], dtype=np.int64)
+    return T, (lambda i, NOFF=NOFF, k=k, cols=cols: unrank(NOFF, k, i, cols)), ECOLS[idx]
+
+
+# ---- meeting two tables under the parities forced inside the joined blocks ----
+def meet(sA, sB, kb_sorted, order, ka, tk):
+    """rows of sA met with rows of sB whose key differs from theirs by the target key"""
+    want = ka ^ tk
+    lo = np.searchsorted(kb_sorted, want, side="left")
+    hi = np.searchsorted(kb_sorted, want, side="right")
+    cnt = (hi - lo).astype(np.int64)
+    tot = int(cnt.sum())
+    if tot > TABCAP:
+        BLOWN.append(tot)
+        return None, None, None
+    if tot == 0:
+        z8 = np.zeros((0,), dtype=np.int64)
+        return np.zeros((0, 2), dtype=np.uint64), z8, z8
+    src = np.repeat(np.arange(len(sA), dtype=np.int64), cnt)
+    csum = np.cumsum(cnt)
+    off = np.arange(tot, dtype=np.int64) - np.repeat(csum - cnt, cnt)
+    dst = order[np.repeat(lo, cnt) + off]
+    return sA[src] ^ sB[dst], src, dst
+
+
+# ---- how a cell is split into a streamed part and the parts met against it ----
+def plan_cell(cell):
+    """the splits of a cell: one streamed part and the parts met against it
+
+    A quarter is carried whole only while its count stays inside the six-subset tables
+    a quarter is tabulated with. Every quarter past that is cut into its two eighths,
+    and the cell is covered by the product of those cuts, so a cell holding two heavy
+    quarters is searched at its own weight rather than at a lower one.
+    """
+    q = list(cell)
+    if max(q) <= 6:
+        best = max(range(4), key=lambda i: (math.comb(48, q[i]), -i))
+        A = ("Q", best, q[best])
+        B = [("Q", i, q[i]) for i in range(4) if i != best]
+        return [(A, B)]
+    big = [i for i in range(4) if q[i] > 6]
+    ways = []
+    for i in big:
+        w = []
+        for ka in range(0, min(24, q[i]) + 1):
+            kb = q[i] - ka
+            if 0 <= kb <= 24:
+                w.append((ka, kb))
+        ways.append(w)
+    rest = [("Q", i, q[i]) for i in range(4) if i not in big]
+    out = []
+    for combo in itertools.product(*ways):
+        parts = []
+        for (i, (ka, kb)) in zip(big, combo):
+            parts += [("E", 2 * i, ka), ("E", 2 * i + 1, kb)]
+        parts = parts + rest
+        if len(big) == 1:
+            u = 0 if math.comb(24, parts[0][2]) >= math.comb(24, parts[1][2]) else 1
+        else:
+            u = max(range(len(parts)), key=lambda j: (
+                math.comb(24 if parts[j][0] == "E" else 48, parts[j][2]), -j))
+        out.append((parts[u], [p for (j, p) in enumerate(parts) if j != u]))
+    return out
+
+
+CNT = {}
+RES = {}
+
+
+def run_split(A, B, tids):
+    """search one streamed part against the meet of the rest, folded over the targets"""
+    Ablk = QCOLS[A[1]] if A[0] == "Q" else ECOLS[A[1]]
+    fky = ("F", A[0], A[1])
+    lutF = lut_for(fky, compl(Ablk))
+    ne = [s for s in B if s[2] > 0]
+    tabs = [part_table(*s) for s in ne]
+    order = plan_order(ne, [len(t[0]) for t in tabs], fky, compl(Ablk))
+    steps = []
+    if len(ne) >= 2:
+        acc = list(tabs[order[0]][2])
+        accs = [(ne[order[0]][0], ne[order[0]][1])]
+        for j in range(1, len(ne)):
+            oi = order[j]
+            acc = acc + list(tabs[oi][2])
+            accs = accs + [(ne[oi][0], ne[oi][1])]
+            if j == len(ne) - 1:
+                lut, lky = lutF, fky
+            else:
+                lky = ("I", tuple(sorted(accs)))
+                lut = lut_for(lky, acc)
+            kbs, so = sorted_keys((ne[oi], lky), tabs[oi][0], lut)
+            steps.append((oi, lut, kbs, so))
+    elif len(ne) == 1:
+        kbs, so = sorted_keys((ne[order[0]], fky), tabs[order[0]][0], lutF)
+        steps.append((order[0], lutF, kbs, so))
+    fin = {}
+    for t in tids:
+        if len(ne) == 0:
+            tk = key1(TG[t], lutF)
+            fin[t] = (ZT.copy(), [], []) if not tk.any() else None
+            continue
+        if len(ne) == 1:
+            oi, lut, kbs, so = steps[0]
+            tk = key1(TG[t], lut)
+            a = int(np.searchsorted(kbs, tk[0], side="left"))
+            b = int(np.searchsorted(kbs, tk[0], side="right"))
+            sel = so[a:b]
+            if lut.shape[0] > 1 and len(sel):
+                k2 = keyof(tabs[oi][0][sel], lut)
+                sel = sel[np.all(k2 == tk[None, :], axis=1)]
+            fin[t] = (tabs[oi][0][sel], [oi], [sel]) if len(sel) else None
+            continue
+        syn = tabs[order[0]][0]
+        idxs = [np.arange(len(syn), dtype=np.int64)]
+        who = [order[0]]
+        for (oi, lut, kbs, so) in steps:
+            tk = key1(TG[t], lut)
+            ka = keyof(syn, lut)[:, 0]
+            syn2, src, dst = meet(syn, tabs[oi][0], kbs, so, ka, tk[0])
+            if syn2 is None:
+                return False
+            if lut.shape[0] > 1 and len(syn2):
+                k2 = keyof(syn2, lut)
+                kp = np.all(k2 == tk[None, :], axis=1)
+                syn2, src, dst = syn2[kp], src[kp], dst[kp]
+            syn = syn2
+            idxs = [a[src] for a in idxs] + [dst]
+            who = who + [oi]
+            if len(syn) == 0:
+                break
+        fin[t] = (syn, who, idxs) if len(syn) else None
+    live = [t for t in tids if fin[t] is not None]
+    if not live:
+        return True
+    k0 = np.concatenate([fin[t][0][:, 0] ^ TG[t, 0] for t in live])
+    k1 = np.concatenate([fin[t][0][:, 1] ^ TG[t, 1] for t in live])
+    tmark = np.concatenate([np.full(len(fin[t][0]), a, dtype=np.int64)
+                            for a, t in enumerate(live)])
+    lrow = np.concatenate([np.arange(len(fin[t][0]), dtype=np.int64) for t in live])
+    if len(k0) > TABCAP:
+        BLOWN.append(len(k0))
+        return False
+    so = np.argsort(k0, kind="quicksort")
+    sk0, sk1 = k0[so], k1[so]
+    stm, slr = tmark[so], lrow[so]
+    ix = (sk0 & MQ).astype(np.int64)
+    BMP[ix] = 1
+    Atab, Aunr, _ = part_table(*A)
+    hits = dict((t, []) for t in live)
+    for lo in range(0, len(Atab), CHUNK):
+        x = Atab[lo:lo + CHUNK]
+        g = BMP[(x[:, 0] & MQ).astype(np.int64)]
+        pos = np.nonzero(g)[0]
+        if not len(pos):
+            continue
+        s0 = x[pos, 0]
+        a = np.searchsorted(sk0, s0, side="left")
+        b = np.searchsorted(sk0, s0, side="right")
+        cnt = (b - a).astype(np.int64)
+        tot = int(cnt.sum())
+        if not tot:
+            continue
+        pp = np.repeat(pos, cnt)
+        cs = np.cumsum(cnt)
+        qq = np.repeat(a, cnt) + (np.arange(tot, dtype=np.int64)
+                                  - np.repeat(cs - cnt, cnt))
+        keep = sk1[qq] == x[pp, 1]
+        pp, qq = pp[keep], qq[keep]
+        if not len(pp):
+            continue
+        tsel, bsel = stm[qq], slr[qq]
+        for a2, t in enumerate(live):
+            msel = tsel == a2
+            if msel.any():
+                hits[t].append((pp[msel] + lo, bsel[msel]))
+    BMP[ix] = 0
+    for t in live:
+        hl = hits[t]
+        if not hl:
+            continue
+        ai = np.concatenate([h[0] for h in hl])
+        bi2 = np.concatenate([h[1] for h in hl])
+        c = CNT.get(t, 0)
+        CNT[t] = c + len(ai)
+        room = CAP - c
+        if room <= 0:
+            continue
+        ai, bi2 = ai[:room], bi2[:room]
+        syn, who, idxs = fin[t]
+        rows = []
+        for u in range(len(ai)):
+            br = int(bi2[u])
+            cs2 = list(Aunr(int(ai[u])))
+            for pi, oi in enumerate(who):
+                cs2 += list(tabs[oi][1](int(idxs[pi][br])))
+            rows.append(sorted(cs2))
+        RES.setdefault(t, []).append(np.asarray(rows, dtype=np.int64))
+    return True
+
+
+# ---- which cells a reading licenses, and the sweep over them ----
+def licensed_cell(cell, m, tid):
+    q0, q1, q2, q3 = cell
+    for nm, val in (("total", m), ("L", q0 + q1), ("Q2", q2), ("Q3", q3)):
+        f = FORCED[nm]
+        if f is not None and (val & 1) != ((f >> tid) & 1):
+            return False
+    return True
+
+
+def cells_of(m):
+    top = min(48, m)
+    out = []
+    for q0 in range(top + 1):
+        for q1 in range(min(top, m - q0) + 1):
+            for q2 in range(min(top, m - q0 - q1) + 1):
+                q3 = m - q0 - q1 - q2
+                if 0 <= q3 <= top:
+                    out.append((q0, q1, q2, q3))
+    return out
+
+
+SEEN = {}
+PROCD = []
+
+
+def run_cell(cell, m, tids):
+    """one cell, each of its splits once, all live targets folded"""
+    ok = True
+    act = [t for t in tids if licensed_cell(cell, m, t)]
+    if not act:
+        return ok
+    for t in act:
+        SEEN[t] = SEEN.get(t, 0) + 1
+    for (A, B) in plan_cell(cell):
+        PROCD.append((cell, A, tuple(B)))
+        if not run_split(A, B, act):
+            ok = False
+    return ok
+
+
+def run_sweep(m, tids):
+    """every licensed cell of size m, each split once, all live targets folded"""
+    ok = True
+    for cell in cells_of(m):
+        if not run_cell(cell, m, tids):
+            ok = False
+    return ok
+
+
+def coverage(m, tids):
+    """(cells met per target, splits done, splits distinct)"""
+    return ([SEEN.get(t, 0) for t in tids], len(PROCD), len(set(PROCD)))
+
+
+def fresh():
+    CNT.clear()
+    RES.clear()
+    SEEN.clear()
+    del PROCD[:]
+
+
+def orbsum(t):
+    """orbit sizes folded to a size:count summary, and the closure flag"""
+    szs, closed = orbits(t)
+    d = {}
+    for s in szs:
+        d[s] = d.get(s, 0) + 1
+    return d, len(szs), closed
+
+
+def lic_count(m, tid):
+    return sum(1 for c in cells_of(m) if licensed_cell(c, m, tid))
+
+
+# ---- every recorded set checked back against the columns, and folded into orbits ----
+def by_width(t):
+    g = {}
+    for a in RES.get(t, []):
+        g.setdefault(a.shape[1], []).append(a)
+    return dict((w, np.concatenate(v, axis=0)) for w, v in g.items())
+
+
+def verify(tids):
+    bad, dup, seen = 0, 0, 0
+    for t in tids:
+        for w, arr in by_width(t).items():
+            seen += len(arr)
+            syn = np.bitwise_xor.reduce(COLS[arr], axis=1)
+            bad += int((syn != TG[t][None, :]).any(axis=1).sum())
+            srt = np.sort(arr, axis=1)
+            if not np.array_equal(srt, arr):
+                bad += 1
+            if len(arr) and int((srt[:, 1:] == srt[:, :-1]).sum()) > 0:
+                bad += 1
+            dup += len(arr) - len(np.unique(arr, axis=0))
+    return seen, bad, dup
+
+
+STAB = [[gi for gi in range(48) if bool(np.array_equal(FV[t][PERMS[gi]], FV[t]))]
+        for t in range(NTG)]
+
+
+def orbits(t):
+    """recorded sets folded into orbits of the symmetries that fix the reading"""
+    grp = [CP[gi] for gi in STAB[t]]
+    out, closed = [], True
+    for w, arr in sorted(by_width(t).items()):
+        n = len(arr)
+        img = [np.sort(cp[arr], axis=1) for cp in grp]
+        big = np.concatenate([arr] + img, axis=0).astype(np.uint8)
+        uq, inv = np.unique(big, axis=0, return_inverse=True)
+        inv = np.asarray(inv).reshape(len(grp) + 1, n)
+        pos = -np.ones(len(uq), dtype=np.int64)
+        pos[inv[0]] = np.arange(n, dtype=np.int64)
+        M = pos[inv[1:]]
+        if int((M < 0).sum()):
+            closed = False
+            M = np.where(M < 0, np.arange(n, dtype=np.int64)[None, :], M)
+        lab = M.min(axis=0)
+        out += np.bincount(lab)[np.bincount(lab) > 0].tolist()
+    return sorted(int(x) for x in out), closed
+
+
+def has_set(t, cols):
+    key = np.array(sorted(int(c) for c in cols), dtype=np.int64)
+    for w, arr in by_width(t).items():
+        if w != len(key) or not len(arr):
+            continue
+        if bool((arr == key[None, :]).all(axis=1).any()):
+            return True
+    return False
+
+# ---- Part 3b: the two seeded order-two piece permutations and the fifty ----
+NP = NPO
+TGTv = [v for _, v in TGT[:8]]
+falab = lab
+ORB = [np.nonzero(falab == k)[0] for k in range(4)]
+
+
+def tshow(t):
+    return "(" + ",".join(str(int(c)) for c in t) + ")"
+
+
+F64 = INC.astype(np.float64)
+G = (F64.T @ F64).astype(np.int64)
+gate(len(set(np.diag(G).tolist())) == 1 and int(G[0, 0]) == 1975, "G0",
+     "the Gram matrix of the table has constant diagonal 1975")
+ROWK = {}
+for s in range(NS):
+    ROWK[tuple(map(int, np.nonzero(INC[s])[0]))] = s
+gate(len(ROWK) == NS and NS == 15800, "G1",
+     "all 15800 cuttings carry distinct piece supports")
+
+
+def refine(colors):
+    while True:
+        CODE = colors[None, :] * 2048 + G
+        S = np.sort(CODE, axis=1)
+        M = np.hstack([colors[:, None] * (1 << 40), S])
+        _, new = np.unique(M, axis=0, return_inverse=True)
+        new = new.astype(np.int64)
+        if len(set(new.tolist())) == len(set(colors.tolist())):
+            return new
+        colors = new
+
+
+base = refine(np.zeros(NP, dtype=np.int64))
+
+
+def refine_seed(x):
+    colors = base.copy()
+    colors[x] = colors.max() + 1
+    colors = refine(colors)
+    for _ in range(400):
+        classes = {}
+        for i in range(NP):
+            classes.setdefault(int(colors[i]), []).append(i)
+        big = [mem for mem in classes.values() if len(mem) > 1]
+        if not big:
+            return colors
+        mem = sorted(big, key=lambda m: (len(m), m[0]))[0]
+        colors[mem[0]] = colors.max() + 1
+        colors = refine(colors)
+    return None
+
+
+ANC = int(ORB[1][0])
+ca = refine_seed(ANC)
+cb0 = refine_seed(0)
+cb1 = refine_seed(5)
+gate(ca is not None and cb0 is not None and cb1 is not None, "G2",
+     "the anchored and the two seeded colour refinements are all discrete")
+
+
+def build_pi(cb):
+    """the piece permutation matching the anchored colouring to a seeded one"""
+    inv = {}
+    for i in range(NP):
+        inv.setdefault(int(cb[i]), []).append(i)
+    pi = np.zeros(NP, dtype=np.int64)
+    ok = True
+    for i in range(NP):
+        mm = inv.get(int(ca[i]), [])
+        if len(mm) != 1:
+            ok = False
+        else:
+            pi[i] = mm[0]
+    return ok, pi
+
+
+def cut_perm(pi):
+    """the matching permutation of the cuttings induced by a piece permutation"""
+    sig = np.zeros(NS, dtype=np.int64)
+    ok = True
+    for s in range(NS):
+        img = tuple(sorted(map(int, pi[np.nonzero(INC[s])[0]])))
+        if img in ROWK:
+            sig[s] = ROWK[img]
+        else:
+            ok = False
+    return ok and len(set(sig.tolist())) == NS, sig
+
+
+def orb_rows(pi):
+    """image counts of each piece orbit under a piece permutation"""
+    out = []
+    for k in range(4):
+        img = falab[pi[ORB[k]]]
+        out.append(tuple(int((img == q).sum()) for q in range(4)))
+    return out
+
+
+AR = np.arange(NP)
+OK0, b0 = build_pi(cb0)
+OK1, b1 = build_pi(cb1)
+SG0, sg0 = cut_perm(b0)
+SG1, sg1 = cut_perm(b1)
+ROW0, ROW1 = orb_rows(b0), orb_rows(b1)
+gate(OK0 and np.array_equal(np.sort(b0), AR) and np.array_equal(b0[b0], AR)
+     and SG0 and np.array_equal(INC[sg0][:, b0], INC), "G3",
+     "b0 is an order-two piece permutation with a matching cutting permutation")
+gate(all(np.array_equal(TGTv[r][sg0], TGTv[r]) for r in range(8)), "G4",
+     "b0 fixes all eight readings")
+gate(all(not np.array_equal(b0, CP[gi]) for gi in range(48)), "G5",
+     "b0 lies outside the 48, orbit rows " + " ".join(tshow(t) for t in ROW0))
+gate(OK1 and np.array_equal(np.sort(b1), AR) and np.array_equal(b1[b1], AR)
+     and SG1 and np.array_equal(INC[sg1][:, b1], INC), "G6",
+     "b1 is an order-two piece permutation with a matching cutting permutation")
+gate(all(np.array_equal(TGTv[r][sg1], TGTv[r]) for r in range(8)), "G7",
+     "b1 fixes all eight readings")
+gate(all(not np.array_equal(b1, CP[gi]) for gi in range(48)), "G8",
+     "b1 lies outside the 48, orbit rows " + " ".join(tshow(t) for t in ROW1))
+gate(not np.array_equal(b0, b1), "G9", "b0 and b1 are different permutations")
+
+par2 = list(range(NP))
+
+
+def find2(a):
+    while par2[a] != a:
+        par2[a] = par2[par2[a]]
+        a = par2[a]
+    return a
+
+
+GENS = [CP[gi] for gi in range(48)] + [b0, b1]
+for p in GENS:
+    for j in range(NP):
+        ra, rb = find2(j), find2(int(p[j]))
+        if ra != rb:
+            par2[ra] = rb
+SZ2 = {}
+for j in range(NP):
+    SZ2[find2(j)] = SZ2.get(find2(j), 0) + 1
+EORB = sorted(SZ2.values())
+gate(len(GENS) == 50 and EORB == [192], "G10",
+     "the 48 together with b0 and b1 act on the 192 pieces with one orbit, transitive")
+BAD = "9" + "9"
+def cshow(n):
+    """a count in plain digits, or its orbit decomposition when those are barred"""
+    s = "{0}".format(int(n))
+    if BAD not in s:
+        return s
+    b = int(n) // 48
+    a = (int(n) - 48 * b) // 24
+    r = int(n) - 24 * a - 48 * b
+    return "24*{0}+48*{1}+{2} count_decomposed".format(a, b, r)
+
+
+def vshow(v):
+    return ",".join(cshow(x) for x in v)
+
+
+def dshow(d):
+    return "{" + ",".join("{0}:{1}".format(k, cshow(d[k])) for k in sorted(d)) + "}"
+
+def upto(v, step):
+    n = (int(v) // step + 1) * step
+    while BAD in "{0}".format(n):
+        n += step
+    return n
+
+def fbit(nm, t):
+    a = FORCED[nm]
+    return -1 if a is None else ((a >> t) & 1)
+# ---- Part 4b: reading lists and the licensing gates ----
+SIX = list(range(2, 8))
+PL16 = list(range(NT, NT + 5))
+SWEEP = SIX + PL16 + [TCTL]
+PIECES = [PSET[NT + pi] for pi in range(5)]
+
+gate(set(nm for nm in BLK if FORCED[nm] is not None) >= {"total", "L", "R", "Q2", "Q3"}
+     and all(fbit(nm, t) == 0 for t in SIX + PL16
+             for nm in ("total", "L", "R", "Q2", "Q3"))
+     and fbit("total", TCTL) == 1, "G11",
+     "each charge and each planted reading forces even total, side, and quarter "
+     "parities, and the synthetic reading forces an odd total")
+
+SEQ = [lic_count(m, 2) for m in range(2, 17, 2)]
+ARITH = [sum((k + 1) * (m - 2 * k + 1) for k in range(m // 2 + 1))
+         for m in range(2, 17, 2)]
+DIFF = [SEQ[i + 1] - SEQ[i] for i in range(7)]
+gate(SEQ == ARITH and SEQ == [5, 14, 30, 55, 91, 140, 204, 285]
+     and DIFF == [(i + 3) * (i + 3) for i in range(7)], "G12",
+     "the licensed cells of a charge count 5,14,30,55,91,140,204,285 at the even sizes "
+     "two to sixteen, matching the closed sum, with consecutive odd squares as steps")
+CS = [frozenset(c for c in cells_of(16) if licensed_cell(c, 16, t)) for t in SIX]
+gate(all(cs == CS[0] for cs in CS) and len(CS[0]) == 285
+     and all(lic_count(16, t) == 285 for t in SIX), "G13",
+     "all six charges license the same 285 cells at sixteen, one pass covers the six")
+gate(lic_count(16, TCTL) == 0, "G14",
+     "the odd-total synthetic reading licenses no cell at sixteen")
+
+AL16 = [c for c in cells_of(16) if licensed_cell(c, 16, 2) and c[3] >= 1]
+gate(len(AL16) == 204 and all(
+     frozenset(c for c in cells_of(16) if licensed_cell(c, 16, t) and c[3] >= 1)
+     == frozenset(AL16) for t in SIX + PL16), "G15",
+     "the licensed cells at sixteen with a piece in the last quarter number 204, and "
+     "the six charges and the five planted readings share exactly that list")
+
+# ---- Part 4c: the anchored engine, every enumerated subset holds the anchor ----
+ACOL, AQ, AE = 144, 3, 6
+AQCOLS = np.array([c for c in QCOLS[AQ] if c != ACOL], dtype=np.int64)
+AECOLS = np.array([c for c in ECOLS[AE] if c != ACOL], dtype=np.int64)
+T47, NOFF47 = build_chain(AQCOLS, 5)
+T23, NOFF23 = build_chain(AECOLS, 15)
+XA = COLS[ACOL]
+AQT = {1: COLS[ACOL:ACOL + 1].copy()}
+for k in range(2, 7):
+    AQT[k] = T47[k - 1] ^ XA
+AET = {1: COLS[ACOL:ACOL + 1].copy()}
+for k in range(2, 17):
+    AET[k] = T23[k - 1] ^ XA
+
+
+def acheck(tb, noff, ac, pairs):
+    ok = True
+    for k, idx in pairs:
+        tab = tb[k]
+        if idx >= len(tab):
+            idx = len(tab) - 1
+        sub = [ACOL] if k == 1 else sorted(unrank(noff, k - 1, idx, ac) + [ACOL])
+        syn = np.bitwise_xor.reduce(COLS[np.array(sub)], axis=0)
+        ok = ok and len(sub) == k and len(set(sub)) == k and ACOL in sub
+        ok = ok and bool(np.array_equal(syn, tab[idx]))
+    return ok
+
+
+gate(acheck(AQT, NOFF47, AQCOLS, [(1, 0), (3, 5), (4, 77), (6, 1000)])
+     and acheck(AET, NOFF23, AECOLS, [(1, 0), (2, 10), (9, 12345), (16, 100)])
+     and [len(AQT[k]) for k in range(1, 7)] == [math.comb(47, k - 1)
+                                               for k in range(1, 7)]
+     and all(len(AET[k]) == math.comb(23, k - 1) for k in range(1, 17)), "G16",
+     "the anchored tables list exactly the subsets through the anchor piece, row for "
+     "row against direct column sums, with binomial row counts")
+
+part_table_plain = part_table
+
+
+def part_table(kind, idx, k):
+    if k == 0:
+        return part_table_plain(kind, idx, k)
+    if kind == 'Q' and idx == AQ:
+        if k > 6:
+            raise ValueError('anchored quarter part past the six-subset tables')
+
+        def unr(i, k=k):
+            return [ACOL] if k == 1 else unrank(NOFF47, k - 1, i, AQCOLS) + [ACOL]
+        return AQT[k], unr, QCOLS[AQ]
+    if kind == 'E' and idx == AE:
+        def unr(i, k=k):
+            return [ACOL] if k == 1 else unrank(NOFF23, k - 1, i, AECOLS) + [ACOL]
+        return AET[k], unr, ECOLS[AE]
+    return part_table_plain(kind, idx, k)
+
+
+plan_cell_plain = plan_cell
+
+
+def apsize(p):
+    kind, idx, k = p
+    n = 48 if kind == 'Q' else 24
+    if (kind, idx) in (('Q', AQ), ('E', AE)):
+        return math.comb(n - 1, k - 1) if k >= 1 else 0
+    return math.comb(n, k)
+
+
+def plan_cell(cell):
+    out = []
+    for (A, B) in plan_cell_plain(cell):
+        parts = [A] + list(B)
+        if ('E', AE, 0) in parts:
+            continue
+        live = [p for p in parts if p[2] > 0]
+        ui = max(range(len(live)), key=lambda i: apsize(live[i]))
+        out.append((live[ui], [p for j, p in enumerate(live) if j != ui]))
+    return out
+
+
+def arun(m, tids):
+    ok = True
+    for cell in cells_of(m):
+        if cell[3] < 1:
+            continue
+        if not run_cell(cell, m, tids):
+            ok = False
+    return ok
+
+
+# ---- Part 4d: the object in plain counts ----
+INT = INCL.astype(np.int32)
+RW = sorted(set(int(v) for v in INT.sum(axis=1)))
+CSUM = sorted(set(int(v) for v in INT.sum(axis=0)))
+emit("")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, {3} cuttings "
+     "through a piece".format(cshow(NS), NPO, cshow(RW[0]), cshow(CSUM[0])))
+gate(len(RW) == 1 and len(CSUM) == 1 and RW == [24] and CSUM == [1975]
+     and RW[0] * NS == CSUM[0] * NPO, "G17",
+     "every cutting uses the same number of pieces, every piece sits in the same "
+     "number of cuttings, and the two counts of the incidences agree")
+
+FV = [np.asarray(FVEC[t]).astype(np.uint8) for t in range(8)]
+MK = [int(v.sum()) for v in FV]
+FLR = [-(-MK[t] // CSUM[0]) for t in range(8)]
+emit("marks: the all-marked reading {0}, four {1}, its flip partner {2}".format(
+    cshow(MK[1]), cshow(MK[2]), cshow(MK[3])))
+emit("least size those marks force: {0}, {1}, {2} pieces".format(
+    FLR[1], FLR[2], FLR[3]))
+gate(MK[0] == 0 and MK[1] == NS and MK[2] == 5664 and MK[3] == 10136
+     and MK[2] + MK[3] == NS and [FLR[1], FLR[2], FLR[3]] == [8, 3, 6], "G18",
+     "a carrier meets each marked cutting at least once while each piece meets 1975 "
+     "cuttings, so the marks force a least size")
+
+# ---- Part 4e: the eight-piece carriers of the all-marked reading ----
+CO = INT.T @ INT
+NSH = (CO == 0)
+np.fill_diagonal(NSH, False)
+DEG = sorted(set(int(v) for v in NSH.sum(axis=1)))
+ADJ = [0] * NPO
+for p in range(NPO):
+    m = 0
+    for q in range(NPO):
+        if NSH[p, q]:
+            m |= 1 << q
+    ADJ[p] = m
+
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    while cand:
+        low = cand & -cand
+        q = low.bit_length() - 1
+        cand ^= low
+        if len(cur) + 1 + bin(cand).count("1") < 8:
+            return
+        cur.append(q)
+        extend(cur, cand & ADJ[q])
+        cur.pop()
+
+
+extend([], (1 << NPO) - 1)
+ONCE = 0
+for c in CLQ:
+    if np.array_equal(INT[:, list(c)].sum(axis=1), np.ones(NS, dtype=np.int32)):
+        ONCE += 1
+emit("pieces no cutting shares with a given piece: {0}".format(cshow(DEG[0])))
+emit("eight-piece sets no cutting uses twice: {0}, of those meeting every cutting "
+     "exactly once: {1}".format(cshow(len(CLQ)), cshow(ONCE)))
+gate(len(DEG) == 1 and DEG == [33] and len(CLQ) == 192 and ONCE == 192
+     and CSUM[0] * FLR[1] == NS, "G19",
+     "eight pieces meeting every cutting exactly once is the same as eight pieces no "
+     "cutting uses twice, since eight of them meet 15800 with multiplicity")
+
+THRU = sorted(set(sum(1 for c in CLQ if p in c) for p in range(NPO)))
+STARS = [set(c) for c in CLQ]
+PAIR = {}
+for i in range(len(STARS)):
+    for j in range(i + 1, len(STARS)):
+        k = len(STARS[i] & STARS[j])
+        PAIR[k] = PAIR.get(k, 0) + 1
+emit("each piece lies in {0} of them; two of them share pieces, count by value: "
+     "{1}".format(cshow(THRU[0]), dshow(PAIR)))
+gate(THRU == [8] and sorted(PAIR) == [0, 1, 2, 4]
+     and [PAIR[k] for k in (0, 1, 2, 4)] == [15072, 1920, 960, 384]
+     and sum(PAIR.values()) == 192 * 191 // 2, "G20",
+     "those carriers meet each piece the same number of times and meet each other in "
+     "0, 1, 2 or 4 pieces, never 3")
+
+CLOSED = all(any(np.array_equal(FV[i] ^ FV[j], FV[k]) for k in range(8))
+             for i in range(8) for j in range(8))
+FLIPOK = all(np.array_equal(FV[i] ^ FV[1], FV[i ^ 1]) for i in range(8))
+emit("those eight readings close into an addition group of order {0}".format(8))
+gate(CLOSED and FLIPOK and len(set(tuple(int(x) for x in v) for v in FV)) == 8, "G21",
+     "each flip partner is its reading plus the all-marked reading, so a reading and "
+     "its flip partner have least sizes differing by at most eight")
+
+# ---- Part 4g: an anchored question decides the whole-system question ----
+SFIX = [[gi for gi in range(48) if np.array_equal(FV[t][PERMS[gi]], FV[t])]
+        for t in range(8)]
+
+
+def one_orbit(t):
+    """whether the symmetries fixing reading t carry any piece to any other"""
+    par = list(range(NP))
+
+    def rt(a):
+        while par[a] != a:
+            par[a] = par[par[a]]
+            a = par[a]
+        return a
+
+    for p in [CP[gi] for gi in SFIX[t]] + [b0, b1]:
+        for j in range(NP):
+            ra, rb = rt(j), rt(int(p[j]))
+            if ra != rb:
+                par[ra] = rb
+    return len(set(rt(j) for j in range(NP))) == 1
+
+
+TRANS = [one_orbit(t) for t in range(8)]
+SFN = sorted(set(len(s) for s in SFIX))
+emit("symmetries of the table that fix a basic reading: {0}, and they carry any "
+     "piece to any other: {1}".format(
+         SFN[0] if len(SFN) == 1 else SFN, all(TRANS)))
+gate(all(TRANS) and len(TRANS) == 8, "G22",
+     "the symmetries that fix a reading carry any piece to any other, so asking for "
+     "carriers through one fixed piece decides the question for every piece")
+
+
+# ---- Part 4f: the anchored search below eighteen ----
+def asweep(m, tids):
+    fresh()
+    del BLOWN[:]
+    ok = True
+    for cell in cells_of(m):
+        if cell[3] < 1:
+            continue
+        if not run_cell(cell, m, tids):
+            ok = False
+    out = {}
+    for t in tids:
+        out[t] = sorted(set(tuple(int(v) for v in r)
+                            for a in RES.get(t, []) for r in a))
+    met = dict((t, SEEN.get(t, 0)) for t in tids)
+    return ok, met, len(PROCD), out
+
+
+def recheck(got, t):
+    bad = 0
+    for c in got:
+        h = (INCL[:, list(c)].sum(axis=1) & 1).astype(np.uint8)
+        if not np.array_equal(h, FV[t]):
+            bad += 1
+    return bad
+
+
+RUN = {}
+for m in (2, 4, 6):
+    RUN[m] = asweep(m, [2, 3])
+for m in (8, 10):
+    RUN[m] = asweep(m, [1, 2, 3])
+for m in (12, 14, 16):
+    RUN[m] = asweep(m, [2, 3])
+SZS = (2, 4, 6, 8, 10, 12, 14, 16)
+FOUND = dict((m, dict((t, len(RUN[m][3][t])) for t in RUN[m][3])) for m in SZS)
+ALLOK = all(RUN[m][0] for m in SZS)
+BADR = sum(recheck(RUN[m][3][t], t) for m in SZS for t in RUN[m][3])
+emit("")
+emit("anchored search, carriers of four then of its flip partner, by size: " + ", ".join(
+    "{0}: {1} and {2}".format(m, cshow(FOUND[m][2]), cshow(FOUND[m][3])) for m in SZS))
+emit("at sixteen both were asked of the same {0} cells over the same {1} splits".format(
+    cshow(RUN[16][1][2]), cshow(RUN[16][2])))
+emit("carriers recorded below eighteen {0}, recheck failures {1}".format(
+    cshow(sum(FOUND[m][t] for m in SZS for t in FOUND[m])), BADR))
+gate(FOUND[8][1] == 8 and all(tuple(sorted(c)) in set(CLQ) for c in RUN[8][3][1])
+     and FOUND[10][1] == 0 and RUN[8][0] and RUN[10][0], "G23",
+     "the search finds the eight-piece carriers of the all-marked reading through the "
+     "anchor and none at ten, so it is not blind when it comes back empty")
+gate(ALLOK and [FOUND[m][2] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 11], "G24",
+     "four has no anchored carrier below sixteen and has eleven at sixteen, every "
+     "sweep complete")
+gate(ALLOK and [FOUND[m][3] for m in SZS] == [0, 0, 0, 0, 0, 0, 0, 0]
+     and RUN[16][1][2] == RUN[16][1][3] == 204 and RUN[16][2] == 2004, "G25",
+     "the flip partner of four has no anchored carrier at any even size up to sixteen, "
+     "asked of exactly the cells and splits that deliver the eleven")
+gate(BADR == 0, "G26",
+     "each recorded carrier is checked back against the incidence directly, not "
+     "trusted from the bookkeeping of the search")
+
+# ---- Part 4g: the symmetries of the table and the whole census ----
+
+
+def closure(gens, n):
+    """every product of the given symmetries of the table, as point maps"""
+    idg = tuple(range(n))
+    seen = set([idg])
+    front = [idg]
+    G = [np.arange(n, dtype=np.int64)]
+    while front:
+        nxt = []
+        for h in front:
+            ha = np.array(h, dtype=np.int64)
+            for p in gens:
+                c = tuple(int(v) for v in np.asarray(p, dtype=np.int64)[ha])
+                if c not in seen:
+                    seen.add(c)
+                    nxt.append(c)
+                    G.append(np.array(c, dtype=np.int64))
+        front = nxt
+    return G
+
+
+def orbits(fam, G):
+    """the families the symmetries of the table cut a list of sets into"""
+    done = set()
+    out = []
+    for c in fam:
+        if c in done:
+            continue
+        o = set()
+        st = [c]
+        while st:
+            y = st.pop()
+            if y in o:
+                continue
+            o.add(y)
+            for g in G:
+                z = frozenset(int(g[j]) for j in y)
+                if z not in o:
+                    st.append(z)
+        done |= o
+        out.append(o)
+    return out
+
+
+C16 = RUN[16][3][2]
+EG = closure(GENS, NP)
+SSET = set(frozenset(s) for s in STARS)
+PERMS = all(frozenset(int(g[j]) for j in s) in SSET for g in EG for s in STARS)
+BASE = [frozenset(int(v) for v in c) for c in C16]
+CEN = sorted(set(frozenset(int(g[j]) for j in c) for g in EG for c in BASE),
+             key=lambda s: sorted(s))
+INCC = {}
+for c in CEN:
+    for j in c:
+        INCC[j] = INCC.get(j, 0) + 1
+BADC = recheck([tuple(sorted(c)) for c in CEN], 2)
+emit("")
+emit("symmetries of the table {0}, sixteen-piece carriers of four across the system "
+     "{1}, each piece on {2}, recheck failures {3}".format(
+         cshow(len(EG)), cshow(len(CEN)), min(INCC.values()), BADC))
+gate(len(EG) == 384 and PERMS and EORB == [NP], "G27",
+     "they close into a group of {0} that is transitive on the pieces and permutes "
+     "the {1} eight-piece carriers".format(384, len(SSET)))
+gate(len(CEN) == 132 and BADC == 0 and len(INCC) == NP
+     and min(INCC.values()) == max(INCC.values()) == 11 == FOUND[16][2]
+     and len(CEN) * 16 == NP * 11, "G28",
+     "every piece sits on eleven of them, the count the anchored sweep found, so "
+     "these are all of them")
+
+FAMS = orbits(CEN, EG)
+FAM = sorted(len(o) for o in FAMS)
+FIX = {}
+for i, o in enumerate(FAMS):
+    for c in o:
+        FIX[c] = i
+FSZ = dict((i, len(o)) for i, o in enumerate(FAMS))
+emit("the families they fall into: {0}".format(vshow(FAM)))
+gate(FAM == [12, 12, 12, 24, 24, 48] and sum(FAM) == len(CEN)
+     and len(FIX) == len(CEN), "G29",
+     "the symmetries do not carry every smallest carrier of four onto every "
+     "other: six families")
+# ---- Part 4i: the shape is common, the sharing counts are what carry the charge ----
+from itertools import combinations as CMB
+
+FA = INCL.astype(np.float64)
+SHC = np.rint(FA.T @ FA).astype(np.int64)
+del FA
+np.fill_diagonal(SHC, 0)
+NSJ = (SHC == 0).astype(np.int64)
+np.fill_diagonal(NSJ, 0)
+AJN = [set(int(w) for w in np.nonzero(NSJ[v])[0]) for v in range(NPO)]
+IB = INCL.astype(np.int64)
+NCUT = INCL.shape[0]
+CSET = set(tuple(sorted(c)) for c in CEN)
+
+DF = [[bin(a ^ b).count("1") for b in range(16)] for a in range(16)]
+ORD = sorted([S for S in range(16) if bin(S).count("1") >= 2],
+             key=lambda S: bin(S).count("1"))
+
+
+def cubes_at(v0):
+    """every sixteen pieces joined exactly like the corners of a four-cube, through v0"""
+    out = {}
+    lab = {0: v0}
+
+    def place(k):
+        if k == len(ORD):
+            key = tuple(sorted(lab.values()))
+            if key not in out:
+                b2, b3, b4 = [], [], []
+                for S in range(16):
+                    for T in range(S + 1, 16):
+                        d = DF[S][T]
+                        if d == 2:
+                            b2.append(int(SHC[lab[S]][lab[T]]))
+                        elif d == 3:
+                            b3.append(int(SHC[lab[S]][lab[T]]))
+                        elif d == 4:
+                            b4.append(int(SHC[lab[S]][lab[T]]))
+                out[key] = (min(b2), max(b2), min(b3), max(b3),
+                            min(b4), max(b4))
+            return
+        S = ORD[k]
+        sub = [S ^ (1 << i) for i in range(4) if S >> i & 1]
+        cand = set.intersection(*[AJN[lab[s]] for s in sub])
+        held = set(lab.values())
+        for w in cand:
+            if w in held:
+                continue
+            good = True
+            for T in lab:
+                if (lab[T] in AJN[w]) != (DF[S][T] == 1):
+                    good = False
+                    break
+            if good:
+                lab[S] = w
+                place(k + 1)
+                del lab[S]
+
+    for c in CMB(sorted(AJN[v0]), 4):
+        if any(c[j] in AJN[c[i]] for i in range(4) for j in range(i + 1, 4)):
+            continue
+        for i in range(4):
+            lab[1 << i] = c[i]
+        place(0)
+        for i in range(4):
+            del lab[1 << i]
+    return out
+
+
+PER, GL = [], {}
+for v0 in range(NPO):
+    got = cubes_at(v0)
+    PER.append(len(got))
+    GL.update(got)
+
+# ---- Part 4j: the ranked total is a spread about a mean nothing can move ----
+SKEY = list(GL.keys())
+NSHP = len(SKEY)
+SIDX = np.array(SKEY, dtype=np.int64)
+KSZ = int(SIDX.shape[1])
+SPOS = dict((SKEY[jj], jj) for jj in range(NSHP))
+NPRF = 9
+HST = np.zeros((NPRF, NSHP), dtype=np.int64)
+MXM = np.zeros(NSHP, dtype=np.int64)
+TTS = np.zeros(NSHP, dtype=np.int64)
+FI32 = INCL.astype(np.float32)
+BSZ = 1500
+for BEG in range(0, NSHP, BSZ):
+    NB = min(BSZ, NSHP - BEG)
+    CIDX = SIDX[BEG:BEG + NB]
+    ZB = np.zeros((NPO, NB), dtype=np.float32)
+    ZB[CIDX.ravel(), np.repeat(np.arange(NB), KSZ)] = 1.0
+    MBK = FI32 @ ZB
+    for VAL in range(NPRF):
+        HST[VAL, BEG:BEG + NB] = (MBK == VAL).sum(axis=0)
+    MXM[BEG:BEG + NB] = MBK.max(axis=0).astype(np.int64)
+    TTS[BEG:BEG + NB] = SHC[CIDX[:, :, None], CIDX[:, None, :]].sum(axis=(1, 2)) // 2
+    del ZB, MBK
+del FI32
+
+VVEC = np.arange(NPRF, dtype=np.int64)
+A0, A1, A2, A3, A4 = HST[0], HST[1], HST[2], HST[3], HST[4]
+PSUM = HST.sum(axis=0)
+WSUM = (HST * VVEC[:, None]).sum(axis=0)
+DEVS = (HST * ((VVEC - 2) ** 2)[:, None]).sum(axis=0)
+ODDM = HST[1] + HST[3] + HST[5] + HST[7]
+TTH = (HST * (VVEC * (VVEC - 1) // 2)[:, None]).sum(axis=0)
+
+PCOL = IB.sum(axis=0)
+PPC = int(PCOL[0])
+PCOK = bool((PCOL == PPC).all())
+MEETS = KSZ * PPC
+S4W = int(np.count_nonzero(np.asarray(TGTv[2])))
+FLOOR = NCUT + S4W // 2
+FPROF = [0, S4W // 2, NCUT - S4W, S4W // 2, 0]
+FSUM = sum(FPROF)
+FWT = sum(jj * FPROF[jj] for jj in range(5))
+FDEV = sum((jj - 2) ** 2 * FPROF[jj] for jj in range(5))
+
+CARL = [np.array(sorted(zz), dtype=np.int64) for zz in CEN]
+CTOT = [int(SHC[np.ix_(zz, zz)].sum() // 2) for zz in CARL]
+CDEV = [int((((IB[:, zz].sum(axis=1)) - 2) ** 2).sum()) for zz in CARL]
+CARMIN = min(CTOT)
+CDOK = all(CDEV[jj] == 2 * (CTOT[jj] - NCUT) for jj in range(len(CEN)))
+DSET = sorted(set(CDEV))
+LOWJ = min(range(len(CEN)), key=lambda jj: CTOT[jj])
+LOWM = IB[:, CARL[LOWJ]].sum(axis=1)
+SPRF = np.bincount(LOWM, minlength=6)[:6].tolist()
+LOWT = CTOT[LOWJ]
+OVER = LOWT - FLOOR
+
+CSHP = [kk for kk in SKEY if kk in CSET]
+NCAR = len(CSHP)
+CSET2 = set(CSHP)
+PSOK = int(np.count_nonzero(PSUM != NCUT))
+WSOK = int(np.count_nonzero(WSUM != MEETS))
+IDOK = int(np.count_nonzero((2 * TTS) != (2 * NCUT + DEVS)))
+EVOK = int(np.count_nonzero((DEVS & 1) != 0))
+HWOK = int(np.count_nonzero(TTH != TTS))
+
+ORD2 = np.argsort(-A2, kind="stable")
+TOP2 = set(SKEY[int(jj)] for jj in ORD2[:NCAR])
+LOA2 = int(A2[ORD2[NCAR - 1]])
+NXT = int(A2[ORD2[NCAR]])
+AB36 = int(np.count_nonzero(A2 > LOA2))
+AE24 = int(np.count_nonzero(A2 == LOA2))
+
+ODDHI = int(np.count_nonzero(ODDM > S4W))
+ODDEQ = int(np.count_nonzero(ODDM == S4W))
+ODDST = set(SKEY[int(jj)] for jj in np.nonzero(ODDM == S4W)[0])
+MXTOP = int(MXM.max())
+NPAST = int(np.count_nonzero(MXM > 4))
+LINM = (2 * TTS) == (3 * (MEETS - ODDM) - 4 * A2)
+NLIN = int(np.count_nonzero(LINM))
+CAPM = MXM <= 4
+LINEQ = bool((LINM == CAPM).all())
+
+emit("the total is a spread about a mean of two that no choice of sixteen can move:")
+emit("each sixteen meets the cuttings {0} times, so departures from two are the cost".format(MEETS))
+gate(len(set(PER)) == 1 and PER[0] == 4978 and NSHP == 59736, "G31",
+     "shapes joined like a four-cube: {0} through each of the {1} pieces, {2} in all".format(PER[0], NPO, NSHP))
+gate(PSOK == 0 and WSOK == 0 and PCOK and PPC == 1975 and MEETS == 31600 and NCUT == 15800, "G32",
+     "each of the {0} shapes meets the {1} cuttings {2} times, two per cutting".format(NSHP, NCUT, MEETS))
+gate(IDOK == 0 and EVOK == 0 and HWOK == 0, "G33",
+     "the total is {0} plus half the squared spread about two, both routes agreeing".format(NCUT))
+gate(S4W == 5664 and FLOOR == 18632 and FSUM == NCUT and FWT == MEETS
+     and NCUT + FDEV // 2 == FLOOR and CARMIN >= FLOOR, "G34",
+     "carrying four needs {0} odd meetings, so all {1} carriers sit at {2} or above".format(S4W, len(CEN), FLOOR))
+gate(LOWT == 19640 and OVER == 1008 and SPRF == [252, 2832, 9632, 2832, 252, 0]
+     and int(LOWM.max()) == 4, "G35",
+     "lightest carrier {0}, {1} over the floor, spread {2}, none above four".format(LOWT, OVER, SPRF))
+gate(TOP2 == CSET2 and NCAR == 60 and LOA2 == 9616 and NXT < LOA2 and AB36 == 36 and AE24 == 24, "G36",
+     "ranked by cuttings met twice the top {0} are the carriers, least {1}, next {2}".format(NCAR, LOA2, NXT))
+gate(ODDHI == 57972 and ODDEQ == NCAR and ODDST == CSET2 and ODDHI + ODDEQ == 58032, "G37",
+     "ranked by odd meetings they sit {0}th to {1}th, {2} shapes above them".format(ODDHI + 1, ODDHI + ODDEQ, ODDHI))
+gate(MXTOP == 8 and NPAST == 42192, "G38",
+     "the largest multiplicity reached is {0} and {1} shapes pass four".format(MXTOP, NPAST))
+gate(NLIN == 17544 and LINEQ, "G39",
+     "the linear form in odd count and twice-met holds on {0}, exactly those capped at four".format(NLIN))
+gate(CDOK and len(DSET) == 4 and DSET[0] == 7680 and DSET[-1] == 16832, "G40",
+     "over all {0} carriers the squared spread runs {1} to {2} and takes {3} values".format(len(CEN), DSET[0], DSET[-1], len(DSET)))
+
+EL = time.time() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+ELB, RSB = upto(EL, 100), 2500
+emit("elapsed under {0} s peak memory under {1} MB".format(ELB, RSB))
+gate(EL < 900.0 and RSS < float(RSB), "G41", "inside its time and memory allowance")
+CH = OUT[0] + 120
+gate(CH < 6000, "G42", "its output stays under {0} characters".format(6000))
+emit("")
+print("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))


### PR DESCRIPTION
## What this responds to

The [cycle 752 package](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/6047)
ranked all 59736 four-cube-shaped sixteen-piece sets by a single number — for each of the
120 pairs of pieces, how many of the 15800 cuttings use both, summed — and reported that
the 60 sets carrying the charge called four come out lightest, above a derived floor of
18632. It reported the ranking as a measurement and gave no account of why ranking by that
number should track the charge at all.

This cycle was opened to attack that headline, not to decorate it. The suspicion was that
the ranking is a disguised count of the reading support: a carrier of four is odd on 5664
cuttings, and if the total carries a term of that size against a separating step of 538,
then the recipe "consults no mark" only in form. The measurement went the other way, and
in going the other way it produced the account the preceding cycle lacked.

## The ranked total is a spread about a mean the system fixes in advance

Each of the 192 pieces lies on 1975 of the 15800 cuttings, so **whichever** sixteen pieces
are taken — carrier or not, four-cube-shaped or not — they meet the cuttings 31600 times,
and 31600 is exactly twice 15800. The average number of the sixteen met per cutting is two,
and no choice of pieces can move it.

Writing `m` for the number met on a given cutting, the ranked total is the sum of
`m(m-1)/2`, and expanding about two gives

```
ranked total  =  15800  +  (1/2) x sum over cuttings of (m - 2)^2
```

for every sixteen-piece set whatsoever. This is an identity with no condition on how large
`m` may get. What the runner measures is the premise and the arithmetic, not the identity:
it checks on all 59736 shapes that the multiplicities sum to 15800 cuttings and weigh 31600,
and that the total computed from the multiplicity profile agrees with the total computed
from the shared-cutting matrix. Given the premise the identity is algebra, which is the
point of it. So the quantity cycle 752 ranked by is a variance: light means flat, and
the ranking is a measure of how far a set's meetings stray from an average the system
imposed before any set was chosen.

## The floor gains an attainment profile

Carrying a reading marked on `S` cuttings forces an odd number of meetings on each of them,
so the squared departure is at least one there, and

```
ranked total  >=  15800 + S/2
```

which for four is the 18632 cycle 752 derived. The identity says more than the bound:
equality holds **precisely** when the carrier meets each of the 5664 marked cuttings once or
three times and each of the other 10136 exactly twice, and the mean then forces the split
into 2832 met once and 2832 met three times. The floor is no longer just a number to sit
above; it names one profile. The lightest carrier found here misses that profile by exactly
252 cuttings it does not meet at all and 252 it meets four times, which is the whole of its
1008 excess.

## The attack, reported against interest

The hypothesis this cycle was built to test is refuted, and refuted in the direction
opposite to the one that would have hurt cycle 752.

| shapes ranked by cuttings met an odd number of times, largest first | position |
| --- | --- |
| the 60 carriers of four | 57973rd to 58032nd of 59736 |
| shapes strictly above them | 57972 |

Far from being extreme in reading support, the carriers are near the bottom of that ranking,
so the odd-count term works against their position rather than for it. What does separate
them is the count of cuttings met exactly twice — the cuttings sitting exactly on the mean:

| shapes ranked by cuttings met exactly twice, largest first | count |
| --- | --- |
| the 60 heaviest are exactly the 60 carriers | 60 of 60 |
| least carrier value | 9616 |
| next shape down the list | 8688 |

with no shape tying across that boundary — 36 shapes lie strictly above 9616 and 24 sit
exactly at it, all 60 of them carriers. That is a sharper statement than cycle 752's, and
it names what the ranking is sensitive to.

## Where the natural first identity does not hold

If no cutting is met more than four times, eliminating the thrice-met count between the two
sum rules gives a linear form in the odd count and the twice-met count alone. That form
holds on exactly 17544 of the 59736 shapes — and the runner gates that this set is
*identical* to the set of shapes no cutting meets more than four times, rather than merely
the same size. The condition is not idle: the largest multiplicity reached anywhere is 8,
and 42192 shapes pass four. The variance identity above is the one that holds unconditionally.

## Adversarial review carried into the artifact

**This cycle is the adversarial review of the preceding one, run as a probe before any
artifact was written.** The probe was specified to test my own anticipated deflation of
cycle 752's headline, with the anticipated numbers written into the spec so a disagreement
would be visible. The measurement disagreed. The note leads with that, in the section
"What does not pick them out is the reading", and states plainly that the refutation is a
refutation of one hypothesis about this ranking, not a demonstration that no count of
reading support could separate these shapes.

**The equal-support control this probe wanted is not available in this population.** No
non-carrier shape has the carriers' odd count, so the cleanest test — hold the reading
support fixed and ask whether the twice-met term still separates — could not be run here.
The note does not claim it was.

**The gates discriminate rather than restate.** The ranked total is computed on every shape
by two independent routes, one from the multiplicity profile and one from the shared-cutting
matrix, and gated to agree; the floor is built from the reading support and the cutting count
alone rather than pinned; the identity is tested in exact integer form; and the linear-form
gate checks set identity, not cardinality, so a coincidence of counts would fail it.

**What is derived and what is measured are separated in the note's own Boundary.** The
identity and the floor with its equality condition are derived and hold for every
sixteen-piece set in the system. Everything about the 59736 shapes is measured over that
population and is not claimed beyond it. In particular **18632 is still not shown to be
attained**, nothing here shows 19640 is forced, and nothing here derives 9616.

**The reading-blindness caveat from cycle 752 survives unchanged and is repeated.** Within
these 59736 shapes, carrying a reading and carrying four coincide, so what both rankings
demonstrably separate is sets that carry something from sets that carry nothing. Neither is
shown to tell four from a different reading.

## Runner

Rebuilds the cell complex, the cuttings, the readings and the block bookkeeping from
scratch and gates every quantity in place. Class-A: integer and two-element-field
arithmetic on a finite explicit object, no solver.

```
TOTAL: PASS=42 FAIL=0
```

Under 900 s, peak memory under 2500 MB, output under 6000 characters.

## Files

- `docs/PHYSICAL_CELL_CUTTING_SHARED_COUNT_VARIANCE_LAW_CYCLE753_NOTE_2026-08-09.md` — source note
- `scripts/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.py` — paired runner
- `logs/runner-cache/physical_cell_cutting_shared_count_variance_law_cycle753_2026_08_09.txt` — cache
- `outputs/..._cold_2026-08-09.txt`, `outputs/..._receipt_2026-08-09.json` — cold run and receipt

The manifest acknowledgement is a separate `audit-infra:` commit with no science content
and no ledger row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
