### PR TITLE
feat(emergent-geometry): cycle 756 blind space is the span of exact-cover differences

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_BLIND_SPACE_CARRIER_SPAN_CYCLE756_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_BLIND_SPACE_CARRIER_SPAN_CYCLE756_NOTE_2026-08-09.md
@@ -1,0 +1,216 @@
+# The space the cuttings cannot see is the span of the differences of their eight-piece exact covers — Cycle 756
+
+Date: 2026-08-09
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the least-volume pieces, the cuttings at the adjacency cost floor,
+the piece sharing table, the eight-piece carriers, the span of their
+differences and a complete sweep of the small supports a blind weighting could
+have, gating each quantity in place. Constitutional effect: none. This package
+changes no axiom, no framework Admissibility rule, no primitive, no policy,
+and no audit status, and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## What this answers
+
+The object is the unit four-cube on sixteen corners, cut into least-volume
+pieces at the adjacency cost floor. There are 15800 such cuttings. Between
+them they draw on 192 pieces, 24 pieces to a cutting, and each piece lies on
+1975 of the cuttings. Write the incidence table of that system: 15800 rows,
+one per cutting, 192 columns, one per piece, a one where the cutting uses the
+piece. Call a weighting of the 192 pieces blind when this table sends it to
+zero, so that every one of the 15800 cuttings, totalled piece by piece against
+the weighting, comes out zero.
+
+The preceding cycle measured the rank of the table as 88, so the blind space
+has dimension 104 and the two add back to 192, and then asked whether the
+group of 384 symmetries fixes 88 on its own. It does not: the seen and the
+blind space share same-type parts, so the trace counts of the group are too
+coarse to pick the blind space out. That cycle left the rank as a
+measurement and named the next place to look — the structure of the incidence
+map itself rather than the trace counts of the group.
+
+This cycle looks there, and finds the whole blind space sitting inside a
+family of objects the incidence table names by itself.
+
+## The result
+
+There are exactly 192 sets of eight pieces that no cutting uses twice. Each
+one of them meets every single one of the 15800 cuttings exactly once: each is
+an exact cover of the cutting system. Call them carriers. Two immediate
+consequences.
+
+**Every carrier difference is blind.** If two carriers both send every cutting
+to one, their difference sends every cutting to zero. So the differences of
+the 192 carriers all lie in the blind space, and nothing about symmetry is
+used to say so.
+
+**Those differences are the whole blind space, and this is exact.** The 192
+carriers, as weightings of the 192 pieces, span 105 dimensions. Their
+differences therefore span 104, one fewer, because no carrier lies in the span
+of the differences — a carrier sends every cutting to one, a difference sends
+every cutting to zero. And 104 is the dimension of the blind space. So the two
+coincide:
+
+> the space the cuttings cannot see is exactly the span of the differences of
+> the eight-piece exact covers of the cutting system, and the rank 88 is the
+> 192 coordinates less those 104.
+
+## The two-sided count that makes it exact
+
+The two numbers 105 and 88 are each measured in a bounded arithmetic, and a
+bounded rank is never larger than the exact rank. That inequality points the
+same way both times, which is what makes the argument close without any exact
+rational elimination at all:
+
+- the table has bounded rank 88, so its exact rank is at least 88, so the
+  blind space has dimension **at most** 104;
+- the carriers have bounded rank 105, so their exact rank is at least 105, so
+  their differences span **at least** 104 dimensions, all of them blind.
+
+At most 104 and at least 104 leaves exactly 104, and forces both bounded ranks
+to have been exact. Two different bounded arithmetics are run and agree on
+both numbers, which a wrong elimination would not give. Nothing here is a
+floating-point rank, a threshold on a small number, or a comparison against a
+value carried in from the preceding cycle: 88 and 104 are re-measured from the
+rebuilt object and then pinned by the inequality.
+
+## No one class of exchange is the source
+
+Two carriers share 0, 1, 2 or 4 pieces, never 3. Over all 18336 pairs the
+counts are 15072, 1920, 960 and 384. The difference of a pair sharing k pieces
+is supported on 16, 14, 12 and 8 pieces respectively, so the 384 pairs sharing
+4 pieces give the shortest differences — the least exchanges, four pieces
+traded for four.
+
+Each of the four sharing classes, taken alone, already spans all 104
+dimensions. So there is no privileged class of exchange generating the space
+and no residue left to the others: the least exchanges alone suffice, and so
+do the widest. This is the sharpest form of the previous cycle's negative
+result. That cycle measured a single orbit of least exchanges falling short of the
+whole blind space, and was careful to make no class-level claim. The
+class-level truth is that the class of least exchanges spans everything; what
+fell short was one orbit inside it.
+
+## The smallest blind support has exactly the size of a carrier
+
+Every cutting meets the support of a blind weighting in 0 or in at least 2
+pieces — a cutting meeting the support once could not cancel. That is a
+necessary condition and not a sufficient one, and necessity is the direction
+the sweep needs: a support failing it carries no blind weighting. So for a
+blind weighting supported on a set S, every piece p in S must have all 1975 of
+its cuttings met by the other members of S. That is a covering condition, and
+it can be pushed hard.
+
+**Sizes 2, 3 and 4 are impossible.** For each of the four kinds of piece, the
+1975 cuttings through a piece are not covered by any 2 other pieces, nor by
+any 3, and are covered by 4. Four is therefore the least number of partners a
+member of a blind support can have, so a blind support holds at least 5
+pieces.
+
+**Sizes 5, 6 and 7 are impossible, by a complete sweep.** The 48 proper cube
+symmetries carry the table to itself and leave four kinds of piece, 48 of each
+kind, so every support of any size is the same, up to symmetry, as one holding
+a fixed piece of one of those four kinds. Anchor on such a piece. Every valid
+support contains a least cover of that piece's 1975 cuttings, and at these
+sizes a least cover uses at most 6 other pieces, so enumerate all least
+covers up to that size and extend each by every way of filling out to the
+target size. That builds every candidate, without exception, and there are
+3306820 of them across the four anchors and the three sizes. A necessary
+count bound — the shares of a member with the rest must total at least 1975 —
+cuts them to 27824, and each survivor is then tested against the full
+condition at every one of its members. None passes.
+
+**And 8 is reached.** The 384 least exchanges are blind and are supported on
+exactly 8 pieces. So:
+
+> no blind weighting of the cutting table touches fewer than 8 pieces, and 8
+> is attained: the smallest blind support has exactly the size of a carrier.
+
+The two results fit together. The blind space is generated by differences of
+eight-piece exact covers, and 8 is the smallest support any blind weighting
+can have. The exact covers are not one convenient family of generators among
+many — they sit at the floor.
+
+## What the runner gates
+
+15 gates, `TOTAL: PASS=15 FAIL=0`, in under 900 s and under 2500 MB, with
+output under 6000 characters. What is checked, and how:
+
+- the cell complex, the pieces and the cuttings are rebuilt from scratch, and
+  the two independent counts of the incidences are gated against each other;
+- the 192 carriers are found as eight-piece sets no cutting uses twice, and
+  then separately gated to meet every one of the 15800 cuttings exactly once,
+  so the exact-cover property is measured and not assumed;
+- both ranks are measured twice, in two different bounded arithmetics, and
+  the gate requires the two to agree before the inequality argument is run;
+- the criterion used throughout is gated to discriminate: all 384 least
+  exchanges meet every cutting 0 or 2 times, while a carrier, which is not
+  blind, meets every cutting exactly once, and the same test applied to the
+  eight pieces of a carrier returns no;
+- each of the 48 proper cube symmetries is gated to carry the table to itself
+  by a piece relabelling paired with a cutting relabelling, which is what
+  licenses anchoring the sweep on four pieces instead of 192;
+- the sweep is gated on the count it built and the count that survived the
+  necessary bound, both non-zero, so a sweep that silently built nothing
+  cannot pass.
+
+## Boundary and honest read
+
+**Derived, and general.** That the difference of two exact covers is blind.
+That a bounded rank is a floor for the exact rank, and hence that a floor on
+the carrier rank and a floor on the table rank, pointing opposite ways, can
+pin both. That every cutting meets the support of a blind weighting in 0 or at
+least 2 pieces, so a support failing that carries no blind weighting — the
+converse is neither claimed nor used. That every valid support contains a least
+cover of any one of its members' cuttings, which is what makes the
+cores-and-extensions sweep complete rather than merely large.
+
+**Measured on this object, and not claimed beyond it.** The counts 15800,
+192, 24 and 1975; the 192 carriers; the sharing profile 15072, 1920, 960, 384
+over 18336 pairs; the ranks 105 and 88 and the blind dimension 104; the
+four-kind orbit structure of the 48; the covering number 4 at each kind; the
+3306820 candidates and the 27824 survivors; and the least blind support 8.
+
+**What the sweep does and does not settle.** It settles that no blind
+weighting has support smaller than 8. It does not settle which supports of
+size 8 carry blind weightings beyond the 384 least exchanges — that would
+need least covers of size 7, a sweep this runner does not attempt. So
+"the smallest blind support is 8" is established; "every blind weighting of
+support 8 is a least exchange" is not, and is not claimed here.
+
+**What is still a measurement.** The rank 88 is now identified with a
+structural quantity — the 192 coordinates less the span of the carrier
+differences — rather than left as a bare elimination result. That is a
+relocation of the question, not a derivation of the number: what remains open
+is why the exact covers span 105 and not some other dimension. This cycle
+moves the question from the rank of a 15800-by-192 table to the span of 192
+explicitly named eight-piece sets, which is a far smaller and far more
+structured object to reason about.
+
+## Next
+
+Three paths open. Ask whether every blind weighting of support 8 is a least
+exchange, which needs the size-7 least covers the present sweep stops short
+of, and which would say the least exchanges are the entire floor and not part
+of it. Ask why the 192 carriers span 105 and not more — 105 is one more than 104, so
+the carriers are as close to independent as an exact-cover family can be while
+all sending every cutting to one, and the count of coordinates they leave
+unspanned falls one short of the rank 88; that near-coincidence is worth a
+cycle on its own.
+And take the sharing profile 15072, 1920, 960, 384 as the next thing to
+derive: it is the multiplication table of the carrier family, and a derivation
+of it would carry the span with it.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15469,
- "node_count": 5440,
+ "edge_count": 15470,
+ "node_count": 5441,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13625,6 +13625,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_blind_space_carrier_span_cycle756_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.py
+runner_sha256: c0afeee388e2efe004e5a0ca490eab85ce398846a8dd77245614ce7bf0880c90
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 225.03
+status: ok
+----- stdout -----
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+eight pieces no cutting uses twice: 192, each meeting every cutting between 1 and 1 times
+PASS C1  each of the 192 carriers meets every one of the 15800 cuttings exactly once, so the table sends every carrier to the same all-ones column
+carrier pairs by shared pieces: 0:15072 1:1920 2:960 4:384
+PASS C2  the shared count of two carriers is 0, 1, 2 or 4, never 3, over all 18336 pairs, and the least sharing pair count is 384
+supports of the differences by shared pieces: 0:16 1:14 2:12 4:8
+PASS C3  a carrier difference is blind because both carriers give the same all-ones column, and the 384 least exchanges are the differences of support 8
+bounded arithmetic ranks: carriers 105 and 105, table 88 and 88
+PASS C4  two different bounded arithmetics agree, and a bounded rank never exceeds the exact rank, so the carriers span at least 105 and the table at least 88
+PASS C5  the table rank being at least 88 leaves the blind space at most 104, while the carriers spanning at least 105 puts at least 104 independent differences inside it, so both are exact: rank 88, blind space 104
+each sharing class alone spans: 0:104 1:104 2:104 4:104
+PASS C6  the differences at each single sharing class already span the whole blind space, so no one class of exchange is the source and the least ones suffice
+cuttings meet a blind support this often: 0 2 ; they meet a carrier this often: 1
+PASS C7  a blind weighting cannot have a cutting meeting its support just once, since that lone piece would then carry no weight, and the two readings separate: all 384 least exchanges meet every cutting 0 or 2 times while a carrier, which is not blind, meets every cutting exactly once
+PASS C8  each of the 48 proper cube symmetries carries the table to itself by a piece relabelling paired with a cutting relabelling, and they leave 4 kinds of piece, 48 of each, so a support of any size is the same up to symmetry as one holding a piece of one of those 4 kinds
+PASS C9  the test the sweep applies says yes on the 8 pieces a least exchange touches and no on the 8 pieces of a carrier, so it is a test that separates and not one that refuses every candidate
+least other pieces covering one piece's cuttings, by piece kind: 4 4 4 4
+PASS C10  the 1975 cuttings through a piece are not covered by 2 or by 3 other pieces but are covered by 4, so a blind support holding that piece holds at least 4 more and no support of size 2, 3 or 4 can be blind
+candidate supports of size 5, 6 and 7 built and tested: 3306820, of those passing the count bound: 27824
+PASS C11  every support of size 5, 6 or 7 was built from a least cover of its anchor piece and tested by the full condition, and none of them is blind
+PASS C12  so no blind weighting of the cutting table touches fewer than 8 pieces, and 8 is reached, by the least exchanges: the smallest blind support has exactly the size of a carrier
+
+elapsed under 900 s peak memory under 2500 MB
+PASS C13  inside its time and memory allowance
+PASS C14  its output stays under 6000 characters
+
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_cold_2026-08-09.txt
+++ b/outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_cold_2026-08-09.txt
@@ -1,0 +1,29 @@
+
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  every cutting uses the same number of pieces, every piece sits in the same number of cuttings, and the two counts of the incidences agree
+eight pieces no cutting uses twice: 192, each meeting every cutting between 1 and 1 times
+PASS C1  each of the 192 carriers meets every one of the 15800 cuttings exactly once, so the table sends every carrier to the same all-ones column
+carrier pairs by shared pieces: 0:15072 1:1920 2:960 4:384
+PASS C2  the shared count of two carriers is 0, 1, 2 or 4, never 3, over all 18336 pairs, and the least sharing pair count is 384
+supports of the differences by shared pieces: 0:16 1:14 2:12 4:8
+PASS C3  a carrier difference is blind because both carriers give the same all-ones column, and the 384 least exchanges are the differences of support 8
+bounded arithmetic ranks: carriers 105 and 105, table 88 and 88
+PASS C4  two different bounded arithmetics agree, and a bounded rank never exceeds the exact rank, so the carriers span at least 105 and the table at least 88
+PASS C5  the table rank being at least 88 leaves the blind space at most 104, while the carriers spanning at least 105 puts at least 104 independent differences inside it, so both are exact: rank 88, blind space 104
+each sharing class alone spans: 0:104 1:104 2:104 4:104
+PASS C6  the differences at each single sharing class already span the whole blind space, so no one class of exchange is the source and the least ones suffice
+cuttings meet a blind support this often: 0 2 ; they meet a carrier this often: 1
+PASS C7  a blind weighting cannot have a cutting meeting its support just once, since that lone piece would then carry no weight, and the two readings separate: all 384 least exchanges meet every cutting 0 or 2 times while a carrier, which is not blind, meets every cutting exactly once
+PASS C8  each of the 48 proper cube symmetries carries the table to itself by a piece relabelling paired with a cutting relabelling, and they leave 4 kinds of piece, 48 of each, so a support of any size is the same up to symmetry as one holding a piece of one of those 4 kinds
+PASS C9  the test the sweep applies says yes on the 8 pieces a least exchange touches and no on the 8 pieces of a carrier, so it is a test that separates and not one that refuses every candidate
+least other pieces covering one piece's cuttings, by piece kind: 4 4 4 4
+PASS C10  the 1975 cuttings through a piece are not covered by 2 or by 3 other pieces but are covered by 4, so a blind support holding that piece holds at least 4 more and no support of size 2, 3 or 4 can be blind
+candidate supports of size 5, 6 and 7 built and tested: 3306820, of those passing the count bound: 27824
+PASS C11  every support of size 5, 6 or 7 was built from a least cover of its anchor piece and tested by the full condition, and none of them is blind
+PASS C12  so no blind weighting of the cutting table touches fewer than 8 pieces, and 8 is reached, by the least exchanges: the smallest blind support has exactly the size of a carrier
+
+elapsed under 900 s peak memory under 2500 MB
+PASS C13  inside its time and memory allowance
+PASS C14  its output stays under 6000 characters
+
+TOTAL: PASS=15 FAIL=0

--- a/outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_receipt_2026-08-09.json
+++ b/outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_receipt_2026-08-09.json
@@ -1,0 +1,58 @@
+{
+ "cycle": 756,
+ "failures": 0,
+ "gates": 15,
+ "headline": "The 15800 least-volume cuttings of the unit four-cube at the adjacency cost floor draw on 192 pieces, 24 pieces to a cutting, each piece lying on 1975 cuttings. Exactly 192 sets of eight pieces are used at most once by any cutting, and each of those meets every one of the 15800 cuttings exactly once, so each is an exact cover of the cutting system. The difference of two exact covers is therefore blind: the incidence table sends it to zero. This cycle measures that the 192 exact covers span 105 dimensions while the incidence table has rank 88, and turns the two bounded-arithmetic ranks into a two-sided argument, since a bounded rank never exceeds the exact rank. Rank at least 88 caps the blind space at 104; span at least 105 puts at least 104 independent differences inside it. Both are therefore exact, and the space the cuttings cannot see is precisely the span of the differences of the eight-piece exact covers, with the rank 88 equal to the 192 coordinates less those 104. Two exact covers share 0, 1, 2 or 4 pieces, never 3, with counts 15072, 1920, 960 and 384 over 18336 pairs, and each of the four sharing classes taken alone already spans all 104 dimensions, so no one class of exchange is the source. The cycle also settles the floor. A blind weighting must meet every cutting in 0 or in at least 2 of its pieces; the 1975 cuttings through a piece need at least 4 other pieces to cover them, at each of the four kinds of piece; and a complete cores-and-extensions sweep anchored at all four kinds builds 3306820 candidate supports of sizes 5, 6 and 7, of which 27824 pass a necessary count bound and none is blind. So no blind weighting of the cutting table touches fewer than 8 pieces, and 8 is attained by the 384 least exchanges: the smallest blind support has exactly the size of an exact cover. Not settled: whether every blind weighting of support 8 is a least exchange, which needs the size-7 least covers this sweep stops short of. The rank 88 is relocated rather than derived; what remains open is why the exact covers span 105.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_BLIND_SPACE_CARRIER_SPAN_CYCLE756_NOTE_2026-08-09.md",
+ "recorded_output": "outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_cold_2026-08-09.txt",
+ "results": {
+  "not_swept": {
+   "whether_every_blind_weighting_of_support_eight_is_a_least_exchange": "open",
+   "why_the_exact_covers_span_105_and_not_more": "open"
+  },
+  "the_criterion_and_its_discriminating_check": {
+   "a_carrier_meets_every_cutting_this_often": 1,
+   "a_carrier_passes_the_test_the_sweep_applies": false,
+   "a_least_exchange_passes_the_test_the_sweep_applies": true,
+   "cuttings_meet_a_least_exchange_support_this_often": [0, 2]
+  },
+  "the_exact_covers": {
+   "eight_piece_sets_no_cutting_uses_twice": 192,
+   "each_meets_every_cutting_exactly_once": true,
+   "pairs_of_them": 18336,
+   "shared_pieces_by_count": {"0": 15072, "1": 1920, "2": 960, "4": 384},
+   "shared_piece_counts_never_include": 3,
+   "support_of_a_difference_by_shared_pieces": {"0": 16, "1": 14, "2": 12, "4": 8}
+  },
+  "the_object": {
+   "cuttings": 15800,
+   "cuttings_through_a_piece": 1975,
+   "pieces": 192,
+   "pieces_to_a_cutting": 24
+  },
+  "the_smallest_blind_support": {
+   "candidate_supports_of_sizes_five_six_and_seven_built": 3306820,
+   "candidates_passing_the_necessary_count_bound": 27824,
+   "candidates_that_are_blind": 0,
+   "least_other_pieces_covering_one_piece_cuttings_by_kind": [4, 4, 4, 4],
+   "orbit_sizes_of_the_48_proper_cube_symmetries_on_the_pieces": [48, 48, 48, 48],
+   "sizes_two_three_and_four_are_impossible": true,
+   "smallest_support_a_blind_weighting_can_have": 8,
+   "the_48_carry_the_table_to_itself": true,
+   "the_size_is_attained_by_the_least_exchanges": 384
+  },
+  "the_span_of_the_differences": {
+   "bounded_rank_of_the_exact_covers_first_arithmetic": 105,
+   "bounded_rank_of_the_exact_covers_second_arithmetic": 105,
+   "bounded_rank_of_the_incidence_table_first_arithmetic": 88,
+   "bounded_rank_of_the_incidence_table_second_arithmetic": 88,
+   "dimension_of_what_no_cutting_sees": 104,
+   "each_sharing_class_alone_spans": {"0": 104, "1": 104, "2": 104, "4": 104},
+   "the_blind_space_is_the_span_of_the_differences": true,
+   "the_two_add_to": 192
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.py
+++ b/scripts/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.py
@@ -1,0 +1,543 @@
+"""Rebuild the cutting system of the unit four-cube and ask where the space the
+cuttings cannot see comes from.
+
+Every count below is measured here. The runner builds the cell complex, the least
+volume pieces, the cuttings at the adjacency cost floor, the piece sharing table,
+the eight-piece carriers that meet every cutting exactly once, the span of their
+differences, the sharing classes of carrier pairs, and a complete sweep of the
+small supports a blind weighting could have, gating each quantity in place.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.time()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+
+
+# ------------------------------------------------- Part 2: the object and its carriers
+
+INT = INCL.astype(np.int32)
+GR = (INT.T @ INT).astype(np.int64)
+RW = INC.sum(axis=1).astype(np.int64)
+CS = INC.sum(axis=0).astype(np.int64)
+emit("")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, "
+     "{3} cuttings through a piece".format(NS, NPO, int(RW[0]), int(CS[0])))
+gate(NS == 15800 and NPO == 192 and int(RW.min()) == int(RW.max()) == 24
+     and int(CS.min()) == int(CS.max()) == 1975 and int(RW.sum()) == int(CS.sum()),
+     "C0", "every cutting uses the same number of pieces, every piece sits in the "
+     "same number of cuttings, and the two counts of the incidences agree")
+
+NSH = (GR == 0)
+np.fill_diagonal(NSH, False)
+ADJ = [0] * NPO
+for a in range(NPO):
+    m = 0
+    for b in np.flatnonzero(NSH[a]):
+        m |= 1 << int(b)
+    ADJ[a] = m
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    c = cand
+    while c:
+        low = c & -c
+        v = low.bit_length() - 1
+        c ^= low
+        extend(cur + [v], c & ADJ[v])
+
+
+extend([], (1 << NPO) - 1)
+NC = len(CLQ)
+W = np.zeros((NC, NPO), dtype=np.int64)
+for i, s in enumerate(CLQ):
+    for p in s:
+        W[i, int(p)] = 1
+COV = INCL @ W.T
+emit("eight pieces no cutting uses twice: {0}, each meeting every cutting "
+     "between {1} and {2} times".format(NC, int(COV.min()), int(COV.max())))
+gate(NC == 192 and int(COV.min()) == 1 and int(COV.max()) == 1, "C1",
+     "each of the 192 carriers meets every one of the 15800 cuttings exactly once, "
+     "so the table sends every carrier to the same all-ones column")
+
+SH = (W @ W.T).astype(np.int64)
+np.fill_diagonal(SH, -1)
+HIS = {}
+for v in (0, 1, 2, 4):
+    HIS[v] = int((SH == v).sum()) // 2
+TOTP = NC * (NC - 1) // 2
+emit("carrier pairs by shared pieces: " + " ".join(
+    "{0}:{1}".format(v, HIS[v]) for v in (0, 1, 2, 4)))
+gate(sum(HIS.values()) == TOTP and TOTP == 18336 and HIS[4] == 384, "C2",
+     "the shared count of two carriers is 0, 1, 2 or 4, never 3, over all "
+     "18336 pairs, and the least sharing pair count is 384")
+
+PR4 = [(i, j) for i in range(NC) for j in range(i + 1, NC) if int(SH[i, j]) == 4]
+D4 = W[[i for i, j in PR4]] - W[[j for i, j in PR4]]
+Z4 = INCL @ D4.T
+SUPP = {}
+for v in (0, 1, 2, 4):
+    SUPP[v] = 16 - 2 * v
+emit("supports of the differences by shared pieces: " + " ".join(
+    "{0}:{1}".format(v, SUPP[v]) for v in (0, 1, 2, 4)))
+gate(len(PR4) == 384 and int(np.abs(Z4).max()) == 0
+     and int(np.abs(D4).sum(axis=1).min()) == 8
+     and int(np.abs(D4).sum(axis=1).max()) == 8, "C3",
+     "a carrier difference is blind because both carriers give the same all-ones "
+     "column, and the 384 least exchanges are the differences of support 8")
+
+
+def rank_mod(M, p, cap=None):
+    A = np.mod(M.astype(np.int64), p)
+    A = A[A.any(axis=1)]
+    piv = []
+    PRW = np.zeros((0, A.shape[1]), dtype=np.int64)
+    i0 = 0
+    while i0 < A.shape[0]:
+        blk = A[i0:i0 + 256].copy()
+        i0 += 256
+        if piv:
+            blk = np.mod(blk - blk[:, piv].dot(PRW), p)
+        for i in range(blk.shape[0]):
+            row = blk[i]
+            nz = np.flatnonzero(row)
+            if nz.size == 0:
+                continue
+            c = int(nz[0])
+            row = np.mod(row * pow(int(row[c]), p - 2, p), p)
+            if i + 1 < blk.shape[0]:
+                blk[i + 1:] = np.mod(
+                    blk[i + 1:] - blk[i + 1:, c:c + 1] * row[None, :], p)
+            if piv:
+                PRW = np.mod(PRW - PRW[:, c:c + 1] * row[None, :], p)
+            piv.append(c)
+            PRW = np.vstack([PRW, row[None, :]])
+            if cap is not None and len(piv) == cap:
+                return len(piv)
+    return len(piv)
+
+
+BIGP = 33554393
+SMLP = 1000003
+RW1 = rank_mod(W, BIGP)
+RW2 = rank_mod(W, SMLP)
+RI1 = rank_mod(INCL, BIGP)
+RI2 = rank_mod(INCL, SMLP)
+emit("bounded arithmetic ranks: carriers {0} and {1}, table {2} and {3}".format(
+    RW1, RW2, RI1, RI2))
+gate(RW1 == RW2 == 105 and RI1 == RI2 == 88, "C4",
+     "two different bounded arithmetics agree, and a bounded rank never exceeds "
+     "the exact rank, so the carriers span at least 105 and the table at least 88")
+gate(RW1 == 105 and RI1 == 88 and 192 - RI1 == 104, "C5",
+     "the table rank being at least 88 leaves the blind space at most 104, while "
+     "the carriers spanning at least 105 puts at least 104 independent differences "
+     "inside it, so both are exact: rank 88, blind space 104")
+
+DALL = []
+for v in (0, 1, 2, 4):
+    idx = [(i, j) for i in range(NC) for j in range(i + 1, NC) if int(SH[i, j]) == v]
+    Dv = W[[i for i, j in idx]] - W[[j for i, j in idx]]
+    rv = rank_mod(Dv, BIGP)
+    DALL.append((v, len(idx), rv))
+emit("each sharing class alone spans: " + " ".join(
+    "{0}:{1}".format(v, r) for v, n, r in DALL))
+gate(all(r == 104 for v, n, r in DALL), "C6",
+     "the differences at each single sharing class already span the whole blind "
+     "space, so no one class of exchange is the source and the least ones suffice")
+
+
+# ------------------------------------------- Part 3: how small a blind support can be
+
+MASK = [0] * NPO
+for p in range(NPO):
+    m = 0
+    for c in np.flatnonzero(INC[:, p]):
+        m |= 1 << int(c)
+    MASK[p] = m
+AB4 = np.abs(D4)
+MEETS = INCL @ AB4.T
+MEET = sorted(set(int(x) for x in np.unique(MEETS)))
+CARR = sorted(set(int(x) for x in np.unique(COV)))
+emit("cuttings meet a blind support this often: " + " ".join(str(x) for x in MEET)
+     + " ; they meet a carrier this often: " + " ".join(str(x) for x in CARR))
+gate(MEET == [0, 2] and CARR == [1], "C7",
+     "a blind weighting cannot have a cutting meeting its support just once, since "
+     "that lone piece would then carry no weight, and the two readings separate: "
+     "all 384 least exchanges meet every cutting 0 or 2 times while a carrier, "
+     "which is not blind, meets every cutting exactly once")
+
+ANCH = []
+for j in range(NORB):
+    ANCH.append(int(np.flatnonzero(lab == j)[0]))
+gate(CPOK and NORB == 4 and sorted(OSZ) == [48, 48, 48, 48] and len(ANCH) == 4,
+     "C8", "each of the 48 proper cube symmetries carries the table to itself by a "
+     "piece relabelling paired with a cutting relabelling, and they leave 4 kinds "
+     "of piece, 48 of each, so a support of any size is the same up to symmetry as "
+     "one holding a piece of one of those 4 kinds")
+
+
+def shut(s):
+    """true when every cutting through a member of s meets a second member"""
+    for p in s:
+        u = 0
+        for q in s:
+            if q != p:
+                u |= MASK[q]
+        if MASK[p] & ~u:
+            return False
+    return True
+
+
+S8 = tuple(int(x) for x in np.flatnonzero(AB4[0]))
+SC = tuple(int(x) for x in CLQ[0])
+gate(len(S8) == 8 and len(SC) == 8 and shut(S8) and not shut(SC), "C9",
+     "the test the sweep applies says yes on the 8 pieces a least exchange touches "
+     "and no on the 8 pieces of a carrier, so it is a test that separates and not "
+     "one that refuses every candidate")
+
+
+def sweep(anchor, top):
+    """all minimal covers of one piece's cuttings up to size top, then every
+    support up to size top + 1 built on them, tested by the full condition"""
+    uni = [int(c) for c in np.flatnonzero(INC[:, anchor])]
+    pos = dict((c, i) for i, c in enumerate(uni))
+    nu = len(uni)
+    sets = [0] * NPO
+    for q in range(NPO):
+        if q == anchor:
+            continue
+        b = 0
+        for c in np.flatnonzero(INC[:, q]):
+            i = pos.get(int(c))
+            if i is not None:
+                b |= 1 << i
+        sets[q] = b
+    full = (1 << nu) - 1
+    mx = max(bin(s).count("1") for s in sets)
+    by = [[] for _ in range(nu)]
+    for q in range(NPO):
+        x = sets[q]
+        while x:
+            low = x & -x
+            by[low.bit_length() - 1].append(q)
+            x ^= low
+    cores = set()
+
+    def rec(cov, chosen):
+        if cov == full:
+            cores.add(tuple(sorted(chosen)))
+            return
+        slots = top - len(chosen)
+        if slots == 0:
+            return
+        rem = full & ~cov
+        if mx * slots < bin(rem).count("1"):
+            return
+        e = (rem & -rem).bit_length() - 1
+        for q in by[e]:
+            if q in chosen:
+                continue
+            rec(cov | sets[q], chosen + [q])
+
+    rec(0, [])
+    bysz = {}
+    for c in cores:
+        bysz.setdefault(len(c), []).append(c)
+    oth = [q for q in range(NPO) if q != anchor]
+    tried = 0
+    passed = 0
+    hits = 0
+    for k in range(5, top + 2):
+        seen = set()
+        for sz in sorted(bysz):
+            extra = k - 1 - sz
+            if extra < 0:
+                continue
+            for cc in bysz[sz]:
+                rest = [q for q in oth if q not in cc]
+                for add in itertools.combinations(rest, extra):
+                    t = tuple(sorted(cc + add))
+                    if t in seen:
+                        continue
+                    seen.add(t)
+                    tried += 1
+                    s = (anchor,) + t
+                    bad = False
+                    for p in s:
+                        tot = 0
+                        for q in s:
+                            if q != p:
+                                tot += int(GR[p, q])
+                        if tot < 1975:
+                            bad = True
+                            break
+                    if bad:
+                        continue
+                    passed += 1
+                    good = True
+                    for p in s:
+                        u = 0
+                        for q in s:
+                            if q != p:
+                                u |= MASK[q]
+                        if MASK[p] & ~u:
+                            good = False
+                            break
+                    if good:
+                        hits += 1
+        seen = None
+    return min(bysz), sorted(bysz), tried, passed, hits
+
+
+LEAST = []
+TRIED = 0
+PASSED = 0
+HITS = 0
+SIZES = None
+for a in ANCH:
+    lo, szs, tr, pa, hi = sweep(a, 6)
+    LEAST.append(lo)
+    if a == ANCH[0]:
+        SIZES = szs
+    TRIED += tr
+    PASSED += pa
+    HITS += hi
+emit("least other pieces covering one piece's cuttings, by piece kind: " + " ".join(
+    str(x) for x in LEAST))
+gate(LEAST == [4, 4, 4, 4], "C10",
+     "the 1975 cuttings through a piece are not covered by 2 or by 3 other pieces "
+     "but are covered by 4, so a blind support holding that piece holds at least "
+     "4 more and no support of size 2, 3 or 4 can be blind")
+emit("candidate supports of size 5, 6 and 7 built and tested: {0}, of those "
+     "passing the count bound: {1}".format(TRIED, PASSED))
+gate(HITS == 0 and TRIED > 0 and PASSED > 0, "C11",
+     "every support of size 5, 6 or 7 was built from a least cover of its anchor "
+     "piece and tested by the full condition, and none of them is blind")
+gate(LEAST == [4, 4, 4, 4] and HITS == 0 and int(np.abs(D4).sum(axis=1).max()) == 8,
+     "C12", "so no blind weighting of the cutting table touches fewer than 8 "
+     "pieces, and 8 is reached, by the least exchanges: the smallest blind "
+     "support has exactly the size of a carrier")
+
+ELAP = time.time() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+emit("")
+emit("elapsed under 900 s peak memory under 2500 MB")
+gate(ELAP < 900.0 and RSS < 2500.0, "C13", "inside its time and memory allowance")
+gate(OUT[0] < 6000, "C14", "its output stays under 6000 characters")
+emit("")
+emit("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))


### PR DESCRIPTION
## What this responds to

Cycle 755 measured the rank of the cutting-system incidence table as 88 and did
not derive it, then showed that the group of 384 symmetries does not pick that
rank out on its own: the seen space and the space the cuttings cannot see share
same-type parts, so the group's trace counts are too coarse. That cycle named
three next places to look, and the third was to find 88 in the structure of the
incidence map itself rather than in the trace counts of the group.

This cycle looks there, and finds the whole blind space sitting inside a family
of objects the incidence table names by itself.

## The result

The unit four-cube on sixteen corners, cut into least-volume pieces at the
adjacency cost floor, has 15800 cuttings drawing on 192 pieces, 24 pieces to a
cutting, each piece on 1975 cuttings. Exactly 192 sets of eight pieces are used
at most once by any cutting, and each of those meets every one of the 15800
cuttings exactly once. Each is an exact cover of the cutting system.

**Every difference of two exact covers is blind**, with no symmetry argument
used: both send every cutting to one, so the difference sends every cutting to
zero.

**Those differences are the whole blind space, and this is exact.** The
argument is two-sided and uses only bounded-arithmetic ranks, each of which is
a floor for the exact rank:

- the incidence table has bounded rank 88, so its exact rank is at least 88, so
  the blind space has dimension at most 104;
- the 192 exact covers have bounded rank 105, so their exact rank is at least
  105, so their differences span at least 104 dimensions, all of them blind.

At most 104 and at least 104 leaves exactly 104, and forces both bounded ranks
to have been exact. Two different bounded arithmetics are run and agree on both
numbers. So the space the cuttings cannot see is precisely the span of the
differences of the eight-piece exact covers, and the rank 88 is the 192
coordinates less those 104. No floating-point rank, no threshold, and no value
carried in from the preceding cycle.

**No one class of exchange is the source.** Two exact covers share 0, 1, 2 or 4
pieces, never 3, with counts 15072, 1920, 960 and 384 over 18336 pairs, and the
differences have supports 16, 14, 12 and 8. Each of the four sharing classes,
taken alone, already spans all 104 dimensions. This sharpens cycle 755's
negative result at the class level: that cycle measured one orbit of least
exchanges falling short of the whole blind space and was careful to make no
class-level claim; the class-level truth is that the class spans everything and
what fell short was one orbit inside it.

**The smallest blind support has exactly the size of an exact cover.** Every
cutting meets the support of a blind weighting in 0 or in at least 2 pieces.
That is necessary and not sufficient, and necessity is the direction used here:
a support failing it carries no blind weighting. So each member of a blind
support must have all 1975 of its cuttings met by the others. For each of the four kinds of piece, those 1975
cuttings are not covered by any 2 other pieces nor by any 3, and are covered by
4, which kills sizes 2, 3 and 4. Sizes 5, 6 and 7 are killed by a complete
sweep: the 48 proper cube symmetries carry the table to itself and leave four
kinds of piece, 48 of each, so anchoring on one piece of each kind is without
loss; every valid support contains a least cover of its anchor's cuttings, so
enumerating all least covers and extending each to the target size builds every
candidate. That is 3306820 candidates, of which 27824 pass a necessary count
bound, and none is blind. And 8 is reached, by the 384 least exchanges. So no
blind weighting of the cutting table touches fewer than 8 pieces.

The two results fit together: the blind space is generated by differences of
eight-piece exact covers, and 8 is the smallest support any blind weighting can
have, so the exact covers sit at the floor rather than being one convenient
family of generators among many.

## Runner

`TOTAL: PASS=15 FAIL=0`, 3278 characters of output, 221 s, 341 MB peak. Fifteen
gates, contiguous, each measuring in place. What the gates defend:

- the cell complex, pieces and cuttings are rebuilt from scratch and the two
  independent counts of the incidences are gated against each other;
- the exact covers are found as eight-piece sets no cutting uses twice, then
  separately gated to meet every cutting exactly once, so the exact-cover
  property is measured rather than assumed;
- both ranks are measured twice, in two different bounded arithmetics, and the
  gate requires the two to agree before the inequality argument runs;
- the covering test used by the sweep is gated to discriminate, on both sides:
  it returns yes on the eight pieces a least exchange touches and no on the
  eight pieces of an exact cover, so its three zeros are not vacuous;
- each of the 48 proper cube symmetries is gated to carry the table to itself
  by a piece relabelling paired with a cutting relabelling, which is what
  licenses anchoring the sweep on four pieces instead of 192;
- the sweep is gated on both the count it built and the count that survived the
  necessary bound, both non-zero, so a sweep that silently built nothing cannot
  pass.

## Boundary

The rank 88 is relocated, not derived: it is now identified with a structural
quantity, the 192 coordinates less the span of the exact-cover differences,
rather than left as a bare elimination result. What remains open is why the
exact covers span 105. The sweep settles that no blind weighting has support
smaller than 8; it does not settle which supports of size 8 carry blind
weightings beyond the 384 least exchanges, which would need least covers of
size 7, and the note declines to claim it.

## Files

- `docs/PHYSICAL_CELL_CUTTING_BLIND_SPACE_CARRIER_SPAN_CYCLE756_NOTE_2026-08-09.md`
- `scripts/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.py`
- `logs/runner-cache/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09.txt`
- `outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_cold_2026-08-09.txt`
- `outputs/physical_cell_cutting_blind_space_carrier_span_cycle756_2026_08_09_receipt_2026-08-09.json`

plus a separate `audit-infra:` commit adding the new note to the citation-graph
manifest.

## Downstream order

This is a follow-on to the cycle 755 package and should land after it. Its only
citation edge is to the minimal axioms; every other prior artifact is referred
to in prose without a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
