### PR TITLE
feat(cell-cutting): add bounded exact-cover sharing identities

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_SHARING_TABLE_NOT_COHERENT_CYCLE757_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_SHARING_TABLE_NOT_COHERENT_CYCLE757_NOTE_2026-08-09.md
@@ -1,0 +1,225 @@
+# The sharing table of the eight-piece exact covers is regular, and its products do not stay inside its span — Cycle 757
+
+Date: 2026-08-09
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the least-volume pieces, the cuttings at the adjacency cost floor,
+the eight-piece exact covers, the table of how many pieces two covers share,
+the products of the classes of that table, the refinement of those classes
+with the fewest parts that carries its own products, and the exact ranks of
+the differences of the covers, gating each quantity in place. Two of the
+gates are controls whose job is to show the closure test is not vacuous on
+either side. Constitutional effect: none. This package changes no axiom, no
+framework Admissibility rule, no primitive, no policy, and no audit status,
+and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## What this answers
+
+The object is the unit four-cube on sixteen corners, cut into least-volume
+pieces at the adjacency cost floor. There are 15800 such cuttings; between
+them they draw on 192 pieces, 24 pieces to a cutting, and each piece lies on
+1975 of the cuttings. Exactly 192 sets of eight pieces are used at most once
+by any cutting, and each of those meets every one of the 15800 cuttings
+exactly once, so each is an exact cover of the cutting system. The preceding
+cycle showed that the differences of those 192 exact covers are precisely the
+space the cutting table cannot see, and then asked for the profile of how many
+pieces two of them share to be derived rather than measured, on the reading
+that the profile is the cover family's multiplication table and would carry
+the space with it.
+
+This cycle goes to that table. It reports two things the table gives up for
+free and one thing it refuses to be.
+
+## Eight is forced, and eight is the largest size at which it can happen
+
+The runner gates the three inputs — 15800 cuttings, 1975 cuttings through each
+piece, and the 192 sets of eight pieces no cutting uses twice. The counting
+step below is done here in the note from those gated inputs; the runner does
+not perform it, since its search is over sets of eight only.
+
+Call a set of pieces *free* when no cutting uses two of them. Each piece of a
+free set lies on 1975 cuttings, and freeness says that for two pieces of the
+set those two collections of cuttings are disjoint. So a free set of size k
+occupies 1975 times k distinct cuttings out of the 15800 available, which
+forces 1975 times k to be at most 15800. Since 15800 is 8 times 1975 exactly,
+a free set has at most 8 pieces.
+
+At exactly 8 the inequality is tight. The eight disjoint collections of 1975
+cuttings then account for all 15800 cuttings with nothing left over, so every
+cutting is met, and disjointness says it is met exactly once. **A free set of
+eight pieces is therefore an exact cover automatically, and eight is the
+largest size at which a free set can exist at all.** The exact-cover property
+the preceding cycle measured is not a coincidence of this geometry; it is
+forced by 15800 being 8 times 1975.
+
+The same reasoning fixes the other side of the table. Fix a cutting; it uses
+24 pieces, and each of the 192 covers contains exactly one of them, so sending
+a cover to its unique piece on that cutting is a well-defined map from the 192
+covers onto those 24 pieces. A cover through a given piece meets the cutting
+at that piece and nowhere else, so the covers landing on a given piece are
+exactly the covers containing it. The 192 covers therefore split into 24
+equal parts, and each piece lies in 8 covers. **The cover-by-piece table being
+8-regular on the piece side is forced too, not a second coincidence.** The
+runner measures both row sums and column sums to be 8 and finds them so.
+
+## The table is as regular as it could be
+
+Two exact covers share 0, 1, 2 or 4 pieces and never 3. The counts are 157,
+20, 10 and 4, and they are **the same for every one of the 192 covers**, not
+merely the same on average: standing on any cover, the view of the rest of the
+family is identical. The runner checks all 192 rows rather than reading one
+off.
+
+The piece side of the same table is regular too and is a different shape: two
+pieces share 0, 1, 2, 3 or 4 covers with counts 158, 18, 10, 2 and 3, the same
+for every piece. The value 3, missing between covers, is present between
+pieces.
+
+That difference does more than break an aesthetic parallel. The cover-by-piece
+table has 192 rows, 192 columns, and 8 in every row sum and every column sum,
+which invites the guess that some relabelling of the pieces makes it
+symmetric — that covers and pieces are the same objects seen twice. **No
+relabelling does.** If a permutation T made the table symmetric after
+relabelling, then the cover-side sharing matrix would equal T transpose times
+the piece-side sharing matrix times T, so the two would be permutation-similar
+and would have the same off-diagonal multiset. Those multisets are 0 with
+multiplicity 30144, 1 with 3840, 2 with 1920 and 4 with 768 on the cover side,
+against 0 with 30336, 1 with 3456, 2 with 1920, 3 with 384 and 4 with 576 on
+the piece side. They differ. This is a proof, not a search that came up empty.
+
+## The products do not stay inside the span
+
+Write AI for the identity relation and A0, A1, A2, A4 for the relations "share
+exactly this many pieces". The runner gates that these five are symmetric,
+zero-one, pairwise disjoint, add up to the all-ones matrix, and that AI is
+exactly the "share 8" relation, with valencies 1, 157, 20, 10 and 4. That is
+everything one would want of a multiplication table except the multiplication.
+
+**The multiplication is not there.** The product of A0 with itself, in exact
+integer arithmetic, takes 11 different values on the class A0: 122, 124, 125,
+126, 127, 128, 129, 130, 131, 132 and 134. Concretely, the pairs (0,20) and
+(0,21) both share 0 pieces, yet the product carries 134 on one and 132 on the
+other. So the number of covers sharing nothing with the first and nothing with
+the second is not a function of how much the first and second share. There is
+no table of numbers indexed by the five classes that reproduces these
+products, because the products are not constant on the classes.
+
+The algebra is not commutative either: A0 times A1 and A1 times A0 differ at
+entry (0,6), 16 against 15.
+
+Two controls establish that the test is discriminating on both sides. On the
+positive side, the 16 corners of the four-cube with the five relations "differ
+in exactly this many coordinates" are built from scratch inside the runner and
+put through the same function; all 25 of its products come back constant on
+all 5 classes, one of them the number 4, so the test can return that the
+products stay inside the span. On the negative side, moving a single symmetric
+pair of that control from the distance-2 relation to the distance-1 relation —
+still a symmetric partition of all ordered pairs — makes the test report a
+product taking 3 values on one class. The test neither accepts everything nor
+refuses everything.
+
+## How much finer a working table would have to be
+
+If the five classes do not carry their own products, one can ask for the
+coarsest partition that does. Refining each ordered pair by the multiset over
+all intermediate covers of the pair of colours it sees, and repeating until
+the count stops growing, gives classes by round of 5, then 76, then 120, then
+120. **The closed refinement with the fewest classes has 120 classes**, of
+sizes 192 with multiplicity 48 and 384 with multiplicity 72, and the five
+original relations split into 1, 100, 10, 6 and 3 parts.
+
+Since iterated refinement of this kind returns the coarsest stable partition
+refining what it is given, 120 is a floor: no partition refining the five
+sharing classes and carrying its own products has fewer than 120 classes. The
+smallest working multiplication table on this family is 24 times as fine as
+the sharing classes, and it splits every one of them except the identity. A
+derivation of the sharing profile of the kind the preceding cycle asked for
+would have to run through an object of that size, not through five numbers.
+
+## What the symmetries reach
+
+All 48 proper cube symmetries send exact covers to exact covers, and they
+leave 5 orbits on the 192 covers, of sizes 24, 24, 48, 48 and 48. Taking the
+differences of each orbit's covers against the first cover of that orbit and
+computing the exact rank over the rationals by integer elimination — no
+floating point and no bounded arithmetic anywhere — gives, as orbit size
+against rank: 24 against 23, 48 against 47, 24 against 23, 48 against 35, and
+48 against 29. All 192 covers together give exactly 104.
+
+So no single orbit of the symmetry group reaches across the space the cuttings
+cannot see. Three of the five already sit at the largest rank their size
+permits and still fall short: an orbit of 24 covers cannot give more than 23
+independent differences however it sits, and one of 48 cannot give more than
+47. The other two size-48 orbits, at 35 and at 29, fall short of even that
+ceiling. The preceding cycle
+found that each *sharing class*, taken alone, already spans all 104
+dimensions. Symmetry orbits do not; incidence classes do.
+
+The 104 here is an exact rational rank computed by fraction-free integer
+elimination, arrived at independently of the preceding cycle's two-sided
+bounded-arithmetic argument, and it agrees with it.
+
+## Runner
+
+`TOTAL: PASS=15 FAIL=0`, 3345 characters of output, under 30 s and under
+500 MB peak, both measured in the run. Fifteen gates, contiguous, each
+measuring in place. What the gates defend:
+
+- the cell complex, the pieces and the cuttings are rebuilt from scratch, and
+  the two independent counts of the incidences are gated against each other;
+- the exact-cover property is measured, not assumed: the eight-piece sets are
+  found by the condition that no cutting uses two of their pieces, and then
+  separately gated to meet every cutting exactly once;
+- the regularity claims are gated across all 192 rows on each side, so a
+  quantity read off one row cannot pass for a constant;
+- the asymmetry of the two sides is gated on the two off-diagonal multisets
+  differing, which is the exact hypothesis the permutation-similarity argument
+  needs, with no search anywhere;
+- the closure test is gated to discriminate on both sides, by a positive
+  control built from scratch that it must accept and a one-pair perturbation
+  of that same control that it must reject, so the negative result on the
+  sharing classes is not a test that refuses everything;
+- the refinement is gated on its round-by-round counts, its final class sizes
+  with multiplicities, and how the five relations split, so a refinement that
+  silently stopped early cannot pass;
+- every rank is exact integer arithmetic, and the orbit ranks are gated both
+  against the whole space and against each orbit's own size.
+
+## Boundary
+
+The negative is about the five sharing classes and is stated at that scope:
+their products are not constant on them, so those five classes carry no
+multiplication table. It is not a claim that the family has no useful algebra
+— the 120-class refinement does carry its own products, and this note does not
+measure how that refinement acts on the space the cuttings cannot see. Whether
+that finer table carries the span is open and is the natural next object.
+
+The 120 classes are not claimed to be the orbits of any group. The
+combinatorial symmetry of the sharing structure is not measured here, so
+whether it is larger than the 48 geometric symmetries is open. Why the covers
+differ inside exactly 104 dimensions is still not derived; this cycle confirms
+the number exactly and relocates none of it.
+
+## Next
+
+Measure whether the 120-class refinement's multiplication table carries the
+span, which is the object this cycle's negative points at. Measure the
+combinatorial symmetry group of the sharing structure and compare it with the
+48 geometric ones. And take the forced count in this note further: 15800 being
+8 times 1975 fixed the size of a free set and forced the exact-cover property
+at that size, so ask which further counts of the cutting system are fixed the
+same way rather than measured.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15469,
- "node_count": 5440,
+ "edge_count": 15470,
+ "node_count": 5441,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13625,6 +13625,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_sharing_table_not_coherent_cycle757_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.py
+runner_sha256: 6a69280a3532b4982726077691afb46abc257247ca9a4a324baaee576323f8b2
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 2.82
+status: ok
+----- stdout -----
+Every count below is measured here.
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them
+the 192 eight piece sets no cutting uses twice meet each of the 15800 cuttings between 1 and 1 times
+PASS C1  each of the 192 sets is an exact cover: the table sends it to the all ones column over all 15800 cuttings
+the cover by piece table has row sums 8 to 8 and column sums 8 to 8
+PASS C2  the zero one table is 8 regular on both sides
+cover side sharing values 0 1 2 4 with per cover counts 157 20 10 4, the same for every one of the 192 covers
+PASS C3  two covers share one of 0 1 2 4 pieces and never 3, at a count that does not depend on which cover you stand on
+piece side sharing values 0 1 2 3 4 with per piece counts 158 18 10 2 3, the same for every one of the 192 pieces
+PASS C4  two pieces do share 3 covers, so the value 3 that is missing between covers is present between pieces
+cover side off diagonal multiset 0:30144 1:3840 2:1920 4:768
+piece side off diagonal multiset 0:30336 1:3456 2:1920 3:384 4:576
+PASS C5  a permutation T making M T symmetric would force S = T transpose N T, hence one multiset for both sides, and these two differ
+the classes AI A0 A1 A2 A4 have valencies 1 157 20 10 4
+PASS C6  the 5 zero one classes are symmetric, disjoint, add up to the all ones matrix, and the share 8 class is the identity
+A0 . A0 takes 11 values on the class A0: 122 124 125 126 127 128 129 130 131 132 134
+pair (0,20) and pair (0,21) both share 0 pieces yet carry 134 and 132
+PASS C7  the product of the least sharing class with itself is not constant on that class, so the products do not stay inside the span
+A0 . A1 and A1 . A0 differ at entry (0,6): 16 against 15
+PASS C8  multiplying these two classes in the two orders gives two different matrices, so the multiplication is not commutative
+control on the 16 corners of the four cube by differing coordinates: 25 products, one number D1 . D1 on D0 = 4
+PASS C9  the same test finds all 25 products of the control constant on all 5 of its classes, so it can return closed
+control with the symmetric pair (0,3) moved from the d 2 class to the d 1 class: product (1,1) takes 3 values on class 1
+PASS C10  the same test rejects a one pair move inside a control that is still a symmetric partition, so it is not a test that refuses everything
+closed refinement with the fewest classes, classes by round: 5 76 120 120
+final classes 120 with sizes 192:48 384:72; the five relations split as 1 100 10 6 3
+PASS C11  no closed refinement of the five classes has fewer classes, and it is strictly finer than they are on every class but the identity
+all 48 proper cube symmetries send covers to covers; orbits on the covers: 5 of sizes 24 24 48 48 48
+PASS C12  every one of the 48 symmetries permutes the 192 covers, and they leave 5 orbits of covers
+cover differences inside each orbit, orbit size then exact rank: 24:23 48:47 24:23 48:35 48:29; all 192 covers together: 104
+PASS C13  the 192 covers differ inside a space of exact dimension 104, and no single orbit of covers reaches across it
+elapsed under 30 s and peak memory under 500 MB, both measured in this run
+PASS C14  inside its time and memory allowance
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09_cold_2026-08-09.txt
+++ b/outputs/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09_cold_2026-08-09.txt
@@ -1,0 +1,35 @@
+Every count below is measured here.
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them
+the 192 eight piece sets no cutting uses twice meet each of the 15800 cuttings between 1 and 1 times
+PASS C1  each of the 192 sets is an exact cover: the table sends it to the all ones column over all 15800 cuttings
+the cover by piece table has row sums 8 to 8 and column sums 8 to 8
+PASS C2  the zero one table is 8 regular on both sides
+cover side sharing values 0 1 2 4 with per cover counts 157 20 10 4, the same for every one of the 192 covers
+PASS C3  two covers share one of 0 1 2 4 pieces and never 3, at a count that does not depend on which cover you stand on
+piece side sharing values 0 1 2 3 4 with per piece counts 158 18 10 2 3, the same for every one of the 192 pieces
+PASS C4  two pieces do share 3 covers, so the value 3 that is missing between covers is present between pieces
+cover side off diagonal multiset 0:30144 1:3840 2:1920 4:768
+piece side off diagonal multiset 0:30336 1:3456 2:1920 3:384 4:576
+PASS C5  a permutation T making M T symmetric would force S = T transpose N T, hence one multiset for both sides, and these two differ
+the classes AI A0 A1 A2 A4 have valencies 1 157 20 10 4
+PASS C6  the 5 zero one classes are symmetric, disjoint, add up to the all ones matrix, and the share 8 class is the identity
+A0 . A0 takes 11 values on the class A0: 122 124 125 126 127 128 129 130 131 132 134
+pair (0,20) and pair (0,21) both share 0 pieces yet carry 134 and 132
+PASS C7  the product of the least sharing class with itself is not constant on that class, so the products do not stay inside the span
+A0 . A1 and A1 . A0 differ at entry (0,6): 16 against 15
+PASS C8  multiplying these two classes in the two orders gives two different matrices, so the multiplication is not commutative
+control on the 16 corners of the four cube by differing coordinates: 25 products, one number D1 . D1 on D0 = 4
+PASS C9  the same test finds all 25 products of the control constant on all 5 of its classes, so it can return closed
+control with the symmetric pair (0,3) moved from the d 2 class to the d 1 class: product (1,1) takes 3 values on class 1
+PASS C10  the same test rejects a one pair move inside a control that is still a symmetric partition, so it is not a test that refuses everything
+closed refinement with the fewest classes, classes by round: 5 76 120 120
+final classes 120 with sizes 192:48 384:72; the five relations split as 1 100 10 6 3
+PASS C11  no closed refinement of the five classes has fewer classes, and it is strictly finer than they are on every class but the identity
+all 48 proper cube symmetries send covers to covers; orbits on the covers: 5 of sizes 24 24 48 48 48
+PASS C12  every one of the 48 symmetries permutes the 192 covers, and they leave 5 orbits of covers
+cover differences inside each orbit, orbit size then exact rank: 24:23 48:47 24:23 48:35 48:29; all 192 covers together: 104
+PASS C13  the 192 covers differ inside a space of exact dimension 104, and no single orbit of covers reaches across it
+elapsed under 30 s and peak memory under 500 MB, both measured in this run
+PASS C14  inside its time and memory allowance
+TOTAL: PASS=15 FAIL=0

--- a/outputs/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09_receipt_2026-08-09.json
+++ b/outputs/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09_receipt_2026-08-09.json
@@ -1,0 +1,64 @@
+{
+ "cycle": 757,
+ "failures": 0,
+ "gates": 15,
+ "headline": "The 15800 least-volume cuttings of the unit four-cube at the adjacency cost floor draw on 192 pieces, 24 pieces to a cutting, each piece lying on 1975 cuttings, and exactly 192 sets of eight pieces are used at most once by any cutting, each meeting every cutting exactly once. This cycle goes to the table of how many pieces two of those exact covers share, which the preceding cycle named as the family's multiplication table. The table is regular: two covers share 0, 1, 2 or 4 pieces and never 3, with per-cover counts 157, 20, 10 and 4 that are the same standing on every one of the 192 covers, and the piece side is regular too with counts 158, 18, 10, 2 and 3, where the value 3 does occur. Two counting facts are forced rather than measured, and the note derives them from gated inputs: since 15800 is 8 times 1975 exactly, a set of pieces no cutting uses twice has at most 8 members and any such set of exactly 8 covers all 15800 cuttings once each, so the exact-cover property is automatic at that size; and since each cutting uses 24 pieces while each of the 192 covers meets it exactly once, each piece lies in 8 covers, so the cover-by-piece table is 8-regular on the piece side by force. The negative result is that the five classes carry no multiplication table: the product of the least sharing class with itself takes 11 values on that class, 122 through 134, with the pairs (0,20) and (0,21) both sharing 0 pieces yet carrying 134 and 132, and the algebra is not commutative, the two orders differing at entry (0,6) by 16 against 15. A positive control on the 16 corners of the four-cube by differing coordinates has all 25 of its products constant on all 5 classes, and moving one symmetric pair of that control between two of its classes makes the same test report 3 values on one class, so the test is discriminating on both sides. The closed refinement with the fewest classes has 120 classes, by rounds 5, 76, 120, 120, of sizes 192 with multiplicity 48 and 384 with multiplicity 72, splitting the five relations into 1, 100, 10, 6 and 3 parts, so the smallest working table on this family is 24 times as fine as the sharing classes. A permutation making the cover-by-piece table symmetric would force the two sharing matrices to be permutation-similar and so to share an off-diagonal multiset; the cover side is 0 with 30144, 1 with 3840, 2 with 1920 and 4 with 768, the piece side 0 with 30336, 1 with 3456, 2 with 1920, 3 with 384 and 4 with 576, and these differ, so no relabelling symmetrizes it. All 48 proper cube symmetries send covers to covers with 5 orbits of sizes 24, 24, 48, 48 and 48; the exact rational ranks of their differences, by integer elimination, are 23, 47, 23, 35 and 29 against orbit sizes 24, 48, 24, 48 and 48, while all 192 covers together give exactly 104. So no symmetry orbit reaches across the space the cuttings cannot see, while the preceding cycle found that each sharing class alone does. Not settled: whether the 120-class refinement carries that span, what the combinatorial symmetry group of the sharing structure is, and why the covers differ inside exactly 104 dimensions.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_SHARING_TABLE_NOT_COHERENT_CYCLE757_NOTE_2026-08-09.md",
+ "recorded_output": "outputs/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09_cold_2026-08-09.txt",
+ "results": {
+  "not_measured_here": {
+   "the_combinatorial_symmetry_group_of_the_sharing_structure": "open",
+   "whether_the_120_class_refinement_carries_the_span": "open",
+   "why_the_covers_differ_inside_exactly_104_dimensions": "open"
+  },
+  "the_controls_on_the_closure_test": {
+   "a_one_pair_move_makes_a_product_take_this_many_values_on_a_class": 3,
+   "classes_of_the_positive_control": 5,
+   "one_product_number_of_the_positive_control": 4,
+   "products_of_the_positive_control_all_constant_on_their_class": true,
+   "products_tested_in_the_positive_control": 25,
+   "the_perturbed_control_is_still_a_symmetric_partition": true
+  },
+  "the_object": {
+   "cuttings": 15800,
+   "cuttings_through_a_piece": 1975,
+   "eight_piece_sets_no_cutting_uses_twice": 192,
+   "each_meets_every_cutting_this_often": 1,
+   "pieces": 192,
+   "pieces_to_a_cutting": 24
+  },
+  "the_products_do_not_stay_inside_the_span": {
+   "distinct_values_of_the_least_class_squared_on_that_class": 11,
+   "entry_where_the_two_orders_differ": [0, 6],
+   "the_two_orders_carry": [16, 15],
+   "two_pairs_sharing_nothing_carry": [134, 132],
+   "values_of_the_least_class_squared_on_that_class": [122, 124, 125, 126, 127, 128, 129, 130, 131, 132, 134]
+  },
+  "the_refinement_with_the_fewest_classes": {
+   "class_sizes_with_multiplicity": {"192": 48, "384": 72},
+   "classes_by_round": [5, 76, 120, 120],
+   "final_classes": 120,
+   "the_five_relations_split_into": [1, 100, 10, 6, 3]
+  },
+  "the_sharing_table_is_regular": {
+   "cover_side_off_diagonal_multiset": {"0": 30144, "1": 3840, "2": 1920, "4": 768},
+   "cover_side_per_cover_counts": {"0": 157, "1": 20, "2": 10, "4": 4},
+   "cover_side_shared_piece_counts_never_include": 3,
+   "no_relabelling_makes_the_table_symmetric": true,
+   "piece_side_off_diagonal_multiset": {"0": 30336, "1": 3456, "2": 1920, "3": 384, "4": 576},
+   "piece_side_per_piece_counts": {"0": 158, "1": 18, "2": 10, "3": 2, "4": 3},
+   "row_sums_and_column_sums_of_the_cover_by_piece_table": 8,
+   "valencies_of_the_five_classes": [1, 157, 20, 10, 4]
+  },
+  "what_the_symmetries_reach": {
+   "exact_rank_of_all_192_cover_differences": 104,
+   "exact_ranks_of_the_orbit_differences": [23, 47, 23, 35, 29],
+   "orbit_sizes_in_the_same_order": [24, 48, 24, 48, 48],
+   "orbits_on_the_covers": 5,
+   "proper_cube_symmetries_sending_covers_to_covers": 48
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.py
+++ b/scripts/physical_cell_cutting_sharing_table_not_coherent_cycle757_2026_08_09.py
@@ -1,0 +1,597 @@
+"""Rebuild the cutting system of the unit four-cube and ask whether the sharing
+table of its exact covers multiplies inside itself.
+
+Every count below is measured here. The runner builds the cell complex, the least
+volume pieces, the cuttings at the adjacency cost floor, the incidence table, the
+eight-piece sets that meet every cutting exactly once, the cover-by-cover and
+piece-by-piece sharing tables, the products of the sharing classes, the closed refinement
+with the fewest classes, the action of the 48 proper cube symmetries
+on the covers, and the exact rank of the cover differences, gating each quantity
+in place. Two controls, one built to pass and one built to fail, show that the
+closure test discriminates.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.monotonic()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair or over-long line"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+def joins(xs):
+    """one space separated string of a sequence of integers"""
+    return " ".join(str(int(x)) for x in xs)
+
+
+def mset(a):
+    """value to count dictionary of an integer array"""
+    v, c = np.unique(np.asarray(a), return_counts=True)
+    return dict((int(x), int(y)) for x, y in zip(v, c))
+
+
+def msets(d):
+    """value:count string of a value to count dictionary"""
+    return " ".join("{0}:{1}".format(k, d[k]) for k in sorted(d))
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+
+
+# ------------------------------------------------- Part 2: the object and its carriers
+
+INT = INCL.astype(np.int32)
+GR = (INT.T @ INT).astype(np.int64)
+RW = INC.sum(axis=1).astype(np.int64)
+CS = INC.sum(axis=0).astype(np.int64)
+
+NSH = (GR == 0)
+np.fill_diagonal(NSH, False)
+ADJ = [0] * NPO
+for a in range(NPO):
+    m = 0
+    for b in np.flatnonzero(NSH[a]):
+        m |= 1 << int(b)
+    ADJ[a] = m
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    c = cand
+    while c:
+        low = c & -c
+        v = low.bit_length() - 1
+        c ^= low
+        extend(cur + [v], c & ADJ[v])
+
+
+extend([], (1 << NPO) - 1)
+NC = len(CLQ)
+W = np.zeros((NC, NPO), dtype=np.int64)
+for i, s in enumerate(CLQ):
+    for p in s:
+        W[i, int(p)] = 1
+COV = INCL @ W.T
+
+
+# ------------------------------------------ Part 2: the sharing tables of the covers
+
+emit("Every count below is measured here.")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, "
+     "{3} cuttings through a piece".format(NS, NPO, int(RW.min()), int(CS.min())))
+gate(NS == 15800 and NPO == 192 and int(RW.min()) == int(RW.max()) == 24
+     and int(CS.min()) == int(CS.max()) == 1975 and int(RW.sum()) == int(CS.sum()),
+     "C0", "the pieces per cutting and the cuttings through a piece are each the "
+     "same number for every one of them")
+
+emit("the {0} eight piece sets no cutting uses twice meet each of the {1} cuttings "
+     "between {2} and {3} times".format(NC, NS, int(COV.min()), int(COV.max())))
+gate(NC == 192 and int(COV.min()) == int(COV.max()) == 1, "C1",
+     "each of the {0} sets is an exact cover: the table sends it to the all ones "
+     "column over all {1} cuttings".format(NC, NS))
+
+M = W
+RSUM = M.sum(axis=1)
+CSUM = M.sum(axis=0)
+emit("the cover by piece table has row sums {0} to {1} and column sums {2} to "
+     "{3}".format(int(RSUM.min()), int(RSUM.max()), int(CSUM.min()), int(CSUM.max())))
+gate(M.shape == (NC, NPO) and set(int(x) for x in np.unique(M)) == set([0, 1])
+     and int(RSUM.min()) == int(RSUM.max()) == 8
+     and int(CSUM.min()) == int(CSUM.max()) == 8, "C2",
+     "the zero one table is {0} regular on both sides".format(int(RSUM.min())))
+
+S = M @ M.T
+N = M.T @ M
+OFFD = ~np.eye(NC, dtype=bool)
+SVAL = sorted(set(int(x) for x in np.unique(S[OFFD])))
+NVAL = sorted(set(int(x) for x in np.unique(N[OFFD])))
+SCNT = dict((v, ((S == v) & OFFD).sum(axis=1)) for v in SVAL)
+NCNT = dict((v, ((N == v) & OFFD).sum(axis=1)) for v in NVAL)
+SPRO = [int(SCNT[v].min()) for v in SVAL]
+NPRO = [int(NCNT[v].min()) for v in NVAL]
+MISS = [v for v in NVAL if v not in SVAL]
+SFIX = all(int(SCNT[v].min()) == int(SCNT[v].max()) for v in SVAL)
+NFIX = all(int(NCNT[v].min()) == int(NCNT[v].max()) for v in NVAL)
+emit("cover side sharing values {0} with per cover counts {1}, the same for every "
+     "one of the {2} covers".format(joins(SVAL), joins(SPRO), NC))
+gate(SVAL == [0, 1, 2, 4] and 3 not in SVAL and SFIX and SPRO == [157, 20, 10, 4]
+     and sum(SPRO) == NC - 1 and MISS == [3], "C3",
+     "two covers share one of {0} pieces and never {1}, at a count that does not "
+     "depend on which cover you stand on".format(joins(SVAL), joins(MISS)))
+emit("piece side sharing values {0} with per piece counts {1}, the same for every "
+     "one of the {2} pieces".format(joins(NVAL), joins(NPRO), NPO))
+gate(NVAL == [0, 1, 2, 3, 4] and NFIX and NPRO == [158, 18, 10, 2, 3]
+     and sum(NPRO) == NPO - 1, "C4",
+     "two pieces do share {0} covers, so the value {0} that is missing between "
+     "covers is present between pieces".format(joins(MISS)))
+
+SMUL = mset(S[OFFD])
+NMUL = mset(N[OFFD])
+emit("cover side off diagonal multiset " + msets(SMUL))
+emit("piece side off diagonal multiset " + msets(NMUL))
+gate(SMUL != NMUL, "C5",
+     "a permutation T making M T symmetric would force S = T transpose N T, hence "
+     "one multiset for both sides, and these two differ")
+
+SDG = sorted(set(int(x) for x in np.unique(np.diag(S))))
+AI = np.eye(NC, dtype=np.int64)
+REL = [AI] + [(S == v).astype(np.int64) for v in SVAL]
+RNM = ["AI"] + ["A{0}".format(v) for v in SVAL]
+RSU = sum(REL)
+VAL = [int(X[0].sum()) for X in REL]
+emit("the classes " + " ".join(RNM) + " have valencies " + joins(VAL))
+gate(all(set(int(x) for x in np.unique(X)) <= set([0, 1]) for X in REL)
+     and int(RSU.min()) == int(RSU.max()) == 1
+     and all(np.array_equal(X, X.T) for X in REL)
+     and len(SDG) == 1 and SDG[0] == 8
+     and np.array_equal(REL[0], (S == SDG[0]).astype(np.int64))
+     and sum(VAL) == NC, "C6",
+     "the {0} zero one classes are symmetric, disjoint, add up to the all ones "
+     "matrix, and the share {1} class is the identity".format(len(REL), SDG[0]))
+
+
+def closure_report(mats):
+    """distinct values of every product of two classes on every class
+
+    The products stay inside the span exactly when each of those lists holds a
+    single value. Products are formed in exact integer arithmetic.
+    """
+    n = len(mats)
+    msk = [X > 0 for X in mats]
+    prods = {}
+    vals = {}
+    for i in range(n):
+        for j in range(n):
+            P = mats[i].astype(np.int64) @ mats[j].astype(np.int64)
+            prods[(i, j)] = P
+            for k in range(n):
+                vals[(i, j, k)] = sorted(int(x) for x in np.unique(P[msk[k]]))
+    return prods, vals
+
+
+def spread(vals):
+    """the triple of class indices carrying the most values, and how many"""
+    worst = None
+    for key in sorted(vals):
+        if worst is None or len(vals[key]) > len(vals[worst]):
+            worst = key
+    return worst, len(vals[worst])
+
+
+PRD, VLS = closure_report(REL)
+P00 = PRD[(1, 1)]
+V00 = VLS[(1, 1, 1)]
+IDX = np.argwhere(REL[1] > 0)
+XA, YA = int(IDX[0][0]), int(IDX[0][1])
+VA = int(P00[XA, YA])
+PICK = None
+for r in range(IDX.shape[0]):
+    xb, yb = int(IDX[r][0]), int(IDX[r][1])
+    if int(P00[xb, yb]) != VA:
+        PICK = (xb, yb, int(P00[xb, yb]))
+        break
+emit("{0} . {0} takes {1} values on the class {0}: {2}".format(
+    RNM[1], len(V00), joins(V00)))
+emit("pair ({0},{1}) and pair ({2},{3}) both share {4} pieces yet carry {5} and "
+     "{6}".format(XA, YA, PICK[0], PICK[1], int(S[XA, YA]), VA, PICK[2]))
+gate(len(V00) > 1 and PICK is not None and int(S[XA, YA]) == 0
+     and int(S[PICK[0], PICK[1]]) == 0 and VA != PICK[2], "C7",
+     "the product of the least sharing class with itself is not constant on that "
+     "class, so the products do not stay inside the span")
+
+XY = PRD[(1, 2)]
+YX = PRD[(2, 1)]
+DIF = np.argwhere(XY != YX)
+XC, YC = int(DIF[0][0]), int(DIF[0][1])
+emit("{0} . {1} and {1} . {0} differ at entry ({2},{3}): {4} against {5}".format(
+    RNM[1], RNM[2], XC, YC, int(XY[XC, YC]), int(YX[XC, YC])))
+gate(DIF.shape[0] > 0 and not np.array_equal(XY, YX)
+     and int(XY[XC, YC]) != int(YX[XC, YC]), "C8",
+     "multiplying these two classes in the two orders gives two different "
+     "matrices, so the multiplication is not commutative")
+
+HV = np.array([[(k >> b) & 1 for b in range(4)] for k in range(16)], dtype=np.int64)
+HD = np.abs(HV[:, None, :] - HV[None, :, :]).sum(axis=2)
+HR = [(HD == d).astype(np.int64) for d in range(5)]
+HP, HVL = closure_report(HR)
+HOK = all(len(v) == 1 for v in HVL.values())
+emit("control on the {0} corners of the four cube by differing coordinates: {1} "
+     "products, one number D1 . D1 on D0 = {2}".format(
+         len(HV), len(HP), HVL[(1, 1, 0)][0]))
+gate(HOK and np.array_equal(sum(HR), np.ones((16, 16), dtype=np.int64))
+     and len(HVL) == 125, "C9",
+     "the same test finds all {0} products of the control constant on all {1} of "
+     "its classes, so it can return closed".format(len(HP), len(HR)))
+
+QR = [X.copy() for X in HR]
+CAN = np.argwhere(HD == 2)
+QX, QY = int(CAN[0][0]), int(CAN[0][1])
+QR[2][QX, QY] = QR[2][QY, QX] = 0
+QR[1][QX, QY] = QR[1][QY, QX] = 1
+QP, QVL = closure_report(QR)
+QOK = all(len(v) == 1 for v in QVL.values())
+QW, QN = spread(QVL)
+emit("control with the symmetric pair ({0},{1}) moved from the d 2 class to the d 1 "
+     "class: product ({2},{3}) takes {4} values on class {5}".format(
+         QX, QY, QW[0], QW[1], QN, QW[2]))
+gate((not QOK) and np.array_equal(sum(QR), np.ones((16, 16), dtype=np.int64))
+     and all(np.array_equal(X, X.T) for X in QR) and QN > 1, "C10",
+     "the same test rejects a one pair move inside a control that is still a "
+     "symmetric partition, so it is not a test that refuses everything")
+
+
+def refine_once(C):
+    """recolour each ordered pair by its old colour together with the multiset of
+    the colour pairs it makes with every third index"""
+    n = C.shape[0]
+    k = int(C.max()) + 1
+    code = C[:, :, None].astype(np.int32) * np.int32(k) + C[None, :, :].astype(np.int32)
+    code.sort(axis=1)
+    sig = np.ascontiguousarray(code.transpose(0, 2, 1)).reshape(n * n, n)
+    key = np.concatenate(
+        [C.reshape(n * n, 1).astype(np.int32), sig], axis=1)
+    raw = np.ascontiguousarray(key).tobytes()
+    wid = key.shape[1] * 4
+    seen = {}
+    out = np.zeros(n * n, dtype=np.int64)
+    for t in range(n * n):
+        h = raw[t * wid:(t + 1) * wid]
+        u = seen.get(h)
+        if u is None:
+            u = len(seen)
+            seen[h] = u
+        out[t] = u
+    return out.reshape(n, n), len(seen)
+
+
+COL = np.zeros((NC, NC), dtype=np.int64)
+for t, v in enumerate([SDG[0]] + SVAL):
+    COL[S == v] = t
+ROUND = [int(COL.max()) + 1]
+while True:
+    NEW, KN = refine_once(COL)
+    ROUND.append(KN)
+    if KN == ROUND[-2]:
+        break
+    COL = NEW
+KF = ROUND[-1]
+CSZ = mset([int((COL == c).sum()) for c in range(KF)])
+SPL = [len(set(int(x) for x in np.unique(COL[REL[t] > 0]))) for t in range(len(REL))]
+emit("closed refinement with the fewest classes, classes by round: " + joins(ROUND))
+emit("final classes {0} with sizes {1}; the five relations split as {2}".format(
+    KF, msets(CSZ), joins(SPL)))
+gate(KF == 120 and CSZ == {192: 48, 384: 72} and SPL == [1, 100, 10, 6, 3]
+     and sum(k * v for k, v in CSZ.items()) == NC * NC, "C11",
+     "no closed refinement of the five classes has fewer classes, and it is "
+     "strictly finer than they are on every class but the identity")
+
+CKEY = dict((frozenset(int(p) for p in CLQ[i]), i) for i in range(NC))
+CARP = []
+for cp in CP:
+    img = []
+    for i in range(NC):
+        j = CKEY.get(frozenset(int(cp[p]) for p in CLQ[i]))
+        if j is None:
+            break
+        img.append(j)
+    if len(img) == NC and len(set(img)) == NC:
+        CARP.append(img)
+SEEN = [-1] * NC
+OSIZ = []
+for i in range(NC):
+    if SEEN[i] < 0:
+        SEEN[i] = len(OSIZ)
+        front, cnt = [i], 0
+        while front:
+            x = front.pop()
+            cnt += 1
+            for pp in CARP:
+                y = pp[x]
+                if SEEN[y] < 0:
+                    SEEN[y] = SEEN[i]
+                    front.append(y)
+        OSIZ.append(cnt)
+emit("all {0} proper cube symmetries send covers to covers; orbits on the covers: "
+     "{1} of sizes {2}".format(len(CARP), len(OSIZ), joins(sorted(OSIZ))))
+gate(CPOK and len(CP) == 48 and len(CARP) == 48 and len(OSIZ) == 5
+     and sorted(OSIZ) == [24, 24, 48, 48, 48] and sum(OSIZ) == NC, "C12",
+     "every one of the {0} symmetries permutes the {1} covers, and they leave {2} "
+     "orbits of covers".format(len(CARP), NC, len(OSIZ)))
+
+
+def rank_exact(rows):
+    """exact rank over the rationals of an integer matrix, integer arithmetic only
+
+    One step fraction free elimination: each combined row is divided through by
+    the greatest common divisor of its entries, so no denominator is ever needed
+    and no floating point is used.
+    """
+    wk = [[int(x) for x in r] for r in rows]
+    nr = len(wk)
+    if nr == 0:
+        return 0
+    m = len(wk[0])
+    rk = 0
+    for col in range(m):
+        piv = -1
+        for r in range(rk, nr):
+            if wk[r][col]:
+                piv = r
+                break
+        if piv < 0:
+            continue
+        wk[rk], wk[piv] = wk[piv], wk[rk]
+        pr = wk[rk]
+        pv = pr[col]
+        for r in range(rk + 1, nr):
+            f = wk[r][col]
+            if f:
+                rw = wk[r]
+                nw = [0] * col + [pv * rw[c] - f * pr[c] for c in range(col, m)]
+                g = 0
+                for x in nw:
+                    if x:
+                        g = math.gcd(g, x if x > 0 else -x)
+                        if g == 1:
+                            break
+                if g > 1:
+                    nw = [x // g for x in nw]
+                wk[r] = nw
+        rk += 1
+    return rk
+
+
+ORK = []
+for j in range(len(OSIZ)):
+    mem = [i for i in range(NC) if SEEN[i] == j]
+    ORK.append(rank_exact([[int(x) for x in (W[i] - W[mem[0]])] for i in mem[1:]]))
+ARK = rank_exact([[int(x) for x in (W[i] - W[0])] for i in range(1, NC)])
+OPR = " ".join("{0}:{1}".format(OSIZ[j], ORK[j]) for j in range(len(OSIZ)))
+emit("cover differences inside each orbit, orbit size then exact rank: {0}; all {1} "
+     "covers together: {2}".format(OPR, NC, ARK))
+gate(ARK == 104 and all(r < ARK for r in ORK)
+     and all(ORK[j] <= OSIZ[j] - 1 for j in range(len(OSIZ)))
+     and any(ORK[j] < OSIZ[j] - 1 for j in range(len(OSIZ)))
+     and len(ORK) == len(OSIZ), "C13",
+     "the {0} covers differ inside a space of exact dimension {1}, and no single "
+     "orbit of covers reaches across it".format(NC, ARK))
+
+ELAP = time.monotonic() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+EBD = 30 * (int(ELAP // 30) + 1)
+RBD = 500 * (int(RSS // 500) + 1)
+emit("elapsed under {0} s and peak memory under {1} MB, both measured in this "
+     "run".format(EBD, RBD))
+gate(ELAP < 900.0 and RSS < 2500.0 and EBD <= 900 and RBD <= 2500, "C14",
+     "inside its time and memory allowance")
+
+emit("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))


### PR DESCRIPTION
## Review-loop landed disposition

The original stacked payload was not landed as written. Review-loop salvaged a self-contained, current-`main` finite-combinatorics package and removed every claim inherited from unlanded PR #6051.

The landed claim is bounded to one explicitly reconstructed labelled unit-four-cube incidence object. It records exact cutting/cover counts, regular sharing profiles, two finite product-value witnesses, the declared refinement sequence `5 -> 76 -> 120 -> 120`, and the declared spatial-rotation/time-flip orbit/rank census. It makes no physical, multicell, global-minimality, algebra-classification, no-go, framework-closure, primitive, or audit-status claim.

Narrow repairs made during review:

- made all runner gates fail closed and mutation-tested them;
- gated the reconstruction integrity surface, exact inverses, and exact integer action construction;
- removed unsupported negative/minimality claims and the false dependency on the minimal-axiom document;
- corrected the 48-map label to 24 proper spatial rotations times optional fourth-coordinate flip;
- added canonical metadata and harness discovery;
- kept only the canonical source-hash-bound runner cache and required citation-topology acknowledgment, stripping custom cold/receipt and pipeline-generated outputs.

Validation passed: live runner 15/15 twice with deterministic stdout, independent incidence/profile/product/refinement/action/rank recomputations, 11 fail-closed mutation checks, 26 relevant repository tests, full audit pipeline, strict audit lint with zero errors, changed-evidence `1/0/0`, vocabulary, portable-link, no-go-shape, generated-surface, and diff gates.

Landed directly on `main` as `be3137f1595433f482f3e10a18a0d3793d706db5` after remote-containment verification. Proposed claim ID `physical_cell_cutting_sharing_table_not_coherent_cycle757_note_2026-08-09` remains `unaudited` and requires the independent audit lane; review-loop applied no audit verdict.
