### PR TITLE
cycle 758: the 104 blind directions are the cover table rank less one

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_COVER_TABLE_RANK_CYCLE758_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_COVER_TABLE_RANK_CYCLE758_NOTE_2026-08-09.md
@@ -1,0 +1,256 @@
+# Why the cuttings are blind in 104 directions: it is the rank of the cover table, less the all-ones direction — Cycle 758
+
+Date: 2026-08-09
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the least-volume pieces, the cuttings at the adjacency cost floor,
+the eight-piece exact covers, the cover-by-piece table, its exact rational
+rank and nullity, the exact ranks of the two products of that table with its
+transpose, and the exact whole-number part of the spectrum of those products,
+gating each quantity in place. Two of the gates are controls whose job is to
+show the spectrum scan is neither vacuous nor canned. Constitutional effect:
+none. This package changes no axiom, no framework Admissibility rule, no
+primitive, no policy, and no audit status, and it adds no import and no
+assumption to [MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## What this answers
+
+The object is the unit four-cube on sixteen corners, cut into least-volume
+pieces at the adjacency cost floor. There are 15800 such cuttings; between
+them they draw on 192 pieces, 24 pieces to a cutting, and each piece lies on
+1975 cuttings. A vector on the pieces is *blind* to the cuttings when every
+cutting sums it to zero. Two cycles back the blind space was measured at
+exactly 104 dimensions and identified with the span of the differences of the
+192 eight-piece exact covers; since then, three separate attempts to explain
+that 104 through the symmetries of the cube have each fallen short, the last
+of them finding that no symmetry orbit reaches across it at all. The
+preceding cycle left the question open in its own words: why the covers
+differ inside exactly 104 dimensions.
+
+This cycle answers it, in the sense that a question is answered when it is
+reduced to a smaller one. **104 is not an independent number.** It is the
+rank of the 192 by 192 cover-by-piece table, less one, and the one is the
+all-ones direction on the pieces. Both steps are derived below from gated
+inputs, not measured; what is measured is the rank, 105, and every input the
+derivations use. The question "why 104" is now the question "why 105", asked
+of a 192 by 192 table instead of a 15800 by 192 one.
+
+The second half of the cycle takes the sharing table apart spectrally, since
+that is where a rank of 105 would have to come from. The whole-number part of
+the spectrum is settled exactly: ten eigenvalues with exact multiplicities,
+accounting for 136 of the 192, with the remaining 56 not rational.
+
+## The blind space is the cover table applied to the zero-sum covers
+
+Write M for the cover-by-piece table: 192 rows, one per exact cover, 192
+columns, one per piece, a one where the cover uses the piece. The runner
+gates that M is 8-regular on both sides, row sums and column sums alike (C2).
+
+**Derived here, from gated inputs.** Every cover meets every cutting exactly
+once (C1), so the difference of two covers is summed to zero by every cutting:
+the differences are blind. A general element of their span is a combination
+of covers whose coefficients add to zero, so the span is exactly the image of
+the zero-sum coefficient vectors under M transposed. Its dimension is
+therefore 191 less the dimension of the part of the kernel of M transposed
+that lies among the zero-sum vectors.
+
+**That kernel lies wholly among the zero-sum vectors, by row-regularity.**
+If a combination of covers is annihilated by M transposed, add up its 192
+piece entries: each cover contributes its coefficient once for each of the 8
+pieces it holds, so the total is 8 times the sum of the coefficients, and it
+is zero. Hence the sum of the coefficients is zero. The runner gates this in
+its dual form (C6): stacking one all-ones cover row onto M transposed leaves
+the rank at 105, so that row already sits in the row space, and every kernel
+vector is orthogonal to it.
+
+The dimension of the blind space is then 191 less the whole nullity of M
+transposed, with nothing to subtract off. The runner measures that nullity as
+87 (C7), and 191 less 87 is 104 — the same 104 the preceding cycles measured
+two other ways. Equivalently, since the nullity is 192 less the rank,
+
+> dimension of the blind space = rank of the cover-by-piece table, less one.
+
+## The one extra dimension is the all-ones piece direction
+
+The step above leaves one dimension unexplained: the row space of M has 105
+dimensions and the blind space, which sits inside it, has 104. What is the
+extra one?
+
+**Derived here, from gated inputs.** Adding up all 192 rows of M gives 8 at
+every piece (C3), because each piece lies in 8 covers — itself a forced count
+from the preceding cycle, where 192 equals 24 times 8. So the all-ones piece
+vector is one eighth of a combination of covers, and lies in the row space.
+It is not blind: the cutting table sends it to the single value 24 at every
+one of the 15800 cuttings (C4), and 24 is not zero. So the row space of M is
+the blind space together with the all-ones piece direction, and the two meet
+only at the origin:
+
+> 105 = 104 + 1.
+
+The two steps use opposite regularities, which is worth recording. The first
+uses row-regularity, that each cover holds 8 pieces. The second uses
+column-regularity, that each piece lies in 8 covers — the count the preceding
+cycle showed to be forced rather than accidental. The blind space is bounded
+above by the covers and pinned from below by the all-ones direction, one
+regularity at each end.
+
+## The rational part of the sharing spectrum, exactly
+
+Write S for the cover-side sharing table, M times M transposed, whose entry
+counts the pieces two covers share, and N for the piece-side table, M
+transposed times M. The runner gates that M, S and N all have exact rational
+rank 105 (C5, C8), so the rank question can be asked of a symmetric table.
+
+Three facts make the whole-number part of the spectrum of S exactly
+determinable in finite work, and the runner states each in place before using
+it (C9):
+
+- S is an integer table times its own transpose, so no eigenvalue is below 0.
+- The largest row sum of S is 64, so no eigenvalue is above 64.
+- A rational eigenvalue of an integer symmetric table is a root of a monic
+  integer polynomial, hence an algebraic integer, hence a whole number.
+
+So a scan of the whole numbers 0 to 64 settles the rational part in full: it
+is a complete test, not a sample of one. The scan is made cheap by a fourth
+fact, also stated in place: the rank over the prime field 1000003 never exceeds the rank over the
+rationals, so a whole number with zero nullity over that field is ruled out
+with no exact work at all. Every whole number that survives the cheap pass is
+then confirmed by fraction-free integer elimination, and only the exact
+multiplicity is reported. The prime field rules candidates out; it never
+rules one in.
+
+The result:
+
+| eigenvalue | 0 | 2 | 4 | 8 | 10 | 12 | 16 | 20 | 24 | 64 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| multiplicity | 87 | 8 | 8 | 3 | 8 | 6 | 2 | 10 | 3 | 1 |
+
+Counted with multiplicity these are 136 of the 192 eigenvalues, so **56 of
+them are not rational**. The 0 with multiplicity 87 is the nullity used
+above; the 64 with multiplicity 1 is the largest row sum, taken once.
+
+Two independent totals confirm the list rather than restate it. The trace of
+S is 1536: each diagonal entry counts the pieces a cover shares with itself,
+which is 8, over 192 covers, and the whole-number eigenvalues supply 592 of
+that, leaving 944. The trace of the square is 36096, of which the whole
+numbers supply 12352, leaving 23744. Both leftovers are strictly positive, as
+they must be when eigenvalues that are not rational are present, and neither
+total is reached by the whole numbers alone (C11). A list that had missed an
+eigenvalue or inflated a multiplicity would have to miss these two totals in
+a coordinated way.
+
+The scan itself is controlled on both sides (C12, C13). On the positive side
+it is run against the sixteen corners of the four-cube joined when they differ
+in one coordinate, whose spectrum is fixed before any measurement is taken:
+eigenvalue 4 once, 2 four times, 0 six times, -2 four times, -4 once, all 16
+whole. The scan recovers exactly that. On the negative side, adding 1 at one
+symmetric pair of that control changes the whole-number spectrum and drops the
+count of whole eigenvalues to 8 of the 16; the gate requires only that the
+spectrum change and the count fall, hard-coding no perturbed answer. So the
+scan is not returning a canned list, and it is sharp enough to notice a
+single-pair change.
+
+## The two sharing tables have one spectrum, and the spectrum cannot see the difference
+
+The piece-side table N returns the same whole-number spectrum as S, entry for
+entry and multiplicity for multiplicity (C10). This is forced, not found: a
+table times its transpose and the transpose times the table share their
+nonzero spectrum, and both are 192 by 192 here, so the multiplicity at 0
+agrees as well. The gate is a consistency check on the machinery.
+
+Its content is the contrast. The preceding cycle proved that S and N are *not*
+related by any relabelling of the 192 covers onto the 192 pieces, by exhibiting
+off-diagonal multisets that differ. So the two tables are cospectral and not
+permutation-similar. **The spectrum is blind to exactly the asymmetry that the
+sharing counts detect.** Anything built on the spectrum alone — including any
+future account of the rank 105 built that way — will not distinguish the cover
+side from the piece side, and must not be read as having done so.
+
+## Runner
+
+`physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py` rebuilds the
+object from the four-cube and gates 15 quantities. The construction is the
+preceding cycle's, byte for byte, through the exact covers; everything after
+is new.
+
+- C0, C1, C2 — the object: pieces per cutting and cuttings per piece each
+  constant; each of the 192 sets meets every cutting exactly once; the
+  cover-by-piece table 8-regular on both sides.
+- C3, C4 — the inputs to the second derivation: all 192 rows add to 8 at every
+  piece, so the all-ones piece vector is in the row space; the cutting table
+  sends it to the single nonzero value 24.
+- C5 — exact rational rank of the cover-by-piece table 105, of its 191 cover
+  differences 104, difference exactly 1.
+- C6, C7 — the input to the first derivation: the all-ones cover row raises no
+  rank when stacked on the transposed table; exact nullity 87, and 191 less 87
+  is 104.
+- C8 — exact rank 105 for the cover-side and piece-side sharing tables alike.
+- C9, C10 — the whole-number spectrum of both sharing tables, by a complete
+  scan over 0 to 64 with prime-field rejection and exact confirmation; 136 of
+  192 whole, 56 not rational.
+- C11 — the trace 1536 splitting as 592 plus 944 and the trace of the square
+  36096 splitting as 12352 plus 23744, with both leftovers positive.
+- C12, C13 — positive and negative controls on the scan.
+- C14 — time and memory inside allowance, both measured in the run.
+
+`TOTAL: PASS=15 FAIL=0`.
+
+## Boundary
+
+- **The rank 105 is measured, not derived.** This cycle reduces 104 to it and
+  supplies the one-dimensional gap exactly; it does not say why the table has
+  that rank. Read the result as a reduction, not an explanation.
+- **The two derivations are done in this note, not by the runner.** The runner
+  gates their inputs — the two regularities, the row-space memberships, the
+  nullity, the nonzero image — and the counting step from those inputs to
+  "104 equals rank less one" is prose here. The prose is short and the inputs
+  are each gated in place, but the arithmetic itself is not machine-checked.
+- **Cospectrality of the two sharing tables is forced,** and is gated only as
+  a consistency check on the machinery. It is not evidence about the object.
+- **The 56 eigenvalues that are not rational are not identified here.** Their
+  count and their contribution to the two totals are exact; their values,
+  their fields, and their multiplicities individually are untouched.
+- The whole-number scan settles the *rational* part of the spectrum only, and
+  its completeness rests on the three stated facts, each of which is a
+  property of this table rather than a general one.
+- Nothing here bears on any physical claim. The object is a finite
+  combinatorial one and every statement about it is a count.
+
+## Next
+
+The rank question is now sharper than it was, and smaller in three ways.
+
+It lives on a 192 by 192 table rather than a 15800 by 192 one. It can be asked
+of a symmetric table, since the cover-by-piece table and both sharing tables
+carry the one rank. And it is entirely a question about the kernel: the rank
+is 192 less the multiplicity of 0, that multiplicity is exactly 87, and the 56
+eigenvalues that are not rational are therefore all nonzero and play no part
+in it. **Why is 0 an eigenvalue of the sharing table exactly 87 times?** —
+that single question now carries the whole of the 104.
+
+Two structural leads sit next to it. The whole-number eigenvalues come with
+multiplicities 8, 8, 3, 8, 6, 2, 10, 3 and 1 away from the kernel, and a
+decomposition of the cover space that explains those multiplicities would very
+likely name the kernel too. Separately, the preceding cycle found the closed
+refinement of the sharing classes with the fewest parts; whether the products
+of that refinement carry the 104-dimensional span is still open, and it is the
+natural place to look for the decomposition, since the sharing classes
+themselves are known not to close under multiplication while that refinement
+does.
+
+Also still open from the preceding cycles: the combinatorial symmetry group of
+the sharing structure, and whether it exceeds the cube symmetries that have now
+been shown three separate ways to be too coarse for this rank.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15469,
- "node_count": 5440,
+ "edge_count": 15470,
+ "node_count": 5441,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13625,6 +13625,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_cover_table_rank_cycle758_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py
+runner_sha256: 9d17a04144370f208757856179f28df3a1d30d054157d11d639f6b1099d454e5
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 45.76
+status: ok
+----- stdout -----
+Every count below is measured here.
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them
+the 192 eight piece sets no cutting uses twice meet each of the 15800 cuttings between 1 and 1 times
+PASS C1  each of the 192 sets is an exact cover: the table sends it to the all ones column over all 15800 cuttings
+the cover by piece table has row sums 8 to 8 and column sums 8 to 8
+PASS C2  the zero one table is 8 regular on both sides
+adding up all 192 rows of the cover by piece table gives 8 at every one of the 192 pieces
+PASS C3  the all ones piece vector is the sum of all the cover rows, so it sits in the row space of the cover by piece table
+the cutting table sends the all ones piece vector to the single value 24 at every one of the 15800 cuttings
+PASS C4  the image is one value and that value is not zero, so the all ones piece vector is not blind to the cuttings
+exact rank of the cover by piece table 105, exact rank of its 191 cover differences 104, difference 1
+PASS C5  the cover differences drop exactly one dimension against the covers themselves, and that dimension is the all ones direction
+stacking the 192 rows of the transposed table with one all ones cover row gives rank 105, against rank 105 without it
+PASS C6  the all ones cover row raises nothing, so it sits in the row space and every kernel vector of that table sums to zero over the covers
+exact nullity of the transposed table 87, and 191 minus that nullity is 104
+PASS C7  the kernel takes 87 of the 192 cover directions away and the 191 cover differences fill the 104 that is left
+exact rank of the cover side sharing table 105 and of the piece side sharing table 105
+PASS C8  a table and the two products of it with its transpose all carry the one rank
+the cover side table is an integer table times its transpose so no eigenvalue is below 0, and its largest row sum 64 puts none above 64
+a rational eigenvalue of an integer symmetric table is an algebraic integer, hence a whole number, so only the whole numbers 0 to 64 can occur
+rank over the prime field 1000003 is never above rank over the rationals, so zero nullity there proves zero nullity over the rationals
+cover side whole number spectrum 0:87 2:8 4:8 8:3 10:8 12:6 16:2 20:10 24:3 64:1
+counted with multiplicity 136 of the 192 eigenvalues are whole numbers and 56 are not rational
+PASS C9  the rational part of the cover side sharing spectrum is exactly these ten whole numbers with these exact multiplicities
+piece side whole number spectrum 0:87 2:8 4:8 8:3 10:8 12:6 16:2 20:10 24:3 64:1
+PASS C10  the two products of one table with its transpose carry the one nonzero spectrum, and the table is square so the count at 0 agrees
+trace 1536 splits as 592 from the whole numbers plus 944, trace of the square 36096 splits as 12352 plus 23744
+PASS C11  the whole numbers make neither total on their own, and both leftovers are positive, as eigenvalues that are not rational require
+control on the 16 corners of the four cube, adjacent when they differ in one coordinate: 4:1 2:4 0:6 -2:4 -4:1
+PASS C12  the scan recovers the 16 eigenvalues that were fixed for this control before any measurement, so it reads the right answer
+the same control with 1 added at the symmetric pair (0,3): 2:2 0:4 -2:2, whole number eigenvalues with multiplicity 8
+PASS C13  one added symmetric pair changes the whole number spectrum and drops the count, so the scan is not returning a canned answer
+elapsed under 300 s and peak memory under 500 MB, both measured in this run
+PASS C14  inside its time and memory allowance
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/outputs/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09_cold_2026-08-09.txt
+++ b/outputs/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09_cold_2026-08-09.txt
@@ -1,0 +1,36 @@
+Every count below is measured here.
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them
+the 192 eight piece sets no cutting uses twice meet each of the 15800 cuttings between 1 and 1 times
+PASS C1  each of the 192 sets is an exact cover: the table sends it to the all ones column over all 15800 cuttings
+the cover by piece table has row sums 8 to 8 and column sums 8 to 8
+PASS C2  the zero one table is 8 regular on both sides
+adding up all 192 rows of the cover by piece table gives 8 at every one of the 192 pieces
+PASS C3  the all ones piece vector is the sum of all the cover rows, so it sits in the row space of the cover by piece table
+the cutting table sends the all ones piece vector to the single value 24 at every one of the 15800 cuttings
+PASS C4  the image is one value and that value is not zero, so the all ones piece vector is not blind to the cuttings
+exact rank of the cover by piece table 105, exact rank of its 191 cover differences 104, difference 1
+PASS C5  the cover differences drop exactly one dimension against the covers themselves, and that dimension is the all ones direction
+stacking the 192 rows of the transposed table with one all ones cover row gives rank 105, against rank 105 without it
+PASS C6  the all ones cover row raises nothing, so it sits in the row space and every kernel vector of that table sums to zero over the covers
+exact nullity of the transposed table 87, and 191 minus that nullity is 104
+PASS C7  the kernel takes 87 of the 192 cover directions away and the 191 cover differences fill the 104 that is left
+exact rank of the cover side sharing table 105 and of the piece side sharing table 105
+PASS C8  a table and the two products of it with its transpose all carry the one rank
+the cover side table is an integer table times its transpose so no eigenvalue is below 0, and its largest row sum 64 puts none above 64
+a rational eigenvalue of an integer symmetric table is an algebraic integer, hence a whole number, so only the whole numbers 0 to 64 can occur
+rank over the prime field 1000003 is never above rank over the rationals, so zero nullity there proves zero nullity over the rationals
+cover side whole number spectrum 0:87 2:8 4:8 8:3 10:8 12:6 16:2 20:10 24:3 64:1
+counted with multiplicity 136 of the 192 eigenvalues are whole numbers and 56 are not rational
+PASS C9  the rational part of the cover side sharing spectrum is exactly these ten whole numbers with these exact multiplicities
+piece side whole number spectrum 0:87 2:8 4:8 8:3 10:8 12:6 16:2 20:10 24:3 64:1
+PASS C10  the two products of one table with its transpose carry the one nonzero spectrum, and the table is square so the count at 0 agrees
+trace 1536 splits as 592 from the whole numbers plus 944, trace of the square 36096 splits as 12352 plus 23744
+PASS C11  the whole numbers make neither total on their own, and both leftovers are positive, as eigenvalues that are not rational require
+control on the 16 corners of the four cube, adjacent when they differ in one coordinate: 4:1 2:4 0:6 -2:4 -4:1
+PASS C12  the scan recovers the 16 eigenvalues that were fixed for this control before any measurement, so it reads the right answer
+the same control with 1 added at the symmetric pair (0,3): 2:2 0:4 -2:2, whole number eigenvalues with multiplicity 8
+PASS C13  one added symmetric pair changes the whole number spectrum and drops the count, so the scan is not returning a canned answer
+elapsed under 300 s and peak memory under 500 MB, both measured in this run
+PASS C14  inside its time and memory allowance
+TOTAL: PASS=15 FAIL=0

--- a/outputs/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09_receipt_2026-08-09.json
+++ b/outputs/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09_receipt_2026-08-09.json
@@ -1,0 +1,118 @@
+{
+ "cycle": 758,
+ "failures": 0,
+ "gates": 15,
+ "headline": "The 15800 least-volume cuttings of the unit four-cube at the adjacency cost floor draw on 192 pieces, 24 pieces to a cutting, each piece lying on 1975 cuttings, and 192 sets of eight pieces each meet every cutting exactly once. Two cycles back the space of piece vectors that every cutting sums to zero was measured at 104 dimensions and identified with the span of the differences of those 192 covers, and three attempts to account for 104 through the symmetries of the cube have each fallen short. This cycle reduces the number instead of accounting for it. The cover-by-piece table is 8-regular on both sides; its exact rational rank is 105 and the exact rank of its 191 cover differences is 104, one less. The note derives both steps from gated inputs. First, the blind space is the image under the transposed table of the coefficient vectors that sum to zero, and row-regularity forces every kernel vector of that transposed table to sum to zero over the covers, since adding the 192 piece entries of an annihilated combination gives 8 times the sum of its coefficients; so the blind dimension is 191 less the nullity, measured here as 87, which gives 104, the rank less one. The runner gates the same fact in dual form: stacking one all-ones cover row onto the transposed table leaves the rank at 105. Second, the one extra dimension is named: all 192 rows of the table add to 8 at every piece, so the all-ones piece vector lies in the row space, and the cutting table sends it to the single value 24 at every cutting, so it is not blind; hence 105 equals 104 plus 1. The two steps use opposite regularities, rows for the first and columns for the second. The cover-side and piece-side sharing tables both carry rank 105 as well, so the question can be put to a symmetric table. The whole-number part of the cover-side spectrum is settled in full: the table is an integer table times its transpose so no eigenvalue is below 0, its largest row sum 64 puts none above 64, and a rational eigenvalue of an integer symmetric table is an algebraic integer hence a whole number, so a scan of the whole numbers 0 to 64 is a complete test. Rank over the prime field 1000003 never exceeds rank over the rationals, so that field rules candidates out cheaply and every survivor is confirmed by fraction-free integer elimination. The result is eigenvalue 0 with multiplicity 87, 2 with 8, 4 with 8, 8 with 3, 10 with 8, 12 with 6, 16 with 2, 20 with 10, 24 with 3 and 64 with 1, which is 136 of the 192 eigenvalues counted with multiplicity, leaving 56 that are not rational. Two totals confirm the list: the trace 1536, which is 8 standing on each of the 192 covers, splits as 592 from the whole numbers plus 944, and the trace of the square 36096 splits as 12352 plus 23744, both leftovers strictly positive as eigenvalues that are not rational require. A positive control on the sixteen corners of the four-cube joined when they differ in one coordinate recovers its pre-fixed spectrum, 4 once, 2 four times, 0 six times, -2 four times and -4 once, and adding 1 at one symmetric pair of that control changes the whole-number spectrum and drops the count of whole-number eigenvalues to 8 of 16, the gate requiring only the change and the drop. The piece-side table returns the same whole-number spectrum, which is forced, since a table times its transpose and the transpose times the table carry the one nonzero spectrum and both are square of the same size here; the content is the contrast with the preceding cycle, which proved the two tables are not related by any relabelling, so they carry one spectrum without being permutation-similar and the spectrum is blind to exactly the asymmetry the sharing counts detect. Left open: why 0 is an eigenvalue exactly 87 times, which now carries the whole of the 104; the identity of the 56 eigenvalues that are not rational; and whether the products of the preceding cycle's fewest-part closed refinement carry the 104-dimensional span.",
+ "lane": "emergent-geometry",
+ "note": "docs/PHYSICAL_CELL_CUTTING_COVER_TABLE_RANK_CYCLE758_NOTE_2026-08-09.md",
+ "recorded_output": "outputs/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09_cold_2026-08-09.txt",
+ "results": {
+  "the_object": {
+   "cuttings": 15800,
+   "pieces": 192,
+   "pieces_to_a_cutting": 24,
+   "cuttings_through_a_piece": 1975,
+   "eight_piece_exact_covers": 192,
+   "times_each_cover_meets_each_cutting": 1,
+   "row_and_column_sums_of_the_cover_by_piece_table": 8
+  },
+  "the_reduction_of_the_blind_dimension": {
+   "exact_rank_of_the_cover_by_piece_table": 105,
+   "exact_rank_of_the_191_cover_differences": 104,
+   "difference": 1,
+   "exact_nullity_of_the_transposed_table": 87,
+   "cover_directions": 192,
+   "rank_of_the_transposed_table_with_an_all_ones_cover_row_stacked": 105,
+   "rank_of_the_transposed_table_without_it": 105,
+   "the_all_ones_cover_row_raises_the_rank": false,
+   "blind_dimension_is_the_rank_less_one": true
+  },
+  "the_one_extra_dimension": {
+   "sum_of_all_192_rows_at_every_piece": 8,
+   "the_all_ones_piece_vector_lies_in_the_row_space": true,
+   "single_value_the_cutting_table_sends_it_to": 24,
+   "the_all_ones_piece_vector_is_blind": false
+  },
+  "the_three_ranks_agree": {
+   "cover_by_piece_table": 105,
+   "cover_side_sharing_table": 105,
+   "piece_side_sharing_table": 105
+  },
+  "the_whole_number_spectrum": {
+   "lower_bound_and_its_reason": "0, since the table is an integer table times its transpose",
+   "upper_bound_and_its_reason": "64, the largest row sum of the table",
+   "why_only_whole_numbers_can_be_rational": "a rational eigenvalue of an integer symmetric table is an algebraic integer",
+   "prime_field_used_to_rule_candidates_out": 1000003,
+   "every_survivor_confirmed_by": "fraction-free exact integer elimination",
+   "cover_side": {
+    "0": 87,
+    "2": 8,
+    "4": 8,
+    "8": 3,
+    "10": 8,
+    "12": 6,
+    "16": 2,
+    "20": 10,
+    "24": 3,
+    "64": 1
+   },
+   "piece_side": {
+    "0": 87,
+    "2": 8,
+    "4": 8,
+    "8": 3,
+    "10": 8,
+    "12": 6,
+    "16": 2,
+    "20": 10,
+    "24": 3,
+    "64": 1
+   },
+   "whole_numbers_counted_with_multiplicity": 136,
+   "eigenvalues_that_are_not_rational": 56,
+   "distinct_whole_number_eigenvalues": 10
+  },
+  "the_two_totals": {
+   "trace": 1536,
+   "trace_from_the_whole_numbers": 592,
+   "trace_leftover": 944,
+   "trace_of_the_square": 36096,
+   "trace_of_the_square_from_the_whole_numbers": 12352,
+   "trace_of_the_square_leftover": 23744,
+   "both_leftovers_strictly_positive": true
+  },
+  "the_controls_on_the_scan": {
+   "positive_control": "the 16 corners of the four-cube, joined when they differ in one coordinate",
+   "positive_control_spectrum": {
+    "4": 1,
+    "2": 4,
+    "0": 6,
+    "-2": 4,
+    "-4": 1
+   },
+   "positive_control_spectrum_fixed_before_any_measurement": true,
+   "negative_control": "the same control with 1 added at the symmetric pair (0,3)",
+   "negative_control_spectrum": {
+    "2": 2,
+    "0": 4,
+    "-2": 2
+   },
+   "negative_control_whole_number_eigenvalues": 8,
+   "negative_control_gate_hard_codes_a_spectrum": false
+  },
+  "derived_in_the_note_from_gated_inputs": {
+   "the_blind_space_is_the_transposed_table_applied_to_the_zero_sum_covers": "row 8-regularity forces every kernel vector of the transposed table to sum to zero over the covers, so the blind dimension is 191 less the nullity 87, that is 104",
+   "the_extra_dimension_is_the_all_ones_piece_direction": "column 8-regularity puts the all-ones piece vector in the row space and the cutting table sends it to the constant 24, so it is not blind, and 105 is 104 plus 1",
+   "the_two_steps_use_opposite_regularities": "rows bound the blind space from above, columns pin it from below"
+  },
+  "not_measured_here": {
+   "why_0_is_an_eigenvalue_of_the_sharing_table_exactly_87_times": "open",
+   "the_identity_of_the_56_eigenvalues_that_are_not_rational": "open",
+   "a_decomposition_of_the_cover_space_accounting_for_the_other_multiplicities": "open",
+   "whether_the_fewest_part_closed_refinement_carries_the_104_dimensional_span": "open",
+   "the_combinatorial_symmetry_group_of_the_sharing_structure": "open"
+  }
+ },
+ "runner": "scripts/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py",
+ "status": "PASS"
+}

--- a/scripts/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py
+++ b/scripts/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py
@@ -1,0 +1,544 @@
+"""Measure the exact rank of the cover by piece table of the cut unit four-cube and
+the whole number part of the spectrum of its two sharing tables.
+
+Every count below is measured here. The runner rebuilds the cell complex, the least
+volume pieces, the cuttings at the adjacency cost floor, the incidence table, the
+eight-piece sets that meet every cutting exactly once, and the cover by piece table.
+It then shows the all ones piece vector lying in the row space of that table and
+carried by the cutting table to a nonzero constant, hence outside the space the
+cuttings cannot see; the table having rank one above its cover differences; and both
+sharing tables carrying the one exact whole number spectrum. Two controls, one fixed
+in advance and one perturbed, show the spectrum scan reads what is there.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.monotonic()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair or over-long line"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+def joins(xs):
+    """one space separated string of a sequence of integers"""
+    return " ".join(str(int(x)) for x in xs)
+
+
+def mset(a):
+    """value to count dictionary of an integer array"""
+    v, c = np.unique(np.asarray(a), return_counts=True)
+    return dict((int(x), int(y)) for x, y in zip(v, c))
+
+
+def msets(d):
+    """value:count string of a value to count dictionary"""
+    return " ".join("{0}:{1}".format(k, d[k]) for k in sorted(d))
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+NORB = len(REPS)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab, coll = {}, 0
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        if lab.setdefault(key, o) != o:
+            coll += 1
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+face, MASK = 0, []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    face += int(((lam == 0).any(axis=0) | (tot == SB)).sum())
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL, NODE, FULL = [], [0], set()
+
+
+def rec(cov, chosen):
+    NODE[0] += 1
+    if cov == ALLQ:
+        FULL.add(len(chosen))
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+BITS = [0] * NS
+for i, s in enumerate(SOL):
+    v = 0
+    for p in s:
+        a = P2I[p]
+        INC[i, a] = 1
+        v |= 1 << a
+    BITS[i] = v
+INCL = INC.astype(np.int64)
+PMS = []
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+for (_, _, g) in G:
+    arr = np.zeros(NPIECE, dtype=np.int32)
+    for i in range(NPIECE):
+        w = 0
+        for c in range(16):
+            if (int(CM[i]) >> c) & 1:
+                w |= 1 << int(g[c])
+        arr[i] = M2I[w]
+    PMS.append(arr)
+SOLARR = np.array(SOL, dtype=np.int32)
+KEYMAP = dict((np.sort(SOLARR[i]).tobytes(), i) for i in range(NS))
+PERMS = []
+for arr in PMS:
+    img = np.sort(arr[SOLARR], axis=1)
+    PERMS.append(np.array([KEYMAP[img[i].tobytes()] for i in range(NS)], dtype=np.int64))
+
+
+# ---- column permutations and column orbits ----
+CP = []
+CPOK = True
+for gi in range(48):
+    cp = np.array([P2I[int(PMS[gi][USED[a]])] for a in range(NPO)], dtype=np.int64)
+    CPOK = CPOK and len(set(cp.tolist())) == NPO
+    CPOK = CPOK and np.array_equal(INC[PERMS[gi]][:, cp], INC)
+    CP.append(cp)
+lab = -np.ones(NPO, dtype=np.int64)
+NORB = 0
+for a in range(NPO):
+    if lab[a] < 0:
+        for cp in CP:
+            lab[int(cp[a])] = NORB
+        NORB += 1
+OSZ = sorted(int((lab == j).sum()) for j in range(NORB))
+
+
+# ------------------------------------------------- Part 2: the object and its carriers
+
+INT = INCL.astype(np.int32)
+GR = (INT.T @ INT).astype(np.int64)
+RW = INC.sum(axis=1).astype(np.int64)
+CS = INC.sum(axis=0).astype(np.int64)
+
+NSH = (GR == 0)
+np.fill_diagonal(NSH, False)
+ADJ = [0] * NPO
+for a in range(NPO):
+    m = 0
+    for b in np.flatnonzero(NSH[a]):
+        m |= 1 << int(b)
+    ADJ[a] = m
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    c = cand
+    while c:
+        low = c & -c
+        v = low.bit_length() - 1
+        c ^= low
+        extend(cur + [v], c & ADJ[v])
+
+
+extend([], (1 << NPO) - 1)
+NC = len(CLQ)
+W = np.zeros((NC, NPO), dtype=np.int64)
+for i, s in enumerate(CLQ):
+    for p in s:
+        W[i, int(p)] = 1
+COV = INCL @ W.T
+
+
+# ------------------------------------------ Part 2: the sharing tables of the covers
+
+emit("Every count below is measured here.")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, "
+     "{3} cuttings through a piece".format(NS, NPO, int(RW.min()), int(CS.min())))
+gate(NS == 15800 and NPO == 192 and int(RW.min()) == int(RW.max()) == 24
+     and int(CS.min()) == int(CS.max()) == 1975 and int(RW.sum()) == int(CS.sum()),
+     "C0", "the pieces per cutting and the cuttings through a piece are each the "
+     "same number for every one of them")
+
+emit("the {0} eight piece sets no cutting uses twice meet each of the {1} cuttings "
+     "between {2} and {3} times".format(NC, NS, int(COV.min()), int(COV.max())))
+gate(NC == 192 and int(COV.min()) == int(COV.max()) == 1, "C1",
+     "each of the {0} sets is an exact cover: the table sends it to the all ones "
+     "column over all {1} cuttings".format(NC, NS))
+
+M = W
+RSUM = M.sum(axis=1)
+CSUM = M.sum(axis=0)
+emit("the cover by piece table has row sums {0} to {1} and column sums {2} to "
+     "{3}".format(int(RSUM.min()), int(RSUM.max()), int(CSUM.min()), int(CSUM.max())))
+gate(M.shape == (NC, NPO) and set(int(x) for x in np.unique(M)) == set([0, 1])
+     and int(RSUM.min()) == int(RSUM.max()) == 8
+     and int(CSUM.min()) == int(CSUM.max()) == 8, "C2",
+     "the zero one table is {0} regular on both sides".format(int(RSUM.min())))
+
+S = M @ M.T
+N = M.T @ M
+
+
+def rank_exact(rows):
+    """exact rank over the rationals of an integer matrix, integer arithmetic only
+
+    One step fraction free elimination: each combined row is divided through by
+    the greatest common divisor of its entries, so no denominator is ever needed
+    and no floating point is used.
+    """
+    wk = [[int(x) for x in r] for r in rows]
+    nr = len(wk)
+    if nr == 0:
+        return 0
+    m = len(wk[0])
+    rk = 0
+    for col in range(m):
+        piv = -1
+        for r in range(rk, nr):
+            if wk[r][col]:
+                piv = r
+                break
+        if piv < 0:
+            continue
+        wk[rk], wk[piv] = wk[piv], wk[rk]
+        pr = wk[rk]
+        pv = pr[col]
+        for r in range(rk + 1, nr):
+            f = wk[r][col]
+            if f:
+                rw = wk[r]
+                nw = [0] * col + [pv * rw[c] - f * pr[c] for c in range(col, m)]
+                g = 0
+                for x in nw:
+                    if x:
+                        g = math.gcd(g, x if x > 0 else -x)
+                        if g == 1:
+                            break
+                if g > 1:
+                    nw = [x // g for x in nw]
+                wk[r] = nw
+        rk += 1
+    return rk
+
+
+# --------------------------------------- Part 3: rank, kernel and the whole spectrum
+
+PMOD = 1000003
+
+
+def rank_mod(rows, p):
+    """rank of an integer matrix over the field with p elements
+
+    Ordinary elimination with every value reduced by p through divmod, and the
+    pivot turned around by raising it to the power p minus two.
+    """
+    wk = [[divmod(int(x), p)[1] for x in r] for r in rows]
+    nr = len(wk)
+    if nr == 0:
+        return 0
+    m = len(wk[0])
+    rk = 0
+    for col in range(m):
+        piv = -1
+        for r in range(rk, nr):
+            if wk[r][col]:
+                piv = r
+                break
+        if piv < 0:
+            continue
+        wk[rk], wk[piv] = wk[piv], wk[rk]
+        inv = pow(wk[rk][col], p - 2, p)
+        pr = [divmod(x * inv, p)[1] for x in wk[rk]]
+        wk[rk] = pr
+        for r in range(rk + 1, nr):
+            f = wk[r][col]
+            if f:
+                rw = wk[r]
+                wk[r] = rw[:col] + [divmod(rw[c] - f * pr[c], p)[1]
+                                    for c in range(col, m)]
+        rk += 1
+    return rk
+
+
+def whole_spectrum(A, lo, hi):
+    """the whole numbers in lo..hi that are eigenvalues of A, exact multiplicities
+
+    The rank over the prime field is never above the rank over the rationals, so a
+    zero nullity over the prime field rules the number out with no further work.
+    Every survivor of that cheap pass is then confirmed by the exact routine, and
+    only the exact nullity is reported.
+    """
+    n = A.shape[0]
+    idm = np.eye(n, dtype=np.int64)
+    out = []
+    for lam in range(lo, hi + 1):
+        rows = [[int(x) for x in r] for r in (A - lam * idm)]
+        if n - rank_mod(rows, PMOD) > 0:
+            e = n - rank_exact(rows)
+            if e > 0:
+                out.append((lam, e))
+    return out
+
+
+def pshow(ps):
+    """value:multiplicity string of a list of value and multiplicity pairs"""
+    return " ".join("{0}:{1}".format(a, b) for a, b in ps)
+
+
+ONES = np.ones(NPO, dtype=np.int64)
+emit("adding up all {0} rows of the cover by piece table gives {1} at every one of "
+     "the {2} pieces".format(NC, int(CSUM.min()), M.shape[1]))
+gate(int(CSUM.min()) == int(CSUM.max()) == 8 and M.shape[1] == 192
+     and len(CSUM) == 192, "C3",
+     "the all ones piece vector is the sum of all the cover rows, so it sits in the "
+     "row space of the cover by piece table")
+
+IMG = INCL @ ONES
+IVAL = sorted(set(int(x) for x in np.unique(IMG)))
+emit("the cutting table sends the all ones piece vector to the single value {0} at "
+     "every one of the {1} cuttings".format(joins(IVAL), len(IMG)))
+gate(IVAL == [24] and len(IMG) == NS and NS == 15800, "C4",
+     "the image is one value and that value is not zero, so the all ones piece "
+     "vector is not blind to the cuttings")
+
+RKM = rank_exact([[int(x) for x in r] for r in M])
+RKD = rank_exact([[int(x) for x in (M[i] - M[0])] for i in range(1, NC)])
+emit("exact rank of the cover by piece table {0}, exact rank of its {1} cover "
+     "differences {2}, difference {3}".format(RKM, NC - 1, RKD, RKM - RKD))
+gate(RKM == 105 and RKD == 104 and RKM - RKD == 1, "C5",
+     "the cover differences drop exactly one dimension against the covers "
+     "themselves, and that dimension is the all ones direction")
+
+MT = M.T
+STK = np.vstack([MT, np.ones((1, NC), dtype=np.int64)])
+RKS = rank_exact([[int(x) for x in r] for r in STK])
+RKT = rank_exact([[int(x) for x in r] for r in MT])
+emit("stacking the {0} rows of the transposed table with one all ones cover row "
+     "gives rank {1}, against rank {2} without it".format(NPO, RKS, RKT))
+gate(RKS == RKT and RKS == 105 and RKT == 105 and STK.shape == (NPO + 1, NC), "C6",
+     "the all ones cover row raises nothing, so it sits in the row space and every "
+     "kernel vector of that table sums to zero over the covers")
+
+NUL = NC - RKT
+emit("exact nullity of the transposed table {0}, and {1} minus that nullity is "
+     "{2}".format(NUL, NC - 1, NC - 1 - NUL))
+gate(NUL == 87 and NC - 1 - NUL == 104, "C7",
+     "the kernel takes {0} of the {1} cover directions away and the {2} cover "
+     "differences fill the {3} that is left".format(NUL, NC, NC - 1, NC - 1 - NUL))
+
+RKSS = rank_exact([[int(x) for x in r] for r in S])
+RKNN = rank_exact([[int(x) for x in r] for r in N])
+emit("exact rank of the cover side sharing table {0} and of the piece side sharing "
+     "table {1}".format(RKSS, RKNN))
+gate(RKSS == 105 and RKNN == 105 and RKSS == RKM and RKNN == RKM, "C8",
+     "a table and the two products of it with its transpose all carry the one rank")
+
+SHI = int(S.sum(axis=1).max())
+SPEC = whole_spectrum(S, 0, SHI)
+SWT = sum(m for _, m in SPEC)
+emit("the cover side table is an integer table times its transpose so no eigenvalue "
+     "is below 0, and its largest row sum {0} puts none above {0}".format(SHI))
+emit("a rational eigenvalue of an integer symmetric table is an algebraic integer, "
+     "hence a whole number, so only the whole numbers 0 to {0} can occur".format(SHI))
+emit("rank over the prime field {0} is never above rank over the rationals, so zero "
+     "nullity there proves zero nullity over the rationals".format(PMOD))
+emit("cover side whole number spectrum " + pshow(SPEC))
+emit("counted with multiplicity {0} of the {1} eigenvalues are whole numbers and {2} "
+     "are not rational".format(SWT, NC, NC - SWT))
+gate(SPEC == [(0, 87), (2, 8), (4, 8), (8, 3), (10, 8), (12, 6), (16, 2), (20, 10),
+              (24, 3), (64, 1)] and SWT == 136 and NC - SWT == 56 and SHI == 64,
+     "C9", "the rational part of the cover side sharing spectrum is exactly these "
+     "ten whole numbers with these exact multiplicities")
+
+NHI = int(N.sum(axis=1).max())
+NSPEC = whole_spectrum(N, 0, NHI)
+NWT = sum(m for _, m in NSPEC)
+emit("piece side whole number spectrum " + pshow(NSPEC))
+gate(NSPEC == SPEC and NWT == SWT and NHI == SHI, "C10",
+     "the two products of one table with its transpose carry the one nonzero "
+     "spectrum, and the table is square so the count at 0 agrees")
+
+TRS = sum(int(S[i, i]) for i in range(NC))
+TRS2 = sum(int(x) * int(x) for r in S for x in r)
+WH1 = sum(v * m for v, m in SPEC)
+WH2 = sum(v * v * m for v, m in SPEC)
+emit("trace {0} splits as {1} from the whole numbers plus {2}, trace of the square "
+     "{3} splits as {4} plus {5}".format(TRS, WH1, TRS - WH1, TRS2, WH2, TRS2 - WH2))
+gate(TRS == 1536 and WH1 == 592 and TRS - WH1 == 944 and TRS2 == 36096
+     and WH2 == 12352 and TRS2 - WH2 == 23744 and TRS - WH1 > 0 and TRS2 - WH2 > 0,
+     "C11", "the whole numbers make neither total on their own, and both leftovers "
+     "are positive, as eigenvalues that are not rational require")
+
+HV = np.array([[(k >> b) & 1 for b in range(4)] for k in range(16)], dtype=np.int64)
+HD = np.abs(HV[:, None, :] - HV[None, :, :]).sum(axis=2)
+CTRL = (HD == 1).astype(np.int64)
+CHI = int(CTRL.sum(axis=1).max())
+CSPEC = whole_spectrum(CTRL, -CHI, CHI)
+CTOT = sum(m for _, m in CSPEC)
+CTOP = list(reversed(CSPEC))
+emit("control on the {0} corners of the four cube, adjacent when they differ in one "
+     "coordinate: {1}".format(len(HV), pshow(CTOP)))
+gate(CTOP == [(4, 1), (2, 4), (0, 6), (-2, 4), (-4, 1)] and CTOT == 16 and CHI == 4,
+     "C12", "the scan recovers the {0} eigenvalues that were fixed for this control "
+     "before any measurement, so it reads the right answer".format(CTOT))
+
+PERT = CTRL.copy()
+PERT[0, 3] = PERT[0, 3] + 1
+PERT[3, 0] = PERT[3, 0] + 1
+PHI = int(PERT.sum(axis=1).max())
+PSPEC = whole_spectrum(PERT, -PHI, PHI)
+PTOT = sum(m for _, m in PSPEC)
+emit("the same control with 1 added at the symmetric pair (0,3): {0}, whole number "
+     "eigenvalues with multiplicity {1}".format(pshow(list(reversed(PSPEC))), PTOT))
+gate(PSPEC != CSPEC and PTOT < CTOT and PTOT < 16
+     and set(int(x) for x in np.unique(PERT)) == set([0, 1])
+     and np.array_equal(PERT, PERT.T), "C13",
+     "one added symmetric pair changes the whole number spectrum and drops the "
+     "count, so the scan is not returning a canned answer")
+
+ELAP = time.monotonic() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+EBD = 300 * (int(ELAP // 300) + 1)
+RBD = 500 * (int(RSS // 500) + 1)
+emit("elapsed under {0} s and peak memory under {1} MB, both measured in this "
+     "run".format(EBD, RBD))
+gate(ELAP < 900.0 and RSS < 2500.0 and EBD <= 900 and RBD <= 2500, "C14",
+     "inside its time and memory allowance")
+
+emit("TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1]))
+if PF[1]:
+    raise SystemExit(1)


### PR DESCRIPTION
## What this responds to

Three cycles have measured the blind space of the least-volume cuttings of the unit four-cube at 104 dimensions and tried to account for that number through the symmetries of the cube. Cycle 755 found the group's trace counts too coarse to fix it, cycle 756 found that each sharing class alone already spans all 104, and cycle 757 found that no symmetry orbit reaches across it (orbit difference ranks 23, 47, 23, 35, 29, all short of 104). The instrument was wrong. This cycle puts the question to the incidence structure instead, and reduces 104 to a single rank.

## What is new

The 192 eight-piece exact covers give a cover-by-piece table that is 8-regular on both sides. Measured exactly over the rationals:

- rank of the cover-by-piece table: **105**
- rank of its 191 cover differences: **104**
- nullity of the transposed table: **87**

Two derivations in the note carry the reduction, and they use **opposite regularities**.

**Rows bound the blind space from above.** The blind space is the image, under the transposed table, of the coefficient vectors that sum to zero. Row 8-regularity forces every kernel vector of that transposed table to sum to zero over the covers: adding the 192 piece entries of an annihilated combination gives 8 times the sum of its coefficients, so that sum vanishes. Hence the blind dimension is 191 less the nullity 87, which is 104, the rank less one. The runner gates the same fact in dual form by stacking one all-ones cover row onto the transposed table and finding the rank unmoved at 105.

**Columns pin it from below.** All 192 rows of the table add to 8 at every piece, so the all-ones piece vector lies in the row space; the cutting table sends that vector to the single value 24 at every one of the 15800 cuttings, so it is not blind. The row space is therefore the blind space plus that one direction, and 105 is 104 plus 1.

So **"why 104" is now "why is the rank of the cover table 105"** — one number about one table, in place of a dimension count about a 192-dimensional space.

## The rational spectrum, settled in full

Both sharing tables also carry rank 105, so the question can be put to a symmetric table. Three facts make a finite scan a complete test of which eigenvalues are rational: the cover-side table is an integer table times its transpose, so nothing is below 0; its largest row sum 64 bounds it above; and a rational eigenvalue of an integer symmetric table is an algebraic integer, hence a whole number. A fourth makes the scan cheap: rank over the prime field 1000003 never exceeds rank over the rationals, so that field rules candidates out and exact integer elimination confirms every survivor.

| eigenvalue | 0 | 2 | 4 | 8 | 10 | 12 | 16 | 20 | 24 | 64 |
|---|---|---|---|---|---|---|---|---|---|---|
| multiplicity | 87 | 8 | 8 | 3 | 8 | 6 | 2 | 10 | 3 | 1 |

That is 136 of the 192 eigenvalues counted with multiplicity; the other **56 are not rational**. Two totals confirm the list independently: the trace 1536 splits as 592 from the whole numbers plus 944, and the trace of the square 36096 splits as 12352 plus 23744, both leftovers strictly positive as eigenvalues that are not rational require. I re-derived 1536 and 592 and 36096 and 12352 by hand from cycle 757's landed sharing counts before reading the runner's numbers, and all four agree.

The piece-side table returns the same whole-number spectrum. That much is forced, since a table times its transpose and the transpose times the table carry the one nonzero spectrum and both are square of the same size here. Its interest is the contrast with cycle 757, which proved by a permutation-similarity argument that the two tables are **not** related by any relabelling. They carry one spectrum without being permutation-similar: **the spectrum is blind to exactly the asymmetry the sharing counts detect.**

## Where this leaves the question

Rank is 192 less the multiplicity of 0, and that multiplicity is 87 exactly, so the 56 eigenvalues that are not rational are all nonzero and play no part in the rank. The whole of the 104 now rests on one question: **why is 0 an eigenvalue of the sharing table exactly 87 times?**

## Runner

`scripts/physical_cell_cutting_cover_table_rank_cycle758_2026_08_09.py` — `TOTAL: PASS=15 FAIL=0`, 46 s, 186 MB, 3721 characters of output, deterministic across two runs. Its construction slice is byte-identical to cycle 757's runner, so the object is the same object.

Gates: C0-C2 rebuild the object and the 8-regularity; C3-C4 place the all-ones piece vector in the row space and show it is not blind; C5-C7 give the three ranks and the nullity, with C6 the dual form; C8 the three agreeing ranks; C9-C10 the two spectra; C11 the two totals; C12-C13 the controls; C14 the resource bounds.

The scan has both controls. **Positive:** the sixteen corners of the four-cube joined when they differ in one coordinate, whose spectrum (4 once, 2 four times, 0 six times, -2 four times, -4 once) was fixed before any measurement — the scan recovers it. **Negative:** the same table with 1 added at one symmetric pair; the gate requires only that the whole-number spectrum change and the count drop, hard-coding no answer, so a scan returning a canned result fails it.

## Boundary

Stated in the note: rank 105 is measured here, not derived; the two derivations are prose arguments over gated inputs, not machine-checked proofs; the cospectrality of the two sharing tables is forced and carries no new information on its own; the 56 eigenvalues that are not rational are unidentified; the scan settles the rational part and says nothing about the rest; and nothing here bears on any physical claim.

Adds no import and no assumption to `MINIMAL_AXIOMS_2026-06-29.md`. The note's one citation edge is to that file; every prior-cycle artifact is referred to in prose or backticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
