### PR TITLE
feat(cell-cutting): exact leverage 11/24 and projector denominator 960

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_VISIBLE_FRACTION_CYCLE760_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_VISIBLE_FRACTION_CYCLE760_NOTE_2026-08-09.md
@@ -1,0 +1,341 @@
+# Every piece is seen in the same fraction, and what makes that fraction whole is the number the two lattices already named — Cycle 760
+
+Date: 2026-08-09
+
+Authority: none
+
+Audit: unset.
+
+Status: computational identities of the finite cutting system
+
+Claim type: computational identities
+
+Runner:
+
+- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py)
+
+Scope: computational identities of the finite cutting system. Every number
+below is machine-checked by the paired runner, which rebuilds the cell
+complex, the least-volume pieces, the cuttings at the adjacency cost floor,
+the cutting-by-piece table and the eight-piece exact covers, then builds the
+relabellings got by permuting the four coordinates of the four-cube and
+flipping any of them, measures the blocks they cut the pieces into, certifies
+an exact whole-number multiple of the orthogonal projector onto the span of
+the cuttings, reads its diagonal, finds the smallest whole multiplier that
+clears it, sets that multiplier beside the invariant factors of the same
+side's Gram matrix, and checks the exact identity tying the two sides
+together, gating each quantity in place. Six of the gates carry
+controls whose job is to show that each hypothesis the argument leans on is
+doing work, and that the routines report something other than the answer
+being looked for when the answer is not there. Constitutional effect: none.
+This package changes no axiom, no framework Admissibility rule, no primitive,
+no policy, and no audit status, and it adds no import and no assumption to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## What this answers
+
+The object is the unit four-cube on sixteen corners, cut into least-volume
+pieces at the adjacency cost floor. There are 15800 such cuttings; between
+them they draw on 192 pieces, 24 pieces to a cutting, and each piece lies on
+1975 cuttings. Those same 192 pieces admit 192 eight-piece exact covers.
+
+Ask how much of each piece the cuttings see. The answer measured here is the
+same fraction at every one of the 192 pieces, 11 over 24, with no piece
+favoured over any other. Separately, an earlier cycle of this lane measured
+960 as the number controlling how two whole-number lattices built from this
+object fail to glue, and read it as the smallest whole number carrying any
+labelling of the pieces into a whole-number seen part plus a whole-number
+blind part; its own boundary said the value was measured and not derived, and
+that nothing there forced it.
+
+This cycle shows two things about that pair of facts. The first fraction is
+forced rather than merely measured: it could not have come out any other way
+once two hypotheses hold, and both hypotheses are shown here to be doing
+work. And the earlier cycle's reading of 960 turns out to be the denominator
+of that same fraction, so the two facts are one fact seen twice. What is new
+is the numerator, and that the numerator is the same at every piece.
+
+## The symmetry the cost supplies, and the symmetry the answer has
+
+The cost that defines this cutting system does not treat the four coordinates
+alike. Adjacency is between nearest neighbours in space, so the cost is
+written in the three spatial coordinates and the fourth, the tick, enters
+differently. What the cost hands over directly is therefore the 48
+relabellings that turn the three spatial coordinates among themselves and may
+flip the tick.
+
+Yet all 384 relabellings got by permuting the four coordinates of the
+four-cube and flipping any of them carry the whole system onto itself: each
+one sends the 15800 cuttings onto the 15800 cuttings and the 192 covers onto
+the 192 covers (C2). The system is blind to which of the four coordinates is
+called the tick.
+
+The ladder of blocks on the 192 pieces:
+
+| relabellings | what they are | blocks on the 192 pieces |
+| --- | --- | --- |
+| 24 | proper turns of the three spatial coordinates | 8 of 24 |
+| 48 | those, with the tick flip allowed | 4 of 48 |
+| 96 | everything that keeps the tick coordinate in place | 2 of 96 |
+| 384 | all four-coordinate permutations and flips | 1 of 192 |
+
+Read down the table: the 192 pieces fall into eight blocks of 24 under the
+proper turns, four blocks of 48 once the tick flip is allowed, two blocks of
+96 under everything that keeps the tick coordinate in place, and one block
+only once relabellings that carry the tick coordinate onto a spatial one are
+allowed.
+
+Earlier cycles of this lane established, and this cycle uses rather than
+re-derives: that the group has order 384; that it is the complete symmetry
+group of the cutting system; that it is transitive on the 192 pieces, which
+is the bottom rung of the table; and that the 48 relabellings the cost
+supplies act with four blocks of 48, which is the second rung. Those cycles
+reached the group by a refinement search that produced two extra involutions
+beyond the ones the cost hands over, and stated in their own boundary that no
+coordinate assignment for any piece appeared in them.
+
+What is new here is the plain identification of that group with permuting the
+four coordinates of the four-cube and flipping any of them. That
+identification gives the two searched-out involutions a reading: they are
+relabellings that carry the tick coordinate onto a spatial one. It also
+supplies the two rungs of the table that were not previously in hand, 24
+giving eight blocks and 96 giving two. And it yields the consequence that the
+table is arranged to display: what the cost supplies is 48 of the 384, and
+neither 48 nor 96 is enough for one block. One block needs exactly the
+relabellings the cost does not hand over.
+
+## The visibility matrix, exactly
+
+Write the cutting-by-piece table as a matrix on the 192 pieces, one row per
+cutting, and let `P` be the orthogonal projector onto the span of its rows.
+`P` is a matrix on the 192 pieces. Its diagonal entry at a piece is the
+fraction of that piece the cuttings see, and the diagonal sums to the rank.
+
+The rank over the rational numbers is 88, and the row lattice is saturated:
+two independently chosen 88 by 88 minors both have absolute value 1, which
+forces every invariant factor to be 1 (C4). The cover side is the same
+statement at rank 105 with 105 by 105 minors of absolute value 1.
+
+The runner certifies `N = 960 P` as an exact matrix of whole numbers. The
+modular step only proposes the lift; what certifies it is arithmetic over the
+whole numbers, carried out in Python integer arithmetic so nothing can
+overflow:
+
+- `N` is symmetric.
+- `N N = 960 N`, which is the projector identity cleared by 960.
+- applied to the selected basis rows, `N` returns 960 times them, so it fixes
+  the span it is supposed to fix.
+- `trace N = 84480`, which is 960 times 88.
+
+Its entries run from -121 to 440 and take 23 different values. Every one of
+the 192 diagonal entries is 440, and 440 times 192 is 84480 (C5, C6). The
+cover side is certified the same way at multiplier 320 and rank 105: trace
+33600, which is 320 times 105, with every diagonal entry 175, entries from
+-42 to 175, and 23 different values (C12).
+
+## Why the fraction is forced
+
+The argument is two lines once the previous two sections are in hand.
+
+A relabelling that carries the row set onto itself acts on the pieces by a
+permutation matrix that commutes with the projector onto the span of those
+rows, because it carries that span onto itself. A permutation matrix
+commuting with `N` moves the diagonal of `N` along its own blocks, so the
+diagonal is constant on each block. All 384 relabellings carry the row set
+onto itself and `N` is unchanged by every one of them (C7). The 384 have one
+block. So the diagonal is constant everywhere.
+
+A constant diagonal on 192 pieces summing to 88 leaves no freedom: every
+entry is 88 over 192, which in lowest terms is 11 over 24. The same two lines
+on the cover side give 105 over 192, which is 35 over 64.
+
+Both hypotheses are load-bearing, and the runner shows it by taking each one
+away in turn.
+
+Take away the one block. Two of the four blocks of the 48, taken as two
+indicator rows with multiplier 96, give a row set that is carried onto itself
+by the 48 but not by the 384. Its projector has rank 2, and its diagonal is 0
+on 96 pieces and 2 on the other 96 — two values, not one, even though 96
+times the rank over 192 is the whole number 1 (C8). With four blocks instead
+of one, constancy fails.
+
+Take away the row set being carried onto itself. The indicator of one single
+piece, a coordinate vector rather than a table row, with multiplier 1, has
+rank 1 and a diagonal that is 1 at that one piece and 0 at the other 191
+(C9). The 384 still have one block; the diagonal is still not constant,
+because this row set is not carried onto itself. Neither hypothesis is idle.
+
+## The smallest whole multiplier is the glue exponent
+
+960 clears the cutting-side projector and nothing smaller does: 192, 320 and
+480 each leave a fraction (C10). On the cover side 320 clears it and 64 and
+160 each leave a fraction (C12).
+
+On each side that number is the largest invariant factor of that side's Gram
+matrix, the exponent of the finite group by which two whole-number lattices
+fail to glue: 960 on the cutting side, whose chain has 42 nontrivial factors,
+and 320 on the cover side, whose chain has 41 (C13). The multiplier and the
+exponent are computed by two separate routines, one a search over candidate
+multipliers and the other an invariant-factor computation, and on each side
+they land on the same number.
+
+The cutting-side 960 re-measures what the preceding cycle already stated in
+its own terms. What is new is the equality itself, that the least clearing
+multiplier and the largest invariant factor are the same number, that this
+needs saturation, and that it holds on the cover side too at 320. What the
+constant diagonal adds on top of it is the numerator. Divide each piece into
+960 parts and the cuttings see 440 of them, and it is 440 at every piece
+rather than 440 on average.
+
+The agreement between multiplier and exponent needs the row lattice to be
+saturated, and the runner shows it fails without that. The line through
+(1, 2) is saturated, and its largest invariant factor 5 equals its smallest
+whole multiplier 5. The line through (2, 0) is not saturated, and gives 4
+against 1, which do not agree (C14).
+
+The two sides are not two separate tables whose agreement is a coincidence,
+and this note does not claim they are. Gate C17 checks, entry by entry over the whole
+numbers, that
+
+    3 N2 = 960 I - N + 5 J
+
+with `I` the identity on the 192 pieces and `J` the all-ones matrix. In
+words: what the covers see is exactly what the cuttings do not see, together
+with the all-ones direction. The cover-side rank is therefore forced,
+105 = 192 - 88 + 1, and with it the cover-side fraction 35 over 64. It is not
+a second confirmation of the cutting-side fraction; it is the same fact seen
+from the complement.
+
+Why the tie holds is visible in three steps, and the runner gates the first
+of them. The all-ones vector is seen by the cuttings: `N` times the all-ones
+vector is 960 times the all-ones vector (C17). An earlier cycle of this lane
+measured that the blind space of the cuttings — the labellings of the pieces
+on which every cutting sums to zero — is exactly the span of the differences
+of the 192 exact covers; that measurement is carried in the preceding
+cycle's package,
+`physical_cell_cutting_blind_lattice_generation_cycle759_2026_08_09.py`.
+Differences are perpendicular to the all-ones vector. So what the covers span
+is the blind space together with the all-ones direction, which is the
+identity above. The 5 in it is 960 divided by 192 and the 3 is 960 divided by
+320. The control inside C17 shows the identity discriminates: with 4 J in
+place of 5 J it fails.
+
+What the two sides do still give the multiplier claim is two different values
+to check it at: 960 and 320 are read off the invariant factors of two
+different Gram matrices built from two different pairs of lattices, and the
+identity above does not make those two numbers equal. Two values, two linked
+spaces.
+
+## Runner
+
+`physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py` rebuilds the
+object from the cell complex up and gates eighteen quantities, printing
+`TOTAL: PASS=18 FAIL=0`. The construction is inherited from the preceding
+cycle's runner, so the pieces, the cuttings, the cutting-by-piece table and
+the covers are the same objects, re-derived here rather than imported. Exact
+ranks and determinants are computed by fraction-free elimination; basis rows
+are selected over a prime field and the resulting whole-number identities are
+then checked exactly in Python integer arithmetic.
+
+- C0 the object: 15800 cuttings, 192 pieces, 24 pieces to a cutting, 1975
+  cuttings through a piece, 192 exact covers.
+- C1 the 384 relabellings exist, are pairwise distinct, and permute the 192
+  pieces; they come from the 16 corners of the four-cube.
+- C2 each of the 384 carries the 15800 cuttings onto themselves and the 192
+  covers onto themselves. Control: one of them followed by a swap of two
+  pieces does not.
+- C3 the four rungs of the ladder: 8 of 24, 4 of 48, 2 of 96, 1 of 192.
+- C4 saturation on both sides: 88 by 88 and 105 by 105 minors of absolute
+  value 1, two independent choices each.
+- C5 the cutting-side certificate: symmetric, `N N = 960 N`, fixes the rows,
+  trace 84480.
+- C6 every one of the 192 diagonal entries is 440, so every piece is seen in
+  the fraction 11 over 24.
+- C7 `N` is unchanged by every one of the 384 relabellings.
+- C8 control: two blocks of the 48 with multiplier 96 give rank 2, kept by
+  the 48 and not by the 384, diagonal 0 on 96 pieces and 2 on 96.
+- C9 control: one piece's indicator with multiplier 1 gives rank 1 and
+  diagonal 1 at one piece, 0 at the other 191.
+- C10 960 is the smallest whole multiplier on the cutting side; 192, 320 and
+  480 each leave a fraction.
+- C11 `N` is constant on each of the 104 classes of ordered piece pairs and
+  takes 23 different values.
+- C12 the cover side: certificate at rank 105, diagonal 175, trace 33600,
+  fraction 35 over 64, smallest multiplier 320 with 64 and 160 leaving a
+  fraction, constant on the same 104 classes, 23 values.
+- C13 the largest invariant factor of each Gram matrix: 960 with 42
+  nontrivial on the cutting side, 320 with 41 on the cover side.
+- C14 control: the saturated line agrees at 5 and 5; the line that is not
+  saturated gives 4 against 1.
+- C15 control: the invariant-factor routine returns 1 6 from the diagonal
+  2 3 and 2 12 from the diagonal 4 6, which are not its own entries.
+- C16 elapsed and peak memory, both measured in the run.
+- C17 the tie `3 N2 = 960 I - N + 5 J` over the whole numbers, `N` times the
+  all-ones vector equal to 960 times it, and 192 - 88 + 1 = 105. Control:
+  the same identity with 4 J in place of 5 J fails.
+
+Measured totals: 18 gates, `TOTAL: PASS=18 FAIL=0`, elapsed under 300 s, peak
+resident memory under 500 MB, stdout 2982 characters.
+
+## Boundary
+
+- **Everything here is a count about one finite object.** The cutting system
+  is a finite combinatorial object and every statement made about it is a
+  count or a whole-number identity between counts. Nothing here bears on any
+  physical claim.
+- **The one-block fact is used, not claimed as new.** That the group has
+  order 384, that it is the complete symmetry group of the cutting system,
+  that it is transitive on the 192 pieces, and that the 48 relabellings the
+  cost supplies give four blocks of 48 were all established in earlier cycles
+  of this lane. This cycle measures those rungs again in its own runner so
+  that the argument stands on gated numbers, but claims none of them as new.
+  What is new is the identification of the group with the coordinate
+  permutations and flips of the four-cube, and the two rungs at 24 and 96.
+- **The identification is a statement about this cutting system.** That the
+  full symmetry group is the coordinate permutations and flips of the
+  four-cube says something about this object and carries no claim about the
+  framework's Admissibility rule, about any primitive, or about any other
+  object.
+- **The reading of 960 is a reading of a whole-number fact, and it is not new
+  here.** That 960 is the smallest number of parts a piece must be divided
+  into was already stated by the preceding cycle of this lane in its own
+  terms, and is re-measured here rather than first established here. It is
+  measured, not derived from anything outside the object, and nothing here
+  says why the exponent is 960 rather than some other number. What this cycle
+  adds to it is the numerator 440 and the fact that the numerator is the same
+  at every piece.
+- **The tie between the sides rests on one imported measurement.** The
+  identity `3 N2 = 960 I - N + 5 J` is gated here directly, so it stands on
+  its own. The account of why it holds uses the earlier cycle's measurement
+  that the blind space is the span of the cover differences, which is not
+  re-derived here.
+- **Saturation is checked by a sufficient condition.** A minor of absolute
+  value 1 proves the lattice is saturated; failing to find one would prove
+  nothing. Every witness reported here succeeded, so the asymmetry does not
+  bite, but it bounds what the technique could be used to deny.
+- **No claim is made that the cost's indifference to which coordinate is the
+  tick has any consequence for emergent time.** What is shown is that this
+  particular finite system does not record the distinction: the 384
+  relabellings carry it onto itself, and the fraction each piece is seen in
+  is the same whether or not a relabelling moves the tick.
+
+## Next
+
+Three things are open and reachable from here.
+
+Which of the 23 entry values of `N` sit on which of the 104 classes of
+ordered piece pairs. `N` is constant on every class, so the 23 values
+partition the 104 classes, and the shape of that partition is a direct next
+measurement.
+
+Whether the 104 classes and the 104 blind dimensions the preceding cycle
+measured are related or merely numerically coincident. Two counts of 104
+arising from the same table over different constructions is the kind of
+agreement that either has a reason or does not, and nothing here decides
+which.
+
+The structure behind the parts of the glue group. The cutting side has 42
+nontrivial invariant factors and the cover side 41, with the two largest
+being 960 and 320. A decomposition of the 192-dimensional space that named
+those parts one by one would say what the exponent counts, which is the
+question the reading of 960 leaves open.

--- a/docs/PHYSICAL_CELL_CUTTING_VISIBLE_FRACTION_CYCLE760_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_VISIBLE_FRACTION_CYCLE760_NOTE_2026-08-09.md
@@ -1,36 +1,95 @@
-# Every piece is seen in the same fraction, and what makes that fraction whole is the number the two lattices already named — Cycle 760
+# Constant algebraic visibility in the finite four-cube cutting system: leverage 11/24 and full-projector denominator 960
 
 Date: 2026-08-09
 
 Authority: none
 
-Audit: unset.
+Audit: unset
 
-Status: computational identities of the finite cutting system
+Status: proposed bounded-support finite theorem; independent audit required
 
-Claim type: computational identities
+Claim type: bounded_theorem
 
 Runner:
 
-- [paired rebuild-and-gate runner](../scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py)
+- [self-contained rebuild-and-gate runner](../scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py)
 
-Scope: computational identities of the finite cutting system. Every number
-below is machine-checked by the paired runner, which rebuilds the cell
+Scope: exact rational and whole-number identities of one finite cutting
+system. Every number below is machine-checked by the runner, which rebuilds the cell
 complex, the least-volume pieces, the cuttings at the adjacency cost floor,
 the cutting-by-piece table and the eight-piece exact covers, then builds the
 relabellings got by permuting the four coordinates of the four-cube and
 flipping any of them, measures the blocks they cut the pieces into, certifies
 an exact whole-number multiple of the orthogonal projector onto the span of
 the cuttings, reads its diagonal, finds the smallest whole multiplier that
-clears it, sets that multiplier beside the invariant factors of the same
+clears the full matrix, sets that multiplier beside the invariant factors of the same
 side's Gram matrix, and checks the exact identity tying the two sides
-together, gating each quantity in place. Six of the gates carry
+together, gating each quantity in place. In this note **algebraic visibility**
+means a coordinate leverage score, the diagonal entry of an orthogonal
+row-space projector. It is not the frequency with which that piece occurs in
+the cutting list: the latter is separately 1975/15800 = 1/8. Six of the gates carry
 controls whose job is to show that each hypothesis the argument leans on is
 doing work, and that the routines report something other than the answer
 being looked for when the answer is not there. Constitutional effect: none.
 This package changes no axiom, no framework Admissibility rule, no primitive,
 no policy, and no audit status, and it adds no import and no assumption to
-[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+`MINIMAL_AXIOMS_2026-06-29.md`.
+
+The runner is scientifically self-contained: it reads no repository file and
+imports no ancestral scientific artifact. Its load-bearing inputs are only the
+finite definitions written in the runner itself.
+
+## Trace gate
+
+```yaml
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: "determine the exact row-space projector invariants of the finite four-cube cutting and exact-cover incidence systems"
+source_of_blocker_text: frontier_question
+reachability_to_target: none
+artifact_role: runner_certificate
+next_trace_action: "seek a structural decomposition that derives the projector denominators 960 and 320 and the 23 orbital entry values without exhaustive reconstruction"
+```
+
+## Status fields
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact certificates for ranks, transitive coordinate actions, rational orthogonal projectors, common diagonal leverage scores, least full-projector denominators, Gram invariant factors, and a linked-projector identity on one explicitly rebuilt finite object"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact target and obligation graph
+
+**Exact target.** For the two finite incidence matrices rebuilt by the runner,
+prove that their rational row-space projectors have constant diagonals 11/24
+and 35/64, least full-matrix clearing multipliers 960 and 320, and satisfy the
+linked-projector identity `Q = I - P + J/192`.
+
+The proof has six load-bearing obligations, all proved in this package rather
+than cited:
+
+1. rebuild the finite row sets and certify their counts (C0);
+2. construct a 384-element coordinate-relabeling subgroup, certify that it
+   preserves both row sets, and certify that it is transitive on the 192
+   coordinates (C1-C3);
+3. certify the two rational ranks, saturation witnesses, and exact scaled
+   orthogonal projectors (C4-C7, C12);
+4. reduce the full integer numerator matrices against their proposed scales to
+   certify the least full-projector denominators (C10, C12);
+5. certify saturated selected Gram bases and their invariant factors, then use
+   the integral-right-inverse argument below to identify the largest factor
+   with the projector denominator (C13-C15); and
+6. certify the linked-projector identity entry by entry (C17).
+
+No completeness claim about the full automorphism group is an obligation or a
+conclusion. The strongest missing structural lemma is a non-enumerative
+decomposition that predicts 960, 320, and the two invariant-factor chains.
 
 ## What this answers
 
@@ -39,86 +98,67 @@ pieces at the adjacency cost floor. There are 15800 such cuttings; between
 them they draw on 192 pieces, 24 pieces to a cutting, and each piece lies on
 1975 cuttings. Those same 192 pieces admit 192 eight-piece exact covers.
 
-Ask how much of each piece the cuttings see. The answer measured here is the
-same fraction at every one of the 192 pieces, 11 over 24, with no piece
-favoured over any other. Separately, an earlier cycle of this lane measured
-960 as the number controlling how two whole-number lattices built from this
-object fail to glue, and read it as the smallest whole number carrying any
-labelling of the pieces into a whole-number seen part plus a whole-number
-blind part; its own boundary said the value was measured and not derived, and
-that nothing there forced it.
+The ordinary incidence frequency is already uniform: each piece occurs in
+1975 of 15800 cuttings, hence in 1/8 of them. The different quantity studied
+below is algebraic visibility. For the cutting row space its value is the same
+at all 192 coordinates, namely 11/24. It is forced once the row space is
+invariant under a transitive coordinate action, and the controls show both
+hypotheses doing work.
 
-This cycle shows two things about that pair of facts. The first fraction is
-forced rather than merely measured: it could not have come out any other way
-once two hypotheses hold, and both hypotheses are shown here to be doing
-work. And the earlier cycle's reading of 960 turns out to be the denominator
-of that same fraction, so the two facts are one fact seen twice. What is new
-is the numerator, and that the numerator is the same at every piece.
+The integer 960 belongs to a different exact statement. It is the least
+positive integer `D` for which every entry of the full matrix `D P` is an
+integer. The scalar diagonal 11/24 has reduced denominator 24, not 960; its
+integer diagonal in `960 P` is 440. Off-diagonal entries require the larger
+full-matrix denominator. The cover projector analogously has leverage 35/64,
+full-projector denominator 320, and integer diagonal 175.
 
-## The symmetry the cost supplies, and the symmetry the answer has
+## The certified coordinate action
 
-The cost that defines this cutting system does not treat the four coordinates
-alike. Adjacency is between nearest neighbours in space, so the cost is
-written in the three spatial coordinates and the fourth, the tick, enters
-differently. What the cost hands over directly is therefore the 48
-relabellings that turn the three spatial coordinates among themselves and may
-flip the tick.
-
-Yet all 384 relabellings got by permuting the four coordinates of the
-four-cube and flipping any of them carry the whole system onto itself: each
-one sends the 15800 cuttings onto the 15800 cuttings and the 192 covers onto
-the 192 covers (C2). The system is blind to which of the four coordinates is
-called the tick.
+The runner's adjacency cost sums the same four-coordinate L1 rule over all
+four coordinates. It therefore makes no spatial-versus-tick distinction. The
+runner constructs the 384 signed coordinate relabellings obtained by
+permuting those four coordinates and independently flipping them. All 384
+induce distinct permutations of the 192 pieces and carry both the 15800
+cuttings and the 192 exact covers onto themselves (C1, C2).
 
 The ladder of blocks on the 192 pieces:
 
 | relabellings | what they are | blocks on the 192 pieces |
 | --- | --- | --- |
-| 24 | proper turns of the three spatial coordinates | 8 of 24 |
-| 48 | those, with the tick flip allowed | 4 of 48 |
-| 96 | everything that keeps the tick coordinate in place | 2 of 96 |
+| 24 | proper turns of a chosen first three coordinates | 8 of 24 |
+| 48 | those, with the fourth-coordinate flip allowed | 4 of 48 |
+| 96 | all signed relabellings that keep the fourth coordinate in place | 2 of 96 |
 | 384 | all four-coordinate permutations and flips | 1 of 192 |
 
-Read down the table: the 192 pieces fall into eight blocks of 24 under the
-proper turns, four blocks of 48 once the tick flip is allowed, two blocks of
-96 under everything that keeps the tick coordinate in place, and one block
-only once relabellings that carry the tick coordinate onto a spatial one are
-allowed.
-
-Earlier cycles of this lane established, and this cycle uses rather than
-re-derives: that the group has order 384; that it is the complete symmetry
-group of the cutting system; that it is transitive on the 192 pieces, which
-is the bottom rung of the table; and that the 48 relabellings the cost
-supplies act with four blocks of 48, which is the second rung. Those cycles
-reached the group by a refinement search that produced two extra involutions
-beyond the ones the cost hands over, and stated in their own boundary that no
-coordinate assignment for any piece appeared in them.
-
-What is new here is the plain identification of that group with permuting the
-four coordinates of the four-cube and flipping any of them. That
-identification gives the two searched-out involutions a reading: they are
-relabellings that carry the tick coordinate onto a spatial one. It also
-supplies the two rungs of the table that were not previously in hand, 24
-giving eight blocks and 96 giving two. And it yields the consequence that the
-table is arranged to display: what the cost supplies is 48 of the 384, and
-neither 48 nor 96 is enough for one block. One block needs exactly the
-relabellings the cost does not hand over.
+Read down this chosen subgroup ladder: the 192 pieces fall into eight orbits
+of 24 under proper turns of the first three coordinates, four orbits of 48
+once the fourth-coordinate flip is allowed, two orbits of 96 under all signed
+coordinate relabellings that keep the fourth coordinate in place, and one
+orbit under all 384 signed coordinate relabellings. Thus the explicitly
+constructed 384-element subgroup is transitive, which is all the projector
+argument needs (C3). The runner does not compute the full automorphism group,
+so no claim of completeness or exact identification with every symmetry of
+the incidence systems is made.
 
 ## The visibility matrix, exactly
 
 Write the cutting-by-piece table as a matrix on the 192 pieces, one row per
 cutting, and let `P` be the orthogonal projector onto the span of its rows.
-`P` is a matrix on the 192 pieces. Its diagonal entry at a piece is the
-fraction of that piece the cuttings see, and the diagonal sums to the rank.
+`P` is a rational matrix on the 192 coordinates. Its diagonal entry is that
+coordinate's leverage score, called algebraic visibility here, and the
+diagonal sums to the rank. This definition is distinct from incidence
+frequency.
 
 The rank over the rational numbers is 88, and the row lattice is saturated:
 two independently chosen 88 by 88 minors both have absolute value 1, which
 forces every invariant factor to be 1 (C4). The cover side is the same
 statement at rank 105 with 105 by 105 minors of absolute value 1.
 
-The runner certifies `N = 960 P` as an exact matrix of whole numbers. The
-modular step only proposes the lift; what certifies it is arithmetic over the
-whole numbers, carried out in Python integer arithmetic so nothing can
+The runner certifies `N = 960 P` as an exact matrix of whole numbers. A
+floating-point inverse proposes the simplex inverse table and is checked
+immediately by exact integer multiplication (C0). The modular projector step
+likewise only proposes the lift; what certifies that lift is arithmetic over
+the whole numbers, carried out in Python integer arithmetic so nothing can
 overflow:
 
 - `N` is symmetric.
@@ -133,7 +173,7 @@ cover side is certified the same way at multiplier 320 and rank 105: trace
 33600, which is 320 times 105, with every diagonal entry 175, entries from
 -42 to 175, and 23 different values (C12).
 
-## Why the fraction is forced
+## Why algebraic visibility is forced
 
 The argument is two lines once the previous two sections are in hand.
 
@@ -165,33 +205,39 @@ rank 1 and a diagonal that is 1 at that one piece and 0 at the other 191
 (C9). The 384 still have one block; the diagonal is still not constant,
 because this row set is not carried onto itself. Neither hypothesis is idle.
 
-## The smallest whole multiplier is the glue exponent
+## The full-projector denominator and the Gram exponent
 
-960 clears the cutting-side projector and nothing smaller does: 192, 320 and
-480 each leave a fraction (C10). On the cover side 320 clears it and 64 and
-160 each leave a fraction (C12).
+The exact integer matrix `N = 960 P` has entry gcd 1. Reducing all entries of
+`N/960` therefore gives common full-matrix denominator
+`960/gcd(960, gcd(N_ij)) = 960`; this excludes every smaller positive clearing
+integer, not merely a list of candidates. The checks that 192, 320, and 480
+leave noninteger entries are additional controls (C10). The same exact gcd
+reduction gives full-projector denominator 320 on the cover side, with 64 and
+160 as non-clearing controls (C12).
 
-On each side that number is the largest invariant factor of that side's Gram
-matrix, the exponent of the finite group by which two whole-number lattices
-fail to glue: 960 on the cutting side, whose chain has 42 nontrivial factors,
-and 320 on the cover side, whose chain has 41 (C13). The multiplier and the
-exponent are computed by two separate routines, one a search over candidate
-multipliers and the other an invariant-factor computation, and on each side
-they land on the same number.
+On each side this full-projector denominator equals the largest invariant
+factor of the selected basis Gram matrix: 960 on the cutting side, whose chain
+has 42 nontrivial factors, and 320 on the cover side, whose chain has 41
+(C13). Equivalently, it is the exponent of the explicitly defined finite
+abelian group `Z^k / G Z^k`, where `G = B B^T`; no broader lattice-gluing
+interpretation is needed here.
 
-The cutting-side 960 re-measures what the preceding cycle already stated in
-its own terms. What is new is the equality itself, that the least clearing
-multiplier and the largest invariant factor are the same number, that this
-needs saturation, and that it holds on the cover side too at 320. What the
-constant diagonal adds on top of it is the numerator. Divide each piece into
-960 parts and the cuttings see 440 of them, and it is 440 at every piece
-rather than 440 on average.
+The equality has an algebraic proof independent of the invariant-factor
+routine. For a selected integer row basis `B`,
 
-The agreement between multiplier and exponent needs the row lattice to be
-saturated, and the runner shows it fails without that. The line through
-(1, 2) is saturated, and its largest invariant factor 5 equals its smallest
-whole multiplier 5. The line through (2, 0) is not saturated, and gives 4
-against 1, which do not agree (C14).
+    P = B^T (B B^T)^(-1) B.
+
+Therefore the denominator of `P` divides the denominator of `G^(-1)`. C13
+also certifies a unit minor of each selected `B`, so `B` has an integer right
+inverse `C` with `B C = I`. Consequently
+
+    G^(-1) = C^T P C,
+
+and the reverse divisibility holds. In Smith normal form, the least integer
+clearing `G^(-1)` is the largest invariant factor of `G`. Hence the two
+denominators are equal. Saturation is load-bearing: the line through (1, 2)
+is saturated and gives 5 against 5, whereas the line through (2, 0) is not
+saturated and gives Gram factor 4 against projector denominator 1 (C14).
 
 The two sides are not two separate tables whose agreement is a coincidence,
 and this note does not claim they are. Gate C17 checks, entry by entry over the whole
@@ -199,46 +245,34 @@ numbers, that
 
     3 N2 = 960 I - N + 5 J
 
-with `I` the identity on the 192 pieces and `J` the all-ones matrix. In
-words: what the covers see is exactly what the cuttings do not see, together
-with the all-ones direction. The cover-side rank is therefore forced,
-105 = 192 - 88 + 1, and with it the cover-side fraction 35 over 64. It is not
-a second confirmation of the cutting-side fraction; it is the same fact seen
-from the complement.
+with `N2 = 320 Q`, `I` the identity on the 192 coordinates, and `J` the
+all-ones matrix. Dividing by 960 gives the claimed linked-projector identity
 
-Why the tie holds is visible in three steps, and the runner gates the first
-of them. The all-ones vector is seen by the cuttings: `N` times the all-ones
-vector is 960 times the all-ones vector (C17). An earlier cycle of this lane
-measured that the blind space of the cuttings — the labellings of the pieces
-on which every cutting sums to zero — is exactly the span of the differences
-of the 192 exact covers; that measurement is carried in the preceding
-cycle's package,
-`physical_cell_cutting_blind_lattice_generation_cycle759_2026_08_09.py`.
-Differences are perpendicular to the all-ones vector. So what the covers span
-is the blind space together with the all-ones direction, which is the
-identity above. The 5 in it is 960 divided by 192 and the 3 is 960 divided by
-320. The control inside C17 shows the identity discriminates: with 4 J in
-place of 5 J it fails.
+    Q = I - P + J/192.
 
-What the two sides do still give the multiplier claim is two different values
-to check it at: 960 and 320 are read off the invariant factors of two
-different Gram matrices built from two different pairs of lattices, and the
-identity above does not make those two numbers equal. Two values, two linked
-spaces.
+This identity is itself the self-contained explanation of the relation. C17
+also certifies `P 1 = 1`. Thus `I-P` is the orthogonal projector onto
+`ker(P)`, while `J/192` is the orthogonal projector onto the all-ones line,
+which lies in `im(P)` and is orthogonal to `ker(P)`. Their sum is therefore
+the projector onto `ker(P)` plus the all-ones line. Since the runner already
+certifies that `Q` is the cover row-space projector, the cover row space has
+exactly that decomposition. Its rank follows as
+`105 = 192 - 88 + 1`, and transitivity then gives leverage 35/64. The
+coefficients are fixed by `960/320 = 3` and `960/192 = 5`; the C17 control
+with `4 J` fails.
 
 ## Runner
 
 `physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py` rebuilds the
 object from the cell complex up and gates eighteen quantities, printing
-`TOTAL: PASS=18 FAIL=0`. The construction is inherited from the preceding
-cycle's runner, so the pieces, the cuttings, the cutting-by-piece table and
-the covers are the same objects, re-derived here rather than imported. Exact
-ranks and determinants are computed by fraction-free elimination; basis rows
-are selected over a prime field and the resulting whole-number identities are
-then checked exactly in Python integer arithmetic.
+`TOTAL: PASS=18 FAIL=0`. All definitions needed for the construction are
+restated in this runner; no sibling runner or repository data file is read.
+Exact ranks and determinants are computed by fraction-free elimination; basis
+rows are selected over a prime field and the resulting whole-number identities
+are then checked exactly in Python integer arithmetic.
 
-- C0 the object: 15800 cuttings, 192 pieces, 24 pieces to a cutting, 1975
-  cuttings through a piece, 192 exact covers.
+- C0 the object: exact simplex inverses, 15800 cuttings, 192 pieces, 24 pieces
+  to a cutting, 1975 cuttings through a piece (incidence 1/8), 192 exact covers.
 - C1 the 384 relabellings exist, are pairwise distinct, and permute the 192
   pieces; they come from the 16 corners of the four-cube.
 - C2 each of the 384 carries the 15800 cuttings onto themselves and the 192
@@ -249,22 +283,23 @@ then checked exactly in Python integer arithmetic.
   value 1, two independent choices each.
 - C5 the cutting-side certificate: symmetric, `N N = 960 N`, fixes the rows,
   trace 84480.
-- C6 every one of the 192 diagonal entries is 440, so every piece is seen in
-  the fraction 11 over 24.
+- C6 every one of the 192 diagonal entries is 440, so every coordinate has
+  leverage score 11/24.
 - C7 `N` is unchanged by every one of the 384 relabellings.
 - C8 control: two blocks of the 48 with multiplier 96 give rank 2, kept by
   the 48 and not by the 384, diagonal 0 on 96 pieces and 2 on 96.
 - C9 control: one piece's indicator with multiplier 1 gives rank 1 and
   diagonal 1 at one piece, 0 at the other 191.
-- C10 960 is the smallest whole multiplier on the cutting side; 192, 320 and
-  480 each leave a fraction.
+- C10 exact gcd reduction makes 960 the least full-projector clearing
+  multiplier on the cutting side; 192, 320 and 480 each leave noninteger entries.
 - C11 `N` is constant on each of the 104 classes of ordered piece pairs and
   takes 23 different values.
 - C12 the cover side: certificate at rank 105, diagonal 175, trace 33600,
-  fraction 35 over 64, smallest multiplier 320 with 64 and 160 leaving a
-  fraction, constant on the same 104 classes, 23 values.
-- C13 the largest invariant factor of each Gram matrix: 960 with 42
-  nontrivial on the cutting side, 320 with 41 on the cover side.
+  leverage 35/64, exact full-projector denominator 320 with 64 and 160 leaving
+  noninteger entries, constant on the same 104 classes, 23 values.
+- C13 the selected Gram bases have unit-minor saturation witnesses; their
+  largest invariant factors are 960 with 42 nontrivial on the cutting side and
+  320 with 41 on the cover side.
 - C14 control: the saturated line agrees at 5 and 5; the line that is not
   saturated gives 4 against 1.
 - C15 control: the invariant-factor routine returns 1 6 from the diagonal
@@ -275,7 +310,29 @@ then checked exactly in Python integer arithmetic.
   the same identity with 4 J in place of 5 J fails.
 
 Measured totals: 18 gates, `TOTAL: PASS=18 FAIL=0`, elapsed under 300 s, peak
-resident memory under 500 MB, stdout 2982 characters.
+resident memory under 500 MB, stdout under 6000 characters.
+
+## Imports and derived surface
+
+### Imports (load-bearing)
+
+- the in-runner definitions of the sixteen binary four-cube corners,
+  unimodular five-corner pieces, the symmetric four-coordinate adjacency
+  cost, minimum-cost exact cuttings, eight-piece exact covers, and rational
+  orthogonal-projector visibility;
+- ordinary integer, rational, finite-group, and linear-algebra identities used
+  explicitly in the proof above.
+
+There are no external scientific inputs, no ancestral runner imports, and no
+load-bearing repository-file reads.
+
+### Derived
+
+- all finite counts and orbit sizes listed under Runner;
+- ranks 88 and 105, leverage scores 11/24 and 35/64, and full-projector
+  denominators 960 and 320;
+- the two selected Gram invariant-factor chains and their largest factors;
+- `Q = I - P + J/192` and the resulting cover-row-space decomposition.
 
 ## Boundary
 
@@ -283,41 +340,26 @@ resident memory under 500 MB, stdout 2982 characters.
   is a finite combinatorial object and every statement made about it is a
   count or a whole-number identity between counts. Nothing here bears on any
   physical claim.
-- **The one-block fact is used, not claimed as new.** That the group has
-  order 384, that it is the complete symmetry group of the cutting system,
-  that it is transitive on the 192 pieces, and that the 48 relabellings the
-  cost supplies give four blocks of 48 were all established in earlier cycles
-  of this lane. This cycle measures those rungs again in its own runner so
-  that the argument stands on gated numbers, but claims none of them as new.
-  What is new is the identification of the group with the coordinate
-  permutations and flips of the four-cube, and the two rungs at 24 and 96.
-- **The identification is a statement about this cutting system.** That the
-  full symmetry group is the coordinate permutations and flips of the
-  four-cube says something about this object and carries no claim about the
-  framework's Admissibility rule, about any primitive, or about any other
-  object.
-- **The reading of 960 is a reading of a whole-number fact, and it is not new
-  here.** That 960 is the smallest number of parts a piece must be divided
-  into was already stated by the preceding cycle of this lane in its own
-  terms, and is re-measured here rather than first established here. It is
-  measured, not derived from anything outside the object, and nothing here
-  says why the exponent is 960 rather than some other number. What this cycle
-  adds to it is the numerator 440 and the fact that the numerator is the same
-  at every piece.
-- **The tie between the sides rests on one imported measurement.** The
-  identity `3 N2 = 960 I - N + 5 J` is gated here directly, so it stands on
-  its own. The account of why it holds uses the earlier cycle's measurement
-  that the blind space is the span of the cover differences, which is not
-  re-derived here.
+- **A transitive subgroup is proved; completeness is not.** The 384 signed
+  coordinate relabellings form an explicitly constructed transitive subgroup
+  preserving both row sets. The full automorphism group is not computed.
+- **Algebraic visibility is not incidence or volume.** The projector diagonal
+  is a coordinate leverage score. Ordinary cutting-incidence frequency is
+  1/8. Neither quantity is a physical fraction of a material piece.
+- **960 is a full-matrix denominator, not the denominator of 11/24.** The
+  scalar leverage has reduced denominator 24. The value 960 is the least
+  integer clearing every projector entry; no geometric subdivision of a piece
+  is asserted.
+- **The relation between sides is self-contained.** The exact identity
+  `Q = I - P + J/192`, together with `P 1 = 1`, proves the stated row-space
+  decomposition without an imported blind-space result.
 - **Saturation is checked by a sufficient condition.** A minor of absolute
   value 1 proves the lattice is saturated; failing to find one would prove
   nothing. Every witness reported here succeeded, so the asymmetry does not
   bite, but it bounds what the technique could be used to deny.
-- **No claim is made that the cost's indifference to which coordinate is the
-  tick has any consequence for emergent time.** What is shown is that this
-  particular finite system does not record the distinction: the 384
-  relabellings carry it onto itself, and the fraction each piece is seen in
-  is the same whether or not a relabelling moves the tick.
+- **No emergent-time interpretation is made.** The cost in this runner is
+  symmetric in all four binary coordinates. Calling one coordinate a tick is
+  only a presentation choice for the displayed subgroup ladder.
 
 ## Next
 
@@ -328,14 +370,48 @@ ordered piece pairs. `N` is constant on every class, so the 23 values
 partition the 104 classes, and the shape of that partition is a direct next
 measurement.
 
-Whether the 104 classes and the 104 blind dimensions the preceding cycle
-measured are related or merely numerically coincident. Two counts of 104
-arising from the same table over different constructions is the kind of
-agreement that either has a reason or does not, and nothing here decides
-which.
+Whether the explicitly constructed order-384 subgroup is the full
+automorphism group of either incidence system. Nothing in this package
+computes or claims that larger-group question.
 
-The structure behind the parts of the glue group. The cutting side has 42
+The structure behind the Gram discriminant groups. The cutting side has 42
 nontrivial invariant factors and the cover side 41, with the two largest
 being 960 and 320. A decomposition of the 192-dimensional space that named
 those parts one by one would say what the exponent counts, which is the
-question the reading of 960 leaves open.
+question the full-projector denominator leaves open.
+
+## Review record
+
+Review-loop iteration 1 requested six corrections: remove the unavailable
+Cycle-759 dependency and the unsupported full-automorphism claim; align the
+cost description with the symmetric four-coordinate runner; distinguish
+projector leverage 11/24 from incidence frequency 1/8; distinguish the scalar
+denominator 24 from the full-projector denominator 960; replace the
+candidate-only minimality wording with an exact gcd certificate; and install
+canonical bounded-theorem metadata plus the declared runner timeout. All six
+were applied before confirmation.
+
+The fixed runner was executed through the content-pinned cache envelope at its
+final source hash and returned `TOTAL: PASS=18 FAIL=0`. Independent review
+recomputed the two ranks modulo a second prime (88 and 105), checked every
+rounded simplex inverse by integer multiplication, reduced the two integer
+projector numerators to entry gcd 1, separately recovered incidence 1/8, and
+verified the linked-projector identity entry by entry. The
+integral-right-inverse proof in the denominator section supplies a second
+route to the largest-invariant-factor equality without reusing the runner's
+Smith-form implementation.
+
+Every gate family was mutation-tested on an isolated in-memory copy of the
+runner, with the named gate required to print `FAIL` and the process required
+to exit nonzero. The mutations were: C0 cutting-count corruption; C1 duplicate
+coordinate map; C2 corrupted cutting row; C3 one removed subgroup map; C4
+collapsed cutting incidence rows; C5 wrong cutting projector scale; C6 wrong
+leverage numerator formula; C7 one changed projector entry; C8 one removed
+orbit-indicator row; C9 one added coordinate in the singleton control; C10
+wrong gcd-denominator formula; C11 one merged ordered-pair orbit label; C12
+wrong cover projector scale; C13 one changed Gram entry; C14 changed
+unsaturated toy line; C15 changed Smith-form toy matrix; C16 one-second time
+budget; and C17 wrong all-ones coefficient. C0 through C17 each failed closed.
+
+No audit verdict is written by this review record. Independent audit remains
+required before any retained-grade status can become effective.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15476,
- "node_count": 5445,
+ "edge_count": 15477,
+ "node_count": 5446,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13641,6 +13641,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_visible_fraction_cycle760_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,5 +1,5 @@
 {
- "edge_count": 15477,
+ "edge_count": 15476,
  "node_count": 5446,
  "nodes": {
   "3d_correction_master_note": {
@@ -13643,8 +13643,8 @@
    "out_degree": 2
   },
   "physical_cell_cutting_visible_fraction_cycle760_note_2026-08-09": {
-   "deps_hash": "c8eee4235fc9",
-   "out_degree": 1
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py
+runner_sha256: 44e4e1fdb1540776c764d1ca6ba4a35c224d738e63808c24f67e367272d84341
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 11.23
+status: ok
+----- stdout -----
+Every count below is measured here.
+the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
+PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them, and there are 192 exact covers
+PASS C1  permuting the four coordinates and flipping any of them gives 384 maps of the 16 corners and 384 distinct piece relabellings
+PASS C2  384 of the 384 carry the 15800 cuttings and the 192 covers onto themselves; one of them after a swap of two pieces gives False
+blocks on the 192 pieces: turns 24 give 8 of 24, with the tick flip 48 give 4 of 48, tick fixed 96 give 2 of 96, all 384 give 1 of 192
+PASS C3  one block only once a relabelling may carry the tick coordinate onto a spatial one
+PASS C4  exact ranks 88 and 105; minors 1 1 and 1 1, so each row lattice is saturated
+cutting side rank 88: N = 960 P symmetric True, N N = 960 N True, N fixes the rows True, trace 84480 = 960 x 88
+cutting side diagonal 440:192, entries -121 to 440 taking 23 values, seen fraction 88 over 192 which is 11 over 24
+PASS C5  the cutting side certificate holds over the whole numbers at rank 88, trace 84480
+PASS C6  every one of the 192 diagonal entries is the same, so each piece is seen in the fraction 11 over 24
+PASS C7  N is unchanged by relabelling the pieces by any of the 384, so its diagonal is constant on each block
+PASS C8  control, two of the 4 blocks of the 48: rank 2, kept by the 48 True, by the 384 False, diagonal 0:96 2:96
+PASS C9  control, the indicator of one piece with multiplier 1: rank 1, diagonal 0:191 1:1, not constant although the 384 give one block
+PASS C10  smallest whole multiplier on the cutting side 960 = 2^6 x 3 x 5; 192 320 480 each leave a fraction
+PASS C11  the 384 carry the ordered pairs of pieces into 104 classes; N is constant on every one and takes 23 values
+cover side rank 105: N = 320 P symmetric True, N N = 320 N True, N fixes the rows True, trace 33600 = 320 x 105
+cover side diagonal 175:192, entries -42 to 175 taking 23 values, seen fraction 105 over 192 which is 35 over 64
+PASS C12  cover side certificate holds, fraction 35 over 64, smallest multiplier 320 = 2^6 x 5, 64 160 leave a fraction, constant on 104 classes
+PASS C13  Gram largest invariant factor: cutting 960 with 42 nontrivial, cover 320 with 41; each is that side's smallest whole multiplier
+PASS C14  control, the line 1 2 is saturated and gives 5 against 5; the line 2 0 is not and gives 4 against 1
+PASS C15  control, the invariant factor routine returns 1 6 from the diagonal 2 3 and 2 12 from the diagonal 4 6, not the entries handed to it
+PASS C16  elapsed under 300 s and peak memory under 500 MB, both measured in this run
+the tie: 3 N2 = 960 I - N + 5 J over the whole numbers True, differing entries 0, largest difference 0; with 4 J it is False
+PASS C17  N times the all ones vector is 960 times it True, and 192 - 88 + 1 = 105 True
+stdout characters: 2982
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.txt
@@ -1,38 +1,39 @@
 ===== runner cache v1 =====
 runner: scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py
-runner_sha256: 44e4e1fdb1540776c764d1ca6ba4a35c224d738e63808c24f67e367272d84341
+runner_sha256: 8e2ad9649cb521b806813fb7bee991a1b45b8f468eb33e3c0ef9bb229bcac07e
 timeout_sec: 300
 exit_code: 0
-elapsed_sec: 11.23
+elapsed_sec: 13.77
 status: ok
 ----- stdout -----
 Every count below is measured here.
 the object: 15800 cuttings and 192 pieces, 24 pieces to a cutting, 1975 cuttings through a piece
-PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them, and there are 192 exact covers
+PASS C0  the pieces per cutting and the cuttings through a piece are each the same number for every one of them; exact simplex inverses; 192 covers
+incidence frequency: each piece occurs in 1975 of 15800 cuttings, which is 1 over 8
 PASS C1  permuting the four coordinates and flipping any of them gives 384 maps of the 16 corners and 384 distinct piece relabellings
 PASS C2  384 of the 384 carry the 15800 cuttings and the 192 covers onto themselves; one of them after a swap of two pieces gives False
-blocks on the 192 pieces: turns 24 give 8 of 24, with the tick flip 48 give 4 of 48, tick fixed 96 give 2 of 96, all 384 give 1 of 192
-PASS C3  one block only once a relabelling may carry the tick coordinate onto a spatial one
+blocks on the 192 pieces: first-three turns 24 give 8 of 24, plus fourth flip 48 give 4 of 48, fourth fixed 96 give 2 of 96, all 384 give 1 of 192
+PASS C3  in this subgroup ladder, allowing the fourth coordinate to move gives one block
 PASS C4  exact ranks 88 and 105; minors 1 1 and 1 1, so each row lattice is saturated
 cutting side rank 88: N = 960 P symmetric True, N N = 960 N True, N fixes the rows True, trace 84480 = 960 x 88
-cutting side diagonal 440:192, entries -121 to 440 taking 23 values, seen fraction 88 over 192 which is 11 over 24
+cutting side diagonal 440:192, entries -121 to 440 taking 23 values, leverage 88 over 192 which is 11 over 24
 PASS C5  the cutting side certificate holds over the whole numbers at rank 88, trace 84480
-PASS C6  every one of the 192 diagonal entries is the same, so each piece is seen in the fraction 11 over 24
+PASS C6  every one of the 192 diagonal entries is the same, so coordinate leverage is 11 over 24
 PASS C7  N is unchanged by relabelling the pieces by any of the 384, so its diagonal is constant on each block
 PASS C8  control, two of the 4 blocks of the 48: rank 2, kept by the 48 True, by the 384 False, diagonal 0:96 2:96
 PASS C9  control, the indicator of one piece with multiplier 1: rank 1, diagonal 0:191 1:1, not constant although the 384 give one block
-PASS C10  smallest whole multiplier on the cutting side 960 = 2^6 x 3 x 5; 192 320 480 each leave a fraction
+PASS C10  exact projector denominator 960 = 2^6 x 3 x 5, numerator entry gcd 1; 192 320 480 each leave noninteger entries
 PASS C11  the 384 carry the ordered pairs of pieces into 104 classes; N is constant on every one and takes 23 values
 cover side rank 105: N = 320 P symmetric True, N N = 320 N True, N fixes the rows True, trace 33600 = 320 x 105
-cover side diagonal 175:192, entries -42 to 175 taking 23 values, seen fraction 105 over 192 which is 35 over 64
-PASS C12  cover side certificate holds, fraction 35 over 64, smallest multiplier 320 = 2^6 x 5, 64 160 leave a fraction, constant on 104 classes
-PASS C13  Gram largest invariant factor: cutting 960 with 42 nontrivial, cover 320 with 41; each is that side's smallest whole multiplier
+cover side diagonal 175:192, entries -42 to 175 taking 23 values, leverage 105 over 192 which is 35 over 64
+PASS C12  cover certificate: leverage 35/64, projector denominator 320, numerator gcd 1; 64 160 leave nonintegers, constant on 104 classes
+PASS C13  saturated Gram bases; largest factors cutting 960 (42 nontrivial), cover 320 (41); each equals the projector denominator
 PASS C14  control, the line 1 2 is saturated and gives 5 against 5; the line 2 0 is not and gives 4 against 1
 PASS C15  control, the invariant factor routine returns 1 6 from the diagonal 2 3 and 2 12 from the diagonal 4 6, not the entries handed to it
 PASS C16  elapsed under 300 s and peak memory under 500 MB, both measured in this run
 the tie: 3 N2 = 960 I - N + 5 J over the whole numbers True, differing entries 0, largest difference 0; with 4 J it is False
 PASS C17  N times the all ones vector is 960 times it True, and 192 - 88 + 1 = 105 True
-stdout characters: 2982
+stdout characters: 3057
 TOTAL: PASS=18 FAIL=0
 
 ----- stderr -----

--- a/scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py
+++ b/scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py
@@ -1,0 +1,877 @@
+"""Measure the fraction of each piece that the cuttings of the unit four-cube see.
+
+Every count below is measured here. The runner rebuilds the cell complex, the least
+volume pieces, the cuttings at the adjacency cost floor, the cutting by piece table
+and the eight piece exact covers. It then builds the maps got by permuting the four
+coordinates of the four-cube and flipping any of them, measures the blocks those maps
+cut the pieces into, and certifies an exact whole number multiple of the orthogonal
+projector onto the span of the cuttings. The diagonal of that projector is the
+fraction of each piece the cuttings see, and it is the same at every piece. The
+smallest whole multiplier that clears the projector is measured on both tables and
+set beside the largest invariant factor of the same table's Gram. Four controls fixed
+in advance show the gates fail when the hypotheses they rest on are taken away.
+"""
+import itertools
+import math
+import resource
+import time
+
+import numpy as np
+
+T0 = time.monotonic()
+PF = [0, 0]
+OUT = [0]
+
+
+def emit(s):
+    """print one line, refusing any barred digit pair or over-long line"""
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+def gate(ok, name, detail):
+    PF[0 if ok else 1] += 1
+    emit(("PASS " if ok else "FAIL ") + name + "  " + detail)
+
+
+def joins(xs):
+    """one space separated string of a sequence of integers"""
+    return " ".join(str(int(x)) for x in xs)
+
+
+def mset(a):
+    """value to count dictionary of an integer array"""
+    v, c = np.unique(np.asarray(a), return_counts=True)
+    return dict((int(x), int(y)) for x, y in zip(v, c))
+
+
+def msets(d):
+    """value:count string of a value to count dictionary"""
+    return " ".join("{0}:{1}".format(k, d[k]) for k in sorted(d))
+
+
+# ---------------------------------------------------------------- Part 1: machinery
+
+
+def det4(A):
+    def minors(r0, r1):
+        out = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                out[(i, j)] = (A[:, r0, i] * A[:, r1, j] - A[:, r0, j] * A[:, r1, i])
+        return out
+    m, c = minors(0, 1), minors(2, 3)
+    return (m[(0, 1)] * c[(2, 3)] - m[(0, 2)] * c[(1, 3)] + m[(0, 3)] * c[(1, 2)]
+            + m[(1, 2)] * c[(0, 3)] - m[(1, 3)] * c[(0, 2)] + m[(2, 3)] * c[(0, 1)])
+
+
+CORN = [(x, y, z, t) for x in (0, 1) for y in (0, 1) for z in (0, 1) for t in (0, 1)]
+V = np.array(CORN, dtype=np.int64)
+POS = dict((c, i) for i, c in enumerate(CORN))
+PAIRS = list(itertools.combinations(range(5), 2))
+SUB = np.array(list(itertools.combinations(range(16), 5)), dtype=np.int64)
+VOL = np.abs(det4(V[SUB[:, 1:]] - V[SUB[:, 0]][:, None, :]))
+UNI = SUB[VOL == 1]
+NPIECE = len(UNI)
+
+
+def cost(P, cols):
+    tot = np.zeros(len(P), dtype=np.int64)
+    for a, b in PAIRS:
+        d = np.abs(V[P[:, a]][:, cols] - V[P[:, b]][:, cols]).sum(axis=1)
+        tot = tot + (d > 1).astype(np.int64)
+    return tot
+
+
+C4 = cost(UNI, [0, 1, 2, 3])
+LO = int(C4.min())
+MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
+MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
+IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+
+ROT = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        R = np.zeros((3, 3), dtype=np.int64)
+        for i, j in enumerate(perm):
+            R[i, j] = sg[i]
+        if int(round(np.linalg.det(R.astype(float)))) == 1:
+            ROT.append(R)
+CEN = np.array([1, 1, 1], dtype=np.int64)
+G = []
+for R in ROT:
+    for tf in (0, 1):
+        img = []
+        for (x, y, z, t) in CORN:
+            w = R @ (2 * np.array([x, y, z], dtype=np.int64) - CEN) + CEN
+            key = (int(w[0]) // 2, int(w[1]) // 2, int(w[2]) // 2, (1 - t) if tf else t)
+            if key not in POS:
+                img = None
+                break
+            img.append(POS[key])
+        if img is not None:
+            G.append((R, tf, np.array(img, dtype=np.int64)))
+
+posp = dict((tuple(int(c) for c in s), i) for i, s in enumerate(UNI))
+LAB = -np.ones(NPIECE, dtype=np.int64)
+REPS = []
+for i in range(NPIECE):
+    if LAB[i] >= 0:
+        continue
+    o = len(REPS)
+    REPS.append(i)
+    for (_, _, g) in G:
+        LAB[posp[tuple(sorted(int(g[c]) for c in UNI[i]))]] = o
+REPS = np.array(REPS, dtype=np.int64)
+
+OFF = np.array([0, 1, 7, 49, 343], dtype=np.int64)
+L = np.einsum("nij,nmj->nmi", IV, V[None, :, :] - V[UNI[:, 0]][:, None, :])
+CB = max(int(np.abs(L).max()), int(np.abs(L.sum(axis=2) - 1).max()))
+WT = 2 * (CB * int(OFF.sum()) + 1 + OFF)
+SB = int(WT.sum())
+SC = np.array([SB // 2, SB // 2, SB // 2], dtype=np.int64)
+lab = {}
+for o, i in enumerate(REPS):
+    q = (WT[:, None] * V[UNI[i]]).sum(axis=0)
+    for (R, tf, _) in G:
+        u = R @ (q[:3] - SC) + SC
+        key = (int(u[0]), int(u[1]), int(u[2]), (SB - int(q[3])) if tf else int(q[3]))
+        lab.setdefault(key, o)
+KEYS = sorted(lab)
+Q = np.array(KEYS, dtype=np.int64)
+NQ = len(Q)
+QT = Q.T
+MASK = []
+MI = np.zeros((NPIECE, NQ), dtype=np.int64)
+for i in range(NPIECE):
+    lam = IV[i] @ (QT - (SB * V[UNI[i, 0]])[:, None])
+    tot = lam.sum(axis=0)
+    ins = (lam > 0).all(axis=0) & (tot < SB)
+    MI[i] = ins.astype(np.int64)
+    b = 0
+    for j in np.flatnonzero(ins):
+        b |= 1 << int(j)
+    MASK.append(b)
+ALLQ = (1 << NQ) - 1
+
+BY, MK = {}, dict((i, MASK[i]) for i in MINP)
+for i in MINP:
+    for j in np.flatnonzero(MI[i]):
+        BY.setdefault(int(j), []).append(i)
+SOL = []
+
+
+def rec(cov, chosen):
+    if cov == ALLQ:
+        SOL.append(tuple(sorted(chosen)))
+        return
+    rem = ALLQ & ~cov
+    j = (rem & -rem).bit_length() - 1
+    for i in BY[j]:
+        if MK[i] & cov:
+            continue
+        chosen.append(i)
+        rec(cov | MK[i], chosen)
+        chosen.pop()
+
+
+rec(0, [])
+NS = len(SOL)
+USED = sorted(set(i for s in SOL for i in s))
+NPO = len(USED)
+P2I = dict((p, a) for a, p in enumerate(USED))
+
+CM = np.zeros(NPIECE, dtype=np.int64)
+for i in range(NPIECE):
+    b = 0
+    for t in UNI[i]:
+        b |= 1 << int(t)
+    CM[i] = b
+M2I = dict((int(CM[i]), i) for i in range(NPIECE))
+
+INC = np.zeros((NS, NPO), dtype=np.uint8)
+for i, s in enumerate(SOL):
+    for p in s:
+        INC[i, P2I[p]] = 1
+INCL = INC.astype(np.int64)
+
+INT = INCL.astype(np.int32)
+GR = (INT.T @ INT).astype(np.int64)
+RW = INC.sum(axis=1).astype(np.int64)
+CS = INC.sum(axis=0).astype(np.int64)
+
+NSH = (GR == 0)
+np.fill_diagonal(NSH, False)
+ADJ = [0] * NPO
+for a in range(NPO):
+    m = 0
+    for b in np.flatnonzero(NSH[a]):
+        m |= 1 << int(b)
+    ADJ[a] = m
+CLQ = []
+
+
+def extend(cur, cand):
+    if len(cur) == 8:
+        CLQ.append(tuple(cur))
+        return
+    c = cand
+    while c:
+        low = c & -c
+        v = low.bit_length() - 1
+        c ^= low
+        extend(cur + [v], c & ADJ[v])
+
+
+extend([], (1 << NPO) - 1)
+NC = len(CLQ)
+W = np.zeros((NC, NPO), dtype=np.int64)
+for i, s in enumerate(CLQ):
+    for p in s:
+        W[i, int(p)] = 1
+
+
+# ----------------------------------------------- Part 2: exact integer machinery
+
+PMOD = 1000003
+
+
+def rank_exact(rows):
+    """exact rank over the rationals of an integer matrix, integer arithmetic only
+
+    One step fraction free elimination: each combined row is divided through by
+    the greatest common divisor of its entries, so no denominator is ever needed
+    and no floating point is used.
+    """
+    wk = [[int(x) for x in r] for r in rows]
+    nr = len(wk)
+    if nr == 0:
+        return 0
+    m = len(wk[0])
+    rk = 0
+    for col in range(m):
+        piv = -1
+        for r in range(rk, nr):
+            if wk[r][col]:
+                piv = r
+                break
+        if piv < 0:
+            continue
+        wk[rk], wk[piv] = wk[piv], wk[rk]
+        pr = wk[rk]
+        pv = pr[col]
+        for r in range(rk + 1, nr):
+            f = wk[r][col]
+            if f:
+                rw = wk[r]
+                nw = [0] * col + [pv * rw[c] - f * pr[c] for c in range(col, m)]
+                g = 0
+                for x in nw:
+                    if x:
+                        g = math.gcd(g, x if x > 0 else -x)
+                        if g == 1:
+                            break
+                if g > 1:
+                    nw = [x // g for x in nw]
+                wk[r] = nw
+        rk += 1
+    return rk
+
+
+def det_exact(rows):
+    """exact determinant of an integer matrix, fraction free, no division left over
+
+    Every combined entry is divided by the previous pivot, which always goes in
+    exactly, so the whole elimination stays inside the integers and the sign is
+    carried by hand through the row swaps.
+    """
+    A = [[int(x) for x in r] for r in rows]
+    n = len(A)
+    sign, prev = 1, 1
+    for k in range(n - 1):
+        if A[k][k] == 0:
+            sw = -1
+            for i in range(k + 1, n):
+                if A[i][k]:
+                    sw = i
+                    break
+            if sw < 0:
+                return 0
+            A[k], A[sw] = A[sw], A[k]
+            sign = -sign
+        for i in range(k + 1, n):
+            Ai, Ak = A[i], A[k]
+            aik = Ai[k]
+            for j in range(k + 1, n):
+                Ai[j] = (Ak[k] * Ai[j] - aik * Ak[j]) // prev
+            Ai[k] = 0
+        prev = A[k][k]
+    return sign * A[n - 1][n - 1]
+
+
+def sub_full(A, p, order):
+    """row and column indices of a submatrix of full rank, chosen over the field with p
+
+    Gauss-Jordan over the prime field, walking the columns in the given order. The
+    columns that take a pivot and the rows that supply one index a square submatrix
+    whose rank over that field is the rank of A, hence its determinant is nonzero
+    there.
+    """
+    W2 = np.mod(A, p).astype(np.int64)
+    n = W2.shape[0]
+    rowsel, colsel = [], []
+    used = np.zeros(n, dtype=bool)
+    for c in order:
+        col = W2[:, c].copy()
+        col[used] = 0
+        nz = np.nonzero(col)[0]
+        if nz.size == 0:
+            continue
+        i = int(nz[0])
+        used[i] = True
+        rowsel.append(i)
+        colsel.append(int(c))
+        inv = pow(int(W2[i, c]), p - 2, p)
+        W2[i] = np.mod(W2[i] * inv, p)
+        hit = np.nonzero(W2[:, c])[0]
+        hit = hit[hit != i]
+        if hit.size:
+            W2[hit] = np.mod(W2[hit] - np.outer(W2[hit, c], W2[i]), p)
+    return rowsel, colsel
+
+
+def divisor_witness(A, r):
+    """greatest common divisor of two independently chosen r by r minors of A
+
+    For an integer matrix of rank r the greatest common divisor of all r by r minors
+    is the product of the invariant factors. A single minor equal to one or minus one
+    therefore forces every invariant factor to be one, so the row lattice is saturated
+    and the rank is r over every field. Two choices are taken here, forward and
+    reverse in the column order, and their greatest common divisor reported.
+    """
+    m = A.shape[1]
+    ds = []
+    for order in (range(m), range(m - 1, -1, -1)):
+        rs, cs = sub_full(A, PMOD, order)
+        if len(rs) != r or len(cs) != r:
+            ds.append(0)
+            continue
+        ds.append(abs(det_exact(A[np.ix_(rs, cs)].tolist())))
+    g = 0
+    for d in ds:
+        g = math.gcd(g, d)
+    return (g, ds)
+
+
+def basis_rows(A, p, roworder):
+    """indices of rows forming a basis of the row space over the field with p"""
+    W2 = np.mod(A, p).astype(np.int64)
+    n, m = W2.shape
+    order = list(range(n)) if roworder is None else list(roworder)
+    rowsel = []
+    used = [False] * n
+    for c in range(m):
+        colv = W2[:, c].tolist()
+        i = -1
+        for r in order:
+            if not used[r] and colv[r]:
+                i = r
+                break
+        if i < 0:
+            continue
+        used[i] = True
+        rowsel.append(i)
+        inv = pow(int(W2[i, c]), p - 2, p)
+        W2[i] = np.mod(W2[i] * inv, p)
+        hit = np.nonzero(W2[:, c])[0]
+        hit = hit[hit != i]
+        if hit.size:
+            W2[hit] = np.mod(W2[hit] - np.outer(W2[hit, c], W2[i]), p)
+    return rowsel
+
+
+def least_spot(wk, t, nr, nc):
+    """position of the smallest nonzero entry in the block from t on, or None"""
+    best = None
+    spot = None
+    for i in range(t, nr):
+        ri = wk[i]
+        for j in range(t, nc):
+            v = ri[j]
+            if v:
+                if v < 0:
+                    v = -v
+                if best is None or v < best:
+                    best = v
+                    spot = (i, j)
+    return spot
+
+
+def invfac(rows):
+    """the chain of invariant factors of an integer matrix, integer arithmetic only"""
+    wk = [[int(x) for x in r] for r in rows]
+    nr = len(wk)
+    nc = len(wk[0])
+    facs = []
+    t = 0
+    while t < min(nr, nc):
+        spot = least_spot(wk, t, nr, nc)
+        if spot is None:
+            break
+        while True:
+            i0, j0 = spot
+            wk[t], wk[i0] = wk[i0], wk[t]
+            for r in range(nr):
+                wk[r][t], wk[r][j0] = wk[r][j0], wk[r][t]
+            pv = wk[t][t]
+            for i in range(t + 1, nr):
+                if wk[i][t]:
+                    q = wk[i][t] // pv
+                    ri = wk[i]
+                    rt = wk[t]
+                    for j in range(t, nc):
+                        ri[j] -= q * rt[j]
+            for j in range(t + 1, nc):
+                if wk[t][j]:
+                    q = wk[t][j] // pv
+                    for i in range(t, nr):
+                        wk[i][j] -= q * wk[i][t]
+            if any(wk[i][t] for i in range(t + 1, nr)):
+                spot = least_spot(wk, t, nr, nc)
+                continue
+            if any(wk[t][j] for j in range(t + 1, nc)):
+                spot = least_spot(wk, t, nr, nc)
+                continue
+            bad = None
+            for i in range(t + 1, nr):
+                for j in range(t + 1, nc):
+                    if divmod(wk[i][j], pv)[1]:
+                        bad = i
+                        break
+                if bad is not None:
+                    break
+            if bad is None:
+                break
+            wk[t] = [wk[t][j] + wk[bad][j] for j in range(nc)]
+            spot = least_spot(wk, t, nr, nc)
+        v = wk[t][t]
+        facs.append(v if v > 0 else -v)
+        t += 1
+    return facs
+
+
+def parts(fs):
+    """the nontrivial part of a chain of invariant factors, as value and count pairs"""
+    out = {}
+    for d in fs:
+        if d != 1:
+            out[d] = out.get(d, 0) + 1
+    return sorted(out.items())
+
+
+def pfac(n):
+    """prime factorisation of a positive integer as a list of base and power pairs"""
+    out = []
+    m = int(n)
+    d = 2
+    while d * d <= m:
+        e = 0
+        while divmod(m, d)[1] == 0:
+            e += 1
+            m = m // d
+        if e:
+            out.append((d, e))
+        d += 1 if d == 2 else 2
+    if m > 1:
+        out.append((m, 1))
+    return out
+
+
+def fshow(fs):
+    """a factorisation as a product string like 2^7 x 3 x 5^2"""
+    return " x ".join(str(b) if e == 1 else "{0}^{1}".format(b, e) for b, e in fs)
+
+
+# ------------------------------- Part 3: the relabellings and the visibility matrix
+
+
+def colperm(img):
+    """a map of the 16 corners turned into a permutation of the pieces"""
+    out = [0] * NPO
+    for a, p in enumerate(USED):
+        w = 0
+        for c in range(16):
+            if (int(CM[p]) >> c) & 1:
+                w |= 1 << img[c]
+        out[a] = P2I[M2I[w]]
+    return tuple(out)
+
+
+FULL, T96, T48, T24 = [], [], [], []
+for perm in itertools.permutations(range(4)):
+    for sg in itertools.product((0, 1), repeat=4):
+        img = tuple(POS[tuple(c[perm[i]] ^ sg[i] for i in range(4))] for c in CORN)
+        cp = colperm(img)
+        FULL.append(cp)
+        if perm[3] == 3:
+            T96.append(cp)
+            d3 = 1
+            for i in range(3):
+                for j in range(i + 1, 3):
+                    if perm[i] > perm[j]:
+                        d3 = -d3
+            if d3 * (1 if divmod(sum(sg[:3]), 2)[1] == 0 else -1) == 1:
+                T48.append(cp)
+                if sg[3] == 0:
+                    T24.append(cp)
+PA = np.array(FULL, dtype=np.int32)
+
+
+def blocks(ps):
+    """the sizes of the blocks a set of piece relabellings cuts the pieces into"""
+    seen = [-1] * NPO
+    sz = []
+    for s in range(NPO):
+        if seen[s] >= 0:
+            continue
+        o = len(sz)
+        blk = {s}
+        front = [s]
+        seen[s] = o
+        while front:
+            x = front.pop()
+            for pm in ps:
+                y = pm[x]
+                if y not in blk:
+                    blk.add(y)
+                    seen[y] = o
+                    front.append(y)
+        sz.append(len(blk))
+    return sorted(sz)
+
+
+def bstr(sz):
+    """block sizes as a count of equal blocks when they are equal"""
+    return "{0} of {1}".format(len(sz), sz[0]) if len(set(sz)) == 1 else joins(sz)
+
+
+def rowset(A):
+    """the rows of an index table, each sorted, then put in one fixed order"""
+    S = np.sort(A, axis=1)
+    return S[np.lexsort(S.T[::-1])]
+
+
+def keeps(cp, A, K):
+    """whether relabelling the pieces by cp carries the row set of A onto itself"""
+    return bool(np.array_equal(rowset(cp[A]), K))
+
+
+PMEMO = {}
+
+
+def liftN(A, D):
+    """the exact integer matrix D times the projector onto the row space of A
+
+    The projector is formed over the field with PMOD elements from a basis of the
+    row space, multiplied by D, and each entry lifted into the range symmetric about
+    zero. That step only proposes the lift. The whole number identities N N = D N
+    and N B transpose = D B transpose, checked by the caller in Python object
+    arithmetic, are what certify it.
+    """
+    key = id(A)
+    if key not in PMEMO:
+        rows = basis_rows(A, PMOD, None)
+        B = np.mod(A[rows], PMOD).astype(np.int64)
+        k = len(rows)
+        aug = np.concatenate([np.mod(B @ B.T, PMOD), B], axis=1)
+        for c in range(k):
+            nz = [i for i in range(c, k) if aug[i, c]]
+            aug[[c, nz[0]]] = aug[[nz[0], c]]
+            aug[c] = np.mod(aug[c] * pow(int(aug[c, c]), PMOD - 2, PMOD), PMOD)
+            hit = np.nonzero(aug[:, c])[0]
+            hit = hit[hit != c]
+            if hit.size:
+                aug[hit] = np.mod(aug[hit] - np.outer(aug[hit, c], aug[c]), PMOD)
+        PMEMO[key] = (np.mod(B.T @ aug[:, k:], PMOD), k, A[rows], A)
+    Pm, k, B, _ = PMEMO[key]
+    N = np.mod(Pm * D, PMOD)
+    N = np.where(N > PMOD // 2, N - PMOD, N).astype(np.int64)
+    return N, k, B
+
+
+def clears(A, D):
+    """whether D times the projector onto the row space of A is a whole matrix"""
+    NO = liftN(A, D)[0].astype(object)
+    return bool((NO @ NO == D * NO).all())
+
+
+def least_mult(A, cands):
+    """the smallest candidate multiplier that clears the projector, and the failures"""
+    bad = []
+    for D in sorted(cands):
+        if clears(A, D):
+            return D, bad
+        bad.append(D)
+    return None, bad
+
+
+def constant_on(N, cls, ncl):
+    """whether an integer matrix takes one value on each class of ordered pairs"""
+    for c in range(ncl):
+        v = N[cls == c]
+        if int(v.min()) != int(v.max()):
+            return False
+    return True
+
+
+# --------------------------------------------------- Part 4: the object and the gates
+
+emit("Every count below is measured here.")
+emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, "
+     "{3} cuttings through a piece".format(NS, NPO, int(RW.min()), int(CS.min())))
+gate(NS == 15800 and NPO == 192 and int(RW.min()) == int(RW.max()) == 24
+     and int(CS.min()) == int(CS.max()) == 1975 and NC == 192, "C0",
+     "the pieces per cutting and the cuttings through a piece are each the same "
+     "number for every one of them, and there are {0} exact covers".format(NC))
+
+DIST = len(set(FULL))
+ISP = all(sorted(cp) == list(range(NPO)) for cp in FULL)
+gate(len(FULL) == 384 and DIST == 384 and ISP, "C1",
+     "permuting the four coordinates and flipping any of them gives {0} maps of the "
+     "{1} corners and {2} distinct piece relabellings".format(len(FULL), 16, DIST))
+
+CUTS = np.zeros((NS, int(RW.min())), dtype=np.int32)
+for i, s in enumerate(SOL):
+    CUTS[i] = sorted(P2I[p] for p in s)
+COVS = np.zeros((NC, 8), dtype=np.int32)
+for i, s in enumerate(CLQ):
+    COVS[i] = sorted(int(p) for p in s)
+CUTKEY, COVKEY = rowset(CUTS), rowset(COVS)
+KEPT = sum(1 for i in range(len(FULL))
+           if keeps(PA[i], CUTS, CUTKEY) and keeps(PA[i], COVS, COVKEY))
+SWP = PA[0].copy()
+SWP[0], SWP[1] = SWP[1], SWP[0]
+CTL2 = keeps(SWP, CUTS, CUTKEY)
+gate(KEPT == 384 and not CTL2, "C2",
+     "{0} of the {1} carry the {2} cuttings and the {3} covers onto themselves; one "
+     "of them after a swap of two pieces gives {4}".format(KEPT, len(FULL), NS, NC,
+                                                           CTL2))
+
+B24, B48, B96, BAL = blocks(T24), blocks(T48), blocks(T96), blocks(FULL)
+emit("blocks on the {0} pieces: turns {1} give {2}, with the tick flip {3} give {4}, "
+     "tick fixed {5} give {6}, all {7} give {8}".format(
+         NPO, len(T24), bstr(B24), len(T48), bstr(B48), len(T96), bstr(B96),
+         len(FULL), bstr(BAL)))
+gate(len(T24) == 24 and len(T48) == 48 and len(T96) == 96 and B24 == [24] * 8
+     and B48 == [48] * 4 and B96 == [96] * 2 and BAL == [NPO], "C3",
+     "one block only once a relabelling may carry the tick coordinate onto a "
+     "spatial one")
+
+RKI = rank_exact((INCL.T @ INCL).tolist())
+RKM = rank_exact((W.T @ W).tolist())
+GI, DI = divisor_witness(INCL, RKI)
+GM, DM = divisor_witness(W, RKM)
+gate(RKI == 88 and RKM == 105 and GI == 1 and GM == 1 and DI == [1, 1]
+     and DM == [1, 1], "C4",
+     "exact ranks {0} and {1}; minors {2} and {3}, so each row lattice is "
+     "saturated".format(RKI, RKM, joins(DI), joins(DM)))
+
+CLS = -np.ones((NPO, NPO), dtype=np.int64)
+NCLS = 0
+PL = PA.astype(np.int64)
+for a in range(NPO):
+    for b in range(NPO):
+        if CLS[a, b] >= 0:
+            continue
+        CLS[a, b] = NCLS
+        fx = np.array([a], dtype=np.int64)
+        fy = np.array([b], dtype=np.int64)
+        while fx.size:
+            ix = PL[:, fx].ravel()
+            iy = PL[:, fy].ravel()
+            m = CLS[ix, iy] < 0
+            kk = np.unique(ix[m] * NPO + iy[m])
+            fx = kk // NPO
+            fy = kk - fx * NPO
+            CLS[fx, fy] = NCLS
+        NCLS += 1
+
+
+def side(A, D, cands, want):
+    """certify D times the projector and collect its diagonal, classes and glue"""
+    N, k, B = liftN(A, D)
+    NO = N.astype(object)
+    BO = B.T.astype(object)
+    sym = bool((N == N.T).all())
+    idm = bool((NO @ NO == D * NO).all())
+    fix = bool((NO @ BO == D * BO).all())
+    tr = int(np.trace(N))
+    dg = mset(np.diag(N))
+    gv = math.gcd(k, NPO)
+    dmin, bad = least_mult(A, cands)
+    return dict(N=N, B=B, k=k, tr=tr, dg=dg, lo=int(N.min()), hi=int(N.max()),
+                nv=len(set(N.ravel().tolist())), num=k // gv, den=NPO // gv,
+                sym=sym, idm=idm, fix=fix, dmin=dmin, bad=bad,
+                ok=(sym and idm and fix and tr == D * k and k == want),
+                dgok=(len(dg) == 1 and int(np.diag(N).min()) * NPO == tr),
+                cst=constant_on(N, CLS, NCLS))
+
+
+def report(s, D, nm):
+    """the two measurement lines for one side"""
+    emit("{0} side rank {1}: N = {2} P symmetric {3}, N N = {2} N {4}, N fixes the "
+         "rows {5}, trace {6} = {2} x {1}".format(nm, s["k"], D, s["sym"], s["idm"],
+                                                  s["fix"], s["tr"]))
+    emit("{0} side diagonal {1}, entries {2} to {3} taking {4} values, seen fraction "
+         "{5} over {6} which is {7} over {8}".format(nm, msets(s["dg"]), s["lo"],
+                                                     s["hi"], s["nv"], s["k"], NPO,
+                                                     s["num"], s["den"]))
+
+
+SA = side(INCL, 960, [192, 320, 480, 960], 88)
+NN = SA["N"]
+report(SA, 960, "cutting")
+gate(SA["ok"], "C5",
+     "the cutting side certificate holds over the whole numbers at rank {0}, trace "
+     "{1}".format(SA["k"], SA["tr"]))
+gate(SA["dgok"] and SA["num"] == 11 and SA["den"] == 24, "C6",
+     "every one of the {0} diagonal entries is the same, so each piece is seen in "
+     "the fraction {1} over {2}".format(NPO, SA["num"], SA["den"]))
+
+COM = all(bool((NN[np.ix_(PA[i], PA[i])] == NN).all()) for i in range(len(FULL)))
+gate(COM, "C7",
+     "N is unchanged by relabelling the pieces by any of the {0}, so its diagonal is "
+     "constant on each block".format(len(FULL)))
+
+CB2 = np.zeros((2, NPO), dtype=np.int64)
+SEEN = [-1] * NPO
+BK = []
+for s in range(NPO):
+    if SEEN[s] >= 0:
+        continue
+    o = len(BK)
+    blk = {s}
+    front = [s]
+    SEEN[s] = o
+    while front:
+        x = front.pop()
+        for pm in T48:
+            y = pm[x]
+            if y not in blk:
+                blk.add(y)
+                SEEN[y] = o
+                front.append(y)
+    BK.append(sorted(blk))
+for r in range(2):
+    CB2[r, BK[r]] = 1
+NB, KB, _ = liftN(CB2, 96)
+QA = np.array(T48, dtype=np.int32)
+K48 = all(bool((NB[np.ix_(QA[i], QA[i])] == NB).all()) for i in range(len(T48)))
+K384 = all(bool((NB[np.ix_(PA[i], PA[i])] == NB).all()) for i in range(len(FULL)))
+DB = mset(np.diag(NB))
+gate(KB == 2 and K48 and not K384 and DB == {0: 96, 2: 96}
+     and 96 * KB // NPO == 1, "C8",
+     "control, two of the {0} blocks of the {1}: rank {2}, kept by the {1} {3}, by "
+     "the {4} {5}, diagonal {6}".format(len(B48), len(T48), KB, K48, len(FULL),
+                                        K384, msets(DB)))
+
+E1 = np.zeros((1, NPO), dtype=np.int64)
+E1[0, 0] = 1
+NE, KE, _ = liftN(E1, 1)
+DE = mset(np.diag(NE))
+gate(KE == 1 and DE == {0: NPO - 1, 1: 1}, "C9",
+     "control, the indicator of one piece with multiplier 1: rank {0}, diagonal {1}, "
+     "not constant although the {2} give one block".format(KE, msets(DE), len(FULL)))
+
+DMA, BDA = SA["dmin"], SA["bad"]
+gate(DMA == 960 and BDA == [192, 320, 480], "C10",
+     "smallest whole multiplier on the cutting side {0} = {1}; {2} each leave a "
+     "fraction".format(DMA, fshow(pfac(DMA)), joins(BDA)))
+
+gate(NCLS == 104 and SA["cst"] and SA["nv"] == 23, "C11",
+     "the {0} carry the ordered pairs of pieces into {1} classes; N is constant on "
+     "every one and takes {2} values".format(len(FULL), NCLS, SA["nv"]))
+
+SB2 = side(W, 320, [64, 160, 320], 105)
+NM = SB2["N"]
+DMB, BDB = SB2["dmin"], SB2["bad"]
+report(SB2, 320, "cover")
+gate(SB2["ok"] and SB2["dgok"] and SB2["num"] == 35 and SB2["den"] == 64
+     and DMB == 320 and BDB == [64, 160] and SB2["cst"] and SB2["nv"] == 23
+     and NCLS == 104, "C12",
+     "cover side certificate holds, fraction {0} over {1}, smallest multiplier {2} "
+     "= {3}, {4} leave a fraction, constant on {5} classes".format(
+         SB2["num"], SB2["den"], DMB, fshow(pfac(DMB)), joins(BDB), NCLS))
+
+FI = invfac((SA["B"].astype(object) @ SA["B"].T.astype(object)).tolist())
+FM = invfac((SB2["B"].astype(object) @ SB2["B"].T.astype(object)).tolist())
+gate(max(FI) == DMA and max(FM) == DMB and len(FI) == RKI and len(FM) == RKM,
+     "C13",
+     "Gram largest invariant factor: cutting {0} with {1} nontrivial, cover {2} with "
+     "{3}; each is that side's smallest whole multiplier".format(
+         max(FI), sum(c for _, c in parts(FI)), max(FM),
+         sum(c for _, c in parts(FM))))
+
+LF, DL = [], []
+for rows in ([[1, 2]], [[2, 0]]):
+    Ax = np.array(rows, dtype=np.int64)
+    LF.append(max(invfac((Ax.astype(object) @ Ax.T.astype(object)).tolist())))
+    DL.append(least_mult(Ax, range(1, 40))[0])
+gate(LF == [5, 4] and DL == [5, 1] and LF[0] == DL[0] and LF[1] != DL[1], "C14",
+     "control, the line 1 2 is saturated and gives {0} against {1}; the line 2 0 is "
+     "not and gives {2} against {3}".format(LF[0], DL[0], LF[1], DL[1]))
+
+KC = invfac([[2, 0], [0, 3]])
+KD = invfac([[4, 0], [0, 6]])
+gate(KC == [1, 6] and KD == [2, 12], "C15",
+     "control, the invariant factor routine returns {0} from the diagonal 2 3 and "
+     "{1} from the diagonal 4 6, not the entries handed to it".format(joins(KC),
+                                                                      joins(KD)))
+
+A5 = DMA // NPO if DMA else 0
+A3 = DMA // DMB if DMA and DMB else 0
+IO = np.zeros((NPO, NPO), dtype=object)
+for i in range(NPO):
+    IO[i, i] = 1
+JO = np.ones((NPO, NPO), dtype=object)
+NO1 = NN.astype(object)
+NO2 = NM.astype(object)
+DIF = A3 * NO2 - (DMA * IO - NO1 + A5 * JO)
+TIE = bool((DIF == 0).all())
+NZ = int((DIF != 0).sum())
+BIG = max([abs(int(x)) for x in DIF.ravel()]) if NZ else 0
+DIF4 = A3 * NO2 - (DMA * IO - NO1 + (A5 - 1) * JO)
+CTL7 = bool((DIF4 == 0).all())
+ONES = np.ones(NPO, dtype=object)
+SEES = bool((NO1 @ ONES == DMA * ONES).all())
+DIMS = (NPO - RKI + 1) == RKM
+
+ELAP = time.monotonic() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+EBD = 300 * (int(ELAP // 300) + 1)
+RBD = 500 * (int(RSS // 500) + 1)
+gate(ELAP < 900.0 and RSS < 2500.0 and EBD <= 900 and RBD <= 2500, "C16",
+     "elapsed under {0} s and peak memory under {1} MB, both measured in this "
+     "run".format(EBD, RBD))
+
+emit("the tie: {0} N2 = {1} I - N + {2} J over the whole numbers {3}, differing "
+     "entries {4}, largest difference {5}; with {6} J it is {7}".format(
+         A3, DMA, A5, TIE, NZ, BIG, A5 - 1, CTL7))
+gate(TIE and SEES and DIMS and not CTL7, "C17",
+     "N times the all ones vector is {0} times it {1}, and {2} - {3} + 1 = {4} "
+     "{5}".format(DMA, SEES, NPO, RKI, RKM, DIMS))
+
+TOT = "TOTAL: PASS={0} FAIL={1}".format(PF[0], PF[1])
+CNT = "stdout characters: {0}"
+n = OUT[0] + len(TOT) + 1
+for _ in range(6):
+    n = OUT[0] + len(CNT.format(n)) + 1 + len(TOT) + 1
+emit(CNT.format(n))
+emit(TOT)
+if PF[1]:
+    raise SystemExit(1)

--- a/scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py
+++ b/scripts/physical_cell_cutting_visible_fraction_cycle760_2026_08_09.py
@@ -1,4 +1,4 @@
-"""Measure the fraction of each piece that the cuttings of the unit four-cube see.
+"""Measure coordinate leverage in the finite unit-four-cube cutting row space.
 
 Every count below is measured here. The runner rebuilds the cell complex, the least
 volume pieces, the cuttings at the adjacency cost floor, the cutting by piece table
@@ -6,17 +6,22 @@ and the eight piece exact covers. It then builds the maps got by permuting the f
 coordinates of the four-cube and flipping any of them, measures the blocks those maps
 cut the pieces into, and certifies an exact whole number multiple of the orthogonal
 projector onto the span of the cuttings. The diagonal of that projector is the
-fraction of each piece the cuttings see, and it is the same at every piece. The
-smallest whole multiplier that clears the projector is measured on both tables and
-set beside the largest invariant factor of the same table's Gram. Four controls fixed
-in advance show the gates fail when the hypotheses they rest on are taken away.
+coordinate leverage score called algebraic visibility here, and it is the same at
+every piece. The least positive integer that clears the full projector is certified
+on both tables and set beside the largest invariant factor of the same table's Gram.
+Six controls fixed in advance show the gates fail when the hypotheses or routines
+they exercise are changed.
 """
 import itertools
 import math
 import resource
+import sys
 import time
 
 import numpy as np
+
+AUDIT_TIMEOUT_SEC = 300
+AUDIT_MEMORY_MB = 500
 
 T0 = time.monotonic()
 PF = [0, 0]
@@ -93,6 +98,10 @@ LO = int(C4.min())
 MINP = [i for i in range(NPIECE) if int(C4[i]) == LO]
 MM = np.stack([(V[p[1:]] - V[p[0]]).T for p in UNI])
 IV = np.rint(np.linalg.inv(MM.astype(float))).astype(np.int64)
+IV_OK = bool(np.array_equal(
+    np.einsum("nij,njk->nik", MM, IV),
+    np.broadcast_to(np.eye(4, dtype=np.int64), MM.shape),
+))
 
 ROT = []
 for perm in itertools.permutations(range(3)):
@@ -100,7 +109,12 @@ for perm in itertools.permutations(range(3)):
         R = np.zeros((3, 3), dtype=np.int64)
         for i, j in enumerate(perm):
             R[i, j] = sg[i]
-        if int(round(np.linalg.det(R.astype(float)))) == 1:
+        det_r = int(
+            R[0, 0] * (R[1, 1] * R[2, 2] - R[1, 2] * R[2, 1])
+            - R[0, 1] * (R[1, 0] * R[2, 2] - R[1, 2] * R[2, 0])
+            + R[0, 2] * (R[1, 0] * R[2, 1] - R[1, 1] * R[2, 0])
+        )
+        if det_r == 1:
             ROT.append(R)
 CEN = np.array([1, 1, 1], dtype=np.int64)
 G = []
@@ -611,13 +625,21 @@ def clears(A, D):
 
 
 def least_mult(A, cands):
-    """the smallest candidate multiplier that clears the projector, and the failures"""
+    """the first supplied multiplier that clears the projector, and prior failures"""
     bad = []
     for D in sorted(cands):
         if clears(A, D):
             return D, bad
         bad.append(D)
     return None, bad
+
+
+def projector_denominator(N, D):
+    """least positive integer clearing P when the exact integer matrix N = D P is known"""
+    entry_gcd = 0
+    for x in N.ravel():
+        entry_gcd = math.gcd(entry_gcd, abs(int(x)))
+    return int(D) // math.gcd(int(D), entry_gcd), entry_gcd
 
 
 def constant_on(N, cls, ncl):
@@ -635,9 +657,10 @@ emit("Every count below is measured here.")
 emit("the object: {0} cuttings and {1} pieces, {2} pieces to a cutting, "
      "{3} cuttings through a piece".format(NS, NPO, int(RW.min()), int(CS.min())))
 gate(NS == 15800 and NPO == 192 and int(RW.min()) == int(RW.max()) == 24
-     and int(CS.min()) == int(CS.max()) == 1975 and NC == 192, "C0",
+     and int(CS.min()) == int(CS.max()) == 1975 and NC == 192 and IV_OK, "C0",
      "the pieces per cutting and the cuttings through a piece are each the same "
-     "number for every one of them, and there are {0} exact covers".format(NC))
+     "number for every one of them; exact simplex inverses; {0} covers".format(NC))
+emit("incidence frequency: each piece occurs in 1975 of 15800 cuttings, which is 1 over 8")
 
 DIST = len(set(FULL))
 ISP = all(sorted(cp) == list(range(NPO)) for cp in FULL)
@@ -663,14 +686,13 @@ gate(KEPT == 384 and not CTL2, "C2",
                                                            CTL2))
 
 B24, B48, B96, BAL = blocks(T24), blocks(T48), blocks(T96), blocks(FULL)
-emit("blocks on the {0} pieces: turns {1} give {2}, with the tick flip {3} give {4}, "
-     "tick fixed {5} give {6}, all {7} give {8}".format(
+emit("blocks on the {0} pieces: first-three turns {1} give {2}, plus fourth flip {3} "
+     "give {4}, fourth fixed {5} give {6}, all {7} give {8}".format(
          NPO, len(T24), bstr(B24), len(T48), bstr(B48), len(T96), bstr(B96),
          len(FULL), bstr(BAL)))
 gate(len(T24) == 24 and len(T48) == 48 and len(T96) == 96 and B24 == [24] * 8
      and B48 == [48] * 4 and B96 == [96] * 2 and BAL == [NPO], "C3",
-     "one block only once a relabelling may carry the tick coordinate onto a "
-     "spatial one")
+     "in this subgroup ladder, allowing the fourth coordinate to move gives one block")
 
 RKI = rank_exact((INCL.T @ INCL).tolist())
 RKM = rank_exact((W.T @ W).tolist())
@@ -703,7 +725,7 @@ for a in range(NPO):
 
 
 def side(A, D, cands, want):
-    """certify D times the projector and collect its diagonal, classes and glue"""
+    """certify D times the projector and collect its diagonal, classes and denominator"""
     N, k, B = liftN(A, D)
     NO = N.astype(object)
     BO = B.T.astype(object)
@@ -713,10 +735,12 @@ def side(A, D, cands, want):
     tr = int(np.trace(N))
     dg = mset(np.diag(N))
     gv = math.gcd(k, NPO)
-    dmin, bad = least_mult(A, cands)
+    dmin, ngcd = projector_denominator(N, D)
+    bad = [d for d in sorted(cands) if d < dmin and not clears(A, d)]
     return dict(N=N, B=B, k=k, tr=tr, dg=dg, lo=int(N.min()), hi=int(N.max()),
                 nv=len(set(N.ravel().tolist())), num=k // gv, den=NPO // gv,
                 sym=sym, idm=idm, fix=fix, dmin=dmin, bad=bad,
+                ngcd=ngcd,
                 ok=(sym and idm and fix and tr == D * k and k == want),
                 dgok=(len(dg) == 1 and int(np.diag(N).min()) * NPO == tr),
                 cst=constant_on(N, CLS, NCLS))
@@ -727,7 +751,7 @@ def report(s, D, nm):
     emit("{0} side rank {1}: N = {2} P symmetric {3}, N N = {2} N {4}, N fixes the "
          "rows {5}, trace {6} = {2} x {1}".format(nm, s["k"], D, s["sym"], s["idm"],
                                                   s["fix"], s["tr"]))
-    emit("{0} side diagonal {1}, entries {2} to {3} taking {4} values, seen fraction "
+    emit("{0} side diagonal {1}, entries {2} to {3} taking {4} values, leverage "
          "{5} over {6} which is {7} over {8}".format(nm, msets(s["dg"]), s["lo"],
                                                      s["hi"], s["nv"], s["k"], NPO,
                                                      s["num"], s["den"]))
@@ -740,8 +764,8 @@ gate(SA["ok"], "C5",
      "the cutting side certificate holds over the whole numbers at rank {0}, trace "
      "{1}".format(SA["k"], SA["tr"]))
 gate(SA["dgok"] and SA["num"] == 11 and SA["den"] == 24, "C6",
-     "every one of the {0} diagonal entries is the same, so each piece is seen in "
-     "the fraction {1} over {2}".format(NPO, SA["num"], SA["den"]))
+     "every one of the {0} diagonal entries is the same, so coordinate leverage is "
+     "{1} over {2}".format(NPO, SA["num"], SA["den"]))
 
 COM = all(bool((NN[np.ix_(PA[i], PA[i])] == NN).all()) for i in range(len(FULL)))
 gate(COM, "C7",
@@ -789,9 +813,9 @@ gate(KE == 1 and DE == {0: NPO - 1, 1: 1}, "C9",
      "not constant although the {2} give one block".format(KE, msets(DE), len(FULL)))
 
 DMA, BDA = SA["dmin"], SA["bad"]
-gate(DMA == 960 and BDA == [192, 320, 480], "C10",
-     "smallest whole multiplier on the cutting side {0} = {1}; {2} each leave a "
-     "fraction".format(DMA, fshow(pfac(DMA)), joins(BDA)))
+gate(DMA == 960 and SA["ngcd"] == 1 and BDA == [192, 320, 480], "C10",
+     "exact projector denominator {0} = {1}, numerator entry gcd {2}; {3} each leave "
+     "noninteger entries".format(DMA, fshow(pfac(DMA)), SA["ngcd"], joins(BDA)))
 
 gate(NCLS == 104 and SA["cst"] and SA["nv"] == 23, "C11",
      "the {0} carry the ordered pairs of pieces into {1} classes; N is constant on "
@@ -802,18 +826,22 @@ NM = SB2["N"]
 DMB, BDB = SB2["dmin"], SB2["bad"]
 report(SB2, 320, "cover")
 gate(SB2["ok"] and SB2["dgok"] and SB2["num"] == 35 and SB2["den"] == 64
-     and DMB == 320 and BDB == [64, 160] and SB2["cst"] and SB2["nv"] == 23
+     and DMB == 320 and SB2["ngcd"] == 1 and BDB == [64, 160]
+     and SB2["cst"] and SB2["nv"] == 23
      and NCLS == 104, "C12",
-     "cover side certificate holds, fraction {0} over {1}, smallest multiplier {2} "
-     "= {3}, {4} leave a fraction, constant on {5} classes".format(
-         SB2["num"], SB2["den"], DMB, fshow(pfac(DMB)), joins(BDB), NCLS))
+     "cover certificate: leverage {0}/{1}, projector denominator {2}, numerator gcd "
+     "{3}; {4} leave nonintegers, constant on {5} classes".format(
+         SB2["num"], SB2["den"], DMB, SB2["ngcd"], joins(BDB), NCLS))
 
 FI = invfac((SA["B"].astype(object) @ SA["B"].T.astype(object)).tolist())
 FM = invfac((SB2["B"].astype(object) @ SB2["B"].T.astype(object)).tolist())
-gate(max(FI) == DMA and max(FM) == DMB and len(FI) == RKI and len(FM) == RKM,
+GBI, GBDI = divisor_witness(SA["B"], RKI)
+GBM, GBDM = divisor_witness(SB2["B"], RKM)
+gate(max(FI) == DMA and max(FM) == DMB and len(FI) == RKI and len(FM) == RKM
+     and GBI == 1 and GBM == 1 and GBDI == [1, 1] and GBDM == [1, 1],
      "C13",
-     "Gram largest invariant factor: cutting {0} with {1} nontrivial, cover {2} with "
-     "{3}; each is that side's smallest whole multiplier".format(
+     "saturated Gram bases; largest factors cutting {0} ({1} nontrivial), cover {2} "
+     "({3}); each equals the projector denominator".format(
          max(FI), sum(c for _, c in parts(FI)), max(FM),
          sum(c for _, c in parts(FM))))
 
@@ -852,10 +880,12 @@ SEES = bool((NO1 @ ONES == DMA * ONES).all())
 DIMS = (NPO - RKI + 1) == RKM
 
 ELAP = time.monotonic() - T0
-RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1048576.0
+RSS_RAW = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+RSS = RSS_RAW / (1048576.0 if sys.platform == "darwin" else 1024.0)
 EBD = 300 * (int(ELAP // 300) + 1)
 RBD = 500 * (int(RSS // 500) + 1)
-gate(ELAP < 900.0 and RSS < 2500.0 and EBD <= 900 and RBD <= 2500, "C16",
+gate(ELAP < AUDIT_TIMEOUT_SEC and RSS < AUDIT_MEMORY_MB
+     and EBD <= AUDIT_TIMEOUT_SEC and RBD <= AUDIT_MEMORY_MB, "C16",
      "elapsed under {0} s and peak memory under {1} MB, both measured in this "
      "run".format(EBD, RBD))
 


### PR DESCRIPTION
## Scope

One self-contained finite-combinatorics source note, one exact runner, and its
content-pinned cache. The package changes no axiom, primitive, policy, registry,
or audit verdict.

For the explicitly rebuilt four-cube cutting incidence system, the runner
certifies:

- 15,800 cuttings on 192 piece coordinates, 24 pieces per cutting, uniform
  incidence frequency 1/8, and 192 eight-piece exact covers;
- a 384-element signed-coordinate subgroup preserving both row sets and acting
  transitively on the 192 coordinates (no claim that it is the full
  automorphism group);
- cutting and cover row-space ranks 88 and 105;
- constant coordinate leverage scores 11/24 and 35/64;
- least full-projector clearing multipliers 960 and 320, distinct from the
  reduced scalar denominators 24 and 64;
- equality of those full-projector denominators with the largest invariant
  factors of saturated selected Gram bases; and
- the exact linked-projector identity `Q = I - P + J/192`.

The runner has no external scientific inputs or repository-file reads. An
unlanded Cycle-759 explanation and unsupported full-symmetry/completeness prose
from the submitted version were removed during review; the final theorem is
self-contained and bounded to this one finite object.

## Review-loop fixes and independent checks

Review iteration 1 corrected the claim class to `bounded_theorem`, installed
the trace/status and proof-obligation surfaces, defined “algebraic visibility”
as projector leverage rather than occurrence frequency, replaced candidate-only
minimality with exact numerator-gcd reduction, added unit-minor witnesses for
the selected Gram bases, and declared `AUDIT_TIMEOUT_SEC = 300`.

Independent review used a second modular prime to recover ranks 88/105, checked
every rounded simplex inverse by exact integer multiplication, independently
reduced the projector numerators to entry gcd 1, recovered incidence 1/8, and
recomputed the linked-projector identity entry by entry. The note also gives an
integral-right-inverse proof of the denominator/invariant-factor equality that
does not reuse the runner's Smith-form algorithm.

Every C0-C17 gate family was mutation-tested on an isolated in-memory source
copy. The mutations were, in order: cutting count; duplicate coordinate map;
corrupted cutting row; removed subgroup map; collapsed incidence rows; wrong
cutting scale; wrong leverage numerator; changed projector entry; removed orbit
indicator; expanded singleton control; wrong denominator formula; merged pair
orbit; wrong cover scale; changed Gram entry; changed unsaturated toy line;
changed Smith-form toy matrix; one-second timeout; wrong all-ones coefficient.
Each named gate printed `FAIL` and each mutated process exited nonzero.

Final source/cache execution: `TOTAL: PASS=18 FAIL=0`; cache is SHA-pinned to
the final runner with the declared 300-second timeout. Independent audit remains
required before any retained-grade status can become effective.
