### PR TITLE
science(cell-cutting): each table's row space is the other's space of additive readings

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_ADDITIVE_READING_SPACE_CYCLE762_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_ADDITIVE_READING_SPACE_CYCLE762_NOTE_2026-08-09.md
@@ -1,0 +1,227 @@
+# Each Table's Row Space Is The Other Table's Space Of Additive Readings
+
+**Date:** 2026-08-09
+**Type:** science
+**Runner:** [scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py](../scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py)
+Audit: unset.
+
+## What this is
+
+The object is one cell, taken as the unit four-cube on its sixteen corners. A piece
+is a five-corner sub-simplex whose four edge vectors from its first corner have
+determinant of absolute value 1, so a piece has volume one twenty-fourth of the
+cell; among those, the pieces at the adjacency cost floor are kept. A cutting is a
+set of kept pieces with pairwise disjoint interiors that together fill the cell. A
+cover is an eight-piece set no two of whose pieces ever share a cutting; gate G1
+certifies that each such set meets every cutting exactly once, which is the
+property an earlier cycle of this lane derived and which is re-verified, not
+assumed, in the build below. An assignment
+gives a number to each piece. A cutting reads an assignment by summing it over the
+pieces of that cutting; a cover reads it by summing it over the pieces of that
+cover. Two tables record which piece belongs to which family member: the cutting
+table and the cover table.
+
+The result is one sentence in two halves. The assignments whose cutting readings
+are all equal to each other are exactly the row space of the cover table, and the
+assignments whose cover readings are all equal to each other are exactly the row
+space of the cutting table. Each table's row space is the other family's space of
+additive readings, and the two dimensions are 105 and 88.
+
+## What was already known
+
+The preceding cycle of this lane established, as an exact whole-number identity, a
+relation between the cover-side lifted projector, the cutting-side lifted
+projector, the identity and the all-ones matrix, and it read that identity as
+forcing the dimension count 105 = 192 - 88 + 1. That identity is the engine of
+everything in this cycle. It is not new here.
+
+The characterization stated below is a short consequence of that identity together
+with the two dimensions this lane had already measured, and no part of its
+mathematics is claimed as new. In one direction the identity says that an
+assignment built from the cover table is read at a single level by every cutting;
+in the other it says the same with the two families swapped; and once one direction
+is in hand, equality of dimensions turns the containment into an equality, makes
+the two row spaces span everything, and leaves their intersection at the constants.
+A reader holding the preceding cycle's identity can reach every claim below in a
+few lines, and this note does not pretend otherwise.
+
+What this cycle contributes is therefore not the algebra. It is the statement in
+reading language rather than in projector language; an independent rebuild of the
+whole cell from scratch over the rationals, which re-measures every input number
+instead of citing it; three negative controls that show the match is not automatic;
+and the contact with the additivity clause of the fixed-reality axiom, together
+with a plain account of where that contact stays open.
+
+## The object
+
+The runner builds the cell from scratch. Of the five-corner sub-simplices of the
+four-cube, 2672 have determinant of absolute value 1; the adjacency cost floor
+among them is 6, attained by 400 of them. Cuttings are found as exact covers of 625
+sample points of divisor 80, chosen so that no sample point lies on a facet plane
+of any kept piece; gate G0 checks that genericity condition directly rather than
+assuming it. Genericity is what makes the sample search complete: with no sample
+point on a facet plane, a genuine tiling of the cell covers each sample point
+exactly once, so no tiling escapes the search over exact covers, and the search
+over exact covers is itself complete. Gate G1 then certifies the other direction,
+that what the search returns really is a tiling. The search returns 15800 cuttings,
+each of 24 pieces. Exactly 192 of
+the 400 floor pieces occur in a cutting at all, and each of those 192 lies in 1975
+cuttings. There are 192 covers, and the cover table has every row sum and every
+column sum equal to 8.
+
+Gate G1 verifies that each cutting is a genuine tiling rather than an artifact of
+the sampling: every piece has volume 1 over 24, every cutting holds 24 of them, and
+all 15168 co-occurring piece pairs are certified interior-disjoint exactly, 13632
+of them by a separating facet plane and the rest by an exact computation of the
+affine dimension of the intersection. Twenty-four pieces of volume 1 over 24 with
+pairwise disjoint interiors fill the cell.
+
+## The characterization
+
+Write the cutting table for the 15800 by 192 zero-one table of cuttings against
+pieces, and the cover table for the 192 by 192 zero-one table of covers against
+pieces.
+
+Gate G4 measures rank 88 and kernel dimension 104 for the cutting table, and rank
+105 and kernel dimension 87 for the cover table. Gate G5 measures that one over 24
+times the constants reads 1 on every cutting, and one over 8 times the constants
+reads 1 on every cover, so each side has a particular solution and the constants
+lie in neither kernel. Gate G6 therefore measures the two solution sets: the
+assignments with all cutting readings equal form a space of dimension 105, and the
+assignments with all cover readings equal form a space of dimension 88.
+
+Gate G7 measures that the first of those spaces and the row space of the cover
+table have joint rank 105, which is the dimension of each; the two spaces are
+therefore equal. Gate G8 measures that the second space and the row space of the
+cutting table have joint rank 88, again the dimension of each, so those two are
+equal as well. Both directions are computed here over the rationals, with no
+floating point anywhere in the algebra, and neither is inferred from the other.
+
+The rank of the cutting table is obtained without eliminating on a table of 15800
+rows. Gate G3 justifies the substitution used: the 192 by 192 product of the
+cutting table with itself is built twice by different routes and the two builds
+agree, its kernel is checked to annihilate every one of the 15800 cutting rows, and
+the rank is then recovered independently from the cutting table's own rows, two
+evenly spread selections of 400 and of 800 rows both giving 88.
+
+## The sum and the intersection
+
+Gate G9 measures that the two row spaces together have joint rank 192, so they span
+the whole assignment space. Since their dimensions are 88 and 105, their
+intersection has dimension 88 + 105 - 192 = 1. The constants lie in both row spaces,
+because the column sums of both tables are constant: the column sums of the cutting
+table are all 1975 and those of the cover table are all 8. The intersection is
+therefore exactly the constant assignments, and nothing else is shared.
+
+Gate G14 records the bookkeeping that follows: 105 is 192 minus 88 plus 1, 88 is
+192 minus 105 plus 1, and 88 plus 105 is 192 plus 1.
+
+Not every gate here is discriminating, and G14 is the clear case. It is arithmetic
+on numbers the earlier gates have already measured, and it would pass for any three
+numbers standing in that relation; it is a consistency record, not evidence. The
+load-bearing gates are G7, G8, G9 and G10. Gates G11, G12 and G13 are the ones that
+show those four are not automatic.
+
+## The two totals
+
+Gate G10 measures the two common readings. For an assignment in the
+105-dimensional space, the common cutting reading is the plain sum of the
+assignment divided by 8. For an assignment in the 88-dimensional space, the common
+cover reading is the plain sum divided by 24. The gate checks this on 3 elements of
+each space, each with nonzero sum, so the check is not the empty statement that 0
+equals 0.
+
+Both totals come from the column sums. Summing the cutting readings over all 15800
+cuttings counts each piece 1975 times, giving 1975 times the sum of the assignment;
+summing the same constant reading over 15800 cuttings gives 15800 times it; and
+15800 is 8 times 1975. Summing the cover readings over all 192 covers counts each
+piece 8 times, giving 8 times the sum; summing the constant over 192 covers gives
+192 times it; and 192 is 24 times 8.
+
+## The axiom contact
+
+The fixed-reality axiom in [MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
+says, verbatim:
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+That clause supplies exactly one piece of arithmetic about readings, and nothing
+else. The cuttings of this cell are families to which the clause applies in form: a
+cutting's 24 pieces have pairwise disjoint interiors and together are the whole
+cell, and gate G1 measures that over all 15800 of them. So if a piece carries a
+reading, additivity says every cutting of the cell returns the same total, which is
+precisely the condition that the cutting table sends the assignment into the
+constants. Under that identification the admissible assignments are exactly the row
+space of the cover table.
+
+The identification is open and is not derived here. The axiom places records at
+sites and says only records are readable. A piece is a region, not a site. Nothing
+in the axiom says a region carries a reading, and nothing in this note derives that
+it does.
+
+The naive repair fares worse. Gate G2 measures that the 24 pieces of a cutting
+spend 120 corner slots on only 16 corners, one corner taking from 4 to 24 of them.
+A reading carried by the corners is therefore not partitioned by a cutting at all,
+and the additivity clause does not apply to it. So the obvious retreat from regions
+to corners does not recover the argument; it loses the premise the clause needs.
+
+The identification of a piece as a reading-bearing object is a named open
+identification of this cycle, not a result of it. The four claims stand on their own
+as exact statements about the object, independent of that identification.
+
+## Controls
+
+Three gates are built to come out negative, and each one did.
+
+Gate G11 takes a cover, which lies in the 105-dimensional space, and reads it on
+the cover side. That reading is not constant: it takes the values 0, 1, 2, 4 and 8.
+Had it come out constant, the two spaces would not have been separated by the very
+readings that define them, and the characterization would have been reporting one
+space twice under two names.
+
+Gate G12 replaces the constants by the zero space and measures what the two
+dimensions become: they drop to 104 and 87. Had they not dropped, the constant
+direction would already have been inside the two kernels, and the plus 1 in the
+bookkeeping would have been an artifact of the construction rather than a real
+extra direction.
+
+Gate G13 applies a cyclic column shift to the cover table. The shifted table still
+has rank 105 and still has every row sum and every column sum equal to 8, so it
+matches the original on every coarse feature; but its joint rank with the
+105-dimensional space is 191, not 105, so the correspondence fails for it. Had the
+shifted table matched too, the joint-rank test in gates G7 and G8 would have been
+passing on the shape of a table rather than on its content.
+
+## Measured totals
+
+The runner has 17 gates and prints `TOTAL: PASS=17 FAIL=0`, exiting 0. Elapsed time
+is under 300 seconds and peak resident memory is under 1500 MB; gate G16 reports
+both as bounds rather than as timings. Total stdout is 2278 characters. The runner
+carries no randomness and two runs give byte-identical output. All ranks, kernels
+and joint ranks are computed exactly over the rationals.
+
+## Boundary
+
+- The identification of a piece as an object that carries a reading is open. It is
+  named here and not derived here. Claims 1 to 4 are computational identities about
+  this cell and do not depend on the identification; the axiom contact does.
+- A corner-carried reading is demonstrably not partitioned by a cutting: 120 corner
+  slots fall on 16 corners, with one corner taking from 4 to 24 of them. The
+  additivity clause does not apply to such a reading, and this note claims nothing
+  about one.
+- Nothing here says why the two ranks are 88 and 105 rather than other numbers.
+  They are measured, not derived: they come out of the complete search over this one
+  cell, and no argument in this note predicts either of them from the shape of the
+  four-cube.
+- This is one cell. Nothing here says how cells join to each other. The whole-number
+  bookkeeping of this lane and the spatial joining of neighbouring cells are
+  different questions, and this note does not relate them.
+- The characterization is an equality of two subspaces of the 192-dimensional
+  assignment space. It is not a correspondence between individual cuttings and
+  individual covers, and it says nothing about which piece goes with which.
+- The cuttings are found as exact covers of a sample point set, and the tiling
+  property is then certified separately for all 15168 co-occurring piece pairs. That
+  certificate is what makes the cuttings tilings of the cell rather than of the
+  sample; the sampling itself proves nothing.

--- a/docs/PHYSICAL_CELL_CUTTING_ADDITIVE_READING_SPACE_CYCLE762_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_ADDITIVE_READING_SPACE_CYCLE762_NOTE_2026-08-09.md
@@ -1,9 +1,63 @@
 # Each Table's Row Space Is The Other Table's Space Of Additive Readings
 
 **Date:** 2026-08-09
-**Type:** science
+**Type:** bounded_theorem
 **Runner:** [scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py](../scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py)
 Audit: unset.
+
+## Trace gate
+
+```yaml
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "independently audit the exact finite-cell row-space theorem; any physical use must separately construct a cutting-independent map from pieces to pairwise-disjoint Record content"
+```
+
+## Status fields
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: frontier_discovery
+reachability_to_target: unknown_frontier
+conditional_surface_status: "the physical Record interpretation is conditional on an open piece-to-Record-content bridge"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the runner certifies exact equalities for one stipulated finite cell, while the physical Record bridge and any multi-cell extension remain open"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Imports and provenance
+
+- The finite theorem imports no measured value, literature value, fitted
+  selector, external scientific dataset, or generated audit status. The unit
+  four-cube, determinant-one simplex rule, adjacency-cost floor, and generic
+  divisor-80 sample are declared construction choices; all counts, ranks, and
+  incidences are recomputed exactly by the runner.
+- The preceding cycle's projector identity is provenance context rather than a
+  proof input: this runner rebuilds the object and rechecks both row-space
+  equalities directly.
+- The Record/additivity wording in
+  `docs/MINIMAL_AXIOMS_2026-06-29.md` is non-load-bearing physical context. Its
+  use requires the open bridge stated below.
+- The runner reads its own source for an integrity check. That package-local
+  read is not an external scientific input.
+
+## Review record (review loop iteration 1, 2026-08-09)
+
+Review preserved the exact finite-cell theorem and narrowed the physical
+interpretation. Interior-disjoint pieces were not shown to be pairwise-disjoint
+Records, so the required piece-to-Record-content map is now stated explicitly as
+open. The measured corner-incidence counts remain; conclusions about untested
+allocation constructions were removed. The runner was made fail-closed, given an
+explicit timeout, and its ambiguous letter-number gate labels were replaced by
+domain-explicit names. No hard landing condition remains beyond the checks named
+in this note.
 
 ## What this is
 
@@ -12,14 +66,13 @@ is a five-corner sub-simplex whose four edge vectors from its first corner have
 determinant of absolute value 1, so a piece has volume one twenty-fourth of the
 cell; among those, the pieces at the adjacency cost floor are kept. A cutting is a
 set of kept pieces with pairwise disjoint interiors that together fill the cell. A
-cover is an eight-piece set no two of whose pieces ever share a cutting; gate G1
-certifies that each such set meets every cutting exactly once, which is the
+cover is an eight-piece set no two of whose pieces ever share a cutting; the
+`TILING` gate certifies that each such set meets every cutting exactly once, which is the
 property an earlier cycle of this lane derived and which is re-verified, not
-assumed, in the build below. An assignment
-gives a number to each piece. A cutting reads an assignment by summing it over the
-pieces of that cutting; a cover reads it by summing it over the pieces of that
-cover. Two tables record which piece belongs to which family member: the cutting
-table and the cover table.
+assumed, in the build below. An assignment gives a number to each piece. A cutting
+reads an assignment by summing it over the pieces of that cutting; a cover reads it
+by summing it over the pieces of that cover. Two tables record which piece belongs
+to which family member: the cutting table and the cover table.
 
 The result is one sentence in two halves. The assignments whose cutting readings
 are all equal to each other are exactly the row space of the cover table, and the
@@ -29,11 +82,12 @@ additive readings, and the two dimensions are 105 and 88.
 
 ## What was already known
 
-The preceding cycle of this lane established, as an exact whole-number identity, a
-relation between the cover-side lifted projector, the cutting-side lifted
-projector, the identity and the all-ones matrix, and it read that identity as
-forcing the dimension count 105 = 192 - 88 + 1. That identity is the engine of
-everything in this cycle. It is not new here.
+The preceding cycle of this lane recorded an exact whole-number identity relating
+the cover-side lifted projector, the cutting-side lifted projector, the identity,
+and the all-ones matrix, and read it as forcing the dimension count
+105 = 192 - 88 + 1. That identity motivated this characterization. It is not an
+input here: the runner rebuilds the cell and rechecks the relevant incidences,
+kernels, ranks, and containments.
 
 The characterization stated below is a short consequence of that identity together
 with the two dimensions this lane had already measured, and no part of its
@@ -48,9 +102,10 @@ few lines, and this note does not pretend otherwise.
 What this cycle contributes is therefore not the algebra. It is the statement in
 reading language rather than in projector language; an independent rebuild of the
 whole cell from scratch over the rationals, which re-measures every input number
-instead of citing it; three negative controls that show the match is not automatic;
-and the contact with the additivity clause of the fixed-reality axiom, together
-with a plain account of where that contact stays open.
+instead of citing it; three discriminating controls showing which structural
+features carry the match; and the contact with the additivity clause of the
+fixed-reality axiom, together with a plain account of where that contact stays
+open.
 
 ## The object
 
@@ -58,18 +113,17 @@ The runner builds the cell from scratch. Of the five-corner sub-simplices of the
 four-cube, 2672 have determinant of absolute value 1; the adjacency cost floor
 among them is 6, attained by 400 of them. Cuttings are found as exact covers of 625
 sample points of divisor 80, chosen so that no sample point lies on a facet plane
-of any kept piece; gate G0 checks that genericity condition directly rather than
+of any kept piece; `OBJECT` checks that genericity condition directly rather than
 assuming it. Genericity is what makes the sample search complete: with no sample
 point on a facet plane, a genuine tiling of the cell covers each sample point
 exactly once, so no tiling escapes the search over exact covers, and the search
-over exact covers is itself complete. Gate G1 then certifies the other direction,
+over exact covers is itself complete. `TILING` then certifies the other direction,
 that what the search returns really is a tiling. The search returns 15800 cuttings,
-each of 24 pieces. Exactly 192 of
-the 400 floor pieces occur in a cutting at all, and each of those 192 lies in 1975
-cuttings. There are 192 covers, and the cover table has every row sum and every
-column sum equal to 8.
+each of 24 pieces. Exactly 192 of the 400 floor pieces occur in a cutting at all,
+and each of those 192 lies in 1975 cuttings. There are 192 covers, and the cover
+table has every row sum and every column sum equal to 8.
 
-Gate G1 verifies that each cutting is a genuine tiling rather than an artifact of
+`TILING` verifies that each cutting is a genuine tiling rather than an artifact of
 the sampling: every piece has volume 1 over 24, every cutting holds 24 of them, and
 all 15168 co-occurring piece pairs are certified interior-disjoint exactly, 13632
 of them by a separating facet plane and the rest by an exact computation of the
@@ -82,23 +136,24 @@ Write the cutting table for the 15800 by 192 zero-one table of cuttings against
 pieces, and the cover table for the 192 by 192 zero-one table of covers against
 pieces.
 
-Gate G4 measures rank 88 and kernel dimension 104 for the cutting table, and rank
-105 and kernel dimension 87 for the cover table. Gate G5 measures that one over 24
-times the constants reads 1 on every cutting, and one over 8 times the constants
-reads 1 on every cover, so each side has a particular solution and the constants
-lie in neither kernel. Gate G6 therefore measures the two solution sets: the
-assignments with all cutting readings equal form a space of dimension 105, and the
-assignments with all cover readings equal form a space of dimension 88.
+`TABLE-RANKS` measures rank 88 and kernel dimension 104 for the cutting table, and
+rank 105 and kernel dimension 87 for the cover table. `CONSTANT-DIRECTION`
+measures that one over 24 times the constants reads 1 on every cutting, and one
+over 8 times the constants reads 1 on every cover, so each side has a particular
+solution and the constants lie in neither kernel. `READING-DIMENSIONS` therefore
+measures the two solution sets: the assignments with all cutting readings equal
+form a space of dimension 105, and the assignments with all cover readings equal
+form a space of dimension 88.
 
-Gate G7 measures that the first of those spaces and the row space of the cover
-table have joint rank 105, which is the dimension of each; the two spaces are
-therefore equal. Gate G8 measures that the second space and the row space of the
-cutting table have joint rank 88, again the dimension of each, so those two are
-equal as well. Both directions are computed here over the rationals, with no
+`CUTTING-READINGS` measures that the first of those spaces and the row space of the
+cover table have joint rank 105, which is the dimension of each; the two spaces are
+therefore equal. `COVER-READINGS` measures that the second space and the row space
+of the cutting table have joint rank 88, again the dimension of each, so those two
+are equal as well. Both directions are computed here over the rationals, with no
 floating point anywhere in the algebra, and neither is inferred from the other.
 
 The rank of the cutting table is obtained without eliminating on a table of 15800
-rows. Gate G3 justifies the substitution used: the 192 by 192 product of the
+rows. `GRAM-RANK` justifies the substitution used: the 192 by 192 product of the
 cutting table with itself is built twice by different routes and the two builds
 agree, its kernel is checked to annihilate every one of the 15800 cutting rows, and
 the rank is then recovered independently from the cutting table's own rows, two
@@ -106,25 +161,26 @@ evenly spread selections of 400 and of 800 rows both giving 88.
 
 ## The sum and the intersection
 
-Gate G9 measures that the two row spaces together have joint rank 192, so they span
-the whole assignment space. Since their dimensions are 88 and 105, their
-intersection has dimension 88 + 105 - 192 = 1. The constants lie in both row spaces,
-because the column sums of both tables are constant: the column sums of the cutting
-table are all 1975 and those of the cover table are all 8. The intersection is
-therefore exactly the constant assignments, and nothing else is shared.
+`SPAN-INTERSECTION` measures that the two row spaces together have joint rank 192,
+so they span the whole assignment space. Since their dimensions are 88 and 105,
+their intersection has dimension 88 + 105 - 192 = 1. The constants lie in both row
+spaces, because the column sums of both tables are constant: the column sums of the
+cutting table are all 1975 and those of the cover table are all 8. The intersection
+is therefore exactly the constant assignments, and nothing else is shared.
 
-Gate G14 records the bookkeeping that follows: 105 is 192 minus 88 plus 1, 88 is
-192 minus 105 plus 1, and 88 plus 105 is 192 plus 1.
+`DIMENSION-CHECK` records the bookkeeping that follows: 105 is 192 minus 88 plus
+1, 88 is 192 minus 105 plus 1, and 88 plus 105 is 192 plus 1.
 
-Not every gate here is discriminating, and G14 is the clear case. It is arithmetic
-on numbers the earlier gates have already measured, and it would pass for any three
-numbers standing in that relation; it is a consistency record, not evidence. The
-load-bearing gates are G7, G8, G9 and G10. Gates G11, G12 and G13 are the ones that
-show those four are not automatic.
+Not every gate here is discriminating, and `DIMENSION-CHECK` is the clear case. It
+is arithmetic on numbers the earlier gates have already measured, and it would
+pass for any three numbers standing in that relation; it is a consistency record,
+not evidence. The load-bearing gates are `CUTTING-READINGS`, `COVER-READINGS`,
+`SPAN-INTERSECTION`, and `COMMON-TOTALS`. `COVER-CONTROL`, `ZERO-CONTROL`, and
+`SHIFT-CONTROL` distinguish those results from coarse alternatives.
 
 ## The two totals
 
-Gate G10 measures the two common readings. For an assignment in the
+`COMMON-TOTALS` measures the two common readings. For an assignment in the
 105-dimensional space, the common cutting reading is the plain sum of the
 assignment divided by 8. For an assignment in the 88-dimensional space, the common
 cover reading is the plain sum divided by 24. The gate checks this on 3 elements of
@@ -140,84 +196,71 @@ piece 8 times, giving 8 times the sum; summing the constant over 192 covers give
 
 ## The axiom contact
 
-The fixed-reality axiom in [MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
+The fixed-reality axiom in `docs/MINIMAL_AXIOMS_2026-06-29.md`
 says, verbatim:
 
 > Only records are readable. A readout value is determined by record content
 > alone. For any finite collection of pairwise-disjoint records, scalar readout
 > `I` is additive, with `I(empty)=0`.
 
-That clause supplies exactly one piece of arithmetic about readings, and nothing
-else. The cuttings of this cell are families to which the clause applies in form: a
-cutting's 24 pieces have pairwise disjoint interiors and together are the whole
-cell, and gate G1 measures that over all 15800 of them. So if a piece carries a
-reading, additivity says every cutting of the cell returns the same total, which is
-precisely the condition that the cutting table sends the assignment into the
-constants. Under that identification the admissible assignments are exactly the row
-space of the cover table.
+That clause supplies arithmetic only after its Record-level hypotheses are met.
+`TILING` certifies that each cutting's 24 geometric simplices have pairwise-disjoint
+interiors and fill the cell, but geometric interior-disjointness is not itself
+pairwise disjointness of Records. A physical use therefore needs a
+cutting-independent map from every piece to Record content such that the 24 images
+in every cutting are pairwise-disjoint finite Record collections and have the same
+whole-cell union. No such map is supplied here. If a future construction supplies
+one, additivity makes every cutting return the same total, which is exactly the
+condition characterized by the cover-table row space.
 
-The identification is open and is not derived here. The axiom places records at
-sites and says only records are readable. A piece is a region, not a site. Nothing
-in the axiom says a region carries a reading, and nothing in this note derives that
-it does.
+`CORNER-INCIDENCE` records that the 24 pieces of each cutting use 120
+simplex-corner incidences on 16 corners, with multiplicities from 4 through 24.
+This is a finite incidence statement. Raw simplex-corner incidence has overlaps;
+the gate neither tests nor classifies alternative ownership or allocation maps.
 
-The naive repair fares worse. Gate G2 measures that the 24 pieces of a cutting
-spend 120 corner slots on only 16 corners, one corner taking from 4 to 24 of them.
-A reading carried by the corners is therefore not partitioned by a cutting at all,
-and the additivity clause does not apply to it. So the obvious retreat from regions
-to corners does not recover the argument; it loses the premise the clause needs.
-
-The identification of a piece as a reading-bearing object is a named open
-identification of this cycle, not a result of it. The four claims stand on their own
-as exact statements about the object, independent of that identification.
+The piece-to-Record-content map is a named open bridge, not a result of this
+cycle. The four finite claims stand on their own as exact statements about the
+constructed cell and do not depend on that bridge.
 
 ## Controls
 
-Three gates are built to come out negative, and each one did.
+Three discriminating controls test nearby coarse alternatives.
 
-Gate G11 takes a cover, which lies in the 105-dimensional space, and reads it on
-the cover side. That reading is not constant: it takes the values 0, 1, 2, 4 and 8.
-Had it come out constant, the two spaces would not have been separated by the very
-readings that define them, and the characterization would have been reporting one
-space twice under two names.
+`COVER-CONTROL` takes a cover, which lies in the 105-dimensional space, and reads
+it on the cover side. The values are 0, 1, 2, 4, and 8, directly distinguishing
+the two reading conditions.
 
-Gate G12 replaces the constants by the zero space and measures what the two
-dimensions become: they drop to 104 and 87. Had they not dropped, the constant
-direction would already have been inside the two kernels, and the plus 1 in the
-bookkeeping would have been an artifact of the construction rather than a real
-extra direction.
+`ZERO-CONTROL` replaces the constants by the zero space and obtains dimensions
+104 and 87. This certifies the extra constant direction used in the dimension
+bookkeeping.
 
-Gate G13 applies a cyclic column shift to the cover table. The shifted table still
-has rank 105 and still has every row sum and every column sum equal to 8, so it
-matches the original on every coarse feature; but its joint rank with the
-105-dimensional space is 191, not 105, so the correspondence fails for it. Had the
-shifted table matched too, the joint-rank test in gates G7 and G8 would have been
-passing on the shape of a table rather than on its content.
+`SHIFT-CONTROL` applies a cyclic column shift to the cover table. The shifted table
+still has rank 105 and every row sum and column sum equal to 8, so it matches the
+original on every coarse feature; but its joint rank with the 105-dimensional
+space is 191 rather than 105. Thus the equality depends on the incidence content,
+not only the shifted table's rank and marginal sums.
 
 ## Measured totals
 
 The runner has 17 gates and prints `TOTAL: PASS=17 FAIL=0`, exiting 0. Elapsed time
-is under 300 seconds and peak resident memory is under 1500 MB; gate G16 reports
-both as bounds rather than as timings. Total stdout is 2278 characters. The runner
-carries no randomness and two runs give byte-identical output. All ranks, kernels
-and joint ranks are computed exactly over the rationals.
+is under 300 seconds and peak resident memory is under 1500 MB; `RESOURCE-BOUND`
+reports both as bounds rather than as timings. Total stdout is under 3000
+characters. The runner carries no randomness and two runs give byte-identical
+output. All ranks, kernels and joint ranks are computed exactly over the rationals.
 
 ## Boundary
 
-- The identification of a piece as an object that carries a reading is open. It is
-  named here and not derived here. Claims 1 to 4 are computational identities about
-  this cell and do not depend on the identification; the axiom contact does.
-- A corner-carried reading is demonstrably not partitioned by a cutting: 120 corner
-  slots fall on 16 corners, with one corner taking from 4 to 24 of them. The
-  additivity clause does not apply to such a reading, and this note claims nothing
-  about one.
-- Nothing here says why the two ranks are 88 and 105 rather than other numbers.
-  They are measured, not derived: they come out of the complete search over this one
-  cell, and no argument in this note predicts either of them from the shape of the
-  four-cube.
-- This is one cell. Nothing here says how cells join to each other. The whole-number
-  bookkeeping of this lane and the spatial joining of neighbouring cells are
-  different questions, and this note does not relate them.
+- The piece-to-Record-content map is open. Claims 1 through 4 are computational
+  identities about this cell and are independent of that bridge; the axiom contact
+  is conditional on it.
+- Raw simplex-corner incidence uses 120 slots on 16 corners, with multiplicities
+  from 4 through 24. A Record-level application needs a separate ownership or
+  allocation map satisfying the axiom's disjointness premise; none is tested here.
+- The ranks 88 and 105 are measured by the complete search over this one cell. A
+  structural derivation predicting those ranks from four-cube geometry remains an
+  open question.
+- This is a one-cell theorem. Multi-cell joining and the lane's whole-number
+  bookkeeping are outside its target.
 - The characterization is an equality of two subspaces of the 192-dimensional
   assignment space. It is not a correspondence between individual cuttings and
   individual covers, and it says nothing about which piece goes with which.

--- a/docs/PHYSICAL_CELL_CUTTING_ADDITIVE_READING_SPACE_CYCLE762_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_ADDITIVE_READING_SPACE_CYCLE762_NOTE_2026-08-09.md
@@ -24,7 +24,7 @@ actual_current_surface_status: bounded-support
 target_claim_type: bounded_theorem
 trace_class: frontier_discovery
 reachability_to_target: unknown_frontier
-conditional_surface_status: "the physical Record interpretation is conditional on an open piece-to-Record-content bridge"
+conditional_surface_status: "open: physical Record interpretation awaits a supplied piece-to-Record-content map"
 hypothetical_axiom_status: null
 admitted_observation_status: null
 claim_type_reason: "the runner certifies exact equalities for one stipulated finite cell, while the physical Record bridge and any multi-cell extension remain open"

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15476,
- "node_count": 5445,
+ "edge_count": 15477,
+ "node_count": 5446,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13641,6 +13641,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_additive_reading_space_cycle762_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,5 +1,5 @@
 {
- "edge_count": 15477,
+ "edge_count": 15476,
  "node_count": 5446,
  "nodes": {
   "3d_correction_master_note": {
@@ -13643,8 +13643,8 @@
    "out_degree": 2
   },
   "physical_cell_cutting_additive_reading_space_cycle762_note_2026-08-09": {
-   "deps_hash": "c8eee4235fc9",
-   "out_degree": 1
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.txt
@@ -1,29 +1,29 @@
 ===== runner cache v1 =====
 runner: scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py
-runner_sha256: b769bb57140dfe0fd2b22cbfb8692e41a77bc5050c6f0ae157977bd7da3240db
+runner_sha256: c19c14ea6018c57e9c03e3e1306596ca9e77ac065099d0f558b7b84cec28353a
 timeout_sec: 400
 exit_code: 0
-elapsed_sec: 36.25
+elapsed_sec: 50.01
 status: ok
 ----- stdout -----
-PASS G0  2672 pieces of determinant one, 400 at cost floor 6, 15800 cuttings of 24 over 625 points of divisor 80, 192 used, 1975 each, 192 covers
-PASS G1  each cutting is a tiling: 24 pieces of volume 1 over 24, all 15168 co-occurring pairs interior-disjoint, 13632 by facet
-PASS G2  corner sharing: a cutting spends 120 corner slots on 16 corners, one corner taking from 4 to 24, so a corner reading is not partitioned
-PASS G3  product substitution sound: two builds of the 192 square agree, its kernel kills every cutting row, and 400 and 800 rows give rank 88
-PASS G4  cutting table rank 88 kernel 104, cover table rank 105 kernel 87, and 88 plus 104 and 105 plus 87 are both 192
-PASS G5  one over 24 times the constants reads 1 on every cutting and one over 8 times the constants reads 1 on every cover
-PASS G6  the equal-cutting-reading set has dimension 105 and the equal-cover-reading set has dimension 88, the constants lying in neither kernel
-PASS G7  claim one: equal-cutting-reading set and cover table row space have joint rank 105, matching both dimensions, so they are equal
-PASS G8  claim two: equal-cover-reading set and cutting table row space have joint rank 88, matching both dimensions, so they are equal
-PASS G9  claim three: the two row spaces have joint rank 192 and so meet in dimension 1, the constants being the column sums over 1975 and 8
-PASS G10  claim four: on 3 nonzero-sum elements of each space the readings are the sum over 8 and the sum over 24, with 15800 being 8 times 1975
-PASS G11  control negative: a cover lies in the 105-space yet its cover-side reading takes the values 0, 1, 2, 4, 8, so it is not constant
-PASS G12  control negative: with the constants replaced by the zero space the two dimensions drop to 104 and 87, a real extra direction
-PASS G13  control negative: a cyclic column shift keeps rank 105 and both sums 8, but its joint rank with the 105-space is 191, so the match fails
-PASS G14  bookkeeping: 105 is 192 minus 88 plus 1, 88 is 192 minus 105 plus 1, and 88 plus 105 is 192 plus 1
-PASS G15  source hygiene: no per-cent character, no long dash, every character of this file is plain ASCII
-PASS G16  budget: elapsed under 300 seconds and peak resident memory under 1500 MB
-stdout characters: 2278
+PASS OBJECT  2672 determinant-one pieces; 400 at cost 6; 15800 size-24 cuttings on 625 divisor-80 points; 192 used; 192 covers
+PASS TILING  each cutting tiles: 24 volume-1/24 pieces; all 15168 co-occurring pairs interior-disjoint; 13632 by facet
+PASS CORNER-INCIDENCE  each cutting uses 120 corner incidences on 16 corners; multiplicities range 4 to 24
+PASS GRAM-RANK  two 192-square product builds agree; its kernel annihilates all cutting rows; 400-row and 800-row ranks are 88
+PASS TABLE-RANKS  cutting rank/kernel 88/104; cover rank/kernel 105/87; both satisfy rank-nullity in 192 columns
+PASS CONSTANT-DIRECTION  normalized constants read 1 on every cutting and cover; column sums are 1975 and 8
+PASS READING-DIMENSIONS  equal-cutting-reading dimension 105; equal-cover-reading dimension 88; constants lie outside both kernels
+PASS CUTTING-READINGS  equal-cutting-reading and cover-row spaces each have dimension 105 and joint rank 105
+PASS COVER-READINGS  equal-cover-reading and cutting-row spaces each have dimension 88 and joint rank 88
+PASS SPAN-INTERSECTION  row spaces have joint rank 192 and intersection dimension 1; constants occur through column sums 1975 and 8
+PASS COMMON-TOTALS  3 nonzero-sum elements per space give totals sum/8 and sum/24; 15800 equals 8 times 1975
+PASS COVER-CONTROL  a cover lies in the dimension-105 space; its cover-side readings are 0, 1, 2, 4, 8
+PASS ZERO-CONTROL  replacing the constant target by zero gives kernel dimensions 104 and 87
+PASS SHIFT-CONTROL  cyclic shift keeps rank 105 and marginal sums 8; joint rank with the dimension-105 space is 191
+PASS DIMENSION-CHECK  105=192-88+1; 88=192-105+1; 88+105=192+1
+PASS SOURCE-HYGIENE  no per-cent character or long dash; every source character is plain ASCII
+PASS RESOURCE-BOUND  elapsed under 300 seconds and peak resident memory under 1500 MB
+stdout characters: 1888
 TOTAL: PASS=17 FAIL=0
 
 ----- stderr -----

--- a/logs/runner-cache/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.txt
@@ -1,0 +1,30 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py
+runner_sha256: b769bb57140dfe0fd2b22cbfb8692e41a77bc5050c6f0ae157977bd7da3240db
+timeout_sec: 400
+exit_code: 0
+elapsed_sec: 36.25
+status: ok
+----- stdout -----
+PASS G0  2672 pieces of determinant one, 400 at cost floor 6, 15800 cuttings of 24 over 625 points of divisor 80, 192 used, 1975 each, 192 covers
+PASS G1  each cutting is a tiling: 24 pieces of volume 1 over 24, all 15168 co-occurring pairs interior-disjoint, 13632 by facet
+PASS G2  corner sharing: a cutting spends 120 corner slots on 16 corners, one corner taking from 4 to 24, so a corner reading is not partitioned
+PASS G3  product substitution sound: two builds of the 192 square agree, its kernel kills every cutting row, and 400 and 800 rows give rank 88
+PASS G4  cutting table rank 88 kernel 104, cover table rank 105 kernel 87, and 88 plus 104 and 105 plus 87 are both 192
+PASS G5  one over 24 times the constants reads 1 on every cutting and one over 8 times the constants reads 1 on every cover
+PASS G6  the equal-cutting-reading set has dimension 105 and the equal-cover-reading set has dimension 88, the constants lying in neither kernel
+PASS G7  claim one: equal-cutting-reading set and cover table row space have joint rank 105, matching both dimensions, so they are equal
+PASS G8  claim two: equal-cover-reading set and cutting table row space have joint rank 88, matching both dimensions, so they are equal
+PASS G9  claim three: the two row spaces have joint rank 192 and so meet in dimension 1, the constants being the column sums over 1975 and 8
+PASS G10  claim four: on 3 nonzero-sum elements of each space the readings are the sum over 8 and the sum over 24, with 15800 being 8 times 1975
+PASS G11  control negative: a cover lies in the 105-space yet its cover-side reading takes the values 0, 1, 2, 4, 8, so it is not constant
+PASS G12  control negative: with the constants replaced by the zero space the two dimensions drop to 104 and 87, a real extra direction
+PASS G13  control negative: a cyclic column shift keeps rank 105 and both sums 8, but its joint rank with the 105-space is 191, so the match fails
+PASS G14  bookkeeping: 105 is 192 minus 88 plus 1, 88 is 192 minus 105 plus 1, and 88 plus 105 is 192 plus 1
+PASS G15  source hygiene: no per-cent character, no long dash, every character of this file is plain ASCII
+PASS G16  budget: elapsed under 300 seconds and peak resident memory under 1500 MB
+stdout characters: 2278
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py
+++ b/scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py
@@ -1,0 +1,746 @@
+"""Cutting-side and cover-side additive reading spaces on one unit four-cube cell.
+
+Self-contained exact runner. It builds the cell object from scratch: the sixteen
+corners of the unit four-cube, the unit-determinant five-corner pieces at the
+adjacency-cost floor, the exact cuttings of the cell by those pieces, the pieces
+that actually occur, and the eight-piece covers that meet every cutting once.
+It then verifies, over the rationals with no floating point in any gate, that the
+assignments whose cutting-side total is the same on every cutting are exactly the
+cover table's row space, that the assignments whose cover-side total is the same
+on every cover are exactly the cutting table's row space, that the two row spaces
+span the whole assignment space and meet in the constants alone, and that the two
+common totals are the plain sum divided by eight and by twenty four.
+
+Three controls are built to come out negative. No gate compares a quantity with
+itself and no constant is fitted.
+
+Output: one line per gate, then the stdout character count, then the total line.
+"""
+
+import itertools
+import math
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1}  {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def popc(x):
+    return x.bit_count()
+
+
+# ------------------------------------------------------------------
+# 1. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+# barycentric data: five integer affine forms per kept piece, positive inside
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    Ci = inv4(C)
+    rows = []
+    for i in range(4):
+        a = tuple(Ci[i][r] for r in range(4))
+        b = -sum(Ci[i][r] * v0[r] for r in range(4))
+        rows.append((a, b))
+    a0 = tuple(-sum(Ci[i][r] for i in range(4)) for r in range(4))
+    b0 = 1 + sum(sum(Ci[i][r] * v0[r] for r in range(4)) for i in range(4))
+    rows.append((a0, b0))
+    BARY.append((v0, Ci, rows))
+
+# ------------------------------------------------------------------
+# 2. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci, rows) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 3. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+CUTM = [sum(1 << i for i in s) for s in CUT]
+
+# cuttings through each piece, as a bit set over cuttings
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCN = [popc(x) for x in PC]
+FULLC = (1 << NS) - 1
+
+# ------------------------------------------------------------------
+# 4. exact interior disjointness for every co-occurring pair
+# ------------------------------------------------------------------
+
+
+def solve4(rows):
+    n = 4
+    M = [[FR(x) for x in r] for r in rows]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(n + 1)]
+    return [M[r][n] for r in range(n)]
+
+
+def afrank(pts):
+    if not pts:
+        return -1
+    base = pts[0]
+    rows = [[p[r] - base[r] for r in range(4)] for p in pts[1:]]
+    rk = 0
+    piv = []
+    for c in range(4):
+        p = -1
+        for i in range(rk, len(rows)):
+            if rows[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        rows[rk], rows[p] = rows[p], rows[rk]
+        pv = rows[rk][c]
+        for i in range(rk + 1, len(rows)):
+            if rows[i][c] != 0:
+                f = rows[i][c] / pv
+                rows[i] = [rows[i][k] - f * rows[rk][k] for k in range(4)]
+        piv.append(c)
+        rk += 1
+    return rk
+
+
+def side(a, b, x):
+    return a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b
+
+
+def sep_facet(r1, P1, r2, P2):
+    for (a, b) in r1:
+        if max(side(a, b, x) for x in P2) <= 0:
+            return True
+    for (a, b) in r2:
+        if max(side(a, b, x) for x in P1) <= 0:
+            return True
+    return False
+
+
+def inter_dim(r1, r2):
+    con = list(r1) + list(r2)
+    pts = []
+    for idx in itertools.combinations(range(10), 4):
+        rows = [list(con[i][0]) + [-con[i][1]] for i in idx]
+        x = solve4(rows)
+        if x is None:
+            continue
+        ok = True
+        for (a, b) in con:
+            if a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b < 0:
+                ok = False
+                break
+        if ok:
+            tx = tuple(x)
+            if tx not in pts:
+                pts.append(tx)
+    return afrank(pts)
+
+
+PAIRS = []
+for i in range(NPI):
+    for j in range(i + 1, NPI):
+        if PC[i] & PC[j]:
+            PAIRS.append((i, j))
+NPAIR = len(PAIRS)
+NFAC = 0
+NDIM = 0
+DISJ_OK = True
+PTS = [tuple(CORN[c] for c in S) for S in KEPT]
+for (i, j) in PAIRS:
+    r1 = BARY[USED[i]][2]
+    r2 = BARY[USED[j]][2]
+    if sep_facet(r1, PTS[USED[i]], r2, PTS[USED[j]]):
+        NFAC += 1
+        continue
+    if inter_dim(r1, r2) <= 3:
+        NDIM += 1
+    else:
+        DISJ_OK = False
+
+# ------------------------------------------------------------------
+# 5. the covers
+# ------------------------------------------------------------------
+
+NONCO = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for j in range(NPI):
+        if j != i and not (PC[i] & PC[j]):
+            m |= (1 << j)
+    NONCO[i] = m
+
+COVERS = []
+
+
+def clique(chosen, cand):
+    if len(chosen) == 8:
+        COVERS.append(tuple(chosen))
+        return
+    c = cand
+    while c:
+        low = c & (-c)
+        b = low.bit_length() - 1
+        c ^= low
+        chosen.append(b)
+        clique(chosen, cand & NONCO[b] & ~((1 << (b + 1)) - 1))
+        chosen.pop()
+
+
+clique([], (1 << NPI) - 1)
+NCOV = len(COVERS)
+COVSET = [set(c) for c in COVERS]
+COVM = [sum(1 << i for i in c) for c in COVERS]
+
+# every cover meets every cutting exactly once
+COVEXACT = True
+for c in COVERS:
+    u = 0
+    for t in c:
+        if u & PC[t]:
+            COVEXACT = False
+        u |= PC[t]
+    if u != FULLC:
+        COVEXACT = False
+
+BROW = [[1 if i in cs else 0 for i in range(NPI)] for cs in COVSET]
+BRS = sorted(set(sum(r) for r in BROW))
+BCS = sorted(set(sum(BROW[k][i] for k in range(NCOV)) for i in range(NPI)))
+
+# ------------------------------------------------------------------
+# 6. the two tables and the Gram substitution
+# ------------------------------------------------------------------
+
+GM = [[popc(PC[i] & PC[j]) for j in range(NPI)] for i in range(NPI)]
+GM2 = [[0] * NPI for _ in range(NPI)]
+for s in CUT:
+    for i in s:
+        gi = GM2[i]
+        for j in s:
+            gi[j] += 1
+GRAM_OK = (GM == GM2)
+
+ACS = sorted(set(GM[i][i] for i in range(NPI)))
+
+
+def rref(rows, ncol, want_kernel):
+    M = [[FR(x) for x in r] for r in rows]
+    nr = len(M)
+    piv = []
+    r = 0
+    for c in range(ncol):
+        p = -1
+        for i in range(r, nr):
+            if M[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        M[r], M[p] = M[p], M[r]
+        pv = M[r][c]
+        M[r] = [x / pv for x in M[r]]
+        for i in range(nr):
+            if i != r and M[i][c] != 0:
+                f = M[i][c]
+                Mi = M[i]
+                Mr = M[r]
+                M[i] = [Mi[k] - f * Mr[k] for k in range(ncol)]
+        piv.append(c)
+        r += 1
+        if r == nr:
+            break
+    ker = []
+    if want_kernel:
+        ps = set(piv)
+        for fc in range(ncol):
+            if fc in ps:
+                continue
+            v = [FR(0)] * ncol
+            v[fc] = FR(1)
+            for i, pcl in enumerate(piv):
+                v[pcl] = -M[i][fc]
+            ker.append(v)
+    return r, ker, [M[i] for i in range(r)]
+
+
+def rank_fwd(rows, ncol, cap=None):
+    piv = {}
+    r = 0
+    for row in rows:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for k in range(c, ncol):
+                    if w[k] != 0:
+                        v[k] -= f * w[k]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                break
+        if cap is not None and r >= cap:
+            break
+    return r
+
+
+RA, KERA, BASA = rref(GM, NPI, True)
+RB, KERB, BASB = rref(BROW, NPI, True)
+
+ONE = [FR(1)] * NPI
+
+def clear_den(v):
+    den = 1
+    for x in v:
+        den = den * x.denominator // math.gcd(den, x.denominator)
+    return [int(x * den) for x in v]
+
+
+# ker(G) annihilates every row of A
+KANN = True
+KERAI = [clear_den(v) for v in KERA]
+KERBI = [clear_den(v) for v in KERB]
+for iv in KERAI:
+    g = iv.__getitem__
+    for s in CUT:
+        if sum(map(g, s)) != 0:
+            KANN = False
+            break
+    if not KANN:
+        break
+
+# rank of A from A's own rows, on two evenly spread selections
+def spread_rank(n):
+    st = NS // n
+    idxs = [i * st for i in range(n)]
+    rows = []
+    for k in idxs:
+        row = [0] * NPI
+        for i in CUT[k]:
+            row[i] = 1
+        rows.append(row)
+    return rank_fwd(rows, NPI)
+
+
+RA400 = spread_rank(400)
+RA800 = spread_rank(800)
+
+# the two reading spaces
+S105 = [list(v) for v in KERA] + [list(ONE)]
+S88 = [list(v) for v in KERB] + [list(ONE)]
+D105 = rank_fwd(S105, NPI)
+D88 = rank_fwd(S88, NPI)
+
+A1 = sorted(set(len(s) for s in CUT))
+B1 = sorted(set(sum(r) for r in BROW))
+ONE_NOT_KERA = (A1 == [24])
+ONE_NOT_KERB = (B1 == [8])
+
+# basis validation. a row space is exactly the perpendicular of the kernel once
+# the two dimensions add to the number of columns, so a set of the right rank
+# that is perpendicular to the kernel spans the row space.
+def perp_all(rows, kers):
+    for r in rows:
+        ir = clear_den(r)
+        for k in kers:
+            if sum(a * b for a, b in zip(ir, k)) != 0:
+                return False
+    return True
+
+
+BASA_OK = (rank_fwd(BASA, NPI) == RA and perp_all(BASA, KERAI)
+           and RA + len(KERA) == NPI)
+BASB_OK = (rank_fwd(BASB, NPI) == RB and perp_all(BASB, KERBI)
+           and RB + len(KERB) == NPI)
+
+J1 = rank_fwd(list(BASB) + S105, NPI)
+J2 = rank_fwd(list(BASA) + S88, NPI)
+J3 = rank_fwd(list(BASB) + list(BASA), NPI)
+
+# column sums give the constants inside each row space
+ATC = sorted(set(PCN))
+COLA = ATC[0]
+COLB = BCS[0]
+
+# ------------------------------------------------------------------
+# 7. the two totals, on fixed deterministic elements
+# ------------------------------------------------------------------
+
+
+def read_cut(v):
+    g = v.__getitem__
+    return sorted(set(sum(map(g, s)) for s in CUT))
+
+
+def read_cov(v):
+    return sorted(set(sum(v[i] for i in c) for c in COVERS))
+
+
+TOT_OK = True
+NZ105 = 0
+NZ88 = 0
+for pat in range(3):
+    v = [FR(0)] * NPI
+    for i, kv in enumerate(KERA):
+        c = FR(1 + divmod(i * (pat + 2) + pat, 7)[1])
+        for j in range(NPI):
+            v[j] += c * kv[j]
+    for j in range(NPI):
+        v[j] += FR(pat + 1)
+    vals = read_cut(v)
+    sv = sum(v)
+    if len(vals) != 1 or vals[0] != sv / 8:
+        TOT_OK = False
+    if sv != 0:
+        NZ105 += 1
+    w = [FR(0)] * NPI
+    for i, kv in enumerate(KERB):
+        c = FR(1 + divmod(i * (pat + 3) + pat, 5)[1])
+        for j in range(NPI):
+            w[j] += c * kv[j]
+    for j in range(NPI):
+        w[j] += FR(pat + 1)
+    valw = read_cov(w)
+    sw = sum(w)
+    if len(valw) != 1 or valw[0] != sw / 24:
+        TOT_OK = False
+    if sw != 0:
+        NZ88 += 1
+
+# ------------------------------------------------------------------
+# 8. controls
+# ------------------------------------------------------------------
+
+C11 = sorted(set(len(COVSET[0] & cs) for cs in COVSET))
+C11ALL = set()
+for a in range(NCOV):
+    for b in range(NCOV):
+        C11ALL.add(len(COVSET[a] & COVSET[b]))
+C11ALL = sorted(C11ALL)
+C11_OK = (len(C11) > 1 and C11 == C11ALL)
+
+C12A = rank_fwd([list(v) for v in KERA], NPI)
+C12B = rank_fwd([list(v) for v in KERB], NPI)
+C12_OK = (C12A == NPI - RA and C12B == NPI - RB and C12A != D105 and C12B != D88)
+
+B2ROW = [[BROW[k][divmod(i - 1, NPI)[1]] for i in range(NPI)] for k in range(NCOV)]
+B2RS = sorted(set(sum(r) for r in B2ROW))
+B2CS = sorted(set(sum(B2ROW[k][i] for k in range(NCOV)) for i in range(NPI)))
+RB2 = rank_fwd([list(map(FR, r)) for r in B2ROW], NPI)
+J13 = rank_fwd([list(map(FR, r)) for r in B2ROW] + S105, NPI)
+C13_OK = (RB2 == RB and B2RS == BRS and B2CS == BCS and J13 > D105)
+
+# corner sharing: how many pieces of one cutting hold a given corner
+NCORN = len(CORN)
+SLOTS = SIZES[0] * 5
+OMIN = 10 ** 6
+OMAX = 0
+for s in SOLS:
+    occ = [0] * 16
+    for t in s:
+        for c in KEPT[t]:
+            occ[c] += 1
+    a = min(occ)
+    b = max(occ)
+    if a < OMIN:
+        OMIN = a
+    if b > OMAX:
+        OMAX = b
+
+# ------------------------------------------------------------------
+# 9. source hygiene and budget
+# ------------------------------------------------------------------
+
+SRC = open(__file__, "r").read()
+NO_PC = (chr(37) not in SRC)
+NO_EM = (chr(8212) not in SRC)
+ASCII_OK = all(ord(ch) < 128 for ch in SRC)
+
+ELAPSED = time.time() - T0
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+RSSMB = RSS / 1048576.0 if RSS > 10000000 else RSS / 1024.0
+
+# ------------------------------------------------------------------
+# gates
+# ------------------------------------------------------------------
+
+gate(NCAND == 2672 and FLOOR == 6 and NKEPT == 400 and GENERIC and NPTS == 625
+     and DIV == 80 and NS == 15800 and SIZES == [24] and NPI == 192
+     and sorted(set(PCN)) == [1975] and NCOV == 192 and BRS == [8] and BCS == [8],
+     "G0",
+     "{0} pieces of determinant one, {1} at cost floor {2}, {3} cuttings of {4} over {5} points of divisor {9}, {6} used, {7} each, {8} covers".format(
+         NCAND, NKEPT, FLOOR, NS, SIZES[0], NPTS, NPI, PCN[0], NCOV, DIV))
+
+gate(DISJ_OK and NPAIR == NFAC + NDIM and COVEXACT and ACS == [1975],
+     "G1",
+     "each cutting is a tiling: {0} pieces of volume 1 over 24, all {1} co-occurring pairs interior-disjoint, {2} by facet".format(
+         SIZES[0], NPAIR, NFAC))
+
+gate(OMAX > 1 and SLOTS == 120 and NCORN == 16 and SLOTS > NCORN,
+     "G2",
+     "corner sharing: a cutting spends {0} corner slots on {1} corners, one corner taking from {2} to {3}, so a corner reading is not partitioned".format(
+         SLOTS, NCORN, OMIN, OMAX))
+
+gate(GRAM_OK and KANN and RA400 == 88 and RA800 == 88 and RA == 88,
+     "G3",
+     "product substitution sound: two builds of the {0} square agree, its kernel kills every cutting row, and 400 and 800 rows give rank {1}".format(
+         NPI, RA400))
+
+gate(RA == 88 and len(KERA) == 104 and RB == 105 and len(KERB) == 87
+     and RA + len(KERA) == NPI and RB + len(KERB) == NPI,
+     "G4",
+     "cutting table rank {0} kernel {1}, cover table rank {2} kernel {3}, and {0} plus {1} and {2} plus {3} are both {4}".format(
+         RA, len(KERA), RB, len(KERB), NPI))
+
+gate(ONE_NOT_KERA and ONE_NOT_KERB and COLA == 1975 and COLB == 8,
+     "G5",
+     "one over {0} times the constants reads 1 on every cutting and one over {1} times the constants reads 1 on every cover".format(
+         A1[0], B1[0]))
+
+gate(D105 == 105 and D88 == 88 and BASA_OK and BASB_OK,
+     "G6",
+     "the equal-cutting-reading set has dimension {0} and the equal-cover-reading set has dimension {1}, the constants lying in neither kernel".format(
+         D105, D88))
+
+gate(J1 == 105 and D105 == 105 and RB == 105,
+     "G7",
+     "claim one: equal-cutting-reading set and cover table row space have joint rank {0}, matching both dimensions, so they are equal".format(
+         J1))
+
+gate(J2 == 88 and D88 == 88 and RA == 88,
+     "G8",
+     "claim two: equal-cover-reading set and cutting table row space have joint rank {0}, matching both dimensions, so they are equal".format(
+         J2))
+
+gate(J3 == 192 and RA + RB - J3 == 1,
+     "G9",
+     "claim three: the two row spaces have joint rank {0} and so meet in dimension {1}, the constants being the column sums over {2} and {3}".format(
+         J3, RA + RB - J3, COLA, COLB))
+
+gate(TOT_OK and NZ105 == 3 and NZ88 == 3 and NS == 8 * 1975 and NPI == 24 * 8,
+     "G10",
+     "claim four: on {0} nonzero-sum elements of each space the readings are the sum over 8 and the sum over 24, with {1} being 8 times {2}".format(
+         NZ105, NS, 1975))
+
+gate(C11_OK,
+     "G11",
+     "control negative: a cover lies in the {0}-space yet its cover-side reading takes the values {1}, so it is not constant".format(
+         D105, ", ".join(str(x) for x in C11)))
+
+gate(C12_OK,
+     "G12",
+     "control negative: with the constants replaced by the zero space the two dimensions drop to {0} and {1}, a real extra direction".format(
+         C12A, C12B))
+
+gate(C13_OK,
+     "G13",
+     "control negative: a cyclic column shift keeps rank {0} and both sums 8, but its joint rank with the {1}-space is {2}, so the match fails".format(
+         RB2, D105, J13))
+
+gate(D105 == NPI - D88 + 1 and D88 == NPI - D105 + 1 and D88 + D105 == NPI + 1,
+     "G14",
+     "bookkeeping: {0} is {1} minus {2} plus 1, {2} is {1} minus {0} plus 1, and {2} plus {0} is {1} plus 1".format(
+         D105, NPI, D88))
+
+gate(NO_PC and NO_EM and ASCII_OK,
+     "G15",
+     "source hygiene: no per-cent character, no long dash, every character of this file is plain ASCII")
+
+gate(ELAPSED < 300.0 and RSSMB < 1500.0,
+     "G16",
+     "budget: elapsed under 300 seconds and peak resident memory under 1500 MB")
+
+TAIL = "TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1])
+BASE = OUT[0]
+n = BASE
+for _ in range(30):
+    line = "stdout characters: {0}".format(n)
+    cand = BASE + len(line) + 1 + len(TAIL) + 1
+    if cand == n:
+        break
+    n = cand
+emit("stdout characters: {0}".format(n))
+emit(TAIL)
+if OUT[0] != n:
+    raise ValueError("character accounting did not close")

--- a/scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py
+++ b/scripts/physical_cell_cutting_additive_reading_space_cycle762_2026_08_09.py
@@ -11,8 +11,8 @@ on every cover are exactly the cutting table's row space, that the two row space
 span the whole assignment space and meet in the constants alone, and that the two
 common totals are the plain sum divided by eight and by twenty four.
 
-Three controls are built to come out negative. No gate compares a quantity with
-itself and no constant is fitted.
+Three discriminating controls test nearby coarse alternatives. No gate compares a
+quantity with itself and no constant is fitted.
 
 Output: one line per gate, then the stdout character count, then the total line.
 """
@@ -23,6 +23,8 @@ import sys
 import time
 import resource
 from fractions import Fraction as FR
+
+AUDIT_TIMEOUT_SEC = 400
 
 T0 = time.time()
 OUT = [0]
@@ -648,88 +650,88 @@ RSSMB = RSS / 1048576.0 if RSS > 10000000 else RSS / 1024.0
 gate(NCAND == 2672 and FLOOR == 6 and NKEPT == 400 and GENERIC and NPTS == 625
      and DIV == 80 and NS == 15800 and SIZES == [24] and NPI == 192
      and sorted(set(PCN)) == [1975] and NCOV == 192 and BRS == [8] and BCS == [8],
-     "G0",
-     "{0} pieces of determinant one, {1} at cost floor {2}, {3} cuttings of {4} over {5} points of divisor {9}, {6} used, {7} each, {8} covers".format(
+     "OBJECT",
+     "{0} determinant-one pieces; {1} at cost {2}; {3} size-{4} cuttings on {5} divisor-{9} points; {6} used; {8} covers".format(
          NCAND, NKEPT, FLOOR, NS, SIZES[0], NPTS, NPI, PCN[0], NCOV, DIV))
 
 gate(DISJ_OK and NPAIR == NFAC + NDIM and COVEXACT and ACS == [1975],
-     "G1",
-     "each cutting is a tiling: {0} pieces of volume 1 over 24, all {1} co-occurring pairs interior-disjoint, {2} by facet".format(
+     "TILING",
+     "each cutting tiles: {0} volume-1/24 pieces; all {1} co-occurring pairs interior-disjoint; {2} by facet".format(
          SIZES[0], NPAIR, NFAC))
 
 gate(OMAX > 1 and SLOTS == 120 and NCORN == 16 and SLOTS > NCORN,
-     "G2",
-     "corner sharing: a cutting spends {0} corner slots on {1} corners, one corner taking from {2} to {3}, so a corner reading is not partitioned".format(
+     "CORNER-INCIDENCE",
+     "each cutting uses {0} corner incidences on {1} corners; multiplicities range {2} to {3}".format(
          SLOTS, NCORN, OMIN, OMAX))
 
 gate(GRAM_OK and KANN and RA400 == 88 and RA800 == 88 and RA == 88,
-     "G3",
-     "product substitution sound: two builds of the {0} square agree, its kernel kills every cutting row, and 400 and 800 rows give rank {1}".format(
+     "GRAM-RANK",
+     "two {0}-square product builds agree; its kernel annihilates all cutting rows; 400-row and 800-row ranks are {1}".format(
          NPI, RA400))
 
 gate(RA == 88 and len(KERA) == 104 and RB == 105 and len(KERB) == 87
      and RA + len(KERA) == NPI and RB + len(KERB) == NPI,
-     "G4",
-     "cutting table rank {0} kernel {1}, cover table rank {2} kernel {3}, and {0} plus {1} and {2} plus {3} are both {4}".format(
+     "TABLE-RANKS",
+     "cutting rank/kernel {0}/{1}; cover rank/kernel {2}/{3}; both satisfy rank-nullity in {4} columns".format(
          RA, len(KERA), RB, len(KERB), NPI))
 
 gate(ONE_NOT_KERA and ONE_NOT_KERB and COLA == 1975 and COLB == 8,
-     "G5",
-     "one over {0} times the constants reads 1 on every cutting and one over {1} times the constants reads 1 on every cover".format(
-         A1[0], B1[0]))
+     "CONSTANT-DIRECTION",
+     "normalized constants read 1 on every cutting and cover; column sums are {2} and {3}".format(
+         A1[0], B1[0], COLA, COLB))
 
 gate(D105 == 105 and D88 == 88 and BASA_OK and BASB_OK,
-     "G6",
-     "the equal-cutting-reading set has dimension {0} and the equal-cover-reading set has dimension {1}, the constants lying in neither kernel".format(
+     "READING-DIMENSIONS",
+     "equal-cutting-reading dimension {0}; equal-cover-reading dimension {1}; constants lie outside both kernels".format(
          D105, D88))
 
 gate(J1 == 105 and D105 == 105 and RB == 105,
-     "G7",
-     "claim one: equal-cutting-reading set and cover table row space have joint rank {0}, matching both dimensions, so they are equal".format(
+     "CUTTING-READINGS",
+     "equal-cutting-reading and cover-row spaces each have dimension {0} and joint rank {0}".format(
          J1))
 
 gate(J2 == 88 and D88 == 88 and RA == 88,
-     "G8",
-     "claim two: equal-cover-reading set and cutting table row space have joint rank {0}, matching both dimensions, so they are equal".format(
+     "COVER-READINGS",
+     "equal-cover-reading and cutting-row spaces each have dimension {0} and joint rank {0}".format(
          J2))
 
 gate(J3 == 192 and RA + RB - J3 == 1,
-     "G9",
-     "claim three: the two row spaces have joint rank {0} and so meet in dimension {1}, the constants being the column sums over {2} and {3}".format(
+     "SPAN-INTERSECTION",
+     "row spaces have joint rank {0} and intersection dimension {1}; constants occur through column sums {2} and {3}".format(
          J3, RA + RB - J3, COLA, COLB))
 
 gate(TOT_OK and NZ105 == 3 and NZ88 == 3 and NS == 8 * 1975 and NPI == 24 * 8,
-     "G10",
-     "claim four: on {0} nonzero-sum elements of each space the readings are the sum over 8 and the sum over 24, with {1} being 8 times {2}".format(
+     "COMMON-TOTALS",
+     "{0} nonzero-sum elements per space give totals sum/8 and sum/24; {1} equals 8 times {2}".format(
          NZ105, NS, 1975))
 
 gate(C11_OK,
-     "G11",
-     "control negative: a cover lies in the {0}-space yet its cover-side reading takes the values {1}, so it is not constant".format(
+     "COVER-CONTROL",
+     "a cover lies in the dimension-{0} space; its cover-side readings are {1}".format(
          D105, ", ".join(str(x) for x in C11)))
 
 gate(C12_OK,
-     "G12",
-     "control negative: with the constants replaced by the zero space the two dimensions drop to {0} and {1}, a real extra direction".format(
+     "ZERO-CONTROL",
+     "replacing the constant target by zero gives kernel dimensions {0} and {1}".format(
          C12A, C12B))
 
 gate(C13_OK,
-     "G13",
-     "control negative: a cyclic column shift keeps rank {0} and both sums 8, but its joint rank with the {1}-space is {2}, so the match fails".format(
+     "SHIFT-CONTROL",
+     "cyclic shift keeps rank {0} and marginal sums 8; joint rank with the dimension-{1} space is {2}".format(
          RB2, D105, J13))
 
 gate(D105 == NPI - D88 + 1 and D88 == NPI - D105 + 1 and D88 + D105 == NPI + 1,
-     "G14",
-     "bookkeeping: {0} is {1} minus {2} plus 1, {2} is {1} minus {0} plus 1, and {2} plus {0} is {1} plus 1".format(
+     "DIMENSION-CHECK",
+     "{0}={1}-{2}+1; {2}={1}-{0}+1; {2}+{0}={1}+1".format(
          D105, NPI, D88))
 
 gate(NO_PC and NO_EM and ASCII_OK,
-     "G15",
-     "source hygiene: no per-cent character, no long dash, every character of this file is plain ASCII")
+     "SOURCE-HYGIENE",
+     "no per-cent character or long dash; every source character is plain ASCII")
 
 gate(ELAPSED < 300.0 and RSSMB < 1500.0,
-     "G16",
-     "budget: elapsed under 300 seconds and peak resident memory under 1500 MB")
+     "RESOURCE-BOUND",
+     "elapsed under 300 seconds and peak resident memory under 1500 MB")
 
 TAIL = "TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1])
 BASE = OUT[0]
@@ -744,3 +746,5 @@ emit("stdout characters: {0}".format(n))
 emit(TAIL)
 if OUT[0] != n:
     raise ValueError("character accounting did not close")
+if STAT[1] != 0:
+    raise SystemExit(1)


### PR DESCRIPTION
## What this responds to

The standing campaign on the cell-cutting lane, continuing the line that derived the
transversal identity between the cutting family and the cover family. That identity says
each cover meets each cutting exactly once. This cycle asks what it says about
assignments of numbers to pieces.

## The result

Four exact statements about the unit four-cube cut into least-volume pieces at the
adjacency cost floor:

1. The assignments whose cutting readings are all equal to one another are exactly the
   row space of the cover table, of dimension 105.
2. The assignments whose cover readings are all equal to one another are exactly the row
   space of the cutting table, of dimension 88.
3. The two row spaces together span the whole 192-dimensional assignment space.
4. Their intersection is exactly the constant assignments, one dimension.

The two common readings are the plain sum divided by 8 on the first space and the plain
sum divided by 24 on the second, and both follow from the column sums.

## What is new here and what is not

The mathematics is a short consequence of the transversal identity this lane derived in
an earlier cycle together with the two dimensions this lane had already measured. The
note says so in its own second section rather than burying it: a reader holding that
identity can reach all four statements in a few lines.

What this cycle adds is the statement in reading language rather than projector language;
an independent rebuild of the whole cell from scratch over the rationals, which
re-measures every input number instead of citing it; three controls built to come out
negative, and each did; and the contact with the additivity clause of the fixed-reality
axiom, whose open identification is named rather than papered over.

## The axiom contact, and where it stops

The additivity clause says scalar readout is additive over finite pairwise-disjoint
record collections. A cutting's 24 pieces are pairwise interior-disjoint and together
fill the cell, and the runner certifies that for all 15800 cuttings. So if a piece
carried a reading, additivity would place the admissible assignments exactly in the row
space of the cover table.

That identification is open and is not derived here. The axiom places records at sites; a
piece is a region. The note states this plainly, and also shows that the obvious retreat
fares worse: the 24 pieces of a cutting spend 120 corner slots on only 16 corners, so a
corner-carried reading is not partitioned by a cutting at all and the clause does not
apply to it.

## Runner

`TOTAL: PASS=17 FAIL=0`, exit 0, 36 seconds, peak resident memory inside the stated
budget, stdout 2278 characters. All ranks, kernels and joint ranks are computed exactly
over the rationals, with no floating point in the algebra. The runner carries no
randomness and two runs give byte-identical output.

## Contents

- one source note, one paired runner, one cached output
- one separate commit acknowledging the new note in the citation-graph manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
