### PR TITLE
science(cell-cutting): certify finite orbit-table rank witnesses

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_SYMMETRY_UNDERDETERMINES_CYCLE763_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_SYMMETRY_UNDERDETERMINES_CYCLE763_NOTE_2026-08-09.md
@@ -1,0 +1,303 @@
+# Covariance Under The Cell's Symmetry Does Not Determine The Cover Table's Dimension
+
+**Date:** 2026-08-09
+**Type:** science
+**Runner:** [scripts/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.py](../scripts/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.py)
+Audit: unset.
+
+## What this is
+
+The object is one cell, taken as the unit four-cube on its sixteen corners. A piece
+is a five-corner sub-simplex whose four edge vectors from its first corner have
+determinant of absolute value 1; among those, the pieces at the adjacency cost
+floor are kept. A cutting is a set of kept pieces with pairwise disjoint interiors
+that together fill the cell. A cover is an eight-piece set no two of whose pieces
+ever share a cutting, and gate G1 re-certifies that each such set meets every
+cutting exactly once. The cutting table records which piece belongs to which
+cutting; the cover table records which piece belongs to which cover.
+
+The preceding cycle of this lane ended on a stated boundary. Its two dimensions,
+88 for the cutting table and 105 for the cover table, were **measured, not derived**:
+nothing in that cycle predicted either number from the shape of the four-cube. This
+cycle asks the next question. The cell has a symmetry group, and the admissibility
+axiom asks a local rule to be covariant. Does covariance under the cell's own
+symmetry deliver the two dimensions?
+
+The measured answer is no, and this note makes the no quantitative in four steps.
+Covariance fixes the entire shape of the split of both row spaces by a stabiliser,
+leaving exactly one integer free, and that integer stays measured. It forces every
+one of the 96 elementary symmetric tables to dimension 144, for a reason that can
+be given by hand and is checked against a bound derived from three counts alone.
+But the cover table is one particular sum of 4 of those 96, and the tables of its
+exact shape that the symmetry permits run in dimension from 57 up to 144, with the
+cover table's own 105 far down in the low tail: 42 of 1500 sampled tables lie at or
+below it.
+
+Two exact numerical agreements between symmetry counts and the two dimensions turn
+up on the way, and both are measured here to be agreements of counting rather than
+of structure. Recording that demotion is part of the result, not an aside.
+
+## The object
+
+The runner builds the cell from scratch and re-measures every input number rather
+than citing it. Of the five-corner sub-simplices of the four-cube, 2672 have
+determinant of absolute value 1; the adjacency cost floor among them is 6, attained
+by 400 of them. Cuttings are found as exact covers of 625 sample points chosen so
+that no sample point lies on a facet plane of any kept piece, which gate G0 checks
+directly; genericity is what makes the sample search complete, and gate G1
+certifies the other direction, that what the search returns really is a tiling.
+There are 15800 cuttings, each of 24 pieces of volume 1 over 24, with all 15168
+co-occurring piece pairs certified interior-disjoint exactly, 13632 of them by a
+separating facet plane. Exactly 192 of the 400 floor pieces occur in a cutting at
+all, and there are 192 covers. Gate G8 re-measures the two tables: rank 88 with
+kernel 104 for the cutting table, rank 105 with kernel 87 for the cover table.
+
+## The symmetry
+
+Gate G4 builds 384 distinct maps of the cell by permuting the four coordinates and
+flipping any of them, and checks closure over all 147456 products. Gate G6 measures
+one orbit on the 192 pieces, so the group is transitive there, and gate G26
+measures the same for the 192 covers. Gate G5 measures that every one of the 384
+carries the sorted cutting table and the sorted cover table to themselves, so both
+row spaces stand under the whole group. This is the strongest symmetry statement
+the object supports, and everything negative below is therefore a negative for
+every subgroup as well: gate G30 exhibits four subgroups of order 24 built from
+proper rotations, each of which breaks the 192 pieces into 8 orbits instead of one
+and gives 1536 orbits on ordered pairs, far above the full group's 104, and a
+group with more orbits constrains less.
+
+Three counts organise the rest. Gate G6 measures fixed-piece counts
+[(0, 371), (16, 12), (192, 1)], whose squares sum to 384 times 104, giving 104
+orbits on ordered pairs of pieces; gate G7 confirms that count independently by
+union-find over all 36864 ordered pairs. Gate G27 measures fixed-cover counts
+[(0, 379), (48, 4), (192, 1)], whose squares sum to 384 times 120, giving 120
+orbits on ordered pairs of covers. Gate G33 pairs the two counts against each
+other and obtains 96 orbits on cover-piece cells. The three numbers 104, 120 and 96
+are the whole input to what follows.
+
+That the piece count and the cover count differ is itself a result, and gate G29
+states it as a test rather than a caveat: the two fixed-point counts do not agree
+element by element, and equal counts would force equal orbit counts, which is
+impossible here because 104 is not 120. The two sides of the object are not
+symmetric copies of each other.
+
+## What covariance does fix: the split by a stabiliser
+
+Gate G20 measures that the stabiliser of a piece has order 2, with orbit sizes
+[(1, 16), (2, 88)]: sixteen fixed pieces and eighty-eight transposed pairs. Its
+non-identity element therefore has a plus space of dimension 104 and a minus space
+of dimension 88, and gate G21 obtains both by two independent exact ranks summing
+to 192. Those two numbers come off the cycle structure of the element and are not
+measured against anything else.
+
+That element is a symmetry of both tables, so it preserves both row spaces and each
+one splits. Gate G22 measures the splits: the cutting row space splits 50 plus 38,
+the cover row space 55 plus 50, against the ranks 88 and 105.
+
+Given the preceding cycle, those four numbers are not four independent quantities.
+That cycle established that the two row spaces together span all 192 dimensions and
+meet exactly in the constants, and gate G10 re-measures both facts here rather than
+citing them. Applying the projector onto either eigenspace to a
+decomposition of a vector into a cutting-side part and a cover-side part keeps each
+part inside its own row space, because the element preserves both; so the two plus
+parts already span the plus space and the two minus parts span the minus space. The
+intersection splits along with everything else, and the constants sit on the plus
+side. Hence the two plus parts must add to 104 plus one and the two minus parts to
+88, which is exactly what gate G23 measures: 50 plus 55 is 105, and 38 plus 50 is
+88. Both identities are obtained by addition of separately measured dimensions,
+never by subtracting one from a total.
+
+Combine that with the two ranks and one more equality falls out: the cutting side's
+plus part and the cover side's minus part must be equal, and both are 50. Every one
+of the four dimensions is then a function of that single number. **Covariance fixes
+the shape of the split completely and leaves exactly one integer free, and this
+note measures that integer rather than deriving it.** Gate G24 measures that all 12
+order-two elements fixing a piece give the same six dimensions
+[104, 88, 50, 38, 55, 50], each by its own exact rank, so the split belongs to the
+conjugacy class and not to a chosen element.
+
+## The two agreements, and why they are demoted
+
+104 is the plus dimension and it is also the cutting table's kernel dimension. 88 is
+the minus dimension and it is also the cutting table's rank. Both agreements are
+exact. Neither is a derivation, and the runner says so in its own output rather than
+in prose: after gate G21 it prints that 104 matches the cutting kernel and 88
+matches the rank, and that neither is derived.
+
+Gate G25 demotes the second agreement by measurement rather than by assertion. If
+the minus space were the cutting table's row space wearing another name, the two
+would coincide. They do not: the cutting rows meet the minus part in dimension 38,
+not 88, and they do not lie inside the 89-dimensional span of the minus part
+together with the constants. The equality of two numbers is not an equality of two
+spaces here, and the note claims nothing from it.
+
+Gate G31 carries the same warning for the first agreement: the pair-orbit count and
+the cutting kernel are both 104 by unrelated routes, and that is recorded as an
+agreement, not offered as evidence. The gate says so in its own text and is
+non-discriminating by construction.
+
+Two further gates measure how far the symmetry is from determining the tables at
+all. The 104 pair-orbits give a 104-dimensional space of matrices commuting with
+the whole group, which gate G11 certifies by measuring that the orbit labels cut all
+36864 entries into classes of sizes from 192 to 384. Of those 104 commuting
+matrices, gate G12 measures that only 2 carry the cutting row space into itself, and
+gate G13 measures that only 2 carry the cover row space into itself. The row spaces
+are very far from being closed under everything the symmetry allows.
+
+## Every elementary table has dimension 144, and that one is derived
+
+Gate G38 measures that all 96 cover-piece orbits have size 384, the full order of
+the group, summing to 36864 cells; the group acts freely on the cells of any one
+orbit. A cover therefore lies in 384 over 192, that is 2, of the cells of a given
+orbit, and so does a piece. Read as a bipartite graph on covers and pieces, one
+orbit is 2-regular: a disjoint union of cycles. A cycle visiting k covers and k
+pieces contributes a k-by-k table with two cyclically placed ones in every row and
+column, whose determinant is 1 plus minus-one to the power k plus one; so such a
+cycle contributes one less than its length when the length is even, and its full
+length when the length is odd.
+
+Gate G36 measures the cycle structure of all 96 orbits and finds a single type: 48
+cycles of length 4 covering all 192 covers, in every orbit. The rule above then
+predicts one dimension for every orbit, and 0 of the 96 orbits differ from the
+prediction. Gate G34 measures the dimensions directly and finds the single value
+144 with count 96. This number is derived, not measured: the cycle rule fixes it,
+and the direct measurement agrees.
+
+Gate G37 checks the largest of them against a bound obtained from the three orbit
+counts alone, with no reference to either table. Both sides break into the same
+list of parts, the covers appearing with one multiplicity in each part and the
+pieces with another; the sum of the squares of the differences of those two
+multiplicities is 104 plus 120 less twice 96, which is 32. Multiplied by the group
+order that is 12288, and the sum of the absolute differences weighted by the part
+dimensions is at most the integer square root of that, by the inequality between a
+sum of products and the two lengths. That weighted sum splits into a positive and a
+negative half which are equal, because the signed version is the difference of the
+two totals 192 and 192 and so vanishes; the positive half is therefore at most half
+the integer square root, that is 55. A symmetric table can reach, in each part, only
+the smaller of the two multiplicities, so the greatest dimension available to any
+symmetric table at all is the total 192 less exactly that positive half: at least
+192 less 55, that is 137. The measured largest, 144, clears the bound. Everything
+here is integer arithmetic; the square root enters only through an integer
+certificate, which gate G37 checks rather than trusting a floating value.
+
+## Where the cover table's own dimension is not fixed
+
+A table carrying entries zero and one that is constant on the 96 cell orbits is a
+union of whole orbits, and gate G39 measures that each orbit puts exactly 2 ones in
+every cover row. A table of the cover table's shape, meaning entries zero and one,
+constant on the orbits, and every one of its 192 rows summing to 8, is therefore a
+union of exactly 4 of them; gate G39 identifies the 4 that rebuild the cover table.
+This is the decisive structural statement of the cycle: **the symmetric tables of
+the cover table's shape are precisely the 4-element subsets of the 96 orbits, and
+the cover table is one of them.**
+
+Gate G40 then measures what those 4 do. Each one alone has dimension 144, the
+largest among the 96. Added one at a time the running dimensions are
+[144, 93, 114, 105], ending at the cover rank 105 as they must. Adding symmetric
+structure lowers the dimension by 39 from where a single orbit sits, and gate G35
+records the bookkeeping that goes with a single orbit: 192 less that dimension plus
+one is 49, not 105.
+
+Gate G41 samples 1500 of the 4-element subsets. The dimensions run from a least of
+57 through a middle value of 135 to a greatest of 144, and 42 of the 1500 lie at or
+below the cover table's 105. The symmetry permits tables of exactly the cover
+table's shape with dimensions spread over most of the available range, and the real
+one sits low among them. Covariance under the cell's full symmetry does not deliver
+105; it does not even make 105 a typical value.
+
+## The axiom contact
+
+The admissibility axiom in [MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md)
+says, verbatim:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+Covariance is the whole of what that clause supplies about symmetry, and this note
+takes it in its strongest available form: not the proper rotations alone, but the
+cell's full symmetry, which contains them. Gate G30 measures that the proper
+rotation subgroups available here have order 24 and give 1536 orbits on ordered
+pairs against the full group's 104, so they constrain strictly less.
+
+Under that strongest reading, covariance is measured here to fix the shape of the
+split by a stabiliser down to one free integer, and to fix the dimension of every
+elementary symmetric table exactly; and it is measured not to fix the dimension of
+the cover table, which is one choice of 4 elementary tables among many that
+covariance permits equally. Whatever supplies 105 is therefore not covariance, and
+this note names that as the input still to be found rather than treating the
+agreement of counts as if it supplied it.
+
+The identification of a piece as an object to which the axioms speak is open, is
+inherited unchanged from the preceding cycle, and is not derived here. All claims
+below the axiom contact are **computational identities** about this one cell and do
+not depend on that identification.
+
+## Controls
+
+Gate G14 measures that the constants times each of the 104 commuting matrices stays
+a multiple of the constants, so gates G12 and G13 are reporting content rather than
+a construction that could not have come out otherwise. Gate G15 measures that a
+cyclic shift of the 192 pieces is not one of the 384 and does not keep the cutting
+table, so the group is not accidentally everything. Gate G16 measures that the first
+commuting matrix failing G12 has, together with the identity, rank 192, and that its
+88 moved rows have rank 88 and all lie outside. Gate G17 measures that two named
+elements generate all 384 and that the moved span keeps rank 88 when stacked with
+its image under each. Gate G28 measures the cover stabiliser, of order 2 with orbit
+sizes [(1, 48), (2, 72)], and that it fixes 0 pieces, so the two stabilisers act
+differently.
+
+Gate G18 is non-discriminating by construction and says so in its own text: it
+checks a property that holds because the orbits were built to have it. Gate G31
+could fail, and does not, but what it certifies is an agreement of two counts
+reached by unrelated routes, which its own text records as an agreement rather
+than as evidence.
+
+The dimensions in gates G34, G36, G40 and G41 are counted modulo a single prime.
+Three controls bound what that can cost. D8 measures that the identity table of size
+192 returns dimension 192 over the integers. D9 measures that the cover table
+stacked on itself gives 105, as does the cover table alone, so stacking a repeat
+adds nothing. D10 computes the cover table's dimension exactly over the integers,
+with no modulus at all, obtains 105, and confirms it agrees with the modular count.
+A modular count can only fall short of the exact one, never exceed it, so the
+sampled tail count of 42 is an upper bound on the true tail and the least value 57
+is a lower bound on the true least: both errors would run in the direction that
+weakens the negative, not in the direction that manufactures it.
+
+## Measured totals
+
+The runner has 47 gates and prints `TOTAL: PASS=47 FAIL=0`, exiting 0. Elapsed time
+is under 600 seconds and peak resident memory is under 2500 MB; gate G43 reports
+both as bounds rather than as timings, so the output carries no machine-dependent
+number. Total stdout is 5652 characters. The only randomness is the fixed-seed draw
+of the 1500 sampled subsets in gate G41, and two runs give byte-identical output.
+All ranks and kernels of the two tables, and both eigenspace splits, are computed
+exactly over the rationals.
+
+## Boundary
+
+- Nothing here derives 105, and nothing here derives 88. They remain **measured, not
+  derived**. What this cycle adds is a measurement of how far the cell's symmetry is
+  from supplying them, and the answer is that it is far.
+- The single free integer in the stabiliser split, 50, is measured. The note derives
+  that every other dimension in the split follows from it, and does not derive it.
+- The two numerical agreements, 104 with the cutting kernel and 88 with the cutting
+  rank, are recorded and demoted. Gate G25 measures the overlap at 38 rather than
+  88. No claim in this note rests on either agreement.
+- Gate G39's statement that the symmetric tables of the cover table's shape are
+  exactly the 4-element subsets of the 96 orbits uses the row sum 8 and the fact
+  that each orbit contributes 2 per row. It says nothing about tables of other
+  shapes, and nothing about tables that are symmetric under a proper subgroup only.
+- The dimensions in gates G34, G36, G40 and G41 are modular. Gate D10 gives the one
+  number the argument leans on, the cover table's 105, exactly over the integers;
+  the others are lower bounds on their exact values, which is the safe direction for
+  every negative stated here.
+- The 1500 subsets in gate G41 are a sample, not a census. The least, middle and
+  greatest values and the tail count are properties of that fixed-seed sample. The
+  spread they exhibit is what the negative rests on, and a wider spread in the full
+  set would only widen it.
+- This is one cell. Nothing here says how cells join to each other, and the spatial
+  question and the whole-number bookkeeping of this lane remain different questions.
+- The group used is the cell's own full symmetry. The axiom names proper cubic
+  rotations, which sit inside it as subgroups of order 24; gate G30 measures that
+  those constrain strictly less. The note therefore states its negative for the
+  larger group, where it is strongest, and inherits it for the smaller ones.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15476,
- "node_count": 5445,
+ "edge_count": 15477,
+ "node_count": 5446,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13641,6 +13641,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_symmetry_underdetermines_cycle763_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.py
+runner_sha256: 63cb92f2bebf951a8d98a82f2715bc15366c1c84d6171f3a889a8aeb2b7b55b9
+timeout_sec: 700
+exit_code: 0
+elapsed_sec: 75.08
+status: ok
+----- stdout -----
+all numbers below are exact computational identities; no floating point enters any gate
+PASS G0 2672 pieces of determinant one, 400 at floor 6, 15800 cuttings of 24 over 625 points, 192 used, 192 covers
+PASS G1 each cutting tiles: 24 pieces of volume 1 over 24, its 15168 co-occurring pairs interior-disjoint, 13632 by facet
+PASS G2 corner sharing: 120 corner slots on 16 corners, one corner taking from 4 to 24
+PASS G3 two builds of the 192 square agree, both kernels give total zero on every cutting and cover
+PASS G4 permuting the four coordinates and flipping any of them gives 384 distinct maps, closed over 147456 products
+PASS G5 stability: all 384 elements carry the sorted cutting and cover tables to themselves, both row spaces stand
+PASS G6 fixed-piece counts [(0, 371), (16, 12), (192, 1)] sum to 384, one orbit on pieces, squares sum to 384 times 104
+PASS G7 union-find over the 36864 ordered piece pairs under all 384 elements gives 104 orbits, matching the squares
+PASS G8 cutting rank 88 kernel 104, cover rank 105 kernel 87, each kernel certified by total zero and its own rank
+PASS G9 independent selections of 88 cutting and 105 cover rows reach those ranks and are zeroed by each kernel
+PASS G10 the two row spaces span all 192 dimensions and meet in dimension 1, the constants, killed by both kernels
+PASS G11 the 104 labels cut all 36864 entries into classes of sizes 192 to 384, so their matrices span the commuters
+PASS G12 the negative: only 2 of the 104 commuting matrices carry the cutting row space into itself
+PASS G13 the same on the cover side: only 2 of the 104 carry the cover row space into itself
+PASS G14 control: the constants times each of the 104 commuting matrices stays a multiple, so the negative has content
+PASS G15 control: the cyclic shift of the 192 pieces is not one of the 384 and does not keep the cutting table
+PASS G16 the first failing matrix, out-degree 2, with the identity has rank 192; its 88 moved rows have rank 88, all outside
+PASS G17 two named elements generate all 384, and the moved span keeps rank 88 stacked with its image under each
+PASS G18 labels survive every element on all 36864 entries; true by construction of the orbits, so non-discriminating
+PASS G19 out-degree census [(1, 16), (2, 88)] from every source piece; degrees by count sum to 192, counts to 104
+PASS G20 the stabilizer of a piece has order 2, orbit sizes [(1, 16), (2, 88)]: 16 plus twice 88 is 192, 16 plus 88 is 104
+PASS G21 its non-identity element has plus and minus dimensions 104 and 88 by two independent exact ranks, sum 192
+recorded agreement, not a derivation: 104 matches the cutting kernel yes, 88 matches the rank yes; neither derived
+PASS G22 that element splits the cutting row space 50 plus 38 and the cover row space 55 plus 50, ranks 88 and 105
+PASS G23 theorem A: 50 plus 55 is 105, the plus dimension 104 plus the constants; 38 plus 50 is 88, the minus
+PASS G24 all 12 order-two elements fixing a piece give the same six dimensions [104, 88, 50, 38, 55, 50], each by its own rank
+PASS G25 demotion: cutting rows meet the minus part in dimension 38; equal to the rank 88: no; inside the 89 span: no
+PASS G26 all 384 elements carry covers to covers, and the action on the 192 covers is transitive
+PASS G27 fixed-cover counts [(0, 379), (48, 4), (192, 1)] sum to 384, squares to 384 times 120; pair orbits cover 120, piece 104
+PASS G28 cover stabilizer order 2, sizes [(1, 48), (2, 72)]: 48 plus twice 72 is 192, 48 plus 72 is 120; it fixes 0 pieces
+PASS G29 the two fixed-point counts agree element by element: no; equal counts would force equal orbit counts, 104 not 120
+cover-side control: pair orbits match the kernel dimension, piece yes, cover no; one-sided yes, so not a feature
+PASS G30 four rotation subgroups of order 24, closed and inside the 384: piece orbits [8], pair orbits [1536], above 104
+PASS G31 pair-orbit count and cutting kernel are both 104 by unrelated routes: recorded agreement, not evidence
+PASS G32 cover-piece orbits 96 label all 36864 cells, the cover table constant on them: yes; the piece sweep gives 104
+PASS G33 pairings of the two fixed-point counts, each dividing exactly: piece 104, cover 120, cross 96
+PASS G34 single-orbit dimensions, value to count: [(144, 96)]; largest 144; the control that must reach 192 gives 192
+PASS G35 one orbit matrix beats the cover rank 105 by 39; pieces minus that dimension plus one is 49
+PASS G36 cycle rule: 0 of 96 orbits differ from the predicted dimension; cycle types [(48, (4,), 192)]
+PASS G37 hand bound: S 32, order times S 12288, half its integer square root 55, bound 137; the largest 144 clears it
+PASS G38 the 96 cover-piece orbits all have size 384, summing to 36864 cells
+PASS G39 each orbit puts 2 ones in every cover row, so 4 orbits make 8; those 4 rebuild the cover table exactly
+PASS G40 each of those 4 orbits alone has dimension 144, the largest; running dimensions [144, 93, 114, 105] end at the cover rank 105
+PASS G41 1500 sampled sums of 4 orbits: least 57, middle 135, greatest 144; at or below the cover rank 105: 42
+PASS D8 control: the identity table of size 192 returns dimension 192 over the integers
+PASS D9 control: the cover table stacked on itself gives dimension 105, the cover table alone gives 105
+PASS D10 exact dimension of the cover table over the integers, no modulus: 105; agrees with the modular count: yes
+PASS G42 source hygiene: plain ASCII, no per-cent character, no tab, no long dash, all 38 barred strings absent
+PASS G43 budget: elapsed under 600 seconds and peak memory under 2500 MB; both vary by machine so neither is printed
+stdout characters: 5652
+TOTAL: PASS=47 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.py
+++ b/scripts/physical_cell_cutting_symmetry_underdetermines_cycle763_2026_08_09.py
@@ -1,0 +1,1624 @@
+"""The cell's coordinate symmetry does not pin the cutting-side reading space.
+
+Self-contained exact runner. It builds the cell object from scratch: the sixteen
+corners of the unit four-cube, the unit-determinant five-corner pieces at the
+adjacency-cost floor, the exact cuttings of the cell by those pieces, the pieces
+that actually occur, and the eight-piece covers that meet every cutting once.
+
+It then builds the maps got by permuting the four coordinates and flipping any of
+them, and measures two things. First, what the symmetry does force: both row
+spaces are carried to themselves, and their dimensions add to the whole space
+while they meet in the constants alone. Second, what it does not force: a matrix
+that commutes with the whole action but carries the cutting row space somewhere
+else, so a second stable subspace of the same dimension exists.
+
+Two controls are built to come out negative and one comparison is carried out on
+the cover side as a check on the piece side. Everything is done over the integers
+and the rationals; no floating point enters any gate, no constant is fitted, and
+no quantity is computed from the quantity it is compared with.
+
+Output: one line per gate, then the stdout character count, then the total line.
+"""
+
+import itertools
+import math
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+import numpy as np
+from numpy.random import default_rng
+
+PRIME = 1000003
+SEED = 3
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def yn(b):
+    return "yes" if b else "no"
+
+
+# ------------------------------------------------------------------
+# 1. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+# barycentric data: five integer affine forms per kept piece, positive inside
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    Ci = inv4(C)
+    rows = []
+    for i in range(4):
+        a = tuple(Ci[i][r] for r in range(4))
+        b = -sum(Ci[i][r] * v0[r] for r in range(4))
+        rows.append((a, b))
+    a0 = tuple(-sum(Ci[i][r] for i in range(4)) for r in range(4))
+    b0 = 1 + sum(sum(Ci[i][r] * v0[r] for r in range(4)) for i in range(4))
+    rows.append((a0, b0))
+    BARY.append((v0, Ci, rows))
+
+# ------------------------------------------------------------------
+# 2. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci, rows) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 3. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+CUTM = [sum(1 << i for i in s) for s in CUT]
+
+# cuttings through each piece, as a bit set over cuttings
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCN = [popc(x) for x in PC]
+FULLC = (1 << NS) - 1
+
+# ------------------------------------------------------------------
+# 4. exact interior disjointness for every co-occurring pair
+# ------------------------------------------------------------------
+
+
+def solve4(rows):
+    n = 4
+    M = [[FR(x) for x in r] for r in rows]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(n + 1)]
+    return [M[r][n] for r in range(n)]
+
+
+def afrank(pts):
+    if not pts:
+        return -1
+    base = pts[0]
+    rows = [[FR(p[r]) - FR(base[r]) for r in range(4)] for p in pts[1:]]
+    rk = 0
+    for c in range(4):
+        p = -1
+        for i in range(rk, len(rows)):
+            if rows[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        rows[rk], rows[p] = rows[p], rows[rk]
+        pv = rows[rk][c]
+        for i in range(rk + 1, len(rows)):
+            if rows[i][c] != 0:
+                f = rows[i][c] / pv
+                rows[i] = [rows[i][k] - f * rows[rk][k] for k in range(4)]
+        rk += 1
+    return rk
+
+
+def side(a, b, x):
+    return a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b
+
+
+def sep_facet(r1, P1, r2, P2):
+    for (a, b) in r1:
+        if max(side(a, b, x) for x in P2) <= 0:
+            return True
+    for (a, b) in r2:
+        if max(side(a, b, x) for x in P1) <= 0:
+            return True
+    return False
+
+
+def inter_dim(r1, r2):
+    con = list(r1) + list(r2)
+    pts = []
+    for idx in itertools.combinations(range(10), 4):
+        rows = [list(con[i][0]) + [-con[i][1]] for i in idx]
+        x = solve4(rows)
+        if x is None:
+            continue
+        ok = True
+        for (a, b) in con:
+            if a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b < 0:
+                ok = False
+                break
+        if ok:
+            tx = tuple(x)
+            if tx not in pts:
+                pts.append(tx)
+    return afrank(pts)
+
+
+PAIRS = []
+for i in range(NPI):
+    for j in range(i + 1, NPI):
+        if PC[i] & PC[j]:
+            PAIRS.append((i, j))
+NPAIR = len(PAIRS)
+NFAC = 0
+NDIM = 0
+DISJ_OK = True
+PTS = [tuple(CORN[c] for c in S) for S in KEPT]
+for (i, j) in PAIRS:
+    r1 = BARY[USED[i]][2]
+    r2 = BARY[USED[j]][2]
+    if sep_facet(r1, PTS[USED[i]], r2, PTS[USED[j]]):
+        NFAC += 1
+        continue
+    if inter_dim(r1, r2) <= 3:
+        NDIM += 1
+    else:
+        DISJ_OK = False
+
+# ------------------------------------------------------------------
+# 5. the covers
+# ------------------------------------------------------------------
+
+NONCO = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for j in range(NPI):
+        if j != i and not (PC[i] & PC[j]):
+            m |= (1 << j)
+    NONCO[i] = m
+
+COVERS = []
+
+
+def clique(chosen, cand):
+    if len(chosen) == 8:
+        COVERS.append(tuple(chosen))
+        return
+    c = cand
+    while c:
+        low = c & (-c)
+        b = low.bit_length() - 1
+        c ^= low
+        chosen.append(b)
+        clique(chosen, cand & NONCO[b] & ~((1 << (b + 1)) - 1))
+        chosen.pop()
+
+
+clique([], (1 << NPI) - 1)
+NCOV = len(COVERS)
+COVSET = [set(c) for c in COVERS]
+
+# every cover meets every cutting exactly once
+COVEXACT = True
+for c in COVERS:
+    u = 0
+    for t in c:
+        if u & PC[t]:
+            COVEXACT = False
+        u |= PC[t]
+    if u != FULLC:
+        COVEXACT = False
+
+BROW = [[1 if i in cs else 0 for i in range(NPI)] for cs in COVSET]
+BRS = sorted(set(sum(r) for r in BROW))
+BCS = sorted(set(sum(BROW[k][i] for k in range(NCOV)) for i in range(NPI)))
+CS = [tuple(sorted(c)) for c in COVERS]
+COVM = [sum(1 << i for i in c) for c in CS]
+
+# corner sharing: how many pieces of one cutting hold a given corner
+NCORN = len(CORN)
+SLOTS = SIZES[0] * 5
+OMIN = 10 ** 6
+OMAX = 0
+for s in SOLS:
+    occ = [0] * 16
+    for t in s:
+        for c in KEPT[t]:
+            occ[c] += 1
+    a = min(occ)
+    b = max(occ)
+    if a < OMIN:
+        OMIN = a
+    if b > OMAX:
+        OMAX = b
+
+# ------------------------------------------------------------------
+# 6. exact ranks and kernels
+# ------------------------------------------------------------------
+
+GM = [[popc(PC[i] & PC[j]) for j in range(NPI)] for i in range(NPI)]
+GM2 = [[0] * NPI for _ in range(NPI)]
+for s in CUT:
+    for i in s:
+        gi = GM2[i]
+        for j in s:
+            gi[j] += 1
+GRAM_OK = (GM == GM2)
+ACS = sorted(set(GM[i][i] for i in range(NPI)))
+
+
+def rref(rows, ncol, want_kernel):
+    M = [[FR(x) for x in r] for r in rows]
+    nr = len(M)
+    piv = []
+    r = 0
+    for c in range(ncol):
+        p = -1
+        for i in range(r, nr):
+            if M[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        M[r], M[p] = M[p], M[r]
+        pv = M[r][c]
+        M[r] = [x / pv for x in M[r]]
+        for i in range(nr):
+            if i != r and M[i][c] != 0:
+                f = M[i][c]
+                Mi = M[i]
+                Mr = M[r]
+                M[i] = [Mi[k] - f * Mr[k] for k in range(ncol)]
+        piv.append(c)
+        r += 1
+        if r == nr:
+            break
+    ker = []
+    if want_kernel:
+        ps = set(piv)
+        for fc in range(ncol):
+            if fc in ps:
+                continue
+            v = [FR(0)] * ncol
+            v[fc] = FR(1)
+            for i, pcl in enumerate(piv):
+                v[pcl] = -M[i][fc]
+            ker.append(v)
+    return r, ker, [M[i] for i in range(r)]
+
+
+def rank_fwd(rows, ncol, cap=None):
+    piv = {}
+    r = 0
+    for row in rows:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for k in range(c, ncol):
+                    if w[k] != 0:
+                        v[k] -= f * w[k]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                break
+        if cap is not None and r >= cap:
+            break
+    return r
+
+
+def select_rows(pairs, ncol, want):
+    piv = {}
+    sel = []
+    r = 0
+    last = -1
+    for k, row in pairs:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for t in range(c, ncol):
+                    if w[t] != 0:
+                        v[t] -= f * w[t]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                sel.append(k)
+                last = k
+                break
+        if r == want:
+            break
+    return sel, last
+
+
+def clear_den(v):
+    den = 1
+    for x in v:
+        den = den * x.denominator // math.gcd(den, x.denominator)
+    return [int(x * den) for x in v]
+
+
+def perp_all(rows, kers):
+    for r in rows:
+        ir = clear_den(r)
+        for k in kers:
+            if sum(a * b for a, b in zip(ir, k)) != 0:
+                return False
+    return True
+
+
+# the cutting table's rank and kernel come through the product substitution
+RANKA, KERA, BASA = rref(GM, NPI, True)
+RANKB, KERB, BASB = rref(BROW, NPI, True)
+KA = [clear_den(v) for v in KERA]
+KB = [clear_den(v) for v in KERB]
+NKA = len(KA)
+NKB = len(KB)
+
+# annihilation, entrywise, on the tables themselves
+KANN_A = True
+for iv in KA:
+    g = iv.__getitem__
+    for s in CUT:
+        if sum(map(g, s)) != 0:
+            KANN_A = False
+            break
+    if not KANN_A:
+        break
+KANN_B = True
+for iv in KB:
+    g = iv.__getitem__
+    for c in CS:
+        if sum(map(g, c)) != 0:
+            KANN_B = False
+            break
+    if not KANN_B:
+        break
+
+RKKA = rank_fwd([list(v) for v in KA], NPI)
+RKKB = rank_fwd([list(v) for v in KB], NPI)
+
+
+def arow(k):
+    r = [0] * NPI
+    for i in CUT[k]:
+        r[i] = 1
+    return r
+
+
+SELA, LASTA = select_rows(((k, arow(k)) for k in range(NS)), NPI, RANKA)
+SELB, LASTB = select_rows(((k, BROW[k]) for k in range(NCOV)), NPI, RANKB)
+RAROW = [arow(k) for k in SELA]
+RBROW = [list(BROW[k]) for k in SELB]
+RSELA = rank_fwd(RAROW, NPI)
+RSELB = rank_fwd(RBROW, NPI)
+
+ONE = [1] * NPI
+DSUM = rank_fwd(RAROW + RBROW, NPI)
+DKERJ = rank_fwd([list(v) for v in KA] + [list(v) for v in KB], NPI)
+DMEET = NPI - DKERJ
+ONE_A = all(sum(a * b for a, b in zip(ONE, v)) == 0 for v in KA)
+ONE_B = all(sum(a * b for a, b in zip(ONE, v)) == 0 for v in KB)
+
+# ------------------------------------------------------------------
+# 7. the group: permuting the four coordinates and flipping any of them
+# ------------------------------------------------------------------
+
+DESC = []
+MAPS = []
+for sg in itertools.permutations(range(4)):
+    for fl in range(16):
+        m = []
+        for c in range(16):
+            b = CORN[c]
+            nb = [0, 0, 0, 0]
+            for i in range(4):
+                nb[sg[i]] = b[i] ^ ((fl >> i) & 1)
+            m.append(sum(nb[k] << k for k in range(4)))
+        DESC.append((sg, fl))
+        MAPS.append(tuple(m))
+
+NGRP = len(MAPS)
+MAPSET = set(MAPS)
+MAPS_DISTINCT = (len(MAPSET) == NGRP)
+CLOSED = True
+NPROD = 0
+for a in MAPS:
+    for b in MAPS:
+        NPROD += 1
+        if tuple(a[b[c]] for c in range(16)) not in MAPSET:
+            CLOSED = False
+            break
+    if not CLOSED:
+        break
+
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PERM = []
+KEEPS_PIECES = True
+for m in MAPS:
+    p = []
+    for i in range(NPI):
+        img = tuple(sorted(m[c] for c in KEPT[USED[i]]))
+        t = KDX.get(img)
+        if t is None or t not in POS:
+            KEEPS_PIECES = False
+            break
+        p.append(POS[t])
+    if not KEEPS_PIECES:
+        break
+    PERM.append(tuple(p))
+PERMSET = set(PERM)
+PERM_DISTINCT = (len(PERMSET) == NGRP)
+BIJ = all(sorted(p) == list(range(NPI)) for p in PERM)
+
+# ------------------------------------------------------------------
+# 8. what the group preserves
+# ------------------------------------------------------------------
+
+AR0 = sorted(CUTM)
+BR0 = sorted(COVM)
+STAB_A = 0
+STAB_B = 0
+for p in PERM:
+    PB = [1 << p[j] for j in range(NPI)]
+    g = PB.__getitem__
+    if sorted(sum(map(g, s)) for s in CUT) == AR0:
+        STAB_A += 1
+    if sorted(sum(map(g, c)) for c in CS) == BR0:
+        STAB_B += 1
+
+CHI = [sum(1 for i in range(NPI) if p[i] == i) for p in PERM]
+HP = {}
+for f in CHI:
+    HP[f] = HP.get(f, 0) + 1
+HIST_P = sorted(HP.items())
+SUMCHI = sum(CHI)
+SUMSQ = sum(f * f for f in CHI)
+
+
+def pair_orbits(perms, n):
+    par = list(range(n * n))
+
+    def find(x):
+        r = x
+        while par[r] != r:
+            r = par[r]
+        while par[x] != r:
+            par[x], x = r, par[x]
+        return r
+
+    for p in perms:
+        for i in range(n):
+            bi = i * n
+            pi = p[i] * n
+            for j in range(n):
+                a = find(bi + j)
+                b = find(pi + p[j])
+                if a != b:
+                    par[a] = b
+    return [find(x) for x in range(n * n)]
+
+
+ROOT = pair_orbits(PERM, NPI)
+CANON = {}
+for x in range(NPI * NPI):
+    r = ROOT[x]
+    if r not in CANON:
+        CANON[r] = len(CANON)
+NORB = len(CANON)
+SUMSQ_OK = (SUMSQ == NGRP * NORB)
+
+# ------------------------------------------------------------------
+# 9. the commuting matrices
+# ------------------------------------------------------------------
+
+LAB = [[CANON[ROOT[i * NPI + j]] for j in range(NPI)] for i in range(NPI)]
+CLS = [0] * NORB
+for i in range(NPI):
+    Li = LAB[i]
+    for j in range(NPI):
+        CLS[Li[j]] += 1
+PARTITION = (sum(CLS) == NPI * NPI and min(CLS) > 0)
+
+LAB_INV = True
+for p in PERM:
+    for i in range(NPI):
+        Li = LAB[i]
+        Lp = LAB[p[i]]
+        for j in range(NPI):
+            if Lp[p[j]] != Li[j]:
+                LAB_INV = False
+                break
+        if not LAB_INV:
+            break
+    if not LAB_INV:
+        break
+
+# out-degree of each label, measured on every source and checked constant
+DEG = [[0] * NORB for _ in range(NPI)]
+for i in range(NPI):
+    Li = LAB[i]
+    di = DEG[i]
+    for j in range(NPI):
+        di[Li[j]] += 1
+DEG_CONST = all(DEG[i] == DEG[0] for i in range(NPI))
+DC = {}
+for k in range(NORB):
+    DC[DEG[0][k]] = DC.get(DEG[0][k], 0) + 1
+CENSUS = sorted(DC.items())
+DEGSUM = sum(d * c for d, c in CENSUS)
+DEGCNT = sum(c for d, c in CENSUS)
+
+# ------------------------------------------------------------------
+# 10. the negative
+# ------------------------------------------------------------------
+
+
+def keep_labels(sups, kers):
+    cnt = []
+    for s in sups:
+        c = [[0] * NORB for _ in range(NPI)]
+        for i in s:
+            Li = LAB[i]
+            for j in range(NPI):
+                c[j][Li[j]] += 1
+        cnt.append(c)
+    keep = []
+    fails = []
+    for k in range(NORB):
+        ok = True
+        for c in cnt:
+            t = [c[j][k] for j in range(NPI)]
+            for v in kers:
+                tot = 0
+                for a, b in zip(t, v):
+                    if a:
+                        tot += a * b
+                if tot != 0:
+                    ok = False
+                    break
+            if not ok:
+                break
+        if ok:
+            keep.append(k)
+        else:
+            fails.append(k)
+    return keep, fails
+
+
+KEEP_A, FAIL_A = keep_labels([CUT[k] for k in SELA], KA)
+KEEP_B, FAIL_B = keep_labels([CS[k] for k in SELB], KB)
+NKEEP_A = len(KEEP_A)
+NKEEP_B = len(KEEP_B)
+KSTAR = FAIL_A[0]
+DEG_KEEP_A = sorted(set(DEG[0][k] for k in KEEP_A))
+DEG_KSTAR = DEG[0][KSTAR]
+
+# ------------------------------------------------------------------
+# 11. controls
+# ------------------------------------------------------------------
+
+CTRL_A = True
+for k in range(NORB):
+    t = [0] * NPI
+    for i in range(NPI):
+        Li = LAB[i]
+        for j in range(NPI):
+            if Li[j] == k:
+                t[j] += 1
+    if len(set(t)) != 1 or t[0] == 0:
+        CTRL_A = False
+
+SHIFT = tuple(divmod(p + 1, NPI)[1] for p in range(NPI))
+SHIFT_IN = (SHIFT in PERMSET)
+SB = [1 << SHIFT[j] for j in range(NPI)]
+SHIFT_KEEPS = (sorted(sum(map(SB.__getitem__, s)) for s in CUT) == AR0)
+
+# ------------------------------------------------------------------
+# 12. the second reading space
+# ------------------------------------------------------------------
+
+UMAT = [[(1 if i == j else 0) + (1 if LAB[i][j] == KSTAR else 0)
+         for j in range(NPI)] for i in range(NPI)]
+RANKU = rank_fwd(UMAT, NPI)
+
+MU = []
+for k in SELA:
+    t = [0] * NPI
+    for i in CUT[k]:
+        Li = LAB[i]
+        t[i] += 1
+        for j in range(NPI):
+            if Li[j] == KSTAR:
+                t[j] += 1
+    MU.append(t)
+RANKMU = rank_fwd(MU, NPI)
+NOUT = 0
+for t in MU:
+    if any(sum(a * b for a, b in zip(t, v)) != 0 for v in KA):
+        NOUT += 1
+
+GEN_DESC = [((1, 2, 3, 0), 0), ((1, 0, 2, 3), 1)]
+GENS = [PERM[DESC.index(d)] for d in GEN_DESC]
+IDP = tuple(range(NPI))
+SEEN = set([IDP])
+FRONT = [IDP]
+while FRONT:
+    NEW = []
+    for a in FRONT:
+        for g in GENS:
+            b = tuple(g[a[i]] for i in range(NPI))
+            if b not in SEEN:
+                SEEN.add(b)
+                NEW.append(b)
+    FRONT = NEW
+GEN_OK = (len(SEEN) == NGRP and SEEN == PERMSET)
+
+MU_STABLE = True
+for g in GENS:
+    inv = [0] * NPI
+    for a in range(NPI):
+        inv[g[a]] = a
+    rows = [list(r) for r in MU] + [[r[inv[j]] for j in range(NPI)] for r in MU]
+    if rank_fwd(rows, NPI) != RANKMU:
+        MU_STABLE = False
+
+# ------------------------------------------------------------------
+# 13. pass-down to the axiom's covariance group
+# ------------------------------------------------------------------
+
+
+def psign(sg):
+    s = 1
+    for a in range(4):
+        for b in range(a + 1, 4):
+            if sg[a] > sg[b]:
+                s = -s
+    return s
+
+
+SUB_SIZE = []
+SUB_PIECE = []
+SUB_PAIR = []
+SUB_OK = True
+for d in range(4):
+    sub = []
+    for e in range(NGRP):
+        sg, fl = DESC[e]
+        if sg[d] != d:
+            continue
+        if (fl >> d) & 1:
+            continue
+        nf = sum((fl >> i) & 1 for i in range(4))
+        if psign(sg) * ((-1) ** nf) != 1:
+            continue
+        sub.append(PERM[e])
+    ss = set(sub)
+    if len(sub) != 24 or not ss.issubset(PERMSET):
+        SUB_OK = False
+    for a in sub:
+        for b in sub:
+            if tuple(a[b[i]] for i in range(NPI)) not in ss:
+                SUB_OK = False
+    seen = [False] * NPI
+    no = 0
+    for a in range(NPI):
+        if seen[a]:
+            continue
+        no += 1
+        fr = [a]
+        seen[a] = True
+        while fr:
+            x = fr.pop()
+            for p in sub:
+                y = p[x]
+                if not seen[y]:
+                    seen[y] = True
+                    fr.append(y)
+    rt = pair_orbits(sub, NPI)
+    SUB_SIZE.append(len(sub))
+    SUB_PIECE.append(no)
+    SUB_PAIR.append(len(set(rt)))
+SUB_BIGGER = all(x > NORB for x in SUB_PAIR)
+
+# ------------------------------------------------------------------
+# 14. the piece stabilizer, its two parts, and theorem A on real numbers
+# ------------------------------------------------------------------
+
+STABP = [p for p in PERM if p[0] == 0]
+NSTABP = len(STABP)
+STABG = [p for p in STABP if p != tuple(range(NPI))][0]
+seen = [False] * NPI
+SZP = {}
+for a in range(NPI):
+    if seen[a]:
+        continue
+    orb = set(p[a] for p in STABP)
+    for x in orb:
+        seen[x] = True
+    SZP[len(orb)] = SZP.get(len(orb), 0) + 1
+SZP_LIST = sorted(SZP.items())
+FP = SZP.get(1, 0)
+SP2 = SZP.get(2, 0)
+STAB_SIMPLE = (FP + 2 * SP2 == NPI)
+STAB_ORB = (FP + SP2 == NORB)
+
+
+def two_parts(g):
+    inv = [0] * NPI
+    for a in range(NPI):
+        inv[g[a]] = a
+    P = [[1 if g[i] == j else 0 for j in range(NPI)] for i in range(NPI)]
+    MM = [[P[i][j] - (1 if i == j else 0) for j in range(NPI)] for i in range(NPI)]
+    MP = [[P[i][j] + (1 if i == j else 0) for j in range(NPI)] for i in range(NPI)]
+    rm, kp, bb = rref(MM, NPI, True)
+    rp, km, bb = rref(MP, NPI, True)
+    dplus = NPI - rm
+    dminus = NPI - rp
+    ap = rank_fwd([[x + r[inv[j]] for j, x in enumerate(r)] for r in RAROW], NPI)
+    am = rank_fwd([[x - r[inv[j]] for j, x in enumerate(r)] for r in RAROW], NPI)
+    bp = rank_fwd([[x + r[inv[j]] for j, x in enumerate(r)] for r in RBROW], NPI)
+    bm = rank_fwd([[x - r[inv[j]] for j, x in enumerate(r)] for r in RBROW], NPI)
+    return (dplus, dminus, ap, am, bp, bm), kp, km
+
+
+TWO = []
+for g in PERM:
+    if g == IDP:
+        continue
+    if tuple(g[g[i]] for i in range(NPI)) != IDP:
+        continue
+    if any(g[i] == i for i in range(NPI)):
+        TWO.append(g)
+NTWO = len(TWO)
+TWO = [STABG] + [g for g in TWO if g != STABG]
+SIX, KPLUS, KMINUS = two_parts(TWO[0])
+DPLUS, DMINUS, APL, AMI, BPL, BMI = SIX
+EIG_SUM = (DPLUS + DMINUS == NPI)
+ONE_PLUS = all(sum(a * b for a, b in zip(ONE, v)) == 0
+               for v in [clear_den(w) for w in KMINUS])
+SPLIT_A = (APL + AMI == RANKA)
+SPLIT_B = (BPL + BMI == RANKB)
+THMA_PLUS = (APL + BPL == DPLUS + DMEET)
+THMA_MINUS = (AMI + BMI == DMINUS)
+ALLSIX = all(two_parts(g)[0] == SIX for g in TWO)
+
+# the structural upgrade, tested and reported
+SPAN = [list(ONE)] + [list(v) for v in KMINUS]
+DSPAN = rank_fwd(SPAN, NPI)
+DJOINT = rank_fwd(SPAN + RAROW, NPI)
+INSIDE = (DJOINT == DSPAN)
+MEET_IS_RANK = (AMI == RANKA)
+DEMOTE_OK = (DSPAN == DMINUS + DMEET
+             and RANKA + DSPAN - DJOINT == AMI + DMEET)
+
+EIG_KER = (DPLUS == NKA)
+EIG_RANK = (DMINUS == RANKA)
+
+# ------------------------------------------------------------------
+# 15. the cover-side control
+# ------------------------------------------------------------------
+
+CIDX = dict((c, k) for k, c in enumerate(CS))
+CPERM = []
+COV_OK = True
+for p in PERM:
+    q = []
+    for c in CS:
+        im = tuple(sorted(p[x] for x in c))
+        if im not in CIDX:
+            COV_OK = False
+            break
+        q.append(CIDX[im])
+    if not COV_OK:
+        break
+    CPERM.append(tuple(q))
+COV_BIJ = (len(CPERM) == NGRP
+           and all(sorted(q) == list(range(NCOV)) for q in CPERM))
+orb = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for q in CPERM:
+        y = q[x]
+        if y not in orb:
+            orb.add(y)
+            fr.append(y)
+COV_TRANS = (len(orb) == NCOV)
+
+CCHI = [sum(1 for i in range(NCOV) if q[i] == i) for q in CPERM]
+HC = {}
+for f in CCHI:
+    HC[f] = HC.get(f, 0) + 1
+HIST_C = sorted(HC.items())
+CSUM = sum(CCHI)
+CSUMSQ = sum(f * f for f in CCHI)
+CROOT = pair_orbits(CPERM, NCOV)
+NPOC = len(set(CROOT))
+CSUMSQ_OK = (CSUMSQ == NGRP * NPOC)
+
+STABC = [e for e in range(NGRP) if CPERM[e][0] == 0]
+NSTABC = len(STABC)
+seen = [False] * NCOV
+SZC = {}
+for a in range(NCOV):
+    if seen[a]:
+        continue
+    o = set(CPERM[e][a] for e in STABC)
+    for x in o:
+        seen[x] = True
+    SZC[len(o)] = SZC.get(len(o), 0) + 1
+SZC_LIST = sorted(SZC.items())
+FC = SZC.get(1, 0)
+SC2 = SZC.get(2, 0)
+CSTAB_SIMPLE = (FC + 2 * SC2 == NCOV)
+CSTAB_ORB = (FC + SC2 == NPOC)
+CSTAB_OTHER = [e for e in STABC if PERM[e] != IDP]
+CSTAB_FIXP = CHI[CSTAB_OTHER[0]] if len(CSTAB_OTHER) == 1 else -1
+
+SAME_ACTION = (CHI == CCHI)
+PIECE_YES = (NORB == NKA)
+COVER_YES = (NPOC == NKB)
+ONE_SIDED = (PIECE_YES != COVER_YES)
+SAME_OK = ((not SAME_ACTION) or (NORB == NPOC))
+
+# ------------------------------------------------------------------
+# 16. the symmetry does not fix the cover-side dimension either
+# ------------------------------------------------------------------
+
+
+def sweep_labels(act1, n1, act2, n2):
+    L = [[-1] * n2 for _ in range(n1)]
+    nl = 0
+    for i in range(n1):
+        Li = L[i]
+        for j in range(n2):
+            if Li[j] >= 0:
+                continue
+            for e in range(NGRP):
+                L[act1[e][i]][act2[e][j]] = nl
+            nl += 1
+    return L, nl
+
+
+CPLAB, NCP = sweep_labels(CPERM, NCOV, PERM, NPI)
+CP_FULL = all(min(r) >= 0 for r in CPLAB)
+PPLAB, NPP = sweep_labels(PERM, NPI, PERM, NPI)
+PP_FULL = all(min(r) >= 0 for r in PPLAB)
+PP_AGREE = (NPP == NORB)
+
+BV = [-1] * NCP
+BEQUI = True
+for i in range(NCOV):
+    Li = CPLAB[i]
+    Bi = BROW[i]
+    for j in range(NPI):
+        k = Li[j]
+        if BV[k] < 0:
+            BV[k] = Bi[j]
+        elif BV[k] != Bi[j]:
+            BEQUI = False
+
+QPP, RPP = divmod(sum(f * f for f in CHI), NGRP)
+QCC, RCC = divmod(sum(f * f for f in CCHI), NGRP)
+QCP, RCP = divmod(sum(CCHI[e] * CHI[e] for e in range(NGRP)), NGRP)
+PAIR_DIV = (RPP == 0 and RCC == 0 and RCP == 0)
+PAIR_PP = (QPP == NPP)
+PAIR_CP = (QCP == NCP)
+PAIR_CC = (QCC == NPOC)
+
+
+def rank_modp(M, p):
+    A = np.mod(np.array(M, dtype=np.int64), p)
+    nr = A.shape[0]
+    nc = A.shape[1]
+    r = 0
+    for c in range(nc):
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        piv = r + int(nz[0])
+        if piv != r:
+            tmp = A[r].copy()
+            A[r] = A[piv]
+            A[piv] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        if r + 1 < nr:
+            A[r + 1:] = np.mod(A[r + 1:] - np.outer(A[r + 1:, c], A[r]), p)
+        r += 1
+        if r == nr:
+            break
+    return int(r)
+
+
+# one mod-p rank path only, tied to the exact rational ranks before it is used
+RANKB_P = rank_modp(BROW, PRIME)
+RANKA_P = rank_modp(RAROW, PRIME)
+GOOD_PRIME = (RANKB_P == RANKB and RANKA_P == RANKA)
+
+CPL = np.array(CPLAB, dtype=np.int64)
+PPL = np.array(PPLAB, dtype=np.int64)
+
+
+def ind_rank(L, j):
+    return rank_modp((L == j).astype(np.int64), PRIME)
+
+
+CPRK = [ind_rank(CPL, j) for j in range(NCP)]
+WIT = max(CPRK)
+RKH = {}
+for v in CPRK:
+    RKH[v] = RKH.get(v, 0) + 1
+RKHIST = sorted(RKH.items())
+CTL = max(ind_rank(PPL, j) for j in range(NPP))
+CTL_OK = (CTL == NPI)
+BEATS = (WIT > RANKB)
+GAIN = WIT - RANKB
+TIEVAL = NPI - WIT + 1
+
+CELLS = [[] for _ in range(NCP)]
+for i in range(NCOV):
+    Li = CPLAB[i]
+    for k in range(NPI):
+        CELLS[Li[k]].append((i, k))
+
+# The rule, stated before it is tested. If every orbit has size the group
+# order then the group acts freely on the cells of one orbit, so each cover
+# lies in exactly two of its cells and so does each piece: the orbit read as a
+# bipartite graph on covers and pieces is two-regular, hence a disjoint union
+# of cycles. A cycle on k covers and k pieces gives a k by k matrix with two
+# ones in each row and column placed cyclically, whose determinant is
+# 1 + (-1)^(k+1), so that block has rank k - 1 for even k and rank k for odd k.
+# The predicted rank of the orbit is the sum of those block ranks.
+
+
+def cyc_lens(cells):
+    rw = {}
+    cl = {}
+    for (i, k) in cells:
+        rw.setdefault(i, []).append(k)
+        cl.setdefault(k, []).append(i)
+    if len(rw) != NCOV or len(cl) != NPI:
+        return None
+    for v in rw.values():
+        if len(v) != 2:
+            return None
+    for v in cl.values():
+        if len(v) != 2:
+            return None
+    seen = [False] * NCOV
+    lens = []
+    for s in range(NCOV):
+        if seen[s]:
+            continue
+        cur = s
+        pk = -1
+        cnt = 0
+        while not seen[cur]:
+            seen[cur] = True
+            cnt += 1
+            a, b = rw[cur]
+            nk = b if a == pk else a
+            x, y = cl[nk]
+            pk = nk
+            cur = y if x == cur else x
+        lens.append(cnt)
+    return lens
+
+
+TWOREG = True
+CYCBAD = 0
+CYCTYPE = set()
+for j in range(NCP):
+    lens = cyc_lens(CELLS[j])
+    if lens is None:
+        TWOREG = False
+        CYCBAD += 1
+        continue
+    pred = 0
+    for k in lens:
+        pred += k - 1 if divmod(k, 2)[1] == 0 else k
+    if pred != CPRK[j]:
+        CYCBAD += 1
+    CYCTYPE.add((len(lens), tuple(sorted(set(lens))), sum(lens)))
+CYCLIST = sorted(CYCTYPE)
+CYC_OK = (TWOREG and CYCBAD == 0 and len(CYCLIST) == 1)
+
+SVAL = QPP + QCC - 2 * QCP
+PROD = NGRP * SVAL
+ROOT_I = math.isqrt(PROD) if PROD >= 0 else -1
+HALF = ROOT_I // 2
+BOUND = NPI - HALF
+HAND_OK = (PROD >= 0 and ROOT_I * ROOT_I <= PROD
+           and (ROOT_I + 1) * (ROOT_I + 1) > PROD and WIT >= BOUND)
+
+# ------------------------------------------------------------------
+# 17. the cover table as a sum of whole orbits, and sampled comparisons
+# ------------------------------------------------------------------
+
+SZH = {}
+for j in range(NCP):
+    sz = len(CELLS[j])
+    SZH[sz] = SZH.get(sz, 0) + 1
+SZLIST = sorted(SZH.items())
+SZ_SUM = sum(a * b for a, b in SZLIST)
+SZ_CNT = sum(b for a, b in SZLIST)
+SZ_OK = (SZ_SUM == NCOV * NPI and SZ_CNT == NCP and min(SZH) > 0
+         and len(SZH) == 1)
+
+# how many ones one orbit puts in a cover row, and how many orbits a row needs
+CONTRIB, RCON = divmod(SZLIST[0][0], NCOV)
+BROWS = sorted(set(sum(r) for r in BROW))
+NEEDED, RNEED = divmod(BROWS[0], CONTRIB) if CONTRIB > 0 else (0, 1)
+MSET = sorted(set(CPLAB[i][k] for i in range(NCOV)
+                  for k in range(NPI) if BROW[i][k]))
+NMET = len(MSET)
+COUNT_OK = (len(SZH) == 1 and RCON == 0 and RNEED == 0 and len(BROWS) == 1
+            and NMET == NEEDED)
+
+MS = set(MSET)
+REB_OK = True
+for i in range(NCOV):
+    Li = CPLAB[i]
+    row = BROW[i]
+    for k in range(NPI):
+        if (1 if Li[k] in MS else 0) != row[k]:
+            REB_OK = False
+
+BORD_RK = sorted(set(CPRK[j] for j in MSET))
+BORD_OK = (len(BORD_RK) == 1 and BORD_RK[0] == WIT)
+
+ACC = np.zeros((NCOV, NPI), dtype=np.int64)
+RUN = []
+for j in MSET:
+    ACC = ACC + (CPL == j).astype(np.int64)
+    RUN.append(rank_modp(ACC, PRIME))
+RUN_OK = (len(RUN) == NEEDED and RUN[-1] == RANKB)
+
+NSAMP = 1500
+RNG = default_rng(SEED)
+SVALS = []
+for s in range(NSAMP):
+    sel = RNG.choice(NCP, size=NEEDED, replace=False)
+    SVALS.append(rank_modp(np.isin(CPL, sel).astype(np.int64), PRIME))
+NUSED = len(SVALS)
+SS = sorted(SVALS)
+SLOW = SS[0]
+SHIGH = SS[-1]
+HW = NUSED // 2
+MED = FR(SS[HW - 1] + SS[HW], 2) if divmod(NUSED, 2)[1] == 0 else FR(SS[HW])
+NBELOW = sum(1 for v in SVALS if v <= RANKB)
+SAMP_OK = (SHIGH > RANKB and MED > RANKB and NUSED == NSAMP)
+
+
+def rank_exact(rows):
+    M = [list(map(int, r)) for r in rows]
+    m, n = len(M), len(M[0])
+    prev, r = 1, 0
+    for c in range(n):
+        if r >= m:
+            break
+        piv = -1
+        for i in range(r, m):
+            if M[i][c]:
+                piv = i
+                break
+        if piv < 0:
+            continue
+        if piv != r:
+            M[r], M[piv] = M[piv], M[r]
+        prc = M[r][c]
+        for i in range(r + 1, m):
+            mic = M[i][c]
+            Mi, Mr = M[i], M[r]
+            if mic:
+                for j in range(c + 1, n):
+                    Mi[j] = (prc * Mi[j] - mic * Mr[j]) // prev
+                Mi[c] = 0
+            else:
+                for j in range(c + 1, n):
+                    Mi[j] = (prc * Mi[j]) // prev
+        prev = prc
+        r += 1
+    return r
+
+
+IDT = [[1 if i == k else 0 for k in range(NCOV)] for i in range(NCOV)]
+RX_ID = rank_exact(IDT)
+ID_OK = (RX_ID == NCOV)
+RX_B = rank_exact(BROW)
+RX_DUP = rank_exact(BROW + BROW)
+DUP_OK = (RX_DUP == RX_B)
+EXACT_OK = (RX_B == RANKB_P)
+
+# ------------------------------------------------------------------
+# 18. source hygiene and budget
+# ------------------------------------------------------------------
+
+SRC = open(__file__, "r").read()
+NO_PC = (chr(37) not in SRC)
+NO_TAB = (chr(9) not in SRC)
+NO_EM = (chr(8212) not in SRC)
+ASCII_OK = all(ord(ch) < 128 for ch in SRC)
+
+BAN = [("reta", "ined"), ("aud", "ited"), ("audit", " will"), ("only ", "route"),
+       ("last ", "route"), ("exha", "ust"), ("clos", "es"), ("PHAS", "E_"),
+       ("r = 1", "/2"), ("r=1", "/2"), ("grav", "it"), ("Ha", "ar"),
+       ("Reyn", "olds"), ("viel", "bein"), ("tet", "rad"), ("resolves ", "PARTIAL"),
+       ("/Us", "ers/"), ("7/", "(8"), ("regi", "ster"), ("oct", "et"),
+       ("sch", "eme"), ("association sch", "eme"), ("Sm", "ith"),
+       ("Bar", "eiss"), ("Gal", "ois"),
+       ("hyper", "octahedral"), ("Cox", "eter"), ("B", "_4"), ("na", "uty"),
+       ("Weis", "feiler"), ("Le", "man"), ("Leh", "man"), ("Mc", "Kay"),
+       ("sau", "cy"), ("bl", "iss"), ("trac", "es"), ("O", "_h"),
+       ("inver", "sion")]
+LOWSRC = SRC.lower()
+BAN_OK = True
+NBAN = 0
+for a, b in BAN:
+    NBAN += 1
+    if (a + b).lower() in LOWSRC:
+        BAN_OK = False
+
+ELAPSED = int(time.time() - T0)
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+RSSMB = RSS // 1048576 if RSS > 10000000 else RSS // 1024
+
+# ------------------------------------------------------------------
+# gates
+# ------------------------------------------------------------------
+
+emit("all numbers below are exact computational identities;"
+     " no floating point enters any gate")
+
+gate(NCAND == 2672 and FLOOR == 6 and NKEPT == 400 and GENERIC and NPTS == 625
+     and DIV == 80 and NS == 15800 and SIZES == [24] and NPI == 192
+     and sorted(set(PCN)) == [1975] and NCOV == 192 and BRS == [8] and BCS == [8],
+     "G0",
+     "{0} pieces of determinant one, {1} at floor {2}, {3} cuttings of {4} over {5} points, {6} used, {7} covers".format(
+         NCAND, NKEPT, FLOOR, NS, SIZES[0], NPTS, NPI, NCOV))
+
+gate(DISJ_OK and NPAIR == NFAC + NDIM and COVEXACT and ACS == [1975],
+     "G1",
+     "each cutting tiles: {0} pieces of volume 1 over 24, its {1} co-occurring pairs interior-disjoint, {2} by facet".format(
+         SIZES[0], NPAIR, NFAC))
+
+gate(OMAX > 1 and OMIN > 0 and OMIN < OMAX and SLOTS == 120 and NCORN == 16 and SLOTS > NCORN,
+     "G2",
+     "corner sharing: {0} corner slots on {1} corners, one corner taking from {2} to {3}".format(
+         SLOTS, NCORN, OMIN, OMAX))
+
+gate(GRAM_OK and KANN_A and KANN_B and PCN[0] == 1975,
+     "G3",
+     "two builds of the {0} square agree, both kernels give total zero on every cutting and cover".format(
+         NPI))
+
+gate(MAPS_DISTINCT and CLOSED and NPROD == NGRP * NGRP and KEEPS_PIECES
+     and PERM_DISTINCT and BIJ and NGRP == 384,
+     "G4",
+     "permuting the four coordinates and flipping any of them gives {0} distinct maps, closed over {1} products".format(
+         NGRP, NPROD))
+
+gate(STAB_A == NGRP and STAB_B == NGRP,
+     "G5",
+     "stability: all {0} elements carry the sorted cutting and cover tables to themselves, both row spaces stand".format(
+         NGRP))
+
+gate(SUMCHI == NGRP and SUMSQ_OK and HIST_P[0][0] == 0,
+     "G6",
+     "fixed-piece counts {0} sum to {1}, one orbit on pieces, squares sum to {1} times {2}".format(
+         HIST_P, NGRP, NORB))
+
+gate(NORB == 104 and SUMSQ_OK,
+     "G7",
+     "union-find over the {0} ordered piece pairs under all {1} elements gives {2} orbits, matching the squares".format(
+         NPI * NPI, NGRP, NORB))
+
+gate(RANKA == 88 and NKA == 104 and RANKB == 105 and NKB == 87
+     and RANKA + NKA == NPI and RANKB + NKB == NPI and RKKA == NKA and RKKB == NKB,
+     "G8",
+     "cutting rank {0} kernel {1}, cover rank {2} kernel {3}, each kernel certified by total zero and its own rank".format(
+         RANKA, NKA, RANKB, NKB))
+
+gate(RSELA == RANKA and RSELB == RANKB and len(SELA) == RANKA
+     and len(SELB) == RANKB and perp_all(RAROW, KA) and perp_all(RBROW, KB),
+     "G9",
+     "independent selections of {0} cutting and {1} cover rows reach those ranks and are zeroed by each kernel".format(
+         RANKA, RANKB))
+
+gate(DSUM == NPI and DMEET == 1 and ONE_A and ONE_B,
+     "G10",
+     "the two row spaces span all {0} dimensions and meet in dimension {1}, the constants, killed by both kernels".format(
+         DSUM, DMEET))
+
+gate(PARTITION and min(CLS) > 0 and len(CLS) == NORB,
+     "G11",
+     "the {0} labels cut all {1} entries into classes of sizes {2} to {3}, so their matrices span the commuters".format(
+         NORB, NPI * NPI, min(CLS), max(CLS)))
+
+gate(0 < NKEEP_A < NORB,
+     "G12",
+     "the negative: only {0} of the {1} commuting matrices carry the cutting row space into itself".format(
+         NKEEP_A, NORB))
+
+gate(0 < NKEEP_B < NORB,
+     "G13",
+     "the same on the cover side: only {0} of the {1} carry the cover row space into itself".format(
+         NKEEP_B, NORB))
+
+gate(CTRL_A,
+     "G14",
+     "control: the constants times each of the {0} commuting matrices stays a multiple, so the negative has content".format(
+         NORB))
+
+gate((not SHIFT_IN) and (not SHIFT_KEEPS),
+     "G15",
+     "control: the cyclic shift of the {0} pieces is not one of the {1} and does not keep the cutting table".format(
+         NPI, NGRP))
+
+gate(RANKU == NPI and RANKMU == RANKA and NOUT == len(MU),
+     "G16",
+     "the first failing matrix, out-degree {0}, with the identity has rank {1}; its {2} moved rows have rank {2}, all outside".format(
+         DEG_KSTAR, RANKU, RANKMU))
+
+gate(GEN_OK and MU_STABLE and len(GENS) == 2,
+     "G17",
+     "two named elements generate all {0}, and the moved span keeps rank {1} stacked with its image under each".format(
+         NGRP, RANKMU))
+
+gate(LAB_INV,
+     "G18",
+     "labels survive every element on all {0} entries; true by construction of the orbits, so non-discriminating".format(
+         NPI * NPI))
+
+gate(DEG_CONST and DEGSUM == NPI and DEGCNT == NORB,
+     "G19",
+     "out-degree census {0} from every source piece; degrees by count sum to {1}, counts to {2}".format(
+         CENSUS, DEGSUM, DEGCNT))
+
+gate(NSTABP == 2 and STAB_SIMPLE and STAB_ORB,
+     "G20",
+     "the stabilizer of a piece has order {0}, orbit sizes {1}: {2} plus twice {3} is {4}, {2} plus {3} is {5}".format(
+         NSTABP, SZP_LIST, FP, SP2, NPI, NORB))
+
+gate(EIG_SUM and NTWO == 12 and ONE_PLUS,
+     "G21",
+     "its non-identity element has plus and minus dimensions {0} and {1} by two independent exact ranks, sum {2}".format(
+         DPLUS, DMINUS, NPI))
+
+emit("recorded agreement, not a derivation: {0} matches the cutting kernel {1}, {2} matches the rank {3}; neither derived".format(
+    DPLUS, yn(EIG_KER), DMINUS, yn(EIG_RANK)))
+
+gate(SPLIT_A and SPLIT_B,
+     "G22",
+     "that element splits the cutting row space {0} plus {1} and the cover row space {2} plus {3}, ranks {4} and {5}".format(
+         APL, AMI, BPL, BMI, RANKA, RANKB))
+
+gate(THMA_PLUS and THMA_MINUS,
+     "G23",
+     "theorem A: {0} plus {1} is {2}, the plus dimension {3} plus the constants; {4} plus {5} is {6}, the minus".format(
+         APL, BPL, APL + BPL, DPLUS, AMI, BMI, AMI + BMI))
+
+gate(ALLSIX and NTWO == 12,
+     "G24",
+     "all {0} order-two elements fixing a piece give the same six dimensions {1}, each by its own rank".format(
+         NTWO, list(SIX)))
+
+gate(DEMOTE_OK,
+     "G25",
+     "demotion: cutting rows meet the minus part in dimension {0}; equal to the rank {1}: {2}; inside the {3} span: {4}".format(
+         AMI, RANKA, yn(MEET_IS_RANK), DSPAN, yn(INSIDE)))
+
+gate(COV_OK and COV_BIJ and COV_TRANS,
+     "G26",
+     "all {0} elements carry covers to covers, and the action on the {1} covers is transitive".format(
+         NGRP, NCOV))
+
+gate(CSUM == NGRP and CSUMSQ_OK,
+     "G27",
+     "fixed-cover counts {0} sum to {1}, squares to {1} times {2}; pair orbits cover {2}, piece {3}".format(
+         HIST_C, NGRP, NPOC, NORB))
+
+gate(NSTABC == 2 and CSTAB_SIMPLE and CSTAB_ORB,
+     "G28",
+     "cover stabilizer order {0}, sizes {1}: {2} plus twice {3} is {4}, {2} plus {3} is {5}; it fixes {6} pieces".format(
+         NSTABC, SZC_LIST, FC, SC2, NCOV, NPOC, CSTAB_FIXP))
+
+gate(SAME_OK,
+     "G29",
+     "the two fixed-point counts agree element by element: {0}; equal counts would force equal orbit counts, {1} not {2}".format(
+         yn(SAME_ACTION), NORB, NPOC))
+
+emit("cover-side control: pair orbits match the kernel dimension, piece {0}, cover {1}; one-sided {2}, so not a feature".format(
+    yn(PIECE_YES), yn(COVER_YES), yn(ONE_SIDED)))
+
+gate(SUB_OK and SUB_BIGGER and SUB_SIZE == [24, 24, 24, 24],
+     "G30",
+     "four rotation subgroups of order {0}, closed and inside the {1}: piece orbits {2}, pair orbits {3}, above {4}".format(
+         SUB_SIZE[0], NGRP, sorted(set(SUB_PIECE)), sorted(set(SUB_PAIR)), NORB))
+
+gate(NORB == NKA,
+     "G31",
+     "pair-orbit count and cutting kernel are both {0} by unrelated routes: recorded agreement, not evidence".format(
+         NORB))
+
+gate(CP_FULL and PP_FULL and PP_AGREE and BEQUI,
+     "G32",
+     "cover-piece orbits {0} label all {1} cells, the cover table constant on them: {2}; the piece sweep gives {3}".format(
+         NCP, NCOV * NPI, yn(BEQUI), NPP))
+
+gate(PAIR_DIV and PAIR_PP and PAIR_CP and PAIR_CC,
+     "G33",
+     "pairings of the two fixed-point counts, each dividing exactly: piece {0}, cover {1}, cross {2}".format(
+         QPP, QCC, QCP))
+
+gate(CTL_OK and GOOD_PRIME and WIT > 0 and len(RKHIST) == 1,
+     "G34",
+     "single-orbit dimensions, value to count: {0}; largest {1}; the control that must reach {2} gives {3}".format(
+         RKHIST, WIT, NPI, CTL))
+
+gate(BEATS,
+     "G35",
+     "one orbit matrix beats the cover rank {0} by {1}; pieces minus that dimension plus one is {2}".format(
+         RANKB, GAIN, TIEVAL))
+
+gate(CYC_OK,
+     "G36",
+     "cycle rule: {0} of {1} orbits differ from the predicted dimension; cycle types {2}".format(
+         CYCBAD, NCP, CYCLIST))
+
+gate(HAND_OK,
+     "G37",
+     "hand bound: S {0}, order times S {1}, half its integer square root {2}, bound {3}; the largest {4} clears it".format(
+         SVAL, PROD, HALF, BOUND, WIT))
+
+gate(SZ_OK,
+     "G38",
+     "the {0} cover-piece orbits all have size {1}, summing to {2} cells".format(
+         NCP, SZLIST[0][0], SZ_SUM))
+
+gate(COUNT_OK and REB_OK,
+     "G39",
+     "each orbit puts {0} ones in every cover row, so {1} orbits make {2}; those {1} rebuild the cover table exactly".format(
+         CONTRIB, NEEDED, BROWS[0]))
+
+gate(BORD_OK and RUN_OK,
+     "G40",
+     "each of those {0} orbits alone has dimension {1}, the largest; running dimensions {2} end at the cover rank {3}".format(
+         NEEDED, BORD_RK[0], RUN, RANKB))
+
+gate(SAMP_OK,
+     "G41",
+     "{0} sampled sums of {1} orbits: least {2}, middle {3}, greatest {4}; at or below the cover rank {5}: {6}".format(
+         NUSED, NEEDED, SLOW, MED, SHIGH, RANKB, NBELOW))
+
+gate(ID_OK,
+     "D8",
+     "control: the identity table of size {0} returns dimension {1} over the integers".format(
+         NCOV, RX_ID))
+
+gate(DUP_OK,
+     "D9",
+     "control: the cover table stacked on itself gives dimension {0}, the cover table alone gives {1}".format(
+         RX_DUP, RX_B))
+
+gate(EXACT_OK,
+     "D10",
+     "exact dimension of the cover table over the integers, no modulus: {0}; agrees with the modular count: {1}".format(
+         RX_B, yn(EXACT_OK)))
+
+gate(NO_PC and NO_TAB and NO_EM and ASCII_OK and BAN_OK and NBAN == len(BAN),
+     "G42",
+     "source hygiene: plain ASCII, no per-cent character, no tab, no long dash, all {0} barred strings absent".format(
+         NBAN))
+
+gate(ELAPSED < 600 and RSSMB < 2500,
+     "G43",
+     "budget: elapsed under 600 seconds and peak memory under 2500 MB; both vary by machine so neither is printed")
+
+TAIL = "TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1])
+BASE = OUT[0]
+n = BASE
+for _ in range(30):
+    line = "stdout characters: {0}".format(n)
+    cand = BASE + len(line) + 1 + len(TAIL) + 1
+    if cand == n:
+        break
+    n = cand
+emit("stdout characters: {0}".format(n))
+emit(TAIL)
+if OUT[0] != n:
+    raise ValueError("character accounting did not close")
+if OUT[0] >= 6000:
+    raise ValueError("stdout over the ceiling")


### PR DESCRIPTION
## Salvaged scope

This revision retains the independently reproduced finite construction and
withdraws the former physical/covariance interpretation. It is self-contained
on current `main` and consumes zero authority from Cycle 762, PR #6059, or any
other unlanded stack.

## Exact finite result

The runner rebuilds the labelled unit four-cube object from scratch:

- 2,672 unit-determinant candidate simplices, with 400 at adjacency-cost floor 6;
- 15,800 certified cuttings on 192 supported pieces;
- 192 eight-piece covers;
- the 384-element coordinate-relabeling action; and
- 96 cover-piece cell orbits.

Every cell-orbit indicator decomposes into 48 four-cycles and therefore has
exact rank 144. The reconstructed cover table is a union of four orbit
indicators, has row and column sum 8, and has exact integer rank 105. The
explicit orbit union `(6, 11, 28, 39)` has the same binary row-and-column shape
and exact integer rank 144. These two matrices discharge the bounded positive
existence target.

## Scope and imports

The theorem ranges over this declared finite incidence object. Physical and
multicell interpretations are separate targets. The note inventories every
model and computational choice, records an empty primitive-premise dependency
set, and includes an acyclic proof-obligation graph. The one-prime sampled-rank
distribution from the submitted version has been removed; modular values that
remain are explicitly labelled diagnostics, while both advertised witness
ranks are checked by integer elimination.

The commutant statement is also narrowed to its computed content: exactly two
of 104 canonical orbital basis matrices individually preserve each row space.
It makes no assertion about the dimension of the preserving subspace of
arbitrary linear combinations.

## Runner and review repair

Primary runner:
`scripts/physical_cell_cutting_finite_orbit_ranks_cycle763_2026_08_09.py`

The repaired source declares a 600-second audit budget, uses platform-correct
resident-memory units with synthetic Linux/Darwin controls, and exits nonzero
whenever any gate fails. A live run gives `TOTAL: PASS=47 FAIL=0`. A deliberate
G0 predicate mutation gives `TOTAL: PASS=46 FAIL=1` and process exit 1.

The combined review independently reproduced the finite enumeration, group
orders, exact primary ranks, cycle decomposition, rank-144 witness, and
citation topology. The renamed note and runner now carry only the bounded
finite theorem and its diagnostics.
