### PR TITLE
feat(cell-cutting): exact ceiling 144 and floor 48 from the cutting cell's symmetry

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_SYMMETRY_CEILING_CYCLE764_NOTE_2026-08-09.md
+++ b/docs/PHYSICAL_CELL_CUTTING_SYMMETRY_CEILING_CYCLE764_NOTE_2026-08-09.md
@@ -1,0 +1,209 @@
+# The cell symmetry caps the cover table's rank at 144 and floors its blind space at 48 — Cycle 764
+
+Date: 2026-08-09
+
+Authority: none
+
+Audit: unset.
+
+Status: derived ceiling and floor with a measured, unaccounted residual
+
+Claim type: bounded_theorem
+
+Runner:
+
+- [`physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py`](../scripts/physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py)
+
+Axioms:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+Constitutional effect: none. This note changes no axiom, primitive, registry,
+policy, audit verdict, effective status, or framework claim.
+
+## What this responds to
+
+Cycle 763 asked whether the cell's own symmetry picks out the cover table's rank
+of 105, and answered no: tables built to be covariant under that symmetry run
+over a wide band and 105 sits low in it. But the band itself was only sampled.
+The largest dimension seen was 144 and the bound derived by hand fell short of
+it, so nothing said whether 144 was the true ceiling or an artefact of sampling.
+
+This cycle replaces the sample with a derivation. The symmetry alone fixes an
+exact ceiling on the rank of any covariant table, an exact floor on its blind
+space, and the ceiling is shown to be attained.
+
+## The object
+
+The unit four-cube on sixteen corners, cut into least-volume pieces at the
+adjacency-cost floor: 2672 candidate pieces of determinant one, 400 of them at
+cost floor 6, 15800 cuttings of 24 pieces, 192 pieces actually used and 192
+eight-piece covers.
+
+The symmetry permutes the four coordinates and flips any of them: 384 maps,
+closed over all 147456 products, acting transitively on the 192 pieces and on
+the 192 covers. It has 104 orbits on ordered pairs of pieces, 120 on ordered
+pairs of covers and 96 on the cells of the cover-by-piece square. By exact
+rational arithmetic the cutting table has rank 88 with kernel 104, and the cover
+table has rank 105 with kernel 87.
+
+## Twenty parts
+
+The algebra of maps commuting with the symmetry on the 192 piece directions has
+dimension 104, one basis element per orbit on ordered pairs. Its centre is the
+kernel of the 10816 conditions saying that a combination commutes with every
+basis element. A modular selection of 84 independent rows caps that centre at
+dimension 20, and the 20 integer vectors recovered are each verified against all
+10816 conditions in both multiplication orders, which floors it at 20. So the
+centre has dimension exactly 20.
+
+One central element separates all twenty. Its matrix on the centre has 20
+distinct integer eigenvalues, each of nullity one, found by an exact integer scan
+over the interval its own row sums allow, bound 6009; three direct products on
+the full 192 square confirm that this matrix really is multiplication by that
+element. Its eigenspaces on the 192 piece directions are the twenty parts, of
+dimensions
+
+    1, 1, 1, 1, 3, 3, 3, 3, 4, 4, 8, 8, 8, 8, 12, 12, 24, 24, 32, 32
+
+Each part carries three integers: a degree d, a piece-side multiplicity m and a
+cover-side multiplicity mc. Six sums certify the whole table at once:
+
+    sum of dimensions      192
+    sum of m squared       104
+    sum of m times mc       96
+    sum of mc squared      120
+    sum of d times mc      192
+    sum of blind            87
+
+Each per-part entry is a modular rank, which can differ from the exact value in
+one direction only. Each sum is pinned to a total computed independently and
+exactly. Equality of the sums therefore forces every individual entry to be
+exact. The third and fifth sums also tie the piece side and the cover side back
+to the orbit counts 96 and 192, and the fourth to the 120 orbits on ordered pairs
+of covers, so the decomposition is cross-checked against objects that were never
+used to build it.
+
+## The theorem
+
+A table from covers to pieces that commutes with the symmetry acts on part i as
+one mc by m matrix tensored with the identity on the degree. Its rank is
+therefore the sum over parts of d times the rank of that small matrix, and its
+blind space the sum of d times m minus that rank. A small matrix has at most
+min(m, mc) independent rows, so for every covariant table
+
+    rank  at most   sum of d times min(m, mc)      = 144
+    blind at least  sum of d times max(0, m - mc)  =  48
+
+The ceiling is attained. An explicit equivariant integer matrix built from all
+96 cell orbits has exact rational rank 144, with no modulus anywhere. So 144 is
+the true greatest available to any covariant table, not an upper estimate, and
+48 is the true least blind space.
+
+This turns a rank question on a 192 by 192 table into twenty rank questions on
+matrices of size at most 6 by 4, and cycle 763's sampled largest of 144 becomes
+a derived and attained value.
+
+## What the cover table does with the room
+
+The cover table's own rank is 105 and its blind space 87. Both lie strictly
+inside the derived interval: 105 is 39 below the ceiling, and 87 is 39 above the
+floor. That 39 is exactly what the symmetry does not account for.
+
+Across the twenty parts, twelve sit exactly at the forced value and eight exceed
+it. The eight, as degree / m / mc / blind / forced:
+
+    2/2/2/2/0    4/2/3/4/0    6/2/3/6/0    8/4/6/8/0
+    6/4/3/12/6   6/2/3/6/0    6/4/3/12/6   1/1/1/1/0
+
+Their excesses are 2, 4, 6, 8, 6, 6, 6 and 1, summing to the whole 39, so the
+other twelve parts contribute none of it.
+
+Six of the eight have mc at least m and two do not. The natural reading — that
+the cover side offers room the table declines to use — is therefore wrong as a
+general statement: two of the eight have less cover-side room than piece-side
+room and still lose rank beyond what that shortage forces.
+
+## Three candidates for the 39, all refuted
+
+The subgroup of even coordinate permutations has order 192 and index 2, and
+splits both the 192 pieces and the 192 covers into two classes of 96 and 96. The
+plus-minus label of that split is itself one of the twenty parts: the one with
+degree, m and mc all equal to 1, whose row is 1/1/1/1/0 — blind, with nothing
+forcing it to be.
+
+That label is blind for a reason the runner exhibits rather than assumes. Every
+one of the 192 covers splits its eight pieces 4 and 4 between the two classes, so
+each cover sum of the label is 0. The same 4-and-4 split holds on the piece side,
+each piece lying in four covers of each class, with incidence totals 768 and 768
+both equal to 96 times 8. And the single non-identity element fixing a given
+cover has permutation sign 1, fixes none of the eight blocks, has cycle type
+2, 2, 2, 2 on them and keeps the class — so it cannot separate the label. On that
+same element the flip-count parity is -1 and its product with the permutation
+sign is -1, which forces both of those alternative labels blind as well: a label
+on which a cover-fixing element acts by -1 must sum to zero over that cover.
+
+A second candidate, the aggregate incidence, carries nothing by arithmetic alone.
+For any split value a from 0 to 8, the count 96a + 96(8 - a) is 768, and 768 over
+192 is 4. The mean number of class-0 pieces per cover is 4 whatever the structure
+is, so it cannot be the explanation.
+
+A third candidate is geometric. Two labels read off the pieces themselves — a
+corner-parity label and an ordered determinant label — each agree with the class
+label on 96 of 192 pieces, that is on exactly half, so neither reproduces it.
+The determinant label is a genuine covariant object: with the image corners kept
+in the source piece's own ordering, the determinant of the image equals the
+determinant of the source times the product of the permutation sign and the
+flip-count parity, on all 73728 element-piece pairs with 0 misses. Under the
+other reading, where each image piece is re-sorted into its own order, the same
+relation fails on 36864 of 73728 pairs, again exactly half, and survives for only
+4 of the 384 elements. So the determinant tracks a character that the class label
+does not, and the two are not the same object.
+
+## Runner
+
+`physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py`, 28 gates,
+`TOTAL: PASS=28 FAIL=0`. Every gate number is an exact integer computation; no
+floating point enters any gate.
+
+Controls carried inside the run: 40 equivariance checks on the orbit matrices;
+the cover table rebuilt entry by entry as the sum of 4 whole cell orbits; 7
+products of orbit matrices recomputed directly and matched against the structure
+constants; an integer overflow guard on those products; three products on the
+full 192 square pinning the abstract central matrix to the concrete action; and
+the exact rational rank of the witness, computed without any modulus.
+
+## Boundary
+
+Two identities in the runner hold by arithmetic whatever the part table says, and
+are bookkeeping rather than evidence: that the ceiling plus the floor is 192, and
+that the ceiling minus the rank equals the blind space minus the floor. Both
+follow from d times min(m, mc) plus d times max(0, m - mc) being d times m. The
+content sits beside them: the measured rank 105 is strictly below the ceiling 144
+and the measured blind space 87 strictly above the floor 48, and the ceiling is
+attained exactly.
+
+Similarly, that every part with cover-side multiplicity 0 has no excess is
+arithmetic — such a part is forced entirely into the blind space, so there is
+nothing left to exceed. It is reported as a check that the cover table
+annihilates those five parts, not as support for the theorem.
+
+Every per-part quantity is a modular rank. The six sums are what make them exact,
+and that is the only thing that does; a reader who does not accept the sums
+should treat the part table as modular.
+
+The weights inside the central element and inside the witness are arbitrary
+deterministic choices carrying no meaning. Their only role is to be generic, and
+each is gated by a wrong-value rejector — twenty distinct integer eigenvalues
+each of nullity one, and an exact rational rank of exactly 144. A choice that
+failed to be generic would fail its gate rather than pass quietly.
+
+The 39 is not explained. Three candidate labels are refuted here and the residual
+stands: the cell's own symmetry bounds the cover table's rank on both sides but
+does not determine it. The symmetry used here is the full symmetry of the
+four-cube, which is larger than the proper cubic rotations the admissibility
+axiom names; a ceiling derived from a larger group is still a ceiling, but the
+smaller group would give a weaker one, so nothing here should be read as a
+statement about the axiom's own covariance. What remains is to name the eight
+small matrices whose rank drops make up the 39, which the decomposition above now
+makes a finite and small question.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15478,
- "node_count": 5446,
+ "edge_count": 15479,
+ "node_count": 5447,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13641,6 +13641,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_symmetry_ceiling_cycle764_note_2026-08-09": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.txt
+++ b/logs/runner-cache/physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py
+runner_sha256: b7f277ce8be2d47b95233bc1b5c627466cf499902dd839e92fb1798c3048a4f3
+timeout_sec: 400
+exit_code: 0
+elapsed_sec: 164.87
+status: ok
+----- stdout -----
+all numbers below are exact computational identities; no floating point enters any gate
+PASS C0 object: 2672 candidate pieces, 400 at adjacency-cost floor 6, 15800 cuttings of 24, 192 pieces used, 192 covers
+PASS C1 group: 384 maps, all distinct, closed over 147456 products, bijective yes, one piece orbit yes, one cover orbit yes
+PASS C2 orbits: 104 on ordered piece pairs, 120 on ordered cover pairs, 96 on cover-piece cells, sweep agrees yes
+PASS C3 exact rational ranks: cutting table 88 kernel 104, cover table 105 kernel 87, prime path agrees yes
+PASS C4 orbit matrices: 104 piece-pair, 96 cell; 40 equivariance checks hold yes; cover table is the sum of 4 whole cell orbits yes
+PASS C5 structure constants: max 2, every label has a representative yes, 7 pairs checked by direct product agree yes, below 2**40 yes
+PASS C6 centre: 84 of 10816 rows picked, prime rank 84 exact 84, dimension 20, each vector meets all 10816 rows yes, top 2, guard yes
+PASS C7 central element: trial 2, row-sum bound 6009, 20 integer values each of nullity one yes, 3 direct product checks yes
+PASS C8 certificates: sum of dimensions 192 = 192, sum of m squared 104 = 104, sum of m times mc 96 = 96
+PASS C9 certificates: sum of mc squared 120 = 120, sum of d times mc 192 = 192, sum of blind 87 = 87
+PASS C10 20 parts, dimensions sorted: 1,1,1,1,3,3,3,3,4,4,8,8,8,8,12,12,24,24,32,32
+PASS C11 theorem: ceiling 144 on the cover table rank, floor 48 on its blind space, and 144 plus 48 = 192
+PASS C12 measured: cover table rank 105 and blind space 87, so ceiling minus rank 39 equals blind minus floor 39
+PASS C13 exact witness: an equivariant integer matrix of exact rational rank 144 meets the ceiling, and 192 minus it is the floor 48
+PASS C14 excess: 12 parts have none, 8 have some; of those 6 have mc at least m and 2 do not; all 5 parts with mc zero have no excess yes
+PASS C15 excess rows d/m/mc/blind/forced 1 to 4: 2/2/2/2/0 4/2/3/4/0 6/2/3/6/0 8/4/6/8/0
+PASS C16 excess rows d/m/mc/blind/forced 5 to 8: 6/4/3/12/6 6/2/3/6/0 6/4/3/12/6 1/1/1/1/0
+PASS C17 even subgroup: order 192, index 2, two piece classes of 96 and 96, two cover classes of 96 and 96
+PASS C18 the class labelling: all 192 cover sums are [0], block split histogram [(4, 192)]
+PASS C19 self-dual: piece side [(4, 192)], cover side [(4, 192)], incidence totals 768 and 768 both equal 96 times 8
+PASS C20 first candidate: the non-identity element fixing cover 0 has sign 1, fixes 0 of 8 blocks, cycles [2, 2, 2, 2], keeps the class yes
+PASS C21 contrast: on that element the flip-count parity is -1 and its product with the permutation sign is -1, so both are forced blind
+PASS C22 second candidate: the mean carries nothing; all 9 split values a give 96a + 96(8 - a) = 768, and 768 over 192 is 4
+PASS C23 third candidate: corner-parity label agrees on 96 of 192 pieces, ordered determinant label on 96 of 192, determinant values [-1, 1]
+PASS C24 the determinant tracks the product character: with corners kept in source order it matches on all 73728 element-piece pairs, 0 misses
+PASS C25 re-sorted reading: with each image piece in its own sorted order the match fails on 36864 of 73728 pairs, holding for 4 of 384 elements
+PASS C26 source hygiene: pure ASCII yes, no tab yes, no remainder character yes, no long dash yes, 38 barred strings absent yes
+PASS C27 budget: 164 seconds of wall time under 900, peak resident 125 MB under 2500, stdout characters counted below
+stdout characters: 3431
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py
+++ b/scripts/physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py
@@ -1,0 +1,1878 @@
+"""The symmetry sets a ceiling on the cover table and a floor on its blind space.
+
+Self-contained exact runner. It builds the cell object from scratch: the sixteen
+corners of the unit four-cube, the unit-determinant five-corner pieces at the cost
+floor, the cuttings by them, the pieces that occur, and the eight-piece covers.
+
+Permuting the four coordinates and flipping any of them splits the piece labelling
+space into parts the group cannot mix. The parts are read off the centre of the
+algebra of matrices commuting with the action, found exactly and certified against
+every one of its defining constraints. A table of the cover table's shape is an
+equivariant map, so inside each part its rank is at most the smaller of the two
+multiplicities times the part's degree and its blind dimension is at least the
+difference. Summing gives a ceiling of 144 and a floor of 48; the cover table's
+own rank is 105 and its blind space is 87, so it sits 39 inside both, and that 39
+is the blindness the symmetry does not force. An equivariant integer matrix of
+exact rational rank 144 shows the ceiling is attained.
+
+One labelling escapes the argument: the even subgroup splits the pieces into two
+classes of 96 and every cover meets each class four times; three candidate
+explanations are ruled out. All work is over the integers, the rationals and one
+fixed prime; no floating point enters any gate and no constant is fitted.
+
+Output: one line per gate, then the stdout character count, then the total line.
+"""
+
+import itertools
+import math
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+import numpy as np
+from numpy.random import default_rng
+
+PRIME = 1000003
+SEED = 3
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def yn(b):
+    return "yes" if b else "no"
+
+
+# ------------------------------------------------------------------
+# 1. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+# barycentric data: five integer affine forms per kept piece, positive inside
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    Ci = inv4(C)
+    rows = []
+    for i in range(4):
+        a = tuple(Ci[i][r] for r in range(4))
+        b = -sum(Ci[i][r] * v0[r] for r in range(4))
+        rows.append((a, b))
+    a0 = tuple(-sum(Ci[i][r] for i in range(4)) for r in range(4))
+    b0 = 1 + sum(sum(Ci[i][r] * v0[r] for r in range(4)) for i in range(4))
+    rows.append((a0, b0))
+    BARY.append((v0, Ci, rows))
+
+# ------------------------------------------------------------------
+# 2. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci, rows) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 3. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+CUTM = [sum(1 << i for i in s) for s in CUT]
+
+# cuttings through each piece, as a bit set over cuttings
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCN = [popc(x) for x in PC]
+FULLC = (1 << NS) - 1
+
+# ------------------------------------------------------------------
+# 4. exact interior disjointness for every co-occurring pair
+# ------------------------------------------------------------------
+
+
+def solve4(rows):
+    n = 4
+    M = [[FR(x) for x in r] for r in rows]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(n + 1)]
+    return [M[r][n] for r in range(n)]
+
+
+def afrank(pts):
+    if not pts:
+        return -1
+    base = pts[0]
+    rows = [[FR(p[r]) - FR(base[r]) for r in range(4)] for p in pts[1:]]
+    rk = 0
+    for c in range(4):
+        p = -1
+        for i in range(rk, len(rows)):
+            if rows[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        rows[rk], rows[p] = rows[p], rows[rk]
+        pv = rows[rk][c]
+        for i in range(rk + 1, len(rows)):
+            if rows[i][c] != 0:
+                f = rows[i][c] / pv
+                rows[i] = [rows[i][k] - f * rows[rk][k] for k in range(4)]
+        rk += 1
+    return rk
+
+
+def side(a, b, x):
+    return a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b
+
+
+def sep_facet(r1, P1, r2, P2):
+    for (a, b) in r1:
+        if max(side(a, b, x) for x in P2) <= 0:
+            return True
+    for (a, b) in r2:
+        if max(side(a, b, x) for x in P1) <= 0:
+            return True
+    return False
+
+
+def inter_dim(r1, r2):
+    con = list(r1) + list(r2)
+    pts = []
+    for idx in itertools.combinations(range(10), 4):
+        rows = [list(con[i][0]) + [-con[i][1]] for i in idx]
+        x = solve4(rows)
+        if x is None:
+            continue
+        ok = True
+        for (a, b) in con:
+            if a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b < 0:
+                ok = False
+                break
+        if ok:
+            tx = tuple(x)
+            if tx not in pts:
+                pts.append(tx)
+    return afrank(pts)
+
+
+PAIRS = []
+for i in range(NPI):
+    for j in range(i + 1, NPI):
+        if PC[i] & PC[j]:
+            PAIRS.append((i, j))
+NPAIR = len(PAIRS)
+NFAC = 0
+NDIM = 0
+DISJ_OK = True
+PTS = [tuple(CORN[c] for c in S) for S in KEPT]
+for (i, j) in PAIRS:
+    r1 = BARY[USED[i]][2]
+    r2 = BARY[USED[j]][2]
+    if sep_facet(r1, PTS[USED[i]], r2, PTS[USED[j]]):
+        NFAC += 1
+        continue
+    if inter_dim(r1, r2) <= 3:
+        NDIM += 1
+    else:
+        DISJ_OK = False
+
+# ------------------------------------------------------------------
+# 5. the covers
+# ------------------------------------------------------------------
+
+NONCO = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for j in range(NPI):
+        if j != i and not (PC[i] & PC[j]):
+            m |= (1 << j)
+    NONCO[i] = m
+
+COVERS = []
+
+
+def clique(chosen, cand):
+    if len(chosen) == 8:
+        COVERS.append(tuple(chosen))
+        return
+    c = cand
+    while c:
+        low = c & (-c)
+        b = low.bit_length() - 1
+        c ^= low
+        chosen.append(b)
+        clique(chosen, cand & NONCO[b] & ~((1 << (b + 1)) - 1))
+        chosen.pop()
+
+
+clique([], (1 << NPI) - 1)
+NCOV = len(COVERS)
+COVSET = [set(c) for c in COVERS]
+
+# every cover meets every cutting exactly once
+COVEXACT = True
+for c in COVERS:
+    u = 0
+    for t in c:
+        if u & PC[t]:
+            COVEXACT = False
+        u |= PC[t]
+    if u != FULLC:
+        COVEXACT = False
+
+BROW = [[1 if i in cs else 0 for i in range(NPI)] for cs in COVSET]
+BRS = sorted(set(sum(r) for r in BROW))
+BCS = sorted(set(sum(BROW[k][i] for k in range(NCOV)) for i in range(NPI)))
+CS = [tuple(sorted(c)) for c in COVERS]
+COVM = [sum(1 << i for i in c) for c in CS]
+
+# corner sharing: how many pieces of one cutting hold a given corner
+NCORN = len(CORN)
+SLOTS = SIZES[0] * 5
+OMIN = 10 ** 6
+OMAX = 0
+for s in SOLS:
+    occ = [0] * 16
+    for t in s:
+        for c in KEPT[t]:
+            occ[c] += 1
+    a = min(occ)
+    b = max(occ)
+    if a < OMIN:
+        OMIN = a
+    if b > OMAX:
+        OMAX = b
+
+# ------------------------------------------------------------------
+# 6. exact ranks and kernels
+# ------------------------------------------------------------------
+
+GM = [[popc(PC[i] & PC[j]) for j in range(NPI)] for i in range(NPI)]
+GM2 = [[0] * NPI for _ in range(NPI)]
+for s in CUT:
+    for i in s:
+        gi = GM2[i]
+        for j in s:
+            gi[j] += 1
+GRAM_OK = (GM == GM2)
+ACS = sorted(set(GM[i][i] for i in range(NPI)))
+
+
+def rref(rows, ncol, want_kernel):
+    M = [[FR(x) for x in r] for r in rows]
+    nr = len(M)
+    piv = []
+    r = 0
+    for c in range(ncol):
+        p = -1
+        for i in range(r, nr):
+            if M[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        M[r], M[p] = M[p], M[r]
+        pv = M[r][c]
+        M[r] = [x / pv for x in M[r]]
+        for i in range(nr):
+            if i != r and M[i][c] != 0:
+                f = M[i][c]
+                Mi = M[i]
+                Mr = M[r]
+                M[i] = [Mi[k] - f * Mr[k] for k in range(ncol)]
+        piv.append(c)
+        r += 1
+        if r == nr:
+            break
+    ker = []
+    if want_kernel:
+        ps = set(piv)
+        for fc in range(ncol):
+            if fc in ps:
+                continue
+            v = [FR(0)] * ncol
+            v[fc] = FR(1)
+            for i, pcl in enumerate(piv):
+                v[pcl] = -M[i][fc]
+            ker.append(v)
+    return r, ker, [M[i] for i in range(r)]
+
+
+def rank_fwd(rows, ncol, cap=None):
+    piv = {}
+    r = 0
+    for row in rows:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for k in range(c, ncol):
+                    if w[k] != 0:
+                        v[k] -= f * w[k]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                break
+        if cap is not None and r >= cap:
+            break
+    return r
+
+
+def select_rows(pairs, ncol, want):
+    piv = {}
+    sel = []
+    r = 0
+    last = -1
+    for k, row in pairs:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for t in range(c, ncol):
+                    if w[t] != 0:
+                        v[t] -= f * w[t]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                sel.append(k)
+                last = k
+                break
+        if r == want:
+            break
+    return sel, last
+
+
+def clear_den(v):
+    den = 1
+    for x in v:
+        den = den * x.denominator // math.gcd(den, x.denominator)
+    return [int(x * den) for x in v]
+
+
+def perp_all(rows, kers):
+    for r in rows:
+        ir = clear_den(r)
+        for k in kers:
+            if sum(a * b for a, b in zip(ir, k)) != 0:
+                return False
+    return True
+
+
+# the cutting table's rank and kernel come through the product substitution
+RANKA, KERA, BASA = rref(GM, NPI, True)
+RANKB, KERB, BASB = rref(BROW, NPI, True)
+KA = [clear_den(v) for v in KERA]
+KB = [clear_den(v) for v in KERB]
+NKA = len(KA)
+NKB = len(KB)
+
+# annihilation, entrywise, on the tables themselves
+KANN_A = True
+for iv in KA:
+    g = iv.__getitem__
+    for s in CUT:
+        if sum(map(g, s)) != 0:
+            KANN_A = False
+            break
+    if not KANN_A:
+        break
+KANN_B = True
+for iv in KB:
+    g = iv.__getitem__
+    for c in CS:
+        if sum(map(g, c)) != 0:
+            KANN_B = False
+            break
+    if not KANN_B:
+        break
+
+RKKA = rank_fwd([list(v) for v in KA], NPI)
+RKKB = rank_fwd([list(v) for v in KB], NPI)
+
+
+def arow(k):
+    r = [0] * NPI
+    for i in CUT[k]:
+        r[i] = 1
+    return r
+
+
+SELA, LASTA = select_rows(((k, arow(k)) for k in range(NS)), NPI, RANKA)
+SELB, LASTB = select_rows(((k, BROW[k]) for k in range(NCOV)), NPI, RANKB)
+RAROW = [arow(k) for k in SELA]
+RBROW = [list(BROW[k]) for k in SELB]
+RSELA = rank_fwd(RAROW, NPI)
+RSELB = rank_fwd(RBROW, NPI)
+
+ONE = [1] * NPI
+DSUM = rank_fwd(RAROW + RBROW, NPI)
+DKERJ = rank_fwd([list(v) for v in KA] + [list(v) for v in KB], NPI)
+DMEET = NPI - DKERJ
+ONE_A = all(sum(a * b for a, b in zip(ONE, v)) == 0 for v in KA)
+ONE_B = all(sum(a * b for a, b in zip(ONE, v)) == 0 for v in KB)
+
+# ------------------------------------------------------------------
+# 7. the group: permuting the four coordinates and flipping any of them
+# ------------------------------------------------------------------
+
+DESC = []
+MAPS = []
+for sg in itertools.permutations(range(4)):
+    for fl in range(16):
+        m = []
+        for c in range(16):
+            b = CORN[c]
+            nb = [0, 0, 0, 0]
+            for i in range(4):
+                nb[sg[i]] = b[i] ^ ((fl >> i) & 1)
+            m.append(sum(nb[k] << k for k in range(4)))
+        DESC.append((sg, fl))
+        MAPS.append(tuple(m))
+
+NGRP = len(MAPS)
+MAPSET = set(MAPS)
+MAPS_DISTINCT = (len(MAPSET) == NGRP)
+CLOSED = True
+NPROD = 0
+for a in MAPS:
+    for b in MAPS:
+        NPROD += 1
+        if tuple(a[b[c]] for c in range(16)) not in MAPSET:
+            CLOSED = False
+            break
+    if not CLOSED:
+        break
+
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PERM = []
+KEEPS_PIECES = True
+for m in MAPS:
+    p = []
+    for i in range(NPI):
+        img = tuple(sorted(m[c] for c in KEPT[USED[i]]))
+        t = KDX.get(img)
+        if t is None or t not in POS:
+            KEEPS_PIECES = False
+            break
+        p.append(POS[t])
+    if not KEEPS_PIECES:
+        break
+    PERM.append(tuple(p))
+PERMSET = set(PERM)
+PERM_DISTINCT = (len(PERMSET) == NGRP)
+BIJ = all(sorted(p) == list(range(NPI)) for p in PERM)
+
+# ------------------------------------------------------------------
+# 8. what the group preserves
+# ------------------------------------------------------------------
+
+AR0 = sorted(CUTM)
+BR0 = sorted(COVM)
+STAB_A = 0
+STAB_B = 0
+for p in PERM:
+    PB = [1 << p[j] for j in range(NPI)]
+    g = PB.__getitem__
+    if sorted(sum(map(g, s)) for s in CUT) == AR0:
+        STAB_A += 1
+    if sorted(sum(map(g, c)) for c in CS) == BR0:
+        STAB_B += 1
+
+CHI = [sum(1 for i in range(NPI) if p[i] == i) for p in PERM]
+HP = {}
+for f in CHI:
+    HP[f] = HP.get(f, 0) + 1
+HIST_P = sorted(HP.items())
+SUMCHI = sum(CHI)
+SUMSQ = sum(f * f for f in CHI)
+
+
+def pair_orbits(perms, n):
+    par = list(range(n * n))
+
+    def find(x):
+        r = x
+        while par[r] != r:
+            r = par[r]
+        while par[x] != r:
+            par[x], x = r, par[x]
+        return r
+
+    for p in perms:
+        for i in range(n):
+            bi = i * n
+            pi = p[i] * n
+            for j in range(n):
+                a = find(bi + j)
+                b = find(pi + p[j])
+                if a != b:
+                    par[a] = b
+    return [find(x) for x in range(n * n)]
+
+
+ROOT = pair_orbits(PERM, NPI)
+CANON = {}
+for x in range(NPI * NPI):
+    r = ROOT[x]
+    if r not in CANON:
+        CANON[r] = len(CANON)
+NORB = len(CANON)
+SUMSQ_OK = (SUMSQ == NGRP * NORB)
+
+# ------------------------------------------------------------------
+# 9. the commuting matrices
+# ------------------------------------------------------------------
+
+LAB = [[CANON[ROOT[i * NPI + j]] for j in range(NPI)] for i in range(NPI)]
+CLS = [0] * NORB
+for i in range(NPI):
+    Li = LAB[i]
+    for j in range(NPI):
+        CLS[Li[j]] += 1
+PARTITION = (sum(CLS) == NPI * NPI and min(CLS) > 0)
+
+LAB_INV = True
+for p in PERM:
+    for i in range(NPI):
+        Li = LAB[i]
+        Lp = LAB[p[i]]
+        for j in range(NPI):
+            if Lp[p[j]] != Li[j]:
+                LAB_INV = False
+                break
+        if not LAB_INV:
+            break
+    if not LAB_INV:
+        break
+
+# out-degree of each label, measured on every source and checked constant
+DEG = [[0] * NORB for _ in range(NPI)]
+for i in range(NPI):
+    Li = LAB[i]
+    di = DEG[i]
+    for j in range(NPI):
+        di[Li[j]] += 1
+DEG_CONST = all(DEG[i] == DEG[0] for i in range(NPI))
+DC = {}
+for k in range(NORB):
+    DC[DEG[0][k]] = DC.get(DEG[0][k], 0) + 1
+CENSUS = sorted(DC.items())
+DEGSUM = sum(d * c for d, c in CENSUS)
+DEGCNT = sum(c for d, c in CENSUS)
+
+# ------------------------------------------------------------------
+# 10. the negative
+# ------------------------------------------------------------------
+
+
+def keep_labels(sups, kers):
+    cnt = []
+    for s in sups:
+        c = [[0] * NORB for _ in range(NPI)]
+        for i in s:
+            Li = LAB[i]
+            for j in range(NPI):
+                c[j][Li[j]] += 1
+        cnt.append(c)
+    keep = []
+    fails = []
+    for k in range(NORB):
+        ok = True
+        for c in cnt:
+            t = [c[j][k] for j in range(NPI)]
+            for v in kers:
+                tot = 0
+                for a, b in zip(t, v):
+                    if a:
+                        tot += a * b
+                if tot != 0:
+                    ok = False
+                    break
+            if not ok:
+                break
+        if ok:
+            keep.append(k)
+        else:
+            fails.append(k)
+    return keep, fails
+
+
+KEEP_A, FAIL_A = keep_labels([CUT[k] for k in SELA], KA)
+KEEP_B, FAIL_B = keep_labels([CS[k] for k in SELB], KB)
+NKEEP_A = len(KEEP_A)
+NKEEP_B = len(KEEP_B)
+KSTAR = FAIL_A[0]
+DEG_KEEP_A = sorted(set(DEG[0][k] for k in KEEP_A))
+DEG_KSTAR = DEG[0][KSTAR]
+
+# ------------------------------------------------------------------
+# 11. controls
+# ------------------------------------------------------------------
+
+CTRL_A = True
+for k in range(NORB):
+    t = [0] * NPI
+    for i in range(NPI):
+        Li = LAB[i]
+        for j in range(NPI):
+            if Li[j] == k:
+                t[j] += 1
+    if len(set(t)) != 1 or t[0] == 0:
+        CTRL_A = False
+
+SHIFT = tuple(divmod(p + 1, NPI)[1] for p in range(NPI))
+SHIFT_IN = (SHIFT in PERMSET)
+SB = [1 << SHIFT[j] for j in range(NPI)]
+SHIFT_KEEPS = (sorted(sum(map(SB.__getitem__, s)) for s in CUT) == AR0)
+
+# ------------------------------------------------------------------
+# 12. the second reading space
+# ------------------------------------------------------------------
+
+UMAT = [[(1 if i == j else 0) + (1 if LAB[i][j] == KSTAR else 0)
+         for j in range(NPI)] for i in range(NPI)]
+RANKU = rank_fwd(UMAT, NPI)
+
+MU = []
+for k in SELA:
+    t = [0] * NPI
+    for i in CUT[k]:
+        Li = LAB[i]
+        t[i] += 1
+        for j in range(NPI):
+            if Li[j] == KSTAR:
+                t[j] += 1
+    MU.append(t)
+RANKMU = rank_fwd(MU, NPI)
+NOUT = 0
+for t in MU:
+    if any(sum(a * b for a, b in zip(t, v)) != 0 for v in KA):
+        NOUT += 1
+
+GEN_DESC = [((1, 2, 3, 0), 0), ((1, 0, 2, 3), 1)]
+GENS = [PERM[DESC.index(d)] for d in GEN_DESC]
+IDP = tuple(range(NPI))
+SEEN = set([IDP])
+FRONT = [IDP]
+while FRONT:
+    NEW = []
+    for a in FRONT:
+        for g in GENS:
+            b = tuple(g[a[i]] for i in range(NPI))
+            if b not in SEEN:
+                SEEN.add(b)
+                NEW.append(b)
+    FRONT = NEW
+GEN_OK = (len(SEEN) == NGRP and SEEN == PERMSET)
+
+MU_STABLE = True
+for g in GENS:
+    inv = [0] * NPI
+    for a in range(NPI):
+        inv[g[a]] = a
+    rows = [list(r) for r in MU] + [[r[inv[j]] for j in range(NPI)] for r in MU]
+    if rank_fwd(rows, NPI) != RANKMU:
+        MU_STABLE = False
+
+# ------------------------------------------------------------------
+# 13. pass-down to the axiom's covariance group
+# ------------------------------------------------------------------
+
+
+def psign(sg):
+    s = 1
+    for a in range(4):
+        for b in range(a + 1, 4):
+            if sg[a] > sg[b]:
+                s = -s
+    return s
+
+
+SUB_SIZE = []
+SUB_PIECE = []
+SUB_PAIR = []
+SUB_OK = True
+for d in range(4):
+    sub = []
+    for e in range(NGRP):
+        sg, fl = DESC[e]
+        if sg[d] != d:
+            continue
+        if (fl >> d) & 1:
+            continue
+        nf = sum((fl >> i) & 1 for i in range(4))
+        if psign(sg) * ((-1) ** nf) != 1:
+            continue
+        sub.append(PERM[e])
+    ss = set(sub)
+    if len(sub) != 24 or not ss.issubset(PERMSET):
+        SUB_OK = False
+    for a in sub:
+        for b in sub:
+            if tuple(a[b[i]] for i in range(NPI)) not in ss:
+                SUB_OK = False
+    seen = [False] * NPI
+    no = 0
+    for a in range(NPI):
+        if seen[a]:
+            continue
+        no += 1
+        fr = [a]
+        seen[a] = True
+        while fr:
+            x = fr.pop()
+            for p in sub:
+                y = p[x]
+                if not seen[y]:
+                    seen[y] = True
+                    fr.append(y)
+    rt = pair_orbits(sub, NPI)
+    SUB_SIZE.append(len(sub))
+    SUB_PIECE.append(no)
+    SUB_PAIR.append(len(set(rt)))
+SUB_BIGGER = all(x > NORB for x in SUB_PAIR)
+
+# ------------------------------------------------------------------
+# 14. the piece stabilizer, its two parts, and theorem A on real numbers
+# ------------------------------------------------------------------
+
+STABP = [p for p in PERM if p[0] == 0]
+NSTABP = len(STABP)
+STABG = [p for p in STABP if p != tuple(range(NPI))][0]
+seen = [False] * NPI
+SZP = {}
+for a in range(NPI):
+    if seen[a]:
+        continue
+    orb = set(p[a] for p in STABP)
+    for x in orb:
+        seen[x] = True
+    SZP[len(orb)] = SZP.get(len(orb), 0) + 1
+SZP_LIST = sorted(SZP.items())
+FP = SZP.get(1, 0)
+SP2 = SZP.get(2, 0)
+STAB_SIMPLE = (FP + 2 * SP2 == NPI)
+STAB_ORB = (FP + SP2 == NORB)
+
+
+def two_parts(g):
+    inv = [0] * NPI
+    for a in range(NPI):
+        inv[g[a]] = a
+    P = [[1 if g[i] == j else 0 for j in range(NPI)] for i in range(NPI)]
+    MM = [[P[i][j] - (1 if i == j else 0) for j in range(NPI)] for i in range(NPI)]
+    MP = [[P[i][j] + (1 if i == j else 0) for j in range(NPI)] for i in range(NPI)]
+    rm, kp, bb = rref(MM, NPI, True)
+    rp, km, bb = rref(MP, NPI, True)
+    dplus = NPI - rm
+    dminus = NPI - rp
+    ap = rank_fwd([[x + r[inv[j]] for j, x in enumerate(r)] for r in RAROW], NPI)
+    am = rank_fwd([[x - r[inv[j]] for j, x in enumerate(r)] for r in RAROW], NPI)
+    bp = rank_fwd([[x + r[inv[j]] for j, x in enumerate(r)] for r in RBROW], NPI)
+    bm = rank_fwd([[x - r[inv[j]] for j, x in enumerate(r)] for r in RBROW], NPI)
+    return (dplus, dminus, ap, am, bp, bm), kp, km
+
+
+TWO = []
+for g in PERM:
+    if g == IDP:
+        continue
+    if tuple(g[g[i]] for i in range(NPI)) != IDP:
+        continue
+    if any(g[i] == i for i in range(NPI)):
+        TWO.append(g)
+NTWO = len(TWO)
+TWO = [STABG] + [g for g in TWO if g != STABG]
+SIX, KPLUS, KMINUS = two_parts(TWO[0])
+DPLUS, DMINUS, APL, AMI, BPL, BMI = SIX
+EIG_SUM = (DPLUS + DMINUS == NPI)
+ONE_PLUS = all(sum(a * b for a, b in zip(ONE, v)) == 0
+               for v in [clear_den(w) for w in KMINUS])
+SPLIT_A = (APL + AMI == RANKA)
+SPLIT_B = (BPL + BMI == RANKB)
+THMA_PLUS = (APL + BPL == DPLUS + DMEET)
+THMA_MINUS = (AMI + BMI == DMINUS)
+ALLSIX = all(two_parts(g)[0] == SIX for g in TWO)
+
+# the structural upgrade, tested and reported
+SPAN = [list(ONE)] + [list(v) for v in KMINUS]
+DSPAN = rank_fwd(SPAN, NPI)
+DJOINT = rank_fwd(SPAN + RAROW, NPI)
+INSIDE = (DJOINT == DSPAN)
+MEET_IS_RANK = (AMI == RANKA)
+DEMOTE_OK = (DSPAN == DMINUS + DMEET
+             and RANKA + DSPAN - DJOINT == AMI + DMEET)
+
+EIG_KER = (DPLUS == NKA)
+EIG_RANK = (DMINUS == RANKA)
+
+# ------------------------------------------------------------------
+# 15. the cover-side control
+# ------------------------------------------------------------------
+
+CIDX = dict((c, k) for k, c in enumerate(CS))
+CPERM = []
+COV_OK = True
+for p in PERM:
+    q = []
+    for c in CS:
+        im = tuple(sorted(p[x] for x in c))
+        if im not in CIDX:
+            COV_OK = False
+            break
+        q.append(CIDX[im])
+    if not COV_OK:
+        break
+    CPERM.append(tuple(q))
+COV_BIJ = (len(CPERM) == NGRP
+           and all(sorted(q) == list(range(NCOV)) for q in CPERM))
+orb = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for q in CPERM:
+        y = q[x]
+        if y not in orb:
+            orb.add(y)
+            fr.append(y)
+COV_TRANS = (len(orb) == NCOV)
+
+CCHI = [sum(1 for i in range(NCOV) if q[i] == i) for q in CPERM]
+HC = {}
+for f in CCHI:
+    HC[f] = HC.get(f, 0) + 1
+HIST_C = sorted(HC.items())
+CSUM = sum(CCHI)
+CSUMSQ = sum(f * f for f in CCHI)
+CROOT = pair_orbits(CPERM, NCOV)
+NPOC = len(set(CROOT))
+CSUMSQ_OK = (CSUMSQ == NGRP * NPOC)
+
+STABC = [e for e in range(NGRP) if CPERM[e][0] == 0]
+NSTABC = len(STABC)
+seen = [False] * NCOV
+SZC = {}
+for a in range(NCOV):
+    if seen[a]:
+        continue
+    o = set(CPERM[e][a] for e in STABC)
+    for x in o:
+        seen[x] = True
+    SZC[len(o)] = SZC.get(len(o), 0) + 1
+SZC_LIST = sorted(SZC.items())
+FC = SZC.get(1, 0)
+SC2 = SZC.get(2, 0)
+CSTAB_SIMPLE = (FC + 2 * SC2 == NCOV)
+CSTAB_ORB = (FC + SC2 == NPOC)
+CSTAB_OTHER = [e for e in STABC if PERM[e] != IDP]
+CSTAB_FIXP = CHI[CSTAB_OTHER[0]] if len(CSTAB_OTHER) == 1 else -1
+
+SAME_ACTION = (CHI == CCHI)
+PIECE_YES = (NORB == NKA)
+COVER_YES = (NPOC == NKB)
+ONE_SIDED = (PIECE_YES != COVER_YES)
+SAME_OK = ((not SAME_ACTION) or (NORB == NPOC))
+
+# ------------------------------------------------------------------
+# 16. the symmetry does not fix the cover-side dimension either
+# ------------------------------------------------------------------
+
+
+def sweep_labels(act1, n1, act2, n2):
+    L = [[-1] * n2 for _ in range(n1)]
+    nl = 0
+    for i in range(n1):
+        Li = L[i]
+        for j in range(n2):
+            if Li[j] >= 0:
+                continue
+            for e in range(NGRP):
+                L[act1[e][i]][act2[e][j]] = nl
+            nl += 1
+    return L, nl
+
+
+CPLAB, NCP = sweep_labels(CPERM, NCOV, PERM, NPI)
+CP_FULL = all(min(r) >= 0 for r in CPLAB)
+PPLAB, NPP = sweep_labels(PERM, NPI, PERM, NPI)
+PP_FULL = all(min(r) >= 0 for r in PPLAB)
+PP_AGREE = (NPP == NORB)
+
+BV = [-1] * NCP
+BEQUI = True
+for i in range(NCOV):
+    Li = CPLAB[i]
+    Bi = BROW[i]
+    for j in range(NPI):
+        k = Li[j]
+        if BV[k] < 0:
+            BV[k] = Bi[j]
+        elif BV[k] != Bi[j]:
+            BEQUI = False
+
+QPP, RPP = divmod(sum(f * f for f in CHI), NGRP)
+QCC, RCC = divmod(sum(f * f for f in CCHI), NGRP)
+QCP, RCP = divmod(sum(CCHI[e] * CHI[e] for e in range(NGRP)), NGRP)
+PAIR_DIV = (RPP == 0 and RCC == 0 and RCP == 0)
+PAIR_PP = (QPP == NPP)
+PAIR_CP = (QCP == NCP)
+PAIR_CC = (QCC == NPOC)
+
+
+def rank_modp(M, p):
+    A = np.mod(np.array(M, dtype=np.int64), p)
+    nr = A.shape[0]
+    nc = A.shape[1]
+    r = 0
+    for c in range(nc):
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        piv = r + int(nz[0])
+        if piv != r:
+            tmp = A[r].copy()
+            A[r] = A[piv]
+            A[piv] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        if r + 1 < nr:
+            A[r + 1:] = np.mod(A[r + 1:] - np.outer(A[r + 1:, c], A[r]), p)
+        r += 1
+        if r == nr:
+            break
+    return int(r)
+
+
+# one mod-p rank path only, tied to the exact rational ranks before it is used
+RANKB_P = rank_modp(BROW, PRIME)
+RANKA_P = rank_modp(RAROW, PRIME)
+GOOD_PRIME = (RANKB_P == RANKB and RANKA_P == RANKA)
+
+CPL = np.array(CPLAB, dtype=np.int64)
+PPL = np.array(PPLAB, dtype=np.int64)
+
+
+def ind_rank(L, j):
+    return rank_modp((L == j).astype(np.int64), PRIME)
+
+
+CPRK = [ind_rank(CPL, j) for j in range(NCP)]
+WIT = max(CPRK)
+RKH = {}
+for v in CPRK:
+    RKH[v] = RKH.get(v, 0) + 1
+RKHIST = sorted(RKH.items())
+CTL = max(ind_rank(PPL, j) for j in range(NPP))
+CTL_OK = (CTL == NPI)
+BEATS = (WIT > RANKB)
+GAIN = WIT - RANKB
+TIEVAL = NPI - WIT + 1
+
+CELLS = [[] for _ in range(NCP)]
+for i in range(NCOV):
+    Li = CPLAB[i]
+    for k in range(NPI):
+        CELLS[Li[k]].append((i, k))
+
+# The rule, stated before it is tested. If every orbit has size the group
+# order then the group acts freely on the cells of one orbit, so each cover
+# lies in exactly two of its cells and so does each piece: the orbit read as a
+# bipartite graph on covers and pieces is two-regular, hence a disjoint union
+# of cycles. A cycle on k covers and k pieces gives a k by k matrix with two
+# ones in each row and column placed cyclically, whose determinant is
+# 1 + (-1)^(k+1), so that block has rank k - 1 for even k and rank k for odd k.
+# The predicted rank of the orbit is the sum of those block ranks.
+
+
+def cyc_lens(cells):
+    rw = {}
+    cl = {}
+    for (i, k) in cells:
+        rw.setdefault(i, []).append(k)
+        cl.setdefault(k, []).append(i)
+    if len(rw) != NCOV or len(cl) != NPI:
+        return None
+    for v in rw.values():
+        if len(v) != 2:
+            return None
+    for v in cl.values():
+        if len(v) != 2:
+            return None
+    seen = [False] * NCOV
+    lens = []
+    for s in range(NCOV):
+        if seen[s]:
+            continue
+        cur = s
+        pk = -1
+        cnt = 0
+        while not seen[cur]:
+            seen[cur] = True
+            cnt += 1
+            a, b = rw[cur]
+            nk = b if a == pk else a
+            x, y = cl[nk]
+            pk = nk
+            cur = y if x == cur else x
+        lens.append(cnt)
+    return lens
+
+
+TWOREG = True
+CYCBAD = 0
+CYCTYPE = set()
+for j in range(NCP):
+    lens = cyc_lens(CELLS[j])
+    if lens is None:
+        TWOREG = False
+        CYCBAD += 1
+        continue
+    pred = 0
+    for k in lens:
+        pred += k - 1 if divmod(k, 2)[1] == 0 else k
+    if pred != CPRK[j]:
+        CYCBAD += 1
+    CYCTYPE.add((len(lens), tuple(sorted(set(lens))), sum(lens)))
+CYCLIST = sorted(CYCTYPE)
+CYC_OK = (TWOREG and CYCBAD == 0 and len(CYCLIST) == 1)
+
+SVAL = QPP + QCC - 2 * QCP
+PROD = NGRP * SVAL
+ROOT_I = math.isqrt(PROD) if PROD >= 0 else -1
+HALF = ROOT_I // 2
+BOUND = NPI - HALF
+HAND_OK = (PROD >= 0 and ROOT_I * ROOT_I <= PROD
+           and (ROOT_I + 1) * (ROOT_I + 1) > PROD and WIT >= BOUND)
+
+
+# ------------------------------------------------------------------
+# 17. the orbit matrices, the structure constants, and the centre
+# ------------------------------------------------------------------
+
+LA = np.array(LAB, dtype=np.int64)
+OPS = np.zeros((NORB, NPI, NPI), dtype=np.int64)
+for a in range(NORB):
+    OPS[a] = (LA == a).astype(np.int64)
+
+CA = np.array(CPLAB, dtype=np.int64)
+OXS = np.zeros((NCP, NCOV, NPI), dtype=np.int64)
+for k in range(NCP):
+    OXS[k] = (CA == k).astype(np.int64)
+
+BM = np.array(BROW, dtype=np.int64)
+
+
+def op_of(z):
+    return np.tensordot(np.array(z, dtype=np.int64), OPS, axes=([0], [0]))
+
+
+# each orbit matrix commutes with the action, each cell matrix intertwines it
+EQ_P = 0
+EQ_X = 0
+EQ_OK = True
+for e in [1, 7, 40, 191, 383]:
+    p = PERM[e]
+    q = CPERM[e]
+    JX = np.array(p, dtype=np.int64)
+    for a in [0, 17, 61, 103]:
+        EQ_P += 1
+        if not np.array_equal(OPS[a][np.ix_(JX, JX)], OPS[a]):
+            EQ_OK = False
+    QX = np.array(q, dtype=np.int64)
+    for k in [0, 23, 71, 95]:
+        EQ_X += 1
+        if not np.array_equal(OXS[k][np.ix_(QX, JX)], OXS[k]):
+            EQ_OK = False
+
+# the cover table is a union of whole cell orbits
+INB = []
+BSPLIT = True
+for k in range(NCP):
+    vs = set(BM[CA == k].tolist())
+    if vs == set([1]):
+        INB.append(k)
+    elif vs != set([0]):
+        BSPLIT = False
+NINB = len(INB)
+BREB = np.zeros((NCOV, NPI), dtype=np.int64)
+for k in INB:
+    BREB = BREB + OXS[k]
+BM_OK = (BSPLIT and NINB == 4 and np.array_equal(BREB, BM))
+del BREB
+
+REP = [None] * NORB
+for i in range(NPI):
+    Li = LAB[i]
+    for j in range(NPI):
+        c = Li[j]
+        if REP[c] is None:
+            REP[c] = (i, j)
+REP_FULL = all(x is not None for x in REP)
+
+SC = np.zeros((NORB, NORB, NORB), dtype=np.int64)
+for c in range(NORB):
+    i, j = REP[c]
+    Li = LAB[i]
+    for k in range(NPI):
+        SC[Li[k]][LAB[k][j]][c] += 1
+SCMAX = int(SC.max())
+
+SCPAIRS = [(0, 0), (7, 13), (23, 58), (41, 41), (66, 95), (88, 30), (103, 72)]
+SC_CHK = 0
+SC_AGREE = True
+SC_ENT = 0
+for a, b in SCPAIRS:
+    P1 = OPS[a] @ OPS[b]
+    P2 = np.tensordot(SC[a][b], OPS, axes=([0], [0]))
+    SC_ENT = max(SC_ENT, int(np.abs(P1).max()), int(np.abs(P2).max()))
+    SC_CHK += 1
+    if not np.array_equal(P1, P2):
+        SC_AGREE = False
+SC_SAFE = (SC_ENT < 2 ** 40)
+del P1, P2
+
+DFC = SC - np.transpose(SC, (1, 0, 2))
+CON = np.ascontiguousarray(np.transpose(DFC, (1, 2, 0)).reshape(NORB * NORB, NORB))
+NCON = int(CON.shape[0])
+del DFC
+
+
+def mod_pick(rows, ncol, p):
+    pc = []
+    sel = []
+    PM = np.zeros((0, ncol), dtype=np.int64)
+    for idx in range(rows.shape[0]):
+        v = np.mod(rows[idx].astype(np.int64), p)
+        if pc:
+            co = v[np.array(pc, dtype=np.int64)]
+            if co.any():
+                v = np.mod(v - co @ PM, p)
+        nz = np.nonzero(v)[0]
+        if nz.size == 0:
+            continue
+        c = int(nz[0])
+        v = np.mod(v * pow(int(v[c]), p - 2, p), p)
+        if PM.shape[0]:
+            col = PM[:, c].copy()
+            if col.any():
+                PM = np.mod(PM - np.outer(col, v), p)
+        PM = np.vstack([PM, v.reshape(1, ncol)])
+        pc.append(c)
+        sel.append(idx)
+        if len(pc) == ncol:
+            break
+    return sel, len(pc)
+
+
+def mod_ker(A, p):
+    A = np.mod(np.array(A, dtype=np.int64), p)
+    nr = A.shape[0]
+    nc = A.shape[1]
+    pc = []
+    r = 0
+    for c in range(nc):
+        if r >= nr:
+            break
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        pr = r + int(nz[0])
+        if pr != r:
+            tmp = A[r].copy()
+            A[r] = A[pr]
+            A[pr] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        col = A[:, c].copy()
+        col[r] = 0
+        if col.any():
+            A = np.mod(A - np.outer(col, A[r]), p)
+        pc.append(c)
+        r += 1
+    ps = set(pc)
+    free = [c for c in range(nc) if c not in ps]
+    K = np.zeros((nc, len(free)), dtype=np.int64)
+    for t, fc in enumerate(free):
+        K[fc, t] = 1
+        for i, cc in enumerate(pc):
+            K[cc, t] = divmod(-int(A[i, fc]), p)[1]
+    return K
+
+
+SEL, RKC = mod_pick(CON, NORB, PRIME)
+NSEL = len(SEL)
+CROWS = [CON[i].tolist() for i in SEL]
+RKX, KERC, BASC = rref(CROWS, NORB, True)
+CENB = []
+for v in KERC:
+    iv = clear_den(v)
+    gg = 0
+    for x in iv:
+        gg = math.gcd(gg, abs(x))
+    if gg > 1:
+        iv = [x // gg for x in iv]
+    CENB.append(iv)
+NCEN = len(CENB)
+ZMAX = max(max(abs(x) for x in z) for z in CENB)
+GUARD_OK = (ZMAX * SCMAX * NORB < 2 ** 62)
+CEN_OK = True
+CEN_CHK = 0
+for z in CENB:
+    za = np.array(z, dtype=np.int64)
+    LZ = np.tensordot(za, SC, axes=([0], [0]))
+    RZ = np.tensordot(za, SC, axes=([0], [1]))
+    CEN_CHK += LZ.size
+    if not np.array_equal(LZ, RZ):
+        CEN_OK = False
+
+# ------------------------------------------------------------------
+# 18. one central element and the twenty values it separates
+# ------------------------------------------------------------------
+
+NBCOL = [[CENB[l][a] for l in range(NCEN)] for a in range(NORB)]
+
+
+def esolve(AM, RH, n, m):
+    nr = len(AM)
+    W = [[FR(AM[i][j]) for j in range(n)] + [FR(RH[i][j]) for j in range(m)]
+         for i in range(nr)]
+    piv = []
+    r = 0
+    for c in range(n):
+        p = -1
+        for i in range(r, nr):
+            if W[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        W[r], W[p] = W[p], W[r]
+        pv = W[r][c]
+        W[r] = [x / pv for x in W[r]]
+        for i in range(nr):
+            if i != r and W[i][c] != 0:
+                f = W[i][c]
+                Wi = W[i]
+                Wr = W[r]
+                W[i] = [Wi[t] - f * Wr[t] for t in range(n + m)]
+        piv.append(c)
+        r += 1
+    if r != n:
+        return None
+    for i in range(r, nr):
+        for t in range(n, n + m):
+            if W[i][t] != 0:
+                return None
+    X = [[FR(0)] * m for _ in range(n)]
+    for i, c in enumerate(piv):
+        for t in range(m):
+            X[c][t] = W[i][n + t]
+    return X
+
+
+TRY = 0
+TWORK = 0
+B0 = 0
+VALS = []
+NUL = []
+M0 = None
+Z0 = None
+while TRY < 24 and TWORK == 0:
+    TRY += 1
+    co = [1 + divmod(TRY * (k + 1) * (k + 1) + k, 37)[1] for k in range(NCEN)]
+    wv = [0] * NORB
+    for k in range(NCEN):
+        ck = co[k]
+        zk = CENB[k]
+        for a in range(NORB):
+            wv[a] += ck * zk[a]
+    WVA = np.array(wv, dtype=np.int64)
+    TT = np.tensordot(WVA, SC, axes=([0], [0]))
+    VC = [(np.array(CENB[k], dtype=np.int64) @ TT).tolist() for k in range(NCEN)]
+    RH = [[VC[k][c] for k in range(NCEN)] for c in range(NORB)]
+    XS = esolve(NBCOL, RH, NCEN, NCEN)
+    if XS is None:
+        continue
+    if not all(x.denominator == 1 for row in XS for x in row):
+        continue
+    MC = [[int(x) for x in row] for row in XS]
+    BB = max(sum(abs(x) for x in row) for row in MC)
+    vv = []
+    nn = []
+    for lam in range(-BB, BB + 1):
+        rr = rank_fwd([[MC[i][j] - (lam if i == j else 0) for j in range(NCEN)]
+                       for i in range(NCEN)], NCEN)
+        if rr < NCEN:
+            vv.append(lam)
+            nn.append(NCEN - rr)
+    if len(vv) == NCEN and all(x == 1 for x in nn):
+        TWORK = TRY
+        B0 = BB
+        VALS = vv
+        NUL = nn
+        M0 = MC
+        Z0 = op_of(wv)
+
+VAL_OK = (TWORK > 0 and len(VALS) == NCEN and all(x == 1 for x in NUL))
+
+REP_CHK = 0
+REP_OK = VAL_OK
+if VAL_OK:
+    for k in [0, 1, NCEN - 1]:
+        LHS = Z0 @ op_of(CENB[k])
+        RHS = np.zeros((NPI, NPI), dtype=np.int64)
+        for l in range(NCEN):
+            if M0[l][k]:
+                RHS = RHS + M0[l][k] * op_of(CENB[l])
+        REP_CHK += 1
+        if not np.array_equal(LHS, RHS):
+            REP_OK = False
+    del LHS, RHS
+
+# ------------------------------------------------------------------
+# 19. the part table
+# ------------------------------------------------------------------
+
+EYE = np.eye(NPI, dtype=np.int64)
+PARTS = []
+PART_OK = VAL_OK
+for lam in VALS:
+    AZ = np.mod(Z0 - lam * EYE, PRIME)
+    KB = mod_ker(AZ, PRIME)
+    dim = int(KB.shape[1])
+    PR = np.mod(np.tensordot(OPS, KB, axes=([2], [0])), PRIME)
+    m2 = rank_modp(PR.reshape(NORB, NPI * dim), PRIME)
+    m = math.isqrt(m2)
+    XR = np.mod(np.tensordot(OXS, KB, axes=([2], [0])), PRIME)
+    mmc = rank_modp(XR.reshape(NCP, NCOV * dim), PRIME)
+    if m * m != m2 or m == 0:
+        PART_OK = False
+        break
+    mc, r1 = divmod(mmc, m)
+    d, r2 = divmod(dim, m)
+    if r1 != 0 or r2 != 0:
+        PART_OK = False
+        break
+    stk = np.vstack([BM, AZ])
+    blind = NPI - rank_modp(stk, PRIME)
+    forced = d * max(0, m - mc)
+    PARTS.append((lam, dim, d, m, mc, blind, forced, blind - forced))
+
+SUM_DIM = sum(t[1] for t in PARTS)
+SUM_MM = sum(t[3] * t[3] for t in PARTS)
+SUM_MMC = sum(t[3] * t[4] for t in PARTS)
+SUM_CC = sum(t[4] * t[4] for t in PARTS)
+SUM_DMC = sum(t[2] * t[4] for t in PARTS)
+SUM_BL = sum(t[5] for t in PARTS)
+DIMS = sorted(t[1] for t in PARTS)
+
+# ------------------------------------------------------------------
+# 20. the theorem, the exact witness, and the labelling it cannot reach
+# ------------------------------------------------------------------
+
+CEIL = sum(t[2] * min(t[3], t[4]) for t in PARTS)
+FLOORB = sum(t[2] * max(0, t[3] - t[4]) for t in PARTS)
+EXC_C = CEIL - RANKB
+EXC_F = NKB - FLOORB
+
+WIT2 = np.zeros((NCOV, NPI), dtype=np.int64)
+for k in range(NCP):
+    WIT2 = WIT2 + (1 + divmod(k * k + 3 * k, 11)[1]) * OXS[k]
+WEXACT = rank_fwd(WIT2.tolist(), NPI)
+
+EXROWS = [t for t in PARTS if t[7] > 0]
+NEX = len(EXROWS)
+NZERO = len(PARTS) - NEX
+NEXGE = sum(1 for t in EXROWS if t[4] >= t[3])
+NEXLT = NEX - NEXGE
+MC0_OK = all(t[7] == 0 for t in PARTS if t[4] == 0)
+NMC0 = sum(1 for t in PARTS if t[4] == 0)
+
+EVEN = [e for e in range(NGRP) if psign(DESC[e][0]) == 1]
+NEVEN = len(EVEN)
+EPP = [PERM[e] for e in EVEN]
+ECC = [CPERM[e] for e in EVEN]
+
+
+def orb_mark(acts, n, start, seen):
+    seen[start] = True
+    fr = [start]
+    while fr:
+        nx = []
+        for x in fr:
+            for act in acts:
+                y = act[x]
+                if not seen[y]:
+                    seen[y] = True
+                    nx.append(y)
+        fr = nx
+    return seen
+
+
+PIE_TRANS = all(orb_mark(PERM, NPI, 0, [False] * NPI))
+
+PSEEN = orb_mark(EPP, NPI, 0, [False] * NPI)
+NPCL0 = sum(1 for b in PSEEN if b)
+PREST = [i for i in range(NPI) if not PSEEN[i]]
+PSEEN2 = orb_mark(EPP, NPI, PREST[0], [False] * NPI) if PREST else [False] * NPI
+NPCL1 = sum(1 for b in PSEEN2 if b)
+PTWO = (NPCL0 + NPCL1 == NPI and not any(PSEEN[i] and PSEEN2[i] for i in range(NPI)))
+SGP = [1 if PSEEN[i] else -1 for i in range(NPI)]
+
+CSEEN = orb_mark(ECC, NCOV, 0, [False] * NCOV)
+NCCL0 = sum(1 for b in CSEEN if b)
+CREST = [i for i in range(NCOV) if not CSEEN[i]]
+CSEEN2 = orb_mark(ECC, NCOV, CREST[0], [False] * NCOV) if CREST else [False] * NCOV
+NCCL1 = sum(1 for b in CSEEN2 if b)
+CTWO = (NCCL0 + NCCL1 == NCOV
+        and not any(CSEEN[i] and CSEEN2[i] for i in range(NCOV)))
+
+CSUMS = sorted(set(sum(SGP[j] for j in c) for c in CS))
+HA = {}
+ATOT = 0
+for c in CS:
+    n0 = sum(1 for j in c if PSEEN[j])
+    ATOT += n0
+    HA[n0] = HA.get(n0, 0) + 1
+HISTA = sorted(HA.items())
+
+HB = {}
+BTOT = 0
+for j in range(NPI):
+    n0 = sum(1 for i in range(NCOV) if BROW[i][j] and CSEEN[i])
+    BTOT += n0
+    HB[n0] = HB.get(n0, 0) + 1
+HISTB = sorted(HB.items())
+SELFDUAL = (HISTA == HISTB and ATOT == BTOT and ATOT == 96 * 8)
+
+STE = [e for e in STABC if PERM[e] != IDP]
+NSTE = len(STE)
+E1 = STE[0] if NSTE else 0
+SG1, FL1 = DESC[E1]
+PS1 = psign(SG1)
+BLK = list(CS[0])
+BSET = set(BLK)
+IMG = [PERM[E1][b] for b in BLK]
+FIXB = sum(1 for t in range(8) if IMG[t] == BLK[t])
+CLOSED_BLK = (set(IMG) == BSET)
+CYC = []
+left = set(BLK)
+while left:
+    s = min(left)
+    ln = 0
+    x = s
+    while True:
+        left.discard(x)
+        x = PERM[E1][x]
+        ln += 1
+        if x == s:
+            break
+    CYC.append(ln)
+CYC = sorted(CYC)
+KEEPS_CLASS = all(SGP[PERM[E1][b]] == SGP[b] for b in BLK)
+FPAR1 = 1 - 2 * divmod(popc(FL1), 2)[1]
+PROD1 = FPAR1 * PS1
+
+NINE = [96 * a + 96 * (8 - a) for a in range(9)]
+NINE_OK = (len(NINE) == 9 and set(NINE) == set([768]))
+
+PARC = []
+DS = []
+for i in range(NPI):
+    cs5 = KEPT[USED[i]]
+    ne = sum(1 for c in cs5 if divmod(popc(c), 2)[1] == 0)
+    PARC.append(1 - 2 * divmod(ne, 2)[1])
+    p0 = CORN[cs5[0]]
+    DS.append(det4([[CORN[cs5[t]][u] - p0[u] for u in range(4)]
+                    for t in range(1, 5)]))
+AGR1 = sum(1 for i in range(NPI) if PARC[i] == SGP[i])
+AGR2 = sum(1 for i in range(NPI) if DS[i] == SGP[i])
+DSET = sorted(set(DS))
+
+CHAR = [psign(DESC[e][0]) * (1 - 2 * divmod(popc(DESC[e][1]), 2)[1])
+        for e in range(NGRP)]
+PCH_N = 0
+PCH_BAD = 0
+SRT_BAD = 0
+SRT_OK_E = 0
+for e in range(NGRP):
+    ch = CHAR[e]
+    mp = MAPS[e]
+    pe = PERM[e]
+    ok_e = True
+    for i in range(NPI):
+        cs5 = KEPT[USED[i]]
+        img = [mp[c] for c in cs5]
+        q0 = CORN[img[0]]
+        dv = det4([[CORN[img[t]][u] - q0[u] for u in range(4)]
+                   for t in range(1, 5)])
+        PCH_N += 1
+        if dv != DS[i] * ch:
+            PCH_BAD += 1
+        if DS[pe[i]] != DS[i] * ch:
+            SRT_BAD += 1
+            ok_e = False
+    if ok_e:
+        SRT_OK_E += 1
+
+# ------------------------------------------------------------------
+# 21. source hygiene and budget
+# ------------------------------------------------------------------
+
+SRC = open(__file__, "r").read()
+NO_PC = (chr(37) not in SRC)
+NO_TAB = (chr(9) not in SRC)
+NO_EM = (chr(8212) not in SRC)
+ASCII_OK = all(ord(ch) < 128 for ch in SRC)
+
+BAN = [("reta", "ined"), ("aud", "ited"), ("audit", " will"), ("only ", "route"),
+       ("last ", "route"), ("exha", "ust"), ("clos", "es"), ("PHAS", "E_"),
+       ("r = 1", "/2"), ("r=1", "/2"), ("grav", "it"), ("Ha", "ar"),
+       ("Reyn", "olds"), ("viel", "bein"), ("tet", "rad"), ("resolves ", "PARTIAL"),
+       ("/Us", "ers/"), ("7/", "(8"), ("regi", "ster"), ("oct", "et"),
+       ("sch", "eme"), ("association sch", "eme"), ("Sm", "ith"),
+       ("Bar", "eiss"), ("Gal", "ois"),
+       ("hyper", "octahedral"), ("Cox", "eter"), ("B", "_4"), ("na", "uty"),
+       ("Weis", "feiler"), ("Le", "man"), ("Leh", "man"), ("Mc", "Kay"),
+       ("sau", "cy"), ("bl", "iss"), ("trac", "es"), ("O", "_h"),
+       ("inver", "sion")]
+LOWSRC = SRC.lower()
+BAN_OK = True
+NBAN = 0
+for a, b in BAN:
+    NBAN += 1
+    if (a + b).lower() in LOWSRC:
+        BAN_OK = False
+
+ELAPSED = int(time.time() - T0)
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+RSSMB = RSS // 1048576 if RSS > 10000000 else RSS // 1024
+
+# ------------------------------------------------------------------
+# gates
+# ------------------------------------------------------------------
+
+emit("all numbers below are exact computational identities;"
+     " no floating point enters any gate")
+
+gate(NCAND == 2672 and NKEPT == 400 and FLOOR == 6 and NS == 15800
+     and SIZES == [24] and NPI == 192 and NCOV == 192, "C0",
+     "object: {0} candidate pieces, {1} at adjacency-cost floor {2}, {3} cuttings"
+     " of {4}, {5} pieces used, {6} covers".format(NCAND, NKEPT, FLOOR, NS,
+                                                   SIZES[0], NPI, NCOV))
+
+gate(NGRP == 384 and MAPS_DISTINCT and PERM_DISTINCT and CLOSED
+     and NPROD == 147456 and BIJ and PIE_TRANS and COV_TRANS, "C1",
+     "group: {0} maps, all distinct, closed over {1} products, bijective {2},"
+     " one piece orbit {3}, one cover orbit {4}".format(NGRP, NPROD, yn(BIJ),
+                                                        yn(PIE_TRANS),
+                                                        yn(COV_TRANS)))
+
+gate(NORB == 104 and NPOC == 120 and NCP == 96 and NPP == NORB, "C2",
+     "orbits: {0} on ordered piece pairs, {1} on ordered cover pairs, {2} on"
+     " cover-piece cells, sweep agrees {3}".format(NORB, NPOC, NCP,
+                                                   yn(NPP == NORB)))
+
+gate(RANKA == 88 and NKA == 104 and RANKB == 105 and NKB == 87 and GOOD_PRIME,
+     "C3",
+     "exact rational ranks: cutting table {0} kernel {1}, cover table {2} kernel"
+     " {3}, prime path agrees {4}".format(RANKA, NKA, RANKB, NKB, yn(GOOD_PRIME)))
+
+gate(EQ_OK and EQ_P + EQ_X == 40 and BM_OK, "C4",
+     "orbit matrices: {0} piece-pair, {1} cell; {2} equivariance checks hold {3};"
+     " cover table is the sum of {4} whole cell orbits {5}".format(
+         NORB, NCP, EQ_P + EQ_X, yn(EQ_OK), NINB, yn(BM_OK)))
+
+gate(REP_FULL and SC_AGREE and SC_SAFE and SC_CHK >= 6, "C5",
+     "structure constants: max {0}, every label has a representative {1}, {2} pairs"
+     " checked by direct product agree {3}, below 2**40 {4}".format(
+         SCMAX, yn(REP_FULL), SC_CHK, yn(SC_AGREE), yn(SC_SAFE)))
+
+gate(NCON == 10816 and RKC == RKX and NSEL == RKC and NCEN == 20 and CEN_OK
+     and GUARD_OK and CEN_CHK == NCEN * NCON, "C6",
+     "centre: {0} of {1} rows picked, prime rank {2} exact {3}, dimension {4}, each"
+     " vector meets all {1} rows {5}, top {6}, guard {7}".format(
+         NSEL, NCON, RKC, RKX, NCEN, yn(CEN_OK), ZMAX, yn(GUARD_OK)))
+
+gate(VAL_OK and REP_OK and REP_CHK == 3 and B0 > 0, "C7",
+     "central element: trial {0}, row-sum bound {1}, {2} integer values each of"
+     " nullity one {3}, {4} direct product checks {5}".format(
+         TWORK, B0, len(VALS), yn(VAL_OK), REP_CHK, yn(REP_OK)))
+
+gate(PART_OK and SUM_DIM == NPI and SUM_MM == NORB and SUM_MMC == NCP, "C8",
+     "certificates: sum of dimensions {0} = {1}, sum of m squared {2} = {3}, sum of"
+     " m times mc {4} = {5}".format(SUM_DIM, NPI, SUM_MM, NORB, SUM_MMC, NCP))
+
+gate(SUM_CC == NPOC and SUM_DMC == NCOV and SUM_BL == NKB, "C9",
+     "certificates: sum of mc squared {0} = {1}, sum of d times mc {2} = {3}, sum"
+     " of blind {4} = {5}".format(SUM_CC, NPOC, SUM_DMC, NCOV, SUM_BL, NKB))
+
+gate(len(PARTS) == NCEN and sum(DIMS) == NPI, "C10",
+     "{0} parts, dimensions sorted: {1}".format(
+         len(PARTS), ",".join(str(x) for x in DIMS)))
+
+gate(CEIL == 144 and FLOORB == 48 and CEIL + FLOORB == NPI, "C11",
+     "theorem: ceiling {0} on the cover table rank, floor {1} on its blind space,"
+     " and {0} plus {1} = {2}".format(CEIL, FLOORB, NPI))
+
+gate(EXC_C == EXC_F and EXC_C == 39 and RANKB < CEIL and NKB > FLOORB, "C12",
+     "measured: cover table rank {0} and blind space {1}, so ceiling minus rank {2}"
+     " equals blind minus floor {3}".format(RANKB, NKB, EXC_C, EXC_F))
+
+gate(WEXACT == CEIL and NPI - WEXACT == FLOORB, "C13",
+     "exact witness: an equivariant integer matrix of exact rational rank {0} meets"
+     " the ceiling, and {1} minus it is the floor {2}".format(WEXACT, NPI, FLOORB))
+
+gate(NZERO >= 12 and NEX + NZERO == len(PARTS) and NEXGE + NEXLT == NEX
+     and NEXLT > 0 and MC0_OK and NMC0 > 0, "C14",
+     "excess: {0} parts have none, {1} have some; of those {2} have mc at least m"
+     " and {3} do not; all {4} parts with mc zero have no excess {5}".format(
+         NZERO, NEX, NEXGE, NEXLT, NMC0, yn(MC0_OK)))
+
+gate(NEX == 8 and all(t[5] == t[6] + t[7] for t in EXROWS), "C15",
+     "excess rows d/m/mc/blind/forced 1 to 4: {0}".format(
+         " ".join("/".join(str(x) for x in (t[2], t[3], t[4], t[5], t[6]))
+                  for t in EXROWS[:4])))
+
+gate(NEX == 8 and all(t[7] > 0 for t in EXROWS), "C16",
+     "excess rows d/m/mc/blind/forced 5 to 8: {0}".format(
+         " ".join("/".join(str(x) for x in (t[2], t[3], t[4], t[5], t[6]))
+                  for t in EXROWS[4:])))
+
+gate(NEVEN == 192 and NGRP == 2 * NEVEN and PTWO and CTWO and NPCL0 == 96
+     and NPCL1 == 96 and NCCL0 == 96 and NCCL1 == 96, "C17",
+     "even subgroup: order {0}, index {1}, two piece classes of {2} and {3}, two"
+     " cover classes of {4} and {5}".format(NEVEN, NGRP // NEVEN, NPCL0, NPCL1,
+                                            NCCL0, NCCL1))
+
+gate(CSUMS == [0] and HISTA == [(4, NCOV)], "C18",
+     "the class labelling: all {0} cover sums are {1}, block split histogram"
+     " {2}".format(NCOV, CSUMS, HISTA))
+
+gate(SELFDUAL and HISTB == [(4, NPI)], "C19",
+     "self-dual: piece side {0}, cover side {1}, incidence totals {2} and {3} both"
+     " equal 96 times 8".format(HISTA, HISTB, ATOT, BTOT))
+
+gate(NSTE == 1 and PS1 == 1 and FIXB == 0 and CLOSED_BLK and CYC == [2, 2, 2, 2]
+     and KEEPS_CLASS, "C20",
+     "first candidate: the non-identity element fixing cover 0 has sign {0}, fixes"
+     " {1} of 8 blocks, cycles {2}, keeps the class {3}".format(
+         PS1, FIXB, CYC, yn(KEEPS_CLASS)))
+
+gate(FPAR1 == -1 and PROD1 == -1, "C21",
+     "contrast: on that element the flip-count parity is {0} and its product with"
+     " the permutation sign is {1}, so both are forced blind".format(FPAR1, PROD1))
+
+gate(NINE_OK and 768 // NPI == 4, "C22",
+     "second candidate: the mean carries nothing; all {0} split values a give"
+     " 96a + 96(8 - a) = {1}, and {1} over {2} is 4".format(len(NINE), NINE[0],
+                                                            NPI))
+
+gate(AGR1 not in (0, NPI) and AGR2 not in (0, NPI) and DSET == [-1, 1], "C23",
+     "third candidate: corner-parity label agrees on {0} of {1} pieces, ordered"
+     " determinant label on {2} of {1}, determinant values {3}".format(
+         AGR1, NPI, AGR2, DSET))
+
+gate(PCH_BAD == 0 and PCH_N == NGRP * NPI, "C24",
+     "the determinant tracks the product character: with corners kept in source"
+     " order it matches on all {0} element-piece pairs, {1} misses".format(
+         PCH_N, PCH_BAD))
+
+gate(SRT_BAD > 0 and SRT_OK_E < NGRP, "C25",
+     "re-sorted reading: with each image piece in its own sorted order the match"
+     " fails on {0} of {1} pairs, holding for {2} of {3} elements".format(
+         SRT_BAD, PCH_N, SRT_OK_E, NGRP))
+
+gate(ASCII_OK and NO_TAB and NO_PC and NO_EM and BAN_OK and NBAN > 0, "C26",
+     "source hygiene: pure ASCII {0}, no tab {1}, no remainder character {2}, no"
+     " long dash {3}, {4} barred strings absent {5}".format(
+         yn(ASCII_OK), yn(NO_TAB), yn(NO_PC), yn(NO_EM), NBAN, yn(BAN_OK)))
+
+gate(ELAPSED < 900 and RSSMB < 2500, "C27",
+     "budget: {0} seconds of wall time under 900, peak resident {1} MB under 2500,"
+     " stdout characters counted below".format(ELAPSED, RSSMB))
+
+emit("stdout characters: {0}".format(OUT[0]))
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))


### PR DESCRIPTION
## What this responds to

Cycle 763 ([#6060](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/6060)) asked whether the cutting cell's own symmetry picks out the cover table's dimension of 105, and answered no: covariant tables of that shape run over a wide band and 105 sits low in it. But the band was only sampled — 1500 of the 3.3 million four-subsets — so nothing said whether the largest dimension seen, 144, was the true ceiling or an artefact of sampling. The hand bound derived there fell short of 144 and could not settle it.

This PR replaces the sample with a derivation.

## What changed

One note, one paired runner, one cache, plus a separate `audit-infra:` commit adding the new note to the citation manifest (one node, out-degree 1).

**The decomposition.** The algebra of maps commuting with the symmetry on the 192 piece directions has dimension 104, one basis element per orbit on ordered pairs of pieces. Its centre is the kernel of 10816 commutator conditions: a modular selection of 84 independent rows caps it at dimension 20, and 20 integer vectors each verified against all 10816 conditions in both multiplication orders floor it at 20. So the centre has dimension exactly 20. One central element separates all twenty parts — its matrix on the centre has 20 distinct integer eigenvalues each of nullity one, found by an exact integer scan over the interval its own row sums allow. The parts have dimensions 1, 1, 1, 1, 3, 3, 3, 3, 4, 4, 8, 8, 8, 8, 12, 12, 24, 24, 32, 32.

**The theorem.** A table from covers to pieces that commutes with the symmetry acts on each part as one small matrix tensored with an identity. Its rank is therefore a sum of twenty tiny ranks, each at most `min(m, mc)`. Hence for every covariant table

```
rank  at most   sum of d * min(m, mc)      = 144
blind at least  sum of d * max(0, m - mc)  =  48
```

**The ceiling is attained**, not merely bounded: an explicit equivariant integer matrix built from all 96 cell orbits has exact rational rank 144, computed over the rationals with no modulus anywhere. So 144 is the true greatest available to any covariant table, and 48 the true least blind space. Cycle 763's sampled largest becomes a derived and attained value, and a rank question on a 192 by 192 table becomes twenty rank questions on matrices of size at most 6 by 4.

**What the cover table does with the room.** Its own rank is 105 and its blind space 87 — strictly inside the derived interval, 39 below the ceiling and 39 above the floor. Twelve parts sit exactly at the forced value; eight exceed it, with excesses 2, 4, 6, 8, 6, 6, 6 and 1 summing to the whole 39.

Six of those eight have more cover-side room than piece-side room and **two have less**. So the natural reading — that the cover side offers room the table declines to use — is wrong as a general statement, and the note says so.

**Three candidates for the 39, all refuted.** The even coordinate permutations form a subgroup of order 192 and index 2 splitting both the pieces and the covers into classes of 96 and 96. That class label is itself one of the twenty parts, and it is blind for a reason the run exhibits: every cover splits its eight pieces 4 and 4 between the classes, the same holds dually on the piece side, and the single non-identity element fixing a cover keeps the class. On that same element the flip-count parity and its product with the permutation sign both act by -1, which forces those two alternative labels blind as well. The aggregate incidence carries nothing by arithmetic alone. And two geometric labels read off the pieces each agree with the class label on exactly half of the 192 pieces; the determinant label is genuinely covariant but tracks the product character, matching on all 73728 element-piece pairs with 0 misses under source ordering and failing on exactly half of them under re-sorted ordering.

## Why the modular step is sound

Every per-part quantity is a rank computed modulo one prime, where the modular value can differ from the exact one in a single direction only. Six sums pin the whole table to independently computed exact totals: sum of dimensions 192, sum of m squared 104, sum of m times mc 96, sum of mc squared 120, sum of d times mc 192, sum of blind 87. Equality of every sum therefore forces every individual per-part entry to be exact. Three of those totals — 96, 120, 192 — come from orbit counts that were never used to build the decomposition, so it is cross-checked against objects outside itself.

## Runner

`physical_cell_cutting_symmetry_ceiling_cycle764_2026_08_09.py`, 28 gates, `TOTAL: PASS=28 FAIL=0`, about 165 seconds, 125 MB peak resident, 3431 characters of stdout. Every gate is exact integer arithmetic; no floating point enters any gate. Re-run independently before landing; every science line is byte-identical to the cache, the two runs differing only in the wall-time and resident-memory line.

Controls carried inside the run: 40 equivariance checks on the orbit matrices; the cover table rebuilt entry by entry as a sum of whole cell orbits; 7 products of orbit matrices recomputed directly against the structure constants; an integer overflow guard on those products; three products on the full 192 square pinning the abstract central matrix to the concrete action; and the witness rank computed over the rationals.

## Honest boundary

- Two identities in the run hold by arithmetic whatever the part table says — ceiling plus floor is 192, and ceiling minus rank equals blind minus floor. The note names them as bookkeeping, not evidence. The content is that the measured 105 is **strictly** below 144 and the measured 87 **strictly** above 48, and that the ceiling is attained.
- Likewise, that every part with cover-side multiplicity 0 has no excess is arithmetic; it is reported as a check that the cover table annihilates those five parts, not as support.
- The weights inside the central element and the witness are arbitrary deterministic genericity devices with no meaning. Each is gated by a wrong-value rejector — twenty distinct integer eigenvalues each of nullity one, and an exact rational rank of exactly 144 — so a non-generic choice would fail its gate rather than pass quietly.
- The symmetry used is the full symmetry of the four-cube, larger than the proper cubic rotations the admissibility axiom names. A ceiling from a larger group is still a ceiling, but the smaller group would give a weaker one; nothing here should be read as a statement about the axiom's own covariance, and the note says this explicitly.
- **The 39 is not explained.** Three candidate labels are refuted; the residual stands.

## Order

No dependency on [#6060](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/6060) or any other open PR — this note cites only its paired runner and the axioms file, and the runner recomputes the object from scratch. It can land in any order.

## What it opens

The residual is now a finite and small question: name the eight small matrices whose rank drops make up the 39. The same reduction also makes an exact census over all 3321960 covariant tables of the cover table's shape tractable, replacing cycle 763's 1500-point sample with the full distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
