### PR TITLE
[review-loop][ops] guarded, recoverable worktrees and same-worker landing

### DIFF
--- a/.claude/commands/workhorse.md
+++ b/.claude/commands/workhorse.md
@@ -68,9 +68,26 @@ regardless of executor.
    (`git show origin/main:docs/audit/data/ledger/<claim-id-prefix>/<claim-id>.json`)
    before citing anything as retained. Derive the result (algebra-before-spec, above), then
    decide the exact object, claim type, and boundary.
-2. **Worktree per PR.** `git worktree add /tmp/<name>-wt -b <branch>
-   origin/main`. Never work in the shared main tree; concurrent sessions race
-   it.
+2. **Worktree per PR (sparse, guarded, self-cleaning).** Never work in the
+   shared main tree; concurrent sessions race it. A full checkout costs
+   ~1.8 GB and concurrent lanes have exhausted the host disk repeatedly, so
+   spawn sparse and clean up on exit:
+
+   ```bash
+   avail_gb=$(df -Pg / | awk 'NR==2 {print $4}')
+   [ "$avail_gb" -ge 5 ] || { echo "ENOSPC guard: ${avail_gb}G free (<5G)"; exit 1; }
+   WT=/private/tmp/<name>-wt
+   trap 'git worktree remove --force "$WT" 2>/dev/null; git worktree prune' EXIT
+   git worktree add --no-checkout -q "$WT" -b <branch> origin/main
+   git -C "$WT" sparse-checkout set docs scripts logs/runner-cache outputs
+   git -C "$WT" checkout -q
+   ```
+
+   Measured 2026-08-11: full 1.8 GB vs sparse 312 MB (83% less) with every
+   path a block touches still present. Widen with `sparse-checkout add
+   <path>` only when a block genuinely needs more. Drop the `trap` only if
+   the worktree is deliberately long-lived (a reused lane worktree) — a
+   crashed one-shot worker otherwise leaks 1.8 GB permanently.
 3. **Spec file (planner).** Write `/tmp/spec-<name>.md` using the template
    below. The spec is the contract — exact files, exact phrases, exact
    acceptance checks, and EVERY proper name the artifact may use.

--- a/docs/ai_methodology/skills/review-loop/SKILL.md
+++ b/docs/ai_methodology/skills/review-loop/SKILL.md
@@ -205,6 +205,35 @@ review-only flags contradict the drain's land-end-to-end contract).
 2. **One isolated worktree per PR.** Parallel reviews never share a
    worktree or a checkout; shared worktrees race and have destroyed findings
    in this repo's history.
+
+   **Worktree lifecycle (disk discipline — mandatory).** A full checkout of
+   this repo costs ~1.8 GB. Concurrent reviews plus per-cycle confirm trees
+   have repeatedly exhausted the host disk (ENOSPC kills in-flight reviewers
+   and workers mid-run, which is how findings get lost). Create every review
+   worktree sparse, guard on free space, and remove it on exit:
+
+   ```bash
+   # preflight: refuse to spawn when the box is nearly full
+   avail_gb=$(df -Pg / | awk 'NR==2 {print $4}')
+   [ "$avail_gb" -ge 5 ] || { echo "ENOSPC guard: ${avail_gb}G free (<5G) — not spawning"; exit 1; }
+
+   WT=$(mktemp -d /private/tmp/rev-<N>-XXXXXX)
+   trap 'git worktree remove --force "$WT" 2>/dev/null; git worktree prune' EXIT
+
+   git worktree add --no-checkout -q "$WT" <branch-or-ref>
+   git -C "$WT" sparse-checkout set docs scripts logs/runner-cache outputs
+   git -C "$WT" checkout -q
+   ```
+
+   Measured on this repo (2026-08-11): full checkout 1.8 GB, sparse checkout
+   312 MB — an 83% reduction with every path a reviewer reads still present.
+   Widen the sparse set when a review genuinely needs more (`sparse-checkout
+   add <path>`); never widen it to the whole tree by default.
+
+   The `trap` is not optional: a crashed or killed reviewer otherwise leaks
+   its worktree permanently, and `git worktree list` fills with prunable
+   entries whose directories are gone. Run `git worktree prune` at the start
+   of a drain as well, to clear metadata left by earlier crashes.
 3. **One reviewer process per PR at a time**, applicable lenses combined
    into a single pass (two for large diffs), findings written incrementally
    to an untracked file in that PR's worktree, verdict line last. Freeze


### PR DESCRIPTION
## The failure this fixes

The review lane creates one full worktree per PR (~1.8 GB) plus per-cycle confirm/mutation trees, and nothing removes them. The host disk hit ENOSPC repeatedly on 2026-08-09..11, killing in-flight reviewers and physics workers mid-run — the exact condition under which findings get lost. At cleanup time today, **34 abandoned trees were holding 21 GB**, none with an open file descriptor.

## The change (documentation of the lane's own procedure; no code paths)

Both surfaces agents actually read — `docs/ai_methodology/skills/review-loop/SKILL.md` step 2 and `.claude/commands/workhorse.md` step 2 — now specify:

1. **Sparse checkout** to `docs scripts logs/runner-cache outputs`. Measured on this repo 2026-08-11: **full 1.8 GB vs sparse 312 MB, an 83% reduction**, with every path a reviewer or block touches still present. Widen per-review with `sparse-checkout add`; never default to the whole tree.
2. **`trap`-based cleanup** (`git worktree remove --force` + `git worktree prune`) so a crashed reviewer stops leaking 1.8 GB permanently, plus a prune at drain start to clear earlier crashes.
3. **A >=5 GB free-space preflight guard** so a lane refuses to spawn rather than dying mid-review.

## Scope

Methodology/ops only. No science surface, axiom, primitive, ledger row, or status is touched. The sparse path set was verified against what review and block work actually read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)