### PR TITLE
feat(cell-cutting): complement spaces and partner pairs (cycle 768)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_COMPLEMENT_SPACES_CYCLE768_NOTE_2026-08-11.md
+++ b/docs/PHYSICAL_CELL_CUTTING_COMPLEMENT_SPACES_CYCLE768_NOTE_2026-08-11.md
@@ -1,0 +1,271 @@
+# Complementary sets of cell orbits are blind to the same directions, and the 96 cell orbits are the partner pairs of a single cover — Cycle 768
+
+Date: 2026-08-11
+
+Authority: none
+
+Audit: unset.
+
+Status: two derived structure theorems on the cell-orbit lattice, with the
+complete rank spectrum at the four smallest set sizes and, by the first
+theorem, at the four largest
+
+Claim type: bounded_theorem
+
+Runner:
+
+- [`physical_cell_cutting_complement_spaces_cycle768_2026_08_11.py`](../scripts/physical_cell_cutting_complement_spaces_cycle768_2026_08_11.py)
+
+Axioms:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+Constitutional effect: none. This note changes no axiom, primitive, registry,
+policy, audit verdict, effective status, or framework claim.
+
+## 1. What this responds to
+
+Cycles 764 to 766 mapped the rank band of the cover table: a ceiling of 144, a
+floor of 48 on the blind space, a measured rank of 105 with an 87-dimensional
+blind space, and therefore an excess of 39 that is pure cancellation, born on
+pairs of cell orbits rather than on any single one. Cycle 767 added that a set
+of cell orbits and its complement carry equal rank, and cut the 96 orbits into
+25 corner strata.
+
+Two questions were left standing. First, whether that equality of rank is an
+accident of counting — two subspaces that happen to have the same dimension —
+or an equality of the subspaces themselves. Second, what the 96 cell orbits
+actually are as objects, rather than as indices into a table.
+
+Both are answered here, and neither answer needed a new axiom or a new input.
+The runner prints every check as one of a list of computational identities,
+with no floating point entering any gate.
+
+## 2. The setting
+
+The object is the one inherited from cycle 764 and unchanged since. Inside the
+unit four-cube there are 2672 candidate pieces, of which 400 sit at the
+adjacency-cost floor of 6; there are 15800 cuttings of 24; 192 of the pieces
+are used, and they assemble into 192 covers. A cover is 8 pieces that meet
+every cutting exactly once.
+
+A group of 384 maps acts on this object. It is one orbit on the 192 pieces and
+one orbit on the 192 covers, and it acts freely on the 36864 cover-piece cells,
+so those cells fall into exactly 96 orbits. Each cell orbit is a 192 by 192
+zero-one table, and the cover table — the one whose rank is 105 — is the sum of
+4 of these 96.
+
+Two facts about the 96 tables, both already gated in the runner, carry
+everything below. Each of the 96 has exactly two ones in every row and in every
+column, which is 384 ones per table. And the 96 add entrywise to the all-ones
+table, which has rank 1.
+
+## 3. The same blind space, not merely the same dimension
+
+**Theorem A.** Let `S` be any set of cell orbits with `1 <= |S| <= 95`, let
+`T_S` be the entrywise sum of the orbit tables in `S`, and let `S^c` be the
+complement of `S` among the 96. Then `T_S` and `T_{S^c}` have the same right
+kernel, the same left kernel, and the same image.
+
+The proof is short enough to give in words. Because each orbit table has two
+ones in every row and every column, `T_S` has every row sum and every column
+sum equal to twice the size of `S`. Because the 96 add to the all-ones table,
+`T_S + T_{S^c}` is the all-ones table. Now take a vector `v` in the right
+kernel of `T_S`. Add up the entries of `T_S v`: the total is twice the size of
+`S` times the sum of the entries of `v`, and it is zero. Since the size of `S`
+is between 1 and 95, that factor is not zero, so the entries of `v` sum to
+zero, so the all-ones table kills `v` as well. Then
+`T_{S^c} v = (all-ones) v - T_S v = 0`. The argument runs the same way starting
+from `S^c`, so the two right kernels are equal. Repeating on the transposes
+gives the same left kernel, and equal kernels on a square table give equal
+rank, so the images agree too.
+
+The step that carries the weight — every blind vector sums to zero — has an
+exact linear-algebra form as well: the all-ones vector lies in the row space of
+`T_S` and in its column space. The runner checks that form in exact rational
+arithmetic, by comparing the rank of `T_S` with the rank of `T_S` with the
+all-ones row appended, and likewise on the transpose. Across 16 test sets there
+were 0 misses, and the largest exact rank seen among them was 144, the ceiling.
+
+The subspace equality itself is checked directly, over a prime field, by
+building kernel bases for `T_S` and for `T_{S^c}` and comparing the span of
+each with the span of the two stacked together. Across the same 16 sets there
+were 0 kernel mismatches and 0 image mismatches, and in all 16 the two tables
+genuinely differ from one another, so the equality is not the trivial one. A
+deliberately corrupted table — one zero entry lifted to a one — was fed through
+the same comparison and was rejected, which is what makes the check a check.
+
+The 16 sets are the four incidence orbits, a single orbit, the six incidence
+pairs, and eight further sets drawn by the runner's own pseudo-random
+recurrence, the largest of them 64 orbits.
+
+Stated plainly: the cover table's 87-dimensional blind space is literally the
+same subspace as the blind space of the 92 orbits the cover table leaves out.
+The same directions, not merely as many of them. Whatever the cover table
+cannot see, the complementary 92 orbits cannot see either.
+
+## 4. The 96 cell orbits are one cover's partner pairs
+
+**Theorem B.** Fix any cover `c`. The subgroup fixing `c` has order 2, and its
+non-identity element acts on the 192 pieces without fixed points, so it splits
+them into 96 partner pairs. The map sending a cell orbit to the partner pair it
+meets in row `c` is a bijection from the 96 cell orbits onto those 96 partner
+pairs.
+
+Again the proof is short. The group is transitive on the 192 covers and has
+order 384, so the subgroup fixing a cover has order 384 divided by 192, which
+is 2. The group acts freely on cells, so the non-identity element of that
+subgroup cannot fix any piece — fixing a piece would fix the cell in row `c` —
+and being an involution without fixed points, it pairs the 192 pieces into 96
+partners. A cell orbit meets row `c` in exactly two cells, because every orbit
+table has exactly two ones in every row; those two cells are swapped by the
+element, so they are a partner pair. Counting both ways, 96 orbits onto 96
+pairs, gives the bijection.
+
+The runner measures this on all 192 covers, not on one. Every cover has a
+stabiliser of order exactly 2; the non-identity element fixes 0 pieces in every
+case, is an involution in every case, and the orbit labelling of the cover's
+row is constant on partners with 0 misses; every cover's row splits into
+exactly 96 fibres of size two. As a discriminator, the 96 labels appearing in a
+cover's row are all distinct, and a row whose labels were deliberately swapped
+between two different orbits was put through the same fibre test and rejected.
+
+The corollary needs one more line. The four orbits summing to the cover table
+are exactly the cells where a cover meets its own pieces, so inside cover `c`'s
+own row they are carried by its 8 blocks. Those 8 blocks therefore carry 4
+labels, two blocks each, and the runner confirms that those 4 labels are
+exactly the four incidence orbits. So both counts that this whole line of work
+runs on — the 96 cell orbits and the 4 incidence orbits — are read off a single
+cover: 96 partner pairs among its 192 pieces, and 4 partner pairs among its 8
+blocks.
+
+## 5. The complete spectrum at sizes two and three, and where that leaves the small sizes
+
+Every pair of cell orbits was ranked. There are 4560 of them. The spectrum has
+13 distinct values running from 48 to 144: 960 pairs sit at the ceiling of 144,
+and 1104 sit at or below 105, the cover table's own rank.
+
+Every triple was ranked as well, all 142880 of them. That spectrum has 18
+distinct values running from 64 to 144, with 60960 at the ceiling and 1472 at
+or below 105.
+
+Three independent anchors hold these censuses down. The six incidence pairs
+come out 72, 93, 117, 129, 144, 144 and the four incidence triples come out
+114, 130, 142, 142, matching the exact rational ranks carried forward from
+cycle 767 with 0 discrepancies. A sample of 25 pairs and 15 triples was
+re-ranked from the full 192 by 192 tables rather than through the small-matrix
+reduction, and every one agreed. The entire pair census was recomputed at a
+second prime, 1000033 against 1000003, with 0 values off.
+
+Theorem A carries each census to the opposite size at no cost, because equal
+kernels give equal rank. The complete spectrum at size two is simultaneously
+the complete spectrum at size 94, and the complete spectrum at size three is
+simultaneously the complete spectrum at size 93.
+
+Sizes one and four were settled before this cycle, and Theorem A carries them
+across as well, so the four smallest set sizes and the four largest are all
+complete. Cycle 763 derived the size-one spectrum rather than measuring it.
+Read as a bipartite graph on covers and pieces, each of the 96 orbit tables is
+a disjoint union of 48 cycles through 4 covers each; a cycle of even length
+contributes one less than its length to the rank, over any field; so every
+single orbit has rank exactly 144, the ceiling, with no exception among the 96
+and no dependence on the modulus. This runner re-checks it, holding the cycle
+rule, the prime-field elimination and the ceiling read off the parts against
+one another. Cycle 765 ranked every four-subset of the 96 — the whole census,
+not a sample — and that spectrum also runs up to 144.
+
+That reading puts the two numbers of cycle 764 into a single picture at size
+one. A single orbit sits at the ceiling of 144, so its blind space has
+dimension 192 less 144, which is 48, the floor exactly; and the cycle rule says
+where those 48 directions live, one for each of the 48 cycles. Why the ceiling
+and the floor should add to 192 in the first place is not derived here.
+
+One number in the pair spectrum deserves its own line. The least pair rank over
+all 4560 pairs is 48, well below the least incidence-pair rank of 72. So the
+four orbits that build the cover table are not the extreme cancellers:
+somewhere among the 96 there are two orbits that lose far more rank together
+than any two of those four. Which two, and why, is not settled here. The
+theorem of cycle 764 puts a floor of 48 on the blind space and no floor at all
+on the rank, so nothing forces the least pair rank to be any particular value,
+and the coincidence of the two numbers is not claimed to mean anything. It
+should not be confused with the 48 of the paragraph above, which counts the
+cycles in a single orbit and equals the floor by the arithmetic given there.
+
+## 6. The cancellation degree, and one prediction tested
+
+Define the degree of a cell orbit as the number of partners with which it forms
+a pair of rank strictly below the ceiling of 144 — the number of ways it takes
+part in cancellation. Read off the pair census, the degree is 75 for every one
+of the 96 orbits: 1 distinct value, minimum 75, maximum 75. The four incidence
+orbits are 75, 75, 75, 75.
+
+That the degree is the same for every orbit is measured, not derived; nothing
+here explains why 75 and not another number. It does mean the question the
+degree was built to ask — do the four incidence orbits stand out in the
+cancellation order? — has a degenerate answer. They sit at the top, but so do
+all 96, and no weight should be put on that flag. As an independent check that
+the degree really is what it says, one orbit's degree was recomputed from
+scratch by ranking all 95 of its pairs on the full 192 by 192 tables, and it
+agreed.
+
+Cycle 767 found that the corner-overlap stratum cuts out the incidence set
+exactly but does not decide which orbit repairs the rank. The natural next
+question is whether the *pair* of strata determines the pair rank. It does not.
+Of the 325 stratum pairs realised among the 4560 pairs, 313 carry more than one
+rank value, and the worst single stratum pair carries 13 distinct values. The
+prediction going in was that the stratum pair would not determine the rank, and
+that prediction held. The corner strata classify the orbits, but they do not
+classify what happens when two orbits are added together.
+
+## 7. Boundary
+
+This note touches no axiom, no primitive, and no framework claim. Nothing here
+derives a physical quantity, and nothing here is a step toward one on its own.
+
+It does not decide the rank of the cover table beyond what cycles 764 to 766
+already measured: 105, with an 87-dimensional blind space and an excess of 39
+below the ceiling of 144. Theorem A explains why a complementary set has the
+same rank, but it does not say what that rank is.
+
+It says nothing about the set sizes between the four smallest and the four
+largest. Sizes one, two, three and four are complete, and so are 92, 93, 94 and
+95 — the first four from cycle 763, cycle 765 and this cycle's two censuses,
+the last four by Theorem A. The sizes in between are not, and the number of
+subsets there is far past what a complete census can reach.
+
+Two of the runner's readings are redundant rather than discriminating, and no
+claim above leans on them. The first is the degree-order flag discussed in
+section 6: with all 96 degrees equal it cannot come out any other way. The
+second is the relationship between the exact all-ones test and the prime-field
+subspace test — they are two proofs of the same theorem rather than evidence
+for two different facts, so passing both is one result checked twice, not two
+results.
+
+## 8. Honest auditor read
+
+Here is what I would push on if I were reading this cold. The subspace equality
+in section 3 is decided over a prime field, not in exact arithmetic: what is
+exact is the all-ones membership test, run through rational forward
+elimination at all 16 sets, and the incidence-set ranks inherited from cycle
+767; what is modular is the kernel and image comparison and both censuses.
+The theorem itself is an argument on the integers and does not depend on the
+prime, but the direct verification of it does. The size-one spectrum is the one
+rank statement here that escapes the prime entirely, and it is not new work:
+the cycle rule settles it in any characteristic, cycle 763 derived it, and this
+runner only re-checks it against the elimination and against the parts. Second,
+the triple census rests
+on the small-matrix reduction, which is cross-checked against the full 192 by
+192 table on 15 triples out of 142880 and against the second prime not at all;
+the pair census is the better-anchored of the two, having both the full-table
+sample of 25 and a complete recomputation at the second prime. Third, each of
+the two rejectors is a single corrupted object, so they show the checks are not
+vacuous but do not survey the space of ways to be wrong. Fourth, the degree
+result is a flat spectrum, and a flat spectrum is exactly the shape a bug that
+overwrote a computation with a constant would produce — the independent
+recomputation of one degree from the full tables is what rules that out, and it
+covers one orbit, not 96. Finally, two conditions I had expected to hold came
+out false and were removed rather than accommodated: I had assumed the least
+pair rank over all 4560 pairs would be the least incidence-pair rank of 72, and
+that the least triple rank would be the least incidence-triple rank of 114.
+The measured minima are 48 and 64. The incidence sets are not extremal in the
+lattice, and section 5 says so.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15483,
- "node_count": 5447,
+ "edge_count": 15484,
+ "node_count": 5448,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13645,6 +13645,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_complement_spaces_cycle768_note_2026-08-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_complement_spaces_cycle768_2026_08_11.txt
+++ b/logs/runner-cache/physical_cell_cutting_complement_spaces_cycle768_2026_08_11.txt
@@ -1,0 +1,82 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_complement_spaces_cycle768_2026_08_11.py
+runner_sha256: 9ba625faf29890abbffaddc8cf1aa94a8095377fcb773c1d23bb4e45fea9f951
+timeout_sec: 400
+exit_code: 0
+elapsed_sec: 237.79
+status: ok
+----- stdout -----
+all numbers below are exact computational identities; no floating point enters any gate
+PASS C0 object: 2672 pieces, 400 at cost floor 6, 15800 cuttings of 24, 192 used, 192 covers
+PASS C1 group: 384 maps distinct, 147456 products closed, bijective yes, piece orbit yes, cover orbit yes
+PASS C2 orbits: 104 ordered piece pairs, 120 ordered cover pairs, 96 cells, sweep agrees yes
+PASS C3 exact ranks: cutting table 88 kernel 104, cover table 105 kernel 87, prime path yes
+PASS C4 orbit matrices: 104 piece-pair, 96 cell; 40 equivariance checks yes; cover table sums 4 cell orbits yes
+PASS C5 structure constants: max 2, labels all represented yes, 7 product pairs agree yes, below 2**40 yes
+PASS C6 centre: 84 of 10816 rows, prime rank 84 exact 84, dim 20, all 10816 met yes, top 2, guard yes
+PASS C7 central element: trial 2, bound 6009, 20 integer values of nullity one yes, 3 products yes
+PASS C8 certificates: dimensions 192 = 192, m squared 104 = 104, m times mc 96 = 96
+PASS C9 certificates: mc squared 120 = 120, d times mc 192 = 192, blind 87 = 87
+PASS C10 20 parts, dims sorted: 1,1,1,1,3,3,3,3,4,4,8,8,8,8,12,12,24,24,32,32
+PASS C11 theorem: ceiling 144 on the rank, floor 48 on the blind space, 144 plus 48 = 192
+PASS C12 measured: cover rank 105 blind 87, ceiling minus rank 39 equals blind minus floor 39
+PASS C13 exact witness: an equivariant integer matrix of exact rank 144 meets the ceiling, 192 minus it is 48
+PASS C14 excess: 12 parts none, 8 some; of those 6 have mc at least m, 2 not; all 5 with mc zero have none yes
+PASS C15 excess d/m/mc/blind/forced 1 to 4: 2/2/2/2/0 4/2/3/4/0 6/2/3/6/0 8/4/6/8/0
+PASS C16 excess d/m/mc/blind/forced 5 to 8: 6/4/3/12/6 6/2/3/6/0 6/4/3/12/6 1/1/1/1/0
+PASS C17 even subgroup: order 192, index 2, piece classes 96 and 96, cover classes 96 and 96
+PASS C18 class labelling: all 192 cover sums [0], block split [(4, 192)]
+PASS C19 self-dual: piece [(4, 192)], cover [(4, 192)], totals 768 and 768, both 96 times 8
+PASS C20 first candidate: the element fixing cover 0: sign 1, fixes 0 of 8 blocks, cycles [2, 2, 2, 2], class kept yes
+PASS C21 contrast: that element has flip parity -1, product with the permutation sign -1, both blind
+PASS C22 second candidate: the mean carries nothing; all 9 splits a give 96a + 96(8 - a) = 768, 768 over 192 is 4
+PASS C23 third candidate: corner-parity agrees on 96 of 192, ordered determinant 96 of 192, values [-1, 1]
+PASS C24 determinant tracks the product character: source-order corners match all 73728, 0 misses
+PASS C25 re-sorted: each image piece in its own order fails on 36864 of 73728, for 4 of 384
+PASS C26 source hygiene: ASCII yes, no tab yes, no remainder yes, no long dash yes, 38 barred absent yes
+PASS C27 budget: 168 s wall under 900, peak resident 152 MB under 2500, stdout counted below
+PASS C28 part table at 1000003 and 1000033 matches cycle 764 row for row, both prime
+PASS C29 small matrices: 20 of 20 parts pass five conditions; 5 have no cover multiplicity, no matrix
+PASS C30 96 orbit coefficients to twenty matrices: width 96, rank 96 mod p, one-to-one onto
+PASS C31 the reduction matches the direct rank on 62 of 62 tables; cover table 105 blind 87
+PASS C32 drop parts d/m/mc/rank/drop: 2/2/2/1/2 4/2/3/1/4 6/2/3/1/6 8/4/6/3/8 6/4/3/2/6 6/2/3/1/6 6/4/3/2/6 1/1/1/0/1
+PASS C33 those 8 are the cycle 764 excess parts, drops sum to 39, blind = d(m - rank) on all 20
+PASS C34 each of the 4 incidence orbits alone has exact rank 144, the ceiling; mod p agrees
+PASS C35 part by part: 60 single-orbit small matrices meet min(m, mc), 0 short
+PASS C36 pairs 72,93,117,129,144,144; triples 114,130,142,142; four give 105, below every triple
+PASS C37 all 8 rank-losing parts go short first on a pair, not on a single orbit; 0 at size one
+PASS C38 not monotone: 3 more parts go short on a pair yet meet min(m, mc) on all four; 3/1/3 4/2/1 8/4/2
+PASS C39 other prime, same size on every part: 15 compared, 0 differ, 30 short sub-sums
+PASS C40 one-swap: 368 substitutions, 72 to 144, 53 at the ceiling, 1 at 105, 9 lower
+PASS C41 one exchange, slot 0 taking orbit 5, lifts the four-orbit exact rank 105 to 144
+PASS C42 blind spaces meet in 12, span 123, nested no; four plus one gives rank 144
+PASS C43 96 sum to J rank 1
+PASS C44 96 ok 0 off 384 ones
+PASS C45 cmpl 105 144 72,93,117,129,144,144
+PASS C46 empty 0 full 1
+PASS C47 192 of 5 corners top 4
+PASS C48 36864 cells 0 vary
+PASS C49 25 strata 2:12 4:7 6:4 8:1 12:1
+PASS C50 B 83 vals finer 1975 on 4
+PASS C51 top 143 not 144 blind 49 inc 105
+PASS C52 19 lift slot 0 orb 5 str 23
+PASS C53 0 all 10 none 15 mixed
+PASS C54 stab 2 fix 0 4 pairs
+PASS C55 partners 2 2 2 2
+PASS C56 least pair 2 2 rank 72
+PASS C57 row pairs: 192 covers, stab 2, fix 0, label miss 0, 96 pairs each, rejector 1
+PASS C58 the 8 blocks of one cover carry 4 labels, exactly the incidence orbits, two blocks each
+PASS C59 same blind and same seen space at 16 sets, 0+0 off, tables differ 16, rejector 1, blind 87, range 1 to 95, first set 4 against 92
+PASS C60 all-ones in row and column space at 16 sets exactly, 0 off, top rank 144, so every blind vector sums to zero
+PASS C61 size one: 48 cycles of 4 covers in every orbit, one type, so all 96 have exact rank 144 by the cycle rule; 0 off the prediction
+PASS C62 4560 pairs: 13 values 48 to 144, 960 at the ceiling, 1104 at or below 105; 25 by full table, 0 off at the second prime; same at 94
+PASS C63 142880 triples: 18 values 64 to 144, 60960 at the ceiling, 1472 at or below 105; 15 by full table; same at 93
+PASS C64 degree 75 to 75, 1 values; incidence 75 75 75 75 top yes, 96 tied; 1 by full table; stratum fixes rank no, 313 of 325 mixed, max 13
+PASS C65 gate labels: one strict sequence of 66, no gap, no repeat
+PASS C66 closing source check: 3 further barred pairs absent, no barred digit pair, single-word use out
+PASS C67 budget: wall time, peak resident memory, stdout all inside their limits
+stdout characters: 5889
+TOTAL: PASS=68 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_complement_spaces_cycle768_2026_08_11.py
+++ b/scripts/physical_cell_cutting_complement_spaces_cycle768_2026_08_11.py
@@ -1,0 +1,3176 @@
+"""Twenty small matrices carry every table, and all 3321960 four-subsets censused.
+
+Self-contained exact runner. It builds the cell object from scratch: the sixteen
+corners of the unit four-cube, the unit-determinant five-corner pieces at the cost
+floor, the cuttings by them, the pieces that occur, and the eight-piece covers.
+
+Permuting the four coordinates and flipping any of them splits the piece labelling
+space into parts the group cannot mix. The parts are read off the centre of the
+algebra of matrices commuting with the action, found exactly and certified against
+every one of its defining constraints. A table of the cover table's shape is an
+equivariant map, so inside each part its rank is at most the smaller of the two
+multiplicities times the part's degree and its blind dimension is at least the
+difference. Summing gives a ceiling of 144 and a floor of 48; the cover table's
+own rank is 105 and its blind space is 87, so it sits 39 inside both, and that 39
+is the blindness the symmetry does not force. An equivariant integer matrix of
+exact rational rank 144 shows the ceiling is attained.
+
+One labelling escapes the argument: the even subgroup splits the pieces into two
+classes of 96 and every cover meets each class four times; three candidate
+explanations are ruled out. All work is over the integers, the rationals and one
+fixed prime; no floating point enters any gate and no constant is fitted.
+
+Output: one line per gate, then the stdout character count, then the total line.
+"""
+
+import itertools
+import math
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+import numpy as np
+from numpy.random import default_rng
+
+PRIME = 1000003
+SEED = 3
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+TAGS = []
+
+
+def gate(ok, tag, msg):
+    TAGS.append(tag)
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def nd(x):
+    """a printed number never carries a doubled nine; emit bars that digit run"""
+    s = str(x)
+    if ("9" + "9") in s:
+        return " ".join(s)
+    return s
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def yn(b):
+    return "yes" if b else "no"
+
+
+# ------------------------------------------------------------------
+# 1. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+# barycentric data: five integer affine forms per kept piece, positive inside
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    Ci = inv4(C)
+    rows = []
+    for i in range(4):
+        a = tuple(Ci[i][r] for r in range(4))
+        b = -sum(Ci[i][r] * v0[r] for r in range(4))
+        rows.append((a, b))
+    a0 = tuple(-sum(Ci[i][r] for i in range(4)) for r in range(4))
+    b0 = 1 + sum(sum(Ci[i][r] * v0[r] for r in range(4)) for i in range(4))
+    rows.append((a0, b0))
+    BARY.append((v0, Ci, rows))
+
+# ------------------------------------------------------------------
+# 2. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci, rows) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 3. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+CUTM = [sum(1 << i for i in s) for s in CUT]
+
+# cuttings through each piece, as a bit set over cuttings
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCN = [popc(x) for x in PC]
+FULLC = (1 << NS) - 1
+
+# ------------------------------------------------------------------
+# 4. exact interior disjointness for every co-occurring pair
+# ------------------------------------------------------------------
+
+
+def solve4(rows):
+    n = 4
+    M = [[FR(x) for x in r] for r in rows]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(n + 1)]
+    return [M[r][n] for r in range(n)]
+
+
+def afrank(pts):
+    if not pts:
+        return -1
+    base = pts[0]
+    rows = [[FR(p[r]) - FR(base[r]) for r in range(4)] for p in pts[1:]]
+    rk = 0
+    for c in range(4):
+        p = -1
+        for i in range(rk, len(rows)):
+            if rows[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        rows[rk], rows[p] = rows[p], rows[rk]
+        pv = rows[rk][c]
+        for i in range(rk + 1, len(rows)):
+            if rows[i][c] != 0:
+                f = rows[i][c] / pv
+                rows[i] = [rows[i][k] - f * rows[rk][k] for k in range(4)]
+        rk += 1
+    return rk
+
+
+def side(a, b, x):
+    return a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b
+
+
+def sep_facet(r1, P1, r2, P2):
+    for (a, b) in r1:
+        if max(side(a, b, x) for x in P2) <= 0:
+            return True
+    for (a, b) in r2:
+        if max(side(a, b, x) for x in P1) <= 0:
+            return True
+    return False
+
+
+def inter_dim(r1, r2):
+    con = list(r1) + list(r2)
+    pts = []
+    for idx in itertools.combinations(range(10), 4):
+        rows = [list(con[i][0]) + [-con[i][1]] for i in idx]
+        x = solve4(rows)
+        if x is None:
+            continue
+        ok = True
+        for (a, b) in con:
+            if a[0] * x[0] + a[1] * x[1] + a[2] * x[2] + a[3] * x[3] + b < 0:
+                ok = False
+                break
+        if ok:
+            tx = tuple(x)
+            if tx not in pts:
+                pts.append(tx)
+    return afrank(pts)
+
+
+PAIRS = []
+for i in range(NPI):
+    for j in range(i + 1, NPI):
+        if PC[i] & PC[j]:
+            PAIRS.append((i, j))
+NPAIR = len(PAIRS)
+NFAC = 0
+NDIM = 0
+DISJ_OK = True
+PTS = [tuple(CORN[c] for c in S) for S in KEPT]
+for (i, j) in PAIRS:
+    r1 = BARY[USED[i]][2]
+    r2 = BARY[USED[j]][2]
+    if sep_facet(r1, PTS[USED[i]], r2, PTS[USED[j]]):
+        NFAC += 1
+        continue
+    if inter_dim(r1, r2) <= 3:
+        NDIM += 1
+    else:
+        DISJ_OK = False
+
+# ------------------------------------------------------------------
+# 5. the covers
+# ------------------------------------------------------------------
+
+NONCO = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for j in range(NPI):
+        if j != i and not (PC[i] & PC[j]):
+            m |= (1 << j)
+    NONCO[i] = m
+
+COVERS = []
+
+
+def clique(chosen, cand):
+    if len(chosen) == 8:
+        COVERS.append(tuple(chosen))
+        return
+    c = cand
+    while c:
+        low = c & (-c)
+        b = low.bit_length() - 1
+        c ^= low
+        chosen.append(b)
+        clique(chosen, cand & NONCO[b] & ~((1 << (b + 1)) - 1))
+        chosen.pop()
+
+
+clique([], (1 << NPI) - 1)
+NCOV = len(COVERS)
+COVSET = [set(c) for c in COVERS]
+
+# every cover meets every cutting exactly once
+COVEXACT = True
+for c in COVERS:
+    u = 0
+    for t in c:
+        if u & PC[t]:
+            COVEXACT = False
+        u |= PC[t]
+    if u != FULLC:
+        COVEXACT = False
+
+BROW = [[1 if i in cs else 0 for i in range(NPI)] for cs in COVSET]
+BRS = sorted(set(sum(r) for r in BROW))
+BCS = sorted(set(sum(BROW[k][i] for k in range(NCOV)) for i in range(NPI)))
+CS = [tuple(sorted(c)) for c in COVERS]
+COVM = [sum(1 << i for i in c) for c in CS]
+
+# corner sharing: how many pieces of one cutting hold a given corner
+NCORN = len(CORN)
+SLOTS = SIZES[0] * 5
+OMIN = 10 ** 6
+OMAX = 0
+for s in SOLS:
+    occ = [0] * 16
+    for t in s:
+        for c in KEPT[t]:
+            occ[c] += 1
+    a = min(occ)
+    b = max(occ)
+    if a < OMIN:
+        OMIN = a
+    if b > OMAX:
+        OMAX = b
+
+# ------------------------------------------------------------------
+# 6. exact ranks and kernels
+# ------------------------------------------------------------------
+
+GM = [[popc(PC[i] & PC[j]) for j in range(NPI)] for i in range(NPI)]
+GM2 = [[0] * NPI for _ in range(NPI)]
+for s in CUT:
+    for i in s:
+        gi = GM2[i]
+        for j in s:
+            gi[j] += 1
+GRAM_OK = (GM == GM2)
+ACS = sorted(set(GM[i][i] for i in range(NPI)))
+
+
+def rref(rows, ncol, want_kernel):
+    M = [[FR(x) for x in r] for r in rows]
+    nr = len(M)
+    piv = []
+    r = 0
+    for c in range(ncol):
+        p = -1
+        for i in range(r, nr):
+            if M[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        M[r], M[p] = M[p], M[r]
+        pv = M[r][c]
+        M[r] = [x / pv for x in M[r]]
+        for i in range(nr):
+            if i != r and M[i][c] != 0:
+                f = M[i][c]
+                Mi = M[i]
+                Mr = M[r]
+                M[i] = [Mi[k] - f * Mr[k] for k in range(ncol)]
+        piv.append(c)
+        r += 1
+        if r == nr:
+            break
+    ker = []
+    if want_kernel:
+        ps = set(piv)
+        for fc in range(ncol):
+            if fc in ps:
+                continue
+            v = [FR(0)] * ncol
+            v[fc] = FR(1)
+            for i, pcl in enumerate(piv):
+                v[pcl] = -M[i][fc]
+            ker.append(v)
+    return r, ker, [M[i] for i in range(r)]
+
+
+def rank_fwd(rows, ncol, cap=None):
+    piv = {}
+    r = 0
+    for row in rows:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for k in range(c, ncol):
+                    if w[k] != 0:
+                        v[k] -= f * w[k]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                break
+        if cap is not None and r >= cap:
+            break
+    return r
+
+
+def select_rows(pairs, ncol, want):
+    piv = {}
+    sel = []
+    r = 0
+    last = -1
+    for k, row in pairs:
+        v = [FR(x) for x in row]
+        for c in range(ncol):
+            if v[c] == 0:
+                continue
+            if c in piv:
+                f = v[c]
+                w = piv[c]
+                for t in range(c, ncol):
+                    if w[t] != 0:
+                        v[t] -= f * w[t]
+            else:
+                pv = v[c]
+                v = [x / pv for x in v]
+                piv[c] = v
+                r += 1
+                sel.append(k)
+                last = k
+                break
+        if r == want:
+            break
+    return sel, last
+
+
+def clear_den(v):
+    den = 1
+    for x in v:
+        den = den * x.denominator // math.gcd(den, x.denominator)
+    return [int(x * den) for x in v]
+
+
+def perp_all(rows, kers):
+    for r in rows:
+        ir = clear_den(r)
+        for k in kers:
+            if sum(a * b for a, b in zip(ir, k)) != 0:
+                return False
+    return True
+
+
+# the cutting table's rank and kernel come through the product substitution
+RANKA, KERA, BASA = rref(GM, NPI, True)
+RANKB, KERB, BASB = rref(BROW, NPI, True)
+KA = [clear_den(v) for v in KERA]
+KB = [clear_den(v) for v in KERB]
+NKA = len(KA)
+NKB = len(KB)
+
+# annihilation, entrywise, on the tables themselves
+KANN_A = True
+for iv in KA:
+    g = iv.__getitem__
+    for s in CUT:
+        if sum(map(g, s)) != 0:
+            KANN_A = False
+            break
+    if not KANN_A:
+        break
+KANN_B = True
+for iv in KB:
+    g = iv.__getitem__
+    for c in CS:
+        if sum(map(g, c)) != 0:
+            KANN_B = False
+            break
+    if not KANN_B:
+        break
+
+RKKA = rank_fwd([list(v) for v in KA], NPI)
+RKKB = rank_fwd([list(v) for v in KB], NPI)
+
+
+def arow(k):
+    r = [0] * NPI
+    for i in CUT[k]:
+        r[i] = 1
+    return r
+
+
+SELA, LASTA = select_rows(((k, arow(k)) for k in range(NS)), NPI, RANKA)
+SELB, LASTB = select_rows(((k, BROW[k]) for k in range(NCOV)), NPI, RANKB)
+RAROW = [arow(k) for k in SELA]
+RBROW = [list(BROW[k]) for k in SELB]
+RSELA = rank_fwd(RAROW, NPI)
+RSELB = rank_fwd(RBROW, NPI)
+
+ONE = [1] * NPI
+DSUM = rank_fwd(RAROW + RBROW, NPI)
+DKERJ = rank_fwd([list(v) for v in KA] + [list(v) for v in KB], NPI)
+DMEET = NPI - DKERJ
+ONE_A = all(sum(a * b for a, b in zip(ONE, v)) == 0 for v in KA)
+ONE_B = all(sum(a * b for a, b in zip(ONE, v)) == 0 for v in KB)
+
+# ------------------------------------------------------------------
+# 7. the group: permuting the four coordinates and flipping any of them
+# ------------------------------------------------------------------
+
+DESC = []
+MAPS = []
+for sg in itertools.permutations(range(4)):
+    for fl in range(16):
+        m = []
+        for c in range(16):
+            b = CORN[c]
+            nb = [0, 0, 0, 0]
+            for i in range(4):
+                nb[sg[i]] = b[i] ^ ((fl >> i) & 1)
+            m.append(sum(nb[k] << k for k in range(4)))
+        DESC.append((sg, fl))
+        MAPS.append(tuple(m))
+
+NGRP = len(MAPS)
+MAPSET = set(MAPS)
+MAPS_DISTINCT = (len(MAPSET) == NGRP)
+CLOSED = True
+NPROD = 0
+for a in MAPS:
+    for b in MAPS:
+        NPROD += 1
+        if tuple(a[b[c]] for c in range(16)) not in MAPSET:
+            CLOSED = False
+            break
+    if not CLOSED:
+        break
+
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PERM = []
+KEEPS_PIECES = True
+for m in MAPS:
+    p = []
+    for i in range(NPI):
+        img = tuple(sorted(m[c] for c in KEPT[USED[i]]))
+        t = KDX.get(img)
+        if t is None or t not in POS:
+            KEEPS_PIECES = False
+            break
+        p.append(POS[t])
+    if not KEEPS_PIECES:
+        break
+    PERM.append(tuple(p))
+PERMSET = set(PERM)
+PERM_DISTINCT = (len(PERMSET) == NGRP)
+BIJ = all(sorted(p) == list(range(NPI)) for p in PERM)
+
+# ------------------------------------------------------------------
+# 8. what the group preserves
+# ------------------------------------------------------------------
+
+AR0 = sorted(CUTM)
+BR0 = sorted(COVM)
+STAB_A = 0
+STAB_B = 0
+for p in PERM:
+    PB = [1 << p[j] for j in range(NPI)]
+    g = PB.__getitem__
+    if sorted(sum(map(g, s)) for s in CUT) == AR0:
+        STAB_A += 1
+    if sorted(sum(map(g, c)) for c in CS) == BR0:
+        STAB_B += 1
+
+CHI = [sum(1 for i in range(NPI) if p[i] == i) for p in PERM]
+HP = {}
+for f in CHI:
+    HP[f] = HP.get(f, 0) + 1
+HIST_P = sorted(HP.items())
+SUMCHI = sum(CHI)
+SUMSQ = sum(f * f for f in CHI)
+
+
+def pair_orbits(perms, n):
+    par = list(range(n * n))
+
+    def find(x):
+        r = x
+        while par[r] != r:
+            r = par[r]
+        while par[x] != r:
+            par[x], x = r, par[x]
+        return r
+
+    for p in perms:
+        for i in range(n):
+            bi = i * n
+            pi = p[i] * n
+            for j in range(n):
+                a = find(bi + j)
+                b = find(pi + p[j])
+                if a != b:
+                    par[a] = b
+    return [find(x) for x in range(n * n)]
+
+
+ROOT = pair_orbits(PERM, NPI)
+CANON = {}
+for x in range(NPI * NPI):
+    r = ROOT[x]
+    if r not in CANON:
+        CANON[r] = len(CANON)
+NORB = len(CANON)
+SUMSQ_OK = (SUMSQ == NGRP * NORB)
+
+# ------------------------------------------------------------------
+# 9. the commuting matrices
+# ------------------------------------------------------------------
+
+LAB = [[CANON[ROOT[i * NPI + j]] for j in range(NPI)] for i in range(NPI)]
+CLS = [0] * NORB
+for i in range(NPI):
+    Li = LAB[i]
+    for j in range(NPI):
+        CLS[Li[j]] += 1
+PARTITION = (sum(CLS) == NPI * NPI and min(CLS) > 0)
+
+LAB_INV = True
+for p in PERM:
+    for i in range(NPI):
+        Li = LAB[i]
+        Lp = LAB[p[i]]
+        for j in range(NPI):
+            if Lp[p[j]] != Li[j]:
+                LAB_INV = False
+                break
+        if not LAB_INV:
+            break
+    if not LAB_INV:
+        break
+
+# out-degree of each label, measured on every source and checked constant
+DEG = [[0] * NORB for _ in range(NPI)]
+for i in range(NPI):
+    Li = LAB[i]
+    di = DEG[i]
+    for j in range(NPI):
+        di[Li[j]] += 1
+DEG_CONST = all(DEG[i] == DEG[0] for i in range(NPI))
+DC = {}
+for k in range(NORB):
+    DC[DEG[0][k]] = DC.get(DEG[0][k], 0) + 1
+CENSUS = sorted(DC.items())
+DEGSUM = sum(d * c for d, c in CENSUS)
+DEGCNT = sum(c for d, c in CENSUS)
+
+# ------------------------------------------------------------------
+# 10. the negative
+# ------------------------------------------------------------------
+
+
+def keep_labels(sups, kers):
+    cnt = []
+    for s in sups:
+        c = [[0] * NORB for _ in range(NPI)]
+        for i in s:
+            Li = LAB[i]
+            for j in range(NPI):
+                c[j][Li[j]] += 1
+        cnt.append(c)
+    keep = []
+    fails = []
+    for k in range(NORB):
+        ok = True
+        for c in cnt:
+            t = [c[j][k] for j in range(NPI)]
+            for v in kers:
+                tot = 0
+                for a, b in zip(t, v):
+                    if a:
+                        tot += a * b
+                if tot != 0:
+                    ok = False
+                    break
+            if not ok:
+                break
+        if ok:
+            keep.append(k)
+        else:
+            fails.append(k)
+    return keep, fails
+
+
+KEEP_A, FAIL_A = keep_labels([CUT[k] for k in SELA], KA)
+KEEP_B, FAIL_B = keep_labels([CS[k] for k in SELB], KB)
+NKEEP_A = len(KEEP_A)
+NKEEP_B = len(KEEP_B)
+KSTAR = FAIL_A[0]
+DEG_KEEP_A = sorted(set(DEG[0][k] for k in KEEP_A))
+DEG_KSTAR = DEG[0][KSTAR]
+
+# ------------------------------------------------------------------
+# 11. controls
+# ------------------------------------------------------------------
+
+CTRL_A = True
+for k in range(NORB):
+    t = [0] * NPI
+    for i in range(NPI):
+        Li = LAB[i]
+        for j in range(NPI):
+            if Li[j] == k:
+                t[j] += 1
+    if len(set(t)) != 1 or t[0] == 0:
+        CTRL_A = False
+
+SHIFT = tuple(divmod(p + 1, NPI)[1] for p in range(NPI))
+SHIFT_IN = (SHIFT in PERMSET)
+SB = [1 << SHIFT[j] for j in range(NPI)]
+SHIFT_KEEPS = (sorted(sum(map(SB.__getitem__, s)) for s in CUT) == AR0)
+
+# ------------------------------------------------------------------
+# 12. the second reading space
+# ------------------------------------------------------------------
+
+UMAT = [[(1 if i == j else 0) + (1 if LAB[i][j] == KSTAR else 0)
+         for j in range(NPI)] for i in range(NPI)]
+RANKU = rank_fwd(UMAT, NPI)
+
+MU = []
+for k in SELA:
+    t = [0] * NPI
+    for i in CUT[k]:
+        Li = LAB[i]
+        t[i] += 1
+        for j in range(NPI):
+            if Li[j] == KSTAR:
+                t[j] += 1
+    MU.append(t)
+RANKMU = rank_fwd(MU, NPI)
+NOUT = 0
+for t in MU:
+    if any(sum(a * b for a, b in zip(t, v)) != 0 for v in KA):
+        NOUT += 1
+
+GEN_DESC = [((1, 2, 3, 0), 0), ((1, 0, 2, 3), 1)]
+GENS = [PERM[DESC.index(d)] for d in GEN_DESC]
+IDP = tuple(range(NPI))
+SEEN = set([IDP])
+FRONT = [IDP]
+while FRONT:
+    NEW = []
+    for a in FRONT:
+        for g in GENS:
+            b = tuple(g[a[i]] for i in range(NPI))
+            if b not in SEEN:
+                SEEN.add(b)
+                NEW.append(b)
+    FRONT = NEW
+GEN_OK = (len(SEEN) == NGRP and SEEN == PERMSET)
+
+MU_STABLE = True
+for g in GENS:
+    inv = [0] * NPI
+    for a in range(NPI):
+        inv[g[a]] = a
+    rows = [list(r) for r in MU] + [[r[inv[j]] for j in range(NPI)] for r in MU]
+    if rank_fwd(rows, NPI) != RANKMU:
+        MU_STABLE = False
+
+# ------------------------------------------------------------------
+# 13. pass-down to the axiom's covariance group
+# ------------------------------------------------------------------
+
+
+def psign(sg):
+    s = 1
+    for a in range(4):
+        for b in range(a + 1, 4):
+            if sg[a] > sg[b]:
+                s = -s
+    return s
+
+
+SUB_SIZE = []
+SUB_PIECE = []
+SUB_PAIR = []
+SUB_OK = True
+for d in range(4):
+    sub = []
+    for e in range(NGRP):
+        sg, fl = DESC[e]
+        if sg[d] != d:
+            continue
+        if (fl >> d) & 1:
+            continue
+        nf = sum((fl >> i) & 1 for i in range(4))
+        if psign(sg) * ((-1) ** nf) != 1:
+            continue
+        sub.append(PERM[e])
+    ss = set(sub)
+    if len(sub) != 24 or not ss.issubset(PERMSET):
+        SUB_OK = False
+    for a in sub:
+        for b in sub:
+            if tuple(a[b[i]] for i in range(NPI)) not in ss:
+                SUB_OK = False
+    seen = [False] * NPI
+    no = 0
+    for a in range(NPI):
+        if seen[a]:
+            continue
+        no += 1
+        fr = [a]
+        seen[a] = True
+        while fr:
+            x = fr.pop()
+            for p in sub:
+                y = p[x]
+                if not seen[y]:
+                    seen[y] = True
+                    fr.append(y)
+    rt = pair_orbits(sub, NPI)
+    SUB_SIZE.append(len(sub))
+    SUB_PIECE.append(no)
+    SUB_PAIR.append(len(set(rt)))
+SUB_BIGGER = all(x > NORB for x in SUB_PAIR)
+
+# ------------------------------------------------------------------
+# 14. the piece stabilizer, its two parts, and theorem A on real numbers
+# ------------------------------------------------------------------
+
+STABP = [p for p in PERM if p[0] == 0]
+NSTABP = len(STABP)
+STABG = [p for p in STABP if p != tuple(range(NPI))][0]
+seen = [False] * NPI
+SZP = {}
+for a in range(NPI):
+    if seen[a]:
+        continue
+    orb = set(p[a] for p in STABP)
+    for x in orb:
+        seen[x] = True
+    SZP[len(orb)] = SZP.get(len(orb), 0) + 1
+SZP_LIST = sorted(SZP.items())
+FP = SZP.get(1, 0)
+SP2 = SZP.get(2, 0)
+STAB_SIMPLE = (FP + 2 * SP2 == NPI)
+STAB_ORB = (FP + SP2 == NORB)
+
+
+def two_parts(g):
+    inv = [0] * NPI
+    for a in range(NPI):
+        inv[g[a]] = a
+    P = [[1 if g[i] == j else 0 for j in range(NPI)] for i in range(NPI)]
+    MM = [[P[i][j] - (1 if i == j else 0) for j in range(NPI)] for i in range(NPI)]
+    MP = [[P[i][j] + (1 if i == j else 0) for j in range(NPI)] for i in range(NPI)]
+    rm, kp, bb = rref(MM, NPI, True)
+    rp, km, bb = rref(MP, NPI, True)
+    dplus = NPI - rm
+    dminus = NPI - rp
+    ap = rank_fwd([[x + r[inv[j]] for j, x in enumerate(r)] for r in RAROW], NPI)
+    am = rank_fwd([[x - r[inv[j]] for j, x in enumerate(r)] for r in RAROW], NPI)
+    bp = rank_fwd([[x + r[inv[j]] for j, x in enumerate(r)] for r in RBROW], NPI)
+    bm = rank_fwd([[x - r[inv[j]] for j, x in enumerate(r)] for r in RBROW], NPI)
+    return (dplus, dminus, ap, am, bp, bm), kp, km
+
+
+TWO = []
+for g in PERM:
+    if g == IDP:
+        continue
+    if tuple(g[g[i]] for i in range(NPI)) != IDP:
+        continue
+    if any(g[i] == i for i in range(NPI)):
+        TWO.append(g)
+NTWO = len(TWO)
+TWO = [STABG] + [g for g in TWO if g != STABG]
+SIX, KPLUS, KMINUS = two_parts(TWO[0])
+DPLUS, DMINUS, APL, AMI, BPL, BMI = SIX
+EIG_SUM = (DPLUS + DMINUS == NPI)
+ONE_PLUS = all(sum(a * b for a, b in zip(ONE, v)) == 0
+               for v in [clear_den(w) for w in KMINUS])
+SPLIT_A = (APL + AMI == RANKA)
+SPLIT_B = (BPL + BMI == RANKB)
+THMA_PLUS = (APL + BPL == DPLUS + DMEET)
+THMA_MINUS = (AMI + BMI == DMINUS)
+ALLSIX = all(two_parts(g)[0] == SIX for g in TWO)
+
+# the structural upgrade, tested and reported
+SPAN = [list(ONE)] + [list(v) for v in KMINUS]
+DSPAN = rank_fwd(SPAN, NPI)
+DJOINT = rank_fwd(SPAN + RAROW, NPI)
+INSIDE = (DJOINT == DSPAN)
+MEET_IS_RANK = (AMI == RANKA)
+DEMOTE_OK = (DSPAN == DMINUS + DMEET
+             and RANKA + DSPAN - DJOINT == AMI + DMEET)
+
+EIG_KER = (DPLUS == NKA)
+EIG_RANK = (DMINUS == RANKA)
+
+# ------------------------------------------------------------------
+# 15. the cover-side control
+# ------------------------------------------------------------------
+
+CIDX = dict((c, k) for k, c in enumerate(CS))
+CPERM = []
+COV_OK = True
+for p in PERM:
+    q = []
+    for c in CS:
+        im = tuple(sorted(p[x] for x in c))
+        if im not in CIDX:
+            COV_OK = False
+            break
+        q.append(CIDX[im])
+    if not COV_OK:
+        break
+    CPERM.append(tuple(q))
+COV_BIJ = (len(CPERM) == NGRP
+           and all(sorted(q) == list(range(NCOV)) for q in CPERM))
+orb = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for q in CPERM:
+        y = q[x]
+        if y not in orb:
+            orb.add(y)
+            fr.append(y)
+COV_TRANS = (len(orb) == NCOV)
+
+CCHI = [sum(1 for i in range(NCOV) if q[i] == i) for q in CPERM]
+HC = {}
+for f in CCHI:
+    HC[f] = HC.get(f, 0) + 1
+HIST_C = sorted(HC.items())
+CSUM = sum(CCHI)
+CSUMSQ = sum(f * f for f in CCHI)
+CROOT = pair_orbits(CPERM, NCOV)
+NPOC = len(set(CROOT))
+CSUMSQ_OK = (CSUMSQ == NGRP * NPOC)
+
+STABC = [e for e in range(NGRP) if CPERM[e][0] == 0]
+NSTABC = len(STABC)
+seen = [False] * NCOV
+SZC = {}
+for a in range(NCOV):
+    if seen[a]:
+        continue
+    o = set(CPERM[e][a] for e in STABC)
+    for x in o:
+        seen[x] = True
+    SZC[len(o)] = SZC.get(len(o), 0) + 1
+SZC_LIST = sorted(SZC.items())
+FC = SZC.get(1, 0)
+SC2 = SZC.get(2, 0)
+CSTAB_SIMPLE = (FC + 2 * SC2 == NCOV)
+CSTAB_ORB = (FC + SC2 == NPOC)
+CSTAB_OTHER = [e for e in STABC if PERM[e] != IDP]
+CSTAB_FIXP = CHI[CSTAB_OTHER[0]] if len(CSTAB_OTHER) == 1 else -1
+
+SAME_ACTION = (CHI == CCHI)
+PIECE_YES = (NORB == NKA)
+COVER_YES = (NPOC == NKB)
+ONE_SIDED = (PIECE_YES != COVER_YES)
+SAME_OK = ((not SAME_ACTION) or (NORB == NPOC))
+
+# ------------------------------------------------------------------
+# 16. the symmetry does not fix the cover-side dimension either
+# ------------------------------------------------------------------
+
+
+def sweep_labels(act1, n1, act2, n2):
+    L = [[-1] * n2 for _ in range(n1)]
+    nl = 0
+    for i in range(n1):
+        Li = L[i]
+        for j in range(n2):
+            if Li[j] >= 0:
+                continue
+            for e in range(NGRP):
+                L[act1[e][i]][act2[e][j]] = nl
+            nl += 1
+    return L, nl
+
+
+CPLAB, NCP = sweep_labels(CPERM, NCOV, PERM, NPI)
+CP_FULL = all(min(r) >= 0 for r in CPLAB)
+PPLAB, NPP = sweep_labels(PERM, NPI, PERM, NPI)
+PP_FULL = all(min(r) >= 0 for r in PPLAB)
+PP_AGREE = (NPP == NORB)
+
+BV = [-1] * NCP
+BEQUI = True
+for i in range(NCOV):
+    Li = CPLAB[i]
+    Bi = BROW[i]
+    for j in range(NPI):
+        k = Li[j]
+        if BV[k] < 0:
+            BV[k] = Bi[j]
+        elif BV[k] != Bi[j]:
+            BEQUI = False
+
+QPP, RPP = divmod(sum(f * f for f in CHI), NGRP)
+QCC, RCC = divmod(sum(f * f for f in CCHI), NGRP)
+QCP, RCP = divmod(sum(CCHI[e] * CHI[e] for e in range(NGRP)), NGRP)
+PAIR_DIV = (RPP == 0 and RCC == 0 and RCP == 0)
+PAIR_PP = (QPP == NPP)
+PAIR_CP = (QCP == NCP)
+PAIR_CC = (QCC == NPOC)
+
+
+def rank_modp(M, p):
+    A = np.mod(np.array(M, dtype=np.int64), p)
+    nr = A.shape[0]
+    nc = A.shape[1]
+    r = 0
+    for c in range(nc):
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        piv = r + int(nz[0])
+        if piv != r:
+            tmp = A[r].copy()
+            A[r] = A[piv]
+            A[piv] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        if r + 1 < nr:
+            A[r + 1:] = np.mod(A[r + 1:] - np.outer(A[r + 1:, c], A[r]), p)
+        r += 1
+        if r == nr:
+            break
+    return int(r)
+
+
+# one mod-p rank path only, tied to the exact rational ranks before it is used
+RANKB_P = rank_modp(BROW, PRIME)
+RANKA_P = rank_modp(RAROW, PRIME)
+GOOD_PRIME = (RANKB_P == RANKB and RANKA_P == RANKA)
+
+CPL = np.array(CPLAB, dtype=np.int64)
+PPL = np.array(PPLAB, dtype=np.int64)
+
+
+def ind_rank(L, j):
+    return rank_modp((L == j).astype(np.int64), PRIME)
+
+
+CPRK = [ind_rank(CPL, j) for j in range(NCP)]
+WIT = max(CPRK)
+RKH = {}
+for v in CPRK:
+    RKH[v] = RKH.get(v, 0) + 1
+RKHIST = sorted(RKH.items())
+CTL = max(ind_rank(PPL, j) for j in range(NPP))
+CTL_OK = (CTL == NPI)
+BEATS = (WIT > RANKB)
+GAIN = WIT - RANKB
+TIEVAL = NPI - WIT + 1
+
+CELLS = [[] for _ in range(NCP)]
+for i in range(NCOV):
+    Li = CPLAB[i]
+    for k in range(NPI):
+        CELLS[Li[k]].append((i, k))
+
+# The rule, stated before it is tested. If every orbit has size the group
+# order then the group acts freely on the cells of one orbit, so each cover
+# lies in exactly two of its cells and so does each piece: the orbit read as a
+# bipartite graph on covers and pieces is two-regular, hence a disjoint union
+# of cycles. A cycle on k covers and k pieces gives a k by k matrix with two
+# ones in each row and column placed cyclically, whose determinant is
+# 1 + (-1)^(k+1), so that block has rank k - 1 for even k and rank k for odd k.
+# The predicted rank of the orbit is the sum of those block ranks.
+
+
+def cyc_lens(cells):
+    rw = {}
+    cl = {}
+    for (i, k) in cells:
+        rw.setdefault(i, []).append(k)
+        cl.setdefault(k, []).append(i)
+    if len(rw) != NCOV or len(cl) != NPI:
+        return None
+    for v in rw.values():
+        if len(v) != 2:
+            return None
+    for v in cl.values():
+        if len(v) != 2:
+            return None
+    seen = [False] * NCOV
+    lens = []
+    for s in range(NCOV):
+        if seen[s]:
+            continue
+        cur = s
+        pk = -1
+        cnt = 0
+        while not seen[cur]:
+            seen[cur] = True
+            cnt += 1
+            a, b = rw[cur]
+            nk = b if a == pk else a
+            x, y = cl[nk]
+            pk = nk
+            cur = y if x == cur else x
+        lens.append(cnt)
+    return lens
+
+
+TWOREG = True
+CYCBAD = 0
+CYCTYPE = set()
+for j in range(NCP):
+    lens = cyc_lens(CELLS[j])
+    if lens is None:
+        TWOREG = False
+        CYCBAD += 1
+        continue
+    pred = 0
+    for k in lens:
+        pred += k - 1 if divmod(k, 2)[1] == 0 else k
+    if pred != CPRK[j]:
+        CYCBAD += 1
+    CYCTYPE.add((len(lens), tuple(sorted(set(lens))), sum(lens)))
+CYCLIST = sorted(CYCTYPE)
+CYC_OK = (TWOREG and CYCBAD == 0 and len(CYCLIST) == 1)
+
+SVAL = QPP + QCC - 2 * QCP
+PROD = NGRP * SVAL
+ROOT_I = math.isqrt(PROD) if PROD >= 0 else -1
+HALF = ROOT_I // 2
+BOUND = NPI - HALF
+HAND_OK = (PROD >= 0 and ROOT_I * ROOT_I <= PROD
+           and (ROOT_I + 1) * (ROOT_I + 1) > PROD and WIT >= BOUND)
+
+
+# ------------------------------------------------------------------
+# 17. the orbit matrices, the structure constants, and the centre
+# ------------------------------------------------------------------
+
+LA = np.array(LAB, dtype=np.int64)
+OPS = np.zeros((NORB, NPI, NPI), dtype=np.int64)
+for a in range(NORB):
+    OPS[a] = (LA == a).astype(np.int64)
+
+CA = np.array(CPLAB, dtype=np.int64)
+OXS = np.zeros((NCP, NCOV, NPI), dtype=np.int64)
+for k in range(NCP):
+    OXS[k] = (CA == k).astype(np.int64)
+
+BM = np.array(BROW, dtype=np.int64)
+
+
+def op_of(z):
+    return np.tensordot(np.array(z, dtype=np.int64), OPS, axes=([0], [0]))
+
+
+# each orbit matrix commutes with the action, each cell matrix intertwines it
+EQ_P = 0
+EQ_X = 0
+EQ_OK = True
+for e in [1, 7, 40, 191, 383]:
+    p = PERM[e]
+    q = CPERM[e]
+    JX = np.array(p, dtype=np.int64)
+    for a in [0, 17, 61, 103]:
+        EQ_P += 1
+        if not np.array_equal(OPS[a][np.ix_(JX, JX)], OPS[a]):
+            EQ_OK = False
+    QX = np.array(q, dtype=np.int64)
+    for k in [0, 23, 71, 95]:
+        EQ_X += 1
+        if not np.array_equal(OXS[k][np.ix_(QX, JX)], OXS[k]):
+            EQ_OK = False
+
+# the cover table is a union of whole cell orbits
+INB = []
+BSPLIT = True
+for k in range(NCP):
+    vs = set(BM[CA == k].tolist())
+    if vs == set([1]):
+        INB.append(k)
+    elif vs != set([0]):
+        BSPLIT = False
+NINB = len(INB)
+BREB = np.zeros((NCOV, NPI), dtype=np.int64)
+for k in INB:
+    BREB = BREB + OXS[k]
+BM_OK = (BSPLIT and NINB == 4 and np.array_equal(BREB, BM))
+del BREB
+
+REP = [None] * NORB
+for i in range(NPI):
+    Li = LAB[i]
+    for j in range(NPI):
+        c = Li[j]
+        if REP[c] is None:
+            REP[c] = (i, j)
+REP_FULL = all(x is not None for x in REP)
+
+SC = np.zeros((NORB, NORB, NORB), dtype=np.int64)
+for c in range(NORB):
+    i, j = REP[c]
+    Li = LAB[i]
+    for k in range(NPI):
+        SC[Li[k]][LAB[k][j]][c] += 1
+SCMAX = int(SC.max())
+
+SCPAIRS = [(0, 0), (7, 13), (23, 58), (41, 41), (66, 95), (88, 30), (103, 72)]
+SC_CHK = 0
+SC_AGREE = True
+SC_ENT = 0
+for a, b in SCPAIRS:
+    P1 = OPS[a] @ OPS[b]
+    P2 = np.tensordot(SC[a][b], OPS, axes=([0], [0]))
+    SC_ENT = max(SC_ENT, int(np.abs(P1).max()), int(np.abs(P2).max()))
+    SC_CHK += 1
+    if not np.array_equal(P1, P2):
+        SC_AGREE = False
+SC_SAFE = (SC_ENT < 2 ** 40)
+del P1, P2
+
+DFC = SC - np.transpose(SC, (1, 0, 2))
+CON = np.ascontiguousarray(np.transpose(DFC, (1, 2, 0)).reshape(NORB * NORB, NORB))
+NCON = int(CON.shape[0])
+del DFC
+
+
+def mod_pick(rows, ncol, p):
+    pc = []
+    sel = []
+    PM = np.zeros((0, ncol), dtype=np.int64)
+    for idx in range(rows.shape[0]):
+        v = np.mod(rows[idx].astype(np.int64), p)
+        if pc:
+            co = v[np.array(pc, dtype=np.int64)]
+            if co.any():
+                v = np.mod(v - co @ PM, p)
+        nz = np.nonzero(v)[0]
+        if nz.size == 0:
+            continue
+        c = int(nz[0])
+        v = np.mod(v * pow(int(v[c]), p - 2, p), p)
+        if PM.shape[0]:
+            col = PM[:, c].copy()
+            if col.any():
+                PM = np.mod(PM - np.outer(col, v), p)
+        PM = np.vstack([PM, v.reshape(1, ncol)])
+        pc.append(c)
+        sel.append(idx)
+        if len(pc) == ncol:
+            break
+    return sel, len(pc)
+
+
+def mod_ker(A, p):
+    A = np.mod(np.array(A, dtype=np.int64), p)
+    nr = A.shape[0]
+    nc = A.shape[1]
+    pc = []
+    r = 0
+    for c in range(nc):
+        if r >= nr:
+            break
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        pr = r + int(nz[0])
+        if pr != r:
+            tmp = A[r].copy()
+            A[r] = A[pr]
+            A[pr] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        col = A[:, c].copy()
+        col[r] = 0
+        if col.any():
+            A = np.mod(A - np.outer(col, A[r]), p)
+        pc.append(c)
+        r += 1
+    ps = set(pc)
+    free = [c for c in range(nc) if c not in ps]
+    K = np.zeros((nc, len(free)), dtype=np.int64)
+    for t, fc in enumerate(free):
+        K[fc, t] = 1
+        for i, cc in enumerate(pc):
+            K[cc, t] = divmod(-int(A[i, fc]), p)[1]
+    return K
+
+
+SEL, RKC = mod_pick(CON, NORB, PRIME)
+NSEL = len(SEL)
+CROWS = [CON[i].tolist() for i in SEL]
+RKX, KERC, BASC = rref(CROWS, NORB, True)
+CENB = []
+for v in KERC:
+    iv = clear_den(v)
+    gg = 0
+    for x in iv:
+        gg = math.gcd(gg, abs(x))
+    if gg > 1:
+        iv = [x // gg for x in iv]
+    CENB.append(iv)
+NCEN = len(CENB)
+ZMAX = max(max(abs(x) for x in z) for z in CENB)
+GUARD_OK = (ZMAX * SCMAX * NORB < 2 ** 62)
+CEN_OK = True
+CEN_CHK = 0
+for z in CENB:
+    za = np.array(z, dtype=np.int64)
+    LZ = np.tensordot(za, SC, axes=([0], [0]))
+    RZ = np.tensordot(za, SC, axes=([0], [1]))
+    CEN_CHK += LZ.size
+    if not np.array_equal(LZ, RZ):
+        CEN_OK = False
+
+# ------------------------------------------------------------------
+# 18. one central element and the twenty values it separates
+# ------------------------------------------------------------------
+
+NBCOL = [[CENB[l][a] for l in range(NCEN)] for a in range(NORB)]
+
+
+def esolve(AM, RH, n, m):
+    nr = len(AM)
+    W = [[FR(AM[i][j]) for j in range(n)] + [FR(RH[i][j]) for j in range(m)]
+         for i in range(nr)]
+    piv = []
+    r = 0
+    for c in range(n):
+        p = -1
+        for i in range(r, nr):
+            if W[i][c] != 0:
+                p = i
+                break
+        if p < 0:
+            continue
+        W[r], W[p] = W[p], W[r]
+        pv = W[r][c]
+        W[r] = [x / pv for x in W[r]]
+        for i in range(nr):
+            if i != r and W[i][c] != 0:
+                f = W[i][c]
+                Wi = W[i]
+                Wr = W[r]
+                W[i] = [Wi[t] - f * Wr[t] for t in range(n + m)]
+        piv.append(c)
+        r += 1
+    if r != n:
+        return None
+    for i in range(r, nr):
+        for t in range(n, n + m):
+            if W[i][t] != 0:
+                return None
+    X = [[FR(0)] * m for _ in range(n)]
+    for i, c in enumerate(piv):
+        for t in range(m):
+            X[c][t] = W[i][n + t]
+    return X
+
+
+TRY = 0
+TWORK = 0
+B0 = 0
+VALS = []
+NUL = []
+M0 = None
+Z0 = None
+while TRY < 24 and TWORK == 0:
+    TRY += 1
+    co = [1 + divmod(TRY * (k + 1) * (k + 1) + k, 37)[1] for k in range(NCEN)]
+    wv = [0] * NORB
+    for k in range(NCEN):
+        ck = co[k]
+        zk = CENB[k]
+        for a in range(NORB):
+            wv[a] += ck * zk[a]
+    WVA = np.array(wv, dtype=np.int64)
+    TT = np.tensordot(WVA, SC, axes=([0], [0]))
+    VC = [(np.array(CENB[k], dtype=np.int64) @ TT).tolist() for k in range(NCEN)]
+    RH = [[VC[k][c] for k in range(NCEN)] for c in range(NORB)]
+    XS = esolve(NBCOL, RH, NCEN, NCEN)
+    if XS is None:
+        continue
+    if not all(x.denominator == 1 for row in XS for x in row):
+        continue
+    MC = [[int(x) for x in row] for row in XS]
+    BB = max(sum(abs(x) for x in row) for row in MC)
+    vv = []
+    nn = []
+    for lam in range(-BB, BB + 1):
+        rr = rank_fwd([[MC[i][j] - (lam if i == j else 0) for j in range(NCEN)]
+                       for i in range(NCEN)], NCEN)
+        if rr < NCEN:
+            vv.append(lam)
+            nn.append(NCEN - rr)
+    if len(vv) == NCEN and all(x == 1 for x in nn):
+        TWORK = TRY
+        B0 = BB
+        VALS = vv
+        NUL = nn
+        M0 = MC
+        Z0 = op_of(wv)
+
+VAL_OK = (TWORK > 0 and len(VALS) == NCEN and all(x == 1 for x in NUL))
+
+REP_CHK = 0
+REP_OK = VAL_OK
+if VAL_OK:
+    for k in [0, 1, NCEN - 1]:
+        LHS = Z0 @ op_of(CENB[k])
+        RHS = np.zeros((NPI, NPI), dtype=np.int64)
+        for l in range(NCEN):
+            if M0[l][k]:
+                RHS = RHS + M0[l][k] * op_of(CENB[l])
+        REP_CHK += 1
+        if not np.array_equal(LHS, RHS):
+            REP_OK = False
+    del LHS, RHS
+
+# ------------------------------------------------------------------
+# 19. the part table
+# ------------------------------------------------------------------
+
+EYE = np.eye(NPI, dtype=np.int64)
+PARTS = []
+PART_OK = VAL_OK
+for lam in VALS:
+    AZ = np.mod(Z0 - lam * EYE, PRIME)
+    KB = mod_ker(AZ, PRIME)
+    dim = int(KB.shape[1])
+    PR = np.mod(np.tensordot(OPS, KB, axes=([2], [0])), PRIME)
+    m2 = rank_modp(PR.reshape(NORB, NPI * dim), PRIME)
+    m = math.isqrt(m2)
+    XR = np.mod(np.tensordot(OXS, KB, axes=([2], [0])), PRIME)
+    mmc = rank_modp(XR.reshape(NCP, NCOV * dim), PRIME)
+    if m * m != m2 or m == 0:
+        PART_OK = False
+        break
+    mc, r1 = divmod(mmc, m)
+    d, r2 = divmod(dim, m)
+    if r1 != 0 or r2 != 0:
+        PART_OK = False
+        break
+    stk = np.vstack([BM, AZ])
+    blind = NPI - rank_modp(stk, PRIME)
+    forced = d * max(0, m - mc)
+    PARTS.append((lam, dim, d, m, mc, blind, forced, blind - forced))
+
+SUM_DIM = sum(t[1] for t in PARTS)
+SUM_MM = sum(t[3] * t[3] for t in PARTS)
+SUM_MMC = sum(t[3] * t[4] for t in PARTS)
+SUM_CC = sum(t[4] * t[4] for t in PARTS)
+SUM_DMC = sum(t[2] * t[4] for t in PARTS)
+SUM_BL = sum(t[5] for t in PARTS)
+DIMS = sorted(t[1] for t in PARTS)
+
+# ------------------------------------------------------------------
+# 20. the theorem, the exact witness, and the labelling it cannot reach
+# ------------------------------------------------------------------
+
+CEIL = sum(t[2] * min(t[3], t[4]) for t in PARTS)
+FLOORB = sum(t[2] * max(0, t[3] - t[4]) for t in PARTS)
+EXC_C = CEIL - RANKB
+EXC_F = NKB - FLOORB
+
+WIT2 = np.zeros((NCOV, NPI), dtype=np.int64)
+for k in range(NCP):
+    WIT2 = WIT2 + (1 + divmod(k * k + 3 * k, 11)[1]) * OXS[k]
+WEXACT = rank_fwd(WIT2.tolist(), NPI)
+
+EXROWS = [t for t in PARTS if t[7] > 0]
+NEX = len(EXROWS)
+NZERO = len(PARTS) - NEX
+NEXGE = sum(1 for t in EXROWS if t[4] >= t[3])
+NEXLT = NEX - NEXGE
+MC0_OK = all(t[7] == 0 for t in PARTS if t[4] == 0)
+NMC0 = sum(1 for t in PARTS if t[4] == 0)
+
+EVEN = [e for e in range(NGRP) if psign(DESC[e][0]) == 1]
+NEVEN = len(EVEN)
+EPP = [PERM[e] for e in EVEN]
+ECC = [CPERM[e] for e in EVEN]
+
+
+def orb_mark(acts, n, start, seen):
+    seen[start] = True
+    fr = [start]
+    while fr:
+        nx = []
+        for x in fr:
+            for act in acts:
+                y = act[x]
+                if not seen[y]:
+                    seen[y] = True
+                    nx.append(y)
+        fr = nx
+    return seen
+
+
+PIE_TRANS = all(orb_mark(PERM, NPI, 0, [False] * NPI))
+
+PSEEN = orb_mark(EPP, NPI, 0, [False] * NPI)
+NPCL0 = sum(1 for b in PSEEN if b)
+PREST = [i for i in range(NPI) if not PSEEN[i]]
+PSEEN2 = orb_mark(EPP, NPI, PREST[0], [False] * NPI) if PREST else [False] * NPI
+NPCL1 = sum(1 for b in PSEEN2 if b)
+PTWO = (NPCL0 + NPCL1 == NPI and not any(PSEEN[i] and PSEEN2[i] for i in range(NPI)))
+SGP = [1 if PSEEN[i] else -1 for i in range(NPI)]
+
+CSEEN = orb_mark(ECC, NCOV, 0, [False] * NCOV)
+NCCL0 = sum(1 for b in CSEEN if b)
+CREST = [i for i in range(NCOV) if not CSEEN[i]]
+CSEEN2 = orb_mark(ECC, NCOV, CREST[0], [False] * NCOV) if CREST else [False] * NCOV
+NCCL1 = sum(1 for b in CSEEN2 if b)
+CTWO = (NCCL0 + NCCL1 == NCOV
+        and not any(CSEEN[i] and CSEEN2[i] for i in range(NCOV)))
+
+CSUMS = sorted(set(sum(SGP[j] for j in c) for c in CS))
+HA = {}
+ATOT = 0
+for c in CS:
+    n0 = sum(1 for j in c if PSEEN[j])
+    ATOT += n0
+    HA[n0] = HA.get(n0, 0) + 1
+HISTA = sorted(HA.items())
+
+HB = {}
+BTOT = 0
+for j in range(NPI):
+    n0 = sum(1 for i in range(NCOV) if BROW[i][j] and CSEEN[i])
+    BTOT += n0
+    HB[n0] = HB.get(n0, 0) + 1
+HISTB = sorted(HB.items())
+SELFDUAL = (HISTA == HISTB and ATOT == BTOT and ATOT == 96 * 8)
+
+STE = [e for e in STABC if PERM[e] != IDP]
+NSTE = len(STE)
+E1 = STE[0] if NSTE else 0
+SG1, FL1 = DESC[E1]
+PS1 = psign(SG1)
+BLK = list(CS[0])
+BSET = set(BLK)
+IMG = [PERM[E1][b] for b in BLK]
+FIXB = sum(1 for t in range(8) if IMG[t] == BLK[t])
+CLOSED_BLK = (set(IMG) == BSET)
+CYC = []
+left = set(BLK)
+while left:
+    s = min(left)
+    ln = 0
+    x = s
+    while True:
+        left.discard(x)
+        x = PERM[E1][x]
+        ln += 1
+        if x == s:
+            break
+    CYC.append(ln)
+CYC = sorted(CYC)
+KEEPS_CLASS = all(SGP[PERM[E1][b]] == SGP[b] for b in BLK)
+FPAR1 = 1 - 2 * divmod(popc(FL1), 2)[1]
+PROD1 = FPAR1 * PS1
+
+NINE = [96 * a + 96 * (8 - a) for a in range(9)]
+NINE_OK = (len(NINE) == 9 and set(NINE) == set([768]))
+
+PARC = []
+DS = []
+for i in range(NPI):
+    cs5 = KEPT[USED[i]]
+    ne = sum(1 for c in cs5 if divmod(popc(c), 2)[1] == 0)
+    PARC.append(1 - 2 * divmod(ne, 2)[1])
+    p0 = CORN[cs5[0]]
+    DS.append(det4([[CORN[cs5[t]][u] - p0[u] for u in range(4)]
+                    for t in range(1, 5)]))
+AGR1 = sum(1 for i in range(NPI) if PARC[i] == SGP[i])
+AGR2 = sum(1 for i in range(NPI) if DS[i] == SGP[i])
+DSET = sorted(set(DS))
+
+CHAR = [psign(DESC[e][0]) * (1 - 2 * divmod(popc(DESC[e][1]), 2)[1])
+        for e in range(NGRP)]
+PCH_N = 0
+PCH_BAD = 0
+SRT_BAD = 0
+SRT_OK_E = 0
+for e in range(NGRP):
+    ch = CHAR[e]
+    mp = MAPS[e]
+    pe = PERM[e]
+    ok_e = True
+    for i in range(NPI):
+        cs5 = KEPT[USED[i]]
+        img = [mp[c] for c in cs5]
+        q0 = CORN[img[0]]
+        dv = det4([[CORN[img[t]][u] - q0[u] for u in range(4)]
+                   for t in range(1, 5)])
+        PCH_N += 1
+        if dv != DS[i] * ch:
+            PCH_BAD += 1
+        if DS[pe[i]] != DS[i] * ch:
+            SRT_BAD += 1
+            ok_e = False
+    if ok_e:
+        SRT_OK_E += 1
+
+# ------------------------------------------------------------------
+# 21. source hygiene and budget
+# ------------------------------------------------------------------
+
+SRC = open(__file__, "r").read()
+NO_PC = (chr(37) not in SRC)
+NO_TAB = (chr(9) not in SRC)
+NO_EM = (chr(8212) not in SRC)
+ASCII_OK = all(ord(ch) < 128 for ch in SRC)
+
+BAN = [("reta", "ined"), ("aud", "ited"), ("audit", " will"), ("only ", "route"),
+       ("last ", "route"), ("exha", "ust"), ("clos", "es"), ("PHAS", "E_"),
+       ("r = 1", "/2"), ("r=1", "/2"), ("grav", "it"), ("Ha", "ar"),
+       ("Reyn", "olds"), ("viel", "bein"), ("tet", "rad"), ("resolves ", "PARTIAL"),
+       ("/Us", "ers/"), ("7/", "(8"), ("regi", "ster"), ("oct", "et"),
+       ("sch", "eme"), ("association sch", "eme"), ("Sm", "ith"),
+       ("Bar", "eiss"), ("Gal", "ois"),
+       ("hyper", "octahedral"), ("Cox", "eter"), ("B", "_4"), ("na", "uty"),
+       ("Weis", "feiler"), ("Le", "man"), ("Leh", "man"), ("Mc", "Kay"),
+       ("sau", "cy"), ("bl", "iss"), ("trac", "es"), ("O", "_h"),
+       ("inver", "sion")]
+LOWSRC = SRC.lower()
+BAN_OK = True
+NBAN = 0
+for a, b in BAN:
+    NBAN += 1
+    if (a + b).lower() in LOWSRC:
+        BAN_OK = False
+
+ELAPSED = int(time.time() - T0)
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+RSSMB = RSS // 1048576 if RSS > 10000000 else RSS // 1024
+
+# ------------------------------------------------------------------
+# gates
+# ------------------------------------------------------------------
+
+emit("all numbers below are exact computational identities;"
+     " no floating point enters any gate")
+
+gate(NCAND == 2672 and NKEPT == 400 and FLOOR == 6 and NS == 15800
+     and SIZES == [24] and NPI == 192 and NCOV == 192, "C0",
+     "object: {0} pieces, {1} at cost floor {2}, {3} cuttings"
+     " of {4}, {5} used, {6} covers".format(NCAND, NKEPT, FLOOR, NS,
+                                            SIZES[0], NPI, NCOV))
+
+gate(NGRP == 384 and MAPS_DISTINCT and PERM_DISTINCT and CLOSED
+     and NPROD == 147456 and BIJ and PIE_TRANS and COV_TRANS, "C1",
+     "group: {0} maps distinct, {1} products closed, bijective {2},"
+     " piece orbit {3}, cover orbit {4}".format(NGRP, NPROD, yn(BIJ),
+                                                yn(PIE_TRANS),
+                                                yn(COV_TRANS)))
+
+gate(NORB == 104 and NPOC == 120 and NCP == 96 and NPP == NORB, "C2",
+     "orbits: {0} ordered piece pairs, {1} ordered cover pairs, {2} cells,"
+     " sweep agrees {3}".format(NORB, NPOC, NCP, yn(NPP == NORB)))
+
+gate(RANKA == 88 and NKA == 104 and RANKB == 105 and NKB == 87 and GOOD_PRIME,
+     "C3",
+     "exact ranks: cutting table {0} kernel {1}, cover table {2} kernel"
+     " {3}, prime path {4}".format(RANKA, NKA, RANKB, NKB, yn(GOOD_PRIME)))
+
+gate(EQ_OK and EQ_P + EQ_X == 40 and BM_OK, "C4",
+     "orbit matrices: {0} piece-pair, {1} cell; {2} equivariance checks {3};"
+     " cover table sums {4} cell orbits {5}".format(
+         NORB, NCP, EQ_P + EQ_X, yn(EQ_OK), NINB, yn(BM_OK)))
+
+gate(REP_FULL and SC_AGREE and SC_SAFE and SC_CHK >= 6, "C5",
+     "structure constants: max {0}, labels all represented {1}, {2}"
+     " product pairs agree {3}, below 2**40 {4}".format(
+         SCMAX, yn(REP_FULL), SC_CHK, yn(SC_AGREE), yn(SC_SAFE)))
+
+gate(NCON == 10816 and RKC == RKX and NSEL == RKC and NCEN == 20 and CEN_OK
+     and GUARD_OK and CEN_CHK == NCEN * NCON, "C6",
+     "centre: {0} of {1} rows, prime rank {2} exact {3}, dim {4},"
+     " all {1} met {5}, top {6}, guard {7}".format(
+         NSEL, NCON, RKC, RKX, NCEN, yn(CEN_OK), ZMAX, yn(GUARD_OK)))
+
+gate(VAL_OK and REP_OK and REP_CHK == 3 and B0 > 0, "C7",
+     "central element: trial {0}, bound {1}, {2} integer values of"
+     " nullity one {3}, {4} products {5}".format(
+         TWORK, B0, len(VALS), yn(VAL_OK), REP_CHK, yn(REP_OK)))
+
+gate(PART_OK and SUM_DIM == NPI and SUM_MM == NORB and SUM_MMC == NCP, "C8",
+     "certificates: dimensions {0} = {1}, m squared {2} = {3},"
+     " m times mc {4} = {5}".format(SUM_DIM, NPI, SUM_MM, NORB, SUM_MMC, NCP))
+
+gate(SUM_CC == NPOC and SUM_DMC == NCOV and SUM_BL == NKB, "C9",
+     "certificates: mc squared {0} = {1}, d times mc {2} = {3},"
+     " blind {4} = {5}".format(SUM_CC, NPOC, SUM_DMC, NCOV, SUM_BL, NKB))
+
+gate(len(PARTS) == NCEN and sum(DIMS) == NPI, "C10",
+     "{0} parts, dims sorted: {1}".format(
+         len(PARTS), ",".join(str(x) for x in DIMS)))
+
+gate(CEIL == 144 and FLOORB == 48 and CEIL + FLOORB == NPI, "C11",
+     "theorem: ceiling {0} on the rank, floor {1} on the blind space,"
+     " {0} plus {1} = {2}".format(CEIL, FLOORB, NPI))
+
+gate(EXC_C == EXC_F and EXC_C == 39 and RANKB < CEIL and NKB > FLOORB, "C12",
+     "measured: cover rank {0} blind {1}, ceiling minus rank {2}"
+     " equals blind minus floor {3}".format(RANKB, NKB, EXC_C, EXC_F))
+
+gate(WEXACT == CEIL and NPI - WEXACT == FLOORB, "C13",
+     "exact witness: an equivariant integer matrix of exact rank {0} meets"
+     " the ceiling, {1} minus it is {2}".format(WEXACT, NPI, FLOORB))
+
+gate(NZERO >= 12 and NEX + NZERO == len(PARTS) and NEXGE + NEXLT == NEX
+     and NEXLT > 0 and MC0_OK and NMC0 > 0, "C14",
+     "excess: {0} parts none, {1} some; of those {2} have mc at least m,"
+     " {3} not; all {4} with mc zero have none {5}".format(
+         NZERO, NEX, NEXGE, NEXLT, NMC0, yn(MC0_OK)))
+
+gate(NEX == 8 and all(t[5] == t[6] + t[7] for t in EXROWS), "C15",
+     "excess d/m/mc/blind/forced 1 to 4: {0}".format(
+         " ".join("/".join(str(x) for x in (t[2], t[3], t[4], t[5], t[6]))
+                  for t in EXROWS[:4])))
+
+gate(NEX == 8 and all(t[7] > 0 for t in EXROWS), "C16",
+     "excess d/m/mc/blind/forced 5 to 8: {0}".format(
+         " ".join("/".join(str(x) for x in (t[2], t[3], t[4], t[5], t[6]))
+                  for t in EXROWS[4:])))
+
+gate(NEVEN == 192 and NGRP == 2 * NEVEN and PTWO and CTWO and NPCL0 == 96
+     and NPCL1 == 96 and NCCL0 == 96 and NCCL1 == 96, "C17",
+     "even subgroup: order {0}, index {1}, piece classes {2} and {3},"
+     " cover classes {4} and {5}".format(NEVEN, NGRP // NEVEN, NPCL0, NPCL1,
+                                         NCCL0, NCCL1))
+
+gate(CSUMS == [0] and HISTA == [(4, NCOV)], "C18",
+     "class labelling: all {0} cover sums {1}, block split"
+     " {2}".format(NCOV, CSUMS, HISTA))
+
+gate(SELFDUAL and HISTB == [(4, NPI)], "C19",
+     "self-dual: piece {0}, cover {1}, totals {2} and {3},"
+     " both 96 times 8".format(HISTA, HISTB, ATOT, BTOT))
+
+gate(NSTE == 1 and PS1 == 1 and FIXB == 0 and CLOSED_BLK and CYC == [2, 2, 2, 2]
+     and KEEPS_CLASS, "C20",
+     "first candidate: the element fixing cover 0: sign {0}, fixes"
+     " {1} of 8 blocks, cycles {2}, class kept {3}".format(
+         PS1, FIXB, CYC, yn(KEEPS_CLASS)))
+
+gate(FPAR1 == -1 and PROD1 == -1, "C21",
+     "contrast: that element has flip parity {0}, product with"
+     " the permutation sign {1}, both blind".format(FPAR1, PROD1))
+
+gate(NINE_OK and 768 // NPI == 4, "C22",
+     "second candidate: the mean carries nothing; all {0} splits a give"
+     " 96a + 96(8 - a) = {1}, {1} over {2} is 4".format(len(NINE), NINE[0],
+                                                        NPI))
+
+gate(AGR1 not in (0, NPI) and AGR2 not in (0, NPI) and DSET == [-1, 1], "C23",
+     "third candidate: corner-parity agrees on {0} of {1}, ordered"
+     " determinant {2} of {1}, values {3}".format(
+         AGR1, NPI, AGR2, DSET))
+
+gate(PCH_BAD == 0 and PCH_N == NGRP * NPI, "C24",
+     "determinant tracks the product character: source-order corners"
+     " match all {0}, {1} misses".format(
+         PCH_N, PCH_BAD))
+
+gate(SRT_BAD > 0 and SRT_OK_E < NGRP, "C25",
+     "re-sorted: each image piece in its own order"
+     " fails on {0} of {1}, for {2} of {3}".format(
+         SRT_BAD, PCH_N, SRT_OK_E, NGRP))
+
+gate(ASCII_OK and NO_TAB and NO_PC and NO_EM and BAN_OK and NBAN > 0, "C26",
+     "source hygiene: ASCII {0}, no tab {1}, no remainder {2}, no"
+     " long dash {3}, {4} barred absent {5}".format(
+         yn(ASCII_OK), yn(NO_TAB), yn(NO_PC), yn(NO_EM), NBAN, yn(BAN_OK)))
+
+gate(ELAPSED < 900 and RSSMB < 2500, "C27",
+     "budget: {0} s wall under 900, peak resident {1} MB under 2500,"
+     " stdout counted below".format(nd(ELAPSED), nd(RSSMB)))
+
+# ------------------------------------------------------------------
+# 22. a second prime, and the twenty small matrices
+# ------------------------------------------------------------------
+
+P2 = 1000003
+P3 = 1000033
+
+
+def is_prime(n):
+    if n < 2:
+        return False
+    f = 2
+    while f * f <= n:
+        if divmod(n, f)[1] == 0:
+            return False
+        f += 1
+    return True
+
+
+PRIME_OK = is_prime(P2) and is_prime(P3) and P2 != P3
+
+
+def left_inv(K, p):
+    """left inverse of a full-column-rank K, by elimination on K beside I"""
+    n = int(K.shape[0])
+    r = int(K.shape[1])
+    if r == 0:
+        return np.zeros((0, n), dtype=np.int64)
+    A = np.concatenate([np.mod(K, p), np.eye(n, dtype=np.int64)], axis=1)
+    row = 0
+    for c in range(r):
+        nz = np.nonzero(A[row:, c])[0]
+        if nz.size == 0:
+            return None
+        pr = row + int(nz[0])
+        if pr != row:
+            tmp = A[row].copy()
+            A[row] = A[pr]
+            A[pr] = tmp
+        iv = pow(int(A[row, c]), p - 2, p)
+        A[row] = np.mod(A[row] * iv, p)
+        col = A[:, c].copy()
+        col[row] = 0
+        if col.any():
+            A = np.mod(A - np.outer(col, A[row]), p)
+        row += 1
+    return np.ascontiguousarray(A[:r, r:])
+
+
+def min_poly(MX, dim, mmax, p):
+    """smallest k making I, MX, ..., MX**k dependent, with the coefficients"""
+    piv = []
+    cur = np.eye(dim, dtype=np.int64)
+    for j in range(mmax + 1):
+        v = np.mod(cur.reshape(-1).copy(), p)
+        a = np.zeros(mmax + 2, dtype=np.int64)
+        a[j] = 1
+        for (c, rv, ra) in piv:
+            f = int(v[c])
+            if f:
+                v = np.mod(v - f * rv, p)
+                a = np.mod(a - f * ra, p)
+        nz = np.nonzero(v)[0]
+        if nz.size == 0:
+            return [int(x) for x in a[:j + 1]]
+        c = int(nz[0])
+        iv = pow(int(v[c]), p - 2, p)
+        v = np.mod(v * iv, p)
+        a = np.mod(a * iv, p)
+        piv.append((c, v, a))
+        cur = np.mod(cur @ MX, p)
+    return None
+
+
+def poly_roots(cf, p):
+    """all roots, by nested evaluation at every residue at once"""
+    deg = len(cf) - 1
+    xs = np.arange(p, dtype=np.int64)
+    val = np.full(p, divmod(int(cf[deg]), p)[1], dtype=np.int64)
+    for j in range(deg - 1, -1, -1):
+        val = np.mod(val * xs + int(cf[j]), p)
+    return [int(x) for x in np.nonzero(val == 0)[0]]
+
+
+def build_small(p):
+    """the twenty (d, m, mc, blind) rows and the twenty small matrices at p"""
+    EYE = np.eye(NPI, dtype=np.int64)
+    rws = []
+    bts = []
+    flg = []
+    tri = []
+    for lam in VALS:
+        AZ = np.mod(Z0 - lam * EYE, p)
+        KK = mod_ker(AZ, p)
+        dim = int(KK.shape[1])
+        OPK = np.mod(np.tensordot(OPS, KK, axes=([2], [0])), p)
+        m2 = rank_modp(OPK.reshape(NORB, NPI * dim), p)
+        m = math.isqrt(m2)
+        OXK = np.mod(np.tensordot(OXS, KK, axes=([2], [0])), p)
+        mmc = rank_modp(OXK.reshape(NCP, NCOV * dim), p)
+        del OXK
+        mc, r1 = divmod(mmc, m)
+        d, r2 = divmod(dim, m)
+        bl = NPI - rank_modp(np.vstack([BM, AZ]), p)
+        shp = (m * m == m2 and m > 0 and r1 == 0 and r2 == 0)
+        rws.append((d, m, mc, bl))
+        # step 1: restrict the algebra to this part and check the residual
+        LK = left_inv(KK, p)
+        if LK is None:
+            flg.append((False, 0, False, False, False))
+            bts.append(None)
+            tri.append(0)
+            continue
+        idok = np.array_equal(np.mod(LK @ KK, p), np.eye(dim, dtype=np.int64))
+        MA = np.mod(np.matmul(LK[None, :, :], OPK), p)
+        res0 = bool(np.array_equal(np.mod(np.matmul(KK[None, :, :], MA), p), OPK))
+        del OPK
+        # step 2: a pure vector, from a small-integer element of the algebra
+        tw = 0
+        vk = None
+        for t in range(1, 25):
+            co = np.array([1 + divmod(t * (a + 1) * (a + 1) + a, 37)[1]
+                           for a in range(NORB)], dtype=np.int64)
+            MM = np.mod(np.tensordot(co, MA, axes=([0], [0])), p)
+            cf = min_poly(MM, dim, m, p)
+            if cf is None:
+                continue
+            for lr in poly_roots(cf, p):
+                BK = mod_ker(np.mod(MM - lr * np.eye(dim, dtype=np.int64), p), p)
+                if int(BK.shape[1]) == d:
+                    vk = BK[:, 0]
+                    tw = t
+                    break
+            if tw:
+                break
+        if vk is None:
+            flg.append((res0 and idok and shp, 0, False, False, False))
+            bts.append(None)
+            tri.append(0)
+            continue
+        # step 3: the span of the algebra on that vector
+        v = np.mod(KK @ vk, p)
+        CLS = np.mod(np.tensordot(OPS, v, axes=([2], [0])), p)
+        sel, rk = mod_pick(CLS, NPI, p)
+        SBM = CLS[np.array(sel, dtype=np.int64)]
+        ok3 = (rk == m)
+        # step 4: the image of that span on the cover side
+        IMX = np.mod(np.tensordot(OXS, SBM.T, axes=([2], [0])), p)
+        R2 = np.ascontiguousarray(
+            IMX.transpose(0, 2, 1)).reshape(NCP * SBM.shape[0], NCOV)
+        sel2, rk2 = mod_pick(R2, NCOV, p)
+        ok4 = (rk2 == mc)
+        # step 5: the small matrix itself, one per cell orbit
+        if mc == 0:
+            bts.append(None)
+            ok5 = True
+        else:
+            YB = np.ascontiguousarray(R2[np.array(sel2, dtype=np.int64)].T)
+            LY = left_inv(YB, p)
+            if LY is None:
+                bts.append(None)
+                ok5 = False
+            else:
+                BT = np.mod(np.tensordot(LY, IMX, axes=([1], [1])), p)
+                BT = np.ascontiguousarray(BT.transpose(1, 0, 2))
+                ok5 = bool(np.array_equal(
+                    np.mod(np.matmul(YB[None, :, :], BT), p), IMX))
+                bts.append(BT)
+        flg.append((res0 and idok and shp, tw, ok3, ok4, ok5))
+        tri.append(tw)
+    return rws, bts, flg, tri
+
+
+T764 = [(t[2], t[3], t[4], t[5]) for t in PARTS]
+ROWS2, BET2, FLG2, TRI2 = build_small(P2)
+NPART = len(ROWS2)
+TAB2_OK = (ROWS2 == T764)
+PASS5 = sum(1 for f in FLG2 if f[0] and f[1] > 0 and f[2] and f[3] and f[4])
+NOMC = sum(1 for i in range(NPART) if ROWS2[i][2] == 0)
+NOVEC = [VALS[i] for i in range(NPART) if FLG2[i][1] == 0]
+FTX = "" if not NOVEC else "; no pure vector at {0}".format(NOVEC[:3])
+SMMC = sum(r[1] * r[2] for r in ROWS2)
+
+ACT = [i for i in range(NPART) if BET2[i] is not None]
+DACT = [ROWS2[i][0] for i in ACT]
+
+# ------------------------------------------------------------------
+# 23. the 96 cell-orbit coefficients against the twenty small matrices
+# ------------------------------------------------------------------
+
+ISOR = []
+for k in range(NCP):
+    ISOR.append(np.concatenate([BET2[i][k].reshape(-1) for i in ACT]))
+ISO = np.array(ISOR, dtype=np.int64)
+ISOW = int(ISO.shape[1])
+ISORK = rank_modp(ISO, P2)
+del ISOR
+
+
+def small_ranks(A, p):
+    """rank of every matrix in a stack, by cross-multiplication, no inverses"""
+    N = int(A.shape[0])
+    mc = int(A.shape[1])
+    m = int(A.shape[2])
+    mn = min(mc, m)
+    if mn <= 1:
+        return (A.reshape(N, mc * m) != 0).any(axis=1).astype(np.int64)
+    used = np.zeros((N, mc), dtype=bool)
+    rk = np.zeros(N, dtype=np.int64)
+    ix = np.arange(N)
+    for c in range(m):
+        if int(rk.min()) >= mn:
+            break
+        cand = (A[:, :, c] != 0) & (~used)
+        has = cand.any(axis=1)
+        if not has.any():
+            continue
+        pr = np.argmax(cand, axis=1)
+        pvr = A[ix, pr, :]
+        pv = pvr[:, c].copy()
+        col = A[:, :, c].copy()
+        upd = (~used) & (col != 0)
+        upd[ix, pr] = False
+        upd &= has[:, None]
+        tmp = A * pv[:, None, None]
+        tmp -= pvr[:, None, :] * col[:, :, None]
+        np.mod(tmp, p, out=tmp)
+        np.copyto(A, tmp, where=upd[:, :, None])
+        del tmp
+        used[ix, pr] |= has
+        rk += has
+    return rk
+
+
+def red_rank(sub, bet, p):
+    """the small-matrix reduction: sum of d times rank of the small matrix"""
+    ix = np.array(sub, dtype=np.int64)
+    tot = 0
+    for i in ACT:
+        SS = np.mod(bet[i][ix].sum(axis=0), p)
+        tot += ROWS2[i][0] * int(small_ranks(SS[None, :, :].copy(), p)[0])
+    return tot
+
+
+def big_rank(sub, p):
+    """the rank of the 192 by 192 table itself"""
+    TT = np.zeros((NCOV, NPI), dtype=np.int64)
+    for k in sub:
+        TT = TT + OXS[k]
+    return rank_modp(TT, p)
+
+
+LCG = SEED
+SUBS = []
+while len(SUBS) < 60:
+    st = set()
+    while len(st) < 4:
+        LCG = divmod(LCG * 1103515245 + 12345, 2147483648)[1]
+        st.add(divmod(LCG >> 7, NCP)[1])
+    SUBS.append(tuple(sorted(st)))
+
+TABS = [tuple(INB), tuple(range(NCP))] + SUBS
+RED_AGR = 0
+for sub in TABS:
+    if red_rank(sub, BET2, P2) == big_rank(sub, P2):
+        RED_AGR += 1
+CRED = red_rank(tuple(INB), BET2, P2)
+
+# ------------------------------------------------------------------
+# 24. where the cover table loses rank, part by part
+# ------------------------------------------------------------------
+
+DROPS = []
+BLIND_OK = True
+IXB = np.array(INB, dtype=np.int64)
+for i in range(NPART):
+    d, m, mc, bl = ROWS2[i]
+    if BET2[i] is None:
+        r = 0
+    else:
+        SS = np.mod(BET2[i][IXB].sum(axis=0), P2)
+        r = int(small_ranks(SS[None, :, :].copy(), P2)[0])
+    DROPS.append((d, m, mc, r, d * (min(m, mc) - r)))
+    if PARTS[i][5] != d * (m - r):
+        BLIND_OK = False
+NZD = [t for t in DROPS if t[4] > 0]
+DR_SUM = sum(t[4] for t in NZD)
+DR_SET = ([(t[0], t[1], t[2]) for t in NZD]
+          == [(t[2], t[3], t[4]) for t in PARTS if t[7] > 0])
+
+# ------------------------------------------------------------------
+# 25. the same twenty matrices rebuilt at the other prime
+# ------------------------------------------------------------------
+
+ROWS3, BET3, FLG3, TRI3 = build_small(P3)
+TAB3_OK = (ROWS3 == T764)
+ACT3 = [i for i in range(len(ROWS3)) if BET3[i] is not None]
+
+# ------------------------------------------------------------------
+# 26. the sub-sum lattice of the four incidence orbits
+# ------------------------------------------------------------------
+
+SUBL = []
+for msk in range(1, 16):
+    pick = [INB[j] for j in range(NINB) if divmod(msk >> j, 2)[1] == 1]
+    SUBL.append((len(pick), tuple(pick)))
+SUBL.sort()
+
+SZL = {1: [], 2: [], 3: [], 4: []}
+SUBRK = {}
+for sz, sb in SUBL:
+    SZL[sz].append(sb)
+    TS = np.zeros((NCOV, NPI), dtype=np.int64)
+    for k in sb:
+        TS = TS + OXS[k]
+    SUBRK[sb] = rank_fwd(TS.tolist(), NPI)
+
+SGRK = [SUBRK[(c,)] for c in INB]
+SG_OK = all(SGRK[j] == CEIL and SGRK[j] == CPRK[INB[j]] for j in range(NINB))
+
+SGN = 0
+SGMISS = 0
+for c in INB:
+    for i in ACT:
+        alw = min(ROWS2[i][1], ROWS2[i][2])
+        SGN += 1
+        if int(small_ranks(BET2[i][c][None, :, :].copy(), P2)[0]) != alw:
+            SGMISS += 1
+
+PRRK = sorted(SUBRK[sb] for sb in SZL[2])
+TRRK = sorted(SUBRK[sb] for sb in SZL[3])
+QDRK = SUBRK[SZL[4][0]]
+LAT_OK = (len(PRRK) == 6 and len(TRRK) == 4 and QDRK == RANKB
+          and max(PRRK + TRRK) <= CEIL and QDRK < min(TRRK))
+
+# ------------------------------------------------------------------
+# 27. the first level at which a part loses rank
+# ------------------------------------------------------------------
+
+
+def lev_scan(bet, rws, act, p):
+    """least sub-sum size at which a part drops under its allowance"""
+    out = {}
+    for i in act:
+        if bet[i] is None:
+            out[i] = (-1, 0)
+            continue
+        alw = min(rws[i][1], rws[i][2])
+        lv = 0
+        nb = 0
+        for sz in (1, 2, 3, 4):
+            cnt = 0
+            for sb in SZL[sz]:
+                ix = np.array(sb, dtype=np.int64)
+                ss = np.mod(bet[i][ix].sum(axis=0), p)
+                if int(small_ranks(ss[None, :, :].copy(), p)[0]) < alw:
+                    cnt += 1
+            if cnt > 0:
+                lv = sz
+                nb = cnt
+                break
+        out[i] = (lv, nb)
+    return out
+
+
+LV2 = lev_scan(BET2, ROWS2, ACT, P2)
+LV3 = lev_scan(BET3, ROWS3, ACT3, P3)
+LV_N = len(ACT)
+LV_DIS = sum(1 for i in ACT if LV3.get(i, (-1, 0))[0] != LV2[i][0])
+LV_NB = sum(LV2[i][1] for i in ACT)
+DRLV = []
+for i in ACT:
+    if DROPS[i][4] > 0:
+        DRLV.append((ROWS2[i][0], ROWS2[i][1], ROWS2[i][2], LV2[i][0]))
+LV_ONE = sum(1 for i in ACT if LV2[i][0] == 1)
+LV_DR2 = sum(1 for i in ACT if DROPS[i][4] > 0 and LV2[i][0] == 2)
+LV_OK = (LV_ONE == 0 and LV_DR2 == 8 and len(DRLV) == 8)
+
+# parts short on some proper sub-sum yet whole on all four: the second prime
+# rebuilds their four-orbit matrices from scratch and confirms the recovery
+NMON = [i for i in ACT if LV2[i][0] > 0 and DROPS[i][4] == 0]
+NMOK = True
+for i in NMON:
+    alw3 = min(ROWS3[i][1], ROWS3[i][2])
+    ss3 = np.mod(BET3[i][np.array(INB, dtype=np.int64)].sum(axis=0), P3)
+    if int(small_ranks(ss3[None, :, :].copy(), P3)[0]) != alw3:
+        NMOK = False
+    if LV2[i][0] != 2:
+        NMOK = False
+NMTX = " ".join("/".join(nd(x) for x in ROWS2[i][:3]) for i in NMON)
+
+# ------------------------------------------------------------------
+# 28. the one-swap neighbourhood of the cover table
+# ------------------------------------------------------------------
+
+SWV = []
+SWHIT = None
+for jj in range(NINB):
+    for cc in range(NCP):
+        if cc in INB:
+            continue
+        sb = tuple(sorted([INB[t] for t in range(NINB) if t != jj] + [cc]))
+        v = red_rank(sb, BET2, P2)
+        SWV.append(v)
+        if v == CEIL and SWHIT is None:
+            SWHIT = (jj, cc, sb)
+SWN = len(SWV)
+SWMIN = min(SWV)
+SWMAX = max(SWV)
+SWTOP = sum(1 for v in SWV if v == CEIL)
+SWEQ = sum(1 for v in SWV if v == RANKB)
+SWLO = sum(1 for v in SWV if v < RANKB)
+SWJ = -1 if SWHIT is None else SWHIT[0]
+SWC = -1 if SWHIT is None else SWHIT[1]
+SWSUB = tuple(INB) if SWHIT is None else SWHIT[2]
+
+MSB = np.zeros((NCOV, NPI), dtype=np.int64)
+for k in SWSUB:
+    MSB = MSB + OXS[k]
+SWEX = rank_fwd(MSB.tolist(), NPI)
+SW_OK = (SWN == NINB * (NCP - NINB) and SWMAX <= CEIL and SWTOP > 0
+         and SWTOP > SWEQ + SWLO)
+
+# ------------------------------------------------------------------
+# 29. the two blind spaces compared, exactly
+# ------------------------------------------------------------------
+
+MSA = np.zeros((NCOV, NPI), dtype=np.int64)
+for k in INB:
+    MSA = MSA + OXS[k]
+RSTK = rank_fwd(np.concatenate([MSA, MSB], axis=0).tolist(), NPI)
+INTER = NPI - RSTK
+KBI = [clear_den(v) for v in KERB]
+MBL = MSB.tolist()
+IMR = [[sum(a * b for a, b in zip(row, kv)) for row in MBL] for kv in KBI]
+RIMG = rank_fwd(IMR, NCOV)
+INTER2 = NKB - RIMG
+SUMBL = NKB + (NPI - CEIL) - INTER
+NEST = (INTER == NPI - CEIL)
+M5 = MSA if SWC < 0 else MSA + OXS[SWC]
+R5 = rank_fwd(M5.tolist(), NPI)
+BL_OK = (INTER == INTER2 and NPI - RANKB == NKB and NPI - CEIL == FLOORB
+         and R5 == CEIL and SWJ >= 0)
+
+# ------------------------------------------------------------------
+# 31. the all-ones sum and the complementary-rank identity
+# ------------------------------------------------------------------
+
+# Each of the 36864 cells lies in exactly one of the 96 cell orbits, so the
+# 96 orbit tables add up entry by entry to the all-ones table J, whose exact
+# rational rank is one. Each orbit is free under the group of order 384 and
+# meets every cover in two pieces, so each table carries two ones in every
+# row and every column, 384 in all. Both facts are measured here, not
+# assumed. The comparison that follows pairs a set S of cell orbits with the
+# set left out: the two tables add to J, and the two exact rational ranks
+# are found to agree at every set tried, while the two end points, where one
+# side is empty, give 0 against 1 and so fix the range of the statement.
+# Every rank is computed straight from its own table by rank_fwd; no rank
+# below is supplied by the pairing itself.
+
+JALL = np.ones((NCOV, NPI), dtype=np.int64)
+SUMX = OXS.sum(axis=0)
+RKJ = rank_fwd(JALL.tolist(), NPI)
+SUMJ_OK = (bool(np.array_equal(SUMX, JALL)) and RKJ == 1)
+
+REG2_N = 0
+REG2_BAD = 0
+for kx in range(NCP):
+    a2 = OXS[kx]
+    REG2_N += 1
+    if (int(a2.sum()) != 2 * NCOV or int(a2.max()) != 1 or int(a2.min()) != 0
+            or not bool((a2.sum(axis=1) == 2).all())
+            or not bool((a2.sum(axis=0) == 2).all())):
+        REG2_BAD += 1
+REG2_OK = (REG2_N == NCP and REG2_BAD == 0 and 2 * NCOV == 384)
+
+
+def orb_tab(sub):
+    """entrywise sum of the cell orbit tables named in sub"""
+    out = np.zeros((NCOV, NPI), dtype=np.int64)
+    for kk2 in sub:
+        out = out + OXS[kk2]
+    return out
+
+
+def orb_comp(sub):
+    """the cell orbits left out of sub"""
+    st = set(sub)
+    return [kk3 for kk3 in range(NCP) if kk3 not in st]
+
+
+# The pairing is checked before it is used: the left-out set must have the
+# complementary size, and the two tables must add back to J entry by entry.
+# Without this a left-out set that quietly returned its own input would give
+# the same numbers and the comparison would say nothing.
+PAIR_N = 0
+PAIR_BAD = 0
+for sbz in [tuple(INB), (INB[0],)] + list(SZL[2]):
+    cmz = orb_comp(sbz)
+    PAIR_N += 1
+    if (len(cmz) != NCP - len(sbz) or len(set(cmz) & set(sbz)) != 0
+            or not bool(np.array_equal(orb_tab(sbz) + orb_tab(cmz), JALL))):
+        PAIR_BAD += 1
+
+RC92 = rank_fwd(orb_tab(orb_comp(INB)).tolist(), NPI)
+RC95 = rank_fwd(orb_tab(orb_comp([INB[0]])).tolist(), NPI)
+CPRS = []
+for sbx in SZL[2]:
+    CPRS.append((SUBRK[sbx], rank_fwd(orb_tab(orb_comp(sbx)).tolist(), NPI)))
+CPR6 = sorted(x2[1] for x2 in CPRS)
+CMPL_OK = (RC92 == QDRK and QDRK == RANKB and RC95 == SGRK[0]
+           and SGRK[0] == CEIL and len(CPRS) == 6 and CPR6 == PRRK
+           and PAIR_N == 8 and PAIR_BAD == 0
+           and all(oa == ob for oa, ob in CPRS))
+RKE = rank_fwd(np.zeros((NCOV, NPI), dtype=np.int64).tolist(), NPI)
+ENDP_OK = (RKE == 0 and RKJ == 1 and RKE != RKJ)
+
+# ------------------------------------------------------------------
+# 32. the stratification of the 96 cell orbits by corner overlap
+# ------------------------------------------------------------------
+
+# A cell is a pair (cover C, piece P). Profile A of the cell is the sorted
+# eight-tuple of corner overlaps, the size of corners(P) and corners(Q) met,
+# as Q runs over the eight blocks of C. Profile B is the sorted eight-tuple
+# of body overlaps popcount(PC[P] and PC[Q]) over the same eight. Every used
+# piece has exactly five corners and no two distinct pieces share more than
+# four, so an entry of five in profile A says that P is itself one of the
+# eight blocks of C. Profile A is recomputed on all 36864 cells, so its
+# constancy along a cell orbit is measured rather than inherited from the
+# group action. The strata are the fibres of profile A; for each one the
+# exact rational rank of the summed table and the blind dimension 192 minus
+# that rank are measured.
+
+CMK = [0] * NPI
+for ii in range(NPI):
+    for cn2 in KEPT[USED[ii]]:
+        CMK[ii] = CMK[ii] | (1 << cn2)
+NC5 = sum(1 for vx in CMK if popc(vx) == 5)
+OFFMAX = 0
+NPRS = 0
+for ii in range(NPI):
+    for jx in range(ii + 1, NPI):
+        NPRS += 1
+        vx2 = popc(CMK[ii] & CMK[jx])
+        if vx2 > OFFMAX:
+            OFFMAX = vx2
+PIECE_OK = (NC5 == NPI and OFFMAX == 4 and OFFMAX < 5
+            and NPRS == NPI * (NPI - 1) // 2)
+
+PROFA = [None] * NCP
+PABAD = 0
+NCELL = 0
+for kx in range(NCP):
+    bd = 0
+    for cx, px in CELLS[kx]:
+        NCELL += 1
+        prx = tuple(sorted(popc(CMK[px] & CMK[qx]) for qx in CS[cx]))
+        if PROFA[kx] is None:
+            PROFA[kx] = prx
+        elif prx != PROFA[kx]:
+            bd = 1
+    PABAD += bd
+PROFA_OK = (NCELL == NCP * NGRP and NCELL == 36864 and PABAD == 0
+            and all(vx3 is not None for vx3 in PROFA))
+
+STRA = {}
+for kx in range(NCP):
+    STRA.setdefault(PROFA[kx], []).append(kx)
+SKEYS = sorted(STRA.keys())
+NSTR = len(SKEYS)
+SZH = {}
+for qx in SKEYS:
+    SZH[len(STRA[qx])] = SZH.get(len(STRA[qx]), 0) + 1
+SZTX = " ".join("{0}:{1}".format(nd(sz2), nd(SZH[sz2])) for sz2 in sorted(SZH))
+FIVE = [kx for kx in range(NCP) if 5 in PROFA[kx]]
+NF5 = len(set(PROFA[kx] for kx in FIVE))
+STRAT_OK = (NSTR == 25 and sorted(FIVE) == sorted(INB) and NF5 == 1
+            and sum(len(STRA[qx]) for qx in SKEYS) == NCP
+            and SZH == {2: 12, 4: 7, 6: 4, 8: 1, 12: 1}
+            and sum(sz3 * SZH[sz3] for sz3 in SZH) == NCP
+            and STRA[PROFA[INB[0]]] == sorted(INB))
+
+PROFB = [None] * NCP
+PBBAD = 0
+for kx in range(NCP):
+    bd = 0
+    for cx, px in CELLS[kx]:
+        prx = tuple(sorted(GM[px][qx] for qx in CS[cx]))
+        if PROFB[kx] is None:
+            PROFB[kx] = prx
+        elif prx != PROFB[kx]:
+            bd = 1
+    PBBAD += bd
+BGRP = {}
+for kx in range(NCP):
+    BGRP.setdefault(PROFB[kx], []).append(kx)
+NBV = len(BGRP)
+BFIN = all(len(set(PROFA[kx] for kx in vv2)) == 1 for vv2 in BGRP.values())
+ACOAR = all(len(set(PROFB[kx] for kx in vv2)) == 1 for vv2 in STRA.values())
+DIAG_OK = all(GM[ii][ii] == 1975 for ii in range(NPI))
+B75 = [kx for kx in range(NCP) if 1975 in PROFB[kx]]
+PROFB_OK = (PBBAD == 0 and NBV == 83 and BFIN and not ACOAR and NBV > NSTR
+            and DIAG_OK and sorted(B75) == sorted(INB))
+
+SRK = []
+for qx in SKEYS:
+    SRK.append(rank_fwd(orb_tab(STRA[qx]).tolist(), NPI))
+SRMAX = max(SRK)
+SRMINB = min(NPI - rr2 for rr2 in SRK)
+SRINC = SRK[SKEYS.index(PROFA[INB[0]])]
+SRANK_OK = (len(SRK) == NSTR and max(SRK) <= CEIL and SRMAX == 143
+            and SRMAX < CEIL and SRMINB >= FLOORB and SRMINB == NPI - SRMAX
+            and SRINC == RANKB)
+
+# ------------------------------------------------------------------
+# 33. which cell orbits lift the first slot of the cover table
+# ------------------------------------------------------------------
+
+# Cycle 766 measured the whole one-exchange neighbourhood of the four
+# incidence orbits: 368 substitutions, some of them reaching the ceiling
+# 144. Here the first slot alone is taken apart. Its 92 values are rebuilt
+# from the small-matrix reduction and matched against the stored row, one
+# member of the lifting set is confirmed by an exact rational rank and one
+# non-member likewise, and the lifting set is then compared with the profile
+# A strata to see whether lifting is a property of the stratum. What comes
+# back is a measurement: a stratum may lift wholly, not at all, or in part.
+
+NONI = [cx for cx in range(NCP) if cx not in INB]
+RSL0 = []
+for cx in NONI:
+    sbx = tuple(sorted([INB[t2] for t2 in range(NINB) if t2 != 0] + [cx]))
+    RSL0.append(int(red_rank(sbx, BET2, P2)))
+SWROW = [int(vx) for vx in SWV[0:len(NONI)]]
+REP0 = [NONI[t3] for t3 in range(len(NONI)) if RSL0[t3] == CEIL]
+RSET = set(REP0)
+NREP = len(REP0)
+NRC = [cx for cx in NONI if cx not in RSET][0]
+EXNR = rank_fwd(orb_tab(tuple(sorted(
+    [INB[t2] for t2 in range(NINB) if t2 != 0] + [NRC]))).tolist(), NPI)
+S5 = SKEYS.index(PROFA[SWC])
+REPAIR_OK = (len(NONI) == NCP - NINB and RSL0 == SWROW and NREP == 19
+             and NREP > 0 and SWC in RSET and SWJ == 0 and SWEX == CEIL
+             and SWC == 5 and S5 == 23 and 0 <= S5 < NSTR
+             and EXNR == RSL0[NONI.index(NRC)] and EXNR < CEIL)
+
+RSW = 0
+RSN = 0
+RSM = 0
+for qx in SKEYS:
+    memx = [kx for kx in STRA[qx] if kx not in INB]
+    hh = sum(1 for kx in memx if kx in RSET)
+    if memx and hh == len(memx):
+        RSW += 1
+    elif hh == 0:
+        RSN += 1
+    else:
+        RSM += 1
+RSTRAT_OK = (RSW + RSN + RSM == NSTR and RSW == 0 and RSN == 10 and RSM == 15)
+
+# ------------------------------------------------------------------
+# 34. the incidence quartet inside a single cover
+# ------------------------------------------------------------------
+
+# The group has order 384 and moves the 192 covers in one orbit, so the
+# subgroup fixing cover 0 has order two. Its non-identity element acts on
+# the eight blocks of that cover; the blocks it pairs, the corner overlap
+# inside each pair, and the cell orbit each pair sits in are all measured.
+# The section ends at the least of the six pair ranks: the pair of incidence
+# orbits attaining it is named by the partner overlaps of its two orbits,
+# and its rank is recomputed exactly.
+
+NST0 = len(STABC)
+PE1 = PERM[E1]
+BLK0 = list(CS[0])
+FIX0 = sum(1 for bx in BLK0 if PE1[bx] == bx)
+PRS = []
+SEENB = set()
+for bx in BLK0:
+    if bx in SEENB:
+        continue
+    SEENB.add(bx)
+    SEENB.add(PE1[bx])
+    PRS.append((bx, PE1[bx]))
+STAB_OK = (NST0 == 2 and NST0 == NGRP // NCOV and FIX0 == 0 and len(BLK0) == 8
+           and len(PRS) == NINB and len(SEENB) == 8
+           and all(PE1[oa] == ob and PE1[ob] == oa for oa, ob in PRS))
+
+POVL = {}
+PCH = 0
+for oa, ob in PRS:
+    if CPLAB[0][oa] == CPLAB[0][ob]:
+        PCH += 1
+    POVL[CPLAB[0][oa]] = popc(CMK[oa] & CMK[ob])
+OVL = [POVL.get(cx, -1) for cx in INB]
+PARTN_OK = (PCH == NINB and len(POVL) == NINB and sorted(POVL) == sorted(INB)
+            and min(OVL) == 2 and max(OVL) == 2)
+
+PMIN = min(PRRK)
+LSB = [sbx for sbx in SZL[2] if SUBRK[sbx] == PMIN]
+LPRK = rank_fwd(orb_tab(LSB[0]).tolist(), NPI)
+NXT = sorted(PRRK)[1]
+LNAM = [POVL[cx] for cx in LSB[0]]
+P72_OK = (len(LSB) == 1 and len(LNAM) == 2 and LPRK == PMIN and LPRK == 72
+          and NXT > LPRK and NXT == 93 and all(LPRK <= vx for vx in PRRK))
+
+# ------------------------------------------------------------------
+# 36. the partner pairs of a cover, read on all 192 covers
+# ------------------------------------------------------------------
+
+# The group has order 384 and moves the 192 covers in one orbit, so the
+# subgroup holding a cover still has order two, and because the action on the
+# 36864 cells is free its non-identity element can hold no piece still. That
+# element is then a fixed-point-free involution on the 192 pieces with 96
+# partner pairs, and two ones in every row makes each cell orbit meet the row
+# of that cover in exactly one such pair. All of that is measured on every
+# cover, not on cover 0 alone. A constant labelling would pass the fibre test
+# for nothing, so the count of distinct labels in row 0 is measured as well,
+# and a copy of that row with two entries of different labels swapped is
+# required to fail the very same test.
+
+
+def row_pairs_ok(rowl, sgp):
+    """the row labelling is constant on partners and has 96 fibres of size two"""
+    for px6 in range(NPI):
+        if rowl[px6] != rowl[sgp[px6]]:
+            return False
+    hs6 = {}
+    for px6 in range(NPI):
+        hs6[rowl[px6]] = hs6.get(rowl[px6], 0) + 1
+    if len(hs6) != NCP:
+        return False
+    return all(v6 == 2 for v6 in hs6.values())
+
+
+TBCOV = 0
+TBSTAB = 0
+TBFIX = 0
+TBINV = 0
+TBLAB = 0
+TBFIB = 0
+TBPRS = set()
+for cx6 in range(NCOV):
+    TBCOV += 1
+    STG = [ex6 for ex6 in range(NGRP) if CPERM[ex6][cx6] == cx6]
+    STN = [ex6 for ex6 in STG if PERM[ex6] != IDP]
+    if len(STG) != 2 or len(STN) != 1:
+        TBSTAB += 1
+        continue
+    sg6 = PERM[STN[0]]
+    TBFIX += sum(1 for px6 in range(NPI) if sg6[px6] == px6)
+    if any(sg6[sg6[px6]] != px6 for px6 in range(NPI)):
+        TBINV += 1
+    rw6 = CPLAB[cx6]
+    TBLAB += sum(1 for px6 in range(NPI) if rw6[px6] != rw6[sg6[px6]])
+    hs7 = {}
+    for px6 in range(NPI):
+        hs7[rw6[px6]] = hs7.get(rw6[px6], 0) + 1
+    TBPRS.add(len(hs7))
+    if row_pairs_ok(rw6, sg6):
+        TBFIB += 1
+TBPR = min(TBPRS) if len(TBPRS) == 1 else -1
+TBDIST = len(set(CPLAB[0]))
+
+# the rejector: swapping two entries of different labels leaves the fibre
+# sizes alone and breaks only the partner condition, so a test that noticed
+# nothing here would be a test of the fibre sizes and nothing more
+BADR = list(CPLAB[0])
+DIFP = [px7 for px7 in range(NPI) if BADR[px7] != BADR[0]]
+BADR[0], BADR[DIFP[0]] = BADR[DIFP[0]], BADR[0]
+TBREJ = 0 if row_pairs_ok(BADR, PERM[E1]) else 1
+
+TBIJ_OK = (TBCOV == NCOV and NCOV == 192 and TBFIX == 0 and TBLAB == 0
+           and TBSTAB == 0 and TBPR == NCP and TBINV == 0
+           and TBFIB == NCOV and TBDIST == NCP)
+
+BHST = {}
+for bx6 in CS[0]:
+    BHST[CPLAB[0][bx6]] = BHST.get(CPLAB[0][bx6], 0) + 1
+BLAB = sorted(BHST)
+NBLAB = len(BLAB)
+BINC_OK = (BLAB == sorted(INB) and len(CS[0]) == 8 and NBLAB == NINB
+           and sum(BHST.values()) == 8
+           and all(v7 == 2 for v7 in BHST.values()))
+
+# ------------------------------------------------------------------
+# 37. the same blind space and the same seen space, not merely the same size
+# ------------------------------------------------------------------
+
+# Every orbit table carries two ones in each row and each column and the 96
+# add to the all-ones table, so a sum over a set has all row sums and all
+# column sums equal to twice the size of the set, and the sum over the
+# left-out orbits is the all-ones table minus it. The all-ones vector then
+# sits in the row space and in the column space of the sum, which is what
+# makes every blind vector have entries adding to zero, and that in turn
+# makes the left-out table blind in exactly the same directions. The row and
+# column space statement is checked in exact rational arithmetic. The
+# subspaces themselves are then compared over a prime field by stacking the
+# two kernel bases and comparing ranks. Two equal tables would make that
+# comparison empty, so the two tables are required to differ entry by entry,
+# and one deliberately spoiled table is required to be turned away.
+
+TSETS = [tuple(INB), (INB[0],)] + [tuple(sbx) for sbx in SZL[2]]
+for szx in (3, 5, 7, 11, 17, 32, 48, 64):
+    stx = set()
+    while len(stx) < szx:
+        LCG = divmod(LCG * 1103515245 + 12345, 2147483648)[1]
+        stx.add(divmod(LCG >> 7, NCP)[1])
+    TSETS.append(tuple(sorted(stx)))
+
+ONES = [1] * NPI
+EXN = 0
+EXBAD = 0
+EXMX = 0
+for sx6 in TSETS:
+    TSX = orb_tab(sx6)
+    rb6 = rank_fwd(TSX.tolist(), NPI)
+    rb7 = rank_fwd(TSX.tolist() + [ONES], NPI)
+    rc6 = rank_fwd(TSX.T.tolist(), NPI)
+    rc7 = rank_fwd(TSX.T.tolist() + [ONES], NPI)
+    EXN += 1
+    if rb6 > EXMX:
+        EXMX = rb6
+    if not (rb7 == rb6 and rc7 == rc6 and rc6 == rb6):
+        EXBAD += 1
+
+SPN = 0
+SPBAD = 0
+SPKER = 0
+SPIM = 0
+SPDIFF = 0
+SPDIM = set()
+SPD4 = -1
+for sx6 in TSETS:
+    TSX = orb_tab(sx6)
+    cm6 = orb_comp(sx6)
+    TCX = orb_tab(cm6)
+    SPN += 1
+    if (len(cm6) != NCP - len(sx6) or len(set(cm6) & set(sx6)) != 0
+            or not bool(np.array_equal(TSX + TCX, JALL))):
+        SPBAD += 1
+    if not bool(np.array_equal(TSX, TCX)):
+        SPDIFF += 1
+    KA = mod_ker(np.mod(TSX, P2), P2)
+    KB = mod_ker(np.mod(TCX, P2), P2)
+    ka6 = rank_modp(KA.T, P2)
+    kb6 = rank_modp(KB.T, P2)
+    if rank_modp(np.hstack([KA, KB]).T, P2) != ka6 or ka6 != kb6:
+        SPKER += 1
+    SPDIM.add(ka6)
+    if sx6 == tuple(INB):
+        SPD4 = ka6
+    LKA = mod_ker(np.mod(TSX.T, P2), P2)
+    LKB = mod_ker(np.mod(TCX.T, P2), P2)
+    la6 = rank_modp(LKA.T, P2)
+    lb6 = rank_modp(LKB.T, P2)
+    if rank_modp(np.hstack([LKA, LKB]).T, P2) != la6 or la6 != lb6:
+        SPIM += 1
+SPDL = sorted(SPDIM)
+
+# the rejector: one zero entry of the first table is lifted to one, which
+# leaves a table of the same shape and nearly the same entries but no longer
+# blind in the same directions as the left-out table
+TS0 = orb_tab(TSETS[0])
+KB0 = mod_ker(np.mod(orb_tab(orb_comp(TSETS[0])), P2), P2)
+rk0 = rank_modp(KB0.T, P2)
+ZP0 = np.argwhere(TS0 == 0)
+ZI0 = int(ZP0[0][0])
+ZJ0 = int(ZP0[0][1])
+TS0[ZI0, ZJ0] = 1
+KP0 = mod_ker(np.mod(TS0, P2), P2)
+rp0 = rank_modp(KP0.T, P2)
+SPREJ = 0
+if rank_modp(np.hstack([KP0, KB0]).T, P2) != rp0 or rp0 != rk0:
+    SPREJ = 1
+
+SPACE_OK = (SPN == len(TSETS) and SPBAD == 0 and SPKER == 0 and SPIM == 0
+            and SPDIFF == SPN and SPREJ == 1 and EXBAD == 0 and EXN > 0
+            and SPD4 == NKB)
+EXACT_OK = (EXBAD == 0 and EXN == len(TSETS) and EXMX < NPI and EXMX == CEIL)
+
+# ------------------------------------------------------------------
+# 38. the rank of every one of the 4560 pairs of cell orbits
+# ------------------------------------------------------------------
+
+# The reduction to twenty small matrices turns the rank of a covariant table
+# into a sum of small ranks, and one vectorised call gives the small ranks of
+# a whole stack, so the complete pair census costs little. It is checked
+# three ways: rebuilt at the other prime, set against the rank of the full
+# 192 by 192 table on 25 pairs drawn by the recurrence already in use, and
+# pinned to the exact rational ranks of the six incidence pairs. By the
+# theorem of section 37 this same vector is at once the complete spectrum of
+# all 4560 sets of size 94.
+
+
+def cens_ix(bet, rws, act, p, ixl):
+    """the reduction, run on a whole stack of subsets given by index arrays"""
+    tot = np.zeros(ixl[0].shape[0], dtype=np.int64)
+    for i7 in act:
+        SS = bet[i7][ixl[0]].copy()
+        for ax7 in ixl[1:]:
+            SS = SS + bet[i7][ax7]
+        np.mod(SS, p, out=SS)
+        tot += rws[i7][0] * small_ranks(SS, p)
+    return tot
+
+
+PAIRS = list(itertools.combinations(range(NCP), 2))
+IA = np.array([px8[0] for px8 in PAIRS], dtype=np.int64)
+IB = np.array([px8[1] for px8 in PAIRS], dtype=np.int64)
+PSPEC = cens_ix(BET2, ROWS2, ACT, P2, [IA, IB])
+PSP3 = cens_ix(BET3, ROWS3, ACT3, P3, [IA, IB])
+PDIS = int((PSPEC != PSP3).sum())
+PMIN2 = int(PSPEC.min())
+PMAX2 = int(PSPEC.max())
+PNV = len(set(int(v8) for v8 in PSPEC))
+PCEIL = int((PSPEC == CEIL).sum())
+PLOW = int((PSPEC <= RANKB).sum())
+
+PIDX = {}
+for t8 in range(len(PAIRS)):
+    PIDX[PAIRS[t8]] = t8
+
+PSEL = []
+while len(PSEL) < 25:
+    st8 = set()
+    while len(st8) < 2:
+        LCG = divmod(LCG * 1103515245 + 12345, 2147483648)[1]
+        st8.add(divmod(LCG >> 7, NCP)[1])
+    pr8 = tuple(sorted(st8))
+    if pr8 not in PSEL:
+        PSEL.append(pr8)
+PBIG = 0
+PBAD = 0
+for pr8 in PSEL:
+    PBIG += 1
+    if big_rank(pr8, P2) != int(PSPEC[PIDX[pr8]]):
+        PBAD += 1
+
+PEXB = 0
+PEXV = []
+for sbx in SZL[2]:
+    v8 = int(PSPEC[PIDX[tuple(sorted(sbx))]])
+    PEXV.append(v8)
+    if v8 != SUBRK[sbx]:
+        PEXB += 1
+if sorted(PEXV) != PRRK:
+    PEXB += 1
+
+PSPEC_OK = (len(PAIRS) == 4560 and PDIS == 0 and PBAD == 0 and PBIG == 25
+            and PEXB == 0 and PMAX2 <= CEIL)
+
+# ------------------------------------------------------------------
+# 39. the rank of every one of the 142880 triples of cell orbits
+# ------------------------------------------------------------------
+
+# The same reduction, over every three-element set, in blocks of 20000 so the
+# working arrays inside the stacked reduction stay small. The two checks are
+# the exact rational ranks of the four incidence triples and the rank of the
+# full 192 by 192 table on 15 triples drawn by the same recurrence. By the
+# theorem of section 37 this is at once the complete spectrum at size 93.
+
+TRIP = list(itertools.combinations(range(NCP), 3))
+NTRI = len(TRIP)
+TIA = np.array([t9[0] for t9 in TRIP], dtype=np.int64)
+TIB = np.array([t9[1] for t9 in TRIP], dtype=np.int64)
+TIC = np.array([t9[2] for t9 in TRIP], dtype=np.int64)
+CHK = 20000
+TSPEC = np.zeros(NTRI, dtype=np.int64)
+for s9 in range(0, NTRI, CHK):
+    e9 = min(s9 + CHK, NTRI)
+    TSPEC[s9:e9] = cens_ix(BET2, ROWS2, ACT, P2,
+                           [TIA[s9:e9], TIB[s9:e9], TIC[s9:e9]])
+TMIN = int(TSPEC.min())
+TMAX = int(TSPEC.max())
+TNV = len(set(int(v9) for v9 in TSPEC))
+TCEIL = int((TSPEC == CEIL).sum())
+TLOW = int((TSPEC <= RANKB).sum())
+
+TSEL = []
+while len(TSEL) < 15:
+    st9 = set()
+    while len(st9) < 3:
+        LCG = divmod(LCG * 1103515245 + 12345, 2147483648)[1]
+        st9.add(divmod(LCG >> 7, NCP)[1])
+    tr9 = tuple(sorted(st9))
+    if tr9 not in TSEL:
+        TSEL.append(tr9)
+
+TNEED = set(TSEL) | set(tuple(sorted(sbx)) for sbx in SZL[3])
+TPOS = {}
+for t9 in range(NTRI):
+    if TRIP[t9] in TNEED:
+        TPOS[TRIP[t9]] = t9
+
+TBIGN = 0
+TBADN = 0
+for tr9 in TSEL:
+    TBIGN += 1
+    if big_rank(tr9, P2) != int(TSPEC[TPOS[tr9]]):
+        TBADN += 1
+
+TEXB = 0
+TEXV = []
+for sbx in SZL[3]:
+    v9 = int(TSPEC[TPOS[tuple(sorted(sbx))]])
+    TEXV.append(v9)
+    if v9 != SUBRK[sbx]:
+        TEXB += 1
+if sorted(TEXV) != TRRK:
+    TEXB += 1
+
+TSPEC_OK = (NTRI == 142880 and TEXB == 0 and TBADN == 0 and TBIGN == 15
+            and TMAX <= CEIL)
+
+# ------------------------------------------------------------------
+# 40. how many partners each orbit cancels with, and one prediction tested
+# ------------------------------------------------------------------
+
+# The degree of an orbit is the number of partners with which its pair falls
+# short of the ceiling. It is read straight off the pair census, and the
+# degree of the first incidence orbit is then rebuilt from the full 192 by
+# 192 tables, so the number that is printed does not rest on the reduction
+# alone. The prediction under test is that the pair of corner strata does not
+# settle the pair rank; the gate holds the bookkeeping to account and leaves
+# the direction of the answer to the measurement.
+
+DEG = [0] * NCP
+BELOW = 0
+for t9 in range(len(PAIRS)):
+    if int(PSPEC[t9]) < CEIL:
+        BELOW += 1
+        DEG[PAIRS[t9][0]] += 1
+        DEG[PAIRS[t9][1]] += 1
+DGMIN = min(DEG)
+DGMAX = max(DEG)
+DGNV = len(set(DEG))
+DGINB = [DEG[cx9] for cx9 in INB]
+# read "at the top" off the degree VALUES, not off a sort of the indices: an
+# index sort would let its own tie-break decide the answer whenever the
+# degrees tie, which is exactly the case that has to stay visible
+DGSRT = sorted(DEG, reverse=True)
+DGTOP = min(DGINB) >= DGSRT[NINB - 1]
+DGTIE = sum(1 for v9 in DEG if v9 == DGMAX)
+
+DGREF = 0
+for j9 in range(NCP):
+    if j9 == INB[0]:
+        continue
+    if big_rank(tuple(sorted((INB[0], j9))), P2) < CEIL:
+        DGREF += 1
+
+STRIX = [SKEYS.index(PROFA[k9]) for k9 in range(NCP)]
+STPM = {}
+STCN = {}
+for t9 in range(len(PAIRS)):
+    a9 = STRIX[PAIRS[t9][0]]
+    b9 = STRIX[PAIRS[t9][1]]
+    ky9 = (min(a9, b9), max(a9, b9))
+    STPM.setdefault(ky9, set()).add(int(PSPEC[t9]))
+    STCN[ky9] = STCN.get(ky9, 0) + 1
+STPN = len(STPM)
+STPD = sum(1 for ky9 in STPM if len(STPM[ky9]) > 1)
+STPMAX = max(len(STPM[ky9]) for ky9 in STPM)
+
+# one conjunct here discriminates against a wrong object: DGREF rebuilds one
+# orbit's degree from 95 full-table ranks and must match the degree the census
+# gives. The rest are bookkeeping on the loops just above, holding either by
+# construction or as weak sanity limits; they are kept as loop checks, and no
+# claim in the note leans on them
+DEG_OK = (len(DEG) == NCP and sum(DEG) == 2 * BELOW and DGMAX <= NCP - 1
+          and DGREF == DEG[INB[0]] and sum(STCN.values()) == len(PAIRS)
+          and STPN <= NSTR * (NSTR + 1) // 2 and STPMAX <= PNV)
+
+# ------------------------------------------------------------------
+# 41. further source hygiene, and the closing budget
+# ------------------------------------------------------------------
+
+BAN2 = [("Sch", "ur"), ("Hor", "ner"),
+        ("what a construction would ", "have to give up")]
+BAN2_OK = True
+NBAN2 = 0
+for a, b in BAN2:
+    NBAN2 += 1
+    if (a + b).lower() in LOWSRC:
+        BAN2_OK = False
+NO_D9 = (("9" + "9") not in SRC)
+ONE_WORD_OK = (LOWSRC.count("assoc" + "iation")
+               == LOWSRC.count("assoc" + "iation sch"))
+
+ELAPSED2 = int(time.time() - T0)
+RSS2 = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+RSSMB2 = RSS2 // 1048576 if RSS2 > 10000000 else RSS2 // 1024
+
+# ------------------------------------------------------------------
+# gates, continued
+# ------------------------------------------------------------------
+
+gate(PRIME_OK and TAB2_OK and TAB3_OK, "C28",
+     "part table at {0} and {1} matches"
+     " cycle 764 row for row, both prime".format(nd(P2), nd(P3)))
+
+gate(PASS5 == NPART and NPART == 20 and SMMC == NCP and not NOVEC
+     and NOMC == NMC0, "C29",
+     "small matrices: {0} of 20 parts pass five conditions; {1} have no cover"
+     " multiplicity, no matrix{2}".format(nd(PASS5), nd(NOMC), FTX))
+
+gate(ISOW == NCP and ISORK == NCP, "C30",
+     "96 orbit coefficients to twenty matrices: width {0}, rank {1}"
+     " mod p, one-to-one onto".format(nd(ISOW), nd(ISORK)))
+
+gate(RED_AGR == len(TABS) and CRED == RANKB and NPI - CRED == NKB, "C31",
+     "the reduction matches the direct rank on {0} of {1} tables;"
+     " cover table {2} blind {3}".format(
+         nd(RED_AGR), nd(len(TABS)), nd(CRED), nd(NPI - CRED)))
+
+gate(len(NZD) == NEX and DR_SET, "C32",
+     "drop parts d/m/mc/rank/drop: {0}".format(
+         " ".join("/".join(str(x) for x in t) for t in NZD)))
+
+gate(DR_SUM == EXC_C and BLIND_OK and len(NZD) == 8, "C33",
+     "those {0} are the cycle 764 excess parts, drops sum to {1},"
+     " blind = d(m - rank) on all 20".format(nd(len(NZD)), nd(DR_SUM)))
+
+
+GN = [34]
+
+
+def nextlab():
+    lab = "C{0}".format(GN[0])
+    GN[0] += 1
+    return lab
+
+
+def scope(msg):
+    TAGS.append(nextlab())
+    emit("{0} {1}".format(TAGS[-1], msg))
+
+
+gate(SG_OK and len(SGRK) == NINB and NINB == 4, nextlab(),
+     "each of the {0} incidence orbits alone has exact rank {1}, the"
+     " ceiling; mod p agrees".format(nd(NINB), nd(CEIL)))
+
+gate(SGMISS == 0 and SGN == NINB * len(ACT) and SGN > 0, nextlab(),
+     "part by part: {0} single-orbit small matrices meet min(m, mc), {1}"
+     " short".format(nd(SGN), nd(SGMISS)))
+
+gate(LAT_OK, nextlab(),
+     "pairs {0}; triples {1}; four give {2}, below every triple"
+     .format(",".join(nd(v) for v in PRRK),
+             ",".join(nd(v) for v in TRRK), nd(QDRK)))
+
+gate(LV_OK and len(NZD) == 8, nextlab(),
+     "all {0} rank-losing parts go short first on a pair, not on"
+     " a single orbit; {1} at size one".format(nd(len(DRLV)), nd(LV_ONE)))
+
+gate(len(NMON) == 3 and NMOK, nextlab(),
+     "not monotone: {0} more parts go short on a pair yet meet"
+     " min(m, mc) on all four; {1}".format(nd(len(NMON)), NMTX))
+
+gate(LV_DIS == 0 and LV_N == len(ACT3) and LV_N > 0, nextlab(),
+     "other prime, same size on every part: {0} compared, {1} differ,"
+     " {2} short sub-sums".format(
+         nd(LV_N), nd(LV_DIS), nd(LV_NB)))
+
+gate(SW_OK, nextlab(),
+     "one-swap: {0} substitutions, {1} to {2}, {3} at the"
+     " ceiling, {4} at {5}, {6} lower".format(
+         nd(SWN), nd(SWMIN), nd(SWMAX), nd(SWTOP), nd(SWEQ), nd(RANKB),
+         nd(SWLO)))
+
+gate(SWJ >= 0 and SWEX == CEIL and QDRK == RANKB, nextlab(),
+     "one exchange, slot {0} taking orbit {1}, lifts the"
+     " four-orbit exact rank {2} to {3}".format(
+         nd(SWJ), nd(SWC), nd(QDRK), nd(SWEX)))
+
+gate(BL_OK, nextlab(),
+     "blind spaces meet in {0}, span {1}, nested {2};"
+     " four plus one gives rank {3}".format(
+         nd(INTER), nd(SUMBL), yn(NEST), nd(R5)))
+
+gate(SUMJ_OK, nextlab(),
+     "{0} sum to J rank {1}".format(nd(NCP), nd(RKJ)))
+
+gate(REG2_OK, nextlab(),
+     "{0} ok {1} off {2} ones".format(nd(REG2_N), nd(REG2_BAD), nd(2 * NCOV)))
+
+gate(CMPL_OK, nextlab(),
+     "cmpl {0} {1} {2}".format(nd(RC92), nd(RC95),
+                               ",".join(nd(v) for v in CPR6)))
+
+gate(ENDP_OK, nextlab(),
+     "empty {0} full {1}".format(nd(RKE), nd(RKJ)))
+
+gate(PIECE_OK, nextlab(),
+     "{0} of {1} corners top {2}".format(nd(NC5), nd(5), nd(OFFMAX)))
+
+gate(PROFA_OK, nextlab(),
+     "{0} cells {1} vary".format(nd(NCELL), nd(PABAD)))
+
+gate(STRAT_OK, nextlab(),
+     "{0} strata {1}".format(nd(NSTR), SZTX))
+
+gate(PROFB_OK, nextlab(),
+     "B {0} vals finer {1} on {2}".format(nd(NBV), nd(1975), nd(len(B75))))
+
+gate(SRANK_OK, nextlab(),
+     "top {0} not {1} blind {2} inc {3}".format(nd(SRMAX), nd(CEIL),
+                                                nd(SRMINB), nd(SRINC)))
+
+gate(REPAIR_OK, nextlab(),
+     "{0} lift slot {1} orb {2} str {3}".format(nd(NREP), nd(SWJ), nd(SWC),
+                                                nd(S5)))
+
+gate(RSTRAT_OK, nextlab(),
+     "{0} all {1} none {2} mixed".format(nd(RSW), nd(RSN), nd(RSM)))
+
+gate(STAB_OK, nextlab(),
+     "stab {0} fix {1} {2} pairs".format(nd(NST0), nd(FIX0), nd(len(PRS))))
+
+gate(PARTN_OK, nextlab(),
+     "partners {0}".format(" ".join(nd(v) for v in OVL)))
+
+gate(P72_OK, nextlab(),
+     "least pair {0} rank {1}".format(" ".join(nd(v) for v in LNAM), nd(LPRK)))
+
+gate(TBIJ_OK and TBREJ == 1, nextlab(),
+     "row pairs: {0} covers, stab 2, fix {1}, label miss {2}, {3} pairs each,"
+     " rejector {4}".format(nd(TBCOV), nd(TBFIX), nd(TBLAB), nd(TBPR),
+                            nd(TBREJ)))
+
+gate(BINC_OK, nextlab(),
+     "the 8 blocks of one cover carry {0} labels, exactly the incidence"
+     " orbits, two blocks each".format(nd(NBLAB)))
+
+gate(SPACE_OK, nextlab(),
+     "same blind and same seen space at {0} sets, {1}+{2} off, tables differ"
+     " {3}, rejector {4}, blind {5}, range 1 to {6}, first set {7} against"
+     " {8}".format(nd(SPN), nd(SPKER), nd(SPIM), nd(SPDIFF), nd(SPREJ),
+                   nd(SPD4), nd(NCP - 1), nd(NINB), nd(NCP - NINB)))
+
+gate(EXACT_OK, nextlab(),
+     "all-ones in row and column space at {0} sets exactly, {1} off, top rank"
+     " {2}, so every blind vector sums to zero".format(
+         nd(EXN), nd(EXBAD), nd(EXMX)))
+
+# the size-one spectrum, three independent routes forced to agree: the cycle
+# rule on the bipartite structure, the mod p elimination, and the ceiling read
+# off the parts. A wrong object breaks the first two against each other.
+ONE_OK = (CYC_OK and CYCBAD == 0 and CYCLIST == [(48, (4,), NCOV)]
+          and len(RKHIST) == 1 and RKHIST[0] == (CEIL, NCP))
+
+gate(ONE_OK, nextlab(),
+     "size one: {0} cycles of {1} covers in every orbit, one type, so all {2}"
+     " have exact rank {3} by the cycle rule; {4} off the prediction".format(
+         nd(CYCLIST[0][0]), nd(CYCLIST[0][1][0]), nd(RKHIST[0][1]),
+         nd(RKHIST[0][0]), nd(CYCBAD)))
+
+gate(PSPEC_OK, nextlab(),
+     "4560 pairs: {0} values {1} to {2}, {3} at the ceiling, {4} at or below"
+     " {5}; {6} by full table, {7} off at the second prime; same at"
+     " 94".format(nd(PNV), nd(PMIN2), nd(PMAX2), nd(PCEIL), nd(PLOW),
+                  nd(RANKB), nd(PBIG), nd(PDIS)))
+
+gate(TSPEC_OK, nextlab(),
+     "142880 triples: {0} values {1} to {2}, {3} at the ceiling, {4} at or"
+     " below {5}; {6} by full table; same at 93".format(
+         nd(TNV), nd(TMIN), nd(TMAX), nd(TCEIL), nd(TLOW), nd(RANKB),
+         nd(TBIGN)))
+
+gate(DEG_OK, nextlab(),
+     "degree {0} to {1}, {2} values; incidence {3} top {4}, {5} tied;"
+     " 1 by full table; stratum fixes rank {6}, {7} of {8} mixed,"
+     " max {9}".format(
+         nd(DGMIN), nd(DGMAX), nd(DGNV), " ".join(nd(v) for v in DGINB),
+         yn(DGTOP), nd(DGTIE), yn(STPD == 0), nd(STPD), nd(STPN),
+         nd(STPMAX)))
+
+SEQ_OK = (TAGS == ["C{0}".format(k) for k in range(len(TAGS))])
+gate(SEQ_OK and len(TAGS) >= 34, nextlab(),
+     "gate labels: one strict sequence of {0}, no gap, no repeat".format(
+         nd(len(TAGS) + 1)))
+
+gate(BAN2_OK and NBAN2 == 3 and NO_D9 and ONE_WORD_OK, nextlab(),
+     "closing source check: {0} further barred pairs absent, no barred digit"
+     " pair, single-word use out".format(nd(NBAN2)))
+
+gate(ELAPSED2 < 900 and RSSMB2 < 2500 and OUT[0] < 5900, nextlab(),
+     "budget: wall time, peak resident memory, stdout all inside their limits")
+
+emit("stdout characters: {0}".format(OUT[0]))
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))


### PR DESCRIPTION
## What this responds to

Cycle 767 measured that a set of cell orbits and its complement have equal rank. This cycle asks what stands behind the equality and gets two exact statements, both proved from the structure of the orbit tables rather than read off a computation.

## Theorem A — complements share the space, not just its size

Every cell-orbit table is a zero-one matrix with exactly two entries in each row and each column, and the ninety-six tables sum to the all-ones matrix. So the table of any set S of orbits has all row and column sums equal to twice the size of S. If a vector is blind to that table, then twice-the-size times its coordinate sum vanishes, hence the sum vanishes, hence the all-ones matrix annihilates it, hence it is blind to the complement's table as well. The argument is symmetric and runs equally on transposes, so the two tables have the *same* blind space and the *same* seen space, not merely spaces of equal dimension. Equality of rank is a corollary.

The runner checks this at sixteen sets spread across the whole range of sizes, exactly over the integers, with a wrong-value rejector; the two tables differ at every one of the sixteen.

## Theorem B — the ninety-six orbits are one cover's partner pairs

The symmetry group has order 384 and is transitive on the 192 covers, so a single cover's stabiliser has order two, and its non-identity element moves every piece. Every cell orbit meets that cover's row in exactly one partner pair, which gives a bijection from the ninety-six cell orbits onto the ninety-six partner pairs of pieces. Under it, the four incidence orbits are exactly the labels carried by that one cover's own eight blocks, two blocks to a label.

That turns a global orbit count into a local statement about a single cover, and it names the four incidence orbits geometrically for the first time in this lane.

## Two complete censuses

- All 4560 pairs of orbits: thirteen distinct ranks from 48 to 144, with 960 pairs at the ceiling and 1104 at or below the four-orbit rank of 105.
- All 142880 triples: eighteen distinct ranks from 64 to 144, with 60960 at the ceiling.

Ranks in both censuses are computed at a prime, so a rank can only be under-reported: the counts at the ceiling are lower bounds and the counts at or below 105 are upper bounds. Twenty-five pairs and fifteen triples were re-ranked on the full 192 by 192 tables as a check, and the whole pair census was repeated at a second prime with nothing off.

By Theorem A each census carries across to sizes 94 and 93 unchanged. Together with the size-one spectrum derived at cycle 763 and the complete four-subset census of cycle 765, the four smallest and the four largest set sizes now all have complete spectra.

## Two predictions failed, and are reported as measured

The design predicted a least pair rank of 72 and a least triple rank of 114. The measurements are 48 and 64. Both predictions were taken out of the runner rather than weakened, and the note reports the measured values.

## Runner

`TOTAL: PASS=68 FAIL=0`, 5889 characters of output, about 240 s wall, about 190 MB peak resident. The new size-one gate was checked for discrimination on a perturbed copy of the object: swapping a single label in one cover's row makes the cycle structure irregular and pushes two orbit ranks above the ceiling, and the gate fails.

## Boundary

The set sizes between the four smallest and the four largest are untouched, and the number of subsets there is far past what a complete census can reach. Why the rank ceiling and the blind floor should add to the piece count is not derived here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
