### PR TITLE
[physics-loop][review-loop] inter-site-gate blockR1 — Cycle 985: bounded theorem (does neighbour-dependence change record content?)

### DIFF
--- a/docs/NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_CYCLE985_BOUNDED_THEOREM_NOTE_2026-08-11.md
+++ b/docs/NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_CYCLE985_BOUNDED_THEOREM_NOTE_2026-08-11.md
@@ -177,7 +177,7 @@ The primary exhausts the two basis readouts and checks finite additivity on
 450 ordered disjoint-content-list pairs; there are zero failures.
 
 The existence statement is not universal over readouts. For example,
-`phi(0)=phi(1)=1` gives record count, which is admissible and blind to the
+`phi(P_0)=phi(P_1)=1` gives record count, which is admissible and blind to the
 content change between equal-size singleton collections. The axiom licenses
 `I_one`; it does not select it or require the unspecified fixed physical
 readout to be content-faithful.
@@ -318,5 +318,5 @@ negative_assertion_classes: []
 packet_primary_runner: scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
 packet_helper_runner: scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
 packet_helper_claim_scope: cycle985_neighbour_dependence_record_content
-review_loop_disposition: pending
+review_loop_disposition: pass
 ```

--- a/docs/NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_CYCLE985_BOUNDED_THEOREM_NOTE_2026-08-11.md
+++ b/docs/NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_CYCLE985_BOUNDED_THEOREM_NOTE_2026-08-11.md
@@ -1,0 +1,288 @@
+# Neighbour-dependence changes locked record content on the finite binary star
+
+Date: 2026-08-11
+
+Cycle: 985
+
+Claim type: `bounded_theorem`
+
+Actual current surface: `bounded-support`
+
+Audit-status authority: independent audit lane only
+
+Effective status: pipeline-derived only after independent audit ratification
+and dependency closure
+
+Constitutional effect: none. This packet edits no axiom, approved primitive,
+premise registry, audit verdict, queue, ledger, or effective-status surface.
+
+## Artifact map
+
+Primary runner:
+
+- [`frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py`](../scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py)
+
+Independent refutation checker:
+
+- [`frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py`](../scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py)
+
+Pinned caches:
+
+- [`frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt`](../logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt)
+- [`frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt`](../logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt)
+
+Receipts:
+
+- [`neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json`](../outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json)
+- [`neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json`](../outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json)
+
+The restricted independent-audit packet must contain the refutation checker:
+
+```text
+neighbour_dependence_record_content_cycle985_bounded_theorem_note_2026-08-11:
+  scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+```
+
+## Exact target claim
+
+On the declared binary, radius-one true-`Z^3`, word-length-at-most-one target
+instance, conditional on a record forming at the target, every one-neighbour
+configuration pair separated by any of the three deterministic dependence
+classes locks different target content. The additive scalar readout
+
+```text
+I_one(R) = number of records in R whose locked content is 1
+```
+
+is determined by record content alone, has `I_one(empty)=0`, is additive on
+finite pairwise-disjoint record collections, and separates every such
+single-target pair. This is a single-site, conditional-on-formation result.
+It is not a mosaic-wide theorem and does not select the framework's physical
+readout.
+
+## Declared finite instance
+
+The target is `C=(0,0,0)` and its six neighbour conditions are the signed unit
+directions `(+x,-x,+y,-y,+z,-z)`. Target input and every neighbour bit lie in
+`{0,1}`. The three representative laws and their proper-cubic orbit data are
+
+| class | representative | target law | multiplicity | stabilizer | `J=||sum controls||^2` |
+|---|---|---|---:|---:|---:|
+| incoming CNOT | `CNOT(+x->C)` | `y=x XOR n_(+x)` | 6 | 4 | 1 |
+| perpendicular-control TOF | `TOF(+x,+y->C)` | `y=x XOR (n_(+x) AND n_(+y))` | 12 | 2 | 2 |
+| opposite-control TOF | `TOF(+x,-x->C)` | `y=x XOR (n_(+x) AND n_(-x))` | 3 | 8 | 0 |
+
+The runner reconstructs these laws directly. PRs #6087, #6111, #6113,
+#6115, #6106, and #6116 are task-supplied provenance only; none of their
+notes, runners, caches, receipts, or verdict fields is read or executed.
+
+## A_LOCKED_CONTENT_CENSUS
+
+The [`Record axiom`](MINIMAL_AXIOMS_2026-06-29.md) says that a record, when
+present, locks one admissible local possibility. In this binary deterministic
+instance that possibility is the target output `y`. All five neighbour bits
+not displayed in a CNOT row, and all four not displayed in a TOF row, are
+arbitrary spectators.
+
+### Incoming CNOT class (`J=1`, multiplicity 6)
+
+| `n_(+x)` | locked content for `x=0` | locked content for `x=1` |
+|---:|---:|---:|
+| 0 | 0 | 1 |
+| 1 | 1 | 0 |
+
+For either target input, toggling the control `0 <-> 1` changes the locked
+content.
+
+### Perpendicular-control TOF class (`J=2`, multiplicity 12)
+
+| `(n_(+x),n_(+y))` | locked content for `x=0` | locked content for `x=1` |
+|---|---:|---:|
+| `(0,0)` | 0 | 1 |
+| `(0,1)` | 0 | 1 |
+| `(1,0)` | 0 | 1 |
+| `(1,1)` | 1 | 0 |
+
+The separated one-bit pairs are `(0,1) <-> (1,1)` when `+x` is toggled and
+`(1,0) <-> (1,1)` when `+y` is toggled, for either target input. Toggling a
+control while the other control is zero does not separate the law.
+
+### Opposite-control TOF class (`J=0`, multiplicity 3)
+
+| `(n_(+x),n_(-x))` | locked content for `x=0` | locked content for `x=1` |
+|---|---:|---:|
+| `(0,0)` | 0 | 1 |
+| `(0,1)` | 0 | 1 |
+| `(1,0)` | 0 | 1 |
+| `(1,1)` | 1 | 0 |
+
+The separated one-bit pairs are again `(0,1) <-> (1,1)` and
+`(1,0) <-> (1,1)`, now for the opposite controls, for either target input.
+
+Across the three representatives there are ten target-input-resolved
+one-neighbour-bit separation rows: two CNOT rows and four rows for each TOF
+class. Every one flips locked content `0 <-> 1`.
+
+## B_READOUT_VISIBILITY
+
+### Declared readout family
+
+For this binary content census, declare the complete additive scalar family
+
+```text
+F_bin = {phi:{0,1}->R},
+I_phi(R) = sum over records r in R of phi(content(r)).
+```
+
+Every `I_phi` is determined by record content alone. The empty sum gives
+`I_phi(empty)=0`, and splitting a finite record collection into pairwise-
+disjoint subcollections splits the sum, so additivity is exact. Conversely,
+within the binary alphabet, every additive content-only scalar readout is
+fixed by its two singleton values `phi(0)` and `phi(1)`. Thus
+`delta_0=(1,0)` and `delta_1=(0,1)` form a basis for the declared family.
+
+### Exact separator
+
+Choose `phi(0)=0`, `phi(1)=1`. Then
+
+```text
+I_one({target record}) = locked target content.
+```
+
+Every separated pair in the census changes `I_one` by `+1` or `-1`. Hence
+some admissible readout sees every locked-content difference in section A.
+The primary exhausts the two basis readouts and checks finite additivity on
+450 ordered disjoint-content-list pairs; there are zero failures.
+
+The existence statement is not universal over readouts. For example,
+`phi(0)=phi(1)=1` gives record count, which is admissible and blind to the
+content change between equal-size singleton collections. The axiom licenses
+`I_one`; it does not select it or require the unspecified fixed physical
+readout to be content-faithful.
+
+For completeness, no separator exists in `F_bin` for a compared singleton
+pair exactly when the two locked contents are equal: both basis functionals
+then agree, so every linear combination agrees. The runner's outcome-neutral
+visibility validator accepts a coherent equal-content/no-separator fixture.
+Therefore a negative result would pass the same bookkeeping gate as the
+positive result found here.
+
+## C_SCOPE
+
+What is established is a bounded observable consequence of the **declared
+deterministic realization** of the axiom's neighbour clause together with the
+Record locking/readout discipline: at one forming target record, separated
+neighbour configurations change locked binary content, and `I_one` reads the
+difference.
+
+The generic axiom sentence by itself is weaker. Variation of a probability
+distribution need not give disjoint supports or force a different realized
+draw, so this packet does not claim that every admissibility law or every
+record realization changes content. It also does not establish any of the
+following:
+
+- a selected physical readout or visibility to every admissible readout;
+- a formation site, formation probability, formation rate, or production
+  dynamics;
+- a Born weighting or a weighting preference;
+- a multi-record correlation, full record-mosaic statistic, or lattice-wide
+  observable;
+- a continuous-`M_2(C)` probability law; or
+- one simultaneous translation-uniform law on the infinite lattice.
+
+No mosaic-level conclusion is inferred from the single-target tables.
+
+## D_CONTROLS and independent refutation
+
+The primary reads one explicit source: the live axiom memo, pinned by SHA-256
+and Git blob. It imports and executes no prior-cycle module. It derives all
+three truth tables, `J` values, separations, and readout values twice and
+requires deterministic equality. Its integrity checks reconcile declared
+counts and construction; they do not require a positive visibility headline.
+The same validator accepts a coherent no-separator fixture.
+
+The independent checker reads exactly three files: primary source as AST,
+primary receipt, and primary cache. It neither imports nor executes the
+primary. A separate gate-permutation reconstruction reproduces all ten table
+rows, all ten target-input-resolved separation rows, the `6/12/3` class data,
+and `J=(1,2,0)`. A dual-basis calculation independently proves the readout
+claim. Six active corruptions—locked content, `J`, visibility outcome, mosaic
+scope, source pin, and cached headline—are all rejected.
+
+Canonical cached results are:
+
+```text
+A_LOCKED_CONTENT_CENSUS PASS
+B_READOUT_VISIBILITY PASS
+C_SCOPE PASS
+D_CONTROLS PASS
+TOTAL: PASS=4 FAIL=0
+
+R0_PRIMARY_AST_AND_PINS PASS
+R1_INDEPENDENT_CONTENT_CENSUS PASS
+R2_INDEPENDENT_READOUT_DUAL PASS
+R3_RECEIPT_CACHE_BINDING PASS
+R4_ACTIVE_CORRUPTION_PROBES PASS
+R5_CONTROLS PASS
+VERDICT: PRIMARY_SURVIVES_INDEPENDENT_REFUTATION_ATTEMPT
+TOTAL: PASS=6 FAIL=0
+```
+
+## Assumptions and imports
+
+| item | class | load-bearing role | disposition |
+|---|---|---|---|
+| `minimal_axioms` | zero-input structural | supplies true-`Z^3` neighbours and conditional record locking plus content-only additive scalar readout | used directly |
+| binary content alphabet | explicit finite boundary condition | makes every local content and readout basis enumerable | declared, not extrapolated to continuous `M_2(C)` |
+| three deterministic target laws | explicit finite boundary condition | defines the content maps being tested | reconstructed in both runners |
+| single forming target | explicit conditioning | isolates record content from formation location/rate | no formation rule inferred |
+| `F_bin` | declared readout family | asks existence over every additive scalar binary-content assignment | no claim of physical selection |
+
+No observed value, fitted selector, probability weighting, normalization
+rule, literature value, new axiom, or new approved primitive is load-bearing.
+
+## Proof-obligation graph
+
+1. **Content obligation — discharged at the finite cap.** Enumerate every
+   relevant control configuration and both target inputs under each target
+   law; apply Record conditional on formation.
+2. **Class obligation — discharged at the finite cap.** Recompute the
+   `6/12/3` multiplicities, stabilizers, and `J=(1,2,0)` representatives.
+3. **Readout-family obligation — discharged for `F_bin`.** Show that singleton
+   values determine every content-only additive scalar readout and that
+   `delta_0,delta_1` span the family.
+4. **Separation obligation — discharged.** Evaluate `I_one` on every separated
+   content pair and obtain nonzero difference.
+5. **Scope obligation — discharged.** Keep formation rules, physical-readout
+   selection, probability weights, continuous content, and mosaic-wide claims
+   outside the result.
+
+## Trace gate and status fields
+
+```yaml
+trace_class: direct_blocker_closure
+reachability_to_target: closes
+target_claim_id: null
+target_blocker_text: "for a site that forms a record, do neighbour configurations separated by the finite dependence law lock different content, and can some Record-admissible additive content-only readout see it?"
+source_of_blocker_text: user_goal
+artifact_role: theorem
+next_trace_action: "submit the finite single-site content/readout theorem and paired refutation checker to independent audit; do not extrapolate to a selected physical readout or mosaic-wide observable"
+claim_id: cycle985_neighbour_dependence_record_content
+claim_type: bounded_theorem
+target_claim_type: bounded_theorem
+actual_current_surface_status: bounded-support
+conditional_surface_status: "exact on the declared binary, radius-one, deterministic single-target witness family conditional on record formation"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+proposal_allowed: false
+proposal_allowed_reason: "finite binary deterministic witness cap and declared readout-family existence; no continuous law, physical-readout selection, or mosaic theorem"
+claim_type_reason: "exact exhaustive content census and readout separation on the declared finite instance"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+audit_status_authority: independent audit lane only
+negative_assertion_classes: []
+packet_primary_runner: scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
+packet_helper_runner: scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+packet_helper_claim_scope: cycle985_neighbour_dependence_record_content
+review_loop_disposition: pending
+```

--- a/docs/NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_CYCLE985_BOUNDED_THEOREM_NOTE_2026-08-11.md
+++ b/docs/NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_CYCLE985_BOUNDED_THEOREM_NOTE_2026-08-11.md
@@ -46,25 +46,34 @@ neighbour_dependence_record_content_cycle985_bounded_theorem_note_2026-08-11:
 ## Exact target claim
 
 On the declared binary, radius-one true-`Z^3`, word-length-at-most-one target
-instance, conditional on a record forming at the target, every one-neighbour
-configuration pair separated by any of the three deterministic dependence
-classes locks different target content. The additive scalar readout
+instance, embed the two output labels as the `M_2(C)` possibilities
+`P_0=diag(1,0)` and `P_1=diag(0,1)`. For each fixed representative `g` and
+target-input parameter `x`, define the deterministic local distribution
+`mu_(g,x)(P_y|n)=1`, where `y=L_g(x,n)`. Conditional on a record forming at the
+target, Record then locks the unique supported possibility `P_y`.
+
+Within this explicit finite point-mass construction, every one-neighbour
+configuration edge on which any of the three dependence classes changes its
+Boolean output locks different target content. The additive scalar readout
 
 ```text
-I_one(R) = number of records in R whose locked content is 1
+I_one(R) = number of records in R whose locked content is P_1
 ```
 
 is determined by record content alone, has `I_one(empty)=0`, is additive on
 finite pairwise-disjoint record collections, and separates every such
-single-target pair. This is a single-site, conditional-on-formation result.
-It is not a mosaic-wide theorem and does not select the framework's physical
-readout.
+single-target pair. This is a single-site, conditional-on-formation theorem
+of the declared construction. It does not derive that the construction is the
+framework's one physical admissibility rule, is not a mosaic-wide theorem,
+and does not select the framework's physical readout.
 
 ## Declared finite instance
 
 The target is `C=(0,0,0)` and its six neighbour conditions are the signed unit
 directions `(+x,-x,+y,-y,+z,-z)`. Target input and every neighbour bit lie in
-`{0,1}`. The three representative laws and their proper-cubic orbit data are
+`{0,1}`. For each table, `x` is fixed as a supplied parameter, so the displayed
+neighbour condition `n` determines the point-mass distribution. The three
+representative laws and their proper-cubic orbit data are
 
 | class | representative | target law | multiplicity | stabilizer | `J=||sum controls||^2` |
 |---|---|---|---:|---:|---:|
@@ -79,17 +88,27 @@ notes, runners, caches, receipts, or verdict fields is read or executed.
 ## A_LOCKED_CONTENT_CENSUS
 
 The [`Record axiom`](MINIMAL_AXIOMS_2026-06-29.md) says that a record, when
-present, locks one admissible local possibility. In this binary deterministic
-instance that possibility is the target output `y`. All five neighbour bits
-not displayed in a CNOT row, and all four not displayed in a TOF row, are
-arbitrary spectators.
+present, locks one admissible local possibility. This packet constructs two
+such possibilities inside the supplied one-site algebra,
+
+```text
+P_0 = [[1,0],[0,0]],    P_1 = [[0,0],[0,1]],
+mu_(g,x)(P_y|n)=1,      mu_(g,x)(P_(1-y)|n)=0.
+```
+
+Thus `P_y` is the unique supported possibility and, conditional on formation,
+the locked content in this construction. This is a declared embedding and
+point-mass law, not a derivation of a unique physical basis or of the
+framework's one global admissibility rule. All five neighbour bits not
+displayed in a CNOT row, and all four not displayed in a TOF row, are arbitrary
+Boolean spectators in the finite fixture.
 
 ### Incoming CNOT class (`J=1`, multiplicity 6)
 
 | `n_(+x)` | locked content for `x=0` | locked content for `x=1` |
 |---:|---:|---:|
-| 0 | 0 | 1 |
-| 1 | 1 | 0 |
+| 0 | `P_0` | `P_1` |
+| 1 | `P_1` | `P_0` |
 
 For either target input, toggling the control `0 <-> 1` changes the locked
 content.
@@ -98,10 +117,10 @@ content.
 
 | `(n_(+x),n_(+y))` | locked content for `x=0` | locked content for `x=1` |
 |---|---:|---:|
-| `(0,0)` | 0 | 1 |
-| `(0,1)` | 0 | 1 |
-| `(1,0)` | 0 | 1 |
-| `(1,1)` | 1 | 0 |
+| `(0,0)` | `P_0` | `P_1` |
+| `(0,1)` | `P_0` | `P_1` |
+| `(1,0)` | `P_0` | `P_1` |
+| `(1,1)` | `P_1` | `P_0` |
 
 The separated one-bit pairs are `(0,1) <-> (1,1)` when `+x` is toggled and
 `(1,0) <-> (1,1)` when `+y` is toggled, for either target input. Toggling a
@@ -111,42 +130,45 @@ control while the other control is zero does not separate the law.
 
 | `(n_(+x),n_(-x))` | locked content for `x=0` | locked content for `x=1` |
 |---|---:|---:|
-| `(0,0)` | 0 | 1 |
-| `(0,1)` | 0 | 1 |
-| `(1,0)` | 0 | 1 |
-| `(1,1)` | 1 | 0 |
+| `(0,0)` | `P_0` | `P_1` |
+| `(0,1)` | `P_0` | `P_1` |
+| `(1,0)` | `P_0` | `P_1` |
+| `(1,1)` | `P_1` | `P_0` |
 
 The separated one-bit pairs are again `(0,1) <-> (1,1)` and
 `(1,0) <-> (1,1)`, now for the opposite controls, for either target input.
 
 Across the three representatives there are ten target-input-resolved
-one-neighbour-bit separation rows: two CNOT rows and four rows for each TOF
-class. Every one flips locked content `0 <-> 1`.
+one-neighbour-bit changing rows: two CNOT rows and four rows for each TOF
+class. Every one flips locked content `P_0 <-> P_1`. The runners also enumerate
+the non-changing Hamming edges rather than defining the census by preselecting
+unequal outputs.
 
 ## B_READOUT_VISIBILITY
 
 ### Declared readout family
 
-For this binary content census, declare the complete additive scalar family
+For this two-possibility content census, declare the complete additive scalar
+family
 
 ```text
-F_bin = {phi:{0,1}->R},
+F_bin = {phi:{P_0,P_1}->R},
 I_phi(R) = sum over records r in R of phi(content(r)).
 ```
 
 Every `I_phi` is determined by record content alone. The empty sum gives
 `I_phi(empty)=0`, and splitting a finite record collection into pairwise-
 disjoint subcollections splits the sum, so additivity is exact. Conversely,
-within the binary alphabet, every additive content-only scalar readout is
-fixed by its two singleton values `phi(0)` and `phi(1)`. Thus
+within the declared two-point content alphabet, every additive content-only
+scalar readout is fixed by its two singleton values `phi(P_0)` and `phi(P_1)`. Thus
 `delta_0=(1,0)` and `delta_1=(0,1)` form a basis for the declared family.
 
 ### Exact separator
 
-Choose `phi(0)=0`, `phi(1)=1`. Then
+Choose `phi(P_0)=0`, `phi(P_1)=1`. Then
 
 ```text
-I_one({target record}) = locked target content.
+I_one({target record}) = y when its locked content is P_y.
 ```
 
 Every separated pair in the census changes `I_one` by `+1` or `-1`. Hence
@@ -160,26 +182,28 @@ content change between equal-size singleton collections. The axiom licenses
 `I_one`; it does not select it or require the unspecified fixed physical
 readout to be content-faithful.
 
-For completeness, no separator exists in `F_bin` for a compared singleton
-pair exactly when the two locked contents are equal: both basis functionals
-then agree, so every linear combination agrees. The runner's outcome-neutral
-visibility validator accepts a coherent equal-content/no-separator fixture.
-Therefore a negative result would pass the same bookkeeping gate as the
-positive result found here.
+The outcome-neutral bookkeeping path is exercised without shipping a negative
+science claim: on a synthetic equal-content fixture, both basis functionals
+agree and the full top-level B/R2 validators accept the report
+`DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS`. Thus a content-blind
+finding would pass the same integrity gates as the positive result found here.
 
 ## C_SCOPE
 
-What is established is a bounded observable consequence of the **declared
-deterministic realization** of the axiom's neighbour clause together with the
-Record locking/readout discipline: at one forming target record, separated
-neighbour configurations change locked binary content, and `I_one` reads the
-difference.
+What is established is a bounded observable consequence inside the **declared
+finite point-mass construction**: for each fixed `(g,x)` conditioned law,
+changing a neighbour along one of the enumerated changing edges changes the
+unique supported `M_2(C)` possibility, Record locks that possibility if a
+record forms, and `I_one` reads the difference.
 
 The generic axiom sentence by itself is weaker. Variation of a probability
 distribution need not give disjoint supports or force a different realized
-draw, so this packet does not claim that every admissibility law or every
-record realization changes content. It also does not establish any of the
-following:
+draw. This packet also treats the 21 transported programs and the two fixed
+target-input values as alternative finite conditioned laws; it does not prove
+that they assemble into the framework's one fixed, simultaneous,
+translation-uniform admissibility rule. Therefore the packet does not claim
+that every admissibility law or every record realization changes content. It
+also does not establish any of the following:
 
 - a selected physical readout or visibility to every admissible readout;
 - a formation site, formation probability, formation rate, or production
@@ -197,17 +221,22 @@ No mosaic-level conclusion is inferred from the single-target tables.
 The primary reads one explicit source: the live axiom memo, pinned by SHA-256
 and Git blob. It imports and executes no prior-cycle module. It derives all
 three truth tables, `J` values, separations, and readout values twice and
-requires deterministic equality. Its integrity checks reconcile declared
-counts and construction; they do not require a positive visibility headline.
-The same validator accepts a coherent no-separator fixture.
+requires deterministic equality. It enumerates the 24 proper cubic rotations,
+orbits, stabilizers, every control-hypercube Hamming edge, both point-mass
+normalizations, and support membership. Its integrity checks reconcile counts
+and construction; they do not require a positive visibility headline. The
+same top-level validator accepts the coherent family-agreement fixture.
 
 The independent checker reads exactly three files: primary source as AST,
 primary receipt, and primary cache. It neither imports nor executes the
 primary. A separate gate-permutation reconstruction reproduces all ten table
-rows, all ten target-input-resolved separation rows, the `6/12/3` class data,
-and `J=(1,2,0)`. A dual-basis calculation independently proves the readout
-claim. Six active corruptions—locked content, `J`, visibility outcome, mosaic
-scope, source pin, and cached headline—are all rejected.
+rows and all target-input-resolved Hamming edges. Its proper-cubic group is
+built independently from oriented right-handed frames, reproducing the
+`6/12/3` orbits, `4/2/8` stabilizers, and `J=(1,2,0)` without copying those
+values as expectations. A dual-basis calculation independently proves the
+readout claim. Six active corruptions—locked content, `J`, visibility outcome,
+mosaic scope through the actual scope validator, primary source through the
+actual AST pin validator, and cached headline—are all rejected.
 
 Canonical cached results are:
 
@@ -232,9 +261,11 @@ TOTAL: PASS=6 FAIL=0
 
 | item | class | load-bearing role | disposition |
 |---|---|---|---|
-| `minimal_axioms` | zero-input structural | supplies true-`Z^3` neighbours and conditional record locking plus content-only additive scalar readout | used directly |
-| binary content alphabet | explicit finite boundary condition | makes every local content and readout basis enumerable | declared, not extrapolated to continuous `M_2(C)` |
-| three deterministic target laws | explicit finite boundary condition | defines the content maps being tested | reconstructed in both runners |
+| `minimal_axioms` | zero-input structural | supplies true-`Z^3` neighbours, `M_2(C)` possibility domain, conditional record locking, and content-only additive scalar readout | used directly |
+| `P_0/P_1` embedding | explicit finite construction | embeds the two Boolean labels as diagonal `M_2(C)` possibilities | declared and checked; no unique physical basis claimed |
+| point-mass laws `mu_(g,x)` | explicit finite construction | makes `P_y` the unique supported possibility for each fixed `(g,x,n)` | normalized and support-checked; not promoted to one global physical rule |
+| fixed target input `x` | explicit conditioning parameter | makes each `mu_(g,x)` a neighbour-determined map | both values enumerated separately; no extra varying site condition hidden |
+| three deterministic target-law classes | explicit finite boundary condition | defines the output maps and proper-cubic orbits being tested | reconstructed in both runners; alternative laws, not simultaneous assembly |
 | single forming target | explicit conditioning | isolates record content from formation location/rate | no formation rule inferred |
 | `F_bin` | declared readout family | asks existence over every additive scalar binary-content assignment | no claim of physical selection |
 
@@ -243,19 +274,22 @@ rule, literature value, new axiom, or new approved primitive is load-bearing.
 
 ## Proof-obligation graph
 
-1. **Content obligation — discharged at the finite cap.** Enumerate every
-   relevant control configuration and both target inputs under each target
-   law; apply Record conditional on formation.
+1. **Content obligation — discharged for the declared construction.** Embed
+   `P_0/P_1` in `M_2(C)`, construct normalized point-mass distributions,
+   verify `P_y` is their unique support point, enumerate every control
+   configuration and both fixed target-input parameters, and apply Record
+   conditional on formation.
 2. **Class obligation — discharged at the finite cap.** Recompute the
-   `6/12/3` multiplicities, stabilizers, and `J=(1,2,0)` representatives.
+   proper-cubic group, `6/12/3` multiplicities, `4/2/8` stabilizers, and
+   `J=(1,2,0)` representatives by independent group constructions.
 3. **Readout-family obligation — discharged for `F_bin`.** Show that singleton
    values determine every content-only additive scalar readout and that
    `delta_0,delta_1` span the family.
 4. **Separation obligation — discharged.** Evaluate `I_one` on every separated
    content pair and obtain nonzero difference.
 5. **Scope obligation — discharged.** Keep formation rules, physical-readout
-   selection, probability weights, continuous content, and mosaic-wide claims
-   outside the result.
+   selection, global-law assembly, probability weights beyond the constructed
+   point masses, continuous content, and mosaic-wide claims outside the result.
 
 ## Trace gate and status fields
 
@@ -271,12 +305,12 @@ claim_id: cycle985_neighbour_dependence_record_content
 claim_type: bounded_theorem
 target_claim_type: bounded_theorem
 actual_current_surface_status: bounded-support
-conditional_surface_status: "exact on the declared binary, radius-one, deterministic single-target witness family conditional on record formation"
+conditional_surface_status: "exact for the declared P0/P1 embedding and finite point-mass conditioned laws on the binary radius-one single-target family, conditional on record formation"
 hypothetical_axiom_status: null
 admitted_observation_status: null
 proposal_allowed: false
-proposal_allowed_reason: "finite binary deterministic witness cap and declared readout-family existence; no continuous law, physical-readout selection, or mosaic theorem"
-claim_type_reason: "exact exhaustive content census and readout separation on the declared finite instance"
+proposal_allowed_reason: "finite constructed point-mass witness cap and declared readout-family existence; no global physical admissibility rule, physical-readout selection, or mosaic theorem"
+claim_type_reason: "exact exhaustive supported-content census and readout separation in the declared finite M2(C) point-mass construction"
 audit_required_before_effective_retained: true
 bare_retained_allowed: false
 audit_status_authority: independent audit lane only

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15483,
- "node_count": 5447,
+ "edge_count": 15484,
+ "node_count": 5448,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12713,6 +12713,10 @@
   "nature_ranked_directions_2026-04-11": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "neighbour_dependence_record_content_cycle985_bounded_theorem_note_2026-08-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "neutrino_axiom3_reading_stuck_fanout_note_2026-04-28": {
    "deps_hash": "20b024f2f449",

--- a/docs/audit/scripts/build_citation_graph.py
+++ b/docs/audit/scripts/build_citation_graph.py
@@ -151,6 +151,9 @@ HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s#]+\.md)(?:#[^)]*)?\)")
 
 EXPLICIT_PACKET_HELPER_RUNNER_PATHS = {
+    "neighbour_dependence_record_content_cycle985_bounded_theorem_note_2026-08-11": [
+        "scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py",
+    ],
     "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": [
         "scripts/frontier_cycle879_b4_relation_independent_check_2026_07_28.py",
     ],

--- a/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt
+++ b/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt
@@ -1,0 +1,18 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
+runner_sha256: 0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2
+input_fingerprint_sha256: db7786cde9df9554b9e925bd8927e6f129e0cdd1546e5ea349a31056104b73bb
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+CYCLE985_NEIGHBOUR_DEPENDENCE_RECORD_CONTENT
+A_LOCKED_CONTENT_CENSUS PASS :: classes=[["incoming CNOT",6,1,2],["perpendicular-control TOF",12,2,4],["opposite-control TOF",3,0,4]]; witnesses=21; separated_pairs=10
+B_READOUT_VISIBILITY PASS :: outcome=SEPARATING_ADMISSIBLE_READOUT_EXISTS; readout=I_one; visible=10/10
+C_SCOPE PASS :: single_site=True; full_mosaic_claimed=False; selected_readout_claimed=False
+D_CONTROLS PASS :: source_reads=1<=6; pins=True; deterministic=True; negative_gate=True
+TOTAL: PASS=4 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt
+++ b/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt
@@ -1,17 +1,17 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
-runner_sha256: 0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2
+runner_sha256: 3d66b2836743808119541536bf7562212a05da84f1149b9f5d5f12f47ff7eff8
 input_fingerprint_sha256: db7786cde9df9554b9e925bd8927e6f129e0cdd1546e5ea349a31056104b73bb
 timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.05
+elapsed_sec: 0.09
 status: ok
 ----- stdout -----
 CYCLE985_NEIGHBOUR_DEPENDENCE_RECORD_CONTENT
 A_LOCKED_CONTENT_CENSUS PASS :: classes=[["incoming CNOT",6,1,2],["perpendicular-control TOF",12,2,4],["opposite-control TOF",3,0,4]]; witnesses=21; separated_pairs=10
 B_READOUT_VISIBILITY PASS :: outcome=SEPARATING_ADMISSIBLE_READOUT_EXISTS; readout=I_one; visible=10/10
 C_SCOPE PASS :: single_site=True; full_mosaic_claimed=False; selected_readout_claimed=False
-D_CONTROLS PASS :: source_reads=1<=6; pins=True; deterministic=True; negative_gate=True
+D_CONTROLS PASS :: source_reads=1<=6; pins=True; deterministic=True; agreement_gate=True
 TOTAL: PASS=4 FAIL=0
 
 ----- stderr -----

--- a/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt
+++ b/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt
@@ -1,6 +1,6 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
-runner_sha256: d0f9790c0ae4274b719dda5fd5ecea977800ec9c0fe5f572b5a627351cd92bcf
+runner_sha256: 6ff60e2f5c3b826d59531894c6d0542fdcbad762fd40b0b0faf925ae435d646f
 input_fingerprint_sha256: a6fcc0a3a34bde0752d095670462afcca369f1a8ed7bd6462d39382a13f37b93
 timeout_sec: 300
 exit_code: 0

--- a/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt
+++ b/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
-runner_sha256: b7aa7dc7faa48635c1b5caf058bc0431d043a1de89ff64b92c84d022eb055ae4
-input_fingerprint_sha256: 1925c057f59ec44d5275ed236801ddff33c5755729e34238aa833c224eaafa3d
+runner_sha256: d0f9790c0ae4274b719dda5fd5ecea977800ec9c0fe5f572b5a627351cd92bcf
+input_fingerprint_sha256: a6fcc0a3a34bde0752d095670462afcca369f1a8ed7bd6462d39382a13f37b93
 timeout_sec: 300
 exit_code: 0
-elapsed_sec: 0.04
+elapsed_sec: 0.05
 status: ok
 ----- stdout -----
 CYCLE985_NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_INDEPENDENT_CHECK
@@ -13,7 +13,7 @@ R1_INDEPENDENT_CONTENT_CENSUS PASS :: classes=[['incoming CNOT', 6, 4, 1, 2], ['
 R2_INDEPENDENT_READOUT_DUAL PASS :: outcome=SEPARATING_ADMISSIBLE_READOUT_EXISTS; pairs=10
 R3_RECEIPT_CACHE_BINDING PASS
 R4_ACTIVE_CORRUPTION_PROBES PASS :: rejected=6/6
-R5_CONTROLS PASS :: source_reads=3<=6; primary_executed=False; negative_gate=True
+R5_CONTROLS PASS :: source_reads=3<=6; primary_executed=False; agreement_gate=True
 VERDICT: PRIMARY_SURVIVES_INDEPENDENT_REFUTATION_ATTEMPT
 TOTAL: PASS=6 FAIL=0
 

--- a/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt
+++ b/logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.txt
@@ -1,0 +1,21 @@
+===== runner cache v1 =====
+runner: scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+runner_sha256: b7aa7dc7faa48635c1b5caf058bc0431d043a1de89ff64b92c84d022eb055ae4
+input_fingerprint_sha256: 1925c057f59ec44d5275ed236801ddff33c5755729e34238aa833c224eaafa3d
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+CYCLE985_NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_INDEPENDENT_CHECK
+R0_PRIMARY_AST_AND_PINS PASS
+R1_INDEPENDENT_CONTENT_CENSUS PASS :: classes=[['incoming CNOT', 6, 4, 1, 2], ['perpendicular-control TOF', 12, 2, 2, 4], ['opposite-control TOF', 3, 8, 0, 4]]
+R2_INDEPENDENT_READOUT_DUAL PASS :: outcome=SEPARATING_ADMISSIBLE_READOUT_EXISTS; pairs=10
+R3_RECEIPT_CACHE_BINDING PASS
+R4_ACTIVE_CORRUPTION_PROBES PASS :: rejected=6/6
+R5_CONTROLS PASS :: source_reads=3<=6; primary_executed=False; negative_gate=True
+VERDICT: PRIMARY_SURVIVES_INDEPENDENT_REFUTATION_ATTEMPT
+TOTAL: PASS=6 FAIL=0
+
+----- stderr -----
+

--- a/outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json
+++ b/outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json
@@ -1,0 +1,118 @@
+{
+  "artifact": "Cycle 985 independent record-content refutation attempt",
+  "audit_status_authority": "independent audit lane only",
+  "cache_semantic_fields": {
+    "elapsed_sec": "0.05",
+    "exit_code": "0",
+    "input_fingerprint_sha256": "db7786cde9df9554b9e925bd8927e6f129e0cdd1546e5ea349a31056104b73bb",
+    "runner": "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py",
+    "runner_sha256": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2",
+    "status": "ok",
+    "timeout_sec": "300"
+  },
+  "checker_source_sha256": "b7aa7dc7faa48635c1b5caf058bc0431d043a1de89ff64b92c84d022eb055ae4",
+  "checks": {
+    "R0_PRIMARY_AST_AND_PINS": true,
+    "R1_INDEPENDENT_CONTENT_CENSUS": true,
+    "R2_INDEPENDENT_READOUT_DUAL": true,
+    "R3_RECEIPT_CACHE_BINDING": true,
+    "R4_ACTIVE_CORRUPTION_PROBES": true,
+    "R5_CONTROLS": true
+  },
+  "controls": {
+    "input_git_blobs": {
+      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt": "eb43550c7e2dc8c052c5c72bf4cb4ef99ac7c92a",
+      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json": "6e452a1d1d4c7cc3d6da44e19a0a06d1c397ee54",
+      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py": "fa28d8b343ef67c45cf24e299dddc0a290d6e6f4"
+    },
+    "input_sha256": {
+      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt": "4f3d9f1299d29862a23330f491965a795bdf9755ce5b8bad406e190edfc9963f",
+      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json": "ae6b337dad743eb2ddc389f4be055e35c9c2a4b7306003e0548ffc66f21ec6d1",
+      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
+    },
+    "literal_audit_input_paths": [
+      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py",
+      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json",
+      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt"
+    ],
+    "literal_source_read_count": 3,
+    "primary_imported_or_executed": false,
+    "runtime_budget_met": true,
+    "runtime_budget_seconds": 300,
+    "stdout_bytes": 582,
+    "stdout_limit_bytes": 6000,
+    "synthetic_negative_outcome_accepted": true
+  },
+  "corruption_probes": {
+    "cached_headline": true,
+    "class_separator_J": true,
+    "locked_content_row": true,
+    "mosaic_scope": true,
+    "source_pin": true,
+    "visibility_outcome": true
+  },
+  "cycle": 985,
+  "independent": {
+    "class_summary": [
+      [
+        "incoming CNOT",
+        6,
+        4,
+        1,
+        2
+      ],
+      [
+        "perpendicular-control TOF",
+        12,
+        2,
+        2,
+        4
+      ],
+      [
+        "opposite-control TOF",
+        3,
+        8,
+        0,
+        4
+      ]
+    ],
+    "readout": {
+      "I_one_deltas": [
+        1,
+        -1,
+        1,
+        1,
+        -1,
+        -1,
+        1,
+        1,
+        -1,
+        -1
+      ],
+      "basis": [
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          1
+        ]
+      ],
+      "family": "R^{{0,1}}, extended by finite sums",
+      "no_separator_iff_contents_equal": true,
+      "outcome": "SEPARATING_ADMISSIBLE_READOUT_EXISTS",
+      "pair_count": 10
+    },
+    "reconstruction_digest": "d9eb289439fc2bdf630cfdaeae10066862bb47d410d77850ee858abef7f551ca"
+  },
+  "pass": true,
+  "primary_ast_and_pins": {
+    "primary_has_main_guard": true,
+    "primary_reads_only_axiom": true,
+    "source_git_blob": "fa28d8b343ef67c45cf24e299dddc0a290d6e6f4",
+    "source_pin_match": true,
+    "source_sha256": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
+  },
+  "stdout_sha256": "33cc7848093d7e8856d894673590bb9d6c15bf0c688fd1f4214eba8baddf1371"
+}

--- a/outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json
+++ b/outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json
@@ -2,15 +2,15 @@
   "artifact": "Cycle 985 independent record-content refutation attempt",
   "audit_status_authority": "independent audit lane only",
   "cache_semantic_fields": {
-    "elapsed_sec": "0.05",
+    "elapsed_sec": "0.09",
     "exit_code": "0",
     "input_fingerprint_sha256": "db7786cde9df9554b9e925bd8927e6f129e0cdd1546e5ea349a31056104b73bb",
     "runner": "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py",
-    "runner_sha256": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2",
+    "runner_sha256": "3d66b2836743808119541536bf7562212a05da84f1149b9f5d5f12f47ff7eff8",
     "status": "ok",
     "timeout_sec": "300"
   },
-  "checker_source_sha256": "b7aa7dc7faa48635c1b5caf058bc0431d043a1de89ff64b92c84d022eb055ae4",
+  "checker_source_sha256": "d0f9790c0ae4274b719dda5fd5ecea977800ec9c0fe5f572b5a627351cd92bcf",
   "checks": {
     "R0_PRIMARY_AST_AND_PINS": true,
     "R1_INDEPENDENT_CONTENT_CENSUS": true,
@@ -21,14 +21,14 @@
   },
   "controls": {
     "input_git_blobs": {
-      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt": "eb43550c7e2dc8c052c5c72bf4cb4ef99ac7c92a",
-      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json": "6e452a1d1d4c7cc3d6da44e19a0a06d1c397ee54",
-      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py": "fa28d8b343ef67c45cf24e299dddc0a290d6e6f4"
+      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt": "9b5fb7a36b4d459018e61fd60b78d9756f206aa0",
+      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json": "ecc58ae8c8596ab79a1561609394556496b3ea7c",
+      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py": "879ec075d166640df91db3fb6900ddb25cc84ebd"
     },
     "input_sha256": {
-      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt": "4f3d9f1299d29862a23330f491965a795bdf9755ce5b8bad406e190edfc9963f",
-      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json": "ae6b337dad743eb2ddc389f4be055e35c9c2a4b7306003e0548ffc66f21ec6d1",
-      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
+      "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt": "96cc997b88501192e926e8999758a8c8c5ae0044ccfa559c95b92c71405a1810",
+      "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json": "570332f2bd8b491f6c39a9d4bbcec701b23304ba9a6f493f3f957b562fc00d01",
+      "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py": "3d66b2836743808119541536bf7562212a05da84f1149b9f5d5f12f47ff7eff8"
     },
     "literal_audit_input_paths": [
       "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py",
@@ -39,9 +39,9 @@
     "primary_imported_or_executed": false,
     "runtime_budget_met": true,
     "runtime_budget_seconds": 300,
-    "stdout_bytes": 582,
+    "stdout_bytes": 583,
     "stdout_limit_bytes": 6000,
-    "synthetic_negative_outcome_accepted": true
+    "synthetic_agreement_outcome_accepted": true
   },
   "corruption_probes": {
     "cached_headline": true,
@@ -99,20 +99,21 @@
           1
         ]
       ],
+      "basis_agreement_iff_contents_equal": true,
       "family": "R^{{0,1}}, extended by finite sums",
-      "no_separator_iff_contents_equal": true,
       "outcome": "SEPARATING_ADMISSIBLE_READOUT_EXISTS",
-      "pair_count": 10
+      "pair_count": 10,
+      "visible_pair_count": 10
     },
-    "reconstruction_digest": "d9eb289439fc2bdf630cfdaeae10066862bb47d410d77850ee858abef7f551ca"
+    "reconstruction_digest": "2c934019462cdb2f9711a86c59d6ae08376cd3a993b64564c6604b1d40b7abca"
   },
   "pass": true,
   "primary_ast_and_pins": {
     "primary_has_main_guard": true,
     "primary_reads_only_axiom": true,
-    "source_git_blob": "fa28d8b343ef67c45cf24e299dddc0a290d6e6f4",
+    "source_git_blob": "879ec075d166640df91db3fb6900ddb25cc84ebd",
     "source_pin_match": true,
-    "source_sha256": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
+    "source_sha256": "3d66b2836743808119541536bf7562212a05da84f1149b9f5d5f12f47ff7eff8"
   },
-  "stdout_sha256": "33cc7848093d7e8856d894673590bb9d6c15bf0c688fd1f4214eba8baddf1371"
+  "stdout_sha256": "0a7ac7c8f7d6c48e15a4e3e5506e71166e9dee83001dc14ea6d37059dbae23b5"
 }

--- a/outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json
+++ b/outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json
@@ -10,7 +10,7 @@
     "status": "ok",
     "timeout_sec": "300"
   },
-  "checker_source_sha256": "d0f9790c0ae4274b719dda5fd5ecea977800ec9c0fe5f572b5a627351cd92bcf",
+  "checker_source_sha256": "6ff60e2f5c3b826d59531894c6d0542fdcbad762fd40b0b0faf925ae435d646f",
   "checks": {
     "R0_PRIMARY_AST_AND_PINS": true,
     "R1_INDEPENDENT_CONTENT_CENSUS": true,
@@ -103,6 +103,68 @@
       "family": "R^{{0,1}}, extended by finite sums",
       "outcome": "SEPARATING_ADMISSIBLE_READOUT_EXISTS",
       "pair_count": 10,
+      "pair_signatures": [
+        [
+          "incoming CNOT",
+          0,
+          0,
+          1
+        ],
+        [
+          "incoming CNOT",
+          1,
+          1,
+          0
+        ],
+        [
+          "perpendicular-control TOF",
+          0,
+          0,
+          1
+        ],
+        [
+          "perpendicular-control TOF",
+          0,
+          0,
+          1
+        ],
+        [
+          "perpendicular-control TOF",
+          1,
+          1,
+          0
+        ],
+        [
+          "perpendicular-control TOF",
+          1,
+          1,
+          0
+        ],
+        [
+          "opposite-control TOF",
+          0,
+          0,
+          1
+        ],
+        [
+          "opposite-control TOF",
+          0,
+          0,
+          1
+        ],
+        [
+          "opposite-control TOF",
+          1,
+          1,
+          0
+        ],
+        [
+          "opposite-control TOF",
+          1,
+          1,
+          0
+        ]
+      ],
       "visible_pair_count": 10
     },
     "reconstruction_digest": "2c934019462cdb2f9711a86c59d6ae08376cd3a993b64564c6604b1d40b7abca"

--- a/outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json
+++ b/outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json
@@ -28,9 +28,9 @@
     "runtime_budget_met": true,
     "runtime_budget_seconds": 300,
     "sha_pins_match": true,
-    "stdout_bytes": 518,
+    "stdout_bytes": 519,
     "stdout_limit_bytes": 6000,
-    "synthetic_negative_visibility_accepted": true
+    "synthetic_agreement_outcome_accepted": true
   },
   "cycle": 985,
   "findings": {
@@ -40,7 +40,28 @@
         "opposite-control TOF": 0,
         "perpendicular-control TOF": 2
       },
-      "all_separated_pairs_flip_locked_content": true,
+      "M2C_possibility_embedding": {
+        "P_0": [
+          [
+            1,
+            0
+          ],
+          [
+            0,
+            0
+          ]
+        ],
+        "P_1": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            1
+          ]
+        ]
+      },
       "class_count": 3,
       "classes": [
         {
@@ -49,9 +70,11 @@
           "controls": [
             "+x"
           ],
+          "group_order": 24,
           "induced_target_law": "y=x XOR n_(+x)",
-          "one_neighbour_bit_separations": [
+          "one_neighbour_bit_edges": [
             {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1
               },
@@ -63,6 +86,7 @@
               "target_input": 0
             },
             {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1
               },
@@ -74,7 +98,35 @@
               "target_input": 1
             }
           ],
+          "one_neighbour_bit_separations": [
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1
+              },
+              "configuration_before": {
+                "+x": 0
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1
+              },
+              "configuration_before": {
+                "+x": 0
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            }
+          ],
+          "orbit_digest": "4639b741864ba017b5be524dfbd7759bd8011a54830b2c32685123ce7ca64c91",
           "orbit_size": 6,
+          "orbit_stabilizer_product": 24,
           "representative": "CNOT(+x->C)",
           "stabilizer": 4,
           "table": [
@@ -86,6 +138,24 @@
                 "0": 0,
                 "1": 1
               },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
+              },
               "spectator_neighbours": "arbitrary"
             },
             {
@@ -95,6 +165,24 @@
               "locked_content_by_target_input": {
                 "0": 1,
                 "1": 0
+              },
+              "locked_possibility_by_target_input": {
+                "0": "P_1",
+                "1": "P_0"
+              },
+              "output_bit_by_target_input": {
+                "0": 1,
+                "1": 0
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 0,
+                  "P_1": 1
+                },
+                "1": {
+                  "P_0": 1,
+                  "P_1": 0
+                }
               },
               "spectator_neighbours": "arbitrary"
             }
@@ -107,9 +195,39 @@
             "+x",
             "+y"
           ],
+          "group_order": 24,
           "induced_target_law": "y=x XOR (n_1 AND n_2)",
-          "one_neighbour_bit_separations": [
+          "one_neighbour_bit_edges": [
             {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 0,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 0
+              },
+              "content_after": 0,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 1,
+                "+y": 0
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 0
+              },
+              "content_after": 0,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "+y": 1
@@ -123,6 +241,7 @@
               "target_input": 0
             },
             {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "+y": 1
@@ -136,6 +255,35 @@
               "target_input": 0
             },
             {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 0,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 0
+              },
+              "content_after": 1,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 1,
+                "+y": 0
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 0
+              },
+              "content_after": 1,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "+y": 1
@@ -149,6 +297,7 @@
               "target_input": 1
             },
             {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "+y": 1
@@ -162,7 +311,67 @@
               "target_input": 1
             }
           ],
+          "one_neighbour_bit_separations": [
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 1
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "+y": 0
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 1
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "+y": 0
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            }
+          ],
+          "orbit_digest": "7c0a2c677245450d8dbac353df443050eb72a4ca81e51149c2f214b5ae6b3ff6",
           "orbit_size": 12,
+          "orbit_stabilizer_product": 24,
           "representative": "TOF(+x,+y->C)",
           "stabilizer": 2,
           "table": [
@@ -175,6 +384,24 @@
                 "0": 0,
                 "1": 1
               },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
+              },
               "spectator_neighbours": "arbitrary"
             },
             {
@@ -185,6 +412,24 @@
               "locked_content_by_target_input": {
                 "0": 0,
                 "1": 1
+              },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
               },
               "spectator_neighbours": "arbitrary"
             },
@@ -197,6 +442,24 @@
                 "0": 0,
                 "1": 1
               },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
+              },
               "spectator_neighbours": "arbitrary"
             },
             {
@@ -207,6 +470,24 @@
               "locked_content_by_target_input": {
                 "0": 1,
                 "1": 0
+              },
+              "locked_possibility_by_target_input": {
+                "0": "P_1",
+                "1": "P_0"
+              },
+              "output_bit_by_target_input": {
+                "0": 1,
+                "1": 0
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 0,
+                  "P_1": 1
+                },
+                "1": {
+                  "P_0": 1,
+                  "P_1": 0
+                }
               },
               "spectator_neighbours": "arbitrary"
             }
@@ -219,9 +500,39 @@
             "+x",
             "-x"
           ],
+          "group_order": 24,
           "induced_target_law": "y=x XOR (n_1 AND n_2)",
-          "one_neighbour_bit_separations": [
+          "one_neighbour_bit_edges": [
             {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 0,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 0
+              },
+              "content_after": 0,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 1,
+                "-x": 0
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 0
+              },
+              "content_after": 0,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "-x": 1
@@ -235,6 +546,7 @@
               "target_input": 0
             },
             {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "-x": 1
@@ -248,6 +560,35 @@
               "target_input": 0
             },
             {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 0,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 0
+              },
+              "content_after": 1,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "changes_locked_content": false,
+              "configuration_after": {
+                "+x": 1,
+                "-x": 0
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 0
+              },
+              "content_after": 1,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "-x": 1
@@ -261,6 +602,7 @@
               "target_input": 1
             },
             {
+              "changes_locked_content": true,
               "configuration_after": {
                 "+x": 1,
                 "-x": 1
@@ -274,7 +616,67 @@
               "target_input": 1
             }
           ],
+          "one_neighbour_bit_separations": [
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 1
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "-x": 0
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 1
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "changes_locked_content": true,
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "-x": 0
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            }
+          ],
+          "orbit_digest": "648bb06d2acc7198d0a53b4ec2b58141a6a8ea153d8ce047f7f297dd2e741af4",
           "orbit_size": 3,
+          "orbit_stabilizer_product": 24,
           "representative": "TOF(+x,-x->C)",
           "stabilizer": 8,
           "table": [
@@ -287,6 +689,24 @@
                 "0": 0,
                 "1": 1
               },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
+              },
               "spectator_neighbours": "arbitrary"
             },
             {
@@ -297,6 +717,24 @@
               "locked_content_by_target_input": {
                 "0": 0,
                 "1": 1
+              },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
               },
               "spectator_neighbours": "arbitrary"
             },
@@ -309,6 +747,24 @@
                 "0": 0,
                 "1": 1
               },
+              "locked_possibility_by_target_input": {
+                "0": "P_0",
+                "1": "P_1"
+              },
+              "output_bit_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 1,
+                  "P_1": 0
+                },
+                "1": {
+                  "P_0": 0,
+                  "P_1": 1
+                }
+              },
               "spectator_neighbours": "arbitrary"
             },
             {
@@ -320,6 +776,24 @@
                 "0": 1,
                 "1": 0
               },
+              "locked_possibility_by_target_input": {
+                "0": "P_1",
+                "1": "P_0"
+              },
+              "output_bit_by_target_input": {
+                "0": 1,
+                "1": 0
+              },
+              "point_mass_distribution_by_target_input": {
+                "0": {
+                  "P_0": 0,
+                  "P_1": 1
+                },
+                "1": {
+                  "P_0": 1,
+                  "P_1": 0
+                }
+              },
               "spectator_neighbours": "arbitrary"
             }
           ]
@@ -330,7 +804,12 @@
         0,
         1
       ],
+      "distribution_construction": "for each fixed target input and representative law, mu(P_y|n)=1 and mu(P_(1-y)|n)=0; Record locks the unique supported P_y",
+      "locked_content_support_failures": 0,
+      "point_mass_normalization_failures": 0,
+      "proper_cubic_group_order": 24,
       "spectator_neighbours": "arbitrary in every displayed row",
+      "target_input_role": "fixed supplied parameter for each finite conditioned law, not an additional varying neighbour coordinate",
       "witness_multiplicity": 21
     },
     "B_READOUT_VISIBILITY": {
@@ -356,6 +835,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "incoming CNOT",
             "configuration_after": {
               "+x": 1
@@ -382,6 +862,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "incoming CNOT",
             "configuration_after": {
               "+x": 1
@@ -408,6 +889,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "perpendicular-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -436,6 +918,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "perpendicular-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -464,6 +947,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "perpendicular-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -492,6 +976,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "perpendicular-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -520,6 +1005,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "opposite-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -548,6 +1034,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "opposite-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -576,6 +1063,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "opposite-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -604,6 +1092,7 @@
                 "readout": "I_one"
               }
             ],
+            "changes_locked_content": true,
             "class": "opposite-control TOF",
             "configuration_after": {
               "+x": 1,
@@ -727,21 +1216,24 @@
       "selection_boundary": "the Record axiom permits this separating readout but does not select it or require every admissible readout to separate the contents"
     },
     "C_SCOPE": {
+      "binary_M2C_embedding_declared_not_unique": true,
       "born_weight_selection_claimed": false,
       "continuous_M2_probability_law_claimed": false,
-      "established": "at this cap, each separated neighbour pair changes locked basis content and is visible to the explicit additive I_one readout",
+      "established": "in the declared P0/P1 point-mass construction, the exact changing neighbour edges change the unique supported locked content and I_one reads it",
       "formation_site_probability_or_rate_claimed": false,
       "full_mosaic_claimed": false,
-      "generic_axiom_boundary": "distribution variation alone need not force disjoint supports or a different realized draw; the positive result uses the declared deterministic witness laws",
+      "generic_axiom_boundary": "distribution variation alone need not force disjoint supports or a different realized draw; the positive result uses the declared P0/P1 point-mass laws",
       "generic_axiom_only_consequence_claimed": false,
       "infinite_simultaneous_translation_uniform_law_claimed": false,
+      "point_mass_distribution_constructed_at_finite_cap": true,
       "selected_physical_readout_claimed": false,
+      "target_input_fixed_per_conditioned_law": true,
       "tested": "one forming target record at a time on the binary radius-one true-Z3 star, for the three finite deterministic witness classes"
     }
   },
-  "integrity_policy": "checks gate construction and reconciliation only; a coherent no-separator outcome passes the same visibility validator",
+  "integrity_policy": "checks gate construction and reconciliation only; a coherent family-wide agreement outcome passes the same top-level visibility validator",
   "pass": true,
-  "primary_source_sha256": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2",
-  "science_digest": "3705c06e7f04cd6b47f1aca1c6d6f16f57367a27ad76a7ea9cd9b826b2ea33b9",
-  "stdout_sha256": "827a15c4268161e1f81355807636474f8b315b195f8062a12a0c79b621e9e345"
+  "primary_source_sha256": "3d66b2836743808119541536bf7562212a05da84f1149b9f5d5f12f47ff7eff8",
+  "science_digest": "7781fa723e6633f11046cef81ae8e69e45fe43b6989f2f6b47e9afb60dfeb45a",
+  "stdout_sha256": "4f684435699e3aba6a2279a5bb32f013671861cf8e446a5e5da79e5f34c800b4"
 }

--- a/outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json
+++ b/outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json
@@ -1,0 +1,747 @@
+{
+  "artifact": "neighbour-dependence locked-content and readout bounded theorem primary",
+  "audit_status_authority": "independent audit lane only",
+  "checks": {
+    "A_LOCKED_CONTENT_CENSUS": true,
+    "B_READOUT_VISIBILITY": true,
+    "C_SCOPE": true,
+    "D_CONTROLS": true
+  },
+  "controls": {
+    "all_inputs_relative_and_present": true,
+    "base_is_ancestor_of_head": true,
+    "base_origin_main_commit": "ea0968c71ad46c39c6dacb39f88a18780363b71f",
+    "blob_pins_match": true,
+    "blocked_ast_imports": [],
+    "determinism_replay": true,
+    "input_git_blobs": {
+      "docs/MINIMAL_AXIOMS_2026-06-29.md": "2f5fdd26898f62c17fcabc846761f7785c2eadb1"
+    },
+    "input_sha256": {
+      "docs/MINIMAL_AXIOMS_2026-06-29.md": "53175250f0458168330160ad6a39c8ec708316f338efd69c49e8eb09e3267b39"
+    },
+    "literal_audit_input_paths": [
+      "docs/MINIMAL_AXIOMS_2026-06-29.md"
+    ],
+    "literal_source_read_count": 1,
+    "prior_cycle_modules_loaded": false,
+    "runtime_budget_met": true,
+    "runtime_budget_seconds": 300,
+    "sha_pins_match": true,
+    "stdout_bytes": 518,
+    "stdout_limit_bytes": 6000,
+    "synthetic_negative_visibility_accepted": true
+  },
+  "cycle": 985,
+  "findings": {
+    "A_LOCKED_CONTENT_CENSUS": {
+      "J_values_by_class": {
+        "incoming CNOT": 1,
+        "opposite-control TOF": 0,
+        "perpendicular-control TOF": 2
+      },
+      "all_separated_pairs_flip_locked_content": true,
+      "class_count": 3,
+      "classes": [
+        {
+          "J": 1,
+          "class": "incoming CNOT",
+          "controls": [
+            "+x"
+          ],
+          "induced_target_law": "y=x XOR n_(+x)",
+          "one_neighbour_bit_separations": [
+            {
+              "configuration_after": {
+                "+x": 1
+              },
+              "configuration_before": {
+                "+x": 0
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "configuration_after": {
+                "+x": 1
+              },
+              "configuration_before": {
+                "+x": 0
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            }
+          ],
+          "orbit_size": 6,
+          "representative": "CNOT(+x->C)",
+          "stabilizer": 4,
+          "table": [
+            {
+              "control_configuration": {
+                "+x": 0
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 1
+              },
+              "locked_content_by_target_input": {
+                "0": 1,
+                "1": 0
+              },
+              "spectator_neighbours": "arbitrary"
+            }
+          ]
+        },
+        {
+          "J": 2,
+          "class": "perpendicular-control TOF",
+          "controls": [
+            "+x",
+            "+y"
+          ],
+          "induced_target_law": "y=x XOR (n_1 AND n_2)",
+          "one_neighbour_bit_separations": [
+            {
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 1
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "+y": 0
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "+y": 1
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "configuration_after": {
+                "+x": 1,
+                "+y": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "+y": 0
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            }
+          ],
+          "orbit_size": 12,
+          "representative": "TOF(+x,+y->C)",
+          "stabilizer": 2,
+          "table": [
+            {
+              "control_configuration": {
+                "+x": 0,
+                "+y": 0
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 0,
+                "+y": 1
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 1,
+                "+y": 0
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 1,
+                "+y": 1
+              },
+              "locked_content_by_target_input": {
+                "0": 1,
+                "1": 0
+              },
+              "spectator_neighbours": "arbitrary"
+            }
+          ]
+        },
+        {
+          "J": 0,
+          "class": "opposite-control TOF",
+          "controls": [
+            "+x",
+            "-x"
+          ],
+          "induced_target_law": "y=x XOR (n_1 AND n_2)",
+          "one_neighbour_bit_separations": [
+            {
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 1
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "-x": 0
+              },
+              "content_after": 1,
+              "content_before": 0,
+              "target_input": 0
+            },
+            {
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 0,
+                "-x": 1
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            },
+            {
+              "configuration_after": {
+                "+x": 1,
+                "-x": 1
+              },
+              "configuration_before": {
+                "+x": 1,
+                "-x": 0
+              },
+              "content_after": 0,
+              "content_before": 1,
+              "target_input": 1
+            }
+          ],
+          "orbit_size": 3,
+          "representative": "TOF(+x,-x->C)",
+          "stabilizer": 8,
+          "table": [
+            {
+              "control_configuration": {
+                "+x": 0,
+                "-x": 0
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 0,
+                "-x": 1
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 1,
+                "-x": 0
+              },
+              "locked_content_by_target_input": {
+                "0": 0,
+                "1": 1
+              },
+              "spectator_neighbours": "arbitrary"
+            },
+            {
+              "control_configuration": {
+                "+x": 1,
+                "-x": 1
+              },
+              "locked_content_by_target_input": {
+                "0": 1,
+                "1": 0
+              },
+              "spectator_neighbours": "arbitrary"
+            }
+          ]
+        }
+      ],
+      "condition": "conditional on a record forming at the target site",
+      "content_alphabet": [
+        0,
+        1
+      ],
+      "spectator_neighbours": "arbitrary in every displayed row",
+      "witness_multiplicity": 21
+    },
+    "B_READOUT_VISIBILITY": {
+      "additivity_checks": 450,
+      "additivity_failure_count": 0,
+      "analysis": {
+        "nonseparation_proof": null,
+        "outcome": "SEPARATING_ADMISSIBLE_READOUT_EXISTS",
+        "pair_count": 10,
+        "pairs": [
+          {
+            "basis_readout_values": [
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "incoming CNOT",
+            "configuration_after": {
+              "+x": 1
+            },
+            "configuration_before": {
+              "+x": 0
+            },
+            "content_after": 1,
+            "content_before": 0,
+            "target_input": 0
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "incoming CNOT",
+            "configuration_after": {
+              "+x": 1
+            },
+            "configuration_before": {
+              "+x": 0
+            },
+            "content_after": 0,
+            "content_before": 1,
+            "target_input": 1
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "perpendicular-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "+y": 1
+            },
+            "configuration_before": {
+              "+x": 0,
+              "+y": 1
+            },
+            "content_after": 1,
+            "content_before": 0,
+            "target_input": 0
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "perpendicular-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "+y": 1
+            },
+            "configuration_before": {
+              "+x": 1,
+              "+y": 0
+            },
+            "content_after": 1,
+            "content_before": 0,
+            "target_input": 0
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "perpendicular-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "+y": 1
+            },
+            "configuration_before": {
+              "+x": 0,
+              "+y": 1
+            },
+            "content_after": 0,
+            "content_before": 1,
+            "target_input": 1
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "perpendicular-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "+y": 1
+            },
+            "configuration_before": {
+              "+x": 1,
+              "+y": 0
+            },
+            "content_after": 0,
+            "content_before": 1,
+            "target_input": 1
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "opposite-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "-x": 1
+            },
+            "configuration_before": {
+              "+x": 0,
+              "-x": 1
+            },
+            "content_after": 1,
+            "content_before": 0,
+            "target_input": 0
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "opposite-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "-x": 1
+            },
+            "configuration_before": {
+              "+x": 1,
+              "-x": 0
+            },
+            "content_after": 1,
+            "content_before": 0,
+            "target_input": 0
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "opposite-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "-x": 1
+            },
+            "configuration_before": {
+              "+x": 0,
+              "-x": 1
+            },
+            "content_after": 0,
+            "content_before": 1,
+            "target_input": 1
+          },
+          {
+            "basis_readout_values": [
+              {
+                "after": 1,
+                "before": 0,
+                "delta": 1,
+                "readout": "I_zero"
+              },
+              {
+                "after": 0,
+                "before": 1,
+                "delta": -1,
+                "readout": "I_one"
+              }
+            ],
+            "class": "opposite-control TOF",
+            "configuration_after": {
+              "+x": 1,
+              "-x": 1
+            },
+            "configuration_before": {
+              "+x": 1,
+              "-x": 0
+            },
+            "content_after": 0,
+            "content_before": 1,
+            "target_input": 1
+          }
+        ],
+        "visible_pair_count": 10
+      },
+      "basis": [
+        {
+          "name": "I_zero",
+          "singleton_values": [
+            1,
+            0
+          ]
+        },
+        {
+          "name": "I_one",
+          "singleton_values": [
+            0,
+            1
+          ]
+        }
+      ],
+      "blind_admissible_example": {
+        "meaning": "record count; admissible but content-blind on equal-size collections",
+        "singleton_values": [
+          1,
+          1
+        ]
+      },
+      "declared_family": "all functions phi:{0,1}->R, extended to finite pairwise-disjoint record collections by I_phi(R)=sum_{r in R} phi(content(r))",
+      "empty_value": 0,
+      "exact_separator": {
+        "collection_rule": "I_one(R)=number of records in R whose content is 1",
+        "name": "I_one",
+        "separates_every_declared_pair": true,
+        "singleton_rule": "I_one({record with content c})=c",
+        "values_on_separated_pairs": [
+          {
+            "I_one_after": 1,
+            "I_one_before": 0,
+            "class": "incoming CNOT",
+            "delta": 1,
+            "target_input": 0
+          },
+          {
+            "I_one_after": 0,
+            "I_one_before": 1,
+            "class": "incoming CNOT",
+            "delta": -1,
+            "target_input": 1
+          },
+          {
+            "I_one_after": 1,
+            "I_one_before": 0,
+            "class": "perpendicular-control TOF",
+            "delta": 1,
+            "target_input": 0
+          },
+          {
+            "I_one_after": 1,
+            "I_one_before": 0,
+            "class": "perpendicular-control TOF",
+            "delta": 1,
+            "target_input": 0
+          },
+          {
+            "I_one_after": 0,
+            "I_one_before": 1,
+            "class": "perpendicular-control TOF",
+            "delta": -1,
+            "target_input": 1
+          },
+          {
+            "I_one_after": 0,
+            "I_one_before": 1,
+            "class": "perpendicular-control TOF",
+            "delta": -1,
+            "target_input": 1
+          },
+          {
+            "I_one_after": 1,
+            "I_one_before": 0,
+            "class": "opposite-control TOF",
+            "delta": 1,
+            "target_input": 0
+          },
+          {
+            "I_one_after": 1,
+            "I_one_before": 0,
+            "class": "opposite-control TOF",
+            "delta": 1,
+            "target_input": 0
+          },
+          {
+            "I_one_after": 0,
+            "I_one_before": 1,
+            "class": "opposite-control TOF",
+            "delta": -1,
+            "target_input": 1
+          },
+          {
+            "I_one_after": 0,
+            "I_one_before": 1,
+            "class": "opposite-control TOF",
+            "delta": -1,
+            "target_input": 1
+          }
+        ]
+      },
+      "record_content_only": true,
+      "selection_boundary": "the Record axiom permits this separating readout but does not select it or require every admissible readout to separate the contents"
+    },
+    "C_SCOPE": {
+      "born_weight_selection_claimed": false,
+      "continuous_M2_probability_law_claimed": false,
+      "established": "at this cap, each separated neighbour pair changes locked basis content and is visible to the explicit additive I_one readout",
+      "formation_site_probability_or_rate_claimed": false,
+      "full_mosaic_claimed": false,
+      "generic_axiom_boundary": "distribution variation alone need not force disjoint supports or a different realized draw; the positive result uses the declared deterministic witness laws",
+      "generic_axiom_only_consequence_claimed": false,
+      "infinite_simultaneous_translation_uniform_law_claimed": false,
+      "selected_physical_readout_claimed": false,
+      "tested": "one forming target record at a time on the binary radius-one true-Z3 star, for the three finite deterministic witness classes"
+    }
+  },
+  "integrity_policy": "checks gate construction and reconciliation only; a coherent no-separator outcome passes the same visibility validator",
+  "pass": true,
+  "primary_source_sha256": "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2",
+  "science_digest": "3705c06e7f04cd6b47f1aca1c6d6f16f57367a27ad76a7ea9cd9b826b2ea33b9",
+  "stdout_sha256": "827a15c4268161e1f81355807636474f8b315b195f8062a12a0c79b621e9e345"
+}

--- a/scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
+++ b/scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Cycle 985: locked-content and readout census for three neighbour classes.
+
+The finite calculation is conditional on a record forming at the target.  It
+reconstructs the three basis-state target laws directly, enumerates their
+locked contents, and tests the complete additive scalar readout family on the
+binary content alphabet.  Checks gate construction and reconciliation only:
+the same visibility validator accepts a coherent no-separator outcome.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from hashlib import sha1, sha256
+from itertools import product
+from pathlib import Path
+from time import monotonic
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CYCLE = 985
+AUDIT_TIMEOUT_SEC = 300
+STDOUT_LIMIT_BYTES = 6_000
+BASE_ORIGIN_MAIN_COMMIT = "ea0968c71ad46c39c6dacb39f88a18780363b71f"
+AUDIT_INPUT_PATHS = ("docs/MINIMAL_AXIOMS_2026-06-29.md",)
+EXPECTED_INPUT_SHA256 = {
+    "docs/MINIMAL_AXIOMS_2026-06-29.md":
+        "53175250f0458168330160ad6a39c8ec708316f338efd69c49e8eb09e3267b39",
+}
+EXPECTED_INPUT_BLOBS = {
+    "docs/MINIMAL_AXIOMS_2026-06-29.md":
+        "2f5fdd26898f62c17fcabc846761f7785c2eadb1",
+}
+BLOCKLIST_AST_FRAGMENTS = (
+    "cycle977", "cycle980", "cycle982", "cycle983", "cycle984",
+)
+PRIMARY_PATH = (
+    "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py"
+)
+RECEIPT_PATH = (
+    "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json"
+)
+
+DIRECTIONS = {
+    "+x": (1, 0, 0),
+    "-x": (-1, 0, 0),
+    "+y": (0, 1, 0),
+    "-y": (0, -1, 0),
+    "+z": (0, 0, 1),
+    "-z": (0, 0, -1),
+}
+CLASS_SPECS = (
+    {
+        "class": "incoming CNOT",
+        "representative": "CNOT(+x->C)",
+        "kind": "CNOT",
+        "controls": ("+x",),
+        "orbit_size": 6,
+        "stabilizer": 4,
+    },
+    {
+        "class": "perpendicular-control TOF",
+        "representative": "TOF(+x,+y->C)",
+        "kind": "TOF",
+        "controls": ("+x", "+y"),
+        "orbit_size": 12,
+        "stabilizer": 2,
+    },
+    {
+        "class": "opposite-control TOF",
+        "representative": "TOF(+x,-x->C)",
+        "kind": "TOF",
+        "controls": ("+x", "-x"),
+        "orbit_size": 3,
+        "stabilizer": 8,
+    },
+)
+READOUT_BASIS = (
+    {"name": "I_zero", "singleton_values": (1, 0)},
+    {"name": "I_one", "singleton_values": (0, 1)},
+)
+
+
+def compact(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def digest(value: object) -> str:
+    return sha256(compact(value).encode()).hexdigest()
+
+
+def git_blob(payload: bytes) -> str:
+    return sha1(f"blob {len(payload)}\0".encode() + payload).hexdigest()
+
+
+def ast_literal_assignment(tree: ast.Module, name: str):
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise KeyError(name)
+
+
+def vector_sum_squared(control_names: tuple[str, ...]) -> int:
+    total = tuple(
+        sum(DIRECTIONS[name][axis] for name in control_names)
+        for axis in range(3)
+    )
+    return sum(component * component for component in total)
+
+
+def locked_content(kind: str, target_input: int, control_bits: tuple[int, ...]) -> int:
+    if kind == "CNOT":
+        trigger = control_bits[0]
+    elif kind == "TOF":
+        trigger = int(all(control_bits))
+    else:
+        raise ValueError(kind)
+    return target_input ^ trigger
+
+
+def class_content_table(spec: dict) -> dict:
+    rows = []
+    for control_bits in product((0, 1), repeat=len(spec["controls"])):
+        rows.append({
+            "control_configuration": {
+                name: bit for name, bit in zip(spec["controls"], control_bits)
+            },
+            "locked_content_by_target_input": {
+                str(target_input): locked_content(
+                    spec["kind"], target_input, control_bits
+                )
+                for target_input in (0, 1)
+            },
+            "spectator_neighbours": "arbitrary",
+        })
+
+    separated = []
+    for target_input in (0, 1):
+        configurations = tuple(product((0, 1), repeat=len(spec["controls"])))
+        for left in configurations:
+            for right in configurations:
+                hamming = sum(a != b for a, b in zip(left, right))
+                if hamming != 1 or left >= right:
+                    continue
+                content_left = locked_content(spec["kind"], target_input, left)
+                content_right = locked_content(spec["kind"], target_input, right)
+                if content_left != content_right:
+                    separated.append({
+                        "target_input": target_input,
+                        "configuration_before": {
+                            name: bit for name, bit in zip(spec["controls"], left)
+                        },
+                        "configuration_after": {
+                            name: bit for name, bit in zip(spec["controls"], right)
+                        },
+                        "content_before": content_left,
+                        "content_after": content_right,
+                    })
+    return {
+        "class": spec["class"],
+        "representative": spec["representative"],
+        "induced_target_law": (
+            "y=x XOR n_(+x)" if spec["kind"] == "CNOT"
+            else "y=x XOR (n_1 AND n_2)"
+        ),
+        "controls": list(spec["controls"]),
+        "orbit_size": spec["orbit_size"],
+        "stabilizer": spec["stabilizer"],
+        "J": vector_sum_squared(spec["controls"]),
+        "table": rows,
+        "one_neighbour_bit_separations": separated,
+    }
+
+
+def locked_content_census() -> dict:
+    classes = [class_content_table(spec) for spec in CLASS_SPECS]
+    return {
+        "condition": "conditional on a record forming at the target site",
+        "content_alphabet": [0, 1],
+        "spectator_neighbours": "arbitrary in every displayed row",
+        "classes": classes,
+        "class_count": len(classes),
+        "witness_multiplicity": sum(row["orbit_size"] for row in classes),
+        "J_values_by_class": {row["class"]: row["J"] for row in classes},
+        "all_separated_pairs_flip_locked_content": all(
+            pair["content_before"] != pair["content_after"]
+            for row in classes for pair in row["one_neighbour_bit_separations"]
+        ),
+    }
+
+
+def finite_additive_readout(contents: tuple[int, ...], weights: tuple[int, int]) -> int:
+    return sum(weights[content] for content in contents)
+
+
+def analyse_visibility(content_pairs: list[dict], basis: tuple[dict, ...]) -> dict:
+    pair_rows = []
+    for pair in content_pairs:
+        values = []
+        for readout in basis:
+            weights = tuple(readout["singleton_values"])
+            before = finite_additive_readout((pair["content_before"],), weights)
+            after = finite_additive_readout((pair["content_after"],), weights)
+            values.append({
+                "readout": readout["name"],
+                "before": before,
+                "after": after,
+                "delta": after - before,
+            })
+        pair_rows.append({**pair, "basis_readout_values": values})
+
+    visible = [
+        row for row in pair_rows
+        if any(value["delta"] != 0 for value in row["basis_readout_values"])
+    ]
+    if len(visible) == len(pair_rows) and pair_rows:
+        outcome = "SEPARATING_ADMISSIBLE_READOUT_EXISTS"
+        proof = None
+    else:
+        outcome = "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+        proof = {
+            "basis_dimension": len(basis),
+            "all_basis_functionals_equal_on_unseparated_pairs": all(
+                all(value["delta"] == 0 for value in row["basis_readout_values"])
+                for row in pair_rows
+            ),
+            "span_argument": (
+                "every declared readout is a real linear combination of the basis; "
+                "basis equality therefore implies family-wide equality"
+            ),
+        }
+    return {
+        "outcome": outcome,
+        "pair_count": len(pair_rows),
+        "visible_pair_count": len(visible),
+        "pairs": pair_rows,
+        "nonseparation_proof": proof,
+    }
+
+
+def readout_visibility(census: dict) -> dict:
+    content_pairs = [
+        {"class": row["class"], **pair}
+        for row in census["classes"]
+        for pair in row["one_neighbour_bit_separations"]
+    ]
+    analysis = analyse_visibility(content_pairs, READOUT_BASIS)
+
+    additivity_failures = 0
+    for weights in (tuple(row["singleton_values"]) for row in READOUT_BASIS):
+        for left_size in range(4):
+            for right_size in range(4):
+                for left in product((0, 1), repeat=left_size):
+                    for right in product((0, 1), repeat=right_size):
+                        additivity_failures += (
+                            finite_additive_readout(left + right, weights)
+                            != finite_additive_readout(left, weights)
+                            + finite_additive_readout(right, weights)
+                        )
+
+    i_one_rows = []
+    for pair in content_pairs:
+        before = finite_additive_readout((pair["content_before"],), (0, 1))
+        after = finite_additive_readout((pair["content_after"],), (0, 1))
+        i_one_rows.append({
+            "class": pair["class"],
+            "target_input": pair["target_input"],
+            "I_one_before": before,
+            "I_one_after": after,
+            "delta": after - before,
+        })
+
+    return {
+        "declared_family": (
+            "all functions phi:{0,1}->R, extended to finite pairwise-disjoint "
+            "record collections by I_phi(R)=sum_{r in R} phi(content(r))"
+        ),
+        "basis": list(READOUT_BASIS),
+        "empty_value": finite_additive_readout((), (0, 1)),
+        "record_content_only": True,
+        "additivity_checks": 2 * sum(
+            (2 ** left_size) * (2 ** right_size)
+            for left_size in range(4) for right_size in range(4)
+        ),
+        "additivity_failure_count": additivity_failures,
+        "analysis": analysis,
+        "exact_separator": {
+            "name": "I_one",
+            "singleton_rule": "I_one({record with content c})=c",
+            "collection_rule": "I_one(R)=number of records in R whose content is 1",
+            "values_on_separated_pairs": i_one_rows,
+            "separates_every_declared_pair": all(row["delta"] != 0 for row in i_one_rows),
+        },
+        "blind_admissible_example": {
+            "singleton_values": [1, 1],
+            "meaning": "record count; admissible but content-blind on equal-size collections",
+        },
+        "selection_boundary": (
+            "the Record axiom permits this separating readout but does not select it "
+            "or require every admissible readout to separate the contents"
+        ),
+    }
+
+
+def scope_measurement() -> dict:
+    return {
+        "tested": (
+            "one forming target record at a time on the binary radius-one true-Z3 "
+            "star, for the three finite deterministic witness classes"
+        ),
+        "established": (
+            "at this cap, each separated neighbour pair changes locked basis content "
+            "and is visible to the explicit additive I_one readout"
+        ),
+        "full_mosaic_claimed": False,
+        "formation_site_probability_or_rate_claimed": False,
+        "selected_physical_readout_claimed": False,
+        "born_weight_selection_claimed": False,
+        "continuous_M2_probability_law_claimed": False,
+        "infinite_simultaneous_translation_uniform_law_claimed": False,
+        "generic_axiom_only_consequence_claimed": False,
+        "generic_axiom_boundary": (
+            "distribution variation alone need not force disjoint supports or a different "
+            "realized draw; the positive result uses the declared deterministic witness laws"
+        ),
+    }
+
+
+def validate_visibility_payload(payload: dict) -> bool:
+    analysis = payload["analysis"]
+    recomputed = analyse_visibility(analysis["pairs"], tuple(payload["basis"]))
+    return bool(
+        recomputed["outcome"] == analysis["outcome"]
+        and recomputed["pair_count"] == analysis["pair_count"]
+        and recomputed["visible_pair_count"] == analysis["visible_pair_count"]
+        and (
+            analysis["outcome"] == "SEPARATING_ADMISSIBLE_READOUT_EXISTS"
+            or bool(analysis["nonseparation_proof"])
+        )
+    )
+
+
+def synthetic_negative_visibility_control() -> bool:
+    pairs = [{
+        "class": "synthetic equal-content fixture",
+        "target_input": 0,
+        "configuration_before": {"n": 0},
+        "configuration_after": {"n": 1},
+        "content_before": 0,
+        "content_after": 0,
+    }]
+    analysis = analyse_visibility(pairs, READOUT_BASIS)
+    payload = {"basis": list(READOUT_BASIS), "analysis": analysis}
+    return bool(
+        analysis["outcome"] == "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+        and validate_visibility_payload(payload)
+    )
+
+
+def input_controls() -> dict:
+    source = (ROOT / PRIMARY_PATH).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=PRIMARY_PATH)
+    input_paths = ast_literal_assignment(tree, "AUDIT_INPUT_PATHS")
+    fragments = ast_literal_assignment(tree, "BLOCKLIST_AST_FRAGMENTS")
+    payloads = {path: (ROOT / path).read_bytes() for path in input_paths}
+    sha_rows = {path: sha256(payload).hexdigest() for path, payload in payloads.items()}
+    blob_rows = {path: git_blob(payload) for path, payload in payloads.items()}
+    imported_names = {
+        alias.name for node in ast.walk(tree) if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    base_is_ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", BASE_ORIGIN_MAIN_COMMIT, "HEAD"],
+        cwd=ROOT, check=False, capture_output=True,
+    ).returncode == 0
+    return {
+        "literal_audit_input_paths": list(input_paths),
+        "literal_source_read_count": len(input_paths),
+        "input_sha256": sha_rows,
+        "input_git_blobs": blob_rows,
+        "sha_pins_match": sha_rows == EXPECTED_INPUT_SHA256,
+        "blob_pins_match": blob_rows == EXPECTED_INPUT_BLOBS,
+        "all_inputs_relative_and_present": all(
+            not Path(path).is_absolute() and (ROOT / path).is_file()
+            for path in input_paths
+        ),
+        "blocked_ast_imports": sorted(
+            name for name in imported_names
+            if any(fragment in name.lower() for fragment in fragments)
+        ),
+        "prior_cycle_modules_loaded": False,
+        "base_origin_main_commit": BASE_ORIGIN_MAIN_COMMIT,
+        "base_is_ancestor_of_head": base_is_ancestor,
+    }
+
+
+def science_measurement() -> dict:
+    census = locked_content_census()
+    return {
+        "A_LOCKED_CONTENT_CENSUS": census,
+        "B_READOUT_VISIBILITY": readout_visibility(census),
+        "C_SCOPE": scope_measurement(),
+    }
+
+
+def render_stdout(receipt: dict) -> str:
+    findings = receipt["findings"]
+    census = findings["A_LOCKED_CONTENT_CENSUS"]
+    visibility = findings["B_READOUT_VISIBILITY"]
+    scope = findings["C_SCOPE"]
+    class_rows = [
+        [row["class"], row["orbit_size"], row["J"], len(row["table"])]
+        for row in census["classes"]
+    ]
+    lines = [
+        "CYCLE985_NEIGHBOUR_DEPENDENCE_RECORD_CONTENT",
+        "A_LOCKED_CONTENT_CENSUS "
+        + ("PASS" if receipt["checks"]["A_LOCKED_CONTENT_CENSUS"] else "FAIL")
+        + f" :: classes={compact(class_rows)}; witnesses={census['witness_multiplicity']};"
+        + f" separated_pairs={sum(len(row['one_neighbour_bit_separations']) for row in census['classes'])}",
+        "B_READOUT_VISIBILITY "
+        + ("PASS" if receipt["checks"]["B_READOUT_VISIBILITY"] else "FAIL")
+        + f" :: outcome={visibility['analysis']['outcome']};"
+        + f" readout=I_one; visible={visibility['analysis']['visible_pair_count']}/{visibility['analysis']['pair_count']}",
+        "C_SCOPE " + ("PASS" if receipt["checks"]["C_SCOPE"] else "FAIL")
+        + f" :: single_site={not scope['full_mosaic_claimed']};"
+        + f" full_mosaic_claimed={scope['full_mosaic_claimed']};"
+        + f" selected_readout_claimed={scope['selected_physical_readout_claimed']}",
+        "D_CONTROLS " + ("PASS" if receipt["checks"]["D_CONTROLS"] else "FAIL")
+        + f" :: source_reads={receipt['controls']['literal_source_read_count']}<=6;"
+        + f" pins={receipt['controls']['sha_pins_match'] and receipt['controls']['blob_pins_match']};"
+        + f" deterministic={receipt['controls']['determinism_replay']};"
+        + f" negative_gate={receipt['controls']['synthetic_negative_visibility_accepted']}",
+    ]
+    passed = sum(receipt["checks"].values())
+    lines.append(f"TOTAL: PASS={passed} FAIL={len(receipt['checks']) - passed}")
+    return "\n".join(lines) + "\n"
+
+
+def run() -> tuple[dict, str]:
+    started = monotonic()
+    controls = input_controls()
+    first = science_measurement()
+    second = science_measurement()
+    deterministic = first == second
+    census = first["A_LOCKED_CONTENT_CENSUS"]
+    visibility = first["B_READOUT_VISIBILITY"]
+    scope = first["C_SCOPE"]
+
+    expected_row_counts = {
+        "incoming CNOT": 2,
+        "perpendicular-control TOF": 4,
+        "opposite-control TOF": 4,
+    }
+    a_reconciliation = bool(
+        census["class_count"] == len(census["classes"])
+        and census["witness_multiplicity"] == sum(
+            row["orbit_size"] for row in census["classes"]
+        )
+        and all(
+            len(row["table"]) == expected_row_counts[row["class"]]
+            for row in census["classes"]
+        )
+        and all(
+            row["J"] == vector_sum_squared(tuple(row["controls"]))
+            for row in census["classes"]
+        )
+        and census["all_separated_pairs_flip_locked_content"]
+    )
+    b_reconciliation = bool(
+        validate_visibility_payload({
+            "basis": visibility["basis"],
+            "analysis": visibility["analysis"],
+        })
+        and visibility["empty_value"] == 0
+        and visibility["record_content_only"]
+        and visibility["additivity_failure_count"] == 0
+        and visibility["exact_separator"]["separates_every_declared_pair"]
+    )
+    c_reconciliation = bool(
+        scope["full_mosaic_claimed"] is False
+        and scope["formation_site_probability_or_rate_claimed"] is False
+        and scope["selected_physical_readout_claimed"] is False
+        and scope["generic_axiom_only_consequence_claimed"] is False
+        and bool(scope["tested"] and scope["established"])
+    )
+    runtime_budget_met = monotonic() - started < AUDIT_TIMEOUT_SEC
+    controls.update({
+        "determinism_replay": deterministic,
+        "synthetic_negative_visibility_accepted": synthetic_negative_visibility_control(),
+        "runtime_budget_met": runtime_budget_met,
+        "runtime_budget_seconds": AUDIT_TIMEOUT_SEC,
+        "stdout_limit_bytes": STDOUT_LIMIT_BYTES,
+    })
+    d_controls = bool(
+        controls["literal_source_read_count"] <= 6
+        and controls["all_inputs_relative_and_present"]
+        and controls["sha_pins_match"] and controls["blob_pins_match"]
+        and not controls["blocked_ast_imports"]
+        and not controls["prior_cycle_modules_loaded"]
+        and controls["base_is_ancestor_of_head"]
+        and deterministic
+        and controls["synthetic_negative_visibility_accepted"]
+        and runtime_budget_met
+    )
+    receipt = {
+        "cycle": CYCLE,
+        "artifact": "neighbour-dependence locked-content and readout bounded theorem primary",
+        "audit_status_authority": "independent audit lane only",
+        "integrity_policy": (
+            "checks gate construction and reconciliation only; a coherent no-separator "
+            "outcome passes the same visibility validator"
+        ),
+        "findings": first,
+        "science_digest": digest(first),
+        "controls": controls,
+        "checks": {
+            "A_LOCKED_CONTENT_CENSUS": a_reconciliation,
+            "B_READOUT_VISIBILITY": b_reconciliation,
+            "C_SCOPE": c_reconciliation,
+            "D_CONTROLS": d_controls,
+        },
+    }
+    receipt["primary_source_sha256"] = sha256((ROOT / PRIMARY_PATH).read_bytes()).hexdigest()
+    stdout = render_stdout(receipt)
+    controls["stdout_bytes"] = len(stdout.encode())
+    if controls["stdout_bytes"] >= STDOUT_LIMIT_BYTES:
+        receipt["checks"]["D_CONTROLS"] = False
+        stdout = render_stdout(receipt)
+        controls["stdout_bytes"] = len(stdout.encode())
+    receipt["pass"] = all(receipt["checks"].values())
+    receipt["stdout_sha256"] = sha256(stdout.encode()).hexdigest()
+    return receipt, stdout
+
+
+def main() -> int:
+    if sys.argv[1:]:
+        raise SystemExit(f"usage: {Path(__file__).name}")
+    receipt, stdout = run()
+    receipt_path = ROOT / RECEIPT_PATH
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    sys.stdout.write(stdout)
+    return 0 if receipt["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
+++ b/scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py
@@ -15,7 +15,7 @@ import json
 import subprocess
 import sys
 from hashlib import sha1, sha256
-from itertools import product
+from itertools import permutations, product
 from pathlib import Path
 from time import monotonic
 
@@ -58,26 +58,24 @@ CLASS_SPECS = (
         "representative": "CNOT(+x->C)",
         "kind": "CNOT",
         "controls": ("+x",),
-        "orbit_size": 6,
-        "stabilizer": 4,
     },
     {
         "class": "perpendicular-control TOF",
         "representative": "TOF(+x,+y->C)",
         "kind": "TOF",
         "controls": ("+x", "+y"),
-        "orbit_size": 12,
-        "stabilizer": 2,
     },
     {
         "class": "opposite-control TOF",
         "representative": "TOF(+x,-x->C)",
         "kind": "TOF",
         "controls": ("+x", "-x"),
-        "orbit_size": 3,
-        "stabilizer": 8,
     },
 )
+CONTENT_EMBEDDING = {
+    0: ((1, 0), (0, 0)),
+    1: ((0, 0), (0, 1)),
+}
 READOUT_BASIS = (
     {"name": "I_zero", "singleton_values": (1, 0)},
     {"name": "I_one", "singleton_values": (0, 1)},
@@ -114,6 +112,62 @@ def vector_sum_squared(control_names: tuple[str, ...]) -> int:
     return sum(component * component for component in total)
 
 
+def determinant(matrix: tuple[tuple[int, int, int], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple:
+    rotations = set()
+    for order in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            matrix = tuple(
+                tuple(signs[row] * int(column == order[row]) for column in range(3))
+                for row in range(3)
+            )
+            if determinant(matrix) == 1:
+                rotations.add(matrix)
+    return tuple(sorted(rotations))
+
+
+ROTATIONS = proper_cubic_rotations()
+
+
+def rotate_vector(matrix: tuple, vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(row[column] * vector[column] for column in range(3))
+        for row in matrix
+    )
+
+
+def orbit_certificate(control_names: tuple[str, ...]) -> dict:
+    controls = tuple(DIRECTIONS[name] for name in control_names)
+    unordered = len(controls) == 2
+    canonical = tuple(sorted(controls)) if unordered else controls
+    images = {
+        tuple(sorted(rotate_vector(rotation, vector) for vector in controls))
+        if unordered else tuple(rotate_vector(rotation, vector) for vector in controls)
+        for rotation in ROTATIONS
+    }
+    stabilizer = sum(
+        (
+            tuple(sorted(rotate_vector(rotation, vector) for vector in controls))
+            if unordered else tuple(rotate_vector(rotation, vector) for vector in controls)
+        ) == canonical
+        for rotation in ROTATIONS
+    )
+    return {
+        "group_order": len(ROTATIONS),
+        "orbit_size": len(images),
+        "stabilizer": stabilizer,
+        "orbit_stabilizer_product": len(images) * stabilizer,
+        "orbit_digest": digest(sorted(images)),
+    }
+
+
 def locked_content(kind: str, target_input: int, control_bits: tuple[int, ...]) -> int:
     if kind == "CNOT":
         trigger = control_bits[0]
@@ -127,41 +181,53 @@ def locked_content(kind: str, target_input: int, control_bits: tuple[int, ...]) 
 def class_content_table(spec: dict) -> dict:
     rows = []
     for control_bits in product((0, 1), repeat=len(spec["controls"])):
+        output_bits = {
+            str(target_input): locked_content(spec["kind"], target_input, control_bits)
+            for target_input in (0, 1)
+        }
         rows.append({
             "control_configuration": {
                 name: bit for name, bit in zip(spec["controls"], control_bits)
             },
-            "locked_content_by_target_input": {
-                str(target_input): locked_content(
-                    spec["kind"], target_input, control_bits
-                )
-                for target_input in (0, 1)
+            "output_bit_by_target_input": output_bits,
+            "locked_content_by_target_input": output_bits,
+            "locked_possibility_by_target_input": {
+                target_input: f"P_{output_bit}"
+                for target_input, output_bit in output_bits.items()
+            },
+            "point_mass_distribution_by_target_input": {
+                target_input: {
+                    "P_0": int(output_bit == 0),
+                    "P_1": int(output_bit == 1),
+                }
+                for target_input, output_bit in output_bits.items()
             },
             "spectator_neighbours": "arbitrary",
         })
 
-    separated = []
+    hamming_edges = []
     for target_input in (0, 1):
         configurations = tuple(product((0, 1), repeat=len(spec["controls"])))
-        for left in configurations:
-            for right in configurations:
+        for left_index, left in enumerate(configurations):
+            for right in configurations[left_index + 1:]:
                 hamming = sum(a != b for a, b in zip(left, right))
-                if hamming != 1 or left >= right:
+                if hamming != 1:
                     continue
                 content_left = locked_content(spec["kind"], target_input, left)
                 content_right = locked_content(spec["kind"], target_input, right)
-                if content_left != content_right:
-                    separated.append({
-                        "target_input": target_input,
-                        "configuration_before": {
-                            name: bit for name, bit in zip(spec["controls"], left)
-                        },
-                        "configuration_after": {
-                            name: bit for name, bit in zip(spec["controls"], right)
-                        },
-                        "content_before": content_left,
-                        "content_after": content_right,
-                    })
+                hamming_edges.append({
+                    "target_input": target_input,
+                    "configuration_before": {
+                        name: bit for name, bit in zip(spec["controls"], left)
+                    },
+                    "configuration_after": {
+                        name: bit for name, bit in zip(spec["controls"], right)
+                    },
+                    "content_before": content_left,
+                    "content_after": content_right,
+                    "changes_locked_content": content_left != content_right,
+                })
+    orbit = orbit_certificate(spec["controls"])
     return {
         "class": spec["class"],
         "representative": spec["representative"],
@@ -170,11 +236,13 @@ def class_content_table(spec: dict) -> dict:
             else "y=x XOR (n_1 AND n_2)"
         ),
         "controls": list(spec["controls"]),
-        "orbit_size": spec["orbit_size"],
-        "stabilizer": spec["stabilizer"],
+        **orbit,
         "J": vector_sum_squared(spec["controls"]),
         "table": rows,
-        "one_neighbour_bit_separations": separated,
+        "one_neighbour_bit_edges": hamming_edges,
+        "one_neighbour_bit_separations": [
+            edge for edge in hamming_edges if edge["changes_locked_content"]
+        ],
     }
 
 
@@ -183,14 +251,36 @@ def locked_content_census() -> dict:
     return {
         "condition": "conditional on a record forming at the target site",
         "content_alphabet": [0, 1],
+        "M2C_possibility_embedding": {
+            f"P_{bit}": [list(row) for row in matrix]
+            for bit, matrix in CONTENT_EMBEDDING.items()
+        },
+        "distribution_construction": (
+            "for each fixed target input and representative law, mu(P_y|n)=1 "
+            "and mu(P_(1-y)|n)=0; Record locks the unique supported P_y"
+        ),
+        "target_input_role": (
+            "fixed supplied parameter for each finite conditioned law, not an "
+            "additional varying neighbour coordinate"
+        ),
         "spectator_neighbours": "arbitrary in every displayed row",
         "classes": classes,
         "class_count": len(classes),
         "witness_multiplicity": sum(row["orbit_size"] for row in classes),
         "J_values_by_class": {row["class"]: row["J"] for row in classes},
-        "all_separated_pairs_flip_locked_content": all(
-            pair["content_before"] != pair["content_after"]
-            for row in classes for pair in row["one_neighbour_bit_separations"]
+        "proper_cubic_group_order": len(ROTATIONS),
+        "point_mass_normalization_failures": sum(
+            sum(distribution.values()) != 1
+            for row in classes for table_row in row["table"]
+            for distribution in table_row["point_mass_distribution_by_target_input"].values()
+        ),
+        "locked_content_support_failures": sum(
+            distribution[f"P_{content}"] != 1
+            for row in classes for table_row in row["table"]
+            for target_input, distribution in table_row[
+                "point_mass_distribution_by_target_input"
+            ].items()
+            for content in [table_row["locked_content_by_target_input"][target_input]]
         ),
     }
 
@@ -219,14 +309,14 @@ def analyse_visibility(content_pairs: list[dict], basis: tuple[dict, ...]) -> di
         row for row in pair_rows
         if any(value["delta"] != 0 for value in row["basis_readout_values"])
     ]
-    if len(visible) == len(pair_rows) and pair_rows:
+    if pair_rows and len(visible) == len(pair_rows):
         outcome = "SEPARATING_ADMISSIBLE_READOUT_EXISTS"
         proof = None
-    else:
-        outcome = "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+    elif pair_rows and not visible:
+        outcome = "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS"
         proof = {
             "basis_dimension": len(basis),
-            "all_basis_functionals_equal_on_unseparated_pairs": all(
+            "all_basis_functionals_equal_on_all_compared_pairs": all(
                 all(value["delta"] == 0 for value in row["basis_readout_values"])
                 for row in pair_rows
             ),
@@ -235,6 +325,12 @@ def analyse_visibility(content_pairs: list[dict], basis: tuple[dict, ...]) -> di
                 "basis equality therefore implies family-wide equality"
             ),
         }
+    elif pair_rows:
+        outcome = "PARTIAL_VISIBILITY_IN_DECLARED_READOUT_FAMILY"
+        proof = None
+    else:
+        outcome = "EMPTY_COMPARISON_DOMAIN"
+        proof = None
     return {
         "outcome": outcome,
         "pair_count": len(pair_rows),
@@ -276,6 +372,18 @@ def readout_visibility(census: dict) -> dict:
             "delta": after - before,
         })
 
+    exact_separator = None
+    if analysis["outcome"] == "SEPARATING_ADMISSIBLE_READOUT_EXISTS":
+        exact_separator = {
+            "name": "I_one",
+            "singleton_rule": "I_one({record with content c})=c",
+            "collection_rule": "I_one(R)=number of records in R whose content is 1",
+            "values_on_separated_pairs": i_one_rows,
+            "separates_every_declared_pair": all(
+                row["delta"] != 0 for row in i_one_rows
+            ),
+        }
+
     return {
         "declared_family": (
             "all functions phi:{0,1}->R, extended to finite pairwise-disjoint "
@@ -290,13 +398,7 @@ def readout_visibility(census: dict) -> dict:
         ),
         "additivity_failure_count": additivity_failures,
         "analysis": analysis,
-        "exact_separator": {
-            "name": "I_one",
-            "singleton_rule": "I_one({record with content c})=c",
-            "collection_rule": "I_one(R)=number of records in R whose content is 1",
-            "values_on_separated_pairs": i_one_rows,
-            "separates_every_declared_pair": all(row["delta"] != 0 for row in i_one_rows),
-        },
+        "exact_separator": exact_separator,
         "blind_admissible_example": {
             "singleton_values": [1, 1],
             "meaning": "record count; admissible but content-blind on equal-size collections",
@@ -315,9 +417,12 @@ def scope_measurement() -> dict:
             "star, for the three finite deterministic witness classes"
         ),
         "established": (
-            "at this cap, each separated neighbour pair changes locked basis content "
-            "and is visible to the explicit additive I_one readout"
+            "in the declared P0/P1 point-mass construction, the exact changing "
+            "neighbour edges change the unique supported locked content and I_one reads it"
         ),
+        "binary_M2C_embedding_declared_not_unique": True,
+        "point_mass_distribution_constructed_at_finite_cap": True,
+        "target_input_fixed_per_conditioned_law": True,
         "full_mosaic_claimed": False,
         "formation_site_probability_or_rate_claimed": False,
         "selected_physical_readout_claimed": False,
@@ -327,7 +432,7 @@ def scope_measurement() -> dict:
         "generic_axiom_only_consequence_claimed": False,
         "generic_axiom_boundary": (
             "distribution variation alone need not force disjoint supports or a different "
-            "realized draw; the positive result uses the declared deterministic witness laws"
+            "realized draw; the positive result uses the declared P0/P1 point-mass laws"
         ),
     }
 
@@ -335,18 +440,48 @@ def scope_measurement() -> dict:
 def validate_visibility_payload(payload: dict) -> bool:
     analysis = payload["analysis"]
     recomputed = analyse_visibility(analysis["pairs"], tuple(payload["basis"]))
-    return bool(
-        recomputed["outcome"] == analysis["outcome"]
-        and recomputed["pair_count"] == analysis["pair_count"]
-        and recomputed["visible_pair_count"] == analysis["visible_pair_count"]
-        and (
-            analysis["outcome"] == "SEPARATING_ADMISSIBLE_READOUT_EXISTS"
-            or bool(analysis["nonseparation_proof"])
+    return recomputed == analysis
+
+
+def validate_readout_measurement(payload: dict) -> bool:
+    if not validate_visibility_payload(payload):
+        return False
+    analysis = payload["analysis"]
+    if payload["empty_value"] != 0 or not payload["record_content_only"]:
+        return False
+    if payload["additivity_failure_count"] != 0:
+        return False
+    if analysis["outcome"] == "SEPARATING_ADMISSIBLE_READOUT_EXISTS":
+        separator = payload["exact_separator"]
+        expected_values = []
+        for pair in analysis["pairs"]:
+            before = finite_additive_readout((pair["content_before"],), (0, 1))
+            after = finite_additive_readout((pair["content_after"],), (0, 1))
+            expected_values.append({
+                "class": pair["class"],
+                "target_input": pair["target_input"],
+                "I_one_before": before,
+                "I_one_after": after,
+                "delta": after - before,
+            })
+        return bool(
+            separator
+            and separator["name"] == "I_one"
+            and separator["values_on_separated_pairs"] == expected_values
+            and separator["separates_every_declared_pair"]
+            == all(row["delta"] != 0 for row in expected_values)
         )
-    )
+    if analysis["outcome"] == "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS":
+        proof = analysis["nonseparation_proof"]
+        return bool(
+            payload["exact_separator"] is None
+            and proof
+            and proof["all_basis_functionals_equal_on_all_compared_pairs"] is True
+        )
+    return payload["exact_separator"] is None
 
 
-def synthetic_negative_visibility_control() -> bool:
+def synthetic_agreement_visibility_control() -> bool:
     pairs = [{
         "class": "synthetic equal-content fixture",
         "target_input": 0,
@@ -356,10 +491,17 @@ def synthetic_negative_visibility_control() -> bool:
         "content_after": 0,
     }]
     analysis = analyse_visibility(pairs, READOUT_BASIS)
-    payload = {"basis": list(READOUT_BASIS), "analysis": analysis}
+    payload = {
+        "basis": list(READOUT_BASIS),
+        "analysis": analysis,
+        "empty_value": 0,
+        "record_content_only": True,
+        "additivity_failure_count": 0,
+        "exact_separator": None,
+    }
     return bool(
-        analysis["outcome"] == "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
-        and validate_visibility_payload(payload)
+        analysis["outcome"] == "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS"
+        and validate_readout_measurement(payload)
     )
 
 
@@ -439,7 +581,7 @@ def render_stdout(receipt: dict) -> str:
         + f" :: source_reads={receipt['controls']['literal_source_read_count']}<=6;"
         + f" pins={receipt['controls']['sha_pins_match'] and receipt['controls']['blob_pins_match']};"
         + f" deterministic={receipt['controls']['determinism_replay']};"
-        + f" negative_gate={receipt['controls']['synthetic_negative_visibility_accepted']}",
+        + f" agreement_gate={receipt['controls']['synthetic_agreement_outcome_accepted']}",
     ]
     passed = sum(receipt["checks"].values())
     lines.append(f"TOTAL: PASS={passed} FAIL={len(receipt['checks']) - passed}")
@@ -456,47 +598,45 @@ def run() -> tuple[dict, str]:
     visibility = first["B_READOUT_VISIBILITY"]
     scope = first["C_SCOPE"]
 
-    expected_row_counts = {
-        "incoming CNOT": 2,
-        "perpendicular-control TOF": 4,
-        "opposite-control TOF": 4,
-    }
     a_reconciliation = bool(
         census["class_count"] == len(census["classes"])
+        and census["proper_cubic_group_order"] == len(ROTATIONS)
         and census["witness_multiplicity"] == sum(
             row["orbit_size"] for row in census["classes"]
         )
         and all(
-            len(row["table"]) == expected_row_counts[row["class"]]
+            len(row["table"]) == 2 ** len(row["controls"])
             for row in census["classes"]
         )
         and all(
             row["J"] == vector_sum_squared(tuple(row["controls"]))
+            and row["orbit_stabilizer_product"] == row["group_order"]
+            and len(row["one_neighbour_bit_edges"])
+            == len(row["controls"]) * 2 ** len(row["controls"])
+            and all(
+                edge["changes_locked_content"]
+                == (edge["content_before"] != edge["content_after"])
+                for edge in row["one_neighbour_bit_edges"]
+            )
             for row in census["classes"]
         )
-        and census["all_separated_pairs_flip_locked_content"]
+        and census["point_mass_normalization_failures"] == 0
+        and census["locked_content_support_failures"] == 0
     )
-    b_reconciliation = bool(
-        validate_visibility_payload({
-            "basis": visibility["basis"],
-            "analysis": visibility["analysis"],
-        })
-        and visibility["empty_value"] == 0
-        and visibility["record_content_only"]
-        and visibility["additivity_failure_count"] == 0
-        and visibility["exact_separator"]["separates_every_declared_pair"]
-    )
+    b_reconciliation = validate_readout_measurement(visibility)
     c_reconciliation = bool(
         scope["full_mosaic_claimed"] is False
         and scope["formation_site_probability_or_rate_claimed"] is False
         and scope["selected_physical_readout_claimed"] is False
         and scope["generic_axiom_only_consequence_claimed"] is False
+        and scope["binary_M2C_embedding_declared_not_unique"] is True
+        and scope["point_mass_distribution_constructed_at_finite_cap"] is True
         and bool(scope["tested"] and scope["established"])
     )
     runtime_budget_met = monotonic() - started < AUDIT_TIMEOUT_SEC
     controls.update({
         "determinism_replay": deterministic,
-        "synthetic_negative_visibility_accepted": synthetic_negative_visibility_control(),
+        "synthetic_agreement_outcome_accepted": synthetic_agreement_visibility_control(),
         "runtime_budget_met": runtime_budget_met,
         "runtime_budget_seconds": AUDIT_TIMEOUT_SEC,
         "stdout_limit_bytes": STDOUT_LIMIT_BYTES,
@@ -509,7 +649,7 @@ def run() -> tuple[dict, str]:
         and not controls["prior_cycle_modules_loaded"]
         and controls["base_is_ancestor_of_head"]
         and deterministic
-        and controls["synthetic_negative_visibility_accepted"]
+        and controls["synthetic_agreement_outcome_accepted"]
         and runtime_budget_met
     )
     receipt = {
@@ -517,8 +657,8 @@ def run() -> tuple[dict, str]:
         "artifact": "neighbour-dependence locked-content and readout bounded theorem primary",
         "audit_status_authority": "independent audit lane only",
         "integrity_policy": (
-            "checks gate construction and reconciliation only; a coherent no-separator "
-            "outcome passes the same visibility validator"
+            "checks gate construction and reconciliation only; a coherent family-wide "
+            "agreement outcome passes the same top-level visibility validator"
         ),
         "findings": first,
         "science_digest": digest(first),

--- a/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+++ b/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
@@ -36,7 +36,11 @@ PRIMARY_CACHE_PATH = (
 RECEIPT_PATH = (
     "outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json"
 )
-AUDIT_INPUT_PATHS = (PRIMARY_PATH, PRIMARY_RECEIPT_PATH, PRIMARY_CACHE_PATH)
+AUDIT_INPUT_PATHS = (
+    "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py",
+    "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json",
+    "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt",
+)
 EXPECTED_PRIMARY_SOURCE_SHA256 = (
     "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
 )

--- a/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+++ b/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Independent refutation attempt for the Cycle-985 record-content theorem.
+
+This checker never imports or executes the primary.  It parses the primary as
+text/AST, reconstructs the three gate permutations and the binary readout dual
+space independently, binds the primary receipt/cache, and runs active
+corruption probes.  Its verdict concerns survival of this refutation attempt,
+not audit status.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from copy import deepcopy
+from hashlib import sha1, sha256
+from itertools import product
+from pathlib import Path
+from time import monotonic
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CYCLE = 985
+AUDIT_TIMEOUT_SEC = 300
+STDOUT_LIMIT_BYTES = 6_000
+PRIMARY_PATH = (
+    "scripts/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.py"
+)
+PRIMARY_RECEIPT_PATH = (
+    "outputs/neighbour_dependence_record_content_cycle985_receipt_2026_08_11.json"
+)
+PRIMARY_CACHE_PATH = (
+    "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt"
+)
+RECEIPT_PATH = (
+    "outputs/neighbour_dependence_record_content_cycle985_independent_check_receipt_2026_08_11.json"
+)
+AUDIT_INPUT_PATHS = (PRIMARY_PATH, PRIMARY_RECEIPT_PATH, PRIMARY_CACHE_PATH)
+EXPECTED_PRIMARY_SOURCE_SHA256 = (
+    "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
+)
+EXPECTED_PRIMARY_RECEIPT_SHA256 = (
+    "ae6b337dad743eb2ddc389f4be055e35c9c2a4b7306003e0548ffc66f21ec6d1"
+)
+EXPECTED_PRIMARY_INPUT_FINGERPRINT_SHA256 = (
+    "db7786cde9df9554b9e925bd8927e6f129e0cdd1546e5ea349a31056104b73bb"
+)
+EXPECTED_PRIMARY_STDOUT_SHA256 = (
+    "827a15c4268161e1f81355807636474f8b315b195f8062a12a0c79b621e9e345"
+)
+
+CLASS_SPECS = (
+    ("incoming CNOT", "CNOT", ((1, 0, 0),), 6, 4),
+    ("perpendicular-control TOF", "TOF", ((1, 0, 0), (0, 1, 0)), 12, 2),
+    ("opposite-control TOF", "TOF", ((1, 0, 0), (-1, 0, 0)), 3, 8),
+)
+
+
+def compact(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def digest(value: object) -> str:
+    return sha256(compact(value).encode()).hexdigest()
+
+
+def git_blob(payload: bytes) -> str:
+    return sha1(f"blob {len(payload)}\0".encode() + payload).hexdigest()
+
+
+def ast_literal_assignment(tree: ast.Module, name: str):
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise KeyError(name)
+
+
+def apply_gate_permutation(kind: str, state: tuple[int, ...]) -> tuple[int, ...]:
+    """Apply the gate as a permutation of a small Boolean state space."""
+    target_and_controls = list(state)
+    active = target_and_controls[1] == 1
+    if kind == "TOF":
+        active = active and target_and_controls[2] == 1
+    if active:
+        target_and_controls[0] = 1 - target_and_controls[0]
+    return tuple(target_and_controls)
+
+
+def j_from_vectors(vectors: tuple[tuple[int, int, int], ...]) -> int:
+    total = tuple(sum(vector[axis] for vector in vectors) for axis in range(3))
+    return sum(value * value for value in total)
+
+
+def independent_class_rows() -> list[dict]:
+    classes = []
+    for label, kind, vectors, orbit_size, stabilizer in CLASS_SPECS:
+        table = []
+        separated = []
+        controls = tuple(product((0, 1), repeat=len(vectors)))
+        for bits in controls:
+            table.append({
+                "bits": bits,
+                "contents": tuple(
+                    apply_gate_permutation(kind, (target, *bits))[0]
+                    for target in (0, 1)
+                ),
+            })
+        for target in (0, 1):
+            for left_index, left in enumerate(controls):
+                for right in controls[left_index + 1:]:
+                    if sum(a != b for a, b in zip(left, right)) != 1:
+                        continue
+                    before = apply_gate_permutation(kind, (target, *left))[0]
+                    after = apply_gate_permutation(kind, (target, *right))[0]
+                    if before != after:
+                        separated.append((target, left, right, before, after))
+        classes.append({
+            "class": label,
+            "kind": kind,
+            "J": j_from_vectors(vectors),
+            "orbit_size": orbit_size,
+            "stabilizer": stabilizer,
+            "table": table,
+            "separated": separated,
+        })
+    return classes
+
+
+def primary_class_rows(receipt: dict) -> list[dict]:
+    rows = []
+    for row in receipt["findings"]["A_LOCKED_CONTENT_CENSUS"]["classes"]:
+        control_names = tuple(row["controls"])
+        table = []
+        for item in row["table"]:
+            bits = tuple(item["control_configuration"][name] for name in control_names)
+            table.append({
+                "bits": bits,
+                "contents": tuple(
+                    item["locked_content_by_target_input"][str(target)]
+                    for target in (0, 1)
+                ),
+            })
+        separated = []
+        for item in row["one_neighbour_bit_separations"]:
+            left = tuple(item["configuration_before"][name] for name in control_names)
+            right = tuple(item["configuration_after"][name] for name in control_names)
+            separated.append((
+                item["target_input"], left, right,
+                item["content_before"], item["content_after"],
+            ))
+        rows.append({
+            "class": row["class"],
+            "kind": "CNOT" if len(control_names) == 1 else "TOF",
+            "J": row["J"],
+            "orbit_size": row["orbit_size"],
+            "stabilizer": row["stabilizer"],
+            "table": table,
+            "separated": separated,
+        })
+    return rows
+
+
+def independent_readout_result(classes: list[dict]) -> dict:
+    pairs = [pair for row in classes for pair in row["separated"]]
+    deltas = [after - before for _, _, _, before, after in pairs]
+    return {
+        "family": "R^{\u007b0,1\u007d}, extended by finite sums",
+        "basis": ((1, 0), (0, 1)),
+        "pair_count": len(pairs),
+        "I_one_deltas": deltas,
+        "outcome": (
+            "SEPARATING_ADMISSIBLE_READOUT_EXISTS" if pairs and all(deltas)
+            else "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+        ),
+        "no_separator_iff_contents_equal": all(
+            (before == after) == all(weights[before] == weights[after] for weights in ((1, 0), (0, 1)))
+            for _, _, _, before, after in pairs
+        ),
+    }
+
+
+def parse_cache(cache_text: str) -> dict:
+    stdout_marker = "----- stdout -----\n"
+    stderr_marker = "\n----- stderr -----"
+    if stdout_marker not in cache_text or stderr_marker not in cache_text:
+        raise ValueError("unrecognized cache envelope")
+    header, tail = cache_text.split(stdout_marker, 1)
+    stdout, _ = tail.split(stderr_marker, 1)
+    fields = {}
+    for line in header.splitlines():
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            fields[key] = value
+    return {"fields": fields, "stdout": stdout}
+
+
+def primary_ast_and_pins(payloads: dict[str, bytes]) -> dict:
+    source = payloads[PRIMARY_PATH]
+    tree = ast.parse(source, filename=PRIMARY_PATH)
+    literal_inputs = ast_literal_assignment(tree, "AUDIT_INPUT_PATHS")
+    return {
+        "source_sha256": sha256(source).hexdigest(),
+        "source_git_blob": git_blob(source),
+        "source_pin_match": sha256(source).hexdigest() == EXPECTED_PRIMARY_SOURCE_SHA256,
+        "primary_reads_only_axiom": literal_inputs == (
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+        "primary_has_main_guard": any(
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            for node in tree.body
+        ),
+    }
+
+
+def compare_receipt(receipt: dict, independent: list[dict]) -> bool:
+    return primary_class_rows(receipt) == independent
+
+
+def readout_agrees(receipt: dict, independent: dict) -> bool:
+    visibility = receipt["findings"]["B_READOUT_VISIBILITY"]
+    separator = visibility["exact_separator"]
+    return bool(
+        visibility["analysis"]["outcome"] == independent["outcome"]
+        and visibility["analysis"]["pair_count"] == independent["pair_count"]
+        and separator["name"] == "I_one"
+        and separator["separates_every_declared_pair"]
+        and [row["delta"] for row in separator["values_on_separated_pairs"]]
+        == independent["I_one_deltas"]
+        and independent["no_separator_iff_contents_equal"]
+    )
+
+
+def negative_outcome_control() -> bool:
+    equal_pair_classes = [{
+        "separated": [(0, (0,), (1,), 0, 0)],
+    }]
+    result = independent_readout_result(equal_pair_classes)
+    return result["outcome"] == "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+
+
+def active_corruption_probes(receipt: dict, independent: list[dict], cache: dict) -> dict:
+    probes = {}
+
+    mutant = deepcopy(receipt)
+    mutant["findings"]["A_LOCKED_CONTENT_CENSUS"]["classes"][0]["table"][0][
+        "locked_content_by_target_input"
+    ]["0"] = 1
+    probes["locked_content_row"] = not compare_receipt(mutant, independent)
+
+    mutant = deepcopy(receipt)
+    mutant["findings"]["A_LOCKED_CONTENT_CENSUS"]["classes"][1]["J"] = 0
+    probes["class_separator_J"] = not compare_receipt(mutant, independent)
+
+    mutant = deepcopy(receipt)
+    mutant["findings"]["B_READOUT_VISIBILITY"]["analysis"]["outcome"] = (
+        "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+    )
+    probes["visibility_outcome"] = not readout_agrees(
+        mutant, independent_readout_result(independent)
+    )
+
+    mutant = deepcopy(receipt)
+    mutant["findings"]["C_SCOPE"]["full_mosaic_claimed"] = True
+    probes["mosaic_scope"] = mutant["findings"]["C_SCOPE"] != receipt["findings"]["C_SCOPE"]
+
+    probes["source_pin"] = sha256(b"corrupted primary").hexdigest() != EXPECTED_PRIMARY_SOURCE_SHA256
+
+    corrupted_stdout = cache["stdout"].replace(
+        "SEPARATING_ADMISSIBLE_READOUT_EXISTS", "NO_ADMISSIBLE_SEPARATOR"
+    )
+    probes["cached_headline"] = (
+        sha256(corrupted_stdout.encode()).hexdigest() != EXPECTED_PRIMARY_STDOUT_SHA256
+    )
+    return probes
+
+
+def render_stdout(receipt: dict) -> str:
+    checks = receipt["checks"]
+    lines = [
+        "CYCLE985_NEIGHBOUR_DEPENDENCE_RECORD_CONTENT_INDEPENDENT_CHECK",
+        "R0_PRIMARY_AST_AND_PINS " + ("PASS" if checks["R0_PRIMARY_AST_AND_PINS"] else "FAIL"),
+        "R1_INDEPENDENT_CONTENT_CENSUS " + ("PASS" if checks["R1_INDEPENDENT_CONTENT_CENSUS"] else "FAIL")
+        + f" :: classes={receipt['independent']['class_summary']}",
+        "R2_INDEPENDENT_READOUT_DUAL " + ("PASS" if checks["R2_INDEPENDENT_READOUT_DUAL"] else "FAIL")
+        + f" :: outcome={receipt['independent']['readout']['outcome']};"
+        + f" pairs={receipt['independent']['readout']['pair_count']}",
+        "R3_RECEIPT_CACHE_BINDING " + ("PASS" if checks["R3_RECEIPT_CACHE_BINDING"] else "FAIL"),
+        "R4_ACTIVE_CORRUPTION_PROBES " + ("PASS" if checks["R4_ACTIVE_CORRUPTION_PROBES"] else "FAIL")
+        + f" :: rejected={sum(receipt['corruption_probes'].values())}/{len(receipt['corruption_probes'])}",
+        "R5_CONTROLS " + ("PASS" if checks["R5_CONTROLS"] else "FAIL")
+        + f" :: source_reads={receipt['controls']['literal_source_read_count']}<=6;"
+        + f" primary_executed={receipt['controls']['primary_imported_or_executed']};"
+        + f" negative_gate={receipt['controls']['synthetic_negative_outcome_accepted']}",
+        "VERDICT: " + (
+            "PRIMARY_SURVIVES_INDEPENDENT_REFUTATION_ATTEMPT"
+            if all(checks.values()) else "PRIMARY_DOES_NOT_SURVIVE_INDEPENDENT_REFUTATION_ATTEMPT"
+        ),
+    ]
+    passed = sum(checks.values())
+    lines.append(f"TOTAL: PASS={passed} FAIL={len(checks) - passed}")
+    return "\n".join(lines) + "\n"
+
+
+def run() -> tuple[dict, str]:
+    started = monotonic()
+    payloads = {path: (ROOT / path).read_bytes() for path in AUDIT_INPUT_PATHS}
+    primary_receipt = json.loads(payloads[PRIMARY_RECEIPT_PATH])
+    cache = parse_cache(payloads[PRIMARY_CACHE_PATH].decode())
+    ast_pins = primary_ast_and_pins(payloads)
+    independent = independent_class_rows()
+    readout = independent_readout_result(independent)
+    probes = active_corruption_probes(primary_receipt, independent, cache)
+
+    cache_fields = cache["fields"]
+    cache_binding = bool(
+        cache_fields.get("runner") == PRIMARY_PATH
+        and cache_fields.get("runner_sha256") == EXPECTED_PRIMARY_SOURCE_SHA256
+        and cache_fields.get("input_fingerprint_sha256")
+        == EXPECTED_PRIMARY_INPUT_FINGERPRINT_SHA256
+        and cache_fields.get("timeout_sec") == "300"
+        and cache_fields.get("exit_code") == "0"
+        and cache_fields.get("status") == "ok"
+        and sha256(cache["stdout"].encode()).hexdigest() == EXPECTED_PRIMARY_STDOUT_SHA256
+        and primary_receipt["stdout_sha256"] == EXPECTED_PRIMARY_STDOUT_SHA256
+        and sha256(payloads[PRIMARY_RECEIPT_PATH]).hexdigest()
+        == EXPECTED_PRIMARY_RECEIPT_SHA256
+        and primary_receipt["primary_source_sha256"] == EXPECTED_PRIMARY_SOURCE_SHA256
+    )
+    runtime_budget_met = monotonic() - started < AUDIT_TIMEOUT_SEC
+    controls = {
+        "literal_audit_input_paths": list(AUDIT_INPUT_PATHS),
+        "literal_source_read_count": len(AUDIT_INPUT_PATHS),
+        "input_sha256": {
+            path: sha256(payload).hexdigest() for path, payload in payloads.items()
+        },
+        "input_git_blobs": {
+            path: git_blob(payload) for path, payload in payloads.items()
+        },
+        "primary_imported_or_executed": False,
+        "synthetic_negative_outcome_accepted": negative_outcome_control(),
+        "runtime_budget_met": runtime_budget_met,
+        "runtime_budget_seconds": AUDIT_TIMEOUT_SEC,
+        "stdout_limit_bytes": STDOUT_LIMIT_BYTES,
+    }
+    checks = {
+        "R0_PRIMARY_AST_AND_PINS": bool(
+            ast_pins["source_pin_match"]
+            and ast_pins["primary_reads_only_axiom"]
+            and ast_pins["primary_has_main_guard"]
+        ),
+        "R1_INDEPENDENT_CONTENT_CENSUS": bool(
+            compare_receipt(primary_receipt, independent)
+            and [row["J"] for row in independent] == [1, 2, 0]
+            and [row["orbit_size"] for row in independent] == [6, 12, 3]
+        ),
+        "R2_INDEPENDENT_READOUT_DUAL": readout_agrees(primary_receipt, readout),
+        "R3_RECEIPT_CACHE_BINDING": cache_binding,
+        "R4_ACTIVE_CORRUPTION_PROBES": all(probes.values()),
+        "R5_CONTROLS": bool(
+            len(AUDIT_INPUT_PATHS) <= 6
+            and not controls["primary_imported_or_executed"]
+            and controls["synthetic_negative_outcome_accepted"]
+            and runtime_budget_met
+        ),
+    }
+    receipt = {
+        "cycle": CYCLE,
+        "artifact": "Cycle 985 independent record-content refutation attempt",
+        "audit_status_authority": "independent audit lane only",
+        "independent": {
+            "class_summary": [
+                [row["class"], row["orbit_size"], row["stabilizer"], row["J"], len(row["table"])]
+                for row in independent
+            ],
+            "readout": readout,
+            "reconstruction_digest": digest(independent),
+        },
+        "primary_ast_and_pins": ast_pins,
+        "cache_semantic_fields": cache_fields,
+        "corruption_probes": probes,
+        "controls": controls,
+        "checks": checks,
+    }
+    stdout = render_stdout(receipt)
+    controls["stdout_bytes"] = len(stdout.encode())
+    if controls["stdout_bytes"] >= STDOUT_LIMIT_BYTES:
+        receipt["checks"]["R5_CONTROLS"] = False
+        stdout = render_stdout(receipt)
+        controls["stdout_bytes"] = len(stdout.encode())
+    receipt["pass"] = all(receipt["checks"].values())
+    receipt["checker_source_sha256"] = sha256(
+        (ROOT / Path(__file__).relative_to(ROOT)).read_bytes()
+    ).hexdigest()
+    receipt["stdout_sha256"] = sha256(stdout.encode()).hexdigest()
+    return receipt, stdout
+
+
+def main() -> int:
+    if sys.argv[1:]:
+        raise SystemExit(f"usage: {Path(__file__).name}")
+    receipt, stdout = run()
+    receipt_path = ROOT / RECEIPT_PATH
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    sys.stdout.write(stdout)
+    return 0 if receipt["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+++ b/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
@@ -42,22 +42,27 @@ AUDIT_INPUT_PATHS = (
     "logs/runner-cache/frontier_cycle985_neighbour_dependence_record_content_2026_08_11.txt",
 )
 EXPECTED_PRIMARY_SOURCE_SHA256 = (
-    "0e66cb4b11c38c78b03d0fab66b0218839005fe32e5c3daaf289eb64040714a2"
+    "3d66b2836743808119541536bf7562212a05da84f1149b9f5d5f12f47ff7eff8"
 )
 EXPECTED_PRIMARY_RECEIPT_SHA256 = (
-    "ae6b337dad743eb2ddc389f4be055e35c9c2a4b7306003e0548ffc66f21ec6d1"
+    "570332f2bd8b491f6c39a9d4bbcec701b23304ba9a6f493f3f957b562fc00d01"
 )
 EXPECTED_PRIMARY_INPUT_FINGERPRINT_SHA256 = (
     "db7786cde9df9554b9e925bd8927e6f129e0cdd1546e5ea349a31056104b73bb"
 )
 EXPECTED_PRIMARY_STDOUT_SHA256 = (
-    "827a15c4268161e1f81355807636474f8b315b195f8062a12a0c79b621e9e345"
+    "4f684435699e3aba6a2279a5bb32f013671861cf8e446a5e5da79e5f34c800b4"
 )
 
 CLASS_SPECS = (
-    ("incoming CNOT", "CNOT", ((1, 0, 0),), 6, 4),
-    ("perpendicular-control TOF", "TOF", ((1, 0, 0), (0, 1, 0)), 12, 2),
-    ("opposite-control TOF", "TOF", ((1, 0, 0), (-1, 0, 0)), 3, 8),
+    ("incoming CNOT", "CNOT", ((1, 0, 0),)),
+    ("perpendicular-control TOF", "TOF", ((1, 0, 0), (0, 1, 0))),
+    ("opposite-control TOF", "TOF", ((1, 0, 0), (-1, 0, 0))),
+)
+UNIT_VECTORS = (
+    (1, 0, 0), (-1, 0, 0),
+    (0, 1, 0), (0, -1, 0),
+    (0, 0, 1), (0, 0, -1),
 )
 
 
@@ -99,18 +104,76 @@ def j_from_vectors(vectors: tuple[tuple[int, int, int], ...]) -> int:
     return sum(value * value for value in total)
 
 
+def dot(left: tuple[int, int, int], right: tuple[int, int, int]) -> int:
+    return sum(a * b for a, b in zip(left, right))
+
+
+def cross(left: tuple[int, int, int], right: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (
+        left[1] * right[2] - left[2] * right[1],
+        left[2] * right[0] - left[0] * right[2],
+        left[0] * right[1] - left[1] * right[0],
+    )
+
+
+def oriented_frame_rotations() -> tuple:
+    frames = []
+    for image_x in UNIT_VECTORS:
+        for image_y in UNIT_VECTORS:
+            if dot(image_x, image_y) == 0:
+                frames.append((image_x, image_y, cross(image_x, image_y)))
+    return tuple(frames)
+
+
+ROTATION_FRAMES = oriented_frame_rotations()
+
+
+def rotate_by_frame(frame: tuple, vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(vector[axis] * frame[axis][component] for axis in range(3))
+        for component in range(3)
+    )
+
+
+def independent_orbit_certificate(vectors: tuple[tuple[int, int, int], ...]) -> dict:
+    unordered = len(vectors) == 2
+    canonical = tuple(sorted(vectors)) if unordered else vectors
+    images = {
+        tuple(sorted(rotate_by_frame(frame, vector) for vector in vectors))
+        if unordered else tuple(rotate_by_frame(frame, vector) for vector in vectors)
+        for frame in ROTATION_FRAMES
+    }
+    stabilizer = sum(
+        (
+            tuple(sorted(rotate_by_frame(frame, vector) for vector in vectors))
+            if unordered else tuple(rotate_by_frame(frame, vector) for vector in vectors)
+        ) == canonical
+        for frame in ROTATION_FRAMES
+    )
+    return {
+        "group_order": len(ROTATION_FRAMES),
+        "orbit_size": len(images),
+        "stabilizer": stabilizer,
+        "orbit_stabilizer_product": len(images) * stabilizer,
+    }
+
+
 def independent_class_rows() -> list[dict]:
     classes = []
-    for label, kind, vectors, orbit_size, stabilizer in CLASS_SPECS:
+    for label, kind, vectors in CLASS_SPECS:
         table = []
-        separated = []
+        edges = []
         controls = tuple(product((0, 1), repeat=len(vectors)))
         for bits in controls:
+            contents = tuple(
+                apply_gate_permutation(kind, (target, *bits))[0]
+                for target in (0, 1)
+            )
             table.append({
                 "bits": bits,
-                "contents": tuple(
-                    apply_gate_permutation(kind, (target, *bits))[0]
-                    for target in (0, 1)
+                "contents": contents,
+                "point_masses": tuple(
+                    (int(content == 0), int(content == 1)) for content in contents
                 ),
             })
         for target in (0, 1):
@@ -120,16 +183,16 @@ def independent_class_rows() -> list[dict]:
                         continue
                     before = apply_gate_permutation(kind, (target, *left))[0]
                     after = apply_gate_permutation(kind, (target, *right))[0]
-                    if before != after:
-                        separated.append((target, left, right, before, after))
+                    edges.append((target, left, right, before, after, before != after))
+        orbit = independent_orbit_certificate(vectors)
         classes.append({
             "class": label,
             "kind": kind,
             "J": j_from_vectors(vectors),
-            "orbit_size": orbit_size,
-            "stabilizer": stabilizer,
+            **orbit,
             "table": table,
-            "separated": separated,
+            "edges": edges,
+            "separated": [edge[:5] for edge in edges if edge[5]],
         })
     return classes
 
@@ -147,14 +210,22 @@ def primary_class_rows(receipt: dict) -> list[dict]:
                     item["locked_content_by_target_input"][str(target)]
                     for target in (0, 1)
                 ),
+                "point_masses": tuple(
+                    (
+                        item["point_mass_distribution_by_target_input"][str(target)]["P_0"],
+                        item["point_mass_distribution_by_target_input"][str(target)]["P_1"],
+                    )
+                    for target in (0, 1)
+                ),
             })
-        separated = []
-        for item in row["one_neighbour_bit_separations"]:
+        edges = []
+        for item in row["one_neighbour_bit_edges"]:
             left = tuple(item["configuration_before"][name] for name in control_names)
             right = tuple(item["configuration_after"][name] for name in control_names)
-            separated.append((
+            edges.append((
                 item["target_input"], left, right,
                 item["content_before"], item["content_after"],
+                item["changes_locked_content"],
             ))
         rows.append({
             "class": row["class"],
@@ -162,8 +233,11 @@ def primary_class_rows(receipt: dict) -> list[dict]:
             "J": row["J"],
             "orbit_size": row["orbit_size"],
             "stabilizer": row["stabilizer"],
+            "group_order": row["group_order"],
+            "orbit_stabilizer_product": row["orbit_stabilizer_product"],
             "table": table,
-            "separated": separated,
+            "edges": edges,
+            "separated": [edge[:5] for edge in edges if edge[5]],
         })
     return rows
 
@@ -171,16 +245,23 @@ def primary_class_rows(receipt: dict) -> list[dict]:
 def independent_readout_result(classes: list[dict]) -> dict:
     pairs = [pair for row in classes for pair in row["separated"]]
     deltas = [after - before for _, _, _, before, after in pairs]
+    visible_count = sum(delta != 0 for delta in deltas)
+    if pairs and visible_count == len(pairs):
+        outcome = "SEPARATING_ADMISSIBLE_READOUT_EXISTS"
+    elif pairs and visible_count == 0:
+        outcome = "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS"
+    elif pairs:
+        outcome = "PARTIAL_VISIBILITY_IN_DECLARED_READOUT_FAMILY"
+    else:
+        outcome = "EMPTY_COMPARISON_DOMAIN"
     return {
         "family": "R^{\u007b0,1\u007d}, extended by finite sums",
         "basis": ((1, 0), (0, 1)),
         "pair_count": len(pairs),
+        "visible_pair_count": visible_count,
         "I_one_deltas": deltas,
-        "outcome": (
-            "SEPARATING_ADMISSIBLE_READOUT_EXISTS" if pairs and all(deltas)
-            else "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
-        ),
-        "no_separator_iff_contents_equal": all(
+        "outcome": outcome,
+        "basis_agreement_iff_contents_equal": all(
             (before == after) == all(weights[before] == weights[after] for weights in ((1, 0), (0, 1)))
             for _, _, _, before, after in pairs
         ),
@@ -222,29 +303,84 @@ def primary_ast_and_pins(payloads: dict[str, bytes]) -> dict:
 
 
 def compare_receipt(receipt: dict, independent: list[dict]) -> bool:
-    return primary_class_rows(receipt) == independent
+    census = receipt["findings"]["A_LOCKED_CONTENT_CENSUS"]
+    return bool(
+        primary_class_rows(receipt) == independent
+        and census["proper_cubic_group_order"] == len(ROTATION_FRAMES)
+        and census["M2C_possibility_embedding"] == {
+            "P_0": [[1, 0], [0, 0]],
+            "P_1": [[0, 0], [0, 1]],
+        }
+        and census["point_mass_normalization_failures"] == 0
+        and census["locked_content_support_failures"] == 0
+    )
 
 
 def readout_agrees(receipt: dict, independent: dict) -> bool:
     visibility = receipt["findings"]["B_READOUT_VISIBILITY"]
     separator = visibility["exact_separator"]
-    return bool(
+    common = bool(
         visibility["analysis"]["outcome"] == independent["outcome"]
         and visibility["analysis"]["pair_count"] == independent["pair_count"]
-        and separator["name"] == "I_one"
-        and separator["separates_every_declared_pair"]
-        and [row["delta"] for row in separator["values_on_separated_pairs"]]
-        == independent["I_one_deltas"]
-        and independent["no_separator_iff_contents_equal"]
+        and visibility["analysis"]["visible_pair_count"]
+        == independent["visible_pair_count"]
+        and independent["basis_agreement_iff_contents_equal"]
     )
+    if not common:
+        return False
+    if independent["outcome"] == "SEPARATING_ADMISSIBLE_READOUT_EXISTS":
+        return bool(
+            separator
+            and separator["name"] == "I_one"
+            and separator["separates_every_declared_pair"]
+            and [row["delta"] for row in separator["values_on_separated_pairs"]]
+            == independent["I_one_deltas"]
+        )
+    if independent["outcome"] == "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS":
+        proof = visibility["analysis"]["nonseparation_proof"]
+        return bool(
+            separator is None
+            and proof
+            and proof["all_basis_functionals_equal_on_all_compared_pairs"] is True
+        )
+    return separator is None
 
 
-def negative_outcome_control() -> bool:
+def agreement_outcome_control(receipt: dict) -> bool:
     equal_pair_classes = [{
         "separated": [(0, (0,), (1,), 0, 0)],
     }]
     result = independent_readout_result(equal_pair_classes)
-    return result["outcome"] == "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+    synthetic = deepcopy(receipt)
+    synthetic["findings"]["B_READOUT_VISIBILITY"]["analysis"] = {
+        "outcome": "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS",
+        "pair_count": 1,
+        "visible_pair_count": 0,
+        "pairs": [],
+        "nonseparation_proof": {
+            "basis_dimension": 2,
+            "all_basis_functionals_equal_on_all_compared_pairs": True,
+            "span_argument": "synthetic checker fixture",
+        },
+    }
+    synthetic["findings"]["B_READOUT_VISIBILITY"]["exact_separator"] = None
+    return readout_agrees(synthetic, result)
+
+
+def scope_agrees(receipt: dict) -> bool:
+    scope = receipt["findings"]["C_SCOPE"]
+    return bool(
+        scope["binary_M2C_embedding_declared_not_unique"] is True
+        and scope["point_mass_distribution_constructed_at_finite_cap"] is True
+        and scope["target_input_fixed_per_conditioned_law"] is True
+        and scope["full_mosaic_claimed"] is False
+        and scope["formation_site_probability_or_rate_claimed"] is False
+        and scope["selected_physical_readout_claimed"] is False
+        and scope["born_weight_selection_claimed"] is False
+        and scope["continuous_M2_probability_law_claimed"] is False
+        and scope["infinite_simultaneous_translation_uniform_law_claimed"] is False
+        and scope["generic_axiom_only_consequence_claimed"] is False
+    )
 
 
 def active_corruption_probes(receipt: dict, independent: list[dict], cache: dict) -> dict:
@@ -262,7 +398,7 @@ def active_corruption_probes(receipt: dict, independent: list[dict], cache: dict
 
     mutant = deepcopy(receipt)
     mutant["findings"]["B_READOUT_VISIBILITY"]["analysis"]["outcome"] = (
-        "NO_ADMISSIBLE_SEPARATOR_IN_DECLARED_LINEAR_FAMILY"
+        "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS"
     )
     probes["visibility_outcome"] = not readout_agrees(
         mutant, independent_readout_result(independent)
@@ -270,12 +406,14 @@ def active_corruption_probes(receipt: dict, independent: list[dict], cache: dict
 
     mutant = deepcopy(receipt)
     mutant["findings"]["C_SCOPE"]["full_mosaic_claimed"] = True
-    probes["mosaic_scope"] = mutant["findings"]["C_SCOPE"] != receipt["findings"]["C_SCOPE"]
+    probes["mosaic_scope"] = scope_agrees(receipt) and not scope_agrees(mutant)
 
-    probes["source_pin"] = sha256(b"corrupted primary").hexdigest() != EXPECTED_PRIMARY_SOURCE_SHA256
+    source_mutant = {path: (ROOT / path).read_bytes() for path in AUDIT_INPUT_PATHS}
+    source_mutant[PRIMARY_PATH] += b"\n"
+    probes["source_pin"] = not primary_ast_and_pins(source_mutant)["source_pin_match"]
 
     corrupted_stdout = cache["stdout"].replace(
-        "SEPARATING_ADMISSIBLE_READOUT_EXISTS", "NO_ADMISSIBLE_SEPARATOR"
+        "SEPARATING_ADMISSIBLE_READOUT_EXISTS", "DECLARED_READOUT_FAMILY_AGREES"
     )
     probes["cached_headline"] = (
         sha256(corrupted_stdout.encode()).hexdigest() != EXPECTED_PRIMARY_STDOUT_SHA256
@@ -299,7 +437,7 @@ def render_stdout(receipt: dict) -> str:
         "R5_CONTROLS " + ("PASS" if checks["R5_CONTROLS"] else "FAIL")
         + f" :: source_reads={receipt['controls']['literal_source_read_count']}<=6;"
         + f" primary_executed={receipt['controls']['primary_imported_or_executed']};"
-        + f" negative_gate={receipt['controls']['synthetic_negative_outcome_accepted']}",
+        + f" agreement_gate={receipt['controls']['synthetic_agreement_outcome_accepted']}",
         "VERDICT: " + (
             "PRIMARY_SURVIVES_INDEPENDENT_REFUTATION_ATTEMPT"
             if all(checks.values()) else "PRIMARY_DOES_NOT_SURVIVE_INDEPENDENT_REFUTATION_ATTEMPT"
@@ -346,7 +484,9 @@ def run() -> tuple[dict, str]:
             path: git_blob(payload) for path, payload in payloads.items()
         },
         "primary_imported_or_executed": False,
-        "synthetic_negative_outcome_accepted": negative_outcome_control(),
+        "synthetic_agreement_outcome_accepted": agreement_outcome_control(
+            primary_receipt
+        ),
         "runtime_budget_met": runtime_budget_met,
         "runtime_budget_seconds": AUDIT_TIMEOUT_SEC,
         "stdout_limit_bytes": STDOUT_LIMIT_BYTES,
@@ -359,8 +499,12 @@ def run() -> tuple[dict, str]:
         ),
         "R1_INDEPENDENT_CONTENT_CENSUS": bool(
             compare_receipt(primary_receipt, independent)
-            and [row["J"] for row in independent] == [1, 2, 0]
-            and [row["orbit_size"] for row in independent] == [6, 12, 3]
+            and all(
+                row["orbit_stabilizer_product"] == row["group_order"]
+                and len(row["edges"])
+                == (len(row["table"]).bit_length() - 1) * len(row["table"])
+                for row in independent
+            )
         ),
         "R2_INDEPENDENT_READOUT_DUAL": readout_agrees(primary_receipt, readout),
         "R3_RECEIPT_CACHE_BINDING": cache_binding,
@@ -368,7 +512,7 @@ def run() -> tuple[dict, str]:
         "R5_CONTROLS": bool(
             len(AUDIT_INPUT_PATHS) <= 6
             and not controls["primary_imported_or_executed"]
-            and controls["synthetic_negative_outcome_accepted"]
+            and controls["synthetic_agreement_outcome_accepted"]
             and runtime_budget_met
         ),
     }

--- a/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
+++ b/scripts/frontier_cycle985_neighbour_dependence_record_content_independent_check_2026_08_11.py
@@ -243,8 +243,11 @@ def primary_class_rows(receipt: dict) -> list[dict]:
 
 
 def independent_readout_result(classes: list[dict]) -> dict:
-    pairs = [pair for row in classes for pair in row["separated"]]
-    deltas = [after - before for _, _, _, before, after in pairs]
+    pairs = [
+        (row.get("class", "synthetic equal-content fixture"), *pair)
+        for row in classes for pair in row["separated"]
+    ]
+    deltas = [after - before for _, _, _, _, before, after in pairs]
     visible_count = sum(delta != 0 for delta in deltas)
     if pairs and visible_count == len(pairs):
         outcome = "SEPARATING_ADMISSIBLE_READOUT_EXISTS"
@@ -260,10 +263,14 @@ def independent_readout_result(classes: list[dict]) -> dict:
         "pair_count": len(pairs),
         "visible_pair_count": visible_count,
         "I_one_deltas": deltas,
+        "pair_signatures": [
+            (class_label, target, before, after)
+            for class_label, target, _, _, before, after in pairs
+        ],
         "outcome": outcome,
         "basis_agreement_iff_contents_equal": all(
             (before == after) == all(weights[before] == weights[after] for weights in ((1, 0), (0, 1)))
-            for _, _, _, before, after in pairs
+            for _, _, _, _, before, after in pairs
         ),
     }
 
@@ -319,11 +326,21 @@ def compare_receipt(receipt: dict, independent: list[dict]) -> bool:
 def readout_agrees(receipt: dict, independent: dict) -> bool:
     visibility = receipt["findings"]["B_READOUT_VISIBILITY"]
     separator = visibility["exact_separator"]
+    receipt_pair_signatures = [
+        (
+            pair["class"], pair["target_input"],
+            pair["content_before"], pair["content_after"],
+        )
+        for pair in visibility["analysis"]["pairs"]
+    ]
     common = bool(
         visibility["analysis"]["outcome"] == independent["outcome"]
         and visibility["analysis"]["pair_count"] == independent["pair_count"]
         and visibility["analysis"]["visible_pair_count"]
         == independent["visible_pair_count"]
+        and len(visibility["analysis"]["pairs"])
+        == visibility["analysis"]["pair_count"]
+        and receipt_pair_signatures == independent["pair_signatures"]
         and independent["basis_agreement_iff_contents_equal"]
     )
     if not common:
@@ -348,6 +365,7 @@ def readout_agrees(receipt: dict, independent: dict) -> bool:
 
 def agreement_outcome_control(receipt: dict) -> bool:
     equal_pair_classes = [{
+        "class": "synthetic equal-content fixture",
         "separated": [(0, (0,), (1,), 0, 0)],
     }]
     result = independent_readout_result(equal_pair_classes)
@@ -356,7 +374,18 @@ def agreement_outcome_control(receipt: dict) -> bool:
         "outcome": "DECLARED_READOUT_FAMILY_AGREES_ON_ALL_COMPARED_PAIRS",
         "pair_count": 1,
         "visible_pair_count": 0,
-        "pairs": [],
+        "pairs": [{
+            "class": "synthetic equal-content fixture",
+            "target_input": 0,
+            "configuration_before": {"n": 0},
+            "configuration_after": {"n": 1},
+            "content_before": 0,
+            "content_after": 0,
+            "basis_readout_values": [
+                {"readout": "I_zero", "before": 1, "after": 1, "delta": 0},
+                {"readout": "I_one", "before": 0, "after": 0, "delta": 0},
+            ],
+        }],
         "nonseparation_proof": {
             "basis_dimension": 2,
             "all_basis_functionals_equal_on_all_compared_pairs": True,
@@ -364,7 +393,9 @@ def agreement_outcome_control(receipt: dict) -> bool:
         },
     }
     synthetic["findings"]["B_READOUT_VISIBILITY"]["exact_separator"] = None
-    return readout_agrees(synthetic, result)
+    broken = deepcopy(synthetic)
+    broken["findings"]["B_READOUT_VISIBILITY"]["analysis"]["pairs"] = []
+    return readout_agrees(synthetic, result) and not readout_agrees(broken, result)
 
 
 def scope_agrees(receipt: dict) -> bool:


### PR DESCRIPTION
## Result

For the declared finite point-mass realization of the three landed witness classes, separated neighbour configurations lock different target-site content. Across the 21 witnesses there are 10 target-input-resolved changing pairs: 2 incoming-CNOT, 4 perpendicular-control-TOF, and 4 opposite-control-TOF.

The declared admissible readout family is all maps phi:{P0,P1}->R, extended additively over pairwise-disjoint records with I(empty)=0. The exact separator I_one(P0)=0, I_one(P1)=1 sees all 10 changing pairs. This is an existence result inside that family; it does not select the physical readout.

## Scope

This is a bounded single-formed-target-site result for an explicit normalized point-mass content law. It does not establish a unique global physical law, formation site/probability/rate, Born weights, or a mosaic-wide observational difference.

## Packet

- theorem note with exact class tables and controls
- deterministic primary runner and pinned cache/receipt
- independent refutation checker with six active corruption probes and pinned cache/receipt
- audit graph registration for both runner paths

## Verification

- primary: PASS=4 FAIL=0
- independent: PASS=6 FAIL=0
- full audit pipeline: PASS
- strict audit lint: no errors
- changed audit evidence: checked=1 failures=0 control_failures=0
- changed-file vocabulary lint: 0 violations
- three-lane review-loop confirmation: code/proof, physics/import, and governance/audit all pass

Independent audit remains required before any retained-grade status change.