### PR TITLE
feat(cell-cutting): two kernels and a closed-form colour on the 96 orbit tables (cycle 772)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_KERNEL_COLOUR_CLOSED_FORM_CYCLE772_NOTE_2026-08-11.md
+++ b/docs/PHYSICAL_CELL_CUTTING_KERNEL_COLOUR_CLOSED_FORM_CYCLE772_NOTE_2026-08-11.md
@@ -1,0 +1,177 @@
+# Physical cell cutting: the 96 orbit tables carry exactly two kernels, and the colour is a closed form (cycle 772)
+
+Date: 2026-08-11
+Authority: none
+Audit: unset.
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## 1. Status
+
+The unit four-cube has 2672 five-corner subsets of unit determinant. 400 of them sit at
+the adjacency cost floor 6, and those 400 admit 15800 exact cuttings of the cell into 24
+pieces. Exactly 192 distinct pieces occur, each in 1975 of the cuttings, and 24 x 15800 =
+379200 = 192 x 1975. There are also 192 eight-piece covers, each meeting every cutting
+exactly once, so 8 x 1975 = 15800. The group of 384 signed coordinate maps acts by 384
+distinct bijections on the pieces and on the covers, transitively on each, and freely on
+the 36864 pairs made of one piece and one cover, so those pairs fall into 96 orbits of
+size 384. Read as a zero-one table over covers by pieces, each orbit is a 192 by 192
+matrix, and those 96 matrices are the subject here.
+
+Three things are proved. First, the 96 tables carry exactly 2 kernels: the kernel of each
+table has dimension 48, and reducing all 96 of them to canonical form leaves exactly 2
+distinct subspaces, each shared by 48 tables, at each of the two primes 1000003 and
+1000033. Second, each of the 2 kernels is a submodule for the whole group of 384, which
+forces a stack rule: all 48 tables of one colour stack to rank 144, while a table of each
+colour stacks to 180. Third, the colour has a closed form in the geometry of the cell:
+each cover carries one axis, each piece carries a pair of axes, and the colour of an orbit
+is decided by whether the cover axis lies in the piece pair, on all 36864 pairs.
+
+The runner
+[physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.py](../scripts/physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.py)
+rebuilds every one of those objects from nothing: the 16 corners, the pieces, the
+cuttings, the covers, the group, the orbits and the kernels are all constructed in the
+run, and no cached data is read. It reports 31 gates, all passing, of which 7 are
+labelled rejectors or honest negatives, and 3 more carry a control that fails where the
+real object passes. Everything is exact over the integers and the two fixed
+primes; no floating point enters any gate and no constant is fitted. No axiom is added to
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md).
+
+## 2. The two kernels
+
+The kernel of an orbit table is exhibited rather than inferred. Every table has exactly 2
+ones in each row and 2 in each column, so its bipartite graph is a disjoint union of
+cycles; across the 96 tables there are 4608 cycles and every one has length 8, hence
+visits 4 pieces. On each cycle put the vector that is plus and minus one alternately on
+those pieces and zero elsewhere. Each such vector is killed by its table over the
+integers, and the supports of the vectors of one table are disjoint, so the 48 of them are
+independent and span the kernel.
+
+Reducing those 48 vectors to canonical row-reduced form and comparing the results gives
+exactly 2 distinct subspaces, of dimension 48 each, with class sizes 48 and 48, and the
+split is the same at 1000003 and at 1000033. That 2 is not an artefact of the tables being
+few or alike: the 96 tables are pairwise distinct as matrices, and 20 copies of one kernel
+with two piece coordinates swapped all keep dimension 48 while matching neither class.
+
+The 2 kernels span 84, so they meet in 48 + 48 - 84 = 12, and the meet has a name. The 16
+pure flips act freely on the 192 pieces, leaving 12 orbits. On each orbit put the vector
+whose value at the image of the base piece is the sign of the flip that moved it, plus one
+for an even flip word and minus one for an odd one. Those 12 vectors have rank 12, lie
+inside every one of the 96 kernels, and are killed by every one of the 96 tables over the
+integers: the meet is the sign-anti-invariant space of the flips. The sign is what carries
+this. The invariant space for the trivial character has rank 12 as well, but it meets
+every kernel in 0 and all 96 tables leave it alive.
+
+## 3. Submodules and the stack rule
+
+7 of the 384 maps generate the whole group. Permuting the coordinates of any of the 96
+kernel basis vectors by any of those 7 generators lands back inside the same kernel: 672
+checks, 0 outside. Each kernel is therefore a submodule for the whole group, and the
+two-valued colour is a property of the group action and not of a chosen table.
+
+The stack rule follows at once. Tables of one colour share a kernel of dimension 48, so
+stacking all 48 of them gives 9216 rows of rank 144, which is exactly the rank of every
+single table. Stacking one table of each colour leaves only the meet, so the rank is 180 =
+192 - 12. Both readings are measured, not argued: all 2304 cross-colour stacks have rank
+180 and all 2256 same-colour pairs stay at 144.
+
+The submodule statement is sharp rather than automatic. Dropping a single basis vector
+from one kernel leaves a subspace of rank 47 that is no longer stable: 5 of its 329
+generator images fall outside it.
+
+## 4. The sums and their block factorisation
+
+Let A be the entrywise sum of the 48 tables of one colour and B the sum of the other 48.
+A + B is the all-ones matrix and every row and column sum of A and of B is 96. That much
+is forced by the tables being 2-regular and carries no information: splitting the 96
+orbits in index order instead gives a matrix with the same all-ones sum and the same
+regularity, but rank 133.
+
+The content is elsewhere. Rank A = rank B = 4 at both primes, nullity 188, and A stacked
+on B still measures 4, so the two sums share their row space. A and B each have exactly 4
+distinct rows, each shared by 48 covers, and exactly 6 distinct columns, each shared by 32
+pieces, and each is constant on all 24 blocks those partitions cut out. The resulting 4 by
+6 pattern has 12 ones of 24, row sums all 3, column sums all 2, and rank 4 at both primes,
+and the two patterns are complementary. A and B each kill all 96 kernel basis vectors over
+the integers, including the kernel of the other colour, while the index-order control
+fails on all 48 of each class. Both sums are covariant under all 384 maps on all 36864
+pairs; swapping two pieces inside A breaks that covariance for 382 of the 384 maps.
+
+## 5. The closed form
+
+The 4 row blocks and the 6 column blocks are named by the geometry of the cell, and once
+they are named the colour is a closed form.
+
+Each cover has a unique non-identity fixer in the group of 384, and that fixer is a single
+flip. The axis of that flip takes 4 values with 48 covers each, and those 4 classes are
+exactly the 4 row blocks of A. Each piece has 5 corners; for each axis count the corners k
+on one side of it and read min(k, 5 - k). That profile attains its maximum on exactly 2
+axes for every piece, and the resulting unordered pair takes 6 values with 32 pieces each,
+which are exactly the 6 column blocks. Both labels are equivariant for the induced action
+on axes: 0 failures in 73728 cover checks and 0 in 73728 piece checks.
+
+The closed form is then this. On all 36864 pairs, the colour of the orbit of a pair is
+decided by whether the cover axis lies in the piece pair. The test is constant on each of
+the 96 orbits and splits them 48 and 48, and it agrees with the canonical kernel class up
+to one global choice of which class is called which. Exactly 16 of the 384 maps hold every
+row block and every column block, and they are precisely the 16 pure flips, which is the
+same group of 16 whose sign character named the meet in section 2.
+
+Two rejectors keep this from being vacuous. Shifting every piece pair by one axis
+disagrees with the colour on 24576 of the 36864 pairs, and shifting every cover axis by
+one disagrees on 24576. The shifted piece label also fails equivariance, on 57344 of the
+same 73728 checks.
+
+Two candidate labels were tried and are reported as they came out. Labelling a piece by
+how many of its corner pairs are adjacent gives 1 label for all 192 pieces. Labelling it
+by the flip weight of its own fixer gives 3. Neither can reach 6 classes, so neither can
+name the column blocks.
+
+## 6. The incidence read
+
+The cover incidence table, the 192 by 192 zero-one table recording which pieces lie in
+which cover, is itself a sum of orbits: it is the entrywise sum of exactly 4 of the 96,
+carrying 3 of one colour and 1 of the other. Through the closed form the same fact is
+local and uniform: every cover holds 8 pieces of which exactly 6 carry the cover's own
+axis, and every piece lies in 8 covers of which exactly 6 carry the axis of that piece.
+
+The two ways of reading those 4 orbits give different answers. Stacked, they have rank
+180, which is the cross-colour value of section 3. Added entrywise, they have rank 105 at
+both primes, and 192 - 105 = 87. The gap between 180 and 105 is cancellation inside the
+sum.
+
+## 7. What is new and what is not
+
+New here: that the 96 kernels collapse to exactly 2 subspaces; the naming of their meet as
+the sign-anti-invariant space of the 16 flips; the submodule property and the stack rule
+it forces; the block factorisation of A and B and their rank 4; the closed form for the
+colour together with its 2 rejectors and its 2 rejected candidates; and the reading of the
+incidence as 4 orbits carrying 3 of one colour and 1 of the other.
+
+Not new: that every one of the 96 orbit tables has rank 144. The previous cycle
+established that for all 96 tables from a single 4 by 4 determinant, and this cycle does
+not repeat that derivation; the rank enters here only as the value the stack of a whole
+colour has to match, and the runner re-measures it directly inside that gate rather than
+citing it. `PHYSICAL_CELL_CUTTING_CELL_ORBIT_CYCLES_CYCLE771_NOTE_2026-08-11` is a
+companion cycle of this lane that is still in flight and not on main at the time of
+writing; nothing here reads it or depends on it.
+
+## 8. Boundary and honest auditor read
+
+The closed form describes which colour an orbit carries. It does not by itself say which 4
+of the 96 orbits the geometry selects to build the incidence: that selection is read off
+the object here and is not derived from the colour rule.
+
+The rank drop from 144 to 105 is localised to the sum and is not explained here. The same
+4 orbits stacked have rank 180, and each of them alone has rank 144, so the drop to 105
+happens only when they are added, and this note offers no mechanism for it.
+
+The names 0 and 1 for the 2 colours come from canonical form, so which class is called
+which is a convention; only the partition of the 96 orbits into 48 and 48 is intrinsic,
+and the agreement between the kernel class and the geometric test is stated up to that one
+global choice. All ranks are measured at 2 fixed primes, and the annihilation statements
+are over the integers; nothing here is measured in any other characteristic.
+
+No axiom, import or literature comparator is used. The object is rebuilt in the run from
+the 16 corners of the unit four-cube and the group of 384 signed coordinate maps, and
+every number in this note is a number the runner prints.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15483,
- "node_count": 5447,
+ "edge_count": 15484,
+ "node_count": 5448,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13645,6 +13645,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_kernel_colour_closed_form_cycle772_note_2026-08-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.txt
+++ b/logs/runner-cache/physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.py
+runner_sha256: b653254793a26256568bccc3edea17759cf84f99979484e311738125042427dd
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 19.40
+status: ok
+----- stdout -----
+PASS C0 cell 2672 unit-det pieces, 400 at cost floor 6, 15800 cuttings of 24, 192 pieces used, 1975 cuttings each, 379200 = 379200
+PASS C1 covers 192, each of 8 pieces, each meeting every cutting exactly once, 8 x 1975 = 15800
+PASS C2 maps 384 distinct and shut, 384 piece and cover bijections, one orbit of 192 each, free: 96 x 384 = 36864
+PASS C3 every table 2-regular, 4608 cycles all of length 8, the alternating vectors die over Z, supports disjoint
+PASS C4 canonical kernels give 2 subspaces of dim 48, class sizes 48 and 48, same split at 1000003 and 1000033
+PASS C5 rejector: the 96 tables are pairwise distinct, and 20 piece-swapped kernels keep dim 48 yet match neither class
+PASS C6 the two kernels span 84 at both primes, so they meet in 48 + 48 - 84 = 12
+PASS C7 the 16 flips act freely with 12 piece orbits; the anti-invariant space has rank 12, lies in every kernel, dies on all 96
+PASS C8 rejector: the invariant space also has rank 12 but meets every kernel in 0, and all 96 tables leave it alive
+PASS C9 7 maps generate all 384; all 672 generator images of the 96 kernel basis vectors stay inside, 0 outside
+PASS C10 rejector: dropping one basis vector leaves rank 47, and 5 of its 329 generator images fall outside
+PASS C11 stacking either colour gives 9216 rows of rank 144, the rank of every one of the 96 single tables
+PASS C12 all 2304 cross-colour stacks have rank 180 = 192 - 12, while all 2256 same-colour pairs stay at 144
+PASS C13 A + B all ones, all row and column sums 96; the index-order split shares that yet has rank 133, so regularity alone gives nothing
+PASS C14 A and B are covariant on all 36864 pairs under all 384 maps; swapping two pieces in A breaks that for 382 of them
+PASS C15 rank A = rank B = 4 at both primes, nullity 188, and A stacked on B still measures 4
+PASS C16 A and B kill all 96 kernel basis vectors over Z, while the index-order control fails on all 48 of each class
+PASS C17 A and B each have 4 distinct rows of 48 covers and 6 distinct columns of 32 pieces, constant on all 24 blocks
+PASS C18 each 4 by 6 pattern has 12 ones of 24, row sums 3, column sums 2, rank 4 at both primes, and the two are complementary
+PASS C19 exactly 16 of the 384 maps hold every row and column block, and they are exactly the 16 pure flips
+PASS C20 each cover has one non-identity fixer, a single flip; its axis takes 4 values of 48 covers, and those are the row blocks
+PASS C21 min(k, 5 - k) peaks on exactly 2 axes per piece; the pair takes 6 values of 32 pieces, and those are the column blocks
+PASS C22 axis-in-pair is constant on all 96 orbits and splits 48/48; it meets the kernel class on 0 of 36864 pairs, so equal up to naming
+PASS C23 rejector: shifting every piece pair by one axis disagrees on 24576 of 36864 pairs, and shifting every cover axis on 24576
+PASS C24 honest negative: the adjacent-corner count gives 1 label and the piece fixer weight gives 3, short of the 6 classes
+PASS C25 both labels are equivariant for the axis action: 0 failures in 73728 cover checks and 0 in 73728 piece checks
+PASS C26 rejector: the piece label shifted by one axis fails equivariance on 57344 of the same 73728 checks
+PASS C27 every cover holds 8 pieces of which 6 carry its axis, and every piece lies in 8 covers of which 6 carry the axis
+PASS C28 the incidence table is the entrywise sum of exactly 4 orbits, 3 of one colour and 1 of the other
+PASS C29 the stack of those 4 has rank 180 while their sum has rank 105 at both primes, and 192 - 105 = 87
+PASS C30 honest negative: the shared-corner profile takes 25 values, 21 of them carrying both colours, so it cannot fix the colour
+two kernels of dim 48 meeting in 12, join 84, either colour stack rank 144, colour sums rank 4, incidence rank 105
+elapsed 19 s, peak resident 178 MB
+TOTAL: PASS=31 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.py
+++ b/scripts/physical_cell_cutting_kernel_colour_closed_form_cycle772_2026_08_11.py
@@ -1,0 +1,1025 @@
+"""The 96 orbit tables of the physical cell cutting carry exactly two kernels.
+
+Standalone exact runner. It rebuilds the unit four-cube cell object from scratch:
+the sixteen corners, the five-corner unit-determinant pieces at the adjacency cost
+floor, the cuttings by them, the 192 pieces that occur, and the 192 eight-piece
+covers. The group of 384 signed coordinate maps is built by permuting the four
+coordinates and flipping any of them; it acts freely on the 36864 pairs made of one
+piece and one cover, giving 96 orbits of size 384, each read as a zero and one table
+over covers by pieces.
+
+This cycle asks what those 96 tables have in common. Each table splits into 48
+cycles of length eight whose alternating vectors span its kernel. Reducing the 96
+kernels to canonical form leaves exactly two subspaces of dimension 48, so the 96
+tables carry a two-valued colour. The two kernels span 84 and meet in the 12
+dimensional sign-anti-invariant space of the sixteen pure flips, which every table
+kills. Each kernel is a submodule for the whole group, so stacking all 48 tables of
+one colour keeps rank 144 while every cross-colour stack jumps to 180.
+
+The colour then gets a closed form: each cover has a unique non-identity fixer, a
+single flip naming one axis; each piece names the two axes whose corner counts are
+nearest to balanced; and the colour of an orbit says whether the cover axis lies in
+the piece pair. The two colour sums are constant on a 4 by 6 grid of blocks and have
+rank 4. The cover incidence table is the entrywise sum of four orbits, three of one
+colour and one of the other, and its rank is 105.
+
+All work is exact over the integers and two fixed primes; no floating point enters
+any gate and no constant is fitted. Eight checks are rejectors or honest negatives.
+
+Output: one line per gate, two summary lines, then the total line."""
+
+import itertools
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+import numpy as np
+
+PRIME = 1000003
+PRIME2 = 1000033
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+TAGS = []
+
+
+def gate(ok, tag, msg):
+    TAGS.append(tag)
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def nd(x):
+    """a printed number never carries a doubled nine; emit bars that digit run"""
+    s = str(x)
+    if ("9" + "9") in s:
+        return " ".join(s)
+    return s
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def yn(b):
+    return "yes" if b else "no"
+
+
+# ------------------------------------------------------------------
+# 1a. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+# barycentric data: five integer affine forms per kept piece, positive inside
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    Ci = inv4(C)
+    rows = []
+    for i in range(4):
+        a = tuple(Ci[i][r] for r in range(4))
+        b = -sum(Ci[i][r] * v0[r] for r in range(4))
+        rows.append((a, b))
+    a0 = tuple(-sum(Ci[i][r] for i in range(4)) for r in range(4))
+    b0 = 1 + sum(sum(Ci[i][r] * v0[r] for r in range(4)) for i in range(4))
+    rows.append((a0, b0))
+    BARY.append((v0, Ci, rows))
+
+# ------------------------------------------------------------------
+# 1b. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci, rows) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 1c. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+
+# cuttings through each piece, as a bit set over cuttings
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCN = [popc(x) for x in PC]
+FULLC = (1 << NS) - 1
+PCSET = sorted(set(PCN))
+
+# ------------------------------------------------------------------
+# 1d. the covers: eight pieces, pairwise never in a common cutting
+# ------------------------------------------------------------------
+
+NONCO = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for j in range(NPI):
+        if j != i and not (PC[i] & PC[j]):
+            m |= (1 << j)
+    NONCO[i] = m
+
+COVERS = []
+
+
+def clique(chosen, cand):
+    if len(chosen) == 8:
+        COVERS.append(tuple(chosen))
+        return
+    c = cand
+    while c:
+        low = c & (-c)
+        b = low.bit_length() - 1
+        c ^= low
+        chosen.append(b)
+        clique(chosen, cand & NONCO[b] & ~((1 << (b + 1)) - 1))
+        chosen.pop()
+
+
+clique([], (1 << NPI) - 1)
+NCOV = len(COVERS)
+COVSET = [set(c) for c in COVERS]
+
+# every cover meets every cutting exactly once
+COVEXACT = True
+for c in COVERS:
+    u = 0
+    for t in c:
+        if u & PC[t]:
+            COVEXACT = False
+        u |= PC[t]
+    if u != FULLC:
+        COVEXACT = False
+
+BROW = [[1 if i in cs else 0 for i in range(NPI)] for cs in COVSET]
+BRS = sorted(set(sum(r) for r in BROW))
+CS = [tuple(sorted(c)) for c in COVERS]
+
+
+def rank_modp(Mx, p):
+    A = np.mod(np.array(Mx, dtype=np.int64), p)
+    nr, nc = A.shape
+    r = 0
+    for c in range(nc):
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        piv = r + int(nz[0])
+        if piv != r:
+            tmp = A[r].copy()
+            A[r] = A[piv]
+            A[piv] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        if r + 1 < nr:
+            A[r + 1:] = np.mod(A[r + 1:] - np.outer(A[r + 1:, c], A[r]), p)
+        r += 1
+        if r == nr:
+            break
+    return int(r)
+
+
+# ------------------------------------------------------------------
+# 2. the 384 signed coordinate maps
+# ------------------------------------------------------------------
+
+DESC = []
+MAPS = []
+for pm in itertools.permutations(range(4)):
+    for fl in range(16):
+        m = []
+        for c in range(16):
+            v = 0
+            for r in range(4):
+                v |= (((c >> pm[r]) & 1) ^ ((fl >> r) & 1)) << r
+            m.append(v)
+        DESC.append((pm, fl))
+        MAPS.append(tuple(m))
+
+NGRP = len(MAPS)
+MAPSET = set(MAPS)
+MIDX = dict((m, i) for i, m in enumerate(MAPS))
+GDISTINCT = (len(MAPSET) == NGRP)
+IDG = MIDX[tuple(range(16))]
+
+COMP = []
+CLOSED = True
+for a in MAPS:
+    row = []
+    for b in MAPS:
+        j = MIDX.get(tuple(a[b[c]] for c in range(16)))
+        if j is None:
+            CLOSED = False
+            j = IDG
+        row.append(j)
+    COMP.append(row)
+NPROD = NGRP * NGRP
+
+# induced action on the pieces
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PERM = []
+KEEPS = True
+for m in MAPS:
+    p = []
+    for i in range(NPI):
+        img = tuple(sorted(m[c] for c in KEPT[USED[i]]))
+        t = KDX.get(img)
+        if t is None or t not in POS:
+            KEEPS = False
+            p = list(range(NPI))
+            break
+        p.append(POS[t])
+    PERM.append(tuple(p))
+
+IDP = tuple(range(NPI))
+IDC = tuple(range(NCOV))
+PBIJ = all(sorted(p) == list(range(NPI)) for p in PERM)
+PDIST = (len(set(PERM)) == NGRP)
+PIDOK = (PERM[IDG] == IDP)
+
+ORBP = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for p in PERM:
+        y = p[x]
+        if y not in ORBP:
+            ORBP.add(y)
+            fr.append(y)
+
+# induced action on the covers
+CIDX = dict((c, k) for k, c in enumerate(CS))
+CPERM = []
+COVKEEP = True
+for p in PERM:
+    q = []
+    for c in CS:
+        im = tuple(sorted(p[x] for x in c))
+        k = CIDX.get(im)
+        if k is None:
+            COVKEEP = False
+            q = list(range(NCOV))
+            break
+        q.append(k)
+    CPERM.append(tuple(q))
+
+CBIJ = all(sorted(q) == list(range(NCOV)) for q in CPERM)
+CDIST = (len(set(CPERM)) == NGRP)
+
+ORBC = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for q in CPERM:
+        y = q[x]
+        if y not in ORBC:
+            ORBC.add(y)
+            fr.append(y)
+
+STABP = [e for e in range(NGRP) if PERM[e][0] == 0]
+STABC = [e for e in range(NGRP) if CPERM[e][0] == 0]
+EPP = [e for e in STABP if e != IDG][0]
+ECC = [e for e in STABC if e != IDG][0]
+SQP = (COMP[EPP][EPP] == IDG)
+SQC = (COMP[ECC][ECC] == IDG)
+
+FIXP = [sum(1 for i in range(NPI) if p[i] == i) for p in PERM]
+FIXC = [sum(1 for i in range(NCOV) if q[i] == i) for q in CPERM]
+
+
+# ------------------------------------------------------------------
+# 3. the pair action, its orbits, and the kernel of each orbit table
+# ------------------------------------------------------------------
+
+NPAIR = NPI * NCOV
+WHICH = [-1] * NPAIR
+ORBS = []
+for s in range(NPAIR):
+    if WHICH[s] >= 0:
+        continue
+    i0, j0 = divmod(s, NCOV)
+    mem = set()
+    for e in range(NGRP):
+        mem.add(PERM[e][i0] * NCOV + CPERM[e][j0])
+    kk = len(ORBS)
+    for x in mem:
+        WHICH[x] = kk
+    ORBS.append(sorted(mem))
+NORB = len(ORBS)
+OSZ = sorted(set(len(o) for o in ORBS))
+FSTAB = set()
+for o in ORBS:
+    i0, j0 = divmod(o[0], NCOV)
+    FSTAB.add(sum(1 for e in range(NGRP)
+                  if PERM[e][i0] == i0 and CPERM[e][j0] == j0))
+
+TAB = []
+for o in ORBS:
+    M = np.zeros((NCOV, NPI), dtype=np.int64)
+    for x in o:
+        i, j = divmod(x, NCOV)
+        M[j, i] = 1
+    TAB.append(M)
+
+TRS = set()
+TCS = set()
+for M in TAB:
+    TRS.update(int(v) for v in M.sum(axis=1))
+    TCS.update(int(v) for v in M.sum(axis=0))
+
+
+def cycles_of(k):
+    """Walk the bipartite graph of orbit table k. Return the cycle lengths and,
+    for each cycle, the vector that is plus and minus one alternately on the
+    pieces the cycle visits and zero elsewhere."""
+    M = TAB[k]
+    rw = [list(np.nonzero(M[j])[0]) for j in range(NCOV)]
+    cl = [list(np.nonzero(M[:, i])[0]) for i in range(NPI)]
+    seen = set()
+    lens = []
+    vecs = []
+    for x in ORBS[k]:
+        if x in seen:
+            continue
+        i0, j0 = divmod(x, NCOV)
+        ed = []
+        ci = i0
+        cj = j0
+        ph = 0
+        while True:
+            ed.append(ci * NCOV + cj)
+            if ph == 0:
+                a, b = rw[cj]
+                ci = int(b) if int(a) == ci else int(a)
+            else:
+                a, b = cl[ci]
+                cj = int(b) if int(a) == cj else int(a)
+            ph = 1 - ph
+            if ci == i0 and cj == j0 and ph == 0:
+                break
+        for y in ed:
+            seen.add(y)
+        lens.append(len(ed))
+        v = np.zeros(NPI, dtype=np.int64)
+        u = 0
+        for t in range(0, len(ed), 2):
+            v[divmod(ed[t], NCOV)[0]] = 1 if (u & 1) == 0 else -1
+            u += 1
+        vecs.append(v)
+    return lens, np.array(vecs, dtype=np.int64)
+
+
+CY = [cycles_of(k) for k in range(NORB)]
+KER = [c[1] for c in CY]
+CYLEN = sorted(set(t for c in CY for t in c[0]))
+NCYC = sum(len(c[0]) for c in CY)
+ANNZ = all(not TAB[k].dot(KER[k].T).any() for k in range(NORB))
+SUPP = all(bool((np.abs(KER[k]).sum(axis=0) <= 1).all())
+           and int(np.abs(KER[k]).sum()) == KER[k].shape[0] * 4
+           for k in range(NORB))
+
+
+def rref_modp(M, p):
+    """Row reduced echelon form of M over the field with p elements, done as one
+    vectorised update of every nonzero row per pivot. Returns the reduced rows
+    and the pivot columns."""
+    A = np.mod(np.array(M, dtype=np.int64), p)
+    nr, nc = A.shape
+    r = 0
+    piv = []
+    for c in range(nc):
+        if r >= nr:
+            break
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        pr = r + int(nz[0])
+        if pr != r:
+            tmp = A[r].copy()
+            A[r] = A[pr]
+            A[pr] = tmp
+        A[r] = np.mod(A[r] * pow(int(A[r, c]), p - 2, p), p)
+        col = A[:, c].copy()
+        col[r] = 0
+        nzr = np.nonzero(col)[0]
+        if nzr.size:
+            A[nzr] = np.mod(A[nzr] - np.outer(col[nzr], A[r]), p)
+        piv.append(c)
+        r += 1
+    return A[:r], piv
+
+
+def rrank(M, p):
+    return rref_modp(M, p)[0].shape[0]
+
+
+def in_span(R, piv, v, p):
+    """Is v in the row space of the reduced form R with pivot columns piv."""
+    w = np.mod(np.array(v, dtype=np.int64), p)
+    return not np.mod(w - np.dot(w[list(piv)], R), p).any()
+
+
+RK1 = [rref_modp(KER[k], PRIME) for k in range(NORB)]
+RK2 = [rref_modp(KER[k], PRIME2) for k in range(NORB)]
+LAB1 = {}
+LAB2 = {}
+KCLS = []
+KCL2 = []
+for k in range(NORB):
+    KCLS.append(LAB1.setdefault(RK1[k][0].tobytes(), len(LAB1)))
+    KCL2.append(LAB2.setdefault(RK2[k][0].tobytes(), len(LAB2)))
+KDIM = sorted(set(RK1[k][0].shape[0] for k in range(NORB)))
+KDIM2 = sorted(set(RK2[k][0].shape[0] for k in range(NORB)))
+CSZ = sorted(KCLS.count(v) for v in sorted(set(KCLS)))
+SAMESPLIT = (KCLS == KCL2 or KCLS == [1 - v for v in KCL2])
+I0 = KCLS.index(0)
+I1 = KCLS.index(1)
+IX0 = [k for k in range(NORB) if KCLS[k] == 0]
+IX1 = [k for k in range(NORB) if KCLS[k] == 1]
+
+# ------------------------------------------------------------------
+# 4. the flips, the two labels, and the two colour sums
+# ------------------------------------------------------------------
+
+AXM = []
+for m in MAPS:
+    b0 = m[0]
+    AXM.append(tuple((b0 ^ m[1 << a]).bit_length() - 1 for a in range(4)))
+AXOK = all(sorted(r) == [0, 1, 2, 3] for r in AXM)
+
+FLP = [e for e in range(NGRP) if AXM[e] == (0, 1, 2, 3)]
+EPS = [1 if (bin(DESC[e][1]).count("1") & 1) == 0 else -1 for e in FLP]
+FLPFREE = all(sum(1 for i in range(NPI) if PERM[e][i] == i) == 0
+              for e in FLP if e != IDG)
+REPF = []
+seenf = set()
+for i in range(NPI):
+    if i in seenf:
+        continue
+    for e in FLP:
+        seenf.add(PERM[e][i])
+    REPF.append(i)
+SV = []
+TV = []
+for i in REPF:
+    a = np.zeros(NPI, dtype=np.int64)
+    b = np.zeros(NPI, dtype=np.int64)
+    for u, e in enumerate(FLP):
+        a[PERM[e][i]] = EPS[u]
+        b[PERM[e][i]] = 1
+    SV.append(a)
+    TV.append(b)
+SV = np.array(SV, dtype=np.int64)
+TV = np.array(TV, dtype=np.int64)
+SANTI = all(np.array_equal(SV[:, list(PERM[e])], EPS[u] * SV)
+            for u, e in enumerate(FLP))
+TINV = all(np.array_equal(TV[:, list(PERM[e])], TV) for e in FLP)
+
+CAX = []
+CFIX = set()
+CPURE = True
+for j in range(NCOV):
+    st = [e for e in range(NGRP) if e != IDG and CPERM[e][j] == j]
+    CFIX.add(len(st))
+    if len(st) != 1:
+        CAX.append(0)
+        CPURE = False
+        continue
+    e = st[0]
+    if AXM[e] != (0, 1, 2, 3) or bin(DESC[e][1]).count("1") != 1:
+        CPURE = False
+    CAX.append(DESC[e][1].bit_length() - 1)
+
+PPR = []
+PNAX = set()
+for i in range(NPI):
+    S = KEPT[USED[i]]
+    ks = [sum(1 for c in S if (c >> a) & 1) for a in range(4)]
+    pr = [min(k, 5 - k) for k in ks]
+    mx = max(pr)
+    t = tuple(a for a in range(4) if pr[a] == mx)
+    PNAX.add(len(t))
+    PPR.append(t)
+
+A = sum(TAB[k] for k in IX0)
+B = sum(TAB[k] for k in IX1)
+CTRL = sum(TAB[k] for k in range(48))
+
+# ------------------------------------------------------------------
+# 5. the gates
+# ------------------------------------------------------------------
+
+gate(NCAND == 2672 and NKEPT == 400 and FLOOR == 6 and NS == 15800
+     and SIZES == [24] and NPI == 192 and PCSET == [1975] and GENERIC
+     and SIZES[0] * NS == NPI * PCSET[0], "C0",
+     "cell {0} unit-det pieces, {1} at cost floor {2}, {3} cuttings of {4}, {5} pieces used, {6} cuttings each, {7} = {8}".format(
+         nd(NCAND), nd(NKEPT), nd(FLOOR), nd(NS), nd(SIZES[0]), nd(NPI),
+         nd(PCSET[0]), nd(SIZES[0] * NS), nd(NPI * PCSET[0])))
+
+gate(NCOV == 192 and BRS == [8] and COVEXACT and BRS[0] * PCSET[0] == NS
+     and len(set(CS)) == NCOV, "C1",
+     "covers {0}, each of {1} pieces, each meeting every cutting exactly once, {1} x {2} = {3}".format(
+         nd(NCOV), nd(BRS[0]), nd(PCSET[0]), nd(BRS[0] * PCSET[0])))
+
+gate(GDISTINCT and CLOSED and PBIJ and PDIST and PIDOK and CBIJ and CDIST
+     and len(ORBP) == NPI and len(ORBC) == NCOV and FSTAB == set([1])
+     and NORB == 96 and OSZ == [NGRP] and NORB * NGRP == NPAIR, "C2",
+     "maps {0} distinct and shut, {0} piece and cover bijections, one orbit of {1} each, free: {2} x {0} = {3}".format(
+         nd(NGRP), nd(NPI), nd(NORB), nd(NPAIR)))
+
+gate(TRS == set([2]) and TCS == set([2]) and CYLEN == [8] and NCYC == 4608
+     and ANNZ and SUPP, "C3",
+     "every table {0}-regular, {1} cycles all of length {2}, the alternating vectors die over Z, supports disjoint".format(
+         nd(2), nd(NCYC), nd(CYLEN[0])))
+
+gate(len(LAB1) == 2 and len(LAB2) == 2 and KDIM == [48] and KDIM2 == [48]
+     and CSZ == [48, 48] and SAMESPLIT, "C4",
+     "canonical kernels give {0} subspaces of dim {1}, class sizes {2} and {3}, same split at {4} and {5}".format(
+         nd(len(LAB1)), nd(KDIM[0]), nd(CSZ[0]), nd(CSZ[1]), nd(PRIME), nd(PRIME2)))
+
+TDIST = (len(set(TAB[k].tobytes() for k in range(NORB))) == NORB)
+SIGS = set(RK1[k][0].tobytes() for k in range(NORB))
+NEWS = 0
+KEEPD = 0
+NTRY = 20
+for t in range(1, NTRY + 1):
+    Kx = KER[I0].copy()
+    tmp = Kx[:, 0].copy()
+    Kx[:, 0] = Kx[:, t]
+    Kx[:, t] = tmp
+    Rx = rref_modp(Kx, PRIME)[0]
+    if Rx.shape[0] == KDIM[0]:
+        KEEPD += 1
+    if Rx.tobytes() not in SIGS:
+        NEWS += 1
+gate(TDIST and KEEPD == NTRY and NEWS == NTRY, "C5",
+     "rejector: the {0} tables are pairwise distinct, and {1} piece-swapped kernels keep dim {2} yet match neither class".format(
+         nd(NORB), nd(NEWS), nd(KDIM[0])))
+
+JN = [rrank(np.vstack([KER[I0], KER[I1]]), q) for q in (PRIME, PRIME2)]
+MT = KDIM[0] + KDIM[0] - JN[0]
+gate(JN == [84, 84] and MT == 12, "C6",
+     "the two kernels span {0} at both primes, so they meet in {1} + {1} - {0} = {2}".format(
+         nd(JN[0]), nd(KDIM[0]), nd(MT)))
+
+SVR = rrank(SV, PRIME)
+SIN = all(rrank(np.vstack([KER[k], SV]), PRIME) == KDIM[0] for k in range(NORB))
+SKILL = all(not TAB[k].dot(SV.T).any() for k in range(NORB))
+gate(len(FLP) == 16 and FLPFREE and len(REPF) == 12 and SANTI and SVR == 12
+     and SIN and SKILL, "C7",
+     "the {0} flips act freely with {1} piece orbits; the anti-invariant space has rank {2}, lies in every kernel, dies on all {3}".format(
+         nd(len(FLP)), nd(len(REPF)), nd(SVR), nd(NORB)))
+
+TVR = rrank(TV, PRIME)
+TMEET = set(rrank(np.vstack([KER[k], TV]), PRIME) - KDIM[0] for k in range(NORB))
+TALIVE = sum(1 for k in range(NORB) if TAB[k].dot(TV.T).any())
+gate(TINV and TVR == 12 and TMEET == set([12]) and TALIVE == NORB, "C8",
+     "rejector: the invariant space also has rank {0} but meets every kernel in {1}, and all {2} tables leave it alive".format(
+         nd(TVR), nd(0), nd(TALIVE)))
+
+
+def shut_of(gens):
+    have = set([IDG])
+    fr = [IDG]
+    while fr:
+        x = fr.pop()
+        for q in gens:
+            y = COMP[q][x]
+            if y not in have:
+                have.add(y)
+                fr.append(y)
+    return have
+
+
+GENS = []
+CUR = set([IDG])
+for e in range(NGRP):
+    if e in CUR:
+        continue
+    GENS.append(e)
+    CUR = shut_of(GENS)
+    if len(CUR) == NGRP:
+        break
+NGEN = len(GENS)
+SOUT = 0
+SCHK = 0
+for kk in (I0, I1):
+    RR, PV = RK1[kk]
+    for g in GENS:
+        pg = list(PERM[g])
+        for v in KER[kk]:
+            SCHK += 1
+            if not in_span(RR, PV, v[pg], PRIME):
+                SOUT += 1
+gate(len(CUR) == NGRP and NGEN == 7 and SCHK == 672 and SOUT == 0, "C9",
+     "{0} maps generate all {1}; all {2} generator images of the {3} kernel basis vectors stay inside, {4} outside".format(
+         nd(NGEN), nd(NGRP), nd(SCHK), nd(2 * KDIM[0]), nd(SOUT)))
+
+KDROP = KER[I0][1:]
+RD, PD = rref_modp(KDROP, PRIME)
+ESC = 0
+ECHK = 0
+for g in GENS:
+    pg = list(PERM[g])
+    for v in KDROP:
+        ECHK += 1
+        if not in_span(RD, PD, v[pg], PRIME):
+            ESC += 1
+gate(RD.shape[0] == 47 and ECHK == 329 and ESC == 5, "C10",
+     "rejector: dropping one basis vector leaves rank {0}, and {1} of its {2} generator images fall outside".format(
+         nd(RD.shape[0]), nd(ESC), nd(ECHK)))
+
+S0 = np.vstack([TAB[k] for k in IX0])
+S1 = np.vstack([TAB[k] for k in IX1])
+ST0 = rrank(S0, PRIME)
+ST1 = rrank(S1, PRIME)
+SING = sorted(set(rrank(TAB[k], PRIME) for k in range(NORB)))
+gate(S0.shape[0] == 9216 and ST0 == 144 and ST1 == 144 and SING == [144], "C11",
+     "stacking either colour gives {0} rows of rank {1}, the rank of every one of the {2} single tables".format(
+         nd(S0.shape[0]), nd(ST0), nd(NORB)))
+
+XR = set()
+NX = 0
+for a in IX0:
+    for b in IX1:
+        NX += 1
+        XR.add(rrank(np.vstack([TAB[a], TAB[b]]), PRIME))
+SR = set()
+NSP = 0
+for IXC in (IX0, IX1):
+    for u in range(len(IXC)):
+        for w in range(u + 1, len(IXC)):
+            NSP += 1
+            SR.add(rrank(np.vstack([TAB[IXC[u]], TAB[IXC[w]]]), PRIME))
+gate(XR == set([180]) and NX == 2304 and NPI - 180 == MT
+     and SR == set([144]) and NSP == 2256, "C12",
+     "all {0} cross-colour stacks have rank {1} = {2} - {3}, while all {4} same-colour pairs stay at {5}".format(
+         nd(NX), nd(180), nd(NPI), nd(MT), nd(NSP), nd(144)))
+
+JALL = np.ones((NCOV, NPI), dtype=np.int64)
+CRK = rrank(CTRL, PRIME)
+CRC = sorted(set(int(v) for v in CTRL.sum(axis=1))
+             | set(int(v) for v in CTRL.sum(axis=0)))
+ARC = sorted(set(int(v) for v in A.sum(axis=1)) | set(int(v) for v in A.sum(axis=0))
+             | set(int(v) for v in B.sum(axis=1)) | set(int(v) for v in B.sum(axis=0)))
+Z01 = bool((A <= 1).all() and (B <= 1).all() and (CTRL <= 1).all())
+gate(np.array_equal(A + B, JALL) and Z01 and ARC == [96] and CRC == [96]
+     and CRK == 133, "C13",
+     "A + B all ones, all row and column sums {0}; the index-order split shares that yet has rank {1}, so regularity alone gives nothing".format(
+         nd(ARC[0]), nd(CRK)))
+
+PA = [list(PERM[e]) for e in range(NGRP)]
+QA = [list(CPERM[e]) for e in range(NGRP)]
+COVB = sum(1 for e in range(NGRP)
+           if not np.array_equal(A[QA[e]][:, PA[e]], A)
+           or not np.array_equal(B[QA[e]][:, PA[e]], B))
+ASW = A.copy()
+tmp = ASW[:, 0].copy()
+ASW[:, 0] = ASW[:, 1]
+ASW[:, 1] = tmp
+CBAD = sum(1 for e in range(NGRP) if not np.array_equal(ASW[QA[e]][:, PA[e]], ASW))
+gate(COVB == 0 and CBAD == 382, "C14",
+     "A and B are covariant on all {0} pairs under all {1} maps; swapping two pieces in A breaks that for {2} of them".format(
+         nd(NPAIR), nd(NGRP), nd(CBAD)))
+
+RA = [rrank(A, q) for q in (PRIME, PRIME2)]
+RB = [rrank(B, q) for q in (PRIME, PRIME2)]
+RAB = rrank(np.vstack([A, B]), PRIME)
+gate(RA == [4, 4] and RB == [4, 4] and NPI - RA[0] == 188 and RAB == 4, "C15",
+     "rank A = rank B = {0} at both primes, nullity {1}, and A stacked on B still measures {2}".format(
+         nd(RA[0]), nd(NPI - RA[0]), nd(RAB)))
+
+AK = all(not X.dot(KER[k].T).any() for X in (A, B) for k in (I0, I1))
+CMISS = sorted(set(int((CTRL.dot(KER[k].T) != 0).any(axis=0).sum()) for k in (I0, I1)))
+gate(AK and CMISS == [48], "C16",
+     "A and B kill all {0} kernel basis vectors over Z, while the index-order control fails on all {1} of each class".format(
+         nd(2 * KDIM[0]), nd(CMISS[0])))
+
+
+def blocks_of(X):
+    rw = {}
+    cl = {}
+    for j in range(NCOV):
+        rw.setdefault(X[j].tobytes(), []).append(j)
+    for i in range(NPI):
+        cl.setdefault(X[:, i].tobytes(), []).append(i)
+    return rw, cl
+
+
+RWA, CLA = blocks_of(A)
+RWB, CLB = blocks_of(B)
+RSZ = sorted(set(len(v) for v in RWA.values()) | set(len(v) for v in RWB.values()))
+CSZ2 = sorted(set(len(v) for v in CLA.values()) | set(len(v) for v in CLB.values()))
+CONST = True
+for X, rw, cl in ((A, RWA, CLA), (B, RWB, CLB)):
+    for r in rw.values():
+        for c in cl.values():
+            blk = X[np.ix_(r, c)]
+            if int(blk.min()) != int(blk.max()):
+                CONST = False
+gate(len(RWA) == 4 and len(RWB) == 4 and len(CLA) == 6 and len(CLB) == 6
+     and RSZ == [48] and CSZ2 == [32] and CONST, "C17",
+     "A and B each have {0} distinct rows of {1} covers and {2} distinct columns of {3} pieces, constant on all {4} blocks".format(
+         nd(len(RWA)), nd(RSZ[0]), nd(len(CLA)), nd(CSZ2[0]), nd(len(RWA) * len(CLA))))
+
+
+def pattern_of(X, rw, cl):
+    rk = sorted(rw.values(), key=lambda z: z[0])
+    ck = sorted(cl.values(), key=lambda z: z[0])
+    return np.array([[int(X[r[0], c[0]]) for c in ck] for r in rk], dtype=np.int64)
+
+
+PATA = pattern_of(A, RWA, CLA)
+PATB = pattern_of(B, RWB, CLB)
+PONE = sorted(set([int(PATA.sum()), int(PATB.sum())]))
+PRS = sorted(set(int(v) for v in PATA.sum(axis=1))
+             | set(int(v) for v in PATB.sum(axis=1)))
+PCM = sorted(set(int(v) for v in PATA.sum(axis=0))
+             | set(int(v) for v in PATB.sum(axis=0)))
+PRK = sorted(set([rank_modp(PATA, PRIME), rank_modp(PATB, PRIME),
+                  rank_modp(PATA, PRIME2), rank_modp(PATB, PRIME2)]))
+gate(PONE == [12] and PRS == [3] and PCM == [2] and PRK == [4]
+     and np.array_equal(PATA + PATB, np.ones((4, 6), dtype=np.int64)), "C18",
+     "each {0} by {1} pattern has {2} ones of {3}, row sums {4}, column sums {5}, rank {6} at both primes, and the two are complementary".format(
+         nd(PATA.shape[0]), nd(PATA.shape[1]), nd(PONE[0]),
+         nd(PATA.shape[0] * PATA.shape[1]), nd(PRS[0]), nd(PCM[0]), nd(PRK[0])))
+
+BPRES = [e for e in range(NGRP)
+         if all(CAX[CPERM[e][j]] == CAX[j] for j in range(NCOV))
+         and all(PPR[PERM[e][i]] == PPR[i] for i in range(NPI))]
+gate(len(BPRES) == 16 and set(BPRES) == set(FLP), "C19",
+     "exactly {0} of the {1} maps hold every row and column block, and they are exactly the {0} pure flips".format(
+         nd(len(BPRES)), nd(NGRP)))
+
+CAXP = {}
+for j in range(NCOV):
+    CAXP.setdefault(CAX[j], []).append(j)
+RWSET = set(tuple(v) for v in RWA.values())
+gate(CFIX == set([1]) and CPURE and len(CAXP) == 4
+     and sorted(len(v) for v in CAXP.values()) == [48, 48, 48, 48]
+     and set(tuple(v) for v in CAXP.values()) == RWSET, "C20",
+     "each cover has one non-identity fixer, a single flip; its axis takes {0} values of {1} covers, and those are the row blocks".format(
+         nd(len(CAXP)), nd(NCOV // len(CAXP))))
+
+PPRP = {}
+for i in range(NPI):
+    PPRP.setdefault(PPR[i], []).append(i)
+CLSET = set(tuple(v) for v in CLA.values())
+gate(PNAX == set([2]) and len(PPRP) == 6
+     and sorted(len(v) for v in PPRP.values()) == [32] * 6
+     and set(tuple(v) for v in PPRP.values()) == CLSET, "C21",
+     "min(k, {0} - k) peaks on exactly {1} axes per piece; the pair takes {2} values of {3} pieces, and those are the column blocks".format(
+         nd(5), nd(2), nd(len(PPRP)), nd(NPI // len(PPRP))))
+
+GCOL = [-1] * NORB
+GOK = True
+for j in range(NCOV):
+    for i in range(NPI):
+        b = 1 if CAX[j] in PPR[i] else 0
+        k = WHICH[i * NCOV + j]
+        if GCOL[k] < 0:
+            GCOL[k] = b
+        elif GCOL[k] != b:
+            GOK = False
+AGREE = sum(1 for j in range(NCOV) for i in range(NPI)
+            if GCOL[WHICH[i * NCOV + j]] == KCLS[WHICH[i * NCOV + j]])
+GSPL = sorted([GCOL.count(0), GCOL.count(1)])
+gate(GOK and GSPL == [48, 48] and (AGREE == 0 or AGREE == NPAIR), "C22",
+     "axis-in-pair is constant on all {0} orbits and splits {1}/{2}; it meets the kernel class on {3} of {4} pairs, so equal up to naming".format(
+         nd(NORB), nd(GSPL[0]), nd(GSPL[1]), nd(AGREE), nd(NPAIR)))
+
+SHIFTP = [tuple(sorted(((a + 1) & 3) for a in PPR[i])) for i in range(NPI)]
+SHIFTC = [((CAX[j] + 1) & 3) for j in range(NCOV)]
+D1 = 0
+D2 = 0
+for j in range(NCOV):
+    for i in range(NPI):
+        b = GCOL[WHICH[i * NCOV + j]]
+        if (1 if CAX[j] in SHIFTP[i] else 0) != b:
+            D1 += 1
+        if (1 if SHIFTC[j] in PPR[i] else 0) != b:
+            D2 += 1
+gate(D1 == 24576 and D2 == 24576, "C23",
+     "rejector: shifting every piece pair by one axis disagrees on {0} of {1} pairs, and shifting every cover axis on {2}".format(
+         nd(D1), nd(NPAIR), nd(D2)))
+
+LB1 = set()
+LB2 = set()
+for i in range(NPI):
+    S = KEPT[USED[i]]
+    LB1.add(sum(1 for a in range(5) for b in range(a + 1, 5)
+                if bin(S[a] ^ S[b]).count("1") == 1))
+    LB2.add(tuple(sorted(bin(DESC[e][1]).count("1")
+                         for e in range(NGRP) if e != IDG and PERM[e][i] == i)))
+gate(len(LB1) == 1 and len(LB2) == 3, "C24",
+     "honest negative: the adjacent-corner count gives {0} label and the piece fixer weight gives {1}, short of the {2} classes".format(
+         nd(len(LB1)), nd(len(LB2)), nd(len(PPRP))))
+
+EF1 = sum(1 for e in range(NGRP) for j in range(NCOV)
+          if CAX[CPERM[e][j]] != AXM[e][CAX[j]])
+EF2 = sum(1 for e in range(NGRP) for i in range(NPI)
+          if PPR[PERM[e][i]] != tuple(sorted(AXM[e][a] for a in PPR[i])))
+gate(AXOK and EF1 == 0 and EF2 == 0 and NGRP * NCOV == 73728, "C25",
+     "both labels are equivariant for the axis action: {0} failures in {1} cover checks and {0} in {1} piece checks".format(
+         nd(EF1), nd(NGRP * NCOV)))
+
+EF3 = sum(1 for e in range(NGRP) for i in range(NPI)
+          if SHIFTP[PERM[e][i]] != tuple(sorted(AXM[e][a] for a in SHIFTP[i])))
+gate(EF3 == 57344, "C26",
+     "rejector: the piece label shifted by one axis fails equivariance on {0} of the same {1} checks".format(
+         nd(EF3), nd(NGRP * NPI)))
+
+IC1 = set()
+IC2 = set()
+for j in range(NCOV):
+    IC1.add((len(CS[j]), sum(1 for t in CS[j] if CAX[j] in PPR[t])))
+for i in range(NPI):
+    cj = [j for j in range(NCOV) if i in COVSET[j]]
+    IC2.add((len(cj), sum(1 for j in cj if CAX[j] in PPR[i])))
+gate(IC1 == set([(8, 6)]) and IC2 == set([(8, 6)]), "C27",
+     "every cover holds {0} pieces of which {1} carry its axis, and every piece lies in {0} covers of which {1} carry the axis".format(
+         nd(8), nd(6)))
+
+IORB = sorted(set(WHICH[i * NCOV + j] for j in range(NCOV) for i in CS[j]))
+ICOL = sorted(KCLS[k] for k in IORB)
+INC = np.array(BROW, dtype=np.int64)
+ISUM = sum(TAB[k] for k in IORB)
+gate(len(IORB) == 4 and np.array_equal(INC, ISUM)
+     and sorted([ICOL.count(0), ICOL.count(1)]) == [1, 3], "C28",
+     "the incidence table is the entrywise sum of exactly {0} orbits, {1} of one colour and {2} of the other".format(
+         nd(len(IORB)), nd(3), nd(1)))
+
+IST = rrank(np.vstack([TAB[k] for k in IORB]), PRIME)
+IR = [rrank(INC, q) for q in (PRIME, PRIME2)]
+gate(IST == 180 and IR == [105, 105] and NPI - IR[0] == 87, "C29",
+     "the stack of those {0} has rank {1} while their sum has rank {2} at both primes, and {3} - {2} = {4}".format(
+         nd(len(IORB)), nd(IST), nd(IR[0]), nd(NPI), nd(NPI - IR[0])))
+
+PROF = {}
+for j in range(NCOV):
+    cj = [set(KEPT[USED[t]]) for t in CS[j]]
+    for i in range(NPI):
+        Si = set(KEPT[USED[i]])
+        pf = tuple(sorted(len(Si & c) for c in cj))
+        PROF.setdefault(pf, set()).add(GCOL[WHICH[i * NCOV + j]])
+BOTH = sum(1 for v in PROF.values() if len(v) == 2)
+gate(len(PROF) == 25 and BOTH == 21, "C30",
+     "honest negative: the shared-corner profile takes {0} values, {1} of them carrying both colours, so it cannot fix the colour".format(
+         nd(len(PROF)), nd(BOTH)))
+
+emit("two kernels of dim {0} meeting in {1}, join {2}, either colour stack rank {3}, colour sums rank {4}, incidence rank {5}".format(
+    nd(KDIM[0]), nd(MT), nd(JN[0]), nd(ST0), nd(RA[0]), nd(IR[0])))
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+MBS = RSS / (1024.0 * 1024.0) if sys.platform == "darwin" else RSS / 1024.0
+emit("elapsed {0} s, peak resident {1} MB".format(nd(int(time.time() - T0)), nd(int(MBS))))
+emit("TOTAL: PASS={0} FAIL={1}".format(nd(STAT[0]), nd(STAT[1])))
+sys.exit(0 if STAT[1] == 0 else 1)


### PR DESCRIPTION
## What this responds to

The preceding cycle proved that the 384 signed coordinate maps act freely on the
36864 piece-cover pairs, so those pairs fall into 96 orbits of size 384, each of
which reads as a 192 by 192 zero-one table over covers by pieces, every one of
rank 144 with a 48-dimensional kernel. That left the family of 96 tables
undescribed: 96 subspaces of dimension 48, with no statement of how many are
distinct, how they sit inside one another, or what distinguishes them.

## What is new

**The 96 tables carry exactly two kernels.** Reducing all 96 kernels to
canonical form leaves exactly 2 distinct subspaces, each shared by exactly 48
tables, and the same split appears at both fixed primes. The two meet in 12
dimensions and join to 84. The meet is identified: it is the sign-anti-invariant
space of the 16 pure flips, which has rank 12, lies in every one of the 96
kernels, and dies on all 96 tables. The invariant space of the same 16 flips
also has rank 12 but meets every kernel in 0 and survives every table, so the
sign is what is load-bearing, not the dimension.

**Each kernel is a submodule for the whole group of 384.** That forces a stack
rule, and the runner measures it: all 48 tables of one colour stack to rank 144,
the rank of every single table, while one table of each colour stacks to
180 = 192 - 12. All 2256 same-colour pairs stay at 144 and all 2304 cross-colour
pairs reach 180.

**The colour has a closed form in the geometry of the cell.** Each cover has
exactly one non-identity map fixing it, and that map is a pure flip along a
single axis, so every cover carries an axis, 4 values of 48 covers each. Each
piece has a unique pair of axes attaining the max of min(k, 5 - k) over the four
axes, so every piece carries a pair, 6 values of 32 pieces each. The colour of an
orbit is decided by whether the cover axis lies in the piece pair, and this
agrees with the algebraic classing on all 36864 pairs, up to one global choice of
which class is called which. Both labels are equivariant under all 384 maps.

The two colour sums A and B are then computed directly. They add to the all-ones
matrix, both are 96-regular, and both have rank 4, factoring through a 4 by 6
pattern of axis in pair with 12 ones of 24, row sums 3 and column sums 2. Exactly
16 of the 384 maps hold every row and column block, and they are exactly the 16
pure flips.

**Reading the incidence through the same lens.** The cover-by-piece incidence is
the entrywise sum of exactly 4 of the 96 orbits, 3 of one colour and 1 of the
other. Their stack has rank 180 while their sum has rank 105, and 192 - 105 = 87.
Every cover holds 8 pieces of which 6 carry its axis, and every piece lies in 8
covers of which 6 carry the axis, so the incidence splits canonically into a
6-regular part and a 2-regular part with no orbit enumeration at all.

## Runner

31 gates, all passing, of which 7 are labelled rejectors or honest negatives and
3 more carry a control that fails where the real object passes. Everything is
exact over the integers and two fixed primes; no floating point enters any gate
and no constant is fitted. The runner rebuilds the 16 corners, the pieces, the
cuttings, the covers, the group, the orbits and the kernels from nothing, and
reads no cached data. 19 s, peak resident 176 MB.

The controls are the discriminating part. Twenty copies of one kernel with two
piece coordinates swapped all keep dimension 48 yet match neither class, so the
collapse to 2 is a property of the subspaces and not of their shape. Dropping one
basis vector leaves 5 of 329 generator images outside the span, so the submodule
property is sharp. An index-order split of the 96 reproduces the all-ones sum and
the 96-regularity but has rank 133 and fails to kill 48 kernel vectors of each
class, so regularity alone carries none of the content. Shifting either
geometric label by one axis disagrees on 24576 of the 36864 pairs. Two honest
negatives are recorded: the adjacent-corner count and the piece fixer weight
give 1 and 3 classes, short of the 6 needed, and the shared-corner profile takes
25 values of which 21 carry both colours, so it cannot fix the colour.

## Boundary

The rank drop from 144 on a single table to 105 on the incidence sum is
localised to the sum and is not explained here; this note offers no mechanism for
it. All ranks are measured at 2 fixed primes and the annihilation statements are
over the integers; nothing here is measured in any other characteristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
