### PR TITLE
feat(cell-cutting): sign-pattern blocks split every rank (cycle 773)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_SIGN_PATTERN_BLOCKS_CYCLE773_NOTE_2026-08-11.md
+++ b/docs/PHYSICAL_CELL_CUTTING_SIGN_PATTERN_BLOCKS_CYCLE773_NOTE_2026-08-11.md
@@ -1,0 +1,160 @@
+# Physical cell cutting: the sign-pattern blocks split every rank, and locate the 39 (cycle 773)
+
+Date: 2026-08-11
+Authority: none
+Audit: unset.
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## 1. What is measured
+
+The object is the cell cutting family of the unit four-cube: its 16 corners, the 2672
+five-corner subsets of unit determinant, the 400 of those at the adjacency cost floor 6,
+the 15800 cuttings of the cell by 24 such pieces, the 192 pieces that actually occur (each
+in 1975 cuttings, so 379200 piece slots counted either way), and the 192 covers of 8
+pieces each that meet every cutting exactly once. The paired runner
+[scripts/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.py](../scripts/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.py)
+builds every one of those objects in-run from the corners upward; it reads no cached data
+and no input file, works exactly over the integers and two fixed primes, and prints one
+line per gate. Every one of those gate lines passes; 3 of them are labelled rejectors and
+3 are labelled honest negatives. The honest negatives carry the sharpest content in this
+note and are stated in section 8, not softened away.
+
+## 2. Sixteen blocks of dimension twelve
+
+The 384 signed coordinate maps act freely on the 36864 pairs made of one piece and one
+cover, giving 96 orbits of 384, and each orbit read as a zero-one table over covers by
+pieces is one of the 96 tables below. Inside that group sit the 16 pure flips, one per
+subset of the 4 axes. They form a subgroup, they act freely on the 192 pieces, and they
+leave 12 orbits of 16 pieces each.
+
+Every sign pattern of the 4 axes is a subset s, and its character sends the flip f to plus
+one when s and f overlap evenly and to minus one when they overlap oddly. Fix one piece per
+flip orbit; the vector carrying the character value of s at f on the image of that piece
+under f, and nothing elsewhere, is one basis vector, so the block of s has dimension 12.
+Then 16 times 12 is 192, the whole piece count, and the 16 blocks together stack to rank
+192, so they fill the piece coordinates rather than merely fitting inside them. The block
+of the empty pattern is the flip-invariant space and the block of the all-axes pattern is
+the space where every flip acts by its sign.
+
+The identity this cycle runs on: when the kernel of a matrix over the pieces is held by the
+16 flips, the rank of that matrix is the sum of its 16 per-block ranks. That recomposition
+is the discriminating statistic. Constancy of the per-block rank inside each weight class
+is not, and the runner shows it is not: the rejector builds a 48-row coordinate slice, four
+pieces from each of the 12 flip orbits, whose per-block rank is 12 in every one of the 16
+blocks and so is perfectly constant by weight, yet it recomposes to 192 while its actual
+rank is 48. A second rejector swaps two pieces of the cover incidence: the rank is
+unchanged at 105, but the hold of 15 of the 16 flips is broken and the recomposition
+returns 121 instead.
+
+## 3. The single-table nullity without linear algebra
+
+Each of the 96 orbit tables is 2-regular in rows and in columns, so it falls into 48 cycles
+of length 8, each visiting 4 pieces, and the vector alternating plus and minus one over
+those 4 pieces is annihilated by the table. The 16 flips permute the 48 cycles of a table
+with 12 classes of 4.
+
+Each cycle is held by exactly 4 flips, and those 4 are precisely the flips supported on one
+axis pair: the identity, the two single-axis flips of that pair, and their product. They
+act simply transitively on the 4 pieces the cycle visits, which is why the holder is a
+group of order 4 and not larger. That axis pair labelling is equivariant: pushing a cycle
+by any of the 384 maps carries its pair to the image pair, with 0 of 18432 checks failing.
+Since the maps reach all 6 axis pairs from any one of them, the 12 classes must be spread
+evenly over the 6 pairs, so each pair carries exactly 12 divided by 6, that is 2 classes.
+That count is forced by the transitivity before any table is looked at; the runner then
+confirms that every measured fibre is 2, on all 96 tables.
+
+A cycle survives into the block of s exactly when its axis pair sits inside s, so a pattern
+of weight w receives 2 times the number of pairs inside it, that is w(w-1) kernel
+dimensions. By weight class that is [0, 0, 2, 6, 12], which weights to 0 + 0 + 12 + 24 + 12
+= 48, the full nullity of the table, and leaves per-block ranks 12 - w(w-1) = [12, 12, 10,
+6, 0] recomposing to 144. Nothing in that derivation reduces a matrix. The rule really is
+"pair inside the pattern" and not "pair meets the pattern": the third rejector uses the
+weaker rule, which would give [0, 6, 10, 12, 12] and a nullity of 144, and misses the
+measured 48 on every table.
+
+## 4. Three kernels, three profiles
+
+The cover incidence, written M, has kernel 87. Its per-block kernel dimensions are
+[3, 3, 6, 6, 12] by pattern weight, constant inside each weight class, and its per-block
+ranks are [9, 9, 6, 6, 0] recomposing to its rank 105; both readings agree at both primes.
+
+Split M by the two labels the object already carries, the axis kept by a cover and the
+axis pair of a piece. The part where the piece carries the axis of its cover, written U,
+has kernel 78, per-block dimensions [2, 2, 4, 8, 12] and per-block ranks [10, 10, 8, 4, 0]
+recomposing to 114. The remaining part, written V, has kernel 48, per-block dimensions
+[0, 0, 2, 6, 12] and per-block ranks [12, 12, 10, 6, 0] recomposing to 144; V is a single
+orbit table, so its profile is exactly the single-table profile of section 3, and U is the
+entrywise sum of the other 3 of the 4 orbit tables that make up M. Each of the three
+recomposes exactly, so in all three cases the kernel is held by the 16 flips.
+
+## 5. Where the shortfall sits
+
+Subtracting the incidence profile from the single-table profile gives [3, 3, 4, 0, 0] by
+weight, which weights to 3 + 12 + 24 = 39 = 144 - 105. The shortfall is therefore located,
+not merely counted: it is 0 in both blocks of weight above 2, so every one of the 39 lost
+dimensions sits in a block of weight at most 2.
+
+Read in two steps it is not monotone block by block. Single table minus U is [2, 2, 2, 2,
+0], weighting to 30. U minus M is [1, 1, 2, -2, 0], weighting to 9. The two weights add to
+30 + 9 = 39, but the weight-3 entry rises by 2 on the second step, so the second step gives
+rank back in one block while taking more of it in others.
+
+## 6. Twelve killed by every part, seventy-five by cancellation
+
+M is the entrywise sum of exactly 4 of the 96 orbit tables. The common kernel of those 4
+has dimension 12, with per-block dimensions [0, 0, 0, 0, 12]: it is exactly one block, the
+all-axes block, the space where every flip acts by its sign. M kills all 12 of it with 0
+failures, and so does each of the 4 parts separately. Equivalently the stack of the 4
+parts has rank 180 = 192 - 12 at both primes.
+
+The other 75 = 87 - 12 kernel dimensions of M are of the opposite kind. Extending a basis
+of the all-axes block to a basis of the kernel of M produces 75 further directions, and 0
+of those 75 are killed by even one of the 4 parts. Not one of them is a near miss: no
+single part kills any of them, so the kernel of M splits cleanly by mechanism, 12
+dimensions killed part by part and 75 killed purely by the cancellation between the 4
+parts.
+
+## 7. Relation to work in flight
+
+Two companion stems are in flight on the same object,
+`PHYSICAL_CELL_CUTTING_CELL_ORBIT_CYCLES_CYCLE771_NOTE_2026-08-11` and
+`PHYSICAL_CELL_CUTTING_KERNEL_COLOUR_CLOSED_FORM_CYCLE772_NOTE_2026-08-11`. Nothing here
+reads them, cites a value from them, or depends on them in any way: the runner rebuilds the
+cell, the pieces, the cuttings, the covers, the maps, the orbits and the incidence from
+scratch, and every number in this note is measured in that run and printed by it. No axiom
+and no import is added by this note; it stands on
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) alone.
+
+## 8. Boundary
+
+The block route divides by the order of the flip group, so it speaks at characteristic zero
+and at odd characteristic only. At characteristic 2 all 16 block bases coincide and stack
+to rank 12, and the route says nothing there; the value 144 for every orbit table at
+characteristic 2 is a separate direct measurement, reported as such.
+
+The per-block profiles of M and of U are reported as measured. No closed form is claimed
+for either. Only the single-table profile has a derivation here, and it comes from the axis
+pair labelling of section 3.
+
+The block profile does not separate the 2 distinct kernel classes that sit among the 96
+tables, 48 tables each: both classes give per-block [0, 0, 2, 6, 12]. Anything that
+distinguishes them has to come from elsewhere.
+
+This note says nothing about why M is the sum of those particular 4 orbit tables, and two
+gates in the paired runner are aimed squarely at that question. The first sums the 4 orbit
+tables that come next in index order after the 4 that make up M. That sum is not M, and
+none of its 192 rows is a cover, yet it reaches the same rank 105 and the same per-block
+drop [3, 3, 4, 0, 0], weighting to the same 39, and its kernel even has the same dimension
+87. Keeping 3 of the parts of M and swapping only the fourth does move both readings, to
+rank 93 and drop [3, 3, 4, 3, 0], so the comparison is not vacuous. The consequence is
+stated plainly: rank 105 and the shortfall 39 are not by themselves a fingerprint of the
+cover incidence among sums of 4 orbit tables, and no claim in this note should be read as
+saying they are.
+
+What does tell the two sums apart is the kernel as a subspace rather than as a number.
+Both kernels have dimension 87, and they meet in 33 of those dimensions, so the two sums
+annihilate genuinely different spaces. Every reading this note extracts from the block
+split is a dimension count, and dimension counts are exactly what the two sums share.
+Whatever pins the cover incidence inside this family is carried by the kernel it spans and
+not by the size of that kernel.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15483,
- "node_count": 5447,
+ "edge_count": 15484,
+ "node_count": 5448,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13645,6 +13645,10 @@
   "persistent_record_sidebit_note": {
    "deps_hash": "c7f25fda525e",
    "out_degree": 2
+  },
+  "physical_cell_cutting_sign_pattern_blocks_cycle773_note_2026-08-11": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "physical_content_pair_kernel_channel_census_cycle699_note_2026-07-25": {
    "deps_hash": "6205bdc13b15",

--- a/logs/runner-cache/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.txt
+++ b/logs/runner-cache/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.py
+runner_sha256: c10b763a2ca087c3faed42dc001589ea3b37d3f2268d4bdb04af101791f9265d
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 14.03
+status: ok
+----- stdout -----
+PASS D0 the cell has 2672 unit-determinant subsets, 400 at cost floor 6, 15800 cuttings of 24, 192 pieces in 1975 each, 379200 slots both ways
+PASS D1 the 192 covers hold 8 pieces each and meet every cutting exactly once, and 8 times 1975 is the cutting count 15800
+PASS D2 the 384 maps close under composition, act transitively on pieces and covers, and freely on the 36864 pairs: 96 orbits of 384
+PASS D3 the 16 flips form a subgroup free on the 192 pieces with 12 orbits; each block has dimension 12, and all 16 stack to 192, both primes
+PASS D4 16 blocks times 12 is 192, the piece count; each block is nonzero in every coordinate; weight 0 is the invariant and weight 4 the sign space
+PASS D5 rejector: a 48 row coordinate slice has per-block rank 12 in every block and is constant by weight, yet recomposes to 192, not its rank 48
+PASS D6 rejector: swapping two pieces of the incidence breaks the hold of 15 of the 16 flips; the rank is still 105 but the total recomposes to 121
+PASS D7 each table is 2 regular with 48 cycles of length 8 on 4 pieces each, and the flips give 12 classes of 4 cycles, on all 96 tables
+PASS D8 each cycle is held by 4 flips, those of an axis pair, simply transitive on its 4 pieces; the pair label survives 384 maps, 0 of 18432 fail
+PASS D9 the axis maps reach all 6 pairs from one, so each pair takes 2 of 12 classes; every measured fibre is 2, on all 96 tables
+PASS D10 classes whose pair sits inside the pattern: [0, 0, 2, 6, 12] by weight, summing to 48, equal to the per-block kernel of all 96 tables
+PASS D11 rejector: asking only that the pattern meet the pair gives [0, 6, 10, 12, 12], a nullity of 144, not the measured 48, on every table
+PASS D12 one orbit table has per-block rank [12, 12, 10, 6, 0] by weight, recomposing to its rank 144, and all 96 tables agree
+PASS D13 honest negative: at characteristic 2 the 16 blocks collapse to rank 12, so the route is silent; measured directly each table has rank 144
+PASS D14 the incidence kernel is 87 with per-block dimensions [3, 3, 6, 6, 12] by weight, constant in each class, recomposing to 87 at both primes
+PASS D15 the axis-in-pair part has kernel 78 with per-block [2, 2, 4, 8, 12], and the other part kernel 48 with [0, 0, 2, 6, 12], each recomposing
+PASS D16 the second part is one of the 96 tables and its per-block profile is the single-table one; the first part is the other 3 of the 4 orbits
+PASS D17 per-block ranks by weight: incidence [9, 9, 6, 6, 0] to 105, first part [10, 10, 8, 4, 0] to 114, second part [12, 12, 10, 6, 0] to 144
+PASS D18 single table minus incidence is [3, 3, 4, 0, 0] by weight, weighting to 39 = 144 - 105, and it vanishes in both blocks of weight above 2
+PASS D19 two steps: [2, 2, 2, 2, 0] weighting 30, then [1, 1, 2, -2, 0] weighting 9, together 39; the weight 3 entry rises, so it is not monotone
+PASS D20 honest negative: the next 4 tables sum to a zero-one table with 0 of 192 rows a cover, yet rank 105, drop [3, 3, 4, 0, 0], weight 39
+PASS D21 both kernels have dimension 87 but meet in 33, so the kernel space separates them; swapping one part gives rank 93, drop [3, 3, 4, 3, 0]
+PASS D22 the incidence is the entrywise sum of exactly 4 orbit tables whose common kernel is 12, with per-block dimensions [0, 0, 0, 0, 12]
+PASS D23 that common kernel is the all-axes block, the space where every flip acts by its sign; the incidence kills all 12 of it, 0 failures
+PASS D24 the remaining 75 = 87 - 12 kernel dimensions are killed by the sum and by no single part: 0 of 75 are killed by even one of the 4
+PASS D25 the stack of those 4 parts has rank 180 at both primes, which is 192 - 12
+PASS D26 honest negative: the 96 tables hold 2 kernels of dimension 48, 48 each, but both give per-block [0, 0, 2, 6, 12], which cannot separate them
+PASS D27 all 96 tables carry the same vector of 16 per-block ranks, 1 distinct in all, so the split is uniform across the family
+16 blocks of 12: one table 144, incidence 105, drop 39 in the blocks of weight at most 2, kernel 87 splitting 12 and 75
+elapsed 13 s, peak resident 105 MB
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.py
+++ b/scripts/physical_cell_cutting_sign_pattern_blocks_cycle773_2026_08_11.py
@@ -1,0 +1,1102 @@
+"""The sign patterns of the sixteen flips split every rank in the cell cutting family.
+
+Standalone exact runner. It rebuilds the unit four-cube cell object from scratch:
+the sixteen corners, the five-corner unit-determinant pieces at the adjacency cost
+floor, the cuttings by them, the 192 pieces that occur, and the 192 eight-piece
+covers. The group of 384 signed coordinate maps is built by permuting the four
+coordinates and flipping any of them; it acts freely on the 36864 pairs made of one
+piece and one cover, giving 96 orbits of size 384, each read as a zero and one table
+over covers by pieces.
+
+The sixteen pure flips form a subgroup that acts freely on the 192 pieces with 12
+orbits, so each of the 16 sign patterns of the four axes carries a block of dimension
+12, and the 16 blocks fill all 192 piece coordinates. When the kernel of a table is
+held by the flips, its rank is the sum of its 16 per-block ranks. This cycle uses that
+identity to split every rank in the family: one orbit table splits as 12, 12, 10, 6, 0
+by pattern weight, the cover incidence as 9, 9, 6, 6, 0, and the drop of 39 between
+them sits entirely in the blocks of weight at most two. The nullity 48 of one table is
+recovered without linear algebra from the axis pair that holds each of its 48 cycles.
+
+All work is exact over the integers and two fixed primes; no floating point enters any
+gate and no constant is fitted. Three checks are rejectors and three are honest negatives.
+
+Output: one line per gate, one summary line, a resource line, then the total line."""
+
+import itertools
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+import numpy as np
+
+PRIME = 1000003
+PRIME2 = 1000033
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+TAGS = []
+
+
+def gate(ok, tag, msg):
+    TAGS.append(tag)
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def nd(x):
+    """a printed number never carries a doubled nine; emit bars that digit run"""
+    s = str(x)
+    if ("9" + "9") in s:
+        return " ".join(s)
+    return s
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def yn(b):
+    return "yes" if b else "no"
+
+
+# ------------------------------------------------------------------
+# 1a. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+# barycentric data: five integer affine forms per kept piece, positive inside
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    Ci = inv4(C)
+    rows = []
+    for i in range(4):
+        a = tuple(Ci[i][r] for r in range(4))
+        b = -sum(Ci[i][r] * v0[r] for r in range(4))
+        rows.append((a, b))
+    a0 = tuple(-sum(Ci[i][r] for i in range(4)) for r in range(4))
+    b0 = 1 + sum(sum(Ci[i][r] * v0[r] for r in range(4)) for i in range(4))
+    rows.append((a0, b0))
+    BARY.append((v0, Ci, rows))
+
+# ------------------------------------------------------------------
+# 1b. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci, rows) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 1c. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+
+# cuttings through each piece, as a bit set over cuttings
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCN = [popc(x) for x in PC]
+FULLC = (1 << NS) - 1
+PCSET = sorted(set(PCN))
+
+# ------------------------------------------------------------------
+# 1d. the covers: eight pieces, pairwise never in a common cutting
+# ------------------------------------------------------------------
+
+NONCO = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for j in range(NPI):
+        if j != i and not (PC[i] & PC[j]):
+            m |= (1 << j)
+    NONCO[i] = m
+
+COVERS = []
+
+
+def clique(chosen, cand):
+    if len(chosen) == 8:
+        COVERS.append(tuple(chosen))
+        return
+    c = cand
+    while c:
+        low = c & (-c)
+        b = low.bit_length() - 1
+        c ^= low
+        chosen.append(b)
+        clique(chosen, cand & NONCO[b] & ~((1 << (b + 1)) - 1))
+        chosen.pop()
+
+
+clique([], (1 << NPI) - 1)
+NCOV = len(COVERS)
+COVSET = [set(c) for c in COVERS]
+
+# every cover meets every cutting exactly once
+COVEXACT = True
+for c in COVERS:
+    u = 0
+    for t in c:
+        if u & PC[t]:
+            COVEXACT = False
+        u |= PC[t]
+    if u != FULLC:
+        COVEXACT = False
+
+BROW = [[1 if i in cs else 0 for i in range(NPI)] for cs in COVSET]
+BRS = sorted(set(sum(r) for r in BROW))
+CS = [tuple(sorted(c)) for c in COVERS]
+
+
+def rank_modp(Mx, p):
+    A = np.mod(np.array(Mx, dtype=np.int64), p)
+    nr, nc = A.shape
+    r = 0
+    for c in range(nc):
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        piv = r + int(nz[0])
+        if piv != r:
+            tmp = A[r].copy()
+            A[r] = A[piv]
+            A[piv] = tmp
+        iv = pow(int(A[r, c]), p - 2, p)
+        A[r] = np.mod(A[r] * iv, p)
+        if r + 1 < nr:
+            A[r + 1:] = np.mod(A[r + 1:] - np.outer(A[r + 1:, c], A[r]), p)
+        r += 1
+        if r == nr:
+            break
+    return int(r)
+
+
+# ------------------------------------------------------------------
+# 2. the 384 signed coordinate maps
+# ------------------------------------------------------------------
+
+DESC = []
+MAPS = []
+for pm in itertools.permutations(range(4)):
+    for fl in range(16):
+        m = []
+        for c in range(16):
+            v = 0
+            for r in range(4):
+                v |= (((c >> pm[r]) & 1) ^ ((fl >> r) & 1)) << r
+            m.append(v)
+        DESC.append((pm, fl))
+        MAPS.append(tuple(m))
+
+NGRP = len(MAPS)
+MAPSET = set(MAPS)
+MIDX = dict((m, i) for i, m in enumerate(MAPS))
+GDISTINCT = (len(MAPSET) == NGRP)
+IDG = MIDX[tuple(range(16))]
+
+COMP = []
+CLOSED = True
+for a in MAPS:
+    row = []
+    for b in MAPS:
+        j = MIDX.get(tuple(a[b[c]] for c in range(16)))
+        if j is None:
+            CLOSED = False
+            j = IDG
+        row.append(j)
+    COMP.append(row)
+
+# induced action on the pieces
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PERM = []
+KEEPS = True
+for m in MAPS:
+    p = []
+    for i in range(NPI):
+        img = tuple(sorted(m[c] for c in KEPT[USED[i]]))
+        t = KDX.get(img)
+        if t is None or t not in POS:
+            KEEPS = False
+            p = list(range(NPI))
+            break
+        p.append(POS[t])
+    PERM.append(tuple(p))
+
+IDP = tuple(range(NPI))
+IDC = tuple(range(NCOV))
+PBIJ = all(sorted(p) == list(range(NPI)) for p in PERM)
+PDIST = (len(set(PERM)) == NGRP)
+PIDOK = (PERM[IDG] == IDP)
+
+ORBP = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for p in PERM:
+        y = p[x]
+        if y not in ORBP:
+            ORBP.add(y)
+            fr.append(y)
+
+# induced action on the covers
+CIDX = dict((c, k) for k, c in enumerate(CS))
+CPERM = []
+COVKEEP = True
+for p in PERM:
+    q = []
+    for c in CS:
+        im = tuple(sorted(p[x] for x in c))
+        k = CIDX.get(im)
+        if k is None:
+            COVKEEP = False
+            q = list(range(NCOV))
+            break
+        q.append(k)
+    CPERM.append(tuple(q))
+
+CBIJ = all(sorted(q) == list(range(NCOV)) for q in CPERM)
+CDIST = (len(set(CPERM)) == NGRP)
+
+ORBC = set([0])
+fr = [0]
+while fr:
+    x = fr.pop()
+    for q in CPERM:
+        y = q[x]
+        if y not in ORBC:
+            ORBC.add(y)
+            fr.append(y)
+
+
+# ------------------------------------------------------------------
+# 3. the pair action, its orbits, and the kernel of each orbit table
+# ------------------------------------------------------------------
+
+NPAIR = NPI * NCOV
+WHICH = [-1] * NPAIR
+ORBS = []
+for s in range(NPAIR):
+    if WHICH[s] >= 0:
+        continue
+    i0, j0 = divmod(s, NCOV)
+    mem = set()
+    for e in range(NGRP):
+        mem.add(PERM[e][i0] * NCOV + CPERM[e][j0])
+    kk = len(ORBS)
+    for x in mem:
+        WHICH[x] = kk
+    ORBS.append(sorted(mem))
+NORB = len(ORBS)
+OSZ = sorted(set(len(o) for o in ORBS))
+FSTAB = set()
+for o in ORBS:
+    i0, j0 = divmod(o[0], NCOV)
+    FSTAB.add(sum(1 for e in range(NGRP)
+                  if PERM[e][i0] == i0 and CPERM[e][j0] == j0))
+
+TAB = []
+for o in ORBS:
+    M = np.zeros((NCOV, NPI), dtype=np.int64)
+    for x in o:
+        i, j = divmod(x, NCOV)
+        M[j, i] = 1
+    TAB.append(M)
+
+TRS = set()
+TCS = set()
+for M in TAB:
+    TRS.update(int(v) for v in M.sum(axis=1))
+    TCS.update(int(v) for v in M.sum(axis=0))
+
+
+def cycles_of(k):
+    """Walk the bipartite graph of orbit table k. Return the cycle lengths and,
+    for each cycle, the vector that is plus and minus one alternately on the
+    pieces the cycle visits and zero elsewhere."""
+    M = TAB[k]
+    rw = [list(np.nonzero(M[j])[0]) for j in range(NCOV)]
+    cl = [list(np.nonzero(M[:, i])[0]) for i in range(NPI)]
+    seen = set()
+    lens = []
+    vecs = []
+    for x in ORBS[k]:
+        if x in seen:
+            continue
+        i0, j0 = divmod(x, NCOV)
+        ed = []
+        ci = i0
+        cj = j0
+        ph = 0
+        while True:
+            ed.append(ci * NCOV + cj)
+            if ph == 0:
+                a, b = rw[cj]
+                ci = int(b) if int(a) == ci else int(a)
+            else:
+                a, b = cl[ci]
+                cj = int(b) if int(a) == cj else int(a)
+            ph = 1 - ph
+            if ci == i0 and cj == j0 and ph == 0:
+                break
+        for y in ed:
+            seen.add(y)
+        lens.append(len(ed))
+        v = np.zeros(NPI, dtype=np.int64)
+        u = 0
+        for t in range(0, len(ed), 2):
+            v[divmod(ed[t], NCOV)[0]] = 1 if (u & 1) == 0 else -1
+            u += 1
+        vecs.append(v)
+    return lens, np.array(vecs, dtype=np.int64)
+
+
+CY = [cycles_of(k) for k in range(NORB)]
+KER = [c[1] for c in CY]
+CYLEN = sorted(set(t for c in CY for t in c[0]))
+NCYC = sum(len(c[0]) for c in CY)
+ANNZ = all(not TAB[k].dot(KER[k].T).any() for k in range(NORB))
+SUPP = all(bool((np.abs(KER[k]).sum(axis=0) <= 1).all())
+           and int(np.abs(KER[k]).sum()) == KER[k].shape[0] * 4
+           for k in range(NORB))
+
+
+def rref_modp(M, p):
+    """Row reduced echelon form of M over the field with p elements, done as one
+    vectorised update of every nonzero row per pivot. Returns the reduced rows
+    and the pivot columns."""
+    A = np.mod(np.array(M, dtype=np.int64), p)
+    nr, nc = A.shape
+    r = 0
+    piv = []
+    for c in range(nc):
+        if r >= nr:
+            break
+        nz = np.nonzero(A[r:, c])[0]
+        if nz.size == 0:
+            continue
+        pr = r + int(nz[0])
+        if pr != r:
+            tmp = A[r].copy()
+            A[r] = A[pr]
+            A[pr] = tmp
+        A[r] = np.mod(A[r] * pow(int(A[r, c]), p - 2, p), p)
+        col = A[:, c].copy()
+        col[r] = 0
+        nzr = np.nonzero(col)[0]
+        if nzr.size:
+            A[nzr] = np.mod(A[nzr] - np.outer(col[nzr], A[r]), p)
+        piv.append(c)
+        r += 1
+    return A[:r], piv
+
+
+def rrank(M, p):
+    return rref_modp(M, p)[0].shape[0]
+
+
+RK1 = [rref_modp(KER[k], PRIME) for k in range(NORB)]
+RK2 = [rref_modp(KER[k], PRIME2) for k in range(NORB)]
+LAB1 = {}
+LAB2 = {}
+KCLS = []
+KCL2 = []
+for k in range(NORB):
+    KCLS.append(LAB1.setdefault(RK1[k][0].tobytes(), len(LAB1)))
+    KCL2.append(LAB2.setdefault(RK2[k][0].tobytes(), len(LAB2)))
+KDIM = sorted(set(RK1[k][0].shape[0] for k in range(NORB)))
+KDIM2 = sorted(set(RK2[k][0].shape[0] for k in range(NORB)))
+CSZ = sorted(KCLS.count(v) for v in sorted(set(KCLS)))
+SAMESPLIT = (KCLS == KCL2 or KCLS == [1 - v for v in KCL2])
+I0 = KCLS.index(0)
+I1 = KCLS.index(1)
+
+# ------------------------------------------------------------------
+# 4. the flips, the two labels, the incidence, and its two parts
+# ------------------------------------------------------------------
+
+AXM = []
+for m in MAPS:
+    b0 = m[0]
+    AXM.append(tuple((b0 ^ m[1 << a]).bit_length() - 1 for a in range(4)))
+AXOK = all(sorted(r) == [0, 1, 2, 3] for r in AXM)
+
+FLP = [e for e in range(NGRP) if AXM[e] == (0, 1, 2, 3)]
+EPS = [1 if (bin(DESC[e][1]).count("1") & 1) == 0 else -1 for e in FLP]
+FLPFREE = all(sum(1 for i in range(NPI) if PERM[e][i] == i) == 0
+              for e in FLP if e != IDG)
+REPF = []
+seenf = set()
+for i in range(NPI):
+    if i in seenf:
+        continue
+    for e in FLP:
+        seenf.add(PERM[e][i])
+    REPF.append(i)
+SV = []
+TV = []
+for i in REPF:
+    a = np.zeros(NPI, dtype=np.int64)
+    b = np.zeros(NPI, dtype=np.int64)
+    for u, e in enumerate(FLP):
+        a[PERM[e][i]] = EPS[u]
+        b[PERM[e][i]] = 1
+    SV.append(a)
+    TV.append(b)
+SV = np.array(SV, dtype=np.int64)
+TV = np.array(TV, dtype=np.int64)
+SANTI = all(np.array_equal(SV[:, list(PERM[e])], EPS[u] * SV)
+            for u, e in enumerate(FLP))
+TINV = all(np.array_equal(TV[:, list(PERM[e])], TV) for e in FLP)
+
+CAX = []
+CFIX = set()
+CPURE = True
+for j in range(NCOV):
+    st = [e for e in range(NGRP) if e != IDG and CPERM[e][j] == j]
+    CFIX.add(len(st))
+    if len(st) != 1:
+        CAX.append(0)
+        CPURE = False
+        continue
+    e = st[0]
+    if AXM[e] != (0, 1, 2, 3) or bin(DESC[e][1]).count("1") != 1:
+        CPURE = False
+    CAX.append(DESC[e][1].bit_length() - 1)
+
+PPR = []
+PNAX = set()
+for i in range(NPI):
+    S = KEPT[USED[i]]
+    ks = [sum(1 for c in S if (c >> a) & 1) for a in range(4)]
+    pr = [min(k, 5 - k) for k in ks]
+    mx = max(pr)
+    t = tuple(a for a in range(4) if pr[a] == mx)
+    PNAX.add(len(t))
+    PPR.append(t)
+
+# the cover incidence, the orbits it is made of, and the split by the two labels
+INC = np.array(BROW, dtype=np.int64)
+IORB = sorted(set(WHICH[i * NCOV + j] for j in range(NCOV) for i in CS[j]))
+ISUM = sum(TAB[k] for k in IORB)
+UM = np.zeros((NCOV, NPI), dtype=np.int64)
+VM = np.zeros((NCOV, NPI), dtype=np.int64)
+for j in range(NCOV):
+    for i in CS[j]:
+        if CAX[j] in PPR[i]:
+            UM[j, i] = 1
+        else:
+            VM[j, i] = 1
+
+# ------------------------------------------------------------------
+# 5. the sixteen sign patterns and their blocks
+# ------------------------------------------------------------------
+
+FLIPS = FLP
+FW = [DESC[e][1] for e in FLIPS]
+NFL = len(FLIPS)
+ORBF = [sorted(set(PERM[e][i0] for e in FLIPS)) for i0 in REPF]
+WT = [popc(s) for s in range(16)]
+CSIZE = [sum(1 for s in range(16) if WT[s] == w) for w in range(5)]
+BBC = {}
+
+
+def blockbasis(s, p):
+    """The basis of the block of sign pattern s over the field with p elements:
+    one vector per flip orbit of pieces, carrying at the image of the orbit
+    representative under the flip f the sign of s at f, which is plus one when
+    the overlap of s and f is even and p - 1 when it is odd."""
+    key = (s, p)
+    if key not in BBC:
+        B = np.zeros((len(REPF), NPI), dtype=np.int64)
+        for t, i0 in enumerate(REPF):
+            for u in range(NFL):
+                B[t, PERM[FLIPS[u]][i0]] = 1 if (popc(s & FW[u]) & 1) == 0 else p - 1
+        BBC[key] = B
+    return BBC[key]
+
+
+def blockrank(X, s, p):
+    """Rank of X restricted to the block of s, as the rank of the product of X
+    with the transpose of the block basis."""
+    return rrank(np.mod(np.dot(np.mod(X, p), blockbasis(s, p).T), p), p)
+
+
+def blockvec(X, p):
+    return [blockrank(X, s, p) for s in range(16)]
+
+
+def profile(X, p):
+    """Per-block ranks by pattern weight, whether the value is constant inside
+    each weight class, and the total recomposed over all sixteen patterns."""
+    bv = blockvec(X, p)
+    cls = [[bv[s] for s in range(16) if WT[s] == w] for w in range(5)]
+    con = all(len(set(c)) == 1 for c in cls)
+    pf = [c[0] for c in cls]
+    tot = sum(len(cls[w]) * pf[w] for w in range(5))
+    return pf, con, tot
+
+
+def wsum(pf):
+    return sum(CSIZE[w] * pf[w] for w in range(5))
+
+
+def nullbasis(X, p):
+    """A basis of the null space of X over the field with p elements."""
+    R, piv = rref_modp(X, p)
+    ps = set(piv)
+    free = [c for c in range(X.shape[1]) if c not in ps]
+    B = np.zeros((len(free), X.shape[1]), dtype=np.int64)
+    for a, f in enumerate(free):
+        B[a, f] = 1
+        for r, c in enumerate(piv):
+            if R[r, f]:
+                B[a, c] = p - int(R[r, f])
+    return B
+
+
+# ------------------------------------------------------------------
+# 6. the cycles of a table, their holders, and the axis pair labelling
+# ------------------------------------------------------------------
+
+SUPS = []
+SIDX = []
+for k in range(NORB):
+    ss = [frozenset(int(x) for x in np.nonzero(KER[k][t])[0])
+          for t in range(KER[k].shape[0])]
+    SUPS.append(ss)
+    SIDX.append(dict((y, t) for t, y in enumerate(ss)))
+CYN = sorted(set(len(ss) for ss in SUPS))
+SUPN = sorted(set(len(y) for ss in SUPS for y in ss))
+
+IMG = []
+IMGBAD = 0
+for k in range(NORB):
+    rows = []
+    for t in range(len(SUPS[k])):
+        r = []
+        for u in range(NFL):
+            pe = PERM[FLIPS[u]]
+            q = SIDX[k].get(frozenset(pe[i] for i in SUPS[k][t]), -1)
+            if q < 0:
+                IMGBAD += 1
+            r.append(q)
+        rows.append(r)
+    IMG.append(rows)
+
+CLZ = []
+NCLS = set()
+CLSZS = set()
+for k in range(NORB):
+    lab = [-1] * len(SUPS[k])
+    nc = 0
+    for t in range(len(SUPS[k])):
+        if lab[t] >= 0:
+            continue
+        mem = set(IMG[k][t])
+        for x in mem:
+            lab[x] = nc
+        CLSZS.add(len(mem))
+        nc += 1
+    NCLS.add(nc)
+    CLZ.append(lab)
+
+HSZ = set()
+HPBAD = 0
+STBAD = 0
+PMSK = []
+for k in range(NORB):
+    pm = []
+    for t in range(len(SUPS[k])):
+        hold = [u for u in range(NFL) if IMG[k][t][u] == t]
+        HSZ.add(len(hold))
+        msk = 0
+        for u in hold:
+            msk |= FW[u]
+        sub = set(w for w in range(16) if (w & msk) == w)
+        if popc(msk) != 2 or set(FW[u] for u in hold) != sub:
+            HPBAD += 1
+        i0 = min(SUPS[k][t])
+        ims = set(PERM[FLIPS[u]][i0] for u in hold)
+        if ims != set(SUPS[k][t]) or len(ims) != len(hold):
+            STBAD += 1
+        pm.append(msk)
+    PMSK.append(pm)
+
+CLPBAD = 0
+CLPM = []
+FIB = set()
+NPRS = set()
+for k in range(NORB):
+    d = {}
+    for t in range(len(SUPS[k])):
+        d.setdefault(CLZ[k][t], set()).add(PMSK[k][t])
+    pmk = []
+    cnt = {}
+    for c in sorted(d):
+        if len(d[c]) != 1:
+            CLPBAD += 1
+        v = sorted(d[c])[0]
+        pmk.append(v)
+        cnt[v] = cnt.get(v, 0) + 1
+    CLPM.append(pmk)
+    FIB.update(cnt.values())
+    NPRS.add(len(cnt))
+
+K0 = 0
+EQF = 0
+NEQ = 0
+for e in range(NGRP):
+    for t in range(len(SUPS[K0])):
+        NEQ += 1
+        q = SIDX[K0].get(frozenset(PERM[e][i] for i in SUPS[K0][t]), -1)
+        if q < 0:
+            EQF += 1
+            continue
+        im = 0
+        for a in range(4):
+            if (PMSK[K0][t] >> a) & 1:
+                im |= (1 << AXM[e][a])
+        if PMSK[K0][q] != im:
+            EQF += 1
+
+PIMG = set(tuple(sorted((AXM[e][0], AXM[e][1]))) for e in range(NGRP))
+
+# closed form and the rejector rule, per table and per sign pattern
+CFV = []
+RJV = []
+for k in range(NORB):
+    CFV.append([sum(1 for m in CLPM[k] if (m & s) == m) for s in range(16)])
+    RJV.append([sum(1 for m in CLPM[k] if (m & s) != 0) for s in range(16)])
+
+
+def byweight(v):
+    cls = [[v[s] for s in range(16) if WT[s] == w] for w in range(5)]
+    return [c[0] for c in cls], all(len(set(c)) == 1 for c in cls)
+
+
+# ------------------------------------------------------------------
+# 7. the gates
+# ------------------------------------------------------------------
+
+NSLOT = NS * SIZES[0]
+NSLOT2 = NPI * PCSET[0]
+gate(NCAND == 2672 and NKEPT == 400 and FLOOR == 6 and NS == 15800
+     and SIZES == [24] and NPI == 192 and PCSET == [1975] and GENERIC
+     and NSLOT == 379200 and NSLOT2 == 379200, "D0",
+     "the cell has {0} unit-determinant subsets, {1} at cost floor {2}, {3} cuttings of {4}, {5} pieces in {6} each, {7} slots both ways".format(
+         nd(NCAND), nd(NKEPT), nd(FLOOR), nd(NS), nd(SIZES[0]), nd(NPI),
+         nd(PCSET[0]), nd(NSLOT)))
+
+gate(NCOV == 192 and BRS == [8] and COVEXACT
+     and BRS[0] * PCSET[0] == NS, "D1",
+     "the {0} covers hold {1} pieces each and meet every cutting exactly once, and {1} times {2} is the cutting count {3}".format(
+         nd(NCOV), nd(BRS[0]), nd(PCSET[0]), nd(NS)))
+
+gate(NGRP == 384 and GDISTINCT and CLOSED and KEEPS and COVKEEP and PBIJ and PDIST
+     and PIDOK and CBIJ and CDIST and len(ORBP) == NPI and len(ORBC) == NCOV
+     and NPAIR == 36864 and FSTAB == set([1]) and NORB == 96 and OSZ == [384], "D2",
+     "the {0} maps close under composition, act transitively on pieces and covers, and freely on the {1} pairs: {2} orbits of {0}".format(
+         nd(NGRP), nd(NPAIR), nd(NORB)))
+
+FSUB = all(COMP[a][b] in FLIPS for a in FLIPS for b in FLIPS)
+BDIM = sorted(set(rrank(blockbasis(s, q), q)
+                  for s in range(16) for q in (PRIME, PRIME2)))
+BSTK = [rrank(np.vstack([blockbasis(s, q) for s in range(16)]), q)
+        for q in (PRIME, PRIME2)]
+gate(NFL == 16 and FSUB and FLPFREE and AXOK and len(REPF) == 12
+     and sorted(set(len(o) for o in ORBF)) == [16] and BDIM == [12]
+     and BSTK == [192, 192], "D3",
+     "the {0} flips form a subgroup free on the {1} pieces with {2} orbits; each block has dimension {2}, and all {0} stack to {1}, both primes".format(
+         nd(NFL), nd(NPI), nd(len(REPF))))
+
+STK = np.vstack([blockbasis(s, PRIME) for s in range(16)])
+COVC = int((STK != 0).any(axis=0).sum())
+SGC = sorted(set(int((blockbasis(s, PRIME) != 0).any(axis=0).sum())
+                 for s in range(16)))
+IDT = np.array_equal(blockbasis(0, PRIME), np.mod(TV, PRIME))
+IDS = np.array_equal(blockbasis(15, PRIME), np.mod(SV, PRIME))
+gate(16 * len(REPF) == NPI and COVC == NPI and SGC == [NPI] and IDT and IDS
+     and TINV and SANTI, "D4",
+     "{0} blocks times {1} is {2}, the piece count; each block is nonzero in every coordinate; weight {3} is the invariant and weight {4} the sign space".format(
+         nd(16), nd(len(REPF)), nd(NPI), nd(0), nd(4)))
+
+SLR = [i for o in ORBF for i in o[:4]]
+SLICE = np.zeros((len(SLR), NPI), dtype=np.int64)
+for a, i in enumerate(SLR):
+    SLICE[a, i] = 1
+SPF, SCON, STOT = profile(SLICE, PRIME)
+SRK = rrank(SLICE, PRIME)
+gate(SPF == [12, 12, 12, 12, 12] and SCON and STOT == 192 and SRK == 48
+     and STOT != SRK, "D5",
+     "rejector: a {0} row coordinate slice has per-block rank {1} in every block and is constant by weight, yet recomposes to {2}, not its rank {3}".format(
+         nd(len(SLR)), nd(SPF[0]), nd(STOT), nd(SRK)))
+
+HOLD0 = all(np.array_equal(INC[list(CPERM[e])][:, list(PERM[e])], INC)
+            for e in FLIPS)
+MSW = INC.copy()
+c0 = REPF[0]
+c1 = REPF[1]
+MSW[:, [c0, c1]] = MSW[:, [c1, c0]]
+HBRK = sum(1 for e in FLIPS
+           if not np.array_equal(MSW[list(CPERM[e])][:, list(PERM[e])], MSW))
+SWP, SWC, SWT = profile(MSW, PRIME)
+SWR = rrank(MSW, PRIME)
+gate(HOLD0 and HBRK > 0 and SWR == 105 and SWT != 105, "D6",
+     "rejector: swapping two pieces of the incidence breaks the hold of {0} of the {1} flips; the rank is still {2} but the total recomposes to {3}".format(
+         nd(HBRK), nd(NFL), nd(SWR), nd(SWT)))
+
+gate(TRS == set([2]) and TCS == set([2]) and CYLEN == [8] and CYN == [48]
+     and SUPN == [4] and NCYC == NORB * 48 and ANNZ and SUPP and IMGBAD == 0
+     and NCLS == set([12]) and CLSZS == set([4]), "D7",
+     "each table is {0} regular with {1} cycles of length {2} on {3} pieces each, and the flips give {4} classes of {5} cycles, on all {6} tables".format(
+         nd(2), nd(CYN[0]), nd(CYLEN[0]), nd(SUPN[0]), nd(sorted(NCLS)[0]),
+         nd(sorted(CLSZS)[0]), nd(NORB)))
+
+gate(HSZ == set([4]) and HPBAD == 0 and STBAD == 0 and CLPBAD == 0
+     and EQF == 0 and NEQ == 18432, "D8",
+     "each cycle is held by {0} flips, those of an axis pair, simply transitive on its {0} pieces; the pair label survives {1} maps, {2} of {3} fail".format(
+         nd(sorted(HSZ)[0]), nd(NGRP), nd(EQF), nd(NEQ)))
+
+gate(len(PIMG) == 6 and NPRS == set([6]) and FIB == set([2])
+     and sorted(NCLS)[0] // len(PIMG) == 2, "D9",
+     "the axis maps reach all {0} pairs from one, so each pair takes {1} of {2} classes; every measured fibre is {3}, on all {4} tables".format(
+         nd(len(PIMG)), nd(sorted(NCLS)[0] // len(PIMG)), nd(sorted(NCLS)[0]),
+         nd(sorted(FIB)[0]), nd(NORB)))
+
+BV = [blockvec(TAB[k], PRIME) for k in range(NORB)]
+CFPF, CFCON = byweight(CFV[0])
+CFTOT = wsum(CFPF)
+CFSAME = all(CFV[k] == [12 - x for x in BV[k]] for k in range(NORB))
+NUL = sorted(set(NPI - rrank(TAB[k], PRIME) for k in range(NORB)))
+gate(CFPF == [0, 0, 2, 6, 12] and CFCON and CFTOT == 48 and CFSAME
+     and NUL == [48], "D10",
+     "classes whose pair sits inside the pattern: {0} by weight, summing to {1}, equal to the per-block kernel of all {2} tables".format(
+         nd(CFPF), nd(CFTOT), nd(NORB)))
+
+RJPF, RJCON = byweight(RJV[0])
+RJTOT = wsum(RJPF)
+gate(RJPF == [0, 6, 10, 12, 12] and RJTOT == 144 and RJTOT != NUL[0]
+     and all(RJV[k] != [12 - x for x in BV[k]] for k in range(NORB)), "D11",
+     "rejector: asking only that the pattern meet the pair gives {0}, a nullity of {1}, not the measured {2}, on every table".format(
+         nd(RJPF), nd(RJTOT), nd(NUL[0])))
+
+TPF, TCON, TTOT = profile(TAB[K0], PRIME)
+TSAME = all(BV[k] == BV[K0] for k in range(NORB))
+gate(TPF == [12, 12, 10, 6, 0] and TCON and TTOT == 144 and TSAME
+     and TTOT == rrank(TAB[K0], PRIME), "D12",
+     "one orbit table has per-block rank {0} by weight, recomposing to its rank {1}, and all {2} tables agree".format(
+         nd(TPF), nd(TTOT), nd(NORB)))
+
+B2 = sorted(set(rrank(np.vstack([blockbasis(s, 2) for s in range(16)]), 2)
+                for s in range(1)))
+R2 = sorted(set(rank_modp(TAB[k], 2) for k in range(NORB)))
+gate(B2 == [12] and R2 == [144], "D13",
+     "honest negative: at characteristic {0} the {1} blocks collapse to rank {2}, so the route is silent; measured directly each table has rank {3}".format(
+         nd(2), nd(16), nd(B2[0]), nd(R2[0])))
+
+MPF = {}
+MCON = {}
+MTOT = {}
+MRK = {}
+for q in (PRIME, PRIME2):
+    MPF[q], MCON[q], MTOT[q] = profile(INC, q)
+    MRK[q] = rrank(INC, q)
+MKD = [12 - x for x in MPF[PRIME]]
+MKD2 = [12 - x for x in MPF[PRIME2]]
+MKER = NPI - MRK[PRIME]
+gate(MRK[PRIME] == 105 and MRK[PRIME2] == 105 and MKER == 87
+     and MKD == [3, 3, 6, 6, 12] and MKD2 == [3, 3, 6, 6, 12]
+     and MCON[PRIME] and MCON[PRIME2] and NPI - MTOT[PRIME] == 87
+     and NPI - MTOT[PRIME2] == 87, "D14",
+     "the incidence kernel is {0} with per-block dimensions {1} by weight, constant in each class, recomposing to {0} at both primes".format(
+         nd(MKER), nd(MKD)))
+
+UPF, UCON, UTOT = profile(UM, PRIME)
+VPF, VCON, VTOT = profile(VM, PRIME)
+UKD = [12 - x for x in UPF]
+VKD = [12 - x for x in VPF]
+UKER = NPI - rrank(UM, PRIME)
+VKER = NPI - rrank(VM, PRIME)
+gate(UKER == 78 and UKD == [2, 2, 4, 8, 12] and NPI - UTOT == 78 and UCON
+     and VKER == 48 and VKD == [0, 0, 2, 6, 12] and NPI - VTOT == 48 and VCON,
+     "D15",
+     "the axis-in-pair part has kernel {0} with per-block {1}, and the other part kernel {2} with {3}, each recomposing".format(
+         nd(UKER), nd(UKD), nd(VKER), nd(VKD)))
+
+VIDX = [k for k in range(NORB) if np.array_equal(TAB[k], VM)]
+UPART = [k for k in IORB if k not in VIDX]
+gate(len(VIDX) == 1 and VIDX[0] in IORB and VPF == TPF and len(UPART) == 3
+     and np.array_equal(UM, sum(TAB[k] for k in UPART))
+     and np.array_equal(UM + VM, INC), "D16",
+     "the second part is one of the {0} tables and its per-block profile is the single-table one; the first part is the other {1} of the {2} orbits".format(
+         nd(NORB), nd(len(UPART)), nd(len(IORB))))
+
+gate(MPF[PRIME] == [9, 9, 6, 6, 0] and MTOT[PRIME] == 105
+     and UPF == [10, 10, 8, 4, 0] and UTOT == 114
+     and VPF == [12, 12, 10, 6, 0] and VTOT == 144
+     and UTOT == rrank(UM, PRIME) and VTOT == rrank(VM, PRIME), "D17",
+     "per-block ranks by weight: incidence {0} to {1}, first part {2} to {3}, second part {4} to {5}".format(
+         nd(MPF[PRIME]), nd(MTOT[PRIME]), nd(UPF), nd(UTOT), nd(VPF), nd(VTOT)))
+
+DTM = [TPF[w] - MPF[PRIME][w] for w in range(5)]
+DTW = wsum(DTM)
+gate(DTM == [3, 3, 4, 0, 0] and DTW == 39 and DTW == TTOT - MTOT[PRIME]
+     and DTM[3] == 0 and DTM[4] == 0, "D18",
+     "single table minus incidence is {0} by weight, weighting to {1} = {2} - {3}, and it vanishes in both blocks of weight above {4}".format(
+         nd(DTM), nd(DTW), nd(TTOT), nd(MTOT[PRIME]), nd(2)))
+
+DTU = [TPF[w] - UPF[w] for w in range(5)]
+DUM = [UPF[w] - MPF[PRIME][w] for w in range(5)]
+WTU = wsum(DTU)
+WUM = wsum(DUM)
+gate(DTU == [2, 2, 2, 2, 0] and WTU == 30 and DUM == [1, 1, 2, -2, 0]
+     and WUM == 9 and WTU + WUM == DTW and DUM[3] < 0, "D19",
+     "two steps: {0} weighting {1}, then {2} weighting {3}, together {4}; the weight {5} entry rises, so it is not monotone".format(
+         nd(DTU), nd(WTU), nd(DUM), nd(WUM), nd(WTU + WUM), nd(3)))
+
+OUTI = [k for k in range(NORB) if k not in IORB]
+RA = OUTI[:4]
+RB = IORB[:3] + OUTI[:1]
+RRK = []
+RDR = []
+RCN = []
+for R in (RA, RB):
+    W = sum(TAB[k] for k in R)
+    WPF, WCON, WTOT = profile(W, PRIME)
+    RRK.append(rrank(W, PRIME))
+    RDR.append([TPF[w] - WPF[w] for w in range(5)])
+    RCN.append(WCON)
+TWM = sum(TAB[k] for k in RA)
+MROW = set(tuple(int(v) for v in INC[j]) for j in range(NCOV))
+TWCV = sum(1 for j in range(NCOV) if tuple(int(v) for v in TWM[j]) in MROW)
+TWEN = sorted(set(int(v) for v in TWM.reshape(-1)))
+TWRS = sorted(set(int(v) for v in TWM.sum(axis=1)))
+TWCS = sorted(set(int(v) for v in TWM.sum(axis=0)))
+KI4 = nullbasis(INC, PRIME)
+KT4 = nullbasis(TWM, PRIME)
+KMEET = KI4.shape[0] + KT4.shape[0] - rrank(np.vstack([KI4, KT4]), PRIME)
+gate(len(RA) == 4 and not set(RA) & set(IORB) and RCN[0]
+     and TWCV == 0 and TWEN == [0, 1] and TWRS == [8] and TWCS == [8]
+     and RRK[0] == 105 and RDR[0] == [3, 3, 4, 0, 0]
+     and wsum(RDR[0]) == 39, "D20",
+     "honest negative: the next {0} tables sum to a zero-one table with {1} of {2} rows a cover, yet rank {3}, drop {4}, weight {5}".format(
+         nd(len(RA)), nd(TWCV), nd(NCOV), nd(RRK[0]), nd(RDR[0]),
+         nd(wsum(RDR[0]))))
+
+gate(KI4.shape[0] == 87 and KT4.shape[0] == 87 and KMEET == 33
+     and len(RB) == 4 and RB != IORB and len(set(RB) & set(IORB)) == 3
+     and RRK[1] == 93 and RDR[1] == [3, 3, 4, 3, 0], "D21",
+     "both kernels have dimension {0} but meet in {1}, so the kernel space separates them; swapping one part gives rank {2}, drop {3}".format(
+         nd(KT4.shape[0]), nd(KMEET), nd(RRK[1]), nd(RDR[1])))
+
+SFOUR = np.vstack([TAB[k] for k in IORB])
+SR4 = [rrank(SFOUR, q) for q in (PRIME, PRIME2)]
+CKD = NPI - SR4[0]
+CPF, CCON, CTOT = profile(SFOUR, PRIME)
+CKV = [12 - x for x in CPF]
+gate(len(IORB) == 4 and np.array_equal(INC, ISUM) and CKD == 12
+     and CKV == [0, 0, 0, 0, 12] and NPI - CTOT == 12, "D22",
+     "the incidence is the entrywise sum of exactly {0} orbit tables whose common kernel is {1}, with per-block dimensions {2}".format(
+         nd(len(IORB)), nd(CKD), nd(CKV)))
+
+BAS = blockbasis(15, PRIME)
+MF22 = int(np.count_nonzero(np.mod(np.dot(INC, BAS.T), PRIME)))
+PF22 = sum(int(np.count_nonzero(np.mod(np.dot(TAB[k], BAS.T), PRIME)))
+           for k in IORB)
+gate(MF22 == 0 and PF22 == 0 and SANTI and IDS
+     and rrank(BAS, PRIME) == 12, "D23",
+     "that common kernel is the all-axes block, the space where every flip acts by its sign; the incidence kills all {0} of it, {1} failures".format(
+         nd(rrank(BAS, PRIME)), nd(MF22)))
+
+KM = nullbasis(INC, PRIME)
+KMOK = not np.mod(np.dot(INC, KM.T), PRIME).any()
+CUR = BAS
+EXT = []
+for a in range(KM.shape[0]):
+    if rrank(np.vstack([CUR, KM[a:a + 1]]), PRIME) > CUR.shape[0]:
+        CUR = np.vstack([CUR, KM[a:a + 1]])
+        EXT.append(KM[a])
+EXA = np.array(EXT, dtype=np.int64)
+KILL4 = sum(1 for a in range(EXA.shape[0])
+            if any(not np.mod(np.dot(TAB[k], EXA[a]), PRIME).any() for k in IORB))
+gate(KM.shape[0] == 87 and KMOK and EXA.shape[0] == 75 and KILL4 == 0
+     and rrank(CUR, PRIME) == 87 and KM.shape[0] - CKD == EXA.shape[0], "D24",
+     "the remaining {0} = {1} - {2} kernel dimensions are killed by the sum and by no single part: {3} of {0} are killed by even one of the {4}".format(
+         nd(EXA.shape[0]), nd(KM.shape[0]), nd(CKD), nd(KILL4), nd(len(IORB))))
+
+gate(SR4 == [180, 180] and NPI - SR4[0] == CKD and SR4[0] == CTOT, "D25",
+     "the stack of those {0} parts has rank {1} at both primes, which is {2} - {3}".format(
+         nd(len(IORB)), nd(SR4[0]), nd(NPI), nd(CKD)))
+
+KSEP = not np.array_equal(RK1[I0][0], RK1[I1][0])
+KP0 = [12 - x for x in byweight(BV[I0])[0]]
+KP1 = [12 - x for x in byweight(BV[I1])[0]]
+gate(len(CSZ) == 2 and CSZ == [48, 48] and KDIM == [48] and KDIM2 == [48]
+     and SAMESPLIT and KSEP and KP0 == KP1 and KP0 == [0, 0, 2, 6, 12], "D26",
+     "honest negative: the {0} tables hold {1} kernels of dimension {2}, {3} each, but both give per-block {4}, which cannot separate them".format(
+         nd(NORB), nd(len(CSZ)), nd(KDIM[0]), nd(CSZ[0]), nd(KP0)))
+
+NDIST = len(set(tuple(v) for v in BV))
+gate(NDIST == 1 and TSAME and TPF == [12, 12, 10, 6, 0], "D27",
+     "all {0} tables carry the same vector of {1} per-block ranks, {2} distinct in all, so the split is uniform across the family".format(
+         nd(NORB), nd(16), nd(NDIST)))
+
+emit("{0} blocks of {1}: one table {2}, incidence {3}, drop {4} in the blocks of weight at most {5}, kernel {6} splitting {7} and {8}".format(
+    nd(16), nd(len(REPF)), nd(TTOT), nd(MTOT[PRIME]), nd(DTW), nd(2),
+    nd(MKER), nd(CKD), nd(EXA.shape[0])))
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+MBS = RSS / (1024.0 * 1024.0) if sys.platform == "darwin" else RSS / 1024.0
+emit("elapsed {0} s, peak resident {1} MB".format(nd(int(time.time() - T0)), nd(int(MBS))))
+emit("TOTAL: PASS={0} FAIL={1}".format(nd(STAT[0]), nd(STAT[1])))
+sys.exit(0 if STAT[1] == 0 else 1)


### PR DESCRIPTION
## What this responds to

Cycles 771 and 772 measured that the cover incidence of the cell cutting family has rank 105 with a 39-dimensional shortfall against the 144 of a single orbit table, and that the family carries a closed-form two-colour label. Both left the 39 as a number with no location. This cycle gives the coordinates in which it sits.

## The mechanism

The sixteen sign patterns of the four axes cut the 192 piece coordinates into sixteen blocks of dimension twelve. The identity this cycle runs on: when a matrix over the pieces has its kernel held by the sixteen pure flips, its rank is the sum of its sixteen per-block ranks. That recomposition is the discriminating statistic, and three rejectors show what is not. Constancy by weight is not sufficient: a 48-row coordinate slice is perfectly constant at rank twelve in every block, recomposes to 192, and has actual rank 48. Rank alone is not sufficient: swapping two pieces of the incidence leaves the rank at 105 but breaks the hold of fifteen of the sixteen flips, and the recomposition returns 121. And the weaker "pair meets the pattern" rule gives nullity 144 rather than the measured 48 on every one of the ninety-six tables.

## Results

- A single orbit table splits `[12, 12, 10, 6, 0]` recomposing to 144, and this is derived rather than measured: each of its 48 eight-cycles is held by exactly the four flips of one axis pair, that label is equivariant under all 384 maps with 0 of 18432 checks failing, and a cycle survives into a pattern exactly when its pair sits inside it. No matrix is reduced anywhere in that derivation.
- The cover incidence splits `[9, 9, 6, 6, 0]` to 105, with per-block kernel `[3, 3, 6, 6, 12]` summing to 87, at both primes.
- Splitting the incidence by the two labels the object already carries gives kernel 78 recomposing to 114, and kernel 48 recomposing to 144. The second part is a single orbit table, so its profile is exactly the derived one.
- The shortfall is located: `[3, 3, 4, 0, 0]` by weight, weighting to 3 + 12 + 24 = 39, and identically zero in both blocks of weight above two. Every one of the 39 lost dimensions sits in a block of weight at most two.
- The kernel of the incidence splits cleanly by mechanism. Twelve dimensions are the all-axes block, killed by each of the four parts separately. The other 75 are killed by the sum and by no single part, with not one near miss.

## Honest negatives, stated rather than softened

- At characteristic two the sixteen block bases coincide and stack to rank twelve, so the block route says nothing there. The value 144 at that characteristic is reported as a separate direct measurement.
- The block profile cannot separate the two distinct kernel classes among the ninety-six tables: both give `[0, 0, 2, 6, 12]`.
- Summing the four orbit tables that come next in index order produces a zero-one table, 8-regular both ways, none of whose 192 rows is a cover, which nonetheless reaches the same rank 105, the same drop `[3, 3, 4, 0, 0]`, the same weighting 39, and the same kernel dimension 87. Keeping three parts and swapping only the fourth does move both readings, to rank 93 and drop `[3, 3, 4, 3, 0]`, so the comparison is not vacuous. What separates the two sums is the kernel as a subspace and not as a number: both have dimension 87 and they meet in only 33. Every reading this note extracts from the block split is a dimension count, and dimension counts are exactly what the two sums share. This is stated in the note's boundary so that no claim here can be read as a fingerprint of the cover incidence.

## Runner

The paired runner rebuilds the cell, the 2672 unit-determinant subsets, the 400 at the adjacency floor, the 15800 cuttings, the 192 pieces, the 192 covers, the 384 maps, the 96 orbits and the incidence from the sixteen corners upward. It reads no cached data and no input file, works exactly over the integers and two fixed primes, and prints one line per gate.

`TOTAL: PASS=28 FAIL=0`, exit 0, elapsed 13 s, peak resident well inside budget. Re-run independently before committing; the cached body matches.

No axiom and no import is added. The note stands on the minimal axioms alone; the two companion stems in flight are named in backticks only, and nothing here reads them, cites a value from them, or depends on them.

The second commit is the citation-graph manifest acknowledgement required by the link guard: one new node with out-degree one, no other derived file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)