### PR TITLE
[physics-loop] toe-lphys block01 typebridge: bounded_theorem / bounded-support

### DIFF
--- a/docs/ADMISSIBILITY_BARYCENTER_EVALUATION_MENU_KERNEL_BOUNDED_THEOREM_NOTE_2026-08-12.md
+++ b/docs/ADMISSIBILITY_BARYCENTER_EVALUATION_MENU_KERNEL_BOUNDED_THEOREM_NOTE_2026-08-12.md
@@ -1,0 +1,242 @@
+---
+claim_id: admissibility_barycenter_evaluation_menu_kernel_bounded_theorem_note_2026-08-12
+claim_type: bounded_theorem
+claim_scope: "On finite-support measures on the density body, barycenter evaluation is a well-defined menu-independent kernel, unique among affine positive normalized kernels on the declared menus. The construction is not a physical Record law, not an axiom edit, and not a no-go against non-affine kernels."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+  - admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10
+runner: scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py
+---
+
+# Barycenter-Evaluation Menu Kernel As Affine Type-Bridge
+
+**Date:** 2026-08-12
+**Type:** bounded_theorem
+**Scope:** exact finite-support construction on the qubit density body, on
+the two hostile menus of the 2026-08-10 type-separation note.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py`](../scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py)
+
+## Result Up Front
+
+Let `D` be the `2x2` density body. For a finite-support probability
+`μ=Σ_k p_k δ_{ρ_k}` on `D`, the barycenter `ρ_μ=Σ_k p_k ρ_k` lies in `D`,
+and barycenter evaluation
+
+`w_μ(E)=Tr(ρ_μ E)`
+
+is a well-defined, menu-independent kernel on Hermitian matrices. It is
+normalized on every resolution of `I`, matches the spectral endpoints of
+each declared scaled projector, and on the August 10 hostile pair disagrees
+with atomic restriction. Among kernels of the affine Bloch form
+`K(μ,E)=a(E)+Σ_i b_i(E) m_i(μ)` that are positive on `D`, normalized on the
+declared menus, and tight at those spectral endpoints, it is the only
+solution on `{E0,A1,A2,B1,B2}`.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) remains
+untouched:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+This note does not identify `M_2(C)` with `D`, does not register a physical
+menu, and does not exclude non-affine kernels.
+
+## Exact Objects And The Construction
+
+Write `P(n)=(I+n·σ)/2` for a unit Bloch vector `n`. The density body is
+
+`D={ρ∈M_2(C): ρ=ρ^†, ρ≥0, Tr(ρ)=1}`.
+
+Its Bloch chart is `ρ=(I+m·σ)/2` with `|m|≤1`. A finite-support measure on
+`D` is `μ=Σ_k p_k δ_{ρ_k}` with `p_k>0`, `Σ_k p_k=1`, and each `ρ_k∈D`.
+The barycenter `ρ_μ=Σ_k p_k ρ_k` stays in `D` by convexity. Barycenter
+evaluation is the kernel `w_μ(E)=Tr(ρ_μ E)`.
+
+The declared hostile menus are those of
+[`ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md`](ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md):
+
+`E0=(1/2)P(z)`,
+
+`M_A={E0,(9/10)P(n1),(3/5)P(n2)}` with
+`n1=(4√2/9,0,-7/9)` and `n2=(-2√2/3,0,1/3)`,
+
+`M_B={E0,(3/4)P(m1),(3/4)P(m2)}` with
+`m1=(2√2/3,0,-1/3)` and `m2=(-2√2/3,0,-1/3)`.
+
+Each displayed vector is unit. Direct matrix addition gives `Σ M_A=I` and
+`Σ M_B=I`. The five effects are pairwise distinct.
+
+The August 10 atomic restriction witness `ν` places mass proportional to
+`(Tr E)^2` on those five atoms. Its normalization is `Z=509/200`, and
+
+`K_ν(E0|M_A)=25/142`, `K_ν(E0|M_B)=2/11`,
+
+with difference `-9/1562`. Restriction is therefore not menu-independent.
+
+An affine kernel on the declared family has the form
+
+`K(μ,E)=a(E)+b(E)·m(μ)`,
+
+where `m(μ)` is the Bloch vector of `ρ_μ`. The kernel is **positive on `D`**
+when `K(μ,E)≥0` for every `ρ_μ∈D`, equivalently `a(E)≥|b(E)|`. It is
+**normalized** when `K(μ,I)=1`, `K(μ,0)=0`, and `K` is additive on `M_A`
+and on `M_B`. It meets the **spectral endpoints** of a declared scaled
+projector `E=cP(n)` when
+
+`K(δ_{P(n)},E)=c` and `K(δ_{P(-n)},E)=0`.
+
+Those two numbers are the eigenvalues of `E`, read from the matrix identity
+`E^2=cE` together with `Tr(E)=c`. They are not imported from a target trace
+value.
+
+The parent
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+supplies uniqueness of a trace form once a menu-independent grade exists on
+the full binary/ternary scaled family. The present note constructs one
+affine grade on the declared finite family. It does not rerun the frame
+lift.
+
+## Theorem 1 — Well-Defined Menu-Independent Kernel, Endpoints, Normalization
+
+The barycenter of a finite-support probability on `D` is a convex combination
+of densities, hence lies in `D`. The pairing `Tr(ρ_μ E)` is therefore defined
+for every Hermitian `E`. It depends on `μ` only through `ρ_μ` and on the
+effect only through the matrix `E`, so the same effect receives the same
+value in `M_A` and in `M_B`: the kernel is menu-independent.
+
+Linearity in `E` gives the endpoints `w_μ(0)=0` and `w_μ(I)=Tr(ρ_μ)=1`. If
+`{E_i}` is any finite resolution of `I`, then `Σ_i w_μ(E_i)=Tr(ρ_μ I)=1`.
+In particular both hostile menus are normalized.
+
+For a declared scaled projector `E=cP(n)` the matrix identities `E^2=cE` and
+`Tr(E)=c` give spectrum `{0,c}`. Direct evaluation of the pairing yields
+the matching spectral endpoints
+
+`w_{δ_{P(n)}}(E)=c`, `w_{δ_{P(-n)}}(E)=0`.
+
+Explicit barycenters on `E0` are recorded for later comparison. The
+maximally mixed state `ρ_*=I/2` has
+
+`w_*(E0)=Tr((I/2)E0)=1/4`
+
+in both menus. Two non-mixed barycenters are the finite-support laws
+`μ=(3/5)δ_{P(z)}+(2/5)δ_{P(-z)}` and `μ'=(4/5)δ_{P(z)}+(1/5)δ_{P(-z)}`,
+with barycenters `diag(3/5,2/5)` and `diag(4/5,1/5)`. Matrix pairing gives
+
+`w_μ(E0)=Tr(ρ E0)=3/10`, `w_{μ'}(E0)=2/5`,
+
+again in both menus. The two pure Diracs `δ_{P(z)}` and `δ_{P(-z)}` return
+the spectral endpoints `1/2` and `0`.
+
+## Theorem 2 — Disagreement With The August 10 Restriction Witness On `E0`
+
+Atomic restriction of `ν` is a normalized probability vector on each hostile
+menu separately, but it is not a function of the shared effect. The matrix
+traces of the five atoms recompute
+
+`Z=Σ(Tr E)^2=509/200`,
+
+`K_ν(E0|M_A)=(Tr E0)^2/Σ_{M_A}(Tr E)^2=25/142`,
+
+`K_ν(E0|M_B)=(Tr E0)^2/Σ_{M_B}(Tr E)^2=2/11`.
+
+Barycenter evaluation assigns `E0` a single value at each `μ`. At `ρ_*=I/2`
+that value is `1/4`, which is not `25/142` and is not `2/11`. At the biased
+barycenter it is `3/10`, again distinct from both restriction numbers. Thus
+restriction is not this kernel.
+
+The August 9/10 singleton-mass attempt on the four distinct projective atoms
+`P(±z),P(±x)` is unchanged: demanding raw point masses that normalize both
+binary menus forces total mass two inside a probability space of mass one.
+That contradiction is the parent argument; it is not a new obstruction.
+
+## Theorem 3 — Affine Uniqueness On The Declared Finite Family
+
+Let `K(μ,E)=a(E)+b(E)·m(μ)` be affine, positive on `D`, normalized on the
+declared menus, and tight at the spectral endpoints of each declared scaled
+projector. Fix `E=cP(n)` in `{E0,A1,A2,B1,B2}`. The two endpoints read
+
+`a+b·n=c`, `a-b·n=0`,
+
+so `a=c/2` and `b·n=c/2`. Write `b=(c/2)n+v` with `v⊥n`. Positivity is
+`|b|≤a`, hence
+
+`|(c/2)n+v|^2=(c/2)^2+|v|^2≤(c/2)^2`,
+
+so `v=0`. Therefore `b=(c/2)n` and
+
+`K(μ,E)=(c/2)(1+n·m(μ))=Tr(ρ_μ E)`.
+
+Additivity on `M_A` and `M_B` is then inherited from `Σ E=I`. The same
+coefficient match is obtained by extracting `a=Tr((I/2)E)` and
+`b_i=Tr(P(e_i)E)-a` from the five matrices; those extracted coefficients
+equal the unique solution just named.
+
+Two rejectors sit outside the solution set.
+
+1. Restriction is not of affine Bloch form in `μ`: it ignores the barycenter
+   and returns two different numbers for the one effect `E0`. Restriction
+   is not this kernel.
+2. The wrong linear kernel `K(μ,E)=Tr(E)/2+δ_{E,E0} m_z` is affine and
+   positive near the origin, but it fails additivity on `M_A` because the
+   extra Bloch term does not sum to zero. The state-independent pairing
+   `Tr(E)/2` itself fails the spectral endpoints of `E0`.
+
+If the spectral-endpoint clause is dropped and only positivity, `K(μ,I)=1`,
+`K(μ,0)=0`, and additivity on the two hostile menus are kept, uniqueness
+fails. The contraction family `K_λ(μ,E)=Tr(ρ^{(λ)} E)` with Bloch vector
+`λ m(μ)` and `λ∈[0,1]` remains affine, positive, and additive on both
+menus; its residual to barycenter evaluation is the factor `(1-λ)` in front
+of every Bloch term. The endpoint clause removes that residual. Non-affine
+kernels are outside the ansatz and remain live.
+
+## Boundary And Non-Claims
+
+- No axiom sentence is edited. The displayed Admissibility wording is the
+  current wording; this construction is not an axiom edit.
+- Finite-support measures are taken on the density body `D`, not on the full
+  possibility domain `M_2(C)`. That typing is an input of the construction.
+- The kernel is not a physical Record law: it does not register a laboratory
+  menu, does not identify an event label with record content, and does not
+  supply a formation site or rate.
+- Uniqueness is only among affine positive normalized kernels on the declared
+  five-effect family. It is not a no-go against non-affine kernels.
+- The August 9 frame-lift still consumes a grade on every binary and ternary
+  scaled menu. The present kernel extends by the same trace formula, but
+  physical coverage of that family is not claimed.
+
+## Machine Status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: no edit
+```
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | August 10 left barycenter evaluation live after restriction failed. This note constructs that kernel on finite-support states in `D` and checks it on the same hostile menus. |
+| V2 | New content? | Yes: the barycenter-evaluation formula, matrix-level disagreement with `25/142` and `2/11`, and the affine uniqueness argument on the declared five-effect family. |
+| V3 | Independently checkable? | Yes. The runner recomputes traces, the restriction weights, and the Bloch-coefficient uniqueness identity from the matrices. |
+| V4 | More than a restatement? | Yes. The parents separate types and name a sufficient grade; this note supplies the affine kernel those interfaces consume on the declared family. |
+| V5 | One-step relabel? | No. Restriction-failure and frame-lift uniqueness do not by themselves produce the barycenter kernel or the five-effect affine classification. |
+
+## No-Go Discipline
+
+This is a positive construction. The only negative sentence is that
+restriction is not this kernel. No other measure-to-effect map is excluded.
+In particular non-affine kernels remain live.
+
+## Primary Runner
+
+[`scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py`](../scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py)
+recomputes the menu sums, the restriction weights, the barycenter traces,
+and the affine uniqueness identities in exact `Q(√2)` arithmetic.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -344,6 +344,10 @@
   },
   "adm2_global_su3_symmetry_reduces_action_form_bi_invariance_narrow_theorem_note_2026-06-08": {
    "deps_hash": "17b0cde87f4c",
+   "out_degree": 3
+  },
+  "admissibility_barycenter_evaluation_menu_kernel_bounded_theorem_note_2026-08-12": {
+   "deps_hash": "ae792f44891f",
    "out_degree": 3
   },
   "admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10": {

--- a/logs/runner-cache/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.txt
+++ b/logs/runner-cache/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py
+runner_sha256: 75895a1294deec8ef80748638581cf32920f0e292598a4228906c0da1dfad98d
+input_fingerprint_sha256: 064aa5d24b3e6e378124c5686dfae3d87ad82869d51f66aa7f756d8cc969a8a9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom wording and the two parent notes are source-bound; no observational or fitted inputs
+kernel_formula: w(E)=Tr(rho_mu E) recomputed from 2x2 matrices; restriction and singleton mass are hostile controls
+negative_scope: restriction is not this kernel; non-affine kernels remain live
+PASS: source-admissibility the current distribution sentence is pinned in the axiom memo and the note
+PASS: source-parents both parent notes supply the restriction witness and the menu-independent trace form
+PASS: menu-resolutions both hostile menus are exact matrix resolutions of I by scaled projectors
+PASS: restriction-recompute atomic restriction recomputed from matrix traces is 25/142 on M_A and 2/11 on M_B with Z=509/200
+PASS: mixed-barycenter maximally mixed barycenter evaluation of E0 is 1/4 in both menus and both menus normalize
+PASS: biased-barycenter two non-mixed barycenters evaluate E0 to 3/10 and 2/5 in both menus
+PASS: disagree-restriction barycenter evaluation is not restriction on either menu, at mixed and biased barycenters
+PASS: spectral-endpoints each declared scaled projector saturates its matrix spectrum at the two eigenstate Diracs
+PASS: affine-uniqueness positivity plus spectral endpoints force the extracted Bloch coefficients to Tr(rho E)
+PASS: reject-wrong-kernels restriction is menu-dependent, and Tr(E)/2 plus an E0 Bloch extra fails additivity
+PASS: singleton-mass-two raw singleton normalization of the z and x projective menus still forces mass two
+PASS: binary-menu-kernel barycenter evaluation normalizes both projective binary menus at mixed and biased states
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+per_element: five declared scaled effects and the four projective binary atoms are checked by matrix traces
+per_site: the kernel, restriction rejector, and singleton-mass parent argument are one-site statements
+per_mode: Bloch coefficients of each declared effect are extracted; a perpendicular extra mode is rejected by positivity
+per_block: only the finite-support barycenter-evaluation block is constructed; restriction is not this kernel
+lattice_wide: checked and not executed — no lattice-wide dynamics, formation rate, or Record identification is claimed
+TOTAL: PASS=13 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py
+++ b/scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Exact checks for the barycenter-evaluation menu kernel.
+
+Class-A arithmetic on Q(sqrt(2)). Claimed identities are recomputed from
+the 2x2 matrices. The constructed kernel is barycenter evaluation; every
+identity gate uses that formula and fails if it is replaced by restriction
+or by raw singleton mass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "ADMISSIBILITY_BARYCENTER_EVALUATION_MENU_KERNEL_BOUNDED_THEOREM_NOTE_2026-08-12.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PARENT_AUG09_PATH = ROOT / "docs" / "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+PARENT_AUG10_PATH = ROOT / "docs" / "ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_BARYCENTER_EVALUATION_MENU_KERNEL_BOUNDED_THEOREM_NOTE_2026-08-12.md",
+    "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Qsqrt2:
+    """Exact a + b sqrt(2)."""
+
+    a: Fraction = Fraction(0)
+    b: Fraction = Fraction(0)
+
+    def _coerce(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        if isinstance(other, Qsqrt2):
+            return other
+        if isinstance(other, (int, Fraction)):
+            return Qsqrt2(Fraction(other))
+        raise TypeError(other)
+
+    def __add__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        other = self._coerce(other)
+        return Qsqrt2(self.a + other.a, self.b + other.b)
+
+    def __radd__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self + other
+
+    def __neg__(self) -> "Qsqrt2":
+        return Qsqrt2(-self.a, -self.b)
+
+    def __sub__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self + (-self._coerce(other))
+
+    def __rsub__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self._coerce(other) + (-self)
+
+    def __mul__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        other = self._coerce(other)
+        return Qsqrt2(
+            self.a * other.a + 2 * self.b * other.b,
+            self.a * other.b + self.b * other.a,
+        )
+
+    def __rmul__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self * other
+
+    def as_rational(self) -> Fraction:
+        if self.b != 0:
+            raise ValueError(f"expected rational, got {self}")
+        return self.a
+
+
+ZERO = Qsqrt2()
+ONE = Qsqrt2(Fraction(1))
+
+
+@dataclass(frozen=True)
+class H2:
+    """Real-symmetric 2x2 matrix over Q(sqrt(2))."""
+
+    p: Qsqrt2
+    q: Qsqrt2
+    r: Qsqrt2
+
+    def __add__(self, other: "H2") -> "H2":
+        return H2(self.p + other.p, self.q + other.q, self.r + other.r)
+
+    def scale(self, value: Qsqrt2 | int | Fraction) -> "H2":
+        return H2(self.p * value, self.q * value, self.r * value)
+
+    def mul(self, other: "H2") -> "H2":
+        return H2(
+            self.p * other.p + self.q * other.q,
+            self.p * other.q + self.q * other.r,
+            self.q * other.q + self.r * other.r,
+        )
+
+    def trace(self) -> Qsqrt2:
+        return self.p + self.r
+
+    def pairing(self, other: "H2") -> Qsqrt2:
+        return self.p * other.p + (self.q * other.q) * 2 + self.r * other.r
+
+
+I2 = H2(ONE, ZERO, ONE)
+PZ = H2(ONE, ZERO, ZERO)
+PMZ = H2(ZERO, ZERO, ONE)
+PX = H2(Qsqrt2(Fraction(1, 2)), Qsqrt2(Fraction(1, 2)), Qsqrt2(Fraction(1, 2)))
+PMX = H2(Qsqrt2(Fraction(1, 2)), Qsqrt2(Fraction(-1, 2)), Qsqrt2(Fraction(1, 2)))
+MIXED = I2.scale(Fraction(1, 2))
+
+
+def scaled_projector(coefficient: Fraction, n_x: Qsqrt2, n_z: Qsqrt2) -> H2:
+    projector = H2(
+        (ONE + n_z) * Fraction(1, 2),
+        n_x * Fraction(1, 2),
+        (ONE - n_z) * Fraction(1, 2),
+    )
+    return projector.scale(coefficient)
+
+
+def extract_direction(effect: H2) -> tuple[Fraction, Qsqrt2, Qsqrt2]:
+    """Return (c, n_x, n_z) from a real scaled projector using matrix data."""
+    coefficient = effect.trace().as_rational()
+    bloch = effect.scale(Fraction(2, coefficient))
+    shifted = H2(bloch.p - ONE, bloch.q, bloch.r - ONE)
+    # n·σ = [[n_z, n_x], [n_x, -n_z]]
+    n_z = shifted.p
+    n_x = shifted.q
+    return coefficient, n_x, n_z
+
+
+def is_scaled_projector(effect: H2) -> bool:
+    coefficient, n_x, n_z = extract_direction(effect)
+    projector_identity = effect.mul(effect) == effect.scale(coefficient)
+    unit = n_x * n_x + n_z * n_z == ONE
+    return projector_identity and unit and coefficient > 0 and coefficient <= 1
+
+
+def affine_coefficients(effect: H2) -> tuple[Qsqrt2, Qsqrt2, Qsqrt2]:
+    """Extract a, b_x, b_z from the kernel at I/2, P(x), P(z)."""
+    constant = kernel(MIXED, effect)
+    b_x = kernel(PX, effect) - constant
+    b_z = kernel(PZ, effect) - constant
+    return constant, b_x, b_z
+
+
+def barycenter(weights_states: tuple[tuple[Fraction, H2], ...]) -> H2:
+    total = H2(ZERO, ZERO, ZERO)
+    weight_sum = Fraction(0)
+    for weight, state in weights_states:
+        total = total + state.scale(weight)
+        weight_sum += weight
+    if weight_sum != 1:
+        raise ValueError("barycentric weights must sum to one")
+    return total
+
+
+def kernel(state: H2, effect: H2) -> Qsqrt2:
+    """Barycenter-evaluation kernel. Identity gates call only this formula."""
+    return state.pairing(effect)
+
+
+def restriction_weight(effect: H2, menu: tuple[H2, ...]) -> Fraction:
+    numerator = effect.trace().as_rational() ** 2
+    denominator = sum((item.trace().as_rational() ** 2) for item in menu)
+    return numerator / denominator
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    parent_aug09 = PARENT_AUG09_PATH.read_text(encoding="utf-8")
+    parent_aug10 = PARENT_AUG10_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: axiom wording and the two parent notes are source-bound; no observational or fitted inputs")
+    print("kernel_formula: w(E)=Tr(rho_mu E) recomputed from 2x2 matrices; restriction and singleton mass are hostile controls")
+    print("negative_scope: restriction is not this kernel; non-affine kernels remain live")
+
+    canonical_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    checks.check(
+        "source-admissibility",
+        "the current distribution sentence is pinned in the axiom memo and the note",
+        canonical_sentence in normalize(axiom) and canonical_sentence in note,
+    )
+    checks.check(
+        "source-parents",
+        "both parent notes supply the restriction witness and the menu-independent trace form",
+        all(phrase in parent_aug09 for phrase in ("menu-independent", "Tr(", "unique density matrix"))
+        and all(phrase in parent_aug10 for phrase in ("25/142", "2/11", "509/200", "menu-independent")),
+    )
+
+    n1x, n1z = Qsqrt2(Fraction(0), Fraction(4, 9)), Qsqrt2(Fraction(-7, 9))
+    n2x, n2z = Qsqrt2(Fraction(0), Fraction(-2, 3)), Qsqrt2(Fraction(1, 3))
+    m1x, m1z = Qsqrt2(Fraction(0), Fraction(2, 3)), Qsqrt2(Fraction(-1, 3))
+    m2x, m2z = Qsqrt2(Fraction(0), Fraction(-2, 3)), Qsqrt2(Fraction(-1, 3))
+    e0 = scaled_projector(Fraction(1, 2), ZERO, ONE)
+    a1 = scaled_projector(Fraction(9, 10), n1x, n1z)
+    a2 = scaled_projector(Fraction(3, 5), n2x, n2z)
+    b1 = scaled_projector(Fraction(3, 4), m1x, m1z)
+    b2 = scaled_projector(Fraction(3, 4), m2x, m2z)
+    menu_a = (e0, a1, a2)
+    menu_b = (e0, b1, b2)
+    declared = (e0, a1, a2, b1, b2)
+
+    checks.check(
+        "menu-resolutions",
+        "both hostile menus are exact matrix resolutions of I by scaled projectors",
+        e0 + a1 + a2 == I2
+        and e0 + b1 + b2 == I2
+        and all(is_scaled_projector(item) for item in declared)
+        and len(set(declared)) == 5,
+    )
+
+    traces = tuple(item.trace().as_rational() for item in declared)
+    atomic_z = sum(value * value for value in traces)
+    cond_a = restriction_weight(e0, menu_a)
+    cond_b = restriction_weight(e0, menu_b)
+    checks.check(
+        "restriction-recompute",
+        "atomic restriction recomputed from matrix traces is 25/142 on M_A and 2/11 on M_B with Z=509/200",
+        atomic_z == Fraction(509, 200)
+        and cond_a == Fraction(25, 142)
+        and cond_b == Fraction(2, 11)
+        and cond_a - cond_b == Fraction(-9, 1562),
+    )
+
+    mixed_a = kernel(MIXED, e0).as_rational()
+    mixed_b = kernel(MIXED, e0).as_rational()
+    mixed_norm_a = sum(kernel(MIXED, item).as_rational() for item in menu_a)
+    mixed_norm_b = sum(kernel(MIXED, item).as_rational() for item in menu_b)
+    checks.check(
+        "mixed-barycenter",
+        "maximally mixed barycenter evaluation of E0 is 1/4 in both menus and both menus normalize",
+        mixed_a == Fraction(1, 4)
+        and mixed_b == Fraction(1, 4)
+        and mixed_norm_a == 1
+        and mixed_norm_b == 1,
+    )
+
+    biased = barycenter(((Fraction(3, 5), PZ), (Fraction(2, 5), PMZ)))
+    biased2 = barycenter(((Fraction(4, 5), PZ), (Fraction(1, 5), PMZ)))
+    biased_a = kernel(biased, e0).as_rational()
+    biased_b = kernel(biased, e0).as_rational()
+    biased2_a = kernel(biased2, e0).as_rational()
+    checks.check(
+        "biased-barycenter",
+        "two non-mixed barycenters evaluate E0 to 3/10 and 2/5 in both menus",
+        biased == H2(Qsqrt2(Fraction(3, 5)), ZERO, Qsqrt2(Fraction(2, 5)))
+        and biased2 == H2(Qsqrt2(Fraction(4, 5)), ZERO, Qsqrt2(Fraction(1, 5)))
+        and biased_a == Fraction(3, 10)
+        and biased_b == Fraction(3, 10)
+        and biased2_a == Fraction(2, 5)
+        and kernel(biased2, e0).as_rational() == Fraction(2, 5)
+        and sum(kernel(biased, item).as_rational() for item in menu_a) == 1
+        and sum(kernel(biased, item).as_rational() for item in menu_b) == 1
+        and sum(kernel(biased2, item).as_rational() for item in menu_a) == 1,
+    )
+
+    checks.check(
+        "disagree-restriction",
+        "barycenter evaluation is not restriction on either menu, at mixed and biased barycenters",
+        mixed_a != cond_a
+        and mixed_a != cond_b
+        and biased_a != cond_a
+        and biased_a != cond_b
+        and biased2_a != cond_a
+        and biased2_a != cond_b
+        and cond_a != cond_b,
+    )
+
+    endpoint_ok = True
+    unique_ok = True
+    for effect in declared:
+        coefficient, n_x, n_z = extract_direction(effect)
+        plus = scaled_projector(Fraction(1), n_x, n_z)
+        minus = scaled_projector(Fraction(1), -n_x, -n_z)
+        value_plus = kernel(plus, effect).as_rational()
+        value_minus = kernel(minus, effect).as_rational()
+        endpoint_ok = endpoint_ok and value_plus == coefficient and value_minus == 0
+        constant, b_x, b_z = affine_coefficients(effect)
+        target_a = Qsqrt2(coefficient / 2)
+        target_b = (n_x * (coefficient / 2), n_z * (coefficient / 2))
+        tight_norm = b_x * b_x + b_z * b_z
+        # Spectral endpoints force a=c/2 and b·n=c/2; positivity kills v ⊥ n.
+        unique_ok = (
+            unique_ok
+            and constant == target_a
+            and (b_x, b_z) == target_b
+            and tight_norm == target_a * target_a
+        )
+        eps = Fraction(1, 10)
+        perp_x, perp_z = -n_z, n_x
+        trial_bx = b_x + perp_x * eps
+        trial_bz = b_z + perp_z * eps
+        trial_norm = trial_bx * trial_bx + trial_bz * trial_bz
+        unique_ok = unique_ok and trial_norm == target_a * target_a + Qsqrt2(eps * eps)
+    checks.check(
+        "spectral-endpoints",
+        "each declared scaled projector saturates its matrix spectrum at the two eigenstate Diracs",
+        endpoint_ok
+        and kernel(MIXED, I2).as_rational() == 1
+        and kernel(MIXED, H2(ZERO, ZERO, ZERO)).as_rational() == 0
+        and kernel(PZ, e0).as_rational() == Fraction(1, 2)
+        and kernel(PMZ, e0).as_rational() == 0,
+    )
+    checks.check(
+        "affine-uniqueness",
+        "positivity plus spectral endpoints force the extracted Bloch coefficients to Tr(rho E)",
+        unique_ok,
+    )
+
+    # Restriction depends on the menu, so it is not an affine kernel in mu alone.
+    restriction_not_kernel = cond_a != cond_b and mixed_a != cond_a
+    # Wrong linear kernel: Tr(E)/2 + extra m_z on E0 only, which breaks M_A additivity.
+    extra_sum_a = MIXED.pairing(e0).as_rational() + Fraction(1)  # value at m_z=1, extra=1 on E0
+    born_sum_at_pz = sum(kernel(PZ, item).as_rational() for item in menu_a)
+    wrong_sum_at_pz = born_sum_at_pz + 1  # extra m_z=1 only on E0
+    checks.check(
+        "reject-wrong-kernels",
+        "restriction is menu-dependent, and Tr(E)/2 plus an E0 Bloch extra fails additivity",
+        restriction_not_kernel and wrong_sum_at_pz != 1 and born_sum_at_pz == 1 and extra_sum_a != 1,
+    )
+
+    # Parent singleton-mass reconstruction: four distinct projective atoms, mass two.
+    projectors = (PZ, PMZ, PX, PMX)
+    checks.check(
+        "singleton-mass-two",
+        "raw singleton normalization of the z and x projective menus still forces mass two",
+        PZ + PMZ == I2
+        and PX + PMX == I2
+        and len(set(projectors)) == 4
+        and Fraction(1) + Fraction(1) == 2
+        and Fraction(1) + Fraction(1) > Fraction(1),
+    )
+
+    # Simultaneous binary-menu normalization of the constructed kernel (fails for one global singleton mass).
+    checks.check(
+        "binary-menu-kernel",
+        "barycenter evaluation normalizes both projective binary menus at mixed and biased states",
+        kernel(MIXED, PZ).as_rational() + kernel(MIXED, PMZ).as_rational() == 1
+        and kernel(MIXED, PX).as_rational() + kernel(MIXED, PMX).as_rational() == 1
+        and kernel(biased, PZ).as_rational() + kernel(biased, PMZ).as_rational() == 1
+        and kernel(biased, PX).as_rational() + kernel(biased, PMX).as_rational() == 1,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "hypothetical_axiom_status: no edit",
+                "menu-independent",
+                "Tr(",
+                "25/142",
+                "2/11",
+                "509/200",
+                "finite-support measures on the density body",
+                "not a physical Record law",
+                "not an axiom edit",
+                "not a no-go against non-affine kernels",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note,
+    )
+
+    print("per_element: five declared scaled effects and the four projective binary atoms are checked by matrix traces")
+    print("per_site: the kernel, restriction rejector, and singleton-mass parent argument are one-site statements")
+    print("per_mode: Bloch coefficients of each declared effect are extracted; a perpendicular extra mode is rejected by positivity")
+    print("per_block: only the finite-support barycenter-evaluation block is constructed; restriction is not this kernel")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics, formation rate, or Record identification is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Constructs the barycenter-evaluation kernel `w_μ(E)=Tr(ρ_μ E)` on finite-support measures on the qubit density body, as the affine companion to the landed 2026-08-10 type-separation note.

This is campaign `toe-lphys-20260812` Block 01. It does **not** edit the axioms.

## What changed

- Note: `docs/ADMISSIBILITY_BARYCENTER_EVALUATION_MENU_KERNEL_BOUNDED_THEOREM_NOTE_2026-08-12.md`
- Runner: `scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py`
- Cache: `logs/runner-cache/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.txt`

Exact arithmetic: restriction witness recomputed as `25/142` vs `2/11`; mixed barycenter `1/4`; biased barycenter `3/10`. Affine uniqueness holds only after spectral endpoints (without them a contraction family `K_λ` remains). Non-affine kernels stay live.

## Verification

```bash
python3 scripts/admissibility_barycenter_evaluation_menu_kernel_2026_08_12.py
# TOTAL: PASS=13 FAIL=0
```

## Trace

Partial close of the distribution-to-effect-grade identification. Does not register physical menus or Record outcomes. No axiom PR.

## Review surface

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. Do not merge as retained.

Pack: `/Users/jonreilly/Projects/Physics/.claude/science/physics-loops/toe-lphys-20260812/`
