### PR TITLE
[physics-loop] toe-lphys block02 record-descent: bounded_theorem / bounded-support

### DIFF
--- a/docs/RECORD_CONTENT_ONLY_SHARED_EFFECT_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-12.md
+++ b/docs/RECORD_CONTENT_ONLY_SHARED_EFFECT_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-12.md
@@ -1,0 +1,285 @@
+---
+claim_id: record_content_only_shared_effect_descent_bounded_theorem_note_2026-08-12
+claim_type: bounded_theorem
+claim_scope: "At one M_2(C) site the Aug 10 atomic restriction assigns two probabilities to one shared effect. Any readout determined by effect-only record content must assign one scalar to that effect. Those two facts are compatible only if record content is allowed to encode the menu name, not only the effect. An effect-only content map and a menu-in-content map are both exhibited. The note edits no axiom, proves no axiom necessity, proves no Born uniqueness, and supplies no formation rate."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10
+runner: scripts/record_content_only_shared_effect_descent_2026_08_12.py
+---
+
+# Record Content-Only Shared-Effect Descent
+
+**Date:** 2026-08-12
+**Type:** bounded_theorem
+**Scope:** one-site Record readout versus the Aug 10 shared-effect
+restriction kernel.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/record_content_only_shared_effect_descent_2026_08_12.py`](../scripts/record_content_only_shared_effect_descent_2026_08_12.py)
+
+## Result Up Front
+
+The current Record axiom in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) says:
+
+> Only records are readable. A readout value is determined by record content alone.
+
+The Aug 10 type-separation note
+[`ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md`](ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md)
+assigns two different normalized restriction values to one shared scaled
+effect `E_0` in two ternary menus. Those two facts can hold together only if
+the record that is read is allowed to encode the menu name, not only the
+effect matrix.
+
+Three exact statements locate the boundary.
+
+1. **Effect-only content is menu-independent.** The map `Φ_eff(M,E)=E` stores
+   the effect and forgets the menu. Any scalar `I` of that matrix assigns one
+   value to `E_0` in both menus.
+2. **Restriction is not an effect-only readout.** Recomputing the Aug 10
+   atomic masses gives `K_ν(E_0|M_A)=25/142` and `K_ν(E_0|M_B)=2/11`. Those
+   are two scalars on one effect, so they are not of the form `I ∘ Φ_eff`.
+3. **Menu-in-content remains a live escape.** Encoding the pair
+   `(label(M),E)` as `Φ_ctx(M,E)=E+i α_M I`, with `α_A=1` and `α_B=2`, and
+   reading `I(Φ)=Im Tr(Φ)/2`, yields the two scalars `1` and `2`. Each value
+   is a function of the stored matrix alone. The construction is not claimed
+   to be physical.
+
+No axiom is edited. The result is a compatibility theorem, not a Born
+uniqueness theorem and not a formation-rate statement.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The three statements are exact on declared one-site content maps and the Aug 10 atomic restriction witness. Physical encoding of a menu in a record, axiom necessity, and Born uniqueness remain open."
+trace_class: negative_route_pruning
+target_claim_id: record_content_only_shared_effect_descent
+target_blocker_text: "decide whether Aug 10 restriction can be a content-only Record readout of a shared effect"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for effect-only descent, restriction non-descent, and the displayed menu-in-content escape; physical realization remains open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site, with possibility domain `X=M_2(C)` as in the current Qubit
+axiom. For a unit Bloch vector `n` write
+
+`P(n)=(I+n · σ)/2`.
+
+Reuse the Aug 10 shared-effect menus exactly. Fix
+
+`E_0=(1/2)P(z)=((1/2,0),(0,0))`.
+
+The two ternary scaled-projector menus sharing only `E_0` are
+
+`M_A={E_0,(9/10)P(n_1),(3/5)P(n_2)}`
+
+with
+
+`n_1=(4 √2/9, 0, -7/9)`,
+`n_2=(-2 √2/3, 0, 1/3)`,
+
+and
+
+`M_B={E_0,(3/4)P(m_1),(3/4)P(m_2)}`
+
+with
+
+`m_1=(2 √2/3, 0, -1/3)`,
+`m_2=(-2 √2/3, 0, -1/3)`.
+
+Each displayed vector has norm one. In both menus the scalar coefficients sum
+to two and the coefficient-weighted Bloch vectors sum to zero, so each menu
+sums to `I`. The parent note records the resolution check; the runner repeats
+it.
+
+The Aug 10 atomic measure `ν` lives on the five distinct effects in
+`M_A ∪ M_B` and assigns mass proportional to the square of the effect's
+trace. Writing `c=Tr(cP(n))` for a scaled rank-one effect, the five masses
+before normalization are
+
+`(1/2)^2=1/4`,
+`(9/10)^2=81/100`,
+`(3/5)^2=9/25`,
+`(3/4)^2=9/16`,
+`(3/4)^2=9/16`.
+
+Their sum is
+
+`Z=1/4+81/100+9/25+9/16+9/16`.
+
+The common denominator `400` gives
+
+`100/400+324/400+144/400+225/400+225/400=1018/400=509/200`.
+
+Normalized restriction on each menu is then
+
+`K_ν(E|M)=ν({E})/ν(M)`
+
+whenever the denominator is positive.
+
+A **content map** is a function `Φ` from outcome pairs `(M,E)` with `E∈M` into
+`M_2(C)`. A **content-only readout** is a fixed scalar function `I` of that
+matrix. The Record sentence quoted above requires the displayed readout to be
+of this form once a content map has been chosen. It does not by itself choose
+the map.
+
+Two maps are used.
+
+1. **Effect-only.** `Φ_eff(M,E)=E`. The menu name is discarded. On the shared
+   effect this is the same Hermitian matrix in both menus.
+2. **Menu-context.** `Φ_ctx(M,E)=E+i α_M I` with labels `α_A=1` and `α_B=2`.
+   The pair `(label(M),E)` is written as one matrix in the Qubit possibility
+   domain. The imaginary multiple of the identity is a label encoding, not a
+   claimed physical formation mechanism.
+
+The displayed readout throughout is the fixed content-only scalar
+
+`I(Φ)=Im Tr(Φ)/2`.
+
+This is additive in the matrix argument and vanishes at `0`. On a Hermitian
+effect it is identically zero. On `Φ_ctx` it recovers the label `α_M`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether the Aug 10 restriction kernel on the shared
+effect can be a Record readout of effect-only content, and whether writing the
+menu name into the record restores formal compatibility with the content-only
+sentence.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin the current content-only Record sentence | premise | quoted from the axiom memo |
+| reuse the Aug 10 menus and atomic masses | common objects | restated and recomputed |
+| show every `I ∘ Φ_eff` is menu-independent on `E_0` | Theorem 1 | proved by substitution |
+| recompute `K_ν(E_0|M_A)` and `K_ν(E_0|M_B)` | Theorem 2 input | exact fractions below |
+| show restriction is not `I ∘ Φ_eff` | Theorem 2 | two unequal scalars |
+| exhibit a content-only `I ∘ Φ_ctx` with two scalars | Theorem 3 | `1` and `2` |
+| derive a physical menu-in-content encoding | autonomous closure | open |
+| prove axiom necessity or Born uniqueness | non-claims | not attempted |
+
+## Theorem 1 — Effect-Only Content Maps Are Menu-Independent On Shared Effects
+
+Let `I` be any scalar function of a matrix in `M_2(C)`. Then
+
+`I(Φ_eff(M_A,E_0))=I(E_0)=I(Φ_eff(M_B,E_0))`.
+
+The two outcome pairs `(M_A,E_0)` and `(M_B,E_0)` produce the same record
+content, so they produce the same readout. This is substitution, not an extra
+continuity or positivity hypothesis.
+
+For the displayed scalar the common value is explicit. The matrix of `E_0` is
+Hermitian with real trace `1/2`, so
+
+`I(Φ_eff(M_A,E_0))=Im(1/2)/2=0`
+
+and likewise on `M_B`. Any other fixed function of `E_0` — for example
+`Re Tr(E_0)/2=1/4` — is likewise the same in both menus.
+
+Thus every content-only readout of an effect-only record is
+menu-independent on shared effects.
+
+## Theorem 2 — The Restriction Kernel Is Not An Effect-Only Content Readout
+
+The Aug 10 atomic masses on `M_A` are `1/4`, `81/100`, and `9/25`. Their sum
+is
+
+`1/4+81/100+9/25=100/400+324/400+144/400=568/400=142/100`.
+
+Normalized restriction of the shared effect is therefore
+
+`K_ν(E_0|M_A)=(1/4)/(142/100)=(1/4)·(100/142)=25/142`.
+
+The Aug 10 atomic masses on `M_B` are `1/4`, `9/16`, and `9/16`. Their sum is
+
+`1/4+9/16+9/16=100/400+225/400+225/400=550/400=11/8`.
+
+Normalized restriction of the shared effect is therefore
+
+`K_ν(E_0|M_B)=(1/4)/(11/8)=(1/4)·(8/11)=2/11`.
+
+These are unequal:
+
+`25/142-2/11=(275-284)/1562=-9/1562`.
+
+Suppose there existed a content-only scalar `I` with
+
+`K_ν(E_0|M)=I(Φ_eff(M,E_0))`
+
+on both menus. Theorem 1 would force `25/142=2/11`, contradicting the
+difference just computed. Therefore the restriction kernel is not of the form
+`I ∘ Φ_eff`.
+
+The extra argument used by restriction is the menu itself. Under the Record
+sentence that extra argument cannot change the readout unless it is written
+into the record content.
+
+## Theorem 3 — Menu-In-Content Maps Realize Two Scalars On The Shared Effect
+
+Define `Φ_ctx(M,E)=E+i α_M I` with `α_A=1` and `α_B=2`, and keep
+`I(Φ)=Im Tr(Φ)/2`. Then
+
+`Φ_ctx(M_A,E_0)=((1/2+i,0),(0,i))`,
+
+`Tr=1/2+2i`,
+`I=Im(1/2+2i)/2=1`,
+
+and
+
+`Φ_ctx(M_B,E_0)=((1/2+2i,0),(0,2i))`,
+
+`Tr=1/2+4i`,
+`I=Im(1/2+4i)/2=2`.
+
+The two matrices are distinct elements of `M_2(C)`. The readout is the same
+function of the stored matrix in both cases, so it is content-only in the
+sense of the quoted Record sentence. The two scalars differ because the menu
+name was written into the content.
+
+This is a live formal escape from Theorem 2: restriction-like menu dependence
+can be rewritten as content dependence after a content map that sees the menu
+label. The escape is not claimed to be a physical record-formation mechanism,
+not claimed to be forced by the four axioms, and not claimed to select the
+Born grade. A later construction would have to derive, from Record and
+Admissibility structure, that forming records actually store a menu label in
+this or some other injective way.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom, or argue that an axiom update is necessary;
+- identify `K_ν` with a physical Record law;
+- prove uniqueness of the Born trace grade;
+- supply a record-formation site or rate;
+- construct a dynamics that writes `α_M` into a forming record;
+- exhaust other content maps.
+
+The discriminating gate is only this: a content map that depends only on the
+effect matrix must give one `I` on `E_0`; a content map that also encodes the
+menu name may give two `I` values. Both sides are exhibited. An honest miss
+on either side would stand.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Record content-only sentence | premise | quoted; no edit |
+| Aug 10 menus, `ν`, and restriction arithmetic | common objects | restated and recomputed |
+| `Φ_eff`, `Φ_ctx`, and `I(Φ)=Im Tr(Φ)/2` | declared maps | constructed here |
+| physical menu-in-content encoding | escape route | live, not derived |
+| axiom necessity, Born uniqueness, formation rate | non-claims | not used |
+
+The exact advance is a compatibility theorem between the Record content-only
+sentence and the Aug 10 shared-effect restriction witness. Independent audit
+remains required before any effective status may change.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15681,6 +15681,10 @@
   "record_conditional_law_three_point_period_series_bounded_theorem_note_2026-06-11": {
    "deps_hash": "7dab68b99d29",
    "out_degree": 1
+  },
+  "record_content_only_shared_effect_descent_bounded_theorem_note_2026-08-12": {
+   "deps_hash": "e8920a7a8b6a",
+   "out_degree": 2
   },
   "record_content_readout_license_split_registration_unreachability_theorem_note_2026-07-02": {
    "deps_hash": "c228186e4577",

--- a/logs/runner-cache/record_content_only_shared_effect_descent_2026_08_12.txt
+++ b/logs/runner-cache/record_content_only_shared_effect_descent_2026_08_12.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/record_content_only_shared_effect_descent_2026_08_12.py
+runner_sha256: e4f43c44d926f23e626d22d01679b42c48b2b10efe98916a755f2422d423c861
+input_fingerprint_sha256: 9fa58d89962b2ed2a9a4b0d1907e1a791ec8f3853b78a6f44cf009017ae84d64
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record wording and the Aug 10 menus/atomic masses are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: only effect-only descent of the Aug 10 restriction kernel is rejected; menu-in-content remains a live formal escape
+PASS: audit-input-paths declared audit inputs exist and match the note, axiom memo, and Aug 10 parent
+PASS: source-record-content-only the exact current content-only Record sentences are present
+PASS: source-aug10-restriction the Aug 10 parent states the shared-effect restriction witness and its masses
+PASS: ternary-menu-a the asymmetric shared-effect menu is an exact scaled-projector resolution
+PASS: ternary-menu-b the symmetric shared-effect menu is an exact scaled-projector resolution
+PASS: shared-effect-incidence the two menus share exactly E0 and otherwise contain distinct effects
+PASS: atomic-global-normalization the five squared-trace atomic weights have exact normalization 509/200
+PASS: atomic-restriction-values normalized restriction recomputes to 25/142 on M_A and 2/11 on M_B
+PASS: atomic-restriction-separation the same effect differs across the two menus by exactly -9/1562
+PASS: effect-only-one-I I circ Phi_eff assigns one scalar to E0 in both menus
+PASS: restriction-not-effect-only the restriction kernel is not I circ Phi_eff because it assigns two scalars to E0
+PASS: menu-context-two-I I circ Phi_ctx assigns the two distinct scalars 1 and 2 to the two (M,E0) pairs
+PASS: menu-context-distinct-content the menu-context records are distinct matrices in M_2(C)
+PASS: menu-context-content-only both menu-context scalars are the same function Im Tr(Phi)/2 of the stored matrix
+PASS: readout-additivity Im Tr(Phi)/2 is additive and vanishes at the zero matrix
+PASS: note-preserves-record-sentences the note quotes both current Record content-only sentences
+PASS: note-preserves-restriction-fractions the note records the recomputed restriction values 25/142 and 2/11
+PASS: note-links-parents the note links the axiom memo and the Aug 10 type-separation note
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: forbidden-rhetoric-absent the note avoids axiom-adoption, promotion, and executor-name rhetoric
+PASS: canonical-nonmutation the menu-context encoding is absent from the canonical axiom file
+PASS: parent-objects-bound the Aug 10 parent still names the shared effect and both menus
+per_element: one shared scaled effect is evaluated under Phi_eff, restriction, and Phi_ctx
+per_site: the three maps are one-site statements; no composite carrier is asserted
+per_mode: no spectral-mode exhaustion is claimed
+per_block: only the effect-only versus restriction versus menu-in-content interface is tested
+lattice_wide: checked and not executed — no lattice-wide dynamics or Born uniqueness is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_content_only_shared_effect_descent_2026_08_12.py
+++ b/scripts/record_content_only_shared_effect_descent_2026_08_12.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Exact checks for Record content-only descent versus Aug 10 restriction.
+
+The runner recomputes the Aug 10 atomic masses, checks that every content-only
+readout of an effect-only record is menu-independent on the shared effect, and
+exhibits a menu-in-content map that yields two scalars. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "RECORD_CONTENT_ONLY_SHARED_EFFECT_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-12.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PARENT_PATH = ROOT / "docs" / "ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_CONTENT_ONLY_SHARED_EFFECT_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-12.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Qsqrt2:
+    """Exact a + b sqrt(2) scalar sufficient for the Bloch witnesses."""
+
+    a: Fraction = Fraction(0)
+    b: Fraction = Fraction(0)
+
+    def __add__(self, other: "Qsqrt2") -> "Qsqrt2":
+        return Qsqrt2(self.a + other.a, self.b + other.b)
+
+    def __neg__(self) -> "Qsqrt2":
+        return Qsqrt2(-self.a, -self.b)
+
+    def __sub__(self, other: "Qsqrt2") -> "Qsqrt2":
+        return self + (-other)
+
+    def __mul__(self, other: "Qsqrt2") -> "Qsqrt2":
+        return Qsqrt2(
+            self.a * other.a + 2 * self.b * other.b,
+            self.a * other.b + self.b * other.a,
+        )
+
+    def scale(self, value: Fraction) -> "Qsqrt2":
+        return Qsqrt2(value * self.a, value * self.b)
+
+
+ZERO = Qsqrt2()
+ONE = Qsqrt2(Fraction(1))
+
+
+def q(value: int | Fraction) -> Qsqrt2:
+    return Qsqrt2(Fraction(value))
+
+
+def rs2(value: int | Fraction) -> Qsqrt2:
+    return Qsqrt2(Fraction(0), Fraction(value))
+
+
+Vector = tuple[Qsqrt2, Qsqrt2, Qsqrt2]
+
+
+def vector_scale(value: Fraction, vector: Vector) -> Vector:
+    return tuple(component.scale(value) for component in vector)  # type: ignore[return-value]
+
+
+def vector_sum(vectors: tuple[Vector, ...]) -> Vector:
+    return tuple(
+        sum((vector[index] for vector in vectors), ZERO)
+        for index in range(3)
+    )  # type: ignore[return-value]
+
+
+def norm_squared(vector: Vector) -> Qsqrt2:
+    return sum((component * component for component in vector), ZERO)
+
+
+@dataclass(frozen=True)
+class C:
+    """Exact complex number with rational parts."""
+
+    re: Fraction = Fraction(0)
+    im: Fraction = Fraction(0)
+
+    def __add__(self, other: "C") -> "C":
+        return C(self.re + other.re, self.im + other.im)
+
+    def __mul__(self, other: "C") -> "C":
+        return C(
+            self.re * other.re - self.im * other.im,
+            self.re * other.im + self.im * other.re,
+        )
+
+    def scale(self, value: Fraction) -> "C":
+        return C(value * self.re, value * self.im)
+
+
+Matrix = tuple[tuple[C, C], tuple[C, C]]
+
+
+def matrix_add(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def matrix_scale(value: C, matrix: Matrix) -> Matrix:
+    return (
+        (value * matrix[0][0], value * matrix[0][1]),
+        (value * matrix[1][0], value * matrix[1][1]),
+    )
+
+
+def matrix_trace(matrix: Matrix) -> C:
+    return matrix[0][0] + matrix[1][1]
+
+
+def content_readout(matrix: Matrix) -> Fraction:
+    return matrix_trace(matrix).im / 2
+
+
+IDENTITY: Matrix = (
+    (C(Fraction(1)), C()),
+    (C(), C(Fraction(1))),
+)
+E0_MATRIX: Matrix = (
+    (C(Fraction(1, 2)), C()),
+    (C(), C()),
+)
+
+
+def phi_eff(_menu_label: str, effect: Matrix) -> Matrix:
+    return effect
+
+
+def phi_ctx(menu_label: str, effect: Matrix) -> Matrix:
+    alpha = {"A": Fraction(1), "B": Fraction(2)}[menu_label]
+    shift = matrix_scale(C(Fraction(0), alpha), IDENTITY)
+    return matrix_add(effect, shift)
+
+
+@dataclass(frozen=True)
+class Effect:
+    coefficient: Fraction
+    bloch: Vector
+
+
+def menu_is_resolution(menu: tuple[Effect, ...]) -> bool:
+    scalar_ok = sum(effect.coefficient for effect in menu) == 2
+    vector = vector_sum(tuple(vector_scale(effect.coefficient, effect.bloch) for effect in menu))
+    unit_vectors = all(norm_squared(effect.bloch) == ONE for effect in menu)
+    scaled_domain = all(Fraction(0) < effect.coefficient <= Fraction(1) for effect in menu)
+    return scalar_ok and vector == (ZERO, ZERO, ZERO) and unit_vectors and scaled_domain
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+    normalized_parent = normalize(parent)
+
+    print("external_scientific_inputs: current Record wording and the Aug 10 menus/atomic masses are source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written")
+    print("negative_scope: only effect-only descent of the Aug 10 restriction kernel is rejected; menu-in-content remains a live formal escape")
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, axiom memo, and Aug 10 parent",
+        AUDIT_INPUT_PATHS == (
+            "docs/RECORD_CONTENT_ONLY_SHARED_EFFECT_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-12.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    record_sentences = (
+        "Only records are readable.",
+        "A readout value is determined by record content alone.",
+    )
+    checks.check(
+        "source-record-content-only",
+        "the exact current content-only Record sentences are present",
+        all(sentence in normalized_axiom for sentence in record_sentences),
+    )
+    checks.check(
+        "source-aug10-restriction",
+        "the Aug 10 parent states the shared-effect restriction witness and its masses",
+        all(
+            phrase in parent
+            for phrase in (
+                "Z=1/4+81/100+9/25+9/16+9/16=509/200",
+                "K_nu(E_0|M_A)=(1/4)/(1/4+81/100+9/25)=25/142",
+                "K_nu(E_0|M_B)=(1/4)/(1/4+9/16+9/16)=2/11",
+            )
+        ),
+    )
+
+    z = (ZERO, ZERO, ONE)
+    n1 = (rs2(Fraction(4, 9)), ZERO, q(Fraction(-7, 9)))
+    n2 = (rs2(Fraction(-2, 3)), ZERO, q(Fraction(1, 3)))
+    m1 = (rs2(Fraction(2, 3)), ZERO, q(Fraction(-1, 3)))
+    m2 = (rs2(Fraction(-2, 3)), ZERO, q(Fraction(-1, 3)))
+
+    e0 = Effect(Fraction(1, 2), z)
+    a1 = Effect(Fraction(9, 10), n1)
+    a2 = Effect(Fraction(3, 5), n2)
+    b1 = Effect(Fraction(3, 4), m1)
+    b2 = Effect(Fraction(3, 4), m2)
+    menu_a = (e0, a1, a2)
+    menu_b = (e0, b1, b2)
+
+    checks.check(
+        "ternary-menu-a",
+        "the asymmetric shared-effect menu is an exact scaled-projector resolution",
+        menu_is_resolution(menu_a),
+    )
+    checks.check(
+        "ternary-menu-b",
+        "the symmetric shared-effect menu is an exact scaled-projector resolution",
+        menu_is_resolution(menu_b),
+    )
+    checks.check(
+        "shared-effect-incidence",
+        "the two menus share exactly E0 and otherwise contain distinct effects",
+        set(menu_a).intersection(menu_b) == {e0} and len(set(menu_a).union(menu_b)) == 5,
+    )
+
+    coefficients = (e0.coefficient, a1.coefficient, a2.coefficient, b1.coefficient, b2.coefficient)
+    atomic_masses = tuple(value * value for value in coefficients)
+    atomic_normalization = sum(atomic_masses)
+    checks.check(
+        "atomic-global-normalization",
+        "the five squared-trace atomic weights have exact normalization 509/200",
+        atomic_normalization == Fraction(509, 200)
+        and sum(mass / atomic_normalization for mass in atomic_masses) == 1,
+        residual=atomic_normalization,
+    )
+
+    e0_square = e0.coefficient * e0.coefficient
+    menu_a_square_sum = sum(effect.coefficient**2 for effect in menu_a)
+    menu_b_square_sum = sum(effect.coefficient**2 for effect in menu_b)
+    conditional_a = e0_square / menu_a_square_sum
+    conditional_b = e0_square / menu_b_square_sum
+    checks.check(
+        "atomic-restriction-values",
+        "normalized restriction recomputes to 25/142 on M_A and 2/11 on M_B",
+        conditional_a == Fraction(25, 142) and conditional_b == Fraction(2, 11),
+        residual=(conditional_a, conditional_b),
+    )
+    checks.check(
+        "atomic-restriction-separation",
+        "the same effect differs across the two menus by exactly -9/1562",
+        conditional_a - conditional_b == Fraction(-9, 1562),
+        residual=conditional_a - conditional_b,
+    )
+
+    i_eff_a = content_readout(phi_eff("A", E0_MATRIX))
+    i_eff_b = content_readout(phi_eff("B", E0_MATRIX))
+    checks.check(
+        "effect-only-one-I",
+        "I circ Phi_eff assigns one scalar to E0 in both menus",
+        i_eff_a == i_eff_b == Fraction(0),
+        residual=(i_eff_a, i_eff_b),
+    )
+    checks.check(
+        "restriction-not-effect-only",
+        "the restriction kernel is not I circ Phi_eff because it assigns two scalars to E0",
+        conditional_a != conditional_b
+        and {conditional_a, conditional_b} != {i_eff_a}
+        and phi_eff("A", E0_MATRIX) == phi_eff("B", E0_MATRIX),
+        residual=(conditional_a, conditional_b, i_eff_a),
+    )
+
+    phi_a = phi_ctx("A", E0_MATRIX)
+    phi_b = phi_ctx("B", E0_MATRIX)
+    i_ctx_a = content_readout(phi_a)
+    i_ctx_b = content_readout(phi_b)
+    checks.check(
+        "menu-context-two-I",
+        "I circ Phi_ctx assigns the two distinct scalars 1 and 2 to the two (M,E0) pairs",
+        i_ctx_a == Fraction(1) and i_ctx_b == Fraction(2) and i_ctx_a != i_ctx_b,
+        residual=(i_ctx_a, i_ctx_b),
+    )
+    checks.check(
+        "menu-context-distinct-content",
+        "the menu-context records are distinct matrices in M_2(C)",
+        phi_a != phi_b and phi_a != E0_MATRIX and phi_b != E0_MATRIX,
+    )
+    checks.check(
+        "menu-context-content-only",
+        "both menu-context scalars are the same function Im Tr(Phi)/2 of the stored matrix",
+        content_readout(phi_a) == i_ctx_a and content_readout(phi_b) == i_ctx_b,
+    )
+    checks.check(
+        "readout-additivity",
+        "Im Tr(Phi)/2 is additive and vanishes at the zero matrix",
+        content_readout(matrix_add(phi_a, phi_b)) == i_ctx_a + i_ctx_b
+        and content_readout(((C(), C()), (C(), C()))) == 0,
+    )
+
+    checks.check(
+        "note-preserves-record-sentences",
+        "the note quotes both current Record content-only sentences",
+        all(sentence in normalized_note for sentence in record_sentences),
+    )
+    checks.check(
+        "note-preserves-restriction-fractions",
+        "the note records the recomputed restriction values 25/142 and 2/11",
+        "25/142" in note and "2/11" in note and "509/200" in note,
+    )
+    checks.check(
+        "note-links-parents",
+        "the note links the axiom memo and the Aug 10 type-separation note",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and "ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+                "hypothetical_axiom_status: \"no edit\"",
+            )
+        ),
+    )
+
+    forbidden = ("new axiom", "we adopt", "promoted", "Codex")
+    retained_hits = [
+        line
+        for line in note.splitlines()
+        if "retained" in line
+        and "audit_required_before_effective_retained" not in line
+        and "bare_retained_allowed" not in line
+    ]
+    checks.check(
+        "forbidden-rhetoric-absent",
+        "the note avoids axiom-adoption, promotion, and executor-name rhetoric",
+        all(phrase not in note for phrase in forbidden) and retained_hits == [],
+        residual=retained_hits,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the menu-context encoding is absent from the canonical axiom file",
+        all(phrase not in axiom for phrase in ("Phi_ctx", "Φ_ctx", "alpha_M", "α_M")),
+    )
+    checks.check(
+        "parent-objects-bound",
+        "the Aug 10 parent still names the shared effect and both menus",
+        all(
+            phrase in normalized_parent
+            for phrase in (
+                "E_0=(1/2)P(z)",
+                "M_A={E_0,(9/10)P(n_1),(3/5)P(n_2)}",
+                "M_B={E_0,(3/4)P(m_1),(3/4)P(m_2)}",
+            )
+        ),
+    )
+
+    print("per_element: one shared scaled effect is evaluated under Phi_eff, restriction, and Phi_ctx")
+    print("per_site: the three maps are one-site statements; no composite carrier is asserted")
+    print("per_mode: no spectral-mode exhaustion is claimed")
+    print("per_block: only the effect-only versus restriction versus menu-in-content interface is tested")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics or Born uniqueness is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Shows that the Aug 10 atomic restriction kernel cannot be a Record readout of *effect-only* content. Menu-in-content remains a live formal escape.

This is campaign `toe-lphys-20260812` Block 02. Independent of Block 01. It does **not** edit the axioms.

## What changed

- Note: `docs/RECORD_CONTENT_ONLY_SHARED_EFFECT_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-12.md`
- Runner: `scripts/record_content_only_shared_effect_descent_2026_08_12.py`
- Cache: `logs/runner-cache/record_content_only_shared_effect_descent_2026_08_12.txt`

`I ∘ Φ_eff` is one scalar on shared `E_0`. Restriction is `25/142` vs `2/11`. `I ∘ Φ_ctx` with `E+iα_M I` yields `1` and `2`. The escape is not claimed physical.

## Verification

```bash
python3 scripts/record_content_only_shared_effect_descent_2026_08_12.py
# TOTAL: PASS=23 FAIL=0
```

## Trace

Supports the Record half of the type-bridge. Does not prove Born uniqueness or axiom necessity.

## Review surface

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required.
