### PR TITLE
[physics-loop] toe-lphys block06 testmass: bounded_theorem / bounded-support

### DIFF
--- a/docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_NEWTON_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_NEWTON_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,288 @@
+---
+claim_id: record_additivity_does_not_supply_newton_product_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Scalar Record additivity supplies I(S∪T)=I(S)+I(T) on disjoint finite collections, a function of the sum only. That single scalar cannot separate (m_s,m_t)=(2,0) from (1,1) from (0,2), so it cannot equal the product m_s m_t. The Newton kernel Green pairing remains source-linear and does not produce a test-mass factor. A declared pairing π(S,T)=I(S)I(T) would be a second object; this note does not install that pairing, edit an axiom, or claim gravity is impossible."
+upstream_dependencies:
+  - minimal_axioms
+  - newton_law_derived_note
+runner: scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py
+---
+
+# Record Additivity Does Not Supply The Newton Product
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** finite exact algebra of scalar Record additivity versus the
+bilinear product `m_s m_t` used by a Newton test-mass factor.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py`](../scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py)
+
+## Result Up Front
+
+The current Record axiom in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies a
+single additive scalar on finite pairwise-disjoint record collections:
+
+> For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+Let `S` and `T` be finite pairwise-disjoint record collections, and write
+`I(S)=m_s`, `I(T)=m_t` for formal integers or rationals. Additivity forces
+
+`I(S∪T)=I(S)+I(T)=m_s+m_t`.
+
+Any function of that one scalar is a function of the sum only. It cannot
+separate the three pairs `(m_s,m_t)=(2,0)`, `(1,1)`, `(0,2)`, which share
+the same union readout `2`. The products of those pairs are `0`, `1`, `0`.
+Therefore no function of `I(S∪T)` equals `m_s m_t` on those three inputs.
+
+The Newton potential-kernel packet
+[`NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) already records
+the source-linear Green pairing
+
+`G(r)=1/(4 pi r)`, `phi=m_s G`, `|grad phi|=m_s/(4 pi r^2)`.
+
+That gradient still carries no test-mass factor. Multiplying by `m_t` is an
+extra bilinear map `B(S,T)=I(S)I(T)`, which is not determined by `I` on the
+union. The same packet lists both `F = -M_test grad(phi)` and the physical
+product law `M_source M_test` among its non-claims.
+
+If a second readout of `T`, or a declared pairing `π(S,T)`, is supplied,
+then `B=I(S)I(T)` is well-defined as a two-argument map. That pairing is
+the missing object. It is not `I` on `S∪T`, is not installed here, and is
+not claimed to be physical.
+
+This is a scoped algebraic gap. It does not say gravity is impossible.
+
+## Machine Status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "I on a disjoint union is the sum, and the three-pair rejector shows that sum cannot equal the product. The Newton Green pairing remains source-linear. A two-argument pairing would supply B=I(S)I(T) but is not Record additivity."
+trace_class: negative_route_pruning
+target_claim_id: record_additivity_does_not_supply_newton_product
+target_blocker_text: "decide whether scalar Record additivity yields the Newton product M_source M_test"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the three-pair rejector, source-linear Green pairing, and the displayed two-argument escape; physical pairing remains open"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work with finite record collections in the sense of the Record axiom. A
+**collection** is a finite family of pairwise-disjoint records, each carrying
+a formal rational strength. Scalar readout `I` is the sum of those
+strengths. The empty collection has `I(empty)=0`. If `A` and `B` are
+disjoint, additivity is
+
+`I(A∪B)=I(A)+I(B)`.
+
+Fix two disjoint collections `S` and `T` and write
+
+`m_s := I(S)`, `m_t := I(T)`.
+
+The three rejector pairs below are realized by unit-strength atoms, and
+again by lumped rational strengths with the same totals. In every
+realization the only Record datum on the disjoint union is the one scalar
+`I(S∪T)`.
+
+| pair `(m_s,m_t)` | unit-atom realization | `I(S∪T)` | `m_s m_t` |
+|---|---|---|---|
+| `(2,0)` | `S={s1,s2}`, `T=empty` | `2` | `0` |
+| `(1,1)` | `S={s1}`, `T={t1}` | `2` | `1` |
+| `(0,2)` | `S=empty`, `T={t1,t2}` | `2` | `0` |
+
+The same sums and products are obtained from lumped strengths
+`S` of total `2` with `T` empty, `S` of total `1` with `T` of total `1`,
+and `S` empty with `T` of total `2`. An extra rational witness with the
+same union sum is `(m_s,m_t)=(3/2,1/2)`, which has `I(S∪T)=2` and
+product `3/4`.
+
+A **function of the union scalar** is any map of the form
+`f(I(S∪T))`. A **bilinear pairing** of the two collections is any map
+`B(S,T)` that is separately linear in `I(S)` and in `I(T)`. The product
+pairing used by a Newton test-mass factor is
+
+`B(S,T)=I(S)I(T)=m_s m_t`.
+
+The Newton packet supplies the radial Green kernel and its source-linear
+potential, not that pairing. Its in-scope algebra, with source coefficient
+written `m_s`, is
+
+```text
+G(r) = 1/(4 pi r),
+phi(r) = m_s G(r) = m_s/(4 pi r),
+|grad phi| = m_s/(4 pi r^2).
+```
+
+The 2026-05-29 scope repair of that packet removed the force/source
+coupling `F = -M_test grad(phi)` from the load-bearing claim. The
+source-side mass-linearity lemma
+[`G_NEWTON_MASS_LINEAR_POISSON_COMPOSITION_BOUNDED_THEOREM_NOTE_2026-05-10.md`](G_NEWTON_MASS_LINEAR_POISSON_COMPOSITION_BOUNDED_THEOREM_NOTE_2026-05-10.md)
+is likewise only linearity in the source mass.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether the single additive scalar `I` on a
+disjoint union can equal the Newton product `m_s m_t`, and whether the
+already-recorded Green pairing produces a test-mass factor.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin `I(empty)=0` and disjoint additivity | premise | quoted from the axiom memo |
+| pin Newton non-claim of `F = -M_test` and `M_source M_test` | premise | quoted from the Newton packet |
+| show `I(S∪T)` is the sum only | Theorem 1 | additivity |
+| rejector `(2,0)`, `(1,1)`, `(0,2)` | Theorem 1 | common sum `2`, products `0,1,0` |
+| show the Green gradient has no `m_t` | Theorem 2 | `|grad phi|=m_s/(4 pi r^2)` |
+| exhibit `B=I(S)I(T)` as a two-argument map | Theorem 3 | declared pairing; not physical |
+| derive a physical pairing or force law | autonomous closure | open |
+| claim gravity is impossible | non-claim | not attempted |
+
+## Theorem 1 — A Function Of `I(S∪T)` Cannot Equal The Product
+
+Let `S` and `T` be disjoint. Record additivity and `I(empty)=0` give
+
+`I(S∪T)=I(S)+I(T)=m_s+m_t`,
+
+and `I(S∪empty)=I(S)`, `I(empty∪T)=I(T)`. The value `I(S∪T)` is therefore
+exactly the sum. Any function of that one scalar is constant on the level
+set `m_s+m_t=σ`.
+
+On the three rejector pairs the sum is the same:
+
+`(2,0): I(S∪T)=2`,
+`(1,1): I(S∪T)=2`,
+`(0,2): I(S∪T)=2`.
+
+The products are not the same:
+
+`(2,0): m_s m_t=0`,
+`(1,1): m_s m_t=1`,
+`(0,2): m_s m_t=0`.
+
+Suppose there existed a function `f` of one scalar such that
+`f(I(S∪T))=m_s m_t` on those three inputs. Then `f(2)=0` from `(2,0)` and
+`f(2)=1` from `(1,1)`, which is impossible. The same collision occurs for
+every other pair of distinct products with a common sum, including the
+rational witness `(3/2,1/2)` with product `3/4`.
+
+Explicit one-variable trial maps fail in the same way. The identity
+`f(σ)=σ` returns `2,2,2`. The constant `f(σ)=1` matches only `(1,1)`. The
+quadratic `f(σ)=σ(σ-2)` returns `0,0,0` and matches the two vanishing
+products but not `(1,1)`. No choice of `f` hits `0,1,0` at a single
+argument `2`.
+
+Thus `I` on the disjoint union cannot distinguish `(2,0)`, `(1,1)`, and
+`(0,2)`, while `m_s m_t` can. Scalar Record additivity does not yield the
+product law.
+
+## Theorem 2 — The Newton Green Pairing Still Has No Test-Mass Factor
+
+The Newton packet's in-scope algebra is the radial kernel `G(r)=1/(4 pi r)`
+and the source-linear potential `phi=m_s G`. Differentiating in `r>0` gives
+
+`d phi/dr = -m_s/(4 pi r^2)`, `|grad phi|=m_s/(4 pi r^2)`.
+
+The right-hand side does not depend on `m_t`. On the three rejector pairs,
+at any common `r>0`, the gradient magnitudes are
+
+`(2,0): 2/(4 pi r^2)`,
+`(1,1): 1/(4 pi r^2)`,
+`(0,2): 0`.
+
+The would-be product-law magnitudes `m_s m_t/(4 pi r^2)` are instead
+
+`(2,0): 0`,
+`(1,1): 1/(4 pi r^2)`,
+`(0,2): 0`.
+
+The pair `(2,0)` is the witness: the Green gradient sees source strength
+`2` and is not the vanishing product. The pair `(1,1)` agrees only because
+`m_t=1`, which is not a derivation of a test-mass factor. Multiplying
+`|grad phi|` by `m_t` is exactly the extra bilinear map
+
+`B(S,T)=I(S)I(T)`,
+
+which Theorem 1 showed is not a function of `I(S∪T)`. Source-side
+linearity of the Poisson potential, as in the G-Newton mass-linear lemma,
+likewise scales only with `m_s`.
+
+The Newton packet already lists the test-mass force/source response rule
+`F = -M_test grad(phi)` and the physical product law `M_source M_test` as
+non-claims. Theorem 2 is the matching algebraic reason: the kernel algebra
+never produces the second factor.
+
+## Theorem 3 — A Declared Pairing Supplies `B`, And Is A Second Object
+
+Suppose a second readout of `T` is available separately from the readout of
+`S`, or a pairing `π(S,T)` of the two collections is declared. Then the
+product
+
+`B(S,T) := I(S)I(T)`
+
+is well-defined. On the three rejector pairs it returns `0`, `1`, `0`, so
+it does distinguish `(1,1)` from `(2,0)` and from `(0,2)`. It is a
+function of two scalars, not of their sum.
+
+This pairing is the missing object for a product law. It is not Record
+additivity. It is not `I(S∪T)`. The four axioms do not name `π`. This note
+does not install `π`, does not argue that an axiom update is required, and
+does not claim that forming records physically carry a source/test split.
+
+The discriminating gate is only this: a bilinear pairing on two disjoint
+additively-read collections can produce an `M_s M_t` number; `I` alone on
+the disjoint union cannot. Both sides are exhibited.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom, or argue that an axiom update is necessary;
+- claim that gravity is impossible, or that a Newton force law cannot be
+  reached by some later bridge;
+- identify `B(S,T)=I(S)I(T)` with a physical Record law;
+- restore `F = -M_test grad(phi)` as a derived response rule;
+- derive the physical product law `M_source M_test`;
+- close gravitational coupling normalization, `G_N`, or a continuum
+  Einstein equation;
+- exhaust other two-collection maps.
+
+The scope is the exact gap: scalar Record additivity does not yield the
+product law.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Record additivity sentence and `I(empty)=0` | premise | quoted; no edit |
+| Newton kernel `G(r)=1/(4 pi r)` and source-linear `phi` | common objects | restated from the Newton packet |
+| Newton non-claim of `F = -M_test` and `M_source M_test` | scope pin | quoted; not reversed |
+| three-pair rejector and `B=I(S)I(T)` | declared algebra | computed here |
+| physical source/test pairing | escape route | live, not derived |
+
+The exact advance is a finite additivity-versus-product theorem. Independent
+audit remains required before any effective status may change.
+
+## Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | The Newton packet removed the test-mass product from its claim. This note proves the matching algebraic gap on Record additivity. |
+| V2 | New content? | Yes: the three-pair rejector, the explicit mismatch of `|grad phi|` with `m_s m_t/(4 pi r^2)`, and the two-argument pairing as a second object. |
+| V3 | Independently checkable? | Yes. The runner recomputes `I` from collections, the products from `m_s m_t`, and the Green derivative from `G`. |
+| V4 | More than a restatement? | Yes. The Newton non-claim is a scope sentence; this note supplies the additivity-versus-bilinear witness. |
+| V5 | One-step relabel? | No. Quoting additivity and quoting the Newton non-claim does not by itself exhibit the `(2,0),(1,1),(0,2)` collision. |
+
+## Primary Runner
+
+[`scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py`](../scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py)
+recomputes disjoint additivity, the three-pair rejector, the Green
+gradient, and the two-argument pairing in exact arithmetic.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15629,6 +15629,10 @@
   "reconstructed_h_quasilocal_from_analytic_dispersion_microcausality_bridge_narrow_theorem_note_2026-06-06": {
    "deps_hash": "8e0303c6f18c",
    "out_degree": 2
+  },
+  "record_additivity_does_not_supply_newton_product_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "f3e3aeef73e3",
+   "out_degree": 3
   },
   "record_asymptotic_reset_convergence_ledger_2026-06-05": {
    "deps_hash": "ffe526446f32",

--- a/logs/runner-cache/record_additivity_does_not_supply_newton_product_2026_08_13.txt
+++ b/logs/runner-cache/record_additivity_does_not_supply_newton_product_2026_08_13.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py
+runner_sha256: dad5756f9fb2355213e7a1f3a1699c34d62c78e6f1482dbd08427720c2a04255
+input_fingerprint_sha256: 8f997a9a8e0e64db6027a8c0da726534f3a2aa05259df23d9bf8dffbd01def24
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.24
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record additivity and the Newton kernel/non-claims are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: only I-on-the-union as a product law is rejected; a two-argument pairing remains a live formal escape; gravity is not claimed impossible
+PASS: audit-input-paths declared audit inputs exist and match the note, axiom memo, and Newton packet
+PASS: source-record-additivity the exact current Record additivity sentence is present in the axiom memo
+PASS: source-newton-nonclaim-product the Newton packet lists the physical product law as a non-claim
+PASS: source-newton-nonclaim-force the Newton packet lists F = -M_test grad(phi) as a non-claim
+PASS: empty-readout I(empty)=0
+PASS: disjoint-additivity I(A union B)=I(A)+I(B) on disjoint unit-atom collections
+PASS: overlap-rejected union is refused when labels are not disjoint
+PASS: rejector-disjoint each rejector pair is pairwise disjoint
+PASS: rejector-disjoint each rejector pair is pairwise disjoint
+PASS: rejector-disjoint each rejector pair is pairwise disjoint
+PASS: union-sum-only I(S union T) equals the sum m_s+m_t on the three rejector pairs
+PASS: union-cannot-distinguish I(S union T) cannot distinguish (2,0), (1,1), (0,2)
+PASS: product-from-factors m_s m_t recomputed from the two readouts is 0, 1, 0
+PASS: product-distinguishes m_s m_t distinguishes (1,1) from (2,0) and from (0,2)
+PASS: no-function-of-the-sum no function of the single scalar I(S union T) can equal the three products
+PASS: trial-maps-fail identity, constant-1, and sigma(sigma-2) all miss the product triple
+PASS: lumped-and-rational lumped (2,0),(1,1),(0,2),(3/2,1/2) keep union sum 2 and products 0,1,0,3/4
+PASS: green-kernel supplied kernel is 1/(4 pi r) and phi is source-linear
+PASS: green-gradient-source-only d phi / dr = -m_s/(4 pi r^2) with no m_t factor
+PASS: green-misses-product Green |grad phi| coefficients are 2,1,0; product-law coefficients are 0,1,0
+PASS: pairing-is-bilinear B(S,T)=I(S)I(T) returns the product triple and is not I on the union
+PASS: note-preserves-empty the note records I(empty)=0
+PASS: note-preserves-force-and-product the note records F = -M_test and M_source M_test
+PASS: note-preserves-additivity-sentence the note quotes the current Record additivity sentence
+PASS: note-links-parents the note links the axiom memo and the Newton packet
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: note-three-pair-rejector the note exhibits (2,0), (1,1), (0,2) and I(S∪T)
+PASS: note-does-not-forbid-gravity the note states the scoped gap and does not claim gravity is impossible
+PASS: forbidden-rhetoric-absent the note avoids axiom-adoption, promotion, executor-name, and Einstein-derived rhetoric
+PASS: canonical-nonmutation the pairing escape is absent from the canonical axiom file
+PASS: newton-kernel-bound the Newton packet still states the source-linear kernel algebra
+per_element: each rejector pair is evaluated under I(union) and under I(S)I(T)
+per_site: the statements are collection-level; no composite carrier is asserted
+per_mode: no spectral-mode exhaustion is claimed
+per_block: only additivity-versus-product versus the Green pairing is tested
+lattice_wide: checked and not executed — no lattice-wide gravity or Einstein equation is claimed
+TOTAL: PASS=32 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py
+++ b/scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Exact checks: Record additivity does not supply the Newton product.
+
+I on a disjoint union is the sum. The triples (2,0), (1,1), (0,2) share
+that sum and do not share the product m_s m_t. The Newton Green pairing
+is source-linear and has no test-mass factor. A two-argument pairing
+B=I(S)I(T) does produce the product. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+import sympy as sp
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "RECORD_ADDITIVITY_DOES_NOT_SUPPLY_NEWTON_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+NEWTON_PATH = ROOT / "docs" / "NEWTON_LAW_DERIVED_NOTE.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_NEWTON_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/NEWTON_LAW_DERIVED_NOTE.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Collection:
+    """Finite labeled record collection with rational strengths."""
+
+    atoms: tuple[tuple[str, Fraction], ...] = ()
+
+    def strength(self) -> Fraction:
+        return sum((weight for _, weight in self.atoms), Fraction(0))
+
+    def labels(self) -> frozenset[str]:
+        return frozenset(label for label, _ in self.atoms)
+
+    def disjoint(self, other: "Collection") -> bool:
+        return self.labels().isdisjoint(other.labels())
+
+    def union(self, other: "Collection") -> "Collection":
+        if not self.disjoint(other):
+            raise ValueError("Record additivity is stated only for disjoint collections")
+        return Collection(self.atoms + other.atoms)
+
+
+def I(collection: Collection) -> Fraction:
+    return collection.strength()
+
+
+def pairing(source: Collection, test: Collection) -> Fraction:
+    return I(source) * I(test)
+
+
+def unit_atoms(prefix: str, count: int) -> Collection:
+    return Collection(tuple((f"{prefix}{index}", Fraction(1)) for index in range(count)))
+
+
+def lumped(label: str, weight: Fraction) -> Collection:
+    if weight == 0:
+        return Collection()
+    return Collection(((label, weight),))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    newton = NEWTON_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+    normalized_newton = normalize(newton)
+
+    print("external_scientific_inputs: current Record additivity and the Newton kernel/non-claims are source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written")
+    print("negative_scope: only I-on-the-union as a product law is rejected; a two-argument pairing remains a live formal escape; gravity is not claimed impossible")
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, axiom memo, and Newton packet",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_NEWTON_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/NEWTON_LAW_DERIVED_NOTE.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    additivity_sentence = (
+        "For any finite collection of pairwise-disjoint records, scalar readout "
+        "`I` is additive, with `I(empty)=0`."
+    )
+    checks.check(
+        "source-record-additivity",
+        "the exact current Record additivity sentence is present in the axiom memo",
+        additivity_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-newton-nonclaim-product",
+        "the Newton packet lists the physical product law as a non-claim",
+        "the physical product law `M_source M_test`" in newton,
+    )
+    checks.check(
+        "source-newton-nonclaim-force",
+        "the Newton packet lists F = -M_test grad(phi) as a non-claim",
+        "F = -M_test grad(phi)" in newton
+        and "test-mass force/source response rule" in newton,
+    )
+
+    empty = Collection()
+    checks.check(
+        "empty-readout",
+        "I(empty)=0",
+        I(empty) == Fraction(0),
+        residual=I(empty),
+    )
+
+    left = unit_atoms("a", 2)
+    right = unit_atoms("b", 3)
+    checks.check(
+        "disjoint-additivity",
+        "I(A union B)=I(A)+I(B) on disjoint unit-atom collections",
+        left.disjoint(right) and I(left.union(right)) == I(left) + I(right) == Fraction(5),
+        residual=(I(left), I(right), I(left.union(right))),
+    )
+    overlap = Collection((("shared", Fraction(1)),))
+    checks.check(
+        "overlap-rejected",
+        "union is refused when labels are not disjoint",
+        not overlap.disjoint(overlap),
+    )
+
+    pair_20 = (unit_atoms("s", 2), Collection())
+    pair_11 = (unit_atoms("s", 1), unit_atoms("t", 1))
+    pair_02 = (Collection(), unit_atoms("t", 2))
+    rejectors = (pair_20, pair_11, pair_02)
+
+    union_values = []
+    product_values = []
+    for source, test in rejectors:
+        checks.check(
+            "rejector-disjoint",
+            "each rejector pair is pairwise disjoint",
+            source.disjoint(test),
+        )
+        union_values.append(I(source.union(test)))
+        product_values.append(pairing(source, test))
+
+    checks.check(
+        "union-sum-only",
+        "I(S union T) equals the sum m_s+m_t on the three rejector pairs",
+        union_values
+        == [
+            I(pair_20[0]) + I(pair_20[1]),
+            I(pair_11[0]) + I(pair_11[1]),
+            I(pair_02[0]) + I(pair_02[1]),
+        ]
+        == [Fraction(2), Fraction(2), Fraction(2)],
+        residual=union_values,
+    )
+    checks.check(
+        "union-cannot-distinguish",
+        "I(S union T) cannot distinguish (2,0), (1,1), (0,2)",
+        len(set(union_values)) == 1 and union_values[0] == Fraction(2),
+        residual=union_values,
+    )
+
+    computed_products = [
+        I(pair_20[0]) * I(pair_20[1]),
+        I(pair_11[0]) * I(pair_11[1]),
+        I(pair_02[0]) * I(pair_02[1]),
+    ]
+    checks.check(
+        "product-from-factors",
+        "m_s m_t recomputed from the two readouts is 0, 1, 0",
+        computed_products == [Fraction(0), Fraction(1), Fraction(0)]
+        and product_values == computed_products,
+        residual=computed_products,
+    )
+    checks.check(
+        "product-distinguishes",
+        "m_s m_t distinguishes (1,1) from (2,0) and from (0,2)",
+        computed_products[1] != computed_products[0]
+        and computed_products[1] != computed_products[2]
+        and computed_products[0] == computed_products[2] == Fraction(0),
+        residual=computed_products,
+    )
+    checks.check(
+        "no-function-of-the-sum",
+        "no function of the single scalar I(S union T) can equal the three products",
+        len(set(union_values)) == 1 and len(set(computed_products)) > 1,
+        residual=(union_values, computed_products),
+    )
+
+    identity_trial = list(union_values)
+    constant_trial = [Fraction(1), Fraction(1), Fraction(1)]
+    quadratic_trial = [sigma * (sigma - 2) for sigma in union_values]
+    checks.check(
+        "trial-maps-fail",
+        "identity, constant-1, and sigma(sigma-2) all miss the product triple",
+        identity_trial != computed_products
+        and constant_trial != computed_products
+        and quadratic_trial != computed_products
+        and set(quadratic_trial) == {Fraction(0)},
+        residual=(identity_trial, constant_trial, quadratic_trial),
+    )
+
+    lumped_pairs = (
+        (lumped("S", Fraction(2)), lumped("T", Fraction(0))),
+        (lumped("S", Fraction(1)), lumped("T", Fraction(1))),
+        (lumped("S", Fraction(0)), lumped("T", Fraction(2))),
+        (lumped("S", Fraction(3, 2)), lumped("T", Fraction(1, 2))),
+    )
+    lumped_unions = [I(source.union(test)) for source, test in lumped_pairs]
+    lumped_products = [I(source) * I(test) for source, test in lumped_pairs]
+    checks.check(
+        "lumped-and-rational",
+        "lumped (2,0),(1,1),(0,2),(3/2,1/2) keep union sum 2 and products 0,1,0,3/4",
+        lumped_unions == [Fraction(2)] * 4
+        and lumped_products
+        == [Fraction(0), Fraction(1), Fraction(0), Fraction(3, 4)],
+        residual=(lumped_unions, lumped_products),
+    )
+
+    r = sp.symbols("r", positive=True)
+    m_s, m_t = sp.symbols("m_s m_t", real=True)
+    green = 1 / (4 * sp.pi * r)
+    phi = m_s * green
+    dphi = sp.diff(phi, r)
+    grad_mag = -dphi
+    product_force = m_s * m_t / (4 * sp.pi * r**2)
+    checks.check(
+        "green-kernel",
+        "supplied kernel is 1/(4 pi r) and phi is source-linear",
+        sp.simplify(green - 1 / (4 * sp.pi * r)) == 0
+        and sp.simplify(phi - m_s / (4 * sp.pi * r)) == 0,
+    )
+    checks.check(
+        "green-gradient-source-only",
+        "d phi / dr = -m_s/(4 pi r^2) with no m_t factor",
+        sp.simplify(dphi + m_s / (4 * sp.pi * r**2)) == 0
+        and sp.simplify(grad_mag - m_s / (4 * sp.pi * r**2)) == 0
+        and m_t not in grad_mag.free_symbols,
+        residual=grad_mag,
+    )
+
+    triple = ((2, 0), (1, 1), (0, 2))
+    grad_coeffs = [sp.simplify(grad_mag.subs({m_s: source, m_t: test}) * (4 * sp.pi * r**2)) for source, test in triple]
+    product_coeffs = [
+        sp.simplify(product_force.subs({m_s: source, m_t: test}) * (4 * sp.pi * r**2)) for source, test in triple
+    ]
+    checks.check(
+        "green-misses-product",
+        "Green |grad phi| coefficients are 2,1,0; product-law coefficients are 0,1,0",
+        grad_coeffs == [sp.Integer(2), sp.Integer(1), sp.Integer(0)]
+        and product_coeffs == [sp.Integer(0), sp.Integer(1), sp.Integer(0)]
+        and grad_coeffs != product_coeffs,
+        residual=(grad_coeffs, product_coeffs),
+    )
+    checks.check(
+        "pairing-is-bilinear",
+        "B(S,T)=I(S)I(T) returns the product triple and is not I on the union",
+        product_values == [Fraction(0), Fraction(1), Fraction(0)]
+        and product_values != union_values
+        and pairing(pair_11[0], pair_11[1]) != I(pair_11[0].union(pair_11[1])),
+        residual=(product_values, union_values),
+    )
+
+    checks.check(
+        "note-preserves-empty",
+        "the note records I(empty)=0",
+        "I(empty)=0" in note,
+    )
+    checks.check(
+        "note-preserves-force-and-product",
+        "the note records F = -M_test and M_source M_test",
+        "F = -M_test" in note and "M_source M_test" in note,
+    )
+    checks.check(
+        "note-preserves-additivity-sentence",
+        "the note quotes the current Record additivity sentence",
+        additivity_sentence in normalized_note,
+    )
+    checks.check(
+        "note-links-parents",
+        "the note links the axiom memo and the Newton packet",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note and "NEWTON_LAW_DERIVED_NOTE.md" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+                "hypothetical_axiom_status: no edit",
+            )
+        ),
+    )
+    checks.check(
+        "note-three-pair-rejector",
+        "the note exhibits (2,0), (1,1), (0,2) and I(S∪T)",
+        "(2,0)" in note and "(1,1)" in note and "(0,2)" in note and "I(S∪T)" in note,
+    )
+    checks.check(
+        "note-does-not-forbid-gravity",
+        "the note states the scoped gap and does not claim gravity is impossible",
+        "does not say gravity is impossible" in note
+        or "does not:" in note and "gravity is impossible" in note,
+    )
+
+    forbidden = ("new axiom", "we adopt", "promoted", "Codex", "Einstein derived")
+    retained_hits = [
+        line
+        for line in note.splitlines()
+        if "retained" in line
+        and "audit_required_before_effective_retained" not in line
+        and "bare_retained_allowed" not in line
+    ]
+    checks.check(
+        "forbidden-rhetoric-absent",
+        "the note avoids axiom-adoption, promotion, executor-name, and Einstein-derived rhetoric",
+        all(phrase not in note for phrase in forbidden) and retained_hits == [],
+        residual=retained_hits,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the pairing escape is absent from the canonical axiom file",
+        all(phrase not in axiom for phrase in ("π(S,T)", "B(S,T)", "m_s m_t", "I(S)I(T)")),
+    )
+    checks.check(
+        "newton-kernel-bound",
+        "the Newton packet still states the source-linear kernel algebra",
+        all(
+            phrase in normalized_newton
+            for phrase in (
+                "G(r) = 1/(4 pi r)",
+                "phi(r) = M G(r) = M/(4 pi r)",
+                "|grad phi| = M/(4 pi r^2)",
+            )
+        ),
+    )
+
+    print("per_element: each rejector pair is evaluated under I(union) and under I(S)I(T)")
+    print("per_site: the statements are collection-level; no composite carrier is asserted")
+    print("per_mode: no spectral-mode exhaustion is claimed")
+    print("per_block: only additivity-versus-product versus the Green pairing is tested")
+    print("lattice_wide: checked and not executed — no lattice-wide gravity or Einstein equation is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Scalar Record additivity cannot produce the Newton product `M_source M_test`. `I(S∪T)` is the same on `(2,0)`, `(1,1)`, and `(0,2)`; the products are `0`, `1`, `0`. The Green kernel remains source-linear. A two-argument pairing would close the gap and is not installed.

Campaign `toe-lphys-20260812` Block 06. No axiom edit.

## Verification

```bash
python3 scripts/record_additivity_does_not_supply_newton_product_2026_08_13.py
# TOTAL: PASS=32 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required.