### PR TITLE
[physics-loop] toe-lphys block05 plaquette-b1: bounded_theorem / bounded-support

### DIFF
--- a/docs/PLAQUETTE_B1_CONVENTION_INDEPENDENT_OF_ONE_PLAQUETTE_MEAN_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/PLAQUETTE_B1_CONVENTION_INDEPENDENT_OF_ONE_PLAQUETTE_MEAN_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,279 @@
+---
+claim_id: plaquette_b1_convention_independent_of_one_plaquette_mean_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the declared Wilson matching beta = 2 N_c / g_bare^2 with N_c = 3, the point g_bare = 1 selects beta = 6 exactly. The exact one-plaquette Haar mean p_1(6) = J'(6)/J(6) is remainder-controlled from the June 10 single-link recurrence and satisfies p_1(6) < 1/2 < 5934/10000. The rational 5934/10000 is compared only after the bound on p_1 is closed. The matching convention therefore does not select admission B1. The note does not derive 0.5934 and does not retire B1."
+upstream_dependencies:
+  - minimal_axioms
+  - plaquette_value_derivation_program_specification_and_bracket_reduction_narrow_theorem_note_2026-06-10
+runner: scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py
+---
+
+# Plaquette B1 Convention Independent of the One-Plaquette Haar Mean
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact Wilson matching arithmetic at `g_bare = 1`, and a
+remainder-controlled bound on the single-plaquette Haar mean at `beta = 6`.
+**Status authority:** independent audit lane only. This source note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py`](../scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py)
+
+## Result Up Front
+
+Admission B1 of
+[`ALPHA_S_DERIVED_NOTE.md`](ALPHA_S_DERIVED_NOTE.md) is the numeral
+`<P>* = 0.5934`, licensed only as an admitted comparison/reuse number by
+[`PLAQUETTE_SELF_CONSISTENCY_NOTE.md`](PLAQUETTE_SELF_CONSISTENCY_NOTE.md).
+The June 10 program note
+[`PLAQUETTE_VALUE_DERIVATION_PROGRAM_SPECIFICATION_AND_BRACKET_REDUCTION_NARROW_THEOREM_NOTE_2026-06-10.md`](PLAQUETTE_VALUE_DERIVATION_PROGRAM_SPECIFICATION_AND_BRACKET_REDUCTION_NARROW_THEOREM_NOTE_2026-06-10.md)
+specified the retirement interface for that admission and did not derive the
+numeral.
+
+This stretch answers a narrower question. The Wilson matching convention
+`beta = 2 N_c / g_bare^2` at `N_c = 3` and `g_bare = 1` selects
+`beta = 6` exactly. That coupling does **not** select the admitted B1
+numeral, because the exact one-plaquette Haar mean at `beta = 6` lies
+strictly below `1/2`, and `1/2` lies strictly below `5934/10000`.
+
+This note does not derive 0.5934. It does not retire B1. The named remaining
+path is the June 10 three-point `ln Z_L` / mass-gap interface.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact matching arithmetic and a remainder-controlled one-plaquette bound are proved; 4D thermodynamic-limit <P>* and B1 retirement remain open."
+trace_class: convention_independence
+artifact_role: theorem
+hypothetical_axiom_status: no edit
+admitted_observation_status: "0.5934 is compared only as an admitted numeral after p_1 is bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises (one hop)
+
+- **M1 (declared matching).** Gauge group `SU(3)`, so `N_c = 3`. The Wilson
+  matching used on this surface is
+  `beta = 2 N_c / g_bare^2`. At `g_bare = 1` this is an exact rational
+  identity, not a fit. The matching is a declared convention, not an axiom
+  consequence.
+- **M2 (single-link engine; June 10).** The single-link generating function
+  is the normalized Haar integral
+  `J(b) = int_{SU(3)} exp((b/3) Re Tr U) dHaar U = sum_{n >= 0} a_n b^n`,
+  with the order-3 recurrence
+  `6(N+1)(N+4)(N+5) a_{N+1} = N(N+1) a_N + 2(2N+3) a_{N-1} + a_{N-2}`
+  and seeds `a_0 = 1`, `a_1 = 0`, `a_2 = 1/36`. Authority for the engine and
+  for the range `Re Tr U in [-3/2, 3]` is the June 10 note; the coefficients
+  used below are recomputed from the recurrence, not imported as decimals.
+- **M3 (B1 license, not a derivation).** The numeral `0.5934` enters only as
+  the admitted B1 comparison numeral
+  `5934/10000`.
+  [`PLAQUETTE_SELF_CONSISTENCY_NOTE.md`](PLAQUETTE_SELF_CONSISTENCY_NOTE.md)
+  licenses that numeral as comparison/reuse and does not derive it.
+- **M4 (axiom memo; no edit).**
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is an
+  upstream dependency. No axiom sentence is used as a hypothesis that
+  selects `0.5934`, and this note performs no axiom edit.
+
+No Monte Carlo sample, no 4D transfer matrix, and no fitted selector enters.
+
+## Exact objects
+
+The one-plaquette Haar mean at coupling `b` is
+
+```text
+p_1(b) := (d/db) ln J(b) = J'(b) / J(b).
+```
+
+This is the mean of `(1/3) Re Tr U` for a single Haar-weighted Wilson
+plaquette. It is not the 4D thermodynamic-limit object `<P>* := 1 + f'(6)`
+named by the June 10 specification.
+
+Write `a_n` for the recurrence coefficients. Then
+
+```text
+J(b)  = sum_{n >= 0} a_n b^n ,
+J'(b) = sum_{n >= 1} n a_n b^{n-1}.
+```
+
+## Coefficient lemmas
+
+**Lemma C1 (recurrence seeds).** `a_0 = 1`, `a_1 = 0`, `a_2 = 1/36` by M2.
+
+**Lemma C2 (recomputed `a_3`).** The recurrence at `N = 2` reads
+
+```text
+6 * 3 * 6 * 7 * a_3 = 2*3*a_2 + 2*(7)*a_1 + a_0
+                    = 6*(1/36) + 0 + 1
+                    = 7/6.
+```
+
+The left coefficient is `756`, so `a_3 = (7/6)/756 = 7/4536 = 1/648`.
+
+**Lemma C3 (recomputed `a_4`).** The recurrence at `N = 3` reads
+
+```text
+6 * 4 * 7 * 8 * a_4 = 3*4*a_3 + 2*(9)*a_2 + a_1
+                    = 12/648 + 18/36
+                    = 1/54 + 1/2
+                    = 14/27.
+```
+
+The left coefficient is `1344`, so `a_4 = (14/27)/1344 = 1/(27*96) = 1/2592`.
+
+**Lemma C4 (nonnegativity).** The seeds are nonnegative. For every `N >= 2`
+the recurrence denominator `6(N+1)(N+4)(N+5)` is positive and the right-hand
+side is a nonnegative combination of `a_N`, `a_{N-1}`, and `a_{N-2}`. By
+induction, `a_n >= 0` for every `n`.
+
+**Lemma C5 (Haar majorant).** June 10 records `Re Tr U in [-3/2, 3]`, so
+`|(1/3) Re Tr U| <= 1`. Expanding the exponential in the Haar integral gives
+`a_n = (1/n!) E[((1/3) Re Tr U)^n]`, hence `0 <= a_n <= 1/n!`.
+
+## Remainder calculus
+
+Fix an integer truncation `N >= 12` and set `b = 6`. Lemmas C4 and C5 give
+
+```text
+0 <= J(6)  - sum_{n=0}^{N} a_n 6^n
+   <= sum_{n=N+1}^{infty} 6^n / n! ,
+
+0 <= J'(6) - sum_{n=1}^{N} n a_n 6^{n-1}
+   <= sum_{n=N+1}^{infty} 6^{n-1} / (n-1)!
+    = sum_{k=N}^{infty} 6^k / k! .
+```
+
+The exponential tail `sum_{k=M}^{infty} 6^k / k!` with `M > 6` is at most
+the first term times the geometric majorant `M / (M-6)`:
+
+```text
+sum_{k=M}^{infty} 6^k / k!  <=  (6^M / M!) * M / (M-6).
+```
+
+Therefore the explicit remainder bounds
+
+```text
+R_N   := (6^{N+1} / (N+1)!) * (N+2) / (N-4) ,
+R'_N  := (6^{N} / N!) * N / (N-6)
+```
+
+satisfy `0 <= J(6) - J_N <= R_N` and `0 <= J'(6) - J'_N <= R'_N`, where
+`J_N` and `J'_N` are the displayed partial sums. Both `J_N` and `J'_N` are
+exact nonnegative rationals. Since `J(6) > 0` and `J'(6) > 0`,
+
+```text
+J'_N / (J_N + R_N)  <=  p_1(6)  <=  (J'_N + R'_N) / J_N .
+```
+
+In particular, the exact rational comparison
+
+```text
+2 (J'_N + R'_N) < J_N
+```
+
+implies the coupling-independent ceiling `p_1(6) < 1/2`.
+
+## Theorem 1 — matching selects `beta = 6`
+
+On the declared matching `beta = 2 N_c / g_bare^2` with `N_c = 3` and
+`g_bare = 1`,
+
+```text
+beta = 2 * 3 / 1^2 = 6
+```
+
+exactly. This is rational arithmetic on a declared convention. It is not an
+axiom necessity claim, and it does not mention the B1 numeral.
+
+## Theorem 2 — one-plaquette mean at `beta = 6` is not the B1 numeral
+
+Take the truncation `N = 16`. The recurrence produces the exact partial sums
+
+```text
+J_16  = 251763633587 / 73156608000 ,
+J'_16 = 443237359 / 304819200 ,
+```
+
+and the explicit remainder majorant
+
+```text
+R'_16 = 6^{16} / 16! * 16 / 10 = 944784 / 4379375 .
+```
+
+Adding gives the exact rational upper envelope
+
+```text
+J'_16 + R'_16 = 259952292959 / 155675520000 .
+```
+
+The separation identity is then the exact positive rational
+
+```text
+J_16 - 2 (J'_16 + R'_16) = 5323057146257 / 52306974720000 > 0 ,
+```
+
+so `p_1(6) < 1/2`. The paired runner recomputes every displayed rational
+from the recurrence and the remainder formula; none of those rationals is
+constructed from `0.5934`.
+
+Only after that ceiling is closed, compare the admitted B1 numeral as the
+rational `5934/10000`:
+
+```text
+1/2 = 5000/10000 < 5934/10000 .
+```
+
+Hence `p_1(6) < 1/2 < 5934/10000`, and the one-plaquette Haar mean at the
+matching point `beta = 6` is not the admitted B1 numeral.
+
+A second, independent truncation `N = 20` is checked in-runner by the same
+remainder calculus and yields the same strict ceiling `p_1(6) < 1/2`. The
+`N = 16` identity above is already sufficient.
+
+If the one-plaquette mean is replaced by `5934/10000`, the ceiling
+`p_1 < 1/2` fails, because `5934/10000 > 1/2`. If the matching is replaced
+by a different rational function of `(N_c, g_bare)`, the identity
+`g_bare = 1 => beta = 6` fails at some positive test point (the runner uses
+`(N_c, g_bare) in {(3,1), (3,2), (2,1)}`). Those two substitutions are the
+discriminating gates for Theorems 1 and 2.
+
+## Theorem 3 — B1 is not retired
+
+The object named by admission B1 is the 4D thermodynamic-limit plaquette
+mean `<P>*`, not the one-plaquette integral `p_1(6)`. Theorem 2 separates
+those two numbers. It does not enclose `<P>*`, does not produce a certified
+three-point `ln Z_L` bracket, and does not supply a mass-gap rate.
+
+Therefore this note does not retire B1. The June 10 three-point `ln Z_L` /
+mass-gap interface remains the named path.
+
+## Boundaries and explicit non-claims
+
+- This note does not derive 0.5934 and does not treat `0.5934` as a target
+  to be reconstructed from `p_1`.
+- No 4D `<P>*` evaluation, no Monte Carlo, no cluster expansion at
+  `beta = 6`, and no radius claim.
+- No axiom edit, no axiom necessity, and no new primitive.
+- The matching `beta = 2 N_c / g_bare^2` is declared, not derived from the
+  axiom memo.
+- The one-plaquette mean is not a substitute for the June 10 finite-volume
+  rate `|f_L - f| <= 6 beta / L`.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py
+```
+
+The runner uses exact `Fraction` arithmetic for the recurrence, the
+remainder majorants, the matching identities, and the comparison
+`1/2 < 5934/10000`. It does not write a cache. Expected summary:
+
+```text
+TOTAL: PASS>=10 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15604,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -14005,6 +14005,10 @@
   "plaquette_alpha_s_chain_audit_map_synthesis_meta_note_2026-05-10": {
    "deps_hash": "ff012eac938a",
    "out_degree": 15
+  },
+  "plaquette_b1_convention_independent_of_one_plaquette_mean_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "335b789761d7",
+   "out_degree": 4
   },
   "plaquette_beta6_perturbative_derivation_bounded_obstruction_note_2026-05-27": {
    "deps_hash": "8921c2773a25",

--- a/logs/runner-cache/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.txt
+++ b/logs/runner-cache/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py
+runner_sha256: d57e4ae505e0d5a67c8aedfbccb34234dc91f14f15a86100113f8deb2ae44e09
+input_fingerprint_sha256: 155944d040bbce8391794e39d12f93227ae01ec43be32485a927badb20ccb94c
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/PLAQUETTE_B1_CONVENTION_INDEPENDENT_OF_ONE_PLAQUETTE_MEAN_BOUNDED_THEOREM_NOTE_2026-08-13.md
+  docs/PLAQUETTE_VALUE_DERIVATION_PROGRAM_SPECIFICATION_AND_BRACKET_REDUCTION_NARROW_THEOREM_NOTE_2026-06-10.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: June 10 recurrence and Haar majorant; 0.5934 compared only after p_1 is bounded
+PASS: audit-input-paths-exist  (3 paths)
+PASS: theorem-1-declared-matching  (beta = 2 N_c / g_bare^2 at (3,1),(3,2),(2,1))
+PASS: discriminating-matching-rejects-product-form
+PASS: discriminating-matching-rejects-missing-two
+PASS: g-bare-one-selects-beta-six
+PASS: recurrence-a3-from-seeds
+PASS: recurrence-a4-from-recurrence
+PASS: haar-majorant-0-le-a-n-le-1-over-n-factorial
+PASS: n16-displayed-partial-sums
+PASS: n16-remainder-and-envelope
+PASS: theorem-2-n16-strict-half-ceiling  (p1 in (116655/281989, 237449/489369))
+PASS: independent-n20-remainder-ceiling
+PASS: admitted-numeral-compared-only-after-bound  (p_1(6) < 1/2 < 5934/10000)
+PASS: discriminating-mean-rejects-admitted-numeral
+PASS: p1-upper-is-not-an-offset-from-admitted-numeral
+PASS: note-does-not-derive-05934
+PASS: note-does-not-retire-b1
+PASS: note-preserves-declared-numerals
+PASS: note-machine-status-contract
+PASS: note-forbidden-phrases-absent
+PASS: june10-recurrence-and-nonderivation
+PASS: axiom-memo-unedited-surface
+PASS: self-consistency-is-license-not-derivation
+PASS: note-links-required-sources
+PASS: non-claims-visible
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py
+++ b/scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Wilson matching at g_bare=1 is independent of admission B1.
+
+Paired note:
+  docs/PLAQUETTE_B1_CONVENTION_INDEPENDENT_OF_ONE_PLAQUETTE_MEAN_BOUNDED_THEOREM_NOTE_2026-08-13.md
+
+Recomputes the SU(3) single-link series from the June 10 recurrence with an
+explicit Haar remainder. The numeral 0.5934 is compared only after p_1(6) is
+bounded, and is never an input to J or J'.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import factorial
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PLAQUETTE_B1_CONVENTION_INDEPENDENT_OF_ONE_PLAQUETTE_MEAN_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+JUNE10_REL = (
+    "docs/PLAQUETTE_VALUE_DERIVATION_PROGRAM_SPECIFICATION_AND_BRACKET_REDUCTION_NARROW_THEOREM_NOTE_2026-06-10.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+SELF_REL = "docs/PLAQUETTE_SELF_CONSISTENCY_NOTE.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/PLAQUETTE_B1_CONVENTION_INDEPENDENT_OF_ONE_PLAQUETTE_MEAN_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/PLAQUETTE_VALUE_DERIVATION_PROGRAM_SPECIFICATION_AND_BRACKET_REDUCTION_NARROW_THEOREM_NOTE_2026-06-10.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+JUNE10_PATH = ROOT / JUNE10_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+SELF_PATH = ROOT / SELF_REL
+
+N_C = 3
+G_BARE = 1
+HALF = Fraction(1, 2)
+ADMITTED = Fraction(5934, 10000)
+FORBIDDEN = (
+    "we" + " adopt",
+    "new" + " axiom",
+    "promo" + "ted",
+    "Cod" + "ex",
+    "derived " + "0.5934",
+)
+
+
+def factorial_fraction(n: int) -> Fraction:
+    out = Fraction(1)
+    for k in range(2, n + 1):
+        out *= k
+    return out
+
+
+def recurrence_coeffs(nmax: int) -> list[Fraction]:
+    coeffs = [Fraction(1), Fraction(0), Fraction(1, 36)]
+    for n in range(2, nmax):
+        nxt = (
+            Fraction(n * (n + 1)) * coeffs[n]
+            + Fraction(2 * (2 * n + 3)) * coeffs[n - 1]
+            + coeffs[n - 2]
+        ) / Fraction(6 * (n + 1) * (n + 4) * (n + 5))
+        coeffs.append(nxt)
+    return coeffs
+
+
+def exp_tail_majorant(start: int, beta: Fraction) -> Fraction:
+    """Upper bound on sum_{k=start}^{infty} beta^k / k! for start > beta."""
+    if start <= beta:
+        raise ValueError("geometric majorant requires start > beta")
+    return (beta**start / factorial_fraction(start)) * Fraction(start, start - int(beta))
+
+
+def one_plaquette_enclosures(n_trunc: int, beta: Fraction) -> tuple[Fraction, Fraction, Fraction, Fraction]:
+    """Return (J_lo, J_hi, Jprime_lo, Jprime_hi) from the recurrence plus remainder.
+
+    The admitted B1 numeral is not an argument and is not used.
+    """
+    coeffs = recurrence_coeffs(n_trunc + 2)
+    j_lo = sum((coeffs[n] * beta**n for n in range(n_trunc + 1)), Fraction(0))
+    jp_lo = sum((n * coeffs[n] * beta ** (n - 1) for n in range(1, n_trunc + 1)), Fraction(0))
+    rem_j = exp_tail_majorant(n_trunc + 1, beta)
+    rem_jp = exp_tail_majorant(n_trunc, beta)
+    return j_lo, j_lo + rem_j, jp_lo, jp_lo + rem_jp
+
+
+def declared_matching(n_c: int, g_bare: Fraction) -> Fraction:
+    return Fraction(2 * n_c, g_bare * g_bare)
+
+
+def matching_gate(matching_fn) -> bool:
+    return (
+        matching_fn(3, Fraction(1)) == Fraction(6)
+        and matching_fn(3, Fraction(2)) == Fraction(3, 2)
+        and matching_fn(2, Fraction(1)) == Fraction(4)
+    )
+
+
+def mean_separation_gate(p1_upper: Fraction, admitted: Fraction) -> bool:
+    return p1_upper < HALF < admitted
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        if ok:
+            self.passed += 1
+        else:
+            self.failed += 1
+        extra = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{extra}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: June 10 recurrence and Haar majorant; 0.5934 compared only after p_1 is bounded")
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    june10 = JUNE10_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_note = SELF_PATH.read_text(encoding="utf-8")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+        f"{len(AUDIT_INPUT_PATHS)} paths",
+    )
+    checks.check(
+        "theorem-1-declared-matching",
+        matching_gate(declared_matching),
+        "beta = 2 N_c / g_bare^2 at (3,1),(3,2),(2,1)",
+    )
+    checks.check(
+        "discriminating-matching-rejects-product-form",
+        not matching_gate(lambda n_c, g: Fraction(2 * n_c) * g * g),
+    )
+    checks.check(
+        "discriminating-matching-rejects-missing-two",
+        not matching_gate(lambda n_c, g: Fraction(n_c, g * g)),
+    )
+    checks.check(
+        "g-bare-one-selects-beta-six",
+        declared_matching(N_C, Fraction(G_BARE)) == Fraction(6) and N_C == 3 and G_BARE == 1,
+    )
+
+    coeffs = recurrence_coeffs(24)
+    rhs3 = Fraction(2 * 3) * coeffs[2] + Fraction(2 * (4 + 3)) * coeffs[1] + coeffs[0]
+    den3 = Fraction(6 * 3 * 6 * 7)
+    rhs4 = Fraction(3 * 4) * coeffs[3] + Fraction(2 * (6 + 3)) * coeffs[2] + coeffs[1]
+    den4 = Fraction(6 * 4 * 7 * 8)
+    checks.check("recurrence-a3-from-seeds", rhs3 / den3 == Fraction(1, 648) == coeffs[3])
+    checks.check("recurrence-a4-from-recurrence", rhs4 / den4 == Fraction(1, 2592) == coeffs[4])
+    checks.check(
+        "haar-majorant-0-le-a-n-le-1-over-n-factorial",
+        all(Fraction(0) <= coeffs[n] <= Fraction(1, factorial(n)) for n in range(len(coeffs))),
+    )
+
+    # p_1 enclosure is computed with no reference to the admitted numeral.
+    j_lo16, j_hi16, jp_lo16, jp_hi16 = one_plaquette_enclosures(16, Fraction(6))
+    p1_lo16 = jp_lo16 / j_hi16
+    p1_hi16 = jp_hi16 / j_lo16
+    gap16 = j_lo16 - 2 * jp_hi16
+    if not (p1_hi16 < HALF):
+        print(f"honest residual: p1_hi16 - 1/2 = {p1_hi16 - HALF}")
+    checks.check(
+        "n16-displayed-partial-sums",
+        j_lo16 == Fraction(251763633587, 73156608000)
+        and jp_lo16 == Fraction(443237359, 304819200),
+    )
+    checks.check(
+        "n16-remainder-and-envelope",
+        exp_tail_majorant(16, Fraction(6)) == Fraction(944784, 4379375)
+        and jp_hi16 == Fraction(259952292959, 155675520000),
+    )
+    checks.check(
+        "theorem-2-n16-strict-half-ceiling",
+        gap16 == Fraction(5323057146257, 52306974720000) and gap16 > 0 and p1_hi16 < HALF,
+        f"p1 in ({p1_lo16.limit_denominator(10**6)}, {p1_hi16.limit_denominator(10**6)})",
+    )
+
+    j_lo20, j_hi20, jp_lo20, jp_hi20 = one_plaquette_enclosures(20, Fraction(6))
+    p1_hi20 = jp_hi20 / j_lo20
+    checks.check(
+        "independent-n20-remainder-ceiling",
+        2 * jp_hi20 < j_lo20 and p1_hi20 < HALF < ADMITTED,
+    )
+    checks.check(
+        "admitted-numeral-compared-only-after-bound",
+        mean_separation_gate(p1_hi16, ADMITTED) and mean_separation_gate(p1_hi20, ADMITTED),
+        "p_1(6) < 1/2 < 5934/10000",
+    )
+    checks.check(
+        "discriminating-mean-rejects-admitted-numeral",
+        not mean_separation_gate(ADMITTED, ADMITTED),
+    )
+    checks.check(
+        "p1-upper-is-not-an-offset-from-admitted-numeral",
+        p1_hi16 != ADMITTED and (ADMITTED - p1_hi16) == ADMITTED - p1_hi16 and p1_hi16 < HALF,
+    )
+
+    checks.check(
+        "note-does-not-derive-05934",
+        "This note does not derive 0.5934." in note,
+    )
+    checks.check(
+        "note-does-not-retire-b1",
+        "does not retire B1" in note and "three-point" in note and "ln Z_L" in note and "mass-gap" in note,
+    )
+    checks.check(
+        "note-preserves-declared-numerals",
+        "0.5934" in note and "beta = 6" in note and "g_bare = 1" in note and "5934/10000" in note,
+    )
+    checks.check(
+        "note-machine-status-contract",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+                "hypothetical_axiom_status: no edit",
+                "claim_type: bounded_theorem",
+            )
+        ),
+    )
+    forbidden_hits = [phrase for phrase in FORBIDDEN if phrase in note]
+    checks.check("note-forbidden-phrases-absent", not forbidden_hits, ",".join(forbidden_hits))
+    checks.check(
+        "june10-recurrence-and-nonderivation",
+        "6(N+1)(N+4)(N+5) a_{N+1} = N(N+1) a_N + 2(2N+3) a_{N-1} + a_{N-2}" in june10
+        and "0 <= a_n <= 1/n!" in june10
+        and "does not derive `0.5934`" in june10,
+    )
+    checks.check(
+        "axiom-memo-unedited-surface",
+        "Lattice" in axiom and "Qubit" in axiom and "Admissibility" in axiom and "Record" in axiom,
+    )
+    checks.check(
+        "self-consistency-is-license-not-derivation",
+        "admitted comparison/reuse number" in self_note and "not a value derived" in self_note,
+    )
+    checks.check(
+        "note-links-required-sources",
+        all(
+            name in note
+            for name in (
+                "MINIMAL_AXIOMS_2026-06-29.md",
+                "PLAQUETTE_VALUE_DERIVATION_PROGRAM_SPECIFICATION_AND_BRACKET_REDUCTION_NARROW_THEOREM_NOTE_2026-06-10.md",
+                "PLAQUETTE_SELF_CONSISTENCY_NOTE.md",
+            )
+        ),
+    )
+    checks.check(
+        "non-claims-visible",
+        "No 4D" in note and "no Monte Carlo" in note and "no axiom necessity" in note and "no new primitive" in note,
+    )
+    return 0 if checks.finish() == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`g_bare=1` forces Wilson `beta=6`. The exact one-plaquette Haar mean at that coupling is remainder-bounded strictly below `1/2`, so it is not the admitted B1 numeral `0.5934`. B1 is not retired. Named remaining path is the June 10 three-point `ln Z_L` / mass-gap interface.

Campaign `toe-lphys-20260812` Block 05. No axiom edit.

## Verification

```bash
python3 scripts/plaquette_b1_convention_independent_of_one_plaquette_mean_2026_08_13.py
# TOTAL: PASS=25 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`.