### PR TITLE
[physics-loop] toe-lphys block09 adm2: bounded_theorem / bounded-support

### DIFF
--- a/docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_AD_INVARIANT_STEP_MEASURE_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_AD_INVARIANT_STEP_MEASURE_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,210 @@
+---
+claim_id: record_additivity_does_not_supply_ad_invariant_step_measure_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Record scalar additivity on a finite dummy collection is a content-only sum with I(empty)=0. On the 3-element cyclic group C_3, a U(1) sample, two distinct probability measures give two distinct one-step kernels and the same additive I. On the quaternion group Q_8, an SU(2) sample, Haar and a non-Ad-invariant measure likewise give distinct kernels and the same I. I is blind to conjugacy-class structure and does not select ADM-2. The heat-kernel notes are context links only. No axiom is edited."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py
+---
+
+# Record Additivity Does Not Supply An Ad-Invariant Step Measure
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** finite exact dummy-record readout versus finite-group one-step
+kernels. The groups are the 3-element cyclic group `C_3` as a `U(1)` sample
+and the quaternion group `Q_8` as an `SU(2)` sample.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py`](../scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py)
+
+## Result Up Front
+
+The Record axiom supplies a content-determined scalar readout `I` on finite
+pairwise-disjoint record collections, with `I(empty)=0`. That scalar is a
+sum. It has no conjugacy-class argument and no step-measure argument.
+
+On `C_3`, Haar and a biased triple produce two different one-step kernels.
+A dummy three-record collection has the same additive `I` under both. On
+`Q_8`, Haar is Ad-invariant and a two-point measure that splits a conjugacy
+class is not; the kernels differ and `I` is again the same. So `I` does not
+pick Haar versus a non-Ad-invariant measure.
+
+ADM-2, the named extra input that a gauge-step measure is Ad-invariant,
+therefore remains an extra input to any later heat-kernel attractor that
+asks for it. This note does not claim Wilson/HK uniqueness. No axiom is
+edited.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite dummy-record additivity and two exact finite-group kernel pairs are proved. ADM-2 is located as an extra input, not derived. Heat-kernel attractor statements stay in the cited context notes."
+trace_class: negative_route_pruning
+target_claim_id: record_additivity_to_ad_invariant_step_measure
+target_blocker_text: "Record additivity does not select an Ad-invariant gauge-step measure"
+source_of_blocker_text: handoff
+reachability_to_target: locates
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed dummy records and the C_3 / Q_8 kernels; no continuum group, no Wilson weight, no heat-kernel uniqueness"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+The current Record wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+is:
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar
+> readout `I` is additive, with `I(empty)=0`.
+
+A dummy record is a pair `(site, content)` with `site` in `Z^3` and
+`content` a rational scalar. Sites of a collection are pairwise distinct, so
+the records are pairwise disjoint. An unused decoration, such as a group
+element, may be written next to a dummy record as a label. It is not record
+content and is not readable.
+
+```text
+I(empty) = 0
+I(R)     = sum_{r in R} content(r)
+```
+
+Additivity on disjoint union is ordinary addition of those scalars.
+
+A finite-group step measure is a probability `μ` on a finite group `G`. The
+one-step kernel is the left increment
+
+```text
+K_μ(g|h) = μ(g h^{-1}).
+```
+
+`μ` is Ad-invariant when `μ(x) = μ(s x s^{-1})` for every `s, x` in `G`.
+Haar on a finite group is the uniform counting measure. ADM-2 is the extra
+input that a gauge-step measure is Ad-invariant.
+
+The dummy collection used below is
+
+```text
+r0 at (0,0,0) with content 1
+r1 at (1,0,0) with content 2
+r2 at (2,0,0) with content 4
+R  = {r0, r1, r2}
+I(R) = 7
+```
+
+Two further dummy records, used only for conjugacy,
+
+```text
+r_i  at (0,0,1) with content 5, unused label i
+r_-i at (0,0,2) with content 5, unused label -i
+```
+
+have equal content, so `I({r_i}) = I({r_-i}) = 5`.
+
+## Theorem 1 — I Is Blind To Conjugacy-Class Structure
+
+Record readout is determined by record content alone. Conjugacy of unused
+labels is not content. If two dummy records have the same content scalar,
+they have the same readout, whether or not any unused labels are conjugate.
+
+On `Q_8` the elements `i` and `-i` are conjugate: `j i j^{-1} = -i`. The
+dummy records `r_i` and `r_-i` carry equal content `5`, so
+
+```text
+I({r_i}) = 5 = I({r_-i}).
+```
+
+`I` cannot tell those labels apart. Therefore `I` cannot test whether a step
+measure is constant on conjugacy classes, and cannot test Ad-invariance.
+
+Writing a class function into the content by hand would be an extra
+assignment, not a consequence of additivity. Additivity would still only
+sum the assigned scalars.
+
+## Theorem 2 — Two Distinct Measures On C_3 Produce Two Kernels; I Cannot Select
+
+Let `C_3 = {0,1,2}` with addition modulo `3`. This is a 3-element group and
+a finite sample of `U(1)`. Define two probability measures
+
+```text
+μ_H(0) = μ_H(1) = μ_H(2) = 1/3
+μ_B(0) = 1/2,   μ_B(1) = 1/3,   μ_B(2) = 1/6.
+```
+
+Both sum to `1`. They are distinct. The kernels are
+
+```text
+K_μ(g|h) = μ((g-h) mod 3).
+```
+
+`K_H` is the constant kernel `1/3`. The biased kernel has
+`K_B(0|0) = 1/2`, so `K_H ≠ K_B`.
+
+The dummy collection `R` does not take a measure argument. Hence
+
+```text
+I(R) under μ_H = 7 = I(R) under μ_B.
+```
+
+`I` cannot select the kernel.
+
+Because `C_3` is abelian, conjugation is trivial and both measures are
+Ad-invariant. That is the honest miss inside this theorem: `I` already
+fails to select between two kernels before Ad-invariance is even in play.
+
+## Theorem 3 — ADM-2 Remains An Extra Input To Any Heat-Kernel Attractor
+
+The following notes are context links only. They are not used as a
+derivation of ADM-2, and this note does not inherit their attractor
+statements:
+
+- [`HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08.md`](HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS_NARROW_THEOREM_NOTE_2026-06-08.md)
+- [`EMERGENT_GAUGE_HEAT_KERNEL_CLT_ATTRACTOR_CONDITIONAL_ON_BI_INVARIANT_DYNAMICS_NARROW_THEOREM_NOTE_2026-06-08.md`](EMERGENT_GAUGE_HEAT_KERNEL_CLT_ATTRACTOR_CONDITIONAL_ON_BI_INVARIANT_DYNAMICS_NARROW_THEOREM_NOTE_2026-06-08.md)
+
+On their own terms those notes still take an Ad-invariant step measure as
+an input when they discuss a heat-kernel attractor. Theorems 1 and 2 show
+that Record additivity cannot supply that input: `I` is a scalar sum, blind
+to conjugacy, and constant on the dummy collection while the kernels move.
+
+The same dummy `I(R) = 7` also fails to pick Haar versus a non-Ad-invariant
+measure on `Q_8`, a finite subgroup of `SU(2)`. Haar is
+
+```text
+μ_Haar(g) = 1/8  for every g in Q_8.
+```
+
+It is Ad-invariant by uniformity. The two-point measure
+
+```text
+μ_N(i) = 1/2,  μ_N(j) = 1/2,  μ_N(g) = 0 otherwise
+```
+
+fails Ad-invariance because `j i j^{-1} = -i` and `μ_N(i) = 1/2 ≠ 0 = μ_N(-i)`.
+The kernels differ: `K_Haar` is constantly `1/8`, while `K_N(i|1) = 1/2` and
+`K_N(-i|1) = 0`. The dummy readout is again `I(R) = 7` for both.
+
+Therefore ADM-2 remains an extra input to any heat-kernel attractor that
+asks for an Ad-invariant step measure. No axiom is edited.
+
+## What This Does Not Claim
+
+- It does not claim Wilson/HK uniqueness.
+- It does not identify a Wilson weight or a heat-kernel weight.
+- It does not derive ADM-2, a continuous Markov generator, a rate, or a
+  gauge action.
+- It does not replace `U(1)` or `SU(2)` by the finite samples; `C_3` and
+  `Q_8` are finite witnesses only.
+- It does not edit
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+  The Record sentence `I(empty)=0` is preserved.
+
+## Verification
+
+```bash
+python3 scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15629,6 +15629,10 @@
   "reconstructed_h_quasilocal_from_analytic_dispersion_microcausality_bridge_narrow_theorem_note_2026-06-06": {
    "deps_hash": "8e0303c6f18c",
    "out_degree": 2
+  },
+  "record_additivity_does_not_supply_ad_invariant_step_measure_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "e5ea68c16df7",
+   "out_degree": 3
   },
   "record_asymptotic_reset_convergence_ledger_2026-06-05": {
    "deps_hash": "ffe526446f32",

--- a/logs/runner-cache/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.txt
+++ b/logs/runner-cache/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py
+runner_sha256: 2a4af5f61115f731b1397493d999fa1b5e668249596e532f16cef352b5989a7a
+input_fingerprint_sha256: 1bed825c5f53796568911a5916bb7112e71cb37b2fc164d933916d46536ebb0d
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+finite_exact: C_3 and Q_8 kernels and dummy-record I are exact rationals
+context_links: heat-kernel notes are named only as context, not as ADM-2 derivations
+PASS: source-record-additivity the current Record sentence has content-only additive I with I(empty)=0
+PASS: source-empty-zero-preserved the source note preserves I(empty)=0
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses bounded-support and the three theorem targets
+PASS: forbidden-phrases-absent the source note omits the barred phrases
+PASS: no-wilson-hk-uniqueness-claim the note states the Wilson/HK uniqueness denial
+PASS: context-not-derivation the heat-kernel notes are context links and are not used to derive ADM-2
+PASS: dummy-empty-zero I(empty)=0 on the dummy collection
+PASS: dummy-additivity I is a content-only sum on disjoint dummy records
+PASS: c3-measures Haar and the biased triple are distinct probabilities on the 3-element group
+PASS: c3-kernels-differ the two C_3 one-step kernels differ at the identity increment
+PASS: c3-same-dummy-I dummy I is the same for both C_3 measures because I has no measure argument
+PASS: q8-conjugacy j i j^{-1} equals -i on the SU(2) finite sample Q_8
+PASS: q8-haar-ad-invariant uniform Haar on Q_8 is Ad-invariant
+PASS: q8-split-not-ad-invariant the two-point measure splits the {i,-i} class and is not Ad-invariant
+PASS: q8-kernels-differ Haar and the split measure give distinct Q_8 one-step kernels
+PASS: conjugacy-blind-I equal-content dummy records labeled by conjugate elements have equal I
+PASS: q8-same-dummy-I dummy I cannot select Haar versus the non-Ad-invariant Q_8 measure
+PASS: axiom-file-unedited-needles the four named axioms remain the only axiom headings in the canonical file
+per_element: dummy contents 1,2,4 and conjugate labels i,-i
+per_group: C_3 as a U(1) sample and Q_8 as an SU(2) sample
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py
+++ b/scripts/record_additivity_does_not_supply_ad_invariant_step_measure_2026_08_13.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Exact finite checks: Record additivity does not supply ADM-2.
+
+Dummy-record I is a content-only scalar sum with I(empty)=0. Two measures on
+C_3 and Haar versus a non-Ad-invariant measure on Q_8 give distinct one-step
+kernels and the same I. The runner computes those objects; it does not embed
+a target constant and compare it to itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "RECORD_ADDITIVITY_DOES_NOT_SUPPLY_AD_INVARIANT_STEP_MEASURE_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_ADDITIVITY_DOES_NOT_SUPPLY_AD_INVARIANT_STEP_MEASURE_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class DummyRecord:
+    site: tuple[int, int, int]
+    content: Fraction
+    label: object = None
+
+
+def readout(records: tuple[DummyRecord, ...]) -> Fraction:
+    return sum((record.content for record in records), Fraction(0))
+
+
+def sites_disjoint(records: tuple[DummyRecord, ...]) -> bool:
+    sites = [record.site for record in records]
+    return len(sites) == len(set(sites))
+
+
+def qmul(
+    left: tuple[int, int, int, int], right: tuple[int, int, int, int]
+) -> tuple[int, int, int, int]:
+    a, b, c, d = left
+    e, f, g, h = right
+    return (
+        a * e - b * f - c * g - d * h,
+        a * f + b * e + c * h - d * g,
+        a * g - b * h + c * e + d * f,
+        a * h + b * g - c * f + d * e,
+    )
+
+
+def qinv(element: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
+    a, b, c, d = element
+    return (a, -b, -c, -d)
+
+
+def qconj(
+    conjugator: tuple[int, int, int, int], element: tuple[int, int, int, int]
+) -> tuple[int, int, int, int]:
+    return qmul(conjugator, qmul(element, qinv(conjugator)))
+
+
+def is_probability(measure: dict[object, Fraction]) -> bool:
+    if any(weight < 0 for weight in measure.values()):
+        return False
+    return sum(measure.values(), Fraction(0)) == 1
+
+
+def cyclic_kernel(
+    measure: dict[int, Fraction], start: int, end: int
+) -> Fraction:
+    return measure[(end - start) % 3]
+
+
+def quaternion_kernel(
+    measure: dict[tuple[int, int, int, int], Fraction],
+    start: tuple[int, int, int, int],
+    end: tuple[int, int, int, int],
+) -> Fraction:
+    return measure[qmul(end, qinv(start))]
+
+
+def ad_invariant_quaternion(
+    measure: dict[tuple[int, int, int, int], Fraction],
+    group: tuple[tuple[int, int, int, int], ...],
+) -> bool:
+    for conjugator in group:
+        for element in group:
+            if measure[element] != measure[qconj(conjugator, element)]:
+                return False
+    return True
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("finite_exact: C_3 and Q_8 kernels and dummy-record I are exact rationals")
+    print("context_links: heat-kernel notes are named only as context, not as ADM-2 derivations")
+
+    checks.check(
+        "source-record-additivity",
+        "the current Record sentence has content-only additive I with I(empty)=0",
+        "A readout value is determined by record content alone." in axiom_flat
+        and "scalar readout `I` is additive, with `I(empty)=0`" in axiom_flat,
+    )
+    checks.check(
+        "source-empty-zero-preserved",
+        "the source note preserves I(empty)=0",
+        "I(empty)=0" in note and "I(empty) = 0" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses bounded-support and the three theorem targets",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "Theorem 1 — I Is Blind To Conjugacy-Class Structure",
+                "Theorem 2 — Two Distinct Measures On C_3 Produce Two Kernels; I Cannot Select",
+                "Theorem 3 — ADM-2 Remains An Extra Input To Any Heat-Kernel Attractor",
+                "No axiom is edited",
+            )
+        ),
+    )
+    forbidden = ("new axiom", "we adopt", "promoted", "Codex", "Einstein")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the source note omits the barred phrases",
+        all(phrase not in note for phrase in forbidden),
+    )
+    checks.check(
+        "no-wilson-hk-uniqueness-claim",
+        "the note states the Wilson/HK uniqueness denial",
+        "This note does not claim Wilson/HK uniqueness." in note,
+    )
+    checks.check(
+        "context-not-derivation",
+        "the heat-kernel notes are context links and are not used to derive ADM-2",
+        "context links only" in note_flat
+        and "not used as a derivation of ADM-2" in note_flat
+        and "HEAT_KERNEL_UNIQUE_DIFFUSION_KERNEL_AMONG_CANDIDATE_GAUGE_ACTIONS"
+        in note
+        and "EMERGENT_GAUGE_HEAT_KERNEL_CLT_ATTRACTOR_CONDITIONAL_ON_BI_INVARIANT_DYNAMICS"
+        in note,
+    )
+
+    r0 = DummyRecord((0, 0, 0), Fraction(1))
+    r1 = DummyRecord((1, 0, 0), Fraction(2))
+    r2 = DummyRecord((2, 0, 0), Fraction(4))
+    dummy = (r0, r1, r2)
+    empty: tuple[DummyRecord, ...] = ()
+    checks.check(
+        "dummy-empty-zero",
+        "I(empty)=0 on the dummy collection",
+        readout(empty) == 0 and sites_disjoint(dummy),
+    )
+    checks.check(
+        "dummy-additivity",
+        "I is a content-only sum on disjoint dummy records",
+        readout((r0, r1)) == readout((r0,)) + readout((r1,))
+        and readout(dummy) == readout((r0,)) + readout((r1,)) + readout((r2,))
+        and readout(dummy) == Fraction(7),
+    )
+
+    c3 = (0, 1, 2)
+    haar_c3 = {g: Fraction(1, 3) for g in c3}
+    bias_c3 = {0: Fraction(1, 2), 1: Fraction(1, 3), 2: Fraction(1, 6)}
+    checks.check(
+        "c3-measures",
+        "Haar and the biased triple are distinct probabilities on the 3-element group",
+        is_probability(haar_c3)
+        and is_probability(bias_c3)
+        and haar_c3 != bias_c3
+        and len(c3) == 3,
+    )
+    haar_kernel_c3 = {
+        (h, g): cyclic_kernel(haar_c3, h, g) for h in c3 for g in c3
+    }
+    bias_kernel_c3 = {
+        (h, g): cyclic_kernel(bias_c3, h, g) for h in c3 for g in c3
+    }
+    checks.check(
+        "c3-kernels-differ",
+        "the two C_3 one-step kernels differ at the identity increment",
+        haar_kernel_c3 != bias_kernel_c3
+        and haar_kernel_c3[(0, 0)] == Fraction(1, 3)
+        and bias_kernel_c3[(0, 0)] == Fraction(1, 2),
+    )
+    checks.check(
+        "c3-same-dummy-I",
+        "dummy I is the same for both C_3 measures because I has no measure argument",
+        readout(dummy) == Fraction(7),
+    )
+
+    one = (1, 0, 0, 0)
+    minus_one = (-1, 0, 0, 0)
+    i_el = (0, 1, 0, 0)
+    minus_i = (0, -1, 0, 0)
+    j_el = (0, 0, 1, 0)
+    minus_j = (0, 0, -1, 0)
+    k_el = (0, 0, 0, 1)
+    minus_k = (0, 0, 0, -1)
+    q8 = (one, minus_one, i_el, minus_i, j_el, minus_j, k_el, minus_k)
+    checks.check(
+        "q8-conjugacy",
+        "j i j^{-1} equals -i on the SU(2) finite sample Q_8",
+        qconj(j_el, i_el) == minus_i and len(q8) == 8 and len(set(q8)) == 8,
+    )
+
+    haar_q8 = {g: Fraction(1, 8) for g in q8}
+    split_q8 = {g: Fraction(0) for g in q8}
+    split_q8[i_el] = Fraction(1, 2)
+    split_q8[j_el] = Fraction(1, 2)
+    checks.check(
+        "q8-haar-ad-invariant",
+        "uniform Haar on Q_8 is Ad-invariant",
+        is_probability(haar_q8) and ad_invariant_quaternion(haar_q8, q8),
+    )
+    checks.check(
+        "q8-split-not-ad-invariant",
+        "the two-point measure splits the {i,-i} class and is not Ad-invariant",
+        is_probability(split_q8)
+        and split_q8[i_el] != split_q8[minus_i]
+        and not ad_invariant_quaternion(split_q8, q8),
+    )
+    haar_kernel_q8 = {
+        (h, g): quaternion_kernel(haar_q8, h, g) for h in q8 for g in q8
+    }
+    split_kernel_q8 = {
+        (h, g): quaternion_kernel(split_q8, h, g) for h in q8 for g in q8
+    }
+    checks.check(
+        "q8-kernels-differ",
+        "Haar and the split measure give distinct Q_8 one-step kernels",
+        haar_kernel_q8 != split_kernel_q8
+        and haar_kernel_q8[(one, i_el)] == Fraction(1, 8)
+        and split_kernel_q8[(one, i_el)] == Fraction(1, 2)
+        and split_kernel_q8[(one, minus_i)] == 0,
+    )
+
+    r_i = DummyRecord((0, 0, 1), Fraction(5), i_el)
+    r_minus_i = DummyRecord((0, 0, 2), Fraction(5), minus_i)
+    checks.check(
+        "conjugacy-blind-I",
+        "equal-content dummy records labeled by conjugate elements have equal I",
+        readout((r_i,)) == readout((r_minus_i,)) == Fraction(5)
+        and r_i.label != r_minus_i.label
+        and qconj(j_el, r_i.label) == r_minus_i.label,
+    )
+    checks.check(
+        "q8-same-dummy-I",
+        "dummy I cannot select Haar versus the non-Ad-invariant Q_8 measure",
+        readout(dummy) == Fraction(7),
+    )
+    checks.check(
+        "axiom-file-unedited-needles",
+        "the four named axioms remain the only axiom headings in the canonical file",
+        axiom.count("### Lattice") == 1
+        and axiom.count("### Qubit") == 1
+        and axiom.count("### Admissibility") == 1
+        and axiom.count("### Record") == 1
+        and "ADM-2" not in axiom,
+    )
+
+    print("per_element: dummy contents 1,2,4 and conjugate labels i,-i")
+    print("per_group: C_3 as a U(1) sample and Q_8 as an SU(2) sample")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Record I cannot select an Ad-invariant gauge-step measure. Haar and a non-Haar measure on C_3 change the kernel and not I. Campaign Block 09. No axiom edit. Runner PASS=19 FAIL=0. bounded-support.