### PR TITLE
[physics-loop] toe-lphys block11 dyadic-registration: bounded_theorem / bounded-support

### DIFF
--- a/docs/RECORD_BIT_DYADIC_REGISTRATION_TRUNCATED_BARYCENTER_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/RECORD_BIT_DYADIC_REGISTRATION_TRUNCATED_BARYCENTER_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,530 @@
+---
+claim_id: record_bit_dyadic_registration_truncated_barycenter_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Finite floor-difference registration on D×U_n with a uniform 2^{-n} truncation bound, a never-dyadic obstruction at 3/10, and an affine-versus-barycenter split; not a physical compiler and not an axiom edit"
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py
+---
+
+# Record-Bit Dyadic Registration And Truncated Barycenter On Finite Product Registers
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact floor-difference registration on the product of the one-site
+density body with a finite dyadic register; uniform truncation; never-dyadic
+obstruction at the declared biased Diracs; affine-versus-barycenter split at
+finite resolution.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py`](../scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py)
+
+## Result Up Front
+
+The August 10 type-separation note names a sufficient interface: registered
+measurable partitions whose pushforward supplies a menu-independent effect
+grade, and leaves a physical construction of those partitions open. This note
+supplies a finite Record-typed product family `D×U_n` and a floor-difference
+kernel on that family. It is a discrete replacement for a continuum `[0,1]`
+factor, not a derivation of that factor from the four axioms.
+
+1. **Floor-difference registration is a partition.** For each finite
+   resolution `M` of `I` and each density `ρ`, the integer bins assigned by
+   prefix-sum floors are pairwise disjoint, exhaust the finite register
+   `U_n={0,...,2^n-1}`, and satisfy `Σ_i q_i(ρ)=2^n`. The product sets
+   `A_n(i|M)` therefore partition `D×U_n` independently of any measure `μ`.
+2. **Uniform truncation, with an exact / never-exact split.** For every
+   `ρ∈D` and every menu member,
+   `|q_i(ρ)/2^n - Tr(ρ E_i)| < 2^{-n}`. At `ρ=I/2` the shared pairing
+   `Tr(ρ E_0)=1/4` is exact for every `n≥2`. At `ρ=diag(3/5,2/5)` the pairing
+   `3/10` is never dyadic, so the truncated mass is never `3/10`. At
+   `ρ=diag(4/5,1/5)` the pairing `2/5` is likewise never exact. Spectral
+   endpoints of `E_0` are exact: `1/2` at `δ_{P(z)}` for `n≥1`, and `0` at
+   `δ_{P(-z)}`.
+3. **Finite-n obstruction (scoped negative).** There is no finite `n` such
+   that the truncated `E_0` mass equals `Tr(ρ E_0)` at every declared Dirac
+   `ρ∈{I/2, diag(3/5,2/5), diag(4/5,1/5)}` in both hostile menus. The mixed
+   state is exact for `n≥2`; the two biased states never are.
+4. **Affine in `μ`, not barycenter evaluation.** For
+   `μ=(3/5)δ_{P(z)}+(2/5)δ_{P(-z)}`, the truncated kernel is the corresponding
+   mixture of the atomic truncated masses. On `E_0` that mixture equals
+   `3/10` exactly, while the single Dirac at the barycenter is not `3/10`.
+   Finite-n floor registration is therefore affine in `μ` and is not a
+   function of the barycenter alone. Continuum `n→∞` recovers barycenter
+   evaluation uniformly at rate `2^{-n}`. Encoding `k∈U_n` as `n` binary
+   Record bits on `n` auxiliary sites is a declared typing, not a physical
+   menu compiler.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is quoted only
+as a premise and is not edited:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record sentences are likewise quoted only as premises:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Floor-difference registration, the uniform 2^{-n} truncation bound, the 3/10 never-dyadic obstruction, and the affine-versus-barycenter split are proved by elementary floor arithmetic on declared one-site objects; physical independence and uniformity of Record bits remain open."
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_distribution_to_effect_grade_bridge
+target_blocker_text: "derive distribution-to-effect-grade identification/functionality and universal binary-and-ternary physical menu eligibility"
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "A physical compiler that produces independent uniform Record bits, or a continuum factor, remains open; do not adopt axiom text."
+conditional_surface_status: "exact for floor-difference registration on D×U_n and the finite-n obstruction at 3/10; physical bit independence/uniformity open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `D` be the `2x2` density body
+
+`D={ρ∈M_2(C): ρ=ρ^†, ρ≥0, Tr(ρ)=1}`.
+
+A finite-support probability on `D` is
+
+`μ=Σ_k p_k δ_{ρ_k}`, `p_k>0`, `Σ_k p_k=1`, `ρ_k∈D`.
+
+Its barycenter is `ρ_μ=Σ_k p_k ρ_k∈D`. Barycenter evaluation is the kernel
+
+`w_μ(E)=Tr(ρ_μ E)`.
+
+The finite register is the dyadic set
+
+`U_n={0,1,...,2^n-1}`
+
+with uniform counting measure `λ_n({k})=2^{-n}`. The product registration
+space is `D×U_n`, equipped with the product of the Borel structure on `D` and
+the discrete σ-algebra on `U_n`.
+
+Write `P(n)=(I+n·σ)/2` for a unit Bloch vector `n`. The declared hostile menus
+are those of
+[`ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md`](ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md):
+
+`E_0=(1/2)P(z)`,
+
+`M_A=(E_0, (9/10)P(n_1), (3/5)P(n_2))` with
+`n_1=(4√2/9,0,-7/9)` and `n_2=(-2√2/3,0,1/3)`,
+
+`M_B=(E_0, (3/4)P(m_1), (3/4)P(m_2))` with
+`m_1=(2√2/3,0,-1/3)` and `m_2=(-2√2/3,0,-1/3)`.
+
+Each displayed vector is unit. Matrix addition gives `Σ M_A=I` and `Σ M_B=I`.
+The five effects are pairwise distinct. Menus are ordered tuples: prefix
+sums, and therefore the floor bins, depend on order. The shared effect `E_0`
+is first in both declared menus.
+
+For a finite menu `M=(E_1,...,E_r)` with `Σ_i E_i=I` and for `ρ∈D`, set
+
+`S_0(ρ)=0`, `S_i(ρ)=Σ_{j=1}^{i} Tr(ρ E_j)` for `i=1,...,r`.
+
+Because `Σ E_i=I` and `Tr(ρ)=1`, one has `S_r(ρ)=1`. The floor-difference
+counts and product sets are
+
+`q_i(ρ)=⌊2^n S_i(ρ)⌋-⌊2^n S_{i-1}(ρ)⌋`,
+
+`A_n(i|M)={(ρ,k)∈D×U_n: ⌊2^n S_{i-1}(ρ)⌋ ≤ k < ⌊2^n S_i(ρ)⌋}`.
+
+For finite-support `μ=Σ_k p_k δ_{ρ_k}`,
+
+`(μ⊗λ_n)(A_n(i|M))=Σ_k p_k q_i(ρ_k)/2^n`.
+
+Call this number `w_n(μ, E_i | M)`. The menu appears only through prefix
+order. The continuum length of the fiber assigned to a fixed effect `E` at a
+fixed `ρ` is always `Tr(ρ E)`, so the shared `E_0` pairing is
+order-independent as a length. When `2^n Tr(ρ E)` is an integer, the
+truncated mass of that increment is likewise order-independent and equals the
+pairing. When the increment is not an integer, the truncated mass may depend
+on the bin's placement among the prefix sums.
+
+When `E_0` is first, `S_0=0` and `q_1(ρ)=⌊2^n Tr(ρ E_0)⌋`, so both declared
+menus assign the same truncated `E_0` mass at every `ρ`.
+
+The August 10 atomic restriction witness `ν` places mass proportional to
+`(Tr E)^2` on the five distinct menu atoms. Its normalization is
+`Z=509/200`, and
+
+`K_ν(E_0|M_A)=25/142`, `K_ν(E_0|M_B)=2/11`,
+
+with difference `-9/1562`. Restriction is a hostile control in this note, not
+the constructed truncated kernel.
+
+The parent
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+supplies uniqueness of a trace form once a menu-independent grade exists on
+the full binary/ternary scaled family. The present note constructs a finite
+product registration and a truncated kernel on the declared menus. It does
+not rerun the frame lift.
+
+A declared encoding of each `k∈U_n` as `n` binary Record bits on `n`
+auxiliary sites is a typing of the discrete factor, not a derivation from
+Admissibility or Record.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** On the declared one-site objects, construct a μ-independent
+finite product partition of `D×U_n` whose counting-measure pushforward
+approximates barycenter evaluation uniformly; decide for which declared Diracs
+the truncated `E_0` mass is exact; and record the finite-n obstruction and
+the affine-versus-barycenter split.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| define μ-independent sets `A_n(i|M)` on `D×U_n` | positive interface | Theorem 1 |
+| prove `{A_n(i|M)}` partitions `D×U_n` and `Σ_i q_i=2^n` | partition | Theorem 1 |
+| bound `|q_i/2^n-Tr(ρ E_i)|` uniformly | truncation | Theorem 2 |
+| separate exact dyadic pairings from never-exact pairings | dichotomy | Theorem 3 |
+| rule out one finite `n` exact at all three declared Diracs | scoped negative | Theorem 4 |
+| compare mixture-of-endpoints to the Dirac at the barycenter | affine split | Theorem 5 |
+| type `k∈U_n` as Record bits without claiming a compiler | residual | Theorem 6 |
+| derive independent uniform bits, or a continuum factor, from the axioms | physical compiler | open |
+| identify the event label with Record readout | content-only bridge | open; Record premises only quoted |
+
+## Theorem 1 — Floor-Difference Registration Is A Partition
+
+**Claim.** For every finite menu `M=(E_1,...,E_r)` with `Σ_i E_i=I`, every
+`ρ∈D`, and every finite resolution `n≥1`, the integer sets
+
+`K_i(ρ)={k∈U_n: ⌊2^n S_{i-1}(ρ)⌋ ≤ k < ⌊2^n S_i(ρ)⌋}`
+
+are pairwise disjoint, their union is `U_n`, and `Σ_i q_i(ρ)=2^n`. Hence
+`{A_n(i|M)}` is a μ-independent partition of `D×U_n`.
+
+**Proof.** Each pairing `Tr(ρ E_j)` is nonnegative because each effect is
+Hermitian with spectrum in `[0,1]` and `ρ` is a density. The prefix sums are
+therefore nondecreasing, and
+
+`S_r(ρ)=Σ_j Tr(ρ E_j)=Tr(ρ Σ_j E_j)=Tr(ρ I)=1`,
+
+with `S_0(ρ)=0` by definition. The integers
+`⌊2^n S_i(ρ)⌋` are likewise nondecreasing, start at `⌊0⌋=0`, and end at
+`⌊2^n·1⌋=2^n`. Adjacent half-open integer intervals with those endpoints
+partition `{0,1,...,2^n-1}`. Empty intervals occur precisely when
+`q_i(ρ)=0` and do not disturb the partition. Summing telescopes:
+
+`Σ_i q_i(ρ)=⌊2^n S_r(ρ)⌋-⌊2^n S_0(ρ)⌋=2^n`.
+
+The product sets `A_n(i|M)` are the graphs of these integer bins over `D`.
+They are pairwise disjoint because the bins are, and their union is `D×U_n`.
+The definition uses only the menu matrices, the trace pairing at `ρ`, and
+`n`. It does not mention `μ`.
+
+## Theorem 2 — Uniform Truncation Bound
+
+**Claim.** For every `ρ∈D`, every menu member, and every finite `n≥1`,
+
+`|q_i(ρ)/2^n - Tr(ρ E_i)| < 2^{-n}`.
+
+**Proof.** Set `a=2^n S_i(ρ)` and `b=2^n S_{i-1}(ρ)`, so
+`a-b=2^n Tr(ρ E_i)` and `q_i(ρ)=⌊a⌋-⌊b⌋`. Write
+`a=⌊a⌋+{a}` and `b=⌊b⌋+{b}` with fractional parts in `[0,1)`. Then
+
+`(⌊a⌋-⌊b⌋)-(a-b)={b}-{a}`,
+
+and `| {b}-{a} |<1`. Dividing by `2^n` gives the bound. Equality to the
+pairing holds if and only if `{a}={b}`; in particular it holds whenever
+`a` and `b` are integers, and, when the increment occupies an initial
+prefix from `0`, if and only if `2^n Tr(ρ E_i)` is an integer.
+
+## Theorem 3 — Exact Dyadic Cases Versus Never-Exact Cases
+
+**Claim.** On the declared menus, with `E_0` first:
+
+- At `ρ=I/2`, `Tr(ρ E_0)=1/4`. For every `n≥2` one has `2^n/4∈Z`, so
+  `q_1(ρ)/2^n=1/4` exactly, in both menus. At `n=1`,
+  `⌊2·(1/4)⌋/2=0≠1/4`.
+- At `ρ=diag(3/5,2/5)`, `Tr(ρ E_0)=3/10`. For every finite `n≥1`,
+  `2^n·3/10∉Z`, because a factor `5` remains in the denominator after all
+  factors of `2` are cancelled. Therefore `q_1(ρ)/2^n≠3/10` for every
+  finite `n`: the pairing `3/10` is never dyadic.
+- At `ρ=diag(4/5,1/5)`, `Tr(ρ E_0)=2/5`. The same unique-factorization
+  obstruction applies: `5` does not divide `2^{n+1}`, so `2^n·2/5∉Z` and
+  the truncated mass is never `2/5`.
+- Spectral endpoints of `E_0`: at `δ_{P(z)}` the pairing `1/2` is exact
+  for every `n≥1`; at `δ_{P(-z)}` the pairing `0` is exact.
+
+**Proof.** The pairings are matrix arithmetic:
+`E_0=diag(1/2,0)`, so `Tr((I/2)E_0)=1/4`,
+`Tr(diag(3/5,2/5)E_0)=3/10`, `Tr(diag(4/5,1/5)E_0)=2/5`,
+`Tr(P(z)E_0)=1/2`, and `Tr(P(-z)E_0)=0`. With `E_0` first,
+`q_1(ρ)=⌊2^n Tr(ρ E_0)⌋`. This equals `2^n Tr(ρ E_0)` if and only if the
+scaled pairing is an integer. The integer claims are the dyadic statements
+above. A rational in lowest terms is a dyadic rational only if its
+denominator is a power of two; `3/10` is not a dyadic rational, and
+`2/5` is not a dyadic rational, so neither can equal any mass `m/2^n`.
+
+The same pairings hold in both hostile menus because they depend only on
+`E_0`. Restriction values `25/142` and `2/11` are distinct from `1/4`,
+`3/10`, and `2/5`.
+
+## Theorem 4 — Finite-n Obstruction On The Declared Dirac Family
+
+**Claim.** There is no finite `n` such that
+
+`w_n(δ_ρ, E_0 | M)=Tr(ρ E_0)`
+
+for every declared Dirac `ρ∈{I/2, diag(3/5,2/5), diag(4/5,1/5)}` and both
+hostile menus `M∈{M_A,M_B}`.
+
+**Proof.** By Theorem 3 the mixed state is exact for every `n≥2` and fails
+at `n=1`. The two biased states fail for every finite `n`. Therefore no
+single finite `n` can be exact at all three Diracs. The claim is a derived
+no-go boundary inside the positive truncation theorem: it is not a no-go
+against registration, against a continuum factor, or against a later
+physical compiler.
+
+**Scope.** The negative is restricted to exact equality of this truncated
+kernel to the three declared pairings at finite `n`. It does not address
+`n→∞`, a different Dirac family, a non-uniform measure on `U_n`,
+μ-dependent bin edges, or a non-affine kernel.
+
+## Theorem 5 — Mixture Identity For The Truncated Kernel
+
+**Claim.** For `μ=(3/5)δ_{P(z)}+(2/5)δ_{P(-z)}` and every menu member,
+
+`w_n(μ, E_i | M)=(3/5) q_i(P(z))/2^n + (2/5) q_i(P(-z))/2^n`.
+
+This equals `Tr(ρ_μ E_i)` if and only if the truncation is exact at both
+atoms. For the shared effect `E_0` the endpoints `1/2` and `0` are dyadic,
+so the mixture equals `3/10` exactly. The single-Dirac value
+`w_n(δ_{ρ_μ}, E_0 | M)` is not `3/10`.
+
+**Proof.** The displayed mixture identity is the definition of
+`(μ⊗λ_n)(A_n(i|M))` on a two-point first factor. At the atoms,
+Theorem 3 gives `q_1(P(z))/2^n=1/2` and `q_1(P(-z))/2^n=0` for every
+`n≥1`, hence
+
+`w_n(μ, E_0 | M)=(3/5)·(1/2)+(2/5)·0=3/10=Tr(ρ_μ E_0)`,
+
+with barycenter `ρ_μ=diag(3/5,2/5)`. The same barycenter, taken as a single
+Dirac, is the never-dyadic case of Theorem 3, so
+`w_n(δ_{ρ_μ}, E_0 | M)≠3/10`.
+
+The split is load-bearing. The map `μ ↦ w_n(μ, E | M)` is affine in `μ`
+because it is a mixture of the atomic truncated masses. It is not a function
+of the barycenter `ρ_μ` alone at finite `n` for non-dyadic pairings:
+`w_n(μ, E_0 | M)≠w_n(δ_{ρ_μ}, E_0 | M)`. Continuum barycenter evaluation
+`w_μ(E)=Tr(ρ_μ E)` is a function of `ρ_μ` only. Finite-n floor registration
+is therefore affine in `μ` and is not barycenter evaluation. Theorem 2
+recovers barycenter evaluation uniformly as `n→∞` at rate `2^{-n}`.
+
+## Theorem 6 — Record Typing Residual
+
+**Claim.** A declared encoding of each register point `k∈U_n` as `n` binary
+Record bits on `n` auxiliary sites is a typing of the discrete factor, not a
+derivation that those bits are independent of `ρ` or uniformly distributed.
+
+**Premises used (quoted only).**
+
+- "When present, a record locks exactly one admissible local possibility."
+- "A readout value is determined by record content alone."
+- "For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`."
+
+**Residual.** Content-only readout and finite additivity permit a scalar
+reading of `n` disjoint one-bit records, and the lock sentence permits each
+bit to lock one admissible local possibility. They do not force the joint
+law of those bits to be the uniform counting measure `λ_n`, and they do not
+force that law to be independent of the system density `ρ`. The current
+Admissibility sentence says that the distribution over possibilities is
+determined by nearest-neighbor conditions; if the auxiliary sites neighbor
+the system site, dependence on `ρ` is not ruled out. This note does not
+claim a physical menu compiler, does not claim that no compiler exists, and
+does not propose axiom text.
+
+## Hostile-Menu Controls
+
+All identities below are recomputed from the declared matrices.
+
+**Menu resolutions.** Both `M_A` and `M_B` sum to `I` by the parent Bloch
+construction. Direct matrix addition confirms the same. Each member is a
+scaled projector, and the five matrices are pairwise distinct.
+
+**Restriction control.** On the five atoms,
+
+`Z=Σ(Tr E)^2=1/4+81/100+9/25+9/16+9/16=509/200`,
+
+`K_ν(E_0|M_A)=(1/4)/(1/4+81/100+9/25)=25/142`,
+
+`K_ν(E_0|M_B)=(1/4)/(1/4+9/16+9/16)=2/11`,
+
+difference `-9/1562`.
+
+**Truncated `E_0` versus restriction.** At `I/2` and `n≥2` the truncated
+mass is exactly `1/4` in both menus. The values `1/4`, `3/10`, and `2/5`
+are distinct from both `25/142` and `2/11`. Replacing the constructed
+function by restriction therefore cannot satisfy the mixed-state identity
+gate.
+
+**Order as length.** Reversing `M_A` moves the placement of the `E_0`
+increment among the prefix sums. The continuum length remains `Tr(ρ E_0)`.
+When that scaled pairing is an integer, the truncated mass is likewise
+unchanged.
+
+## Boundary And Non-Claims
+
+- No axiom sentence is edited. The Admissibility distribution sentence and
+  the Record lock, content-only, and additivity sentences are quoted only as
+  premises.
+- The discrete factor `U_n` is a declared registration coordinate. It is not
+  derived from the four axioms, not a new primitive of the axiom surface, and
+  not an axiom edit.
+- This note is not a physical menu compiler, not a formation site or rate,
+  and not a Record-content identification of the event label.
+- Finite-n floor registration is not barycenter evaluation. The continuum
+  comparison is an approximation bound, not an executed continuum
+  construction.
+- Partitions are not unique: reorderings and null modifications of empty
+  bins give other families with the same counting masses when increments are
+  integral, and possibly different masses otherwise.
+- Non-affine kernels remain live. Theorem 4 does not address them.
+- Independent audit is required. This note authors no audit verdict.
+- Status prose is bounded-support / bounded_theorem only. No broader surface
+  status is asserted.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current four axiom sentences | exact semantic baseline | supplied; no edit |
+| August 10 type-separation note | hostile menus, restriction witness, partition interface left open | parent dependency |
+| August 9 frame-lift note | menu-independent trace-form target | parent dependency |
+| floor arithmetic and dyadic rationals | Theorems 2--4 | definition-level mathematics |
+| product measure `μ⊗λ_n` and floor-difference bins | Theorems 1, 5 | constructed here |
+| finite-support barycenter evaluation `Tr(ρ_μ E)` | comparison target | parent kernel; not equal to `w_n` at finite `n` on non-dyadic pairings |
+| physical bit compiler | independent uniform Record bits, or a continuum factor | open |
+| content-only event-label bridge | physical Record readout | open |
+| observed probabilities, frequencies, fits | none | not used |
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | August 10 states that the strongest missing lemma is "a physical construction that produces registered measurable event partitions" from Record and Admissibility structure, and leaves that construction open. This note supplies a finite Record-typed product family `D×U_n` together with the exact truncation bound and the never-dyadic obstruction. It does not claim that the upstream interface is unratified. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git ls-tree` / `git grep` for dyadic registration, truncated barycenter, unit-interval ancilla, product registration, and registration coordinate. Hits: the August 10 type-separation note names the registered-partition interface and leaves construction open; the universal-QG barycentric-dyadic notes are a different object (refinement nets on `PL S^3×R`); the formation-gate "registration coordinate" is a different object (the grain `(w,1-w)`). No landed floor-difference kernel on the August 10 menus appears on that commit. Unmerged pull requests 6160–6163 construct continuum product partitions and kernels; they are not on `origin/main` and are not premises. The discrete `U_n` construction, the `3/10` never-dyadic obstruction, and the affine-but-not-barycentric split are new. |
+| V3 | Independently checkable? | Textbook floor functions do not mention the August 10 menus, the restriction pair `25/142` versus `2/11`, or the `3/10` never-dyadic obstruction on those states. The runner recomputes menus, restriction, floor-difference masses, and the mixture split in exact `Q(√2)` arithmetic. |
+| V4 | More than a restatement? | Yes. The exact `1/4` versus `3/10` dichotomy, and the split in which the mixture of endpoints equals `3/10` while the Dirac at the barycenter does not, are not restatements of the parent type-separation or of the parent grade. |
+| V5 | One-step relabel? | No. The claim is not a corollary of August 10 (negative type-separation) or August 9 (grade granted). The closest landed wording is the August 10 hypothetical partition interface. The closest unmerged comparison is a continuum factor `D×[0,1]`; the present object is a finite discrete replacement with a new non-barycentric split. |
+
+## No-Go Discipline Gate (Theorem 4 only)
+
+The negative claim is restricted to exact equality of the truncated `E_0`
+mass to `Tr(ρ E_0)` at all three declared Diracs for one finite `n`. The
+gate does not ship a global non-derivability theorem.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| finite-n floor registration | require `w_n(δ_ρ,E_0\|M)=Tr(ρ E_0)` at all three declared Diracs | Theorem 4: `1/4` is exact only for `n≥2`; `3/10` and `2/5` are never dyadic | **ATTEMPTED** |
+| `n=∞` / continuum Lebesgue factor | replace `U_n` by `[0,1]` with Lebesgue measure | an escape from the finite-n claim, not a counterexample to it | **ATTEMPTED** (escape) |
+| shrink the Dirac family to dyadic pairings | keep only `I/2` and the spectral endpoints | a different claim; the declared family includes `3/10` | **ATTEMPTED** |
+| non-uniform `λ_n` | change the counting weights on `U_n` | a different measure; masses need not lie in `2^{-n}Z` | **ATTEMPTED** |
+| μ-dependent bin edges | let the partition depend on `μ` rather than only on `ρ` and `M` | a different object; Theorem 4 is about the constructed μ-independent bins | **ATTEMPTED** |
+| one-site Hermitian content as `U_n` | identify register points with on-site matrix entries | typing residual (Theorem 6), not an exact-equality repair of Theorem 4 | **ATTEMPTED** |
+| treat `3/10` as a dyadic rational | assert `2^n·3/10∈Z` for some finite `n` | forbidden by unique factorization: `5` does not divide `2^n·3` | **RULED OUT BY PRIOR** |
+
+### N2 — wall independence
+
+Theorem 4 closes only exact finite-n equality on the declared Dirac family
+for this truncated kernel. It does not close continuum lifts, non-affine
+kernels, a physical bit compiler, or a content-only event-label bridge.
+Those walls remain independent.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `D`, `U_n`, `D×U_n` | declared mathematical domains |
+| floor-difference bins | explicit construction |
+| declared Dirac family | explicit hypothesis of Theorem 4 |
+| August 10 menus | declared finite hostile family |
+| uniform `λ_n` | declared counting measure |
+| physical bit compiler | open; not assumed |
+| continuum factor | live escape; not executed here |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Admissibility distribution sentence; Record lock, content-only, and additivity sentences | quoted as premises only; no edit |
+| August 10 type-separation note | hostile menus, restriction numbers, registered-partition interface left open | parent dependency; finite registration constructed here |
+| August 9 frame-lift note | menu-independent trace-form target | not re-proved; not a premise of Theorem 4 |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | `E_0` and the remaining declared menu members at named Diracs | no classification of every map from measures to effects |
+| per site | one `M_2(C)` density body times `U_n` | no composite theorem |
+| per mode | prefix-sum floor bins on the declared menus | no spectral/harmonic mode exhaustion |
+| per block | finite-n exact-equality obstruction only | no dynamics, formation rate, or Record identification |
+| lattice-wide | checked and not executed | no lattice-wide no-go |
+
+The obstruction is per-Dirac / one-site / declared menus; it is not
+lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. The continuum limit `n→∞`, or an explicit Lebesgue factor, recovering
+   barycenter evaluation uniformly at rate `2^{-n}`.
+2. Non-affine kernels outside barycenter evaluation.
+3. A physical compiler that produces independent uniform Record bits from
+   Record and Admissibility structure.
+4. A content-only bridge from the mathematical event label to Record
+   readout.
+
+No axiom sentence is required by the finite-n obstruction. Those four paths
+remain live.
+
+### N7 — hostile steelman
+
+> Use only states whose pairings are dyadic, or take `n` large enough that
+> `2^{-n}` is smaller than any physical distinction. Then Theorem 4 is an
+> artifact of an unphysical exact-equality demand.
+
+**Answer.** Theorem 2 already grants the approximation bound. Theorem 4 is
+exact equality on the declared finite Dirac family, which includes the
+never-dyadic pairing `3/10`. Changing the family, or replacing equality by
+an approximation, is a different claim.
+
+### N8 — cross-cycle echo
+
+August 10 Theorems 1--3 are the parent negatives (singleton mass, atomless
+restriction, contextual restriction). The present negative is a different
+residual: this truncated kernel cannot be exact at all three declared Diracs
+for any finite `n`. The positive construction does not cancel the parent
+negatives; it answers the open partition interface those negatives
+motivated, inside a finite discrete replacement.
+
+**Gate disposition.** PASS for the scoped finite-n exact-equality
+obstruction. FAIL / DO NOT SHIP for "no registration exists", "the axioms
+cannot supply bits", or "continuum is impossible".
+
+## Primary Runner
+
+[`scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py`](../scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py)
+recomputes the floor-difference partition, the uniform truncation bound, the
+exact-versus-never-dyadic dichotomy, the finite-n obstruction, the mixture
+split, and the hostile-menu controls, all in exact `Q(√2)` arithmetic.
+Identity gates call `floor_diff_mass` and `truncated_pushforward`; replacing
+either by restriction `25/142` or by raw `Tr(ρ E)` must fail those checks.
+Executed depths are `n=1` (the mixed quarter is not exact) and `n=3` (the
+mixed quarter is exact and `3/10` is not), with `n=2` included as a cheap
+witness that `1/4` becomes exact at the first dyadic threshold.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15637,6 +15637,10 @@
   "record_axiom_audit_application_map_2026-06-06": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "record_bit_dyadic_registration_truncated_barycenter_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "ae792f44891f",
+   "out_degree": 3
   },
   "record_blank_boundary_reset_no_go_2026-06-05": {
    "deps_hash": "bd23f7108fdf",

--- a/logs/runner-cache/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.txt
+++ b/logs/runner-cache/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py
+runner_sha256: b6f85adf6a2a67642ceb047cf71b390489401ff481c20cc17cd69e81c6781031
+input_fingerprint_sha256: b4987b86a985425035c6e2290ea491191e02e28c438a6f1a9bf2fad59bf4cc88
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom wording and the August 9 and August 10 parent notes are source-bound; no observational or fitted inputs
+integrity_reads: this runner, its paired note, the axiom memo, and the two parent notes; no other repository scientific inputs
+construction: floor-difference registration on D×U_n; w_n is affine in μ and is not barycenter evaluation at finite n
+negative_scope: no finite n makes truncated E_0 mass equal Tr at all three declared Diracs; continuum and compilers remain live
+PASS: source-admissibility the current distribution sentence is pinned in the axiom memo and the note
+PASS: source-record the Record lock, content-only, and additivity sentences are pinned
+PASS: source-parents Aug 10 has restriction witness and partition language; Aug 9 has menu-independent Tr form
+PASS: menu-resolutions both hostile menus are exact matrix resolutions of I by five distinct scaled projectors
+PASS: restriction-recompute atomic restriction recomputed from matrix traces is 25/142 on M_A and 2/11 on M_B with Z=509/200
+PASS: pairings-recompute declared E_0 pairings are 1/4, 3/10, 2/5, 1/2, and 0 in both menus
+PASS: partition-cover prefix floors start at 0, end at 2^n, are nondecreasing, and sum of q_i is 2^n
+PASS: uniform-truncation-bound constructed floor_diff_mass stays strictly inside 2^{-n} of each pairing
+PASS: mixed-exact-quarter floor_diff_mass at I/2 equals 1/4 for n>=2 and is not 1/4 at n=1
+PASS: biased-never-dyadic floor_diff_mass at the biased Diracs is never 3/10 or 2/5; those pairings are not dyadic rationals
+PASS: spectral-endpoints at δ_P(z) the truncated E_0 mass is 1/2; at δ_P(-z) the mass is 0
+PASS: finite-n-obstruction no executed finite n makes truncated E_0 mass exact at all three declared Diracs
+PASS: mixture-identity truncated pushforward of 3/5 δ_P(z)+2/5 δ_P(-z) equals the atomic mixture of floor_diff_mass
+PASS: mixture-not-barycenter-at-biased endpoint mixture truncated E_0 mass is 3/10; Dirac at the barycenter is not
+PASS: disagree-restriction truncated E_0 values disagree with restriction 25/142 and 2/11
+PASS: order-independence-length reversed M_A keeps the same pairing lengths; exact E_0 truncated mass is unchanged when the increment is integral
+PASS: mutation-restriction-would-fail replacing floor_diff_mass by restriction 25/142 would fail mixed-exact-quarter and mixture-not-barycenter
+PASS: mutation-raw-trace-would-fail replacing floor_diff_mass by raw Tr would fail biased-never-dyadic and mixture-not-barycenter
+PASS: singleton-mass-two raw singleton normalization of the z and x projective menus still forces mass two
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+per_element: E_0 and remaining declared menu members checked by floor-difference masses and restriction controls
+per_site: finite-n obstruction, product partition, and truncated kernel identities are one-site statements
+per_mode: prefix-sum floor bins on the declared menus; register points are typed, not compiled
+per_block: only the finite-n exact-equality obstruction and the truncated-kernel identities are executed
+lattice_wide: checked and not executed — no lattice-wide dynamics, formation rate, or Record identification is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py
+++ b/scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""Exact checks for finite dyadic registration and truncated barycenter.
+
+Class-A arithmetic on Q(sqrt(2)). Identity gates call floor_diff_mass and
+truncated_pushforward; replacing either by restriction or by raw Tr must fail
+those checks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "RECORD_BIT_DYADIC_REGISTRATION_TRUNCATED_BARYCENTER_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PARENT_AUG09_PATH = (
+    ROOT
+    / "docs"
+    / "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+)
+PARENT_AUG10_PATH = (
+    ROOT
+    / "docs"
+    / "ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_BIT_DYADIC_REGISTRATION_TRUNCATED_BARYCENTER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Qsqrt2:
+    """Exact a + b sqrt(2)."""
+
+    a: Fraction = Fraction(0)
+    b: Fraction = Fraction(0)
+
+    def _coerce(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        if isinstance(other, Qsqrt2):
+            return other
+        if isinstance(other, (int, Fraction)):
+            return Qsqrt2(Fraction(other))
+        raise TypeError(other)
+
+    def __add__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        other = self._coerce(other)
+        return Qsqrt2(self.a + other.a, self.b + other.b)
+
+    def __radd__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self + other
+
+    def __neg__(self) -> "Qsqrt2":
+        return Qsqrt2(-self.a, -self.b)
+
+    def __sub__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self + (-self._coerce(other))
+
+    def __rsub__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self._coerce(other) + (-self)
+
+    def __mul__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        other = self._coerce(other)
+        return Qsqrt2(
+            self.a * other.a + 2 * self.b * other.b,
+            self.a * other.b + self.b * other.a,
+        )
+
+    def __rmul__(self, other: "Qsqrt2 | int | Fraction") -> "Qsqrt2":
+        return self * other
+
+    def as_rational(self) -> Fraction:
+        if self.b != 0:
+            raise ValueError(f"expected rational, got {self}")
+        return self.a
+
+
+ZERO = Qsqrt2()
+ONE = Qsqrt2(Fraction(1))
+
+
+@dataclass(frozen=True)
+class H2:
+    """Real-symmetric 2x2 matrix over Q(sqrt(2))."""
+
+    p: Qsqrt2
+    q: Qsqrt2
+    r: Qsqrt2
+
+    def __add__(self, other: "H2") -> "H2":
+        return H2(self.p + other.p, self.q + other.q, self.r + other.r)
+
+    def scale(self, value: Qsqrt2 | int | Fraction) -> "H2":
+        return H2(self.p * value, self.q * value, self.r * value)
+
+    def mul(self, other: "H2") -> "H2":
+        return H2(
+            self.p * other.p + self.q * other.q,
+            self.p * other.q + self.q * other.r,
+            self.q * other.q + self.r * other.r,
+        )
+
+    def trace(self) -> Qsqrt2:
+        return self.p + self.r
+
+    def pairing(self, other: "H2") -> Qsqrt2:
+        return self.p * other.p + (self.q * other.q) * 2 + self.r * other.r
+
+
+I2 = H2(ONE, ZERO, ONE)
+PZ = H2(ONE, ZERO, ZERO)
+PMZ = H2(ZERO, ZERO, ONE)
+PX = H2(Qsqrt2(Fraction(1, 2)), Qsqrt2(Fraction(1, 2)), Qsqrt2(Fraction(1, 2)))
+PMX = H2(Qsqrt2(Fraction(1, 2)), Qsqrt2(Fraction(-1, 2)), Qsqrt2(Fraction(1, 2)))
+MIXED = I2.scale(Fraction(1, 2))
+
+
+def scaled_projector(coefficient: Fraction, n_x: Qsqrt2, n_z: Qsqrt2) -> H2:
+    projector = H2(
+        (ONE + n_z) * Fraction(1, 2),
+        n_x * Fraction(1, 2),
+        (ONE - n_z) * Fraction(1, 2),
+    )
+    return projector.scale(coefficient)
+
+
+def extract_direction(effect: H2) -> tuple[Fraction, Qsqrt2, Qsqrt2]:
+    coefficient = effect.trace().as_rational()
+    bloch = effect.scale(Fraction(2, coefficient))
+    shifted = H2(bloch.p - ONE, bloch.q, bloch.r - ONE)
+    n_z = shifted.p
+    n_x = shifted.q
+    return coefficient, n_x, n_z
+
+
+def is_scaled_projector(effect: H2) -> bool:
+    coefficient, n_x, n_z = extract_direction(effect)
+    projector_identity = effect.mul(effect) == effect.scale(coefficient)
+    unit = n_x * n_x + n_z * n_z == ONE
+    return projector_identity and unit and coefficient > 0 and coefficient <= 1
+
+
+def barycenter(weights_states: tuple[tuple[Fraction, H2], ...]) -> H2:
+    total = H2(ZERO, ZERO, ZERO)
+    weight_sum = Fraction(0)
+    for weight, state in weights_states:
+        total = total + state.scale(weight)
+        weight_sum += weight
+    if weight_sum != 1:
+        raise ValueError("barycentric weights must sum to one")
+    return total
+
+
+def pairing(state: H2, effect: H2) -> Qsqrt2:
+    return state.pairing(effect)
+
+
+def floor_fraction(value: Fraction) -> int:
+    return value.numerator // value.denominator
+
+
+def prefix_sums(state: H2, menu: tuple[H2, ...]) -> tuple[Fraction, ...]:
+    totals: list[Fraction] = [Fraction(0)]
+    running = Fraction(0)
+    for effect in menu:
+        running += pairing(state, effect).as_rational()
+        totals.append(running)
+    return tuple(totals)
+
+
+def floor_diff_count(state: H2, menu: tuple[H2, ...], index: int, n: int) -> int:
+    """Integer count q_i(ρ) from prefix-sum floors."""
+    prefixes = prefix_sums(state, menu)
+    scale = 1 << n
+    high = floor_fraction(prefixes[index + 1] * scale)
+    low = floor_fraction(prefixes[index] * scale)
+    return high - low
+
+
+def floor_diff_mass(state: H2, menu: tuple[H2, ...], index: int, n: int) -> Fraction:
+    """Truncated mass q_i(ρ)/2^n. Identity-gate function."""
+    return Fraction(floor_diff_count(state, menu, index, n), 1 << n)
+
+
+def truncated_pushforward(
+    weights_states: tuple[tuple[Fraction, H2], ...],
+    menu: tuple[H2, ...],
+    index: int,
+    n: int,
+) -> Fraction:
+    """Product pushforward (μ⊗λ_n)(A_n(index|M)) via floor-difference masses."""
+    total = Fraction(0)
+    weight_sum = Fraction(0)
+    for weight, state in weights_states:
+        total += weight * floor_diff_mass(state, menu, index, n)
+        weight_sum += weight
+    if weight_sum != 1:
+        raise ValueError("mixture weights must sum to one")
+    return total
+
+
+def restriction_weight(effect: H2, menu: tuple[H2, ...]) -> Fraction:
+    numerator = effect.trace().as_rational() ** 2
+    denominator = sum((item.trace().as_rational() ** 2) for item in menu)
+    return numerator / denominator
+
+
+def is_dyadic_rational(value: Fraction) -> bool:
+    denominator = value.denominator
+    return denominator > 0 and denominator.bit_count() == 1
+
+
+def assigned_edges(state: H2, menu: tuple[H2, ...], n: int) -> tuple[int, ...]:
+    scale = 1 << n
+    return tuple(floor_fraction(prefix * scale) for prefix in prefix_sums(state, menu))
+
+
+def partition_ok(state: H2, menu: tuple[H2, ...], n: int) -> bool:
+    edges = assigned_edges(state, menu, n)
+    if edges[0] != 0 or edges[-1] != (1 << n):
+        return False
+    if any(edges[index] > edges[index + 1] for index in range(len(edges) - 1)):
+        return False
+    counts = [floor_diff_count(state, menu, index, n) for index in range(len(menu))]
+    if sum(counts) != (1 << n):
+        return False
+    if any(count != edges[index + 1] - edges[index] for index, count in enumerate(counts)):
+        return False
+    return all(count >= 0 for count in counts)
+
+
+def truncation_bound_ok(state: H2, menu: tuple[H2, ...], n: int) -> bool:
+    scale = 1 << n
+    for index, effect in enumerate(menu):
+        mass = floor_diff_mass(state, menu, index, n)
+        target = pairing(state, effect).as_rational()
+        if abs(mass * scale - target * scale) >= 1:
+            return False
+        if abs(mass - target) >= Fraction(1, scale):
+            return False
+    return True
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    parent_aug09 = PARENT_AUG09_PATH.read_text(encoding="utf-8")
+    parent_aug10 = PARENT_AUG10_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: axiom wording and the August 9 and "
+        "August 10 parent notes are source-bound; no observational or fitted inputs"
+    )
+    print(
+        "integrity_reads: this runner, its paired note, the axiom memo, and "
+        "the two parent notes; no other repository scientific inputs"
+    )
+    print(
+        "construction: floor-difference registration on D×U_n; "
+        "w_n is affine in μ and is not barycenter evaluation at finite n"
+    )
+    print(
+        "negative_scope: no finite n makes truncated E_0 mass equal Tr at all "
+        "three declared Diracs; continuum and compilers remain live"
+    )
+
+    canonical_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_additivity = (
+        "For any finite collection of pairwise-disjoint records, scalar readout"
+    )
+    checks.check(
+        "source-admissibility",
+        "the current distribution sentence is pinned in the axiom memo and the note",
+        canonical_sentence in normalize(axiom) and canonical_sentence in note,
+    )
+    checks.check(
+        "source-record",
+        "the Record lock, content-only, and additivity sentences are pinned",
+        record_lock in normalize(axiom)
+        and record_content in normalize(axiom)
+        and record_additivity in normalize(axiom)
+        and record_lock in note
+        and record_content in note
+        and record_additivity in note,
+    )
+    checks.check(
+        "source-parents",
+        "Aug 10 has restriction witness and partition language; Aug 9 has menu-independent Tr form",
+        all(
+            phrase in parent_aug10
+            for phrase in (
+                "25/142",
+                "2/11",
+                "509/200",
+                "registered",
+                "partition",
+                "physical construction that produces registered measurable event partitions",
+            )
+        )
+        and all(phrase in parent_aug09 for phrase in ("menu-independent", "Tr(")),
+    )
+
+    n1x, n1z = Qsqrt2(Fraction(0), Fraction(4, 9)), Qsqrt2(Fraction(-7, 9))
+    n2x, n2z = Qsqrt2(Fraction(0), Fraction(-2, 3)), Qsqrt2(Fraction(1, 3))
+    m1x, m1z = Qsqrt2(Fraction(0), Fraction(2, 3)), Qsqrt2(Fraction(-1, 3))
+    m2x, m2z = Qsqrt2(Fraction(0), Fraction(-2, 3)), Qsqrt2(Fraction(-1, 3))
+    e0 = scaled_projector(Fraction(1, 2), ZERO, ONE)
+    a1 = scaled_projector(Fraction(9, 10), n1x, n1z)
+    a2 = scaled_projector(Fraction(3, 5), n2x, n2z)
+    b1 = scaled_projector(Fraction(3, 4), m1x, m1z)
+    b2 = scaled_projector(Fraction(3, 4), m2x, m2z)
+    menu_a = (e0, a1, a2)
+    menu_b = (e0, b1, b2)
+    menu_a_rev = (a2, a1, e0)
+    declared = (e0, a1, a2, b1, b2)
+
+    checks.check(
+        "menu-resolutions",
+        "both hostile menus are exact matrix resolutions of I by five distinct scaled projectors",
+        e0 + a1 + a2 == I2
+        and e0 + b1 + b2 == I2
+        and all(is_scaled_projector(item) for item in declared)
+        and len(set(declared)) == 5,
+    )
+
+    traces = tuple(item.trace().as_rational() for item in declared)
+    atomic_z = sum(value * value for value in traces)
+    cond_a = restriction_weight(e0, menu_a)
+    cond_b = restriction_weight(e0, menu_b)
+    checks.check(
+        "restriction-recompute",
+        "atomic restriction recomputed from matrix traces is 25/142 on M_A and 2/11 on M_B with Z=509/200",
+        atomic_z == Fraction(509, 200)
+        and cond_a == Fraction(25, 142)
+        and cond_b == Fraction(2, 11)
+        and cond_a - cond_b == Fraction(-9, 1562),
+    )
+
+    biased = barycenter(((Fraction(3, 5), PZ), (Fraction(2, 5), PMZ)))
+    biased2 = barycenter(((Fraction(4, 5), PZ), (Fraction(1, 5), PMZ)))
+    declared_states = (MIXED, biased, biased2, PZ, PMZ)
+    executed_depths = (1, 2, 3)
+
+    checks.check(
+        "pairings-recompute",
+        "declared E_0 pairings are 1/4, 3/10, 2/5, 1/2, and 0 in both menus",
+        pairing(MIXED, e0).as_rational() == Fraction(1, 4)
+        and pairing(biased, e0).as_rational() == Fraction(3, 10)
+        and pairing(biased2, e0).as_rational() == Fraction(2, 5)
+        and pairing(PZ, e0).as_rational() == Fraction(1, 2)
+        and pairing(PMZ, e0).as_rational() == 0
+        and biased == H2(Qsqrt2(Fraction(3, 5)), ZERO, Qsqrt2(Fraction(2, 5)))
+        and biased2 == H2(Qsqrt2(Fraction(4, 5)), ZERO, Qsqrt2(Fraction(1, 5))),
+    )
+
+    checks.check(
+        "partition-cover",
+        "prefix floors start at 0, end at 2^n, are nondecreasing, and sum of q_i is 2^n",
+        all(
+            partition_ok(state, menu, depth)
+            for state in declared_states
+            for menu in (menu_a, menu_b, menu_a_rev)
+            for depth in executed_depths
+        ),
+    )
+
+    checks.check(
+        "uniform-truncation-bound",
+        "constructed floor_diff_mass stays strictly inside 2^{-n} of each pairing",
+        all(
+            truncation_bound_ok(state, menu, depth)
+            for state in declared_states
+            for menu in (menu_a, menu_b, menu_a_rev)
+            for depth in executed_depths
+        ),
+    )
+
+    checks.check(
+        "mixed-exact-quarter",
+        "floor_diff_mass at I/2 equals 1/4 for n>=2 and is not 1/4 at n=1",
+        floor_diff_mass(MIXED, menu_a, 0, 3) == Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_b, 0, 3) == Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_a, 0, 2) == Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_b, 0, 2) == Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_a, 0, 1) != Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_b, 0, 1) != Fraction(1, 4)
+        and pairing(MIXED, e0).as_rational() == Fraction(1, 4),
+    )
+
+    never_dyadic_ok = True
+    for depth in executed_depths:
+        for menu in (menu_a, menu_b):
+            if floor_diff_mass(biased, menu, 0, depth) == Fraction(3, 10):
+                never_dyadic_ok = False
+            if floor_diff_mass(biased2, menu, 0, depth) == Fraction(2, 5):
+                never_dyadic_ok = False
+    checks.check(
+        "biased-never-dyadic",
+        "floor_diff_mass at the biased Diracs is never 3/10 or 2/5; those pairings are not dyadic rationals",
+        never_dyadic_ok
+        and not is_dyadic_rational(Fraction(3, 10))
+        and not is_dyadic_rational(Fraction(2, 5))
+        and is_dyadic_rational(Fraction(1, 4))
+        and (Fraction(3, 10) * (1 << 20)).denominator != 1
+        and (Fraction(2, 5) * (1 << 20)).denominator != 1
+        and Fraction(3, 10).denominator % 5 == 0
+        and Fraction(2, 5).denominator % 5 == 0,
+    )
+
+    checks.check(
+        "spectral-endpoints",
+        "at δ_P(z) the truncated E_0 mass is 1/2; at δ_P(-z) the mass is 0",
+        all(
+            floor_diff_mass(PZ, menu, 0, depth) == Fraction(1, 2)
+            and floor_diff_mass(PMZ, menu, 0, depth) == 0
+            for menu in (menu_a, menu_b)
+            for depth in executed_depths
+        ),
+    )
+
+    finite_n_hits = []
+    for depth in executed_depths:
+        exact_all = True
+        for menu in (menu_a, menu_b):
+            exact_all = exact_all and floor_diff_mass(MIXED, menu, 0, depth) == Fraction(1, 4)
+            exact_all = exact_all and floor_diff_mass(biased, menu, 0, depth) == Fraction(3, 10)
+            exact_all = exact_all and floor_diff_mass(biased2, menu, 0, depth) == Fraction(2, 5)
+        finite_n_hits.append(exact_all)
+    checks.check(
+        "finite-n-obstruction",
+        "no executed finite n makes truncated E_0 mass exact at all three declared Diracs",
+        not any(finite_n_hits)
+        and not is_dyadic_rational(Fraction(3, 10))
+        and not is_dyadic_rational(Fraction(2, 5)),
+    )
+
+    mixture = ((Fraction(3, 5), PZ), (Fraction(2, 5), PMZ))
+    mixture_affine_ok = True
+    for menu in (menu_a, menu_b):
+        for depth in executed_depths:
+            for index in range(len(menu)):
+                pushed = truncated_pushforward(mixture, menu, index, depth)
+                rebuilt = (
+                    Fraction(3, 5) * floor_diff_mass(PZ, menu, index, depth)
+                    + Fraction(2, 5) * floor_diff_mass(PMZ, menu, index, depth)
+                )
+                mixture_affine_ok = mixture_affine_ok and pushed == rebuilt
+    checks.check(
+        "mixture-identity",
+        "truncated pushforward of 3/5 δ_P(z)+2/5 δ_P(-z) equals the atomic mixture of floor_diff_mass",
+        mixture_affine_ok
+        and truncated_pushforward(mixture, menu_a, 0, 1) == Fraction(3, 10)
+        and truncated_pushforward(mixture, menu_a, 0, 2) == Fraction(3, 10)
+        and truncated_pushforward(mixture, menu_a, 0, 3) == Fraction(3, 10)
+        and truncated_pushforward(mixture, menu_b, 0, 3) == Fraction(3, 10),
+    )
+
+    checks.check(
+        "mixture-not-barycenter-at-biased",
+        "endpoint mixture truncated E_0 mass is 3/10; Dirac at the barycenter is not",
+        all(
+            truncated_pushforward(mixture, menu, 0, depth) == Fraction(3, 10)
+            and floor_diff_mass(biased, menu, 0, depth) != Fraction(3, 10)
+            for menu in (menu_a, menu_b)
+            for depth in executed_depths
+        ),
+    )
+
+    checks.check(
+        "disagree-restriction",
+        "truncated E_0 values disagree with restriction 25/142 and 2/11",
+        floor_diff_mass(MIXED, menu_a, 0, 3) != cond_a
+        and floor_diff_mass(MIXED, menu_a, 0, 3) != cond_b
+        and floor_diff_mass(biased, menu_a, 0, 3) != cond_a
+        and floor_diff_mass(biased, menu_a, 0, 3) != cond_b
+        and floor_diff_mass(biased2, menu_a, 0, 3) != cond_a
+        and floor_diff_mass(biased2, menu_a, 0, 3) != cond_b
+        and cond_a != cond_b
+        and cond_a != Fraction(1, 4)
+        and cond_b != Fraction(1, 4),
+    )
+
+    e0_index_rev = menu_a_rev.index(e0)
+    continuum_lengths_a = sorted(
+        pairing(MIXED, item).as_rational() for item in menu_a
+    )
+    continuum_lengths_rev = sorted(
+        pairing(MIXED, item).as_rational() for item in menu_a_rev
+    )
+    checks.check(
+        "order-independence-length",
+        "reversed M_A keeps the same pairing lengths; exact E_0 truncated mass is unchanged when the increment is integral",
+        continuum_lengths_a == continuum_lengths_rev
+        and pairing(MIXED, menu_a_rev[e0_index_rev]).as_rational() == Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_a_rev, e0_index_rev, 3) == Fraction(1, 4)
+        and floor_diff_mass(MIXED, menu_a_rev, e0_index_rev, 2) == Fraction(1, 4)
+        and floor_diff_mass(PZ, menu_a_rev, e0_index_rev, 3) == Fraction(1, 2)
+        and floor_diff_mass(PMZ, menu_a_rev, e0_index_rev, 3) == 0,
+    )
+
+    checks.check(
+        "mutation-restriction-would-fail",
+        "replacing floor_diff_mass by restriction 25/142 would fail mixed-exact-quarter and mixture-not-barycenter",
+        cond_a == Fraction(25, 142)
+        and cond_a != Fraction(1, 4)
+        and cond_b != Fraction(1, 4)
+        and cond_a == restriction_weight(e0, menu_a)
+        and cond_a != floor_diff_mass(MIXED, menu_a, 0, 3)
+        and cond_a != truncated_pushforward(mixture, menu_a, 0, 3),
+    )
+    checks.check(
+        "mutation-raw-trace-would-fail",
+        "replacing floor_diff_mass by raw Tr would fail biased-never-dyadic and mixture-not-barycenter",
+        pairing(biased, e0).as_rational() == Fraction(3, 10)
+        and pairing(biased, e0).as_rational()
+        == truncated_pushforward(mixture, menu_a, 0, 3)
+        and pairing(biased, e0).as_rational()
+        != floor_diff_mass(biased, menu_a, 0, 3)
+        and pairing(MIXED, e0).as_rational() == Fraction(1, 4),
+    )
+
+    projectors = (PZ, PMZ, PX, PMX)
+    checks.check(
+        "singleton-mass-two",
+        "raw singleton normalization of the z and x projective menus still forces mass two",
+        PZ + PMZ == I2
+        and PX + PMX == I2
+        and len(set(projectors)) == 4
+        and Fraction(1) + Fraction(1) == 2
+        and Fraction(1) + Fraction(1) > Fraction(1),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "hypothetical_axiom_status: \"no edit\"",
+                "trace_class: direct_blocker_closure",
+                "target_claim_id: admissibility_distribution_to_effect_grade_bridge",
+                "reachability_to_target: partially_closes",
+                "next_trace_action: \"A physical compiler that produces independent uniform Record bits, or a continuum factor, remains open; do not adopt axiom text.\"",
+                "conditional_surface_status: \"exact for floor-difference registration on D×U_n and the finite-n obstruction at 3/10; physical bit independence/uniformity open\"",
+                "25/142",
+                "2/11",
+                "509/200",
+                "3/10",
+                "never dyadic",
+                "not a physical menu compiler",
+                "authors no audit verdict",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "Block 11" not in note
+        and "toe-lphys" not in note,
+    )
+
+    print(
+        "per_element: E_0 and remaining declared menu members checked by "
+        "floor-difference masses and restriction controls"
+    )
+    print(
+        "per_site: finite-n obstruction, product partition, and truncated "
+        "kernel identities are one-site statements"
+    )
+    print(
+        "per_mode: prefix-sum floor bins on the declared menus; register "
+        "points are typed, not compiled"
+    )
+    print(
+        "per_block: only the finite-n exact-equality obstruction and the "
+        "truncated-kernel identities are executed"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide dynamics, "
+        "formation rate, or Record identification is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Constructs a finite Record-typed replacement for an undeclared continuum `[0,1]` factor: floor-difference registration on `D×U_n` with uniform counting measure `λ_n`. The sets `A_n(i|M)` are a μ-independent partition of the product. The truncated kernel

`w_n(μ, E_i | M) = Σ_k p_k q_i(ρ_k)/2^n`, `q_i = ⌊2^n S_i⌋ − ⌊2^n S_{i-1}⌋`

satisfies `|q_i/2^n − Tr(ρ E_i)| < 2^{-n}`.

On the August 10 menus, with `E_0` first:
- at `I/2`, truncated `E_0` mass is exactly `1/4` for every `n≥2`;
- at `diag(3/5,2/5)`, pairing `3/10` is never a dyadic rational, so the truncated mass is never `3/10`;
- at `diag(4/5,1/5)`, pairing `2/5` is likewise never exact.

No finite `n` is exact at all three declared Diracs. The kernel is affine in `μ` and is **not** barycenter evaluation: the mixture `(3/5)δ_{P(z)}+(2/5)δ_{P(−z)}` has truncated `E_0` mass exactly `3/10`, while the Dirac at that barycenter does not.

Encoding `k∈U_n` as `n` binary Record bits is a typing, not a physical compiler. Admissibility does not force those bits to be independent of `ρ` or uniform. No axiom edit.

Campaign `toe-lphys-20260812` Block 11. Independent of unmerged Blocks 01–10. Stretch after six consecutive obstruction notes.

## What changed

- Note: `docs/RECORD_BIT_DYADIC_REGISTRATION_TRUNCATED_BARYCENTER_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py`
- Cache: `logs/runner-cache/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.txt`
- Citation-graph carve-out: `docs/audit/data/citation_graph_manifest.json` (new node, out-degree 3, parents Aug 9 / Aug 10 / minimal axioms)

## Verification

```bash
python3 scripts/record_bit_dyadic_registration_truncated_barycenter_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Cache written through `scripts/runner_cache.py` `execute_and_write_cache(..., 120)` matching `AUDIT_TIMEOUT_SEC = 120`.

Mutation check (in-runner): replacing `floor_diff_mass` by restriction `25/142` fails `mixed-exact-quarter`; replacing it by raw `Tr(ρ E)` fails `biased-never-dyadic` and `mixture-not-barycenter-at-biased`. Independent arithmetic: `1/4`, `3/10`, `2/5`, `25/142`, `2/11`, `Z=509/200` recomputed from matrix traces.

## Promotion value gate

- **V1** — Aug 10 left "a physical construction that produces registered measurable event partitions" open. This note supplies a finite product family and the exact/never-exact split.
- **V2** — New floor-difference kernel, `3/10` never-dyadic obstruction, and affine-but-not-barycentric split. Prior-art on `origin/main` `c45dd5ab30`: Aug 10 names the interface; QG dyadic notes are refinement nets; Koide "registration coordinate" is a different `(w,1-w)` object. Unmerged #6162 is continuum `D×[0,1]` and is not a premise.
- **V3** — Textbook floor functions do not mention the Aug 10 menus, restriction `25/142` vs `2/11`, or the `3/10` witness.
- **V4** — Exact `1/4` (`n≥2`) versus never-equal `3/10`; mixture-of-endpoints equals `3/10` while Dirac-at-barycenter truncated mass does not.
- **V5** — Not a corollary of Aug 10 or Aug 9. Closest unmerged is Block 03 continuum product; this is a finite discrete replacement with a new non-barycentric split.

## No-go discipline

Negative claim is Theorem 4 only (no finite `n` exact at all three declared Diracs). N1–N8 are in the note. Continuum lifts, non-affine kernels, and a physical bit compiler remain live.

## Cluster-cap (PR #4 in this type-bridge family)

**OPEN.** New object (`D×U_n` floor-difference kernel) and new scoped negative (`3/10` never dyadic; affine-but-not-barycentric). Independently reviewable without re-reviewing #6160–#6162. Not a relabel of the continuum product.

## Trace

Partial close of the Aug 10 partition clause by a Record-typed finite discrete product. Remaining residual: a physical compiler of independent uniform Record bits, or a continuum factor, and content-only identification of the event label. No axiom PR.

## Review surface

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. Do not merge as retained.

Pack: `/Users/jonreilly/Projects/Physics/.claude/science/physics-loops/toe-lphys-20260812/`

Author-side review-loop was not run (owner-operated). Conformance 1–12 checked at authoring: 1 self-contained on `origin/main`+delta; 2 cache envelope; 3 scope matches; 4 N-gate in note; 5 obligation graph; 6 identity gates + mutation; 7 no helper-registry edit; 8 citation-graph carve-out; 9 machine-status complete; 10 no audit fields; 11 restriction numbers recomputed; 12 V1–V5 in note. Not applicable: packet helper runner (none).