### PR TITLE
[physics-loop] toe-lphys block14 source-test-typing: bounded_theorem / bounded-support

### DIFF
--- a/docs/RECORD_DOES_NOT_TYPE_NEWTON_SOURCE_VERSUS_TEST_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/RECORD_DOES_NOT_TYPE_NEWTON_SOURCE_VERSUS_TEST_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,480 @@
+---
+claim_id: record_does_not_type_newton_source_versus_test_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Record content-only readout and additivity are swap-symmetric on a disjoint pair of collections, so they do not assign which collection is the Newton source mass M in the source-linear Green pairing; the unequal-mass Green split at r=1 is exact, and a declared typing remains a second object."
+upstream_dependencies:
+  - minimal_axioms
+  - newton_law_derived_note
+runner: scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py
+---
+
+# Record Does Not Type Newton Source Versus Test
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact source-versus-test typing of two disjoint Record collections
+against the already-recorded source-linear Green pairing; a declared typing
+remains a second object.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py`](../scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py)
+
+## Result Up Front
+
+The Newton potential-kernel packet
+[`NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) supplies the
+source-linear Green pairing
+
+`G(r)=1/(4 pi r)`, `phi = M G`, `|grad phi| = M/(4 pi r^2)`
+
+and lists among its non-claims both
+
+`F = -M_test grad(phi)`
+
+and
+
+the physical product law `M_source M_test`.
+
+If two disjoint Record collections `S` and `T` are given, that Green
+assignment still needs a **typing**: which collection is the source mass `M`
+that enters `phi`. Record additivity and content-only readout are
+swap-symmetric. This note proves that the axioms do not assign the typing.
+
+The current Record sentences in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) are quoted
+only as premises and are not edited:
+
+> A readout value is determined by record content alone.
+
+> For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+Five exact statements locate the split.
+
+1. **Two Green assignments.** For disjoint `S,T` and `r>0`,
+   `|grad phi_S|(r)=I(S)/(4 pi r^2)` and
+   `|grad phi_T|(r)=I(T)/(4 pi r^2)`. These are equal if and only if
+   `I(S)=I(T)`.
+2. **Swap symmetry of Record data.** The unordered pair of contents
+   `{content(S), content(T)}`, the union collection `S∪T` when disjoint,
+   and the scalar `I(S∪T)=I(S)+I(T)` are invariant under exchanging the
+   labels `S↔T`. Content-only readout therefore supplies no ordered typing.
+3. **Unequal-mass rejector.** Unit-atom collections with `I(S)=2` and
+   `I(T)=1`, evaluated at `r=1`, give
+   `|grad phi_S|(1)=1/(2 pi)` and `|grad phi_T|(1)=1/(4 pi)`. These are
+   unequal. The Record union readout is `I(S∪T)=3` either way. The two
+   possible Green assignments are not a function of the unlabeled Record
+   data.
+4. **Scoped negative.** There is no function of the unlabeled pair `{S,T}`
+   — equivalently of `I(S∪T)` together with the unordered pair
+   `{I(S),I(T)}` without an order — that equals the Newton source-linear
+   gradient for a uniquely selected source. A declared typing
+   `τ(source)=S` is a second object. Record does not type source versus
+   test.
+5. **Typed pairing remains an escape.** If a typing `τ` is supplied, the
+   maps `B_τ=I(source)I(test)` and `F_τ=-I(test) grad(phi_source)` are
+   well-defined formal maps. This note does not install `τ`, does not
+   claim those maps are physical, and does not claim gravity is impossible.
+
+A neighboring residual, not claimed here, is that the single scalar
+`I(S∪T)` cannot equal a two-argument product. The object of this note is
+source-versus-test typing.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two source-linear Green assignments disagree on the unequal-mass witness, while Record additivity and content-only readout are swap-symmetric. Unlabeled Record data therefore do not select which collection is the Newton source. A declared typing remains a second object."
+trace_class: negative_route_pruning
+target_claim_id: newton_source_test_typing
+target_blocker_text: "two-argument source–test pairing (Newton product residual)"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "A declared source/test typing, or another two-argument instrument, remains open; do not adopt axiom text."
+conditional_surface_status: "exact for the unequal-mass Green split and Record swap symmetry; physical typing remains open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work with finite record collections in the sense of the Record axiom. A
+**collection** is a finite family of pairwise-disjoint records, each carrying
+a formal rational strength. Scalar readout `I` is the sum of those
+strengths. The empty collection has `I(empty)=0`. If `A` and `B` are
+disjoint, additivity is
+
+`I(A∪B)=I(A)+I(B)`.
+
+The **content** of a collection is the unordered family of its record
+payloads. Content-only readout means that any readout value is a function of
+that content alone.
+
+Fix two pairwise-disjoint collections `S` and `T`. The **unlabeled Record
+data** of the pair are the unordered pair of contents `{content(S), content(T)}`,
+equivalently the pair consisting of the union collection `S∪T` together with
+the unordered pair of scalars `{I(S), I(T)}`. In particular the single
+union readout `I(S∪T)=I(S)+I(T)` is part of that data and carries no order.
+
+Newton objects are restated from the packet. The radial Green kernel and the
+source-linear potential attached to a typed collection `X` are
+
+```text
+G(r) = 1/(4 pi r),
+phi_X(r) = I(X) G(r) = I(X)/(4 pi r),
+|grad phi_X|(r) = I(X)/(4 pi r^2).
+```
+
+The derivative is recomputed below; it is not imported as a bare number.
+These formulae use one typed mass. They do not mention a second collection.
+
+A **typing** `τ` is a declared ordered pair `(source, test)` of the two
+collections. Writing `τ(source)=S` means that the Green assignment uses
+`M=I(S)` and treats `T` as the complementary test collection. The opposite
+typing is `τ(source)=T`. The axioms name neither ordered pair.
+
+The unequal-mass witness used below is realized by unit-strength atoms
+`S={s0,s1}` and `T={t0}`, so `I(S)=2`, `I(T)=1`, and `I(S∪T)=3`. The same
+totals are obtained from lumped rational strengths with those sums. An
+equal-mass control is the pair of unit atoms `S'={s0}`, `T'={t0}`.
+
+The source-side mass-linearity lemma
+[`G_NEWTON_MASS_LINEAR_POISSON_COMPOSITION_BOUNDED_THEOREM_NOTE_2026-05-10.md`](G_NEWTON_MASS_LINEAR_POISSON_COMPOSITION_BOUNDED_THEOREM_NOTE_2026-05-10.md)
+is source-linearity of a Poisson potential in an already-typed source mass.
+It does not assign which of two Record collections is that mass.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether unlabeled Record data of a disjoint pair
+select which collection is the Newton source in the already-recorded
+source-linear Green pairing, and record that a declared typing is a second
+object.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin content-only readout and disjoint additivity | premise | quoted from the axiom memo |
+| pin Newton non-claim of `F = -M_test grad(phi)` and `M_source M_test` | premise | quoted from the Newton packet |
+| recompute the two Green assignments from `G` | Theorem 1 | derivative of `phi_X=I(X)G` |
+| show Record data are swap-symmetric | Theorem 2 | content, union, and `I` |
+| exhibit the unequal-mass Green split | Theorem 3 | `1/(2 pi)` versus `1/(4 pi)` at `r=1` |
+| rule out a function of unlabeled data as a unique source gradient | Theorem 4 | scoped negative |
+| exhibit typed `B_τ` and `F_τ` as formal escapes | Theorem 5 | declared typing; not physical |
+| derive a physical source/test typing or force law | autonomous closure | open |
+| claim gravity is impossible, or that no pairing exists | non-claim | not attempted |
+
+## Theorem 1 — Two Green Assignments
+
+**Claim.** Let `S` and `T` be pairwise disjoint, and let `r>0`. The two
+source-linear Green assignments are
+
+`|grad phi_S|(r) = I(S)/(4 pi r^2)`,
+`|grad phi_T|(r) = I(T)/(4 pi r^2)`.
+
+These magnitudes are equal if and only if `I(S)=I(T)`.
+
+**Proof.** The packet kernel is `G(r)=1/(4 pi r)`. Attaching the Record
+readout of `S` as the source coefficient gives
+
+`phi_S(r)=I(S) G(r)=I(S)/(4 pi r)`.
+
+Differentiating in `r>0` yields
+
+`d phi_S/dr = -I(S)/(4 pi r^2)`,
+
+so `|grad phi_S|(r)=I(S)/(4 pi r^2)`. The same computation with `T` in
+place of `S` yields `|grad phi_T|(r)=I(T)/(4 pi r^2)`. The two right-hand
+sides are equal if and only if `I(S)=I(T)`, because `4 pi r^2>0`.
+
+Both formulae use a single typed mass. Neither formula selects which of
+`S,T` is that mass.
+
+## Theorem 2 — Swap Symmetry Of Record Data
+
+**Claim.** The unordered pair of contents `{content(S), content(T)}`, the
+union collection `S∪T` when `S` and `T` are disjoint, and the scalar
+`I(S∪T)=I(S)+I(T)` are invariant under exchanging the labels `S↔T`.
+Content-only readout therefore supplies no ordered typing.
+
+**Proof.** Content is an unordered family of record payloads, so
+
+`{content(S), content(T)}={content(T), content(S)}`
+
+as an unordered pair. Disjoint union of finite collections is commutative
+as a set of records: the family of atoms of `S∪T` equals the family of
+atoms of `T∪S`. Additivity and commutativity of rational addition give
+
+`I(S∪T)=I(S)+I(T)=I(T)+I(S)=I(T∪S)`.
+
+The content-only sentence says that a readout value is determined by
+record content alone. Any readout of the unlabeled pair is therefore a
+function of `{content(S), content(T)}`, or of the union content, or of
+the commutative sum `I(S)+I(T)`. None of those objects is an ordered pair
+`(source, test)`. An order `S` before `T` is extra data, not a Record
+readout.
+
+## Theorem 3 — Unequal-Mass Rejector
+
+**Claim.** Take unit-atom collections with `I(S)=2` and `I(T)=1`, and
+evaluate at `r=1`. Then
+
+`|grad phi_S|(1) = 2/(4 pi) = 1/(2 pi)`,
+`|grad phi_T|(1) = 1/(4 pi)`.
+
+These are unequal. The Record union readout is `I(S∪T)=3` either way.
+Therefore the two possible Green assignments are not a function of the
+unlabeled Record data.
+
+**Proof.** Realize `S` by two unit atoms and `T` by one unit atom, pairwise
+disjoint. Additivity gives `I(S)=2`, `I(T)=1`, and
+
+`I(S∪T)=I(S)+I(T)=3=I(T∪S)`.
+
+Theorem 1 at `r=1` gives
+
+`|grad phi_S|(1)=2/(4 pi)=1/(2 pi)`,
+`|grad phi_T|(1)=1/(4 pi)`.
+
+The identity `2/(4 pi)=1/(2 pi)` is cancellation in `Q(pi)`. The two
+values are unequal because `2≠1`. Theorem 2 says the unlabeled Record data
+of `{S,T}` equal those of `{T,S}`: same contents as an unordered pair, same
+union, same scalar `3`. A function of those data therefore returns one
+value on the pair. It cannot return both `1/(2 pi)` and `1/(4 pi)`. Hence
+the two Green assignments are not a function of the unlabeled Record data.
+
+The same split is obtained from lumped strengths with totals `2` and `1`.
+The equal-mass control `I(S')=I(T')=1` makes the two Green magnitudes
+equal, which is the “if and only if” direction of Theorem 1; it still
+supplies no order if a later map needs a distinguished test factor.
+
+## Theorem 4 — Unlabeled Record Data Do Not Select The Newton Source
+
+**Claim.** There is no function of the unlabeled pair `{S,T}` —
+equivalently of `I(S∪T)` together with the unordered pair `{I(S),I(T)}`
+without an order — that equals the Newton source-linear gradient for a
+uniquely selected source. A declared typing `τ(source)=S` is a second
+object. Record does not assign source versus test.
+
+**Proof.** Write `U({S,T})` for the unlabeled data of Theorem 2. Any
+function `f` of `U({S,T})` is swap-invariant:
+
+`f(U({S,T}))=f(U({T,S}))`.
+
+The Newton source-linear gradient for a uniquely selected source would be
+one of `|grad phi_S|` or `|grad phi_T|`, not both, and not an unordered
+pair of those numbers. On the Theorem 3 witness those two numbers are
+`1/(2 pi)` and `1/(4 pi)`, which are unequal. A swap-invariant `f` cannot
+equal a uniquely selected one of them: selecting which collection is the
+source is exactly the missing order.
+
+The same obstruction is visible on the scalar data
+`(I(S∪T), {I(S),I(T)})=(3,{2,1})`. Using the union scalar as the source
+mass produces
+
+`|grad phi_{S∪T}|(1)=3/(4 pi)`,
+
+which equals neither `1/(2 pi)` nor `1/(4 pi)`. Using `min` or `max` of
+`{2,1}` as a selector is an extra rule, not a Record readout. Declaring
+that the first Python label is the source is a typing, not a theorem of
+content-only additivity. Reading each collection separately still returns
+an unordered pair of scalars and still needs an order to name one of them
+the source. A geometric distinguished site — which collection sits at the
+origin — is an extra lattice typing, not a Record sentence.
+
+Therefore no function of the unlabeled pair equals the Newton
+source-linear gradient for a uniquely selected source. The object that
+would make the assignment is a declared typing `τ`. That typing is not
+`I`, not content, and not the union.
+
+## Theorem 5 — A Declared Typing Supplies Formal Maps, And Is A Second Object
+
+**Claim.** If a typing `τ` is supplied, the maps
+
+`B_τ = I(source) I(test)`,
+`F_τ = -I(test) grad(phi_source)`
+
+are well-defined formal maps. This note does not install `τ`, does not
+claim those maps are physical, and does not claim gravity is impossible.
+
+**Proof.** Given an ordered pair `(source, test)`, the scalars `I(source)`
+and `I(test)` are ordinary Record readouts of the two collections
+separately. Their product is then a number, and the source-linear field
+`grad(phi_source)` of Theorem 1 is defined, so the displayed formulae are
+ordinary algebra. On the Theorem 3 witness the two typings give two
+different source fields,
+
+`|grad phi_S|(1)=1/(2 pi)` versus `|grad phi_T|(1)=1/(4 pi)`,
+
+and two well-defined formal forces built from those fields. The four
+axioms do not name `τ`. The Newton packet already lists both
+`F = -M_test grad(phi)` and the physical product law `M_source M_test` as
+non-claims. This note does not reverse those non-claims, does not identify
+`B_τ` or `F_τ` with a physical Record law, and does not close a force law.
+
+The discriminating gate is only this: a declared typing makes those maps
+writable; unlabeled Record data do not select the typing. Both sides are
+exhibited. Gravity is not claimed impossible.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom sentence, or argue that an axiom update is necessary;
+- claim that gravity is impossible, or that no two-argument pairing can exist;
+- install a physical source/test typing `τ`;
+- identify `B_τ` or `F_τ` with a physical Record law;
+- restore `F = -M_test grad(phi)` as a derived response rule;
+- derive the physical product law `M_source M_test`;
+- restate as a new claim the neighboring residual that a function of the
+  single scalar `I(S∪T)` cannot equal a two-argument product;
+- close gravitational coupling normalization, `G_N`, or a continuum
+  Einstein equation;
+- treat a geometric distinguished site, or a min/max selector, as a Record
+  theorem.
+
+The scope is the exact gap: Record does not type Newton source versus test.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Record content-only sentence | premise | quoted; no edit |
+| current Record additivity sentence and `I(empty)=0` | premise | quoted; no edit |
+| Newton kernel `G(r)=1/(4 pi r)` and source-linear `phi` | common objects | restated from the Newton packet; derivative recomputed |
+| Newton non-claim of `F = -M_test grad(phi)` and `M_source M_test` | scope pin | quoted; not reversed |
+| source-side mass-linearity lemma | neighboring landed linearity | source-linearity only; not a typing |
+| unequal-mass Green split and swap symmetry | declared algebra | computed here |
+| physical source/test typing | escape route | live, not derived |
+
+The exact advance is a finite typing obstruction. Independent audit remains
+required before any effective status may change. This note authors no audit verdict.
+
+## Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | The Newton packet lists `F = -M_test grad(phi)` and the physical product law `M_source M_test` as non-claims. This note isolates the missing typing that would even let those maps be written as functions of Record data. It does not call the upstream packet unratified. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for source-versus-test, source-test typing, and which collection is the source. Hits: the Newton packet is source-linear and lists the product/force as non-claims; the mass-linear Poisson composition lemma is source-linearity only. No landed swap-symmetry / unequal-mass typing obstruction appears on that commit. |
+| V3 | Independently checkable? | No: textbook Green functions do not mention Record content-only swap symmetry or the axiom `I`. The runner recomputes the Green derivative, the two assignments, the union readout `3`, and the split `1/(2 pi)` versus `1/(4 pi)` in exact `sympy` arithmetic. |
+| V4 | More than a restatement? | Yes. The exact `1/(2 pi)` versus `1/(4 pi)` split at `r=1` with union readout `3` is not a restatement of the Newton non-claim sentence. |
+| V5 | One-step relabel? | No. The claim is not a corollary of source-linearity alone — that uses an already-typed `M` — and is not a restatement of the Newton non-claim sentence. The closest landed wording is the non-claim list; this note supplies the rejector. |
+
+## No-Go Discipline Gate (Theorem 4 only)
+
+The negative claim is restricted to: unlabeled Record data do not select
+which collection is the Newton source. The gate does not ship a global
+non-existence theorem against pairings, and it does not ship a claim that
+gravity is impossible.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| use `I(S∪T)` as the source mass `M` | set `|grad phi|=3/(4 pi)` at `r=1` | fails the unequal-mass split: `3/(4 pi)` equals neither `1/(2 pi)` nor `1/(4 pi)` | **ATTEMPTED** |
+| use `min` or `max` of `{I(S),I(T)}` | declare the heavier (or lighter) collection to be the source | extra selector, not a Record readout; see N7 | **ATTEMPTED** |
+| declared label order | take the first Python tuple slot as source | a typing, not a Record theorem; swap changes `grad_magnitude` when the masses differ | **ATTEMPTED** |
+| separate content-only readouts | read `I(S)` and `I(T)` each by content | still an unordered pair; an order is needed to assign source versus test | **ATTEMPTED** |
+| geometric distinguished site | take whichever collection sits at the origin as source | extra lattice typing, not a Record sentence | **ATTEMPTED** |
+| restore `F=-M_test ∇φ` by fiat | write the force/source response rule as if derived | Newton non-claim, not derived | **ATTEMPTED** |
+| add a typing sentence to the axiom memo | put `τ` into Record | not attempted; N6; no axiom sentence is edited | **NOT ATTEMPTED** |
+
+### N2 — wall independence
+
+Theorem 4 closes only unique selection of a Newton source from unlabeled
+Record data. It does not close a later declared typing, a two-argument
+instrument, a physical product law, or a force-response bridge. Those walls
+remain independent.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| finite disjoint collections `S,T` with rational strengths | declared Record objects |
+| scalar `I` and content-only readout | quoted axiom sentences |
+| Green kernel `G(r)=1/(4 pi r)` | restated Newton object |
+| source-linear `phi_X=I(X)G` | restated Newton object; `X` already typed |
+| unlabeled pair `{S,T}` and `{I(S),I(T)}` | explicit hypothesis of Theorem 4 |
+| declared typing `τ` | live escape; not derived |
+| min/max selector or geometric origin | extra selectors; not Record |
+| physical product or force law | Newton non-claims; not reversed |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | content-only sentence; additivity and `I(empty)=0` | quoted as premises only; no edit |
+| [`docs/NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) | source-linear kernel algebra; non-claims `F = -M_test grad(phi)` and the physical product law `M_source M_test` | quoted; derivative recomputed; non-claims not reversed |
+| mass-linear Poisson composition lemma | source-linearity in an already-typed `M` | neighboring landed linearity; not a typing |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | named collections with totals `2` and `1`, and the two Green numbers `1/(2 pi)` and `1/(4 pi)` | no classification of every two-collection map |
+| per site | collection-level readout and a radial kernel; no composite carrier | no bonded-pair or lattice-site theorem |
+| per mode | source-linear radial Green assignments, not spectral modes | no harmonic-mode exhaustion |
+| per block | typing obstruction and the displayed formal escape only | no dynamics, `G_N`, or Einstein equation |
+| lattice-wide | checked and not executed | no lattice-wide no-go against pairings or gravity |
+
+The obstruction is per-pair / declared unequal-mass witness; it is not
+lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. A later derivation that supplies a declared typing `τ` from some
+   already-landed instrument other than unlabeled Record data.
+2. A later two-argument instrument that is not a function of `{S,T}`
+   without order.
+3. A content-only bridge that is nonetheless ordered by some extra
+   landed structure, if and when that structure is derived.
+4. Leaving the Newton force and product sentences as non-claims.
+
+The quoted Record and Newton sentences already name content-only readout,
+additivity, the source-linear kernel, and the non-claim of the force and
+product maps. A declared typing remains a second object. No axiom sentence
+is edited here. This note does not argue that an axiom update is necessary.
+
+### N7 — hostile steelman
+
+> Call the heavier collection the source. Then `I(S)=2` is selected by
+> `max{I(S),I(T)}`, the Green assignment is uniquely `1/(2 pi)`, and
+> Theorem 4 is empty.
+
+**Answer.** That is a declared selector (max-`I` typing). Record does not
+supply it: content-only additivity returns the unordered pair `{2,1}` and
+the sum `3`, not a “heavier-is-source” rule. The same selector still fails
+when `I(S)=I(T)` if one still needs an ordered test factor: `max` and `min`
+then coincide, and the order `(source, test)` remains extra data. Theorem 4
+is the absence of a unique source from unlabeled data, not the absence of
+every conceivable extra selector.
+
+### N8 — cross-cycle echo
+
+The Newton packet’s non-claim list already withholds
+`F = -M_test grad(phi)` and the physical product law `M_source M_test`.
+The mass-linear Poisson lemma is source-linearity in an already-typed
+mass. The present negative is a different residual: unlabeled Record data
+do not select which of two collections is that mass. The unequal-mass
+split is not a restatement of those parent sentences. The positive escape
+(Theorem 5) does not cancel the packet non-claims; it records that a
+declared typing would make the maps writable as formal algebra.
+
+**Gate disposition.** PASS for the scoped typing obstruction. FAIL / DO NOT SHIP for "gravity is impossible" or "no two-argument pairing can exist."
+
+## Primary Runner
+
+[`scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py`](../scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py)
+recomputes the two Green assignments from `G`, the Record swap symmetries,
+the unequal-mass split `1/(2 pi)` versus `1/(4 pi)`, the unlabeled-data
+obstruction, and the typed formal escape, all in exact `Fraction`/`sympy`
+arithmetic. Identity gates call `grad_magnitude(mass, radius)` defined as
+`mass / (4 pi radius**2)`. Replacing `grad_magnitude` by a swap-invariant
+rule that always uses `I(S)+I(T)` must fail the unequal-mass split.
+Replacing `grad_magnitude` by the product law `I(S)I(T)/(4 pi r^2)` must
+fail source-linearity of the Newton packet. A declared “always `S` is
+source by label order in the Python tuple” is a typing, not a Record
+theorem: the swap of the two collections must change `grad_magnitude`
+exactly when the masses differ.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15700,6 +15700,10 @@
   },
   "record_dephasing_broadcast_interface_2026-06-05": {
    "deps_hash": "9f8fd308f473",
+   "out_degree": 3
+  },
+  "record_does_not_type_newton_source_versus_test_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "f3e3aeef73e3",
    "out_degree": 3
   },
   "record_dominated_pointer_sector_transport_generator_vacuous_link_bounded_theorem_note_2026-06-09": {

--- a/logs/runner-cache/record_does_not_type_newton_source_versus_test_2026_08_13.txt
+++ b/logs/runner-cache/record_does_not_type_newton_source_versus_test_2026_08_13.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py
+runner_sha256: fde8fbd208eb5cf84b22b410020fbe5c9a8ce49464b047c9e3772c2a0e4f6282
+input_fingerprint_sha256: 3cd888b6ee19695e5420ff0474cc33405edbded91312c6c46cbed37df8855461
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.53
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/RECORD_DOES_NOT_TYPE_NEWTON_SOURCE_VERSUS_TEST_BOUNDED_THEOREM_NOTE_2026-08-13.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+  docs/NEWTON_LAW_DERIVED_NOTE.md
+cache_write: false
+two-kinds split: external_scientific_inputs versus package_local_integrity_reads
+external_scientific_inputs: current Record content-only and additivity sentences plus the Newton kernel and non-claims are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: only unlabeled Record data as a unique Newton source selector is rejected; a declared typing remains a live formal escape; gravity is not claimed impossible
+PASS: audit-input-paths declared audit inputs exist and match the note, axiom memo, and Newton packet
+PASS: source-record-content-only the exact current Record content-only sentence is present in the axiom memo and the note
+PASS: source-record-additivity the exact current Record additivity sentence is present in the axiom memo and the note
+PASS: source-newton-nonclaim-force the Newton packet lists F = -M_test grad(phi) as a non-claim
+PASS: source-newton-nonclaim-product the Newton packet lists the physical product law as a non-claim
+PASS: note-pins-newton-nonclaims the note records F = -M_test grad(phi) and the physical product law M_source M_test
+PASS: empty-readout I(empty)=0
+PASS: witness-collections unit-atom collections realize I(S)=2, I(T)=1, I(S union T)=3 and are disjoint
+PASS: green-kernel supplied kernel is 1/(4 pi r) and phi is source-linear
+PASS: theorem-1-derivative d phi / dr = -m/(4 pi r^2) and |grad phi| equals grad_magnitude(m, r)
+PASS: theorem-1-two-assignments |grad phi_S| = I(S)/(4 pi r^2) and |grad phi_T| = I(T)/(4 pi r^2)
+PASS: theorem-1-equal-iff-masses-equal the two Green assignments are equal iff I(S)=I(T)
+PASS: theorem-2-swap-symmetry contents, union atoms, and I(S union T) are invariant under S <-> T
+PASS: theorem-2-no-ordered-typing content-only unlabeled data are an unordered pair, not an ordered typing
+PASS: theorem-3-unequal-mass-split |grad phi_S|(1) = 1/(2 pi) and |grad phi_T|(1) = 1/(4 pi) are unequal
+PASS: theorem-3-union-readout swap leaves I(S union T)=3
+PASS: theorem-3-lumped lumped strengths with totals 2 and 1 reproduce the same Green split and union 3
+PASS: theorem-4-union-as-mass-fails using I(S union T) as M yields 3/(4 pi), which equals neither Green assignment
+PASS: theorem-4-unlabeled-cannot-select swap-invariant unlabeled data cannot equal a uniquely selected source gradient
+PASS: theorem-5-typed-maps if a typing is supplied, B_tau and F_tau are well-defined formal maps
+PASS: theorem-5-escape-not-physical the note records the typed maps as a formal escape and does not claim gravity is impossible
+PASS: mutation-union-mass-fails-split replacing grad_magnitude by a swap-invariant I(S)+I(T) rule fails 1/(2 pi) vs 1/(4 pi)
+PASS: mutation-product-fails-source-linearity replacing grad_magnitude by the product law fails source-linearity of phi = M G
+PASS: mutation-label-order-is-typing always taking the first Python tuple entry as source is a typing: swap changes grad_magnitude when masses differ
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: note-links-parents the note links the axiom memo and the Newton packet
+PASS: newton-kernel-bound the Newton packet still states the source-linear kernel algebra
+PASS: canonical-nonmutation the typing escape is absent from the canonical axiom file
+PASS: n-gate-disposition the N-gate passes the scoped typing obstruction and refuses gravity-impossible and no-pairing claims
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: named collections with totals 2 and 1 have Green assignments 1/(2 pi) and 1/(4 pi) recomputed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: collection-level readout and a radial kernel are checked; no composite carrier is asserted
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: source-linear radial Green assignments are checked; no spectral or harmonic mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only the typing obstruction, the unequal-mass split, and the typed formal escape are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide pairing, force law, or Einstein equation is claimed
+TOTAL: PASS=35 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py
+++ b/scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Exact checks: Record does not type Newton source versus test.
+
+The source-linear Green pairing supplies two assignments on a disjoint
+pair. Content-only additivity is swap-symmetric and does not select which
+collection is the source. The unequal-mass split is 1/(2 pi) versus
+1/(4 pi). A declared typing remains a second object. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+import sympy as sp
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_DOES_NOT_TYPE_NEWTON_SOURCE_VERSUS_TEST_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/NEWTON_LAW_DERIVED_NOTE.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+NEWTON_PATH = ROOT / AUDIT_INPUT_PATHS[2]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Collection:
+    """Finite labeled record collection with rational strengths."""
+
+    atoms: tuple[tuple[str, Fraction], ...] = ()
+
+    def strength(self) -> Fraction:
+        return sum((weight for _, weight in self.atoms), Fraction(0))
+
+    def labels(self) -> frozenset[str]:
+        return frozenset(label for label, _ in self.atoms)
+
+    def content(self) -> frozenset[tuple[str, Fraction]]:
+        return frozenset(self.atoms)
+
+    def disjoint(self, other: "Collection") -> bool:
+        return self.labels().isdisjoint(other.labels())
+
+    def union(self, other: "Collection") -> "Collection":
+        if not self.disjoint(other):
+            raise ValueError("Record additivity is stated only for disjoint collections")
+        return Collection(self.atoms + other.atoms)
+
+
+def I(collection: Collection) -> Fraction:
+    return collection.strength()
+
+
+def as_sympy(value: Fraction | int | sp.Expr) -> sp.Expr:
+    if isinstance(value, sp.Expr):
+        return value
+    if isinstance(value, Fraction):
+        return sp.Rational(value.numerator, value.denominator)
+    return sp.Integer(value)
+
+
+def is_zero(expr: object) -> bool:
+    return sp.simplify(sp.sympify(expr)) == 0
+
+
+def grad_magnitude(mass: object, radius: object) -> sp.Expr:
+    """Identity-gate function: Newton source-linear gradient magnitude."""
+    return as_sympy(mass) / (4 * sp.pi * as_sympy(radius) ** 2)
+
+
+def swap_invariant_union_grad(source: Collection, test: Collection, radius: object) -> sp.Expr:
+    """Mutation: always use I(S)+I(T) as the mass."""
+    return (as_sympy(I(source) + I(test))) / (4 * sp.pi * as_sympy(radius) ** 2)
+
+
+def product_law_grad(source: Collection, test: Collection, radius: object) -> sp.Expr:
+    """Mutation: product law I(S)I(T)/(4 pi r^2)."""
+    return (as_sympy(I(source) * I(test))) / (4 * sp.pi * as_sympy(radius) ** 2)
+
+
+def label_order_grad(pair: tuple[Collection, Collection], radius: object) -> sp.Expr:
+    """Declared typing: first Python tuple entry is the source."""
+    source, _test = pair
+    return grad_magnitude(I(source), radius)
+
+
+def unit_atoms(prefix: str, count: int) -> Collection:
+    return Collection(tuple((f"{prefix}{index}", Fraction(1)) for index in range(count)))
+
+
+def lumped(label: str, weight: Fraction) -> Collection:
+    if weight == 0:
+        return Collection()
+    return Collection(((label, weight),))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    newton = NEWTON_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+    normalized_newton = normalize(newton)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("two-kinds split: external_scientific_inputs versus package_local_integrity_reads")
+    print(
+        "external_scientific_inputs: current Record content-only and additivity "
+        "sentences plus the Newton kernel and non-claims are source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; no runner cache is written"
+    )
+    print(
+        "negative_scope: only unlabeled Record data as a unique Newton source "
+        "selector is rejected; a declared typing remains a live formal escape; "
+        "gravity is not claimed impossible"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, axiom memo, and Newton packet",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/RECORD_DOES_NOT_TYPE_NEWTON_SOURCE_VERSUS_TEST_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/NEWTON_LAW_DERIVED_NOTE.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    record_content = "A readout value is determined by record content alone."
+    record_additivity = (
+        "For any finite collection of pairwise-disjoint records, scalar readout "
+        "`I` is additive, with `I(empty)=0`."
+    )
+    newton_force = "F = -M_test grad(phi)"
+    newton_product = "the physical product law `M_source M_test`"
+
+    checks.check(
+        "source-record-content-only",
+        "the exact current Record content-only sentence is present in the axiom memo and the note",
+        record_content in normalized_axiom and record_content in normalized_note,
+    )
+    checks.check(
+        "source-record-additivity",
+        "the exact current Record additivity sentence is present in the axiom memo and the note",
+        record_additivity in normalized_axiom and record_additivity in normalized_note,
+    )
+    checks.check(
+        "source-newton-nonclaim-force",
+        "the Newton packet lists F = -M_test grad(phi) as a non-claim",
+        newton_force in newton and "test-mass force/source response rule" in newton,
+    )
+    checks.check(
+        "source-newton-nonclaim-product",
+        "the Newton packet lists the physical product law as a non-claim",
+        newton_product in newton,
+    )
+    checks.check(
+        "note-pins-newton-nonclaims",
+        "the note records F = -M_test grad(phi) and the physical product law M_source M_test",
+        newton_force in note and newton_product in note,
+    )
+
+    empty = Collection()
+    checks.check(
+        "empty-readout",
+        "I(empty)=0",
+        I(empty) == Fraction(0),
+        residual=I(empty),
+    )
+
+    source = unit_atoms("s", 2)
+    test = unit_atoms("t", 1)
+    checks.check(
+        "witness-collections",
+        "unit-atom collections realize I(S)=2, I(T)=1, I(S union T)=3 and are disjoint",
+        source.disjoint(test)
+        and I(source) == Fraction(2)
+        and I(test) == Fraction(1)
+        and I(source.union(test)) == I(source) + I(test) == Fraction(3),
+        residual=(I(source), I(test), I(source.union(test))),
+    )
+
+    r = sp.symbols("r", positive=True)
+    mass = sp.symbols("m", real=True)
+    green = 1 / (4 * sp.pi * r)
+    phi = mass * green
+    dphi = sp.diff(phi, r)
+    checks.check(
+        "green-kernel",
+        "supplied kernel is 1/(4 pi r) and phi is source-linear",
+        is_zero(green - 1 / (4 * sp.pi * r)) and is_zero(phi - mass / (4 * sp.pi * r)),
+        residual=green,
+    )
+    checks.check(
+        "theorem-1-derivative",
+        "d phi / dr = -m/(4 pi r^2) and |grad phi| equals grad_magnitude(m, r)",
+        is_zero(dphi + mass / (4 * sp.pi * r**2))
+        and is_zero(-dphi - grad_magnitude(mass, r)),
+        residual=dphi,
+    )
+
+    grad_s = grad_magnitude(I(source), r)
+    grad_t = grad_magnitude(I(test), r)
+    checks.check(
+        "theorem-1-two-assignments",
+        "|grad phi_S| = I(S)/(4 pi r^2) and |grad phi_T| = I(T)/(4 pi r^2)",
+        is_zero(grad_s - as_sympy(I(source)) / (4 * sp.pi * r**2))
+        and is_zero(grad_t - as_sympy(I(test)) / (4 * sp.pi * r**2)),
+        residual=(grad_s, grad_t),
+    )
+    equal_left = unit_atoms("u", 1)
+    equal_right = unit_atoms("v", 1)
+    checks.check(
+        "theorem-1-equal-iff-masses-equal",
+        "the two Green assignments are equal iff I(S)=I(T)",
+        not is_zero(grad_s - grad_t)
+        and I(source) != I(test)
+        and I(equal_left) == I(equal_right)
+        and is_zero(grad_magnitude(I(equal_left), r) - grad_magnitude(I(equal_right), r)),
+        residual=(sp.simplify(grad_s - grad_t), I(equal_left), I(equal_right)),
+    )
+
+    union_st = source.union(test)
+    union_ts = test.union(source)
+    unlabeled = (I(union_st), frozenset({I(source), I(test)}))
+    unlabeled_swapped = (I(union_ts), frozenset({I(test), I(source)}))
+    checks.check(
+        "theorem-2-swap-symmetry",
+        "contents, union atoms, and I(S union T) are invariant under S <-> T",
+        {source.content(), test.content()} == {test.content(), source.content()}
+        and union_st.content() == union_ts.content()
+        and I(union_st) == I(union_ts) == I(source) + I(test)
+        and unlabeled == unlabeled_swapped,
+        residual=(unlabeled, unlabeled_swapped),
+    )
+    checks.check(
+        "theorem-2-no-ordered-typing",
+        "content-only unlabeled data are an unordered pair, not an ordered typing",
+        unlabeled == (Fraction(3), frozenset({Fraction(2), Fraction(1)}))
+        and (I(source), I(test)) != (I(test), I(source)),
+        residual=unlabeled,
+    )
+
+    radius_one = sp.Integer(1)
+    grad_s_at_one = grad_magnitude(I(source), radius_one)
+    grad_t_at_one = grad_magnitude(I(test), radius_one)
+    half_pi = 1 / (2 * sp.pi)
+    quarter_pi = 1 / (4 * sp.pi)
+    checks.check(
+        "theorem-3-unequal-mass-split",
+        "|grad phi_S|(1) = 1/(2 pi) and |grad phi_T|(1) = 1/(4 pi) are unequal",
+        is_zero(grad_s_at_one - sp.Integer(2) / (4 * sp.pi))
+        and is_zero(sp.Integer(2) / (4 * sp.pi) - half_pi)
+        and is_zero(grad_s_at_one - half_pi)
+        and is_zero(grad_t_at_one - quarter_pi)
+        and not is_zero(grad_s_at_one - grad_t_at_one),
+        residual=(grad_s_at_one, grad_t_at_one),
+    )
+    checks.check(
+        "theorem-3-union-readout",
+        "swap leaves I(S union T)=3",
+        I(union_st) == Fraction(3) and I(union_ts) == Fraction(3),
+        residual=(I(union_st), I(union_ts)),
+    )
+    lumped_source = lumped("S", Fraction(2))
+    lumped_test = lumped("T", Fraction(1))
+    checks.check(
+        "theorem-3-lumped",
+        "lumped strengths with totals 2 and 1 reproduce the same Green split and union 3",
+        I(lumped_source.union(lumped_test)) == Fraction(3)
+        and is_zero(grad_magnitude(I(lumped_source), radius_one) - half_pi)
+        and is_zero(grad_magnitude(I(lumped_test), radius_one) - quarter_pi),
+    )
+
+    union_as_source = grad_magnitude(I(union_st), radius_one)
+    checks.check(
+        "theorem-4-union-as-mass-fails",
+        "using I(S union T) as M yields 3/(4 pi), which equals neither Green assignment",
+        is_zero(union_as_source - sp.Integer(3) / (4 * sp.pi))
+        and not is_zero(union_as_source - half_pi)
+        and not is_zero(union_as_source - quarter_pi),
+        residual=union_as_source,
+    )
+    checks.check(
+        "theorem-4-unlabeled-cannot-select",
+        "swap-invariant unlabeled data cannot equal a uniquely selected source gradient",
+        unlabeled == unlabeled_swapped
+        and not is_zero(grad_s_at_one - grad_t_at_one)
+        and I(source) != I(test),
+    )
+
+    typed_product_st = I(source) * I(test)
+    typed_product_ts = I(test) * I(source)
+    force_mag_st = as_sympy(I(test)) * grad_s_at_one
+    force_mag_ts = as_sympy(I(source)) * grad_t_at_one
+    checks.check(
+        "theorem-5-typed-maps",
+        "if a typing is supplied, B_tau and F_tau are well-defined formal maps",
+        typed_product_st == Fraction(2)
+        and typed_product_ts == Fraction(2)
+        and is_zero(force_mag_st - as_sympy(I(test)) * half_pi)
+        and is_zero(force_mag_ts - as_sympy(I(source)) * quarter_pi),
+        residual=(typed_product_st, force_mag_st, force_mag_ts),
+    )
+    checks.check(
+        "theorem-5-escape-not-physical",
+        "the note records the typed maps as a formal escape and does not claim gravity is impossible",
+        "does not install" in note
+        and "does not claim gravity is impossible" in note
+        and "well-defined formal maps" in note,
+    )
+
+    union_grad_st = swap_invariant_union_grad(source, test, radius_one)
+    union_grad_ts = swap_invariant_union_grad(test, source, radius_one)
+    checks.check(
+        "mutation-union-mass-fails-split",
+        "replacing grad_magnitude by a swap-invariant I(S)+I(T) rule fails 1/(2 pi) vs 1/(4 pi)",
+        is_zero(union_grad_st - union_grad_ts)
+        and not is_zero(union_grad_st - half_pi)
+        and not is_zero(union_grad_st - quarter_pi)
+        and not is_zero(union_grad_st - grad_s_at_one)
+        and not is_zero(union_grad_st - grad_t_at_one),
+        residual=union_grad_st,
+    )
+
+    heavier_test = unit_atoms("w", 3)
+    product_at_witness = product_law_grad(source, test, radius_one)
+    product_at_heavier = product_law_grad(source, heavier_test, radius_one)
+    source_linear_at_heavier = grad_magnitude(I(source), radius_one)
+    checks.check(
+        "mutation-product-fails-source-linearity",
+        "replacing grad_magnitude by the product law fails source-linearity of phi = M G",
+        I(test) == Fraction(1)
+        and is_zero(product_at_witness - half_pi)
+        and I(heavier_test) == Fraction(3)
+        and is_zero(product_at_heavier - sp.Integer(6) / (4 * sp.pi))
+        and is_zero(source_linear_at_heavier - half_pi)
+        and not is_zero(product_at_heavier - source_linear_at_heavier)
+        and product_law_grad(source, heavier_test, radius_one).has(sp.pi),
+        residual=(product_at_witness, product_at_heavier, source_linear_at_heavier),
+    )
+
+    pair = (source, test)
+    swapped = (test, source)
+    checks.check(
+        "mutation-label-order-is-typing",
+        "always taking the first Python tuple entry as source is a typing: swap changes grad_magnitude when masses differ",
+        I(pair[0]) != I(swapped[0])
+        and is_zero(label_order_grad(pair, radius_one) - half_pi)
+        and is_zero(label_order_grad(swapped, radius_one) - quarter_pi)
+        and not is_zero(
+            label_order_grad(pair, radius_one) - label_order_grad(swapped, radius_one)
+        )
+        and I(source) != I(test),
+        residual=(label_order_grad(pair, radius_one), label_order_grad(swapped, radius_one)),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required_phrases = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "trace_class: negative_route_pruning",
+        "target_claim_id: newton_source_test_typing",
+        'target_blocker_text: "two-argument source–test pairing (Newton product residual)"',
+        "reachability_to_target: prunes",
+        'next_trace_action: "A declared source/test typing, or another two-argument instrument, remains open; do not adopt axiom text."',
+        'conditional_surface_status: "exact for the unequal-mass Green split and Record swap symmetry; physical typing remains open"',
+        "1/(2 pi)",
+        "1/(4 pi)",
+        "authors no audit verdict",
+    )
+    has_typing_phrase = "does not type" in note or "does not assign" in note
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(phrase in note for phrase in required_phrases)
+        and has_typing_phrase
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "Block 14" not in note
+        and "toe-lphys" not in note,
+        residual=[phrase for phrase in required_phrases if phrase not in note],
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "note-links-parents",
+        "the note links the axiom memo and the Newton packet",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note and "NEWTON_LAW_DERIVED_NOTE.md" in note,
+    )
+    checks.check(
+        "newton-kernel-bound",
+        "the Newton packet still states the source-linear kernel algebra",
+        all(
+            phrase in normalized_newton
+            for phrase in (
+                "G(r) = 1/(4 pi r)",
+                "phi(r) = M G(r) = M/(4 pi r)",
+                "|grad phi| = M/(4 pi r^2)",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the typing escape is absent from the canonical axiom file",
+        all(
+            phrase not in axiom
+            for phrase in ("τ(source)", "B_τ", "phi_S", "source versus test")
+        ),
+    )
+    checks.check(
+        "n-gate-disposition",
+        "the N-gate passes the scoped typing obstruction and refuses gravity-impossible and no-pairing claims",
+        "PASS for the scoped typing obstruction" in note
+        and "gravity is impossible" in note
+        and "no two-argument pairing can exist" in note
+        and "FAIL / DO" in note,
+    )
+
+    n5_lines = (
+        "per_element: named collections with totals 2 and 1 have Green assignments 1/(2 pi) and 1/(4 pi) recomputed",
+        "per_site: collection-level readout and a radial kernel are checked; no composite carrier is asserted",
+        "per_mode: source-linear radial Green assignments are checked; no spectral or harmonic mode is claimed",
+        "per_block: only the typing obstruction, the unequal-mass split, and the typed formal escape are executed",
+        "lattice_wide: checked and not executed — no lattice-wide pairing, force law, or Einstein equation is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The Newton packet is source-linear and lists `F = -M_test grad(phi)` and `M_source M_test` as non-claims. If two disjoint Record collections `S` and `T` are given, the Green assignment still needs a **typing**: which collection is the source mass.

- Record content-only readout and `I(S∪T)` are swap-symmetric.
- At `I(S)=2`, `I(T)=1`, `r=1`, the two Green assignments are `1/(2 pi)` versus `1/(4 pi)`.
- No function of the unlabeled Record data selects a unique source. A declared typing `τ` is a second object; typed maps `B_τ` and `F_τ` remain a formal escape.

This note does not claim gravity is impossible and does not install a pairing. No axiom edit.

Campaign `toe-lphys-20260812` Block 14. Independent of unmerged Blocks 01–13. Stretch on the Newton pairing residual.

## What changed

- Note: `docs/RECORD_DOES_NOT_TYPE_NEWTON_SOURCE_VERSUS_TEST_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py`
- Cache: `logs/runner-cache/record_does_not_type_newton_source_versus_test_2026_08_13.txt`
- Citation-graph carve-out: `docs/audit/data/citation_graph_manifest.json`

## Verification

```bash
python3 scripts/record_does_not_type_newton_source_versus_test_2026_08_13.py
# TOTAL: PASS=35 FAIL=0
```

Cache via `execute_and_write_cache(..., 120)`. Mutations: union-as-mass fails the unequal-mass split; product law fails source-linearity; tuple order is a typing.

## Trace / status

- `actual_current_surface_status`: bounded-support
- `target_claim_type`: bounded_theorem
- `trace_class`: negative_route_pruning
- N-gate in the source note; N5 in cached stdout.
- Independent audit remains required.

Pack: `.claude/science/physics-loops/toe-lphys-20260812/`