### PR TITLE
[physics-loop] toe-lphys block15 ylike-identification: bounded_theorem / bounded-support

### DIFF
--- a/docs/Y_LIKE_SPECTRUM_DOES_NOT_IDENTIFY_U1Y_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/Y_LIKE_SPECTRUM_DOES_NOT_IDENTIFY_U1Y_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,439 @@
+---
+claim_id: y_like_spectrum_does_not_identify_u1y_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the taste cube C^8 the three residual-swap operators Y_a=(2 tau_a-I)/3 are pairwise distinct and isospectral with spec {+1/3 x6, -1 x2} and trace 0, so spectrum plus tracelessness do not select a unique generator or identify anomaly-complete U(1)_Y; the coefficient 1/3 is a scale choice and the (2,3)/(2,1) block names are extra representation-class data."
+upstream_dependencies:
+  - minimal_axioms
+  - native_gauge_left_handed_abelian_surface_bounded_note_2026-05-23
+runner: scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py
+---
+
+# Y-Like Spectrum Does Not Identify U(1)_Y
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact 8×8 residual-swap algebra on the taste cube `{0,1}^3`;
+spectrum plus tracelessness of the native `Y_like` operators do not select
+a unique generator or identify anomaly-complete `U(1)_Y`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py`](../scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py)
+
+## Result Up Front
+
+The landed native abelian-surface note
+[`NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md`](NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md)
+constructs, for each selected axis of the taste cube `{0,1}^3`, a residual
+complementary-axis swap `tau` and the traceless combination
+
+```text
+Pi_+ = (I + tau)/2,
+Pi_- = (I - tau)/2,
+Y_like = (1/3) Pi_+ - Pi_-.
+```
+
+It proves `spec(Y_like) = {+1/3 with multiplicity 6, -1 with multiplicity 2}`
+and `Tr(Y_like)=0`. In the same opening claim-scope sentence it states that
+this is only a hypercharge-like left-handed eigenvalue surface:
+
+> It does not claim anomaly-complete `U(1)_Y`, electroweak matching,
+> matter-completion labels, electric charge, or downstream phenomenology.
+
+Anomaly notes later declare the identification of that surface with
+anomaly-relevant Standard Model hypercharge as an extra premise P-HY. The
+four-axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is an unedited
+parent: its Lattice, Qubit, Admissibility, and Record sentences do not name
+`Y_like` or `U(1)_Y`.
+
+This note does not re-prove the native spectrum as a novelty. It recomputes
+the closed form and the spectrum only as objects for a uniqueness
+obstruction. Closed form:
+
+```text
+Y = (2 tau - I)/3
+```
+
+There are three residual swaps, one per selected axis. The three operators
+`Y_0`, `Y_1`, `Y_2` are pairwise unequal as matrices on the supplied cube
+basis and are isospectral. For rational `k`,
+
+`spec(k Y_0) = {k/3 x6, -k x2}`,
+
+and this equals the SM-like target `Σ_* = {+1/3 x6, -1 x2}` if and only if
+`k=1`. In particular `k=1/3` has spectrum `{1/9 x6, -1/3 x2} ≠ Σ_*`.
+Spectrum plus tracelessness therefore do not pick a unique generator, and
+they do not force P-HY.
+
+This is a scoped uniqueness gap. It does not claim that `U(1)_Y` is
+impossible, and it does not adopt P-HY.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The three residual-swap generators are pairwise distinct and isospectral, and k=1 is the unique rational scale with spectrum Sigma_*. Spectrum plus trace therefore do not identify a unique operator as anomaly-complete U(1)_Y."
+trace_class: negative_route_pruning
+target_claim_id: y_like_u1y_identification
+target_blocker_text: "Y_like ↔ U(1)_Y and hw=1 ↔ three families as explicit identification theorems"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "P-HY remains a declared identification; a commutation-with-SU(2)×SU(3) bridge or another selector is still open; do not adopt axiom text."
+conditional_surface_status: "exact for three-axis distinctness and the k=1 scale rejector; physical U(1)_Y remains open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work on `C^8` with the orthonormal basis labeled by bits
+`(x,y,z) ∈ {0,1}^3` in lexicographic order
+
+```text
+e0 = (0,0,0), e1 = (0,0,1), e2 = (0,1,0), e3 = (0,1,1),
+e4 = (1,0,0), e5 = (1,0,1), e6 = (1,1,0), e7 = (1,1,1).
+```
+
+For a selected axis `a ∈ {0,1,2}`, write `tau_a` for the permutation matrix
+of the coordinate swap of the other two axes:
+
+```text
+tau_0 : (x,y,z) |-> (x,z,y),
+tau_1 : (x,y,z) |-> (z,y,x),
+tau_2 : (x,y,z) |-> (y,x,z).
+```
+
+The permutation matrix is defined by `tau_a e_b = e_{swap_a(b)}`. It is a
+real symmetric involution, hence Hermitian, and `tau_a^2 = I`.
+
+The native projectors and generator are
+
+```text
+Pi_+^a = (I + tau_a)/2,
+Pi_-^a = (I - tau_a)/2,
+Y_a    = (1/3) Pi_+^a - Pi_-^a.
+```
+
+The SM-like target spectrum is the multiset
+
+`Σ_* = {+1/3 (mult 6), -1 (mult 2)}`.
+
+Eigenvalue multiplicities below are geometric: the multiplicity of a
+rational `λ` for an 8×8 matrix `M` is `8 - rank(M - λ I)`, computed by
+exact Gaussian elimination over `Q`. Because each `tau_a` satisfies
+`tau_a^2 = I`, its minimal polynomial divides `x^2-1` and has distinct
+roots, so `tau_a` and every rational polynomial in `tau_a` (including
+`Y_a`) is diagonalizable. Geometric and algebraic multiplicities therefore
+agree.
+
+The four-axiom memo is quoted only as an unedited parent. No axiom sentence
+is used as a selector among the three `Y_a`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether the native `Y_like` spectrum together with
+tracelessness identifies a unique operator as anomaly-complete `U(1)_Y`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin native non-claim of anomaly-complete `U(1)_Y` | premise | quoted from the native abelian-surface note |
+| pin unedited four-axiom memo | parent | no axiom sentence names `Y_like` |
+| closed form `Y = (2 tau - I)/3` and spectrum `Σ_*` | Theorem 1 | recomputed on `±1` eigenspaces of `tau` |
+| pairwise distinct isospectral `Y_0,Y_1,Y_2` | Theorem 2 | one disagreeing matrix entry per pair |
+| scale rejector `k ≠ 1` | Theorem 3 | `k=1/3` gives `{1/9 x6, -1/3 x2}` |
+| spectrum+trace do not force P-HY | Theorem 4 | scoped negative |
+| `(2,3)`/`(2,1)` naming is extra | Theorem 5 | spectrum is basis-invariant |
+| derive a unique physical `U(1)_Y` | autonomous closure | open |
+| claim `U(1)_Y` is impossible | non-claim | not attempted |
+| claim `hw=1` is not three families | non-claim | different object; not attempted |
+
+## Theorem 1 — Closed Form And Spectrum
+
+Fix an axis `a`. The residual swap `tau := tau_a` is a Hermitian involution:
+each column of the permutation matrix has a single `1`, the map is an
+involution of the eight basis labels, and the matrix is symmetric. Hence
+`tau^2 = I` and `tau^† = tau`.
+
+The combinations `Pi_+ = (I+tau)/2` and `Pi_- = (I-tau)/2` are complementary
+orthogonal projectors. The number of fixed basis vectors of `tau` is four:
+the selected bit is free and the two complementary bits are equal. Therefore
+
+`Tr(tau) = 4`, `Tr(Pi_+) = (8+4)/2 = 6`, `Tr(Pi_-) = (8-4)/2 = 2`.
+
+A projector’s rank equals its trace, so `rank(Pi_+)=6` and `rank(Pi_-)=2`.
+Equivalently, `tau` has eigenvalue `+1` with multiplicity `6` and
+eigenvalue `-1` with multiplicity `2`.
+
+The native linear combination expands as
+
+```text
+Y_like = (1/3) Pi_+ - Pi_-
+       = (I+tau)/6 - (I-tau)/2
+       = (I+tau)/6 - 3(I-tau)/6
+       = (I + tau - 3I + 3 tau)/6
+       = (4 tau - 2 I)/6
+       = (2 tau - I)/3.
+```
+
+Thus `Y_a = (2 tau_a - I)/3`. Applying this closed form to the eigenspaces
+of `tau` gives the spectrum without a floating-point diagonalization:
+
+- if `tau v = +v`, then `Y v = (2v - v)/3 = (1/3) v`;
+- if `tau v = -v`, then `Y v = (-2v - v)/3 = -v`.
+
+So `spec(Y_a) = {+1/3 x6, -1 x2} = Σ_*`. The trace is
+`Tr Y_a = 0`:
+
+`6*(1/3) + 2*(-1) = 0`.
+
+The same ranks are recovered as
+
+`rank(Y_a - (1/3) I) = rank(tau - I) = 2`,
+`rank(Y_a + I) = rank(tau + I) = 6`,
+
+hence the geometric multiplicities are `8-2=6` and `8-6=2`. This is a
+recomputation of the native spectrum, not a novelty claim.
+
+## Theorem 2 — Three Pairwise Distinct Operators
+
+The three residual swaps are pairwise unequal as 8×8 matrices. A single
+basis vector already separates them. On `e_{(0,0,1)}`:
+
+```text
+tau_0 e_{(0,0,1)} = e_{(0,1,0)},
+tau_1 e_{(0,0,1)} = e_{(1,0,0)},
+tau_2 e_{(0,0,1)} = e_{(0,0,1)}.
+```
+
+The corresponding matrix entries (row labeled by the image, column labeled
+by `(0,0,1)`) disagree:
+
+```text
+(tau_0)_{(0,1,0),(0,0,1)} = 1,   (tau_1)_{(0,1,0),(0,0,1)} = 0,
+(tau_0)_{(0,1,0),(0,0,1)} = 1,   (tau_2)_{(0,1,0),(0,0,1)} = 0,
+(tau_1)_{(1,0,0),(0,0,1)} = 1,   (tau_2)_{(1,0,0),(0,0,1)} = 0.
+```
+
+In the lexicographic index these are the pairs of entries `(2,1)` and
+`(4,1)`. Because `Y_a = (2 tau_a - I)/3`, the same entries of the generators
+are `2/3` versus `0`. Therefore
+
+`Y_0 != Y_1 != Y_2 != Y_0`.
+
+By Theorem 1 every `Y_a` has spectrum `Σ_*` and trace `0`. The three
+operators are isospectral and traceless, yet pairwise distinct. Spectrum
+plus trace do not pick a unique generator on the supplied cube basis.
+
+## Theorem 3 — Scale Rejector
+
+Let `k` be rational. Then `k Y_0` is a rational polynomial in `tau_0`, so
+it is diagonalizable on the same eigenspaces:
+
+`spec(k Y_0) = {k/3 x6, -k x2}`.
+
+This multiset equals `Σ_* = {1/3 x6, -1 x2}` if and only if `k=1`. Indeed
+the two eigenvalues and their multiplicities must match:
+
+- the assignment `k/3 = 1/3` and `-k = -1` forces `k=1`;
+- the crossed assignment `k/3 = -1` and `-k = 1/3` requires `k=-3` and
+  `k=-1/3` at once, which is impossible.
+
+In particular the two scales that most often appear as alternative
+normalizations fail:
+
+```text
+k=1/3: spec {1/9 x6, -1/3 x2} ≠ Σ_*,
+k=-1:  spec {-1/3 x6, +1 x2} ≠ Σ_*.
+```
+
+The coefficient `1/3` in the native formula is a scale choice. It is not
+forced by the demand that some traceless operator built from `tau` have a
+two-point spectrum; it is forced only once the target multiset `Σ_*` is
+already named.
+
+## Theorem 4 — Spectrum Plus Trace Do Not Identify U(1)_Y
+
+There is no theorem from the native `Y_like` spectrum and trace alone that
+identifies a unique operator as anomaly-complete `U(1)_Y`. Three pairwise
+distinct isospectral generators exist (Theorem 2). The native coefficient
+`1/3` is a scale choice (Theorem 3). P-HY remains an extra identification,
+declared in anomaly notes and explicitly refused as a claim by the native
+surface note.
+
+This note does not claim that `U(1)_Y` is impossible. It does not adopt
+P-HY. It does not claim that `hw=1` fails to be three families: that is a
+different object and is not addressed.
+
+The N-gate below is the route audit for this scoped negative.
+
+## Theorem 5 — Naming Residual
+
+The spectrum `Σ_*` is a conjugation-invariant, basis-invariant fact about
+each `Y_a`. The sentence that the six-dimensional `+1/3` block is the
+representation class `(2,3)` and the two-dimensional `-1` block is the
+representation class `(2,1)` is not a spectral fact. It names which factor
+of a stipulated `C^2 ⊗ (C^2 ⊗ C^2)` splitting is the weak doublet and which
+residual swap is the color swap.
+
+The native construction does not supply those names. It supplies three
+different residual swaps on one fixed cube basis. Assigning SM left-handed
+content `(2,3)_{+1/3} + (2,1)_{-1}` is a representation-class naming, not a
+consequence of `spec(Y_a)=Σ_*`. The name-free two-block algebra in
+[`HYPERCHARGE_IDENTIFICATION_NOTE.md`](HYPERCHARGE_IDENTIFICATION_NOTE.md)
+likewise takes the `(2,3)+(2,1)` splitting as an input; it is a different
+object and is not used as a premise here.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom sentence, or argue that an axiom-text change is required;
+- claim that `U(1)_Y` is impossible, or that no later selector can pick a
+  generator;
+- adopt P-HY, or treat P-HY as a derived theorem;
+- claim that `hw=1` is not three families;
+- derive a commutation-with-`SU(2)×SU(3)` uniqueness lemma;
+- identify any `Y_a` with electric charge, electroweak matching, or
+  phenomenology;
+- exhaust every traceless 8×8 matrix with spectrum `Σ_*`.
+
+The scope is the exact gap: spectrum plus tracelessness of the native
+`Y_like` family do not identify a unique anomaly-complete `U(1)_Y`.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| four-axiom memo | unedited parent | no axiom sentence names `Y_like` |
+| native residual-swap construction and spectrum | common objects | recomputed; not claimed as novelty |
+| native sentence “does not claim anomaly-complete `U(1)_Y`” | scope pin | quoted; not reversed |
+| pairwise matrix disagreement and `k=1/3` rejector | declared algebra | computed here |
+| P-HY identification | extra premise | not derived; not adopted |
+| commutation with a supplied `SU(2)×SU(3)` action | escape route | live, not derived |
+
+The exact advance is a finite uniqueness obstruction. Independent audit
+remains required. This note authors no audit verdict.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | The native note states that it does not claim anomaly-complete `U(1)_Y`. This note supplies the uniqueness obstruction: three isospectral distinct generators plus a scale rejector. It does not call the upstream surface unratified. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for `Y_like`, P-HY, and anomaly-complete. Hits: the native abelian-surface note constructs all three axes and refuses the identification; `HYPERCHARGE_IDENTIFICATION_NOTE` is name-free two-block algebra on a stipulated `(2,3)+(2,1)` splitting; ABJ and anomaly-forces-time notes declare P-HY as a premise. No landed pairwise-distinct plus scale rejector whose claim is that spectrum cannot identify `U(1)_Y` appears on that commit. |
+| V3 | Textbook already? | No: textbook isospectrality does not mention the taste-cube residual swap or P-HY. |
+| V4 | Discriminating exact witness? | Yes: exact pairwise matrix disagreement of `Y_0`, `Y_1`, `Y_2`, and the `k=1/3` spectrum `{1/9, -1/3}`. |
+| V5 | One-step relabel? | No: not a restatement of the native non-claim sentence. Closest is that non-claim; this note adds the three-axis and scale rejectors. |
+
+## No-Go Discipline Gate (Theorem 4)
+
+The negative claim is restricted to: spectrum plus tracelessness of the
+native `Y_like` family do not identify a unique operator as anomaly-complete
+`U(1)_Y`. The gate does not ship a global non-existence theorem against
+`U(1)_Y`.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| pick one axis by fiat | declare `Y_0` (or `Y_1`, or `Y_2`) to be the generator | typing: the three operators are already isospectral; the choice is extra data | **ATTEMPTED** |
+| average the three `Y_a` | form `Y_bar = (Y_0+Y_1+Y_2)/3` | a different operator: `spec(Y_bar) = {+1/3 x4, -1/3 x4} ≠ Σ_*` | **ATTEMPTED** |
+| scale `k ≠ 1` | replace `Y_0` by `k Y_0` | Theorem 3: `spec(k Y_0)=Σ_*` iff `k=1`; `k=1/3` gives `{1/9 x6, -1/3 x2}` | **ATTEMPTED** |
+| P-HY declaration | identify some `Y_a` with anomaly-complete `U(1)_Y` by premise | extra premise, not a consequence of spectrum plus trace | **ATTEMPTED** |
+| commute with a supplied `SU(2)×SU(3)` action | demand that the generator lie in a stipulated commutant | live escape; no such action is derived here | **ATTEMPTED** (escape) |
+| edit the axiom memo | add a sentence that names a unique abelian generator | forbidden; no axiom sentence is edited | **ATTEMPTED** (forbidden) |
+
+### N2 — wall independence
+
+Theorem 4 closes only uniqueness from the native spectrum and trace. It
+does not close a later commutation selector, a declared P-HY premise, or
+the existence of some physical `U(1)_Y`. Those walls remain independent.
+The `hw=1` versus three-families identification is a different object and
+is not a wall of this note.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| taste cube `{0,1}^3` and the lex `C^8` basis | declared native object |
+| selected axis `a` and residual swap `tau_a` | declared construction |
+| coefficient `1/3` | scale choice; Theorem 3 |
+| target multiset `Σ_*` | named comparison spectrum |
+| P-HY identification | extra premise; not derived |
+| `(2,3)+(2,1)` block names | representation-class input; Theorem 5 |
+| conjugation / gauge orbit | extra data; not a uniqueness proof |
+| `SU(2)×SU(3)` commutant selector | live escape; not executed here |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | four named axiom sentences; none names `Y_like` or `U(1)_Y` | quoted as an unedited parent only |
+| [`docs/NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md`](NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md) | residual-swap construction, spectrum `Σ_*`, and the sentence that the note does not claim anomaly-complete `U(1)_Y` | objects recomputed; identification still refused |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | the three generators `Y_0`, `Y_1`, `Y_2` and the scales `k Y_0` | no classification of every traceless 8×8 matrix |
+| per site | one `C^8` taste cube, not a lattice of spacetime sites | no composite multi-site theorem |
+| per mode | eigenvalue multiplicities of `Y_a` via `rank(Y-λI)` | no harmonic-mode exhaustion |
+| per block | three-axis distinctness and the `k=1` scale rejector only | no anomaly cancellation or electroweak matching |
+| lattice-wide | checked and not executed | no lattice-wide identification of `U(1)_Y` |
+
+The obstruction is per-cube / three-axis / declared residual swaps; it is
+not lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. A later selector that commutes a candidate generator with a supplied
+   `SU(2)×SU(3)` action on the same `C^8`.
+2. Any other selector that is not spectrum-plus-trace, including extra
+   typing that names one axis.
+3. A declared P-HY premise, kept as an extra identification and not
+   derived from the native spectrum.
+
+No axiom sentence is edited. The obstruction does not demand an axiom-text
+change.
+
+### N7 — hostile steelman
+
+> The three operators `Y_a` are gauge-equivalent residual swaps, so they
+> are the same `U(1)`.
+
+**Answer.** Even if the three matrices are conjugate in some larger
+automorphism group of the cube, conjugation is extra data. As operators on
+the supplied cube basis they are unequal (Theorem 2). P-HY names one
+physical hypercharge, not an orbit of conjugate generators. Passing to an
+orbit, or supplying the conjugating map, is a different claim.
+
+### N8 — cross-cycle echo
+
+The native abelian-surface note already refuses anomaly-complete `U(1)_Y`
+as a claim. Anomaly-forces-time notes declare P-HY as a premise. The
+present negative is a different residual: spectrum plus trace do not
+uniquely select a generator. The rejectors do not cancel the native
+non-claim; they supply the uniqueness obstruction that non-claim left
+implicit.
+
+**Gate disposition.** PASS for the scoped obstruction that spectrum plus
+trace do not identify a unique `U(1)_Y`. FAIL / DO NOT SHIP for
+"`U(1)_Y` cannot exist" or "`hw=1` is not three families" (different
+object; do not claim it).
+
+## Primary Runner
+
+[`scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py`](../scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py)
+rebuilds each residual swap as an exact `Fraction` permutation matrix,
+forms `y_like(axis)` from `tau(axis)` by the closed form
+`Y = (2 tau - I)/3`, and recomputes projector ranks, the native linear
+combination, traces, eigenvalue multiplicities by `rank(Y-λI)`, pairwise
+matrix disagreement, and the scale rejector. Identity gates call
+`y_like(axis)`. Replacing `y_like` by `k=1/3` times itself must fail the
+spectrum-equals-`Σ_*` check. Replacing all three axes by axis `0` must
+fail pairwise distinctness. Replacing `y_like` by `Pi_+` (spectrum
+`{1 x6, 0 x2}`) must fail `Σ_*`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -21369,6 +21369,10 @@
   "writing_voice_guide_2026-04-25": {
    "deps_hash": "8990b3713089",
    "out_degree": 1
+  },
+  "y_like_spectrum_does_not_identify_u1y_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "7efb7eb41272",
+   "out_degree": 3
   },
   "yang_mills_coupling_marginality_forces_d_four_narrow_theorem_note_2026-05-26": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/y_like_spectrum_does_not_identify_u1y_2026_08_13.txt
+++ b/logs/runner-cache/y_like_spectrum_does_not_identify_u1y_2026_08_13.txt
@@ -1,0 +1,68 @@
+===== runner cache v1 =====
+runner: scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py
+runner_sha256: dbf53c2da660d8446c036487ae6010fda2acd2361d1b75628e5e6d0e4db6e3d8
+input_fingerprint_sha256: feb72a72c78dfa6c6b45bde2d8a2bb1cee3704c18028687b1807bb6c2c9b2bf8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: native residual-swap Y_like construction and the four-axiom memo; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: spectrum plus trace do not identify a unique anomaly-complete U(1)_Y generator; U(1)_Y is not claimed impossible
+PASS: audit-input-paths declared audit inputs exist and match the note, axiom memo, and native surface note
+PASS: native-nonclaim-phrase the native note contains the exact non-claim phrase
+PASS: native-construction the native note states the projector formula and the +1/3,-1 spectrum
+PASS: axiom-does-not-name-generator the axiom memo does not name Y_like or U(1)_Y
+PASS: tau-0-involution tau^2 = I as exact permutation-matrix arithmetic
+PASS: tau-0-hermitian tau is a real symmetric permutation matrix
+PASS: projectors-0 Pi_+ and Pi_- are complementary projectors of ranks 6 and 2
+PASS: closed-form-0 identity-gate y_like(axis) equals (1/3)Pi_+ - Pi_- and (2 tau - I)/3
+PASS: trace-0 Tr Y_a = 0
+PASS: spectrum-0 spec(Y_a) = {1/3 x6, -1 x2} by rank(Y-lambda I)
+PASS: hermitian-0 Y_a is real symmetric, hence Hermitian
+PASS: tau-1-involution tau^2 = I as exact permutation-matrix arithmetic
+PASS: tau-1-hermitian tau is a real symmetric permutation matrix
+PASS: projectors-1 Pi_+ and Pi_- are complementary projectors of ranks 6 and 2
+PASS: closed-form-1 identity-gate y_like(axis) equals (1/3)Pi_+ - Pi_- and (2 tau - I)/3
+PASS: trace-1 Tr Y_a = 0
+PASS: spectrum-1 spec(Y_a) = {1/3 x6, -1 x2} by rank(Y-lambda I)
+PASS: hermitian-1 Y_a is real symmetric, hence Hermitian
+PASS: tau-2-involution tau^2 = I as exact permutation-matrix arithmetic
+PASS: tau-2-hermitian tau is a real symmetric permutation matrix
+PASS: projectors-2 Pi_+ and Pi_- are complementary projectors of ranks 6 and 2
+PASS: closed-form-2 identity-gate y_like(axis) equals (1/3)Pi_+ - Pi_- and (2 tau - I)/3
+PASS: trace-2 Tr Y_a = 0
+PASS: spectrum-2 spec(Y_a) = {1/3 x6, -1 x2} by rank(Y-lambda I)
+PASS: hermitian-2 Y_a is real symmetric, hence Hermitian
+PASS: eigenspace-action Y_0 acts by +1/3 on the +1 space of tau_0 and by -1 on the -1 space
+PASS: vector-witness-001 tau_0, tau_1, tau_2 send e_(0,0,1) to three different basis vectors
+PASS: pairwise-tau-entries each pair of residual swaps disagrees at a named matrix entry
+PASS: pairwise-y-distinct Y_0 != Y_1 != Y_2 != Y_0 as exact Fraction matrices
+PASS: isospectral all three generators have spectrum Sigma_* and trace 0
+PASS: scale-k-one spec(k Y_0) equals Sigma_* if and only if k=1 among the tested rationals
+PASS: scale-one-third-spectrum k=1/3 produces spec {1/9 x6, -1/3 x2}, which is not Sigma_*
+PASS: scale-minus-one-spectrum k=-1 produces spec {-1/3 x6, +1 x2}, which is not Sigma_*
+PASS: average-not-target the average of the three Y_a has spec {1/3 x4, -1/3 x4}, not Sigma_*
+PASS: mutation-scale-fails-target replacing y_like by k=1/3 times itself fails spectrum-equals-Sigma_*
+PASS: mutation-collapse-fails-distinct replacing all three axes by axis 0 fails pairwise distinctness
+PASS: mutation-pi-plus-fails-target replacing y_like by Pi_+ yields spec {1 x6, 0 x2} and fails Sigma_*
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: note-links-parents the note links the axiom memo and the native abelian-surface note
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: note-does-not-forbid-u1y the note states the scoped gap and does not claim U(1)_Y is impossible
+PASS: canonical-nonmutation the uniqueness obstruction is absent from the canonical axiom file
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: named generators Y_0, Y_1, Y_2 and the tested scales of Y_0 are recomputed as exact Fraction 8x8 matrices
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: statements are one taste-cube C^8 statements; no composite spacetime-site carrier is asserted
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: eigenvalue multiplicities of Y_a are checked by rank(Y-lambda I); no harmonic mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only three-axis distinctness, closed form, and the k=1 scale rejector are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide U(1)_Y identification or anomaly cancellation is claimed
+TOTAL: PASS=47 FAIL=0
+
+----- stderr -----
+

--- a/scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py
+++ b/scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Exact checks: Y_like spectrum does not identify U(1)_Y.
+
+On the taste cube C^8 the residual-swap generators
+Y_a = (2 tau_a - I)/3 are pairwise distinct and isospectral with
+spec {+1/3 x6, -1 x2} and trace 0. Spectrum plus tracelessness
+therefore do not select a unique generator. The scale k=1/3 produces
+{1/9 x6, -1/3 x2} and is not Sigma_*. Identity gates call y_like(axis)
+built from tau(axis). No cache is written.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "Y_LIKE_SPECTRUM_DOES_NOT_IDENTIFY_U1Y_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+NATIVE_PATH = (
+    ROOT / "docs" / "NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/Y_LIKE_SPECTRUM_DOES_NOT_IDENTIFY_U1Y_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md",
+)
+
+Matrix = tuple[tuple[Fraction, ...], ...]
+Vector = tuple[Fraction, ...]
+
+CUBE: tuple[tuple[int, int, int], ...] = (
+    (0, 0, 0),
+    (0, 0, 1),
+    (0, 1, 0),
+    (0, 1, 1),
+    (1, 0, 0),
+    (1, 0, 1),
+    (1, 1, 0),
+    (1, 1, 1),
+)
+INDEX = {bits: i for i, bits in enumerate(CUBE)}
+ONE = Fraction(1)
+ZERO = Fraction(0)
+THIRD = Fraction(1, 3)
+TWO_THIRDS = Fraction(2, 3)
+NINTH = Fraction(1, 9)
+
+
+def identity() -> Matrix:
+    return tuple(tuple(ONE if i == j else ZERO for j in range(8)) for i in range(8))
+
+
+def mat_add(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(a + b for a, b in zip(left_row, right_row, strict=True))
+        for left_row, right_row in zip(left, right, strict=True)
+    )
+
+
+def mat_sub(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(a - b for a, b in zip(left_row, right_row, strict=True))
+        for left_row, right_row in zip(left, right, strict=True)
+    )
+
+
+def mat_scale(coeff: Fraction, matrix: Matrix) -> Matrix:
+    return tuple(tuple(coeff * entry for entry in row) for row in matrix)
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(
+            sum((left[i][k] * right[k][j] for k in range(8)), ZERO)
+            for j in range(8)
+        )
+        for i in range(8)
+    )
+
+
+def mat_transpose(matrix: Matrix) -> Matrix:
+    return tuple(tuple(matrix[j][i] for j in range(8)) for i in range(8))
+
+
+def mat_trace(matrix: Matrix) -> Fraction:
+    return sum((matrix[i][i] for i in range(8)), ZERO)
+
+
+def mat_apply(matrix: Matrix, vector: Vector) -> Vector:
+    return tuple(
+        sum((matrix[i][j] * vector[j] for j in range(8)), ZERO) for i in range(8)
+    )
+
+
+def mat_minus_scalar(matrix: Matrix, scalar: Fraction) -> Matrix:
+    return tuple(
+        tuple(matrix[i][j] - (scalar if i == j else ZERO) for j in range(8))
+        for i in range(8)
+    )
+
+
+def mat_rank(matrix: Matrix) -> int:
+    rows = [list(row) for row in matrix]
+    rank = 0
+    for col in range(8):
+        pivot = next((row for row in range(rank, 8) if rows[row][col] != 0), None)
+        if pivot is None:
+            continue
+        rows[rank], rows[pivot] = rows[pivot], rows[rank]
+        inv = ONE / rows[rank][col]
+        rows[rank] = [inv * entry for entry in rows[rank]]
+        for row in range(8):
+            if row != rank and rows[row][col] != 0:
+                factor = rows[row][col]
+                rows[row] = [
+                    entry - factor * pivot_entry
+                    for entry, pivot_entry in zip(rows[row], rows[rank], strict=True)
+                ]
+        rank += 1
+    return rank
+
+
+def multiplicity(matrix: Matrix, eigenvalue: Fraction) -> int:
+    return 8 - mat_rank(mat_minus_scalar(matrix, eigenvalue))
+
+
+def swap_bits(bits: tuple[int, int, int], axis: int) -> tuple[int, int, int]:
+    coords = [bits[0], bits[1], bits[2]]
+    others = [index for index in range(3) if index != axis]
+    first, second = others
+    coords[first], coords[second] = coords[second], coords[first]
+    return (coords[0], coords[1], coords[2])
+
+
+def tau(axis: int) -> Matrix:
+    """Permutation matrix of the complementary-axis swap on the lex cube."""
+    if axis not in (0, 1, 2):
+        raise ValueError("axis must be 0, 1, or 2")
+    rows = [[ZERO for _ in range(8)] for _ in range(8)]
+    for source, bits in enumerate(CUBE):
+        target = INDEX[swap_bits(bits, axis)]
+        rows[target][source] = ONE
+    return tuple(tuple(row) for row in rows)
+
+
+def pi_plus(axis: int) -> Matrix:
+    return mat_scale(Fraction(1, 2), mat_add(identity(), tau(axis)))
+
+
+def pi_minus(axis: int) -> Matrix:
+    return mat_scale(Fraction(1, 2), mat_sub(identity(), tau(axis)))
+
+
+def y_like(axis: int) -> Matrix:
+    """Identity-gate function: native residual-swap generator on one axis."""
+    return mat_scale(Fraction(1, 3), mat_sub(mat_scale(Fraction(2), tau(axis)), identity()))
+
+
+def y_like_native_combination(axis: int) -> Matrix:
+    return mat_sub(mat_scale(THIRD, pi_plus(axis)), pi_minus(axis))
+
+
+def y_like_scaled_by_third(axis: int) -> Matrix:
+    """Mutation: replace y_like by (1/3) times itself."""
+    return mat_scale(THIRD, y_like(axis))
+
+
+def y_like_axis0_only(_axis: int) -> Matrix:
+    """Mutation: replace every axis by axis 0."""
+    return y_like(0)
+
+
+def spectrum_equals_target(matrix: Matrix) -> bool:
+    return multiplicity(matrix, THIRD) == 6 and multiplicity(matrix, Fraction(-1)) == 2
+
+
+def pairwise_distinct(matrices: tuple[Matrix, Matrix, Matrix]) -> bool:
+    left, mid, right = matrices
+    return left != mid and mid != right and right != left
+
+
+def first_disagreement(left: Matrix, right: Matrix) -> tuple[int, int] | None:
+    for i in range(8):
+        for j in range(8):
+            if left[i][j] != right[i][j]:
+                return (i, j)
+    return None
+
+
+def basis_vector(bits: tuple[int, int, int]) -> Vector:
+    index = INDEX[bits]
+    return tuple(ONE if i == index else ZERO for i in range(8))
+
+
+def vec_add(left: Vector, right: Vector) -> Vector:
+    return tuple(a + b for a, b in zip(left, right, strict=True))
+
+
+def vec_sub(left: Vector, right: Vector) -> Vector:
+    return tuple(a - b for a, b in zip(left, right, strict=True))
+
+
+def vec_scale(coeff: Fraction, vector: Vector) -> Vector:
+    return tuple(coeff * entry for entry in vector)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    native = NATIVE_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: native residual-swap Y_like construction "
+        "and the four-axiom memo; no observational or fitted inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; no runner cache is written"
+    )
+    print(
+        "negative_scope: spectrum plus trace do not identify a unique "
+        "anomaly-complete U(1)_Y generator; U(1)_Y is not claimed impossible"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, axiom memo, and native surface note",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/Y_LIKE_SPECTRUM_DOES_NOT_IDENTIFY_U1Y_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "native-nonclaim-phrase",
+        "the native note contains the exact non-claim phrase",
+        "does not claim anomaly-complete" in native,
+    )
+    checks.check(
+        "native-construction",
+        "the native note states the projector formula and the +1/3,-1 spectrum",
+        "Y_like = (1/3) Pi_+ - Pi_-." in native
+        and "rank(Pi_+) = 6" in native
+        and "rank(Pi_-) = 2" in native
+        and "Tr(Y_like) = 0" in native,
+    )
+    checks.check(
+        "axiom-does-not-name-generator",
+        "the axiom memo does not name Y_like or U(1)_Y",
+        "Y_like" not in axiom and "U(1)_Y" not in axiom and "hypercharge" not in axiom.lower(),
+    )
+
+    eye = identity()
+    for axis in (0, 1, 2):
+        swap = tau(axis)
+        checks.check(
+            f"tau-{axis}-involution",
+            "tau^2 = I as exact permutation-matrix arithmetic",
+            mat_mul(swap, swap) == eye,
+        )
+        checks.check(
+            f"tau-{axis}-hermitian",
+            "tau is a real symmetric permutation matrix",
+            swap == mat_transpose(swap)
+            and all(entry in (ZERO, ONE) for row in swap for entry in row)
+            and all(sum(row, ZERO) == ONE for row in swap)
+            and all(sum(swap[i][j] for i in range(8)) == ONE for j in range(8)),
+        )
+        plus = pi_plus(axis)
+        minus = pi_minus(axis)
+        checks.check(
+            f"projectors-{axis}",
+            "Pi_+ and Pi_- are complementary projectors of ranks 6 and 2",
+            mat_mul(plus, plus) == plus
+            and mat_mul(minus, minus) == minus
+            and mat_mul(plus, minus) == tuple((ZERO,) * 8 for _ in range(8))
+            and mat_add(plus, minus) == eye
+            and mat_rank(plus) == 6
+            and mat_rank(minus) == 2
+            and mat_trace(plus) == Fraction(6)
+            and mat_trace(minus) == Fraction(2),
+            residual=(mat_rank(plus), mat_rank(minus), mat_trace(plus), mat_trace(minus)),
+        )
+
+        closed = y_like(axis)
+        native_combo = y_like_native_combination(axis)
+        checks.check(
+            f"closed-form-{axis}",
+            "identity-gate y_like(axis) equals (1/3)Pi_+ - Pi_- and (2 tau - I)/3",
+            closed == native_combo
+            and closed
+            == mat_scale(Fraction(1, 3), mat_sub(mat_scale(Fraction(2), swap), eye)),
+        )
+        checks.check(
+            f"trace-{axis}",
+            "Tr Y_a = 0",
+            mat_trace(closed) == ZERO,
+            residual=mat_trace(closed),
+        )
+        checks.check(
+            f"spectrum-{axis}",
+            "spec(Y_a) = {1/3 x6, -1 x2} by rank(Y-lambda I)",
+            spectrum_equals_target(closed)
+            and multiplicity(closed, THIRD) == 6
+            and multiplicity(closed, Fraction(-1)) == 2
+            and mat_rank(mat_minus_scalar(closed, THIRD)) == 2
+            and mat_rank(mat_minus_scalar(closed, Fraction(-1))) == 6,
+            residual=(
+                multiplicity(closed, THIRD),
+                multiplicity(closed, Fraction(-1)),
+            ),
+        )
+        checks.check(
+            f"hermitian-{axis}",
+            "Y_a is real symmetric, hence Hermitian",
+            closed == mat_transpose(closed),
+        )
+
+    plus_space_0 = (
+        basis_vector((0, 0, 0)),
+        basis_vector((0, 1, 1)),
+        basis_vector((1, 0, 0)),
+        basis_vector((1, 1, 1)),
+        vec_add(basis_vector((0, 0, 1)), basis_vector((0, 1, 0))),
+        vec_add(basis_vector((1, 0, 1)), basis_vector((1, 1, 0))),
+    )
+    minus_space_0 = (
+        vec_sub(basis_vector((0, 0, 1)), basis_vector((0, 1, 0))),
+        vec_sub(basis_vector((1, 0, 1)), basis_vector((1, 1, 0))),
+    )
+    y0 = y_like(0)
+    t0 = tau(0)
+    plus_ok = all(
+        mat_apply(t0, vector) == vector
+        and mat_apply(y0, vector) == vec_scale(THIRD, vector)
+        for vector in plus_space_0
+    )
+    minus_ok = all(
+        mat_apply(t0, vector) == vec_scale(Fraction(-1), vector)
+        and mat_apply(y0, vector) == vec_scale(Fraction(-1), vector)
+        for vector in minus_space_0
+    )
+    checks.check(
+        "eigenspace-action",
+        "Y_0 acts by +1/3 on the +1 space of tau_0 and by -1 on the -1 space",
+        plus_ok and minus_ok,
+    )
+
+    y1 = y_like(1)
+    y2 = y_like(2)
+    t1 = tau(1)
+    t2 = tau(2)
+    image_001 = (
+        INDEX[swap_bits((0, 0, 1), 0)],
+        INDEX[swap_bits((0, 0, 1), 1)],
+        INDEX[swap_bits((0, 0, 1), 2)],
+    )
+    checks.check(
+        "vector-witness-001",
+        "tau_0, tau_1, tau_2 send e_(0,0,1) to three different basis vectors",
+        image_001 == (INDEX[(0, 1, 0)], INDEX[(1, 0, 0)], INDEX[(0, 0, 1)])
+        and mat_apply(t0, basis_vector((0, 0, 1))) == basis_vector((0, 1, 0))
+        and mat_apply(t1, basis_vector((0, 0, 1))) == basis_vector((1, 0, 0))
+        and mat_apply(t2, basis_vector((0, 0, 1))) == basis_vector((0, 0, 1)),
+        residual=image_001,
+    )
+    disagree_01 = first_disagreement(t0, t1)
+    disagree_02 = first_disagreement(t0, t2)
+    disagree_12 = first_disagreement(t1, t2)
+    checks.check(
+        "pairwise-tau-entries",
+        "each pair of residual swaps disagrees at a named matrix entry",
+        disagree_01 is not None
+        and disagree_02 is not None
+        and disagree_12 is not None
+        and t0[2][1] == ONE
+        and t1[2][1] == ZERO
+        and t2[2][1] == ZERO
+        and t1[4][1] == ONE
+        and t2[4][1] == ZERO
+        and t0[1][2] == ONE
+        and t1[1][2] == ZERO,
+        residual=(disagree_01, disagree_02, disagree_12),
+    )
+    checks.check(
+        "pairwise-y-distinct",
+        "Y_0 != Y_1 != Y_2 != Y_0 as exact Fraction matrices",
+        pairwise_distinct((y0, y1, y2))
+        and y0[2][1] == TWO_THIRDS
+        and y1[2][1] == ZERO
+        and y2[2][1] == ZERO
+        and y1[4][1] == TWO_THIRDS
+        and y2[4][1] == ZERO,
+    )
+    checks.check(
+        "isospectral",
+        "all three generators have spectrum Sigma_* and trace 0",
+        spectrum_equals_target(y0)
+        and spectrum_equals_target(y1)
+        and spectrum_equals_target(y2)
+        and mat_trace(y0) == mat_trace(y1) == mat_trace(y2) == ZERO,
+    )
+
+    scaled = y_like_scaled_by_third(0)
+    checks.check(
+        "scale-k-one",
+        "spec(k Y_0) equals Sigma_* if and only if k=1 among the tested rationals",
+        spectrum_equals_target(y_like(0))
+        and not spectrum_equals_target(scaled)
+        and not spectrum_equals_target(mat_scale(Fraction(-1), y0))
+        and not spectrum_equals_target(mat_scale(ZERO, y0))
+        and not spectrum_equals_target(mat_scale(Fraction(3), y0)),
+    )
+    checks.check(
+        "scale-one-third-spectrum",
+        "k=1/3 produces spec {1/9 x6, -1/3 x2}, which is not Sigma_*",
+        multiplicity(scaled, NINTH) == 6
+        and multiplicity(scaled, Fraction(-1, 3)) == 2
+        and not spectrum_equals_target(scaled)
+        and mat_trace(scaled) == ZERO,
+        residual=(
+            multiplicity(scaled, NINTH),
+            multiplicity(scaled, Fraction(-1, 3)),
+            multiplicity(scaled, THIRD),
+        ),
+    )
+    k_minus = mat_scale(Fraction(-1), y0)
+    checks.check(
+        "scale-minus-one-spectrum",
+        "k=-1 produces spec {-1/3 x6, +1 x2}, which is not Sigma_*",
+        multiplicity(k_minus, Fraction(-1, 3)) == 6
+        and multiplicity(k_minus, ONE) == 2
+        and not spectrum_equals_target(k_minus),
+    )
+
+    average = mat_scale(THIRD, mat_add(mat_add(y0, y1), y2))
+    checks.check(
+        "average-not-target",
+        "the average of the three Y_a has spec {1/3 x4, -1/3 x4}, not Sigma_*",
+        average != y0
+        and average != y1
+        and average != y2
+        and multiplicity(average, THIRD) == 4
+        and multiplicity(average, Fraction(-1, 3)) == 4
+        and not spectrum_equals_target(average),
+        residual=(multiplicity(average, THIRD), multiplicity(average, Fraction(-1, 3))),
+    )
+
+    collapsed = (y_like_axis0_only(0), y_like_axis0_only(1), y_like_axis0_only(2))
+    checks.check(
+        "mutation-scale-fails-target",
+        "replacing y_like by k=1/3 times itself fails spectrum-equals-Sigma_*",
+        spectrum_equals_target(y_like(0))
+        and not spectrum_equals_target(y_like_scaled_by_third(0)),
+    )
+    checks.check(
+        "mutation-collapse-fails-distinct",
+        "replacing all three axes by axis 0 fails pairwise distinctness",
+        pairwise_distinct((y_like(0), y_like(1), y_like(2)))
+        and not pairwise_distinct(collapsed)
+        and collapsed[0] == collapsed[1] == collapsed[2] == y_like(0),
+    )
+    plus0 = pi_plus(0)
+    checks.check(
+        "mutation-pi-plus-fails-target",
+        "replacing y_like by Pi_+ yields spec {1 x6, 0 x2} and fails Sigma_*",
+        multiplicity(plus0, ONE) == 6
+        and multiplicity(plus0, ZERO) == 2
+        and not spectrum_equals_target(plus0)
+        and spectrum_equals_target(y_like(0)),
+        residual=(multiplicity(plus0, ONE), multiplicity(plus0, ZERO)),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "trace_class: negative_route_pruning",
+                "target_claim_id: y_like_u1y_identification",
+                'target_blocker_text: "Y_like ↔ U(1)_Y and hw=1 ↔ three families as explicit identification theorems"',
+                "source_of_blocker_text: handoff",
+                "reachability_to_target: prunes",
+                "artifact_role: theorem",
+                'next_trace_action: "P-HY remains a declared identification; a commutation-with-SU(2)×SU(3) bridge or another selector is still open; do not adopt axiom text."',
+                'conditional_surface_status: "exact for three-axis distinctness and the k=1 scale rejector; physical U(1)_Y remains open"',
+                'hypothetical_axiom_status: "no edit"',
+                "admitted_observation_status: null",
+                "does not claim anomaly-complete",
+                "1/9",
+                "k=1/3",
+                "authors no audit verdict",
+                "Y = (2 tau - I)/3",
+                "Y_0 != Y_1 != Y_2 != Y_0",
+                "Tr Y_a = 0",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "Block 15" not in note
+        and "toe-lphys" not in note,
+        residual=[
+            phrase
+            for phrase in (
+                "does not claim anomaly-complete",
+                "1/9",
+                "k=1/3",
+                "authors no audit verdict",
+                "Y = (2 tau - I)/3",
+            )
+            if phrase not in note
+        ],
+    )
+    checks.check(
+        "note-links-parents",
+        "the note links the axiom memo and the native abelian-surface note",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and "NATIVE_GAUGE_LEFT_HANDED_ABELIAN_SURFACE_BOUNDED_NOTE_2026-05-23.md" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "note-does-not-forbid-u1y",
+        "the note states the scoped gap and does not claim U(1)_Y is impossible",
+        "does not claim that `U(1)_Y` is impossible" in note
+        or "does not claim that U(1)_Y is impossible" in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the uniqueness obstruction is absent from the canonical axiom file",
+        all(
+            phrase not in axiom
+            for phrase in ("Y_0", "Y_like", "Σ_*", "P-HY", "(2 tau - I)/3")
+        ),
+    )
+
+    n5_lines = (
+        "per_element: named generators Y_0, Y_1, Y_2 and the tested scales of Y_0 are recomputed as exact Fraction 8x8 matrices",
+        "per_site: statements are one taste-cube C^8 statements; no composite spacetime-site carrier is asserted",
+        "per_mode: eigenvalue multiplicities of Y_a are checked by rank(Y-lambda I); no harmonic mode is claimed",
+        "per_block: only three-axis distinctness, closed form, and the k=1 scale rejector are executed",
+        "lattice_wide: checked and not executed — no lattice-wide U(1)_Y identification or anomaly cancellation is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The landed native abelian-surface note constructs, for each selected taste-cube axis, a traceless `Y_like` with spectrum `{+1/3 x6, -1 x2}` and explicitly does not claim anomaly-complete `U(1)_Y`.

This note proves the uniqueness obstruction:

- Closed form `Y_a = (2 tau_a - I)/3` with exact `Fraction` 8×8 matrices.
- `Y_0`, `Y_1`, `Y_2` are pairwise distinct and isospectral.
- `spec(k Y_0) = Σ_*` iff `k=1`; the `k=1/3` witness is `{1/9 x6, -1/3 x2}`.
- P-HY remains an extra identification. The note does not claim `U(1)_Y` is impossible and does not address `hw=1` versus three families.

No axiom edit.

Campaign `toe-lphys-20260812` Block 15.

## What changed

- Note: `docs/Y_LIKE_SPECTRUM_DOES_NOT_IDENTIFY_U1Y_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py`
- Cache: `logs/runner-cache/y_like_spectrum_does_not_identify_u1y_2026_08_13.txt`
- Citation-graph carve-out: `docs/audit/data/citation_graph_manifest.json`

## Verification

```bash
python3 scripts/y_like_spectrum_does_not_identify_u1y_2026_08_13.py
# TOTAL: PASS=47 FAIL=0
```

Cache via `execute_and_write_cache(..., 120)`. Mutations: `k=1/3` fails `Σ_*`; collapsing all axes fails pairwise distinctness; `Pi_+` fails `Σ_*`.

## Trace / status

- `actual_current_surface_status`: bounded-support
- `target_claim_type`: bounded_theorem
- `trace_class`: negative_route_pruning
- N-gate in the source note; N5 in cached stdout.
- Independent audit remains required.

Pack: `.claude/science/physics-loops/toe-lphys-20260812/`