### PR TITLE
[physics-loop] toe-lphys jointlaw: bounded_theorem / bounded-support

### DIFF
--- a/docs/DISJOINT_NEIGHBOR_SUPPORT_ONE_SITE_LAWS_FACTORIZE_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/DISJOINT_NEIGHBOR_SUPPORT_ONE_SITE_LAWS_FACTORIZE_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,433 @@
+---
+claim_id: disjoint_neighbor_support_one_site_laws_factorize_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On Z^3, a pair of one-site Admissibility laws whose conditions live on the disjoint nearest-neighbor 6-tuples of 3e1 and 6e1 is a product measure on the two possibility sets; the perfectly correlated fair joint violates the independence identity and is therefore not that product, so a distant correlated assignment is not supplied by those one-site laws alone."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py
+---
+
+# Disjoint-Neighbor-Support One-Site Laws Factorize
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact cubic nearest-neighbor listings for `3e1` and `6e1`, product
+factorization of a pair of one-site laws on those disjoint 6-tuples, and the
+`1/4` versus `0` independence-identity split for the perfectly correlated fair
+joint; a joint on distant sites remains extra.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py`](../scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py)
+
+## Result Up Front
+
+Admissibility is a per-site distribution. Its current sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is quoted only
+as a premise and is not edited:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Lattice sentence is likewise quoted only as a premise:
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+Five exact statements locate the split.
+
+1. **Disjoint supports.** The six-point sets `N(3e1)` and `N(6e1)` are
+   disjoint. Neither contains the origin.
+2. **Product factorization.** A pair of one-site laws whose conditions live
+   on those two 6-tuples is the product measure
+   `P(α,β)=P_x(α|η_x) P_y(β|η_y)` on the two possibility sets. Every such
+   product obeys the independence identity
+   `P(α,β) P(α',β') = P(α,β') P(α',β)`.
+3. **Correlated witness is not a product.** The joint
+   `P(00)=P(11)=1/2`, `P(01)=P(10)=0` has fair margins and violates the
+   identity: `P(00)P(11)=1/4` while `P(01)P(10)=0`. Fair margins do not imply
+   a product.
+4. **Path residual (scoped).** That correlated joint is therefore not
+   supplied by one-site Admissibility laws at `3e1` and `6e1` alone. Possible
+   escapes, none of them derived and none of them declared here, are a law
+   whose condition includes sites outside `N(3e1)∪N(6e1)`, intermediate records on a connecting path, or a declared joint `L_phys`.
+5. **Not a global no-go.** The result is a factorization theorem for one-site
+   laws on disjoint neighbor supports. It does not rule out every distant
+   correlation. It does not declare `L_phys`. It does not edit an
+   axiom sentence.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The neighbor listings, the product factorization identity, and the 1/4-versus-0 correlated witness are proved by finite lattice enumeration and exact Fraction arithmetic; a joint on distant sites remains extra and is not declared."
+trace_class: negative_route_pruning
+target_claim_id: joint_law_l_phys
+target_blocker_text: "a physical joint law on distant sites, including correlated bits"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "One-site laws on disjoint neighbor supports factorize. A joint L_phys remains extra and must not be adopted until executable. Do not adopt axiom text."
+conditional_surface_status: "exact for disjoint NN 6-tuples at spacing 3 and for the product-versus-correlated 2x2 table; a joint on distant sites remains extra"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work on the cubic lattice `Z^3` with the Lattice axiom's nearest-neighbor
+adjacency. Write
+
+`e1=(1,0,0)`, `e2=(0,1,0)`, `e3=(0,0,1)`, `0=(0,0,0)`.
+
+The neighbor set of a site `x` is the six-point set
+
+`N(x)={x±e1, x±e2, x±e3}`.
+
+Thus `|N(x)|=6` at every site. Graph distance is the taxicab metric
+
+`d(x,y)=|x_1-y_1|+|x_2-y_2|+|x_3-y_3|`.
+
+The executed sites are `x=3e1=(3,0,0)` and `y=6e1=(6,0,0)`, with system
+origin `0`. Distances: `d(0,x)=3`, `d(0,y)=6`, `d(x,y)=3`.
+
+A **one-site law** at a site `z` is a map `P_z(· | η_z)` from 6-tuples of
+labels on `N(z)` to a probability distribution on a declared two-element
+possibility set `{0,1}`. The executed `{0,1}` is that declared finite menu.
+It is not a derivation that the Qubit one-site domain is binary.
+
+A **product assignment** on `{x,y}` is `P_x ⊗ P_y`, the joint
+
+`P(α,β) = P_x(α | η_x) P_y(β | η_y)`, `α,β ∈ {0,1}`.
+
+A **correlated assignment** on `{0,1}^2` is any joint that is not a product.
+The executed witness is the perfectly correlated fair law
+
+`P_corr(00)=P_corr(11)=1/2`, `P_corr(01)=P_corr(10)=0`.
+
+Its one-site margins are fair, `P_corr,x(0)=P_corr,y(0)=1/2`, yet
+`P_corr(00) ≠ (1/2)·(1/2)`.
+
+The fair product used as the positive control is
+
+`P_prod(α,β)=1/4` for every `(α,β) ∈ {0,1}^2`.
+
+Explicit neighbor lists used as witnesses:
+
+```text
+N(0)    = {(±1,0,0),(0,±1,0),(0,0,±1)}
+N(2e1)  = {(1,0,0),(3,0,0),(2,±1,0),(2,0,±1)}   — shares e1 with N(0)
+N(3e1)  = {(2,0,0),(4,0,0),(3,±1,0),(3,0,±1)}   — 0 ∉ N(3e1)
+N(6e1)  = {(5,0,0),(7,0,0),(6,±1,0),(6,0,±1)}   — 0 ∉ N(6e1)
+N(3e1) ∩ N(6e1) = empty
+```
+
+The 26-site Moore neighborhood of a site is the Chebyshev-1 punctured cube.
+It is a live adjacency mutation, not the Lattice neighbor set.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** On declared cubic nearest-neighbor objects, list `N(3e1)`
+and `N(6e1)`, prove those supports are disjoint and exclude the origin, prove
+that a pair of one-site laws on those 6-tuples is a product obeying the
+independence identity, and exhibit the perfectly correlated fair joint as a
+non-product with the same fair margins.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin the Admissibility distribution sentence | premise | quoted; no edit |
+| pin Lattice NN adjacency and `N(x)` | premise | quoted; `|N(x)|=6` listed |
+| show `N(3e1) ∩ N(6e1)=empty` and origin exclusion | Theorem 1 | listing |
+| show `P(α,β)=P_x(α\|η_x) P_y(β\|η_y)` and the identity | Theorem 2 | product of Fractions |
+| show `P_corr(00)P_corr(11)=1/4 ≠ 0=P_corr(01)P_corr(10)` | Theorem 3 | 2x2 table |
+| record that a correlated joint is not supplied by the pair alone | Theorem 4 | scoped residual |
+| record that this is not a no-go against all distant correlation | Theorem 5 | scoped negative |
+| declare a joint `L_phys` | non-claim | not attempted |
+| claim that every distant correlation is ruled out | non-claim | not attempted |
+
+## Theorem 1 — Disjoint Supports
+
+**Claim.** `N(3e1) ∩ N(6e1)=empty`, `0 ∉ N(3e1)`, and `0 ∉ N(6e1)`.
+
+**Proof.** The six neighbors of `3e1=(3,0,0)` are
+
+`(2,0,0)`, `(4,0,0)`, `(3,1,0)`, `(3,-1,0)`, `(3,0,1)`, `(3,0,-1)`.
+
+None is the origin. The six neighbors of `6e1=(6,0,0)` are
+
+`(5,0,0)`, `(7,0,0)`, `(6,1,0)`, `(6,-1,0)`, `(6,0,1)`, `(6,0,-1)`.
+
+None is the origin. The two six-point sets are disjoint by direct comparison.
+
+A one-line metric reason is available and is not a substitute for the
+listing. Distinct sites share a nearest neighbor if and only if `d≤2`,
+because a shared neighbor `z` would give `d(x,y)≤d(x,z)+d(z,y)=2`. Here
+`d(3e1,6e1)=3`, so a shared neighbor is impossible, matching the listing.
+
+The spacing-2 contrast used by the identity gate is the nonempty intersection
+
+`N(0) ∩ N(2e1)={(1,0,0)}={e1}`.
+
+A predicate that returns disjointness at every pair of sites is therefore
+false on `(0,2e1)`.
+
+## Theorem 2 — Product Factorization
+
+**Claim.** Let `P_x(· | η_x)` and `P_y(· | η_y)` be one-site laws whose
+conditions live on `N(3e1)` and `N(6e1)` respectively. The pair defines the
+product measure
+
+`P(α,β) = P_x(α | η_x) P_y(β | η_y)`
+
+on `{0,1}^2`. In particular the independence identity
+
+`P(α,β) P(α',β') = P(α,β') P(α',β)`
+
+holds for every `α,β,α',β' ∈ {0,1}`.
+
+**Proof.** By definition a one-site law at `x` is a function of a 6-tuple
+indexed by `N(x)` only, and likewise at `y`. Theorem 1 says those index sets
+are disjoint, so the pair is a function of two disjoint condition tuples.
+The joint assigned to the two possibility sets is the product of the two
+one-site values. Expanding both sides of the identity then gives
+
+`P_x(α) P_y(β) P_x(α') P_y(β')`
+
+on each side, so the identity holds in `Q`.
+
+The executed fair product has every atom equal to `1/4`. Its margins are
+fair, and the identity holds as ` (1/4)·(1/4)=(1/4)·(1/4) `. Every other
+pair of Bernoulli one-site laws, including biased coins, likewise yields a
+product: if `P_x(1)=p` and `P_y(1)=q` then the four atoms are
+`(1-p)(1-q)`, `(1-p)q`, `p(1-q)`, `pq`.
+
+The identity is a statement about the pair of one-site maps. It is not a
+statement that neighbor *values* on the two 6-tuples are themselves
+independent, and it is not a statement that records form at `x` or `y`.
+
+## Theorem 3 — Correlated Witness Is Not A Product
+
+**Claim.** The joint `P_corr(00)=P_corr(11)=1/2`, `P_corr(01)=P_corr(10)=0`
+violates the independence identity and is therefore not a product of one-site
+Bernoulli laws. Fair margins do not imply a product.
+
+**Proof.** Direct evaluation gives
+
+`P_corr(00) P_corr(11) = (1/2)·(1/2) = 1/4`,
+
+`P_corr(01) P_corr(10) = 0·0 = 0`.
+
+The independence identity requires these products to be equal. They are not.
+Hence `P_corr` is not a product assignment.
+
+The same table has fair one-site margins:
+
+`P_corr(0,*) = 1/2 + 0 = 1/2`, `P_corr(*,0) = 1/2 + 0 = 1/2`.
+
+If those margins came from one-site laws, the product assignment would be
+the fair product of Theorem 2, whose four atoms are each `1/4`. That is a
+different table: `P_corr(00)=1/2 ≠ 1/4`. Fair margins therefore do not
+select the product.
+
+The witness is also not a product of *any* Bernoulli pair, fair or biased.
+A product with `P(01)=0` would force `P_x(0)=0` or `P_y(1)=0`; the first
+makes `P(00)=0`, the second makes `P(11)=0`; both contradict
+`P(00)=P(11)=1/2`.
+
+## Theorem 4 — Path Residual (Scoped)
+
+**Claim.** A correlated joint on `{3e1,6e1}` is not supplied by one-site
+Admissibility laws at those two sites alone.
+
+**Proof.** Theorems 2 and 3. Every pair of one-site laws on the disjoint
+6-tuples of Theorem 1 lands in the product class. The executed correlated
+table is not in that class.
+
+The following escapes are recorded as residuals. None is derived. None is declared.
+
+1. A law whose condition includes at least one site outside `N(3e1)∪N(6e1)`.
+   That object is not a pair of one-site Admissibility maps.
+2. Intermediate records on a path joining `3e1` to `6e1`. Neighbor *values*
+   on the two 6-tuples could then carry dependence even though the
+   *conditional* pair remains a product given those values. No such path of
+   records is constructed here.
+3. A declared joint `L_phys` on the two sites. That would be an extra law,
+   not a consequence of the two one-site maps.
+
+The Admissibility sentence determines, for each site, a distribution from
+that site's nearest-neighbor conditions. It does not, by itself, name a
+joint on a distant pair, a path of intermediate records, or `L_phys`.
+
+## Theorem 5 — Not A Global No-Go
+
+**Claim.** Theorem 4 is a factorization theorem for one-site laws on
+disjoint neighbor supports. It is not a no-go against all distant
+correlation.
+
+**Scope.** The negative is restricted to the claim that the executed
+correlated table is already a pair of one-site Admissibility laws at
+`3e1` and `6e1`. The note does not rule out every distant correlation.
+It does not say that an axiom sentence must be edited. Do not declare `L_phys`.
+
+In particular `L_phys` is not required as an axiom. If a later derivation
+produces a joint on a distant pair from executable objects, that derivation
+can be checked then. Until it is executable it remains extra.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom sentence, or argue that an axiom update is necessary;
+- declare a joint `L_phys`, or treat `L_phys` as named axiom content;
+- claim that every distant correlation is ruled out;
+- construct intermediate records on a path, or derive record formation;
+- replace nearest-neighbor adjacency by the 26-site Moore neighborhood;
+- identify the executed `{0,1}` menu with the full one-site possibility
+  domain `M_2(C)`;
+- derive a physical compiler of fair formed bits.
+
+The scope is the exact cubic split: disjoint 6-tuples at spacing 3, product
+factorization of one-site laws on those tuples, and the `1/4` versus `0`
+witness that the perfectly correlated fair joint is not that product.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice NN sentence | premise | quoted; no edit |
+| current Admissibility distribution sentence | premise | quoted; no edit |
+| six-neighbor listings at `3e1` and `6e1` | Theorem 1 | computed here |
+| product of one-site Bernoulli laws | Theorem 2 | computed here |
+| perfectly correlated fair 2x2 table | Theorem 3 | computed here |
+| path records, non-one-site laws, `L_phys` | residuals | extra; not declared |
+| observed frequencies or fitted joints | none | not used |
+
+The exact advance is a finite lattice-geometry theorem plus a four-atom
+exact table. Independent audit is required. This note authors no audit verdict.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | The current Admissibility sentence says that for each site the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions. The named residual is a physical joint on distant sites, including correlated bits. This note asks whether that joint is already a pair of one-site maps on disjoint 6-tuples, and answers no. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for disjoint-support factorization of one-site Admissibility laws, distant correlation supplied by nearest-neighbor 6-tuples, and a joint `L_phys`. Hits: the 2026-06-18 outcome-factorization note uses the same `1/4` versus `(1/2,0,0,1/2)` table to show that one-copy Born margins do not *force* factorization — the opposite implication; the 2026-07-11 G3 note likewise leaves cross-edge factorization unforced by an unraveled step-law; the Tomita/tensor-trace notes factorize a tracial state on a tensor product of one-site algebras, a different object; the token `L_phys` on that commit is a continuum path length in the valley-linear note, not a joint law. An unmerged 2026-08-13 graph-separated origin-exclusion listing treats product-law independence from the origin; it is not this factorization identity and is not a landed premise. No landed disjoint-NN one-site factorization identity appears on that commit. |
+| V3 | Independently checkable? | Textbook independence of a 2x2 table does not mention nearest-neighbor 6-tuples, the sites `3e1` and `6e1`, or the Admissibility distribution sentence. The runner recomputes `N(x)` by integer shifts and the four-atom table by exact `Fraction` arithmetic. |
+| V4 | More than a restatement? | Yes. The discriminating witness is `P_corr(00)P_corr(11)=1/4` against `P_corr(01)P_corr(10)=0`, together with the empty intersection `N(3e1) ∩ N(6e1)`. Neither identity is a restatement of the axiom sentence. |
+| V5 | One-step relabel? | No. The claim is not a corollary of the Admissibility sentence alone. That sentence names a per-site distribution determined by nearest-neighbor conditions; it does not name the pairing of two such maps, the independence identity, or the correlated non-product. |
+
+## No-Go Discipline Gate (Theorems 4 and 5 only)
+
+The negative claims are restricted to: a correlated joint on `{3e1,6e1}` is
+not a pair of one-site Admissibility laws on those disjoint 6-tuples; this
+is not a no-go against all distant correlation; `L_phys` is extra and is
+not declared. The gate does not ship a global non-existence theorem against
+distant correlation.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| one-site product | take `P_x ⊗ P_y` on the disjoint 6-tuples | Theorem 2: the joint is a product and the independence identity holds, including the fair table of four `1/4` atoms | **ATTEMPTED** |
+| correlated joint | take `P(00)=P(11)=1/2`, `P(01)=P(10)=0` as if it were that product | Theorem 3: `1/4 ≠ 0`; the table is not a product of one-site Bernoulli laws | **ATTEMPTED** |
+| path records | let intermediate records on a path join `3e1` to `6e1` and correlate neighbor values | residual; not constructed and not declared; the *conditional* pair remains a product given the 6-tuples | **ATTEMPTED** (escape) |
+| declared `L_phys` | name a joint on the distant pair as an extra law | residual; extra; not declared and not executable here | **ATTEMPTED** (escape) |
+| 26-site Moore neighborhood | replace `N(x)` by the Chebyshev-1 26-set | different adjacency; `0` lies in the Moore neighborhood of the L1-distance-2 site `e1+e2`, so a blanket distance-2 origin exclusion fails | **ATTEMPTED** (mutation) |
+| axiom edit | treat the residual as requiring an axiom-sentence change | Theorem 5: factorization is already the content of pairing one-site laws; an axiom edit is not required and is not performed | **ATTEMPTED** |
+
+### N2 — wall independence
+
+Theorems 4 and 5 close only the route that reads a correlated distant joint
+off a pair of one-site Admissibility maps on disjoint supports. They do not
+close a later path-of-records construction, a later executable joint, or a
+content-only event-label bridge. Those walls remain independent.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `Z^3` with six-neighbor `N(x)` | declared Lattice object |
+| one-site condition 6-tuple | declared domain of `η` |
+| sites `3e1`, `6e1` and origin `0` | explicit hypothesis of Theorems 1--4 |
+| declared menu `{0,1}` | executed possibility set; not the full `M_2(C)` domain |
+| product of one-site laws | declared pairing `P_x ⊗ P_y` |
+| perfectly correlated fair table | executed non-product witness |
+| path of intermediate records | residual; not constructed |
+| declared `L_phys` | extra; not declared |
+| Moore adjacency | live mutation; not the Lattice adjacency |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Lattice NN sentence; Admissibility distribution sentence | quoted as premises only; no edit |
+| one-site pairing on disjoint 6-tuples | product class and independence identity | computed here |
+| perfectly correlated fair table | `1/4` versus `0` | computed here |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | named sites `0`, `2e1`, `3e1`, `6e1` and the four atoms of the 2x2 table | no classification of every map on `Z^3` |
+| per site | one-site laws at `3e1` and `6e1` and their product | no composite bonded-pair theorem |
+| per mode | nearest-neighbor condition 6-tuples and the independence identity, not spectral modes | no harmonic-mode exhaustion |
+| per block | disjointness, product factorization, and the correlated non-product only | no dynamics, formation rate, or declared joint |
+| lattice-wide | checked and not executed | no lattice-wide no-go against distant correlation |
+
+The obstruction is per-site / declared axis pair; it is not lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. A later construction of intermediate records on a path joining the two
+   sites, making neighbor *values* dependent while the conditional pair
+   remains a product.
+2. A later executable joint whose condition includes sites outside
+   `N(3e1)∪N(6e1)`.
+3. A later executable object that one might label `L_phys`, if and when it
+   is derived rather than declared. That object is not required as an axiom.
+4. A different adjacency, including the 26-site Moore neighborhood, if and
+   when that adjacency is the Lattice object. It is not the present object.
+
+The quoted Admissibility sentence already names a per-site distribution
+determined by nearest-neighbor conditions. Pairing two such maps on disjoint
+supports is already a product. No axiom sentence is edited here.
+
+### N7 — hostile steelman
+
+> Any two bits may be correlated, so one can simply write down the
+> perfectly correlated fair table on `{3e1,6e1}`. Factorization of one-site
+> laws is then empty: the joint is already there.
+
+**Answer.** Writing down a non-product joint is exactly declaring an object
+other than a pair of one-site Admissibility maps. Theorems 2 and 3 identify
+that extra object: it is not in the image of `P_x ⊗ P_y` on the disjoint
+6-tuples. Theorem 4 records the residual; Theorem 5 does not convert the
+residual into a global no-go or into axiom text. The discriminating fact
+remains `1/4 ≠ 0` together with `N(3e1) ∩ N(6e1)=empty`.
+
+### N8 — cross-cycle echo
+
+The 2026-06-18 outcome-factorization note and the 2026-07-11 G3 note prune
+routes that would *force* a product from one-copy Born margins or from an
+unraveled step-law. The present negatives face the opposite direction: when
+the maps *are* one-site Admissibility laws on disjoint neighbor supports,
+the product *is* forced, and the same numerical table is then a witness
+that a correlated joint is not those maps. The earlier notes are not
+cancelled. They remain notes about different premises.
+
+**Gate disposition.** PASS for the scoped factorization and the two
+negatives of Theorems 4 and 5. FAIL / DO NOT SHIP for ruling out every
+distant correlation or for declaring `L_phys`.
+
+## Primary Runner
+
+[`scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py`](../scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py)
+recomputes nearest-neighbor sets, the spacing-3 disjoint-support listing,
+the spacing-2 shared-neighbor contrast, the product of one-site Bernoulli
+laws, and the four-atom product-versus-correlated table in exact integer
+lattice geometry and `Fraction` arithmetic. Identity gates call
+`neighbors(x)` and `is_product(joint)`. Replacing spacing 3 by spacing 2
+must fail disjoint-support. A declared always-disjoint predicate must fail
+on `(0,2e1)`. Replacing the correlated witness by the fair product must fail
+the "not a product" assertion. Replacing `neighbors` by the 26-site Moore
+neighborhood must fail a blanket distance-2 origin exclusion.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3125,6 +3125,10 @@
   "discrete_einstein_regge_lift_note": {
    "deps_hash": "dfa5ac62f565",
    "out_degree": 3
+  },
+  "disjoint_neighbor_support_one_site_laws_factorize_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "dispersion_high_p_tiebreaker_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.txt
+++ b/logs/runner-cache/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.txt
@@ -1,0 +1,49 @@
+===== runner cache v1 =====
+runner: scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py
+runner_sha256: 9a292f37185987862191e06ada0b2bad737bfb291dd26e32a8b5527d94415e3d
+input_fingerprint_sha256: 64863b08bf6ae01af3c08ad1cfccc8a089cda82882cd38cfc11e7449d22d5461
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice and Admissibility wording are source-bound; no observational or fitted inputs
+integrity_reads: this runner, its paired note, and the axiom memo; no other repository scientific inputs
+construction: spacing-3 disjoint NN 6-tuples; one-site product versus the perfectly correlated fair joint
+negative_scope: a correlated joint is not a pair of one-site laws on those tuples; not a no-go against all distant correlation
+PASS: audit-input-paths declared audit inputs exist and match the note and axiom memo
+PASS: source-lattice the current Lattice nearest-neighbor sentence is pinned in the axiom memo and the note
+PASS: source-admissibility the current distribution sentence is pinned in the axiom memo and the note
+PASS: neighbors-type neighbors(x) returns a frozenset of integer 3-tuples of size 6
+PASS: witness-N3e1 N(3e1) matches the listing and excludes the origin
+PASS: witness-N6e1 N(6e1) matches the listing and excludes the origin
+PASS: distances d(0,3e1)=3, d(0,6e1)=6, d(3e1,6e1)=3
+PASS: theorem-1-disjoint-supports N(3e1) ∩ N(6e1) is empty, and 0 lies in neither set
+PASS: theorem-1-spacing2-contrast spacing 2 is not disjoint-support: N(0) ∩ N(2e1) = {e1}
+table: product_fair 00=1/4 01=1/4 10=1/4 11=1/4
+table: correlated 00=1/2 01=0 10=0 11=1/2
+PASS: theorem-2-product-factorization a pair of one-site laws is the product of its margins and obeys the independence identity
+PASS: theorem-2-disjoint-conditions the two executed 6-tuples live on disjoint neighbor supports
+PASS: theorem-3-correlated-not-product P_corr(00)P_corr(11)=1/4 and P_corr(01)P_corr(10)=0, so is_product fails
+PASS: theorem-3-fair-margins-do-not-imply-product the correlated witness has fair margins yet is not the fair product
+PASS: theorem-4-not-supplied-by-one-site-pair every executed one-site pair is a product; the correlated table is not
+PASS: theorem-4-residuals-not-declared path records and L_phys are recorded as extra residuals, not declared
+PASS: theorem-5-not-global-nogo the note refuses a global no-go and does not declare L_phys
+PASS: mutation-always-disjoint-fails an always-disjoint predicate is true on (0,2e1) while neighbors() is not
+PASS: mutation-product-fails-not-product replacing the correlated witness by the fair product fails the not-a-product assertion
+PASS: mutation-moore-fails-distance2 replacing neighbors by the 26-site Moore neighborhood fails blanket distance-2 origin exclusion
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: named sites 0, 2e1, 3e1, 6e1 and the four 2x2 atoms are recomputed by integer listing
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: one-site Bernoulli laws at 3e1 and 6e1 are site-local maps, not a composite arena
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: nearest-neighbor 6-tuples and the independence identity are checked; no spectral mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only disjointness, product factorization, and the correlated non-product are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide no-go against distant correlation is claimed
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py
+++ b/scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Exact cubic-lattice checks: one-site laws on disjoint neighbor supports.
+
+Spacing-3 disjoint 6-tuples, product factorization of a pair of one-site
+Bernoulli laws, and the 1/4-versus-0 correlated non-product. Identity gates
+call neighbors(x) and is_product(joint). No cache is written.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from fractions import Fraction
+from itertools import product as cartesian
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "DISJOINT_NEIGHBOR_SUPPORT_ONE_SITE_LAWS_FACTORIZE_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/DISJOINT_NEIGHBOR_SUPPORT_ONE_SITE_LAWS_FACTORIZE_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Joint = dict[tuple[int, int], Fraction]
+
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN_SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+BITS = (0, 1)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def scale(coefficient: int, vector: Point) -> Point:
+    return (coefficient * vector[0], coefficient * vector[1], coefficient * vector[2])
+
+
+def graph_distance(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def neighbors(site: Point) -> frozenset[Point]:
+    """Identity-gate function: the six nearest neighbors of a cubic site."""
+    return frozenset(add(site, shift) for shift in NN_SHIFTS)
+
+
+def moore_neighbors(site: Point) -> frozenset[Point]:
+    """26-site Chebyshev-1 neighborhood; mutation of neighbors()."""
+    offsets = [
+        (i, j, k)
+        for i, j, k in cartesian((-1, 0, 1), repeat=3)
+        if (i, j, k) != (0, 0, 0)
+    ]
+    return frozenset(add(site, offset) for offset in offsets)
+
+
+def disjoint_supports(sites: Iterable[Point]) -> bool:
+    """Pairwise-empty nearest-neighbor supports, via neighbors()."""
+    listed = tuple(sites)
+    neighborhoods = [neighbors(site) for site in listed]
+    for index, left in enumerate(neighborhoods):
+        for right in neighborhoods[index + 1 :]:
+            if left & right:
+                return False
+    return True
+
+
+def always_disjoint(_sites: Iterable[Point]) -> bool:
+    """Mutation: declare every pair of neighbor supports disjoint."""
+    return True
+
+
+def one_site_law(margin: Fraction, eta: tuple[int, ...]) -> dict[int, Fraction]:
+    """Bernoulli law on {0,1}. Domain is the 6-tuple; value may ignore it."""
+    if len(eta) != 6:
+        raise ValueError("one-site condition must be a 6-tuple")
+    if margin < 0 or margin > 1:
+        raise ValueError("margin must lie in [0, 1]")
+    return {0: Fraction(1) - margin, 1: margin}
+
+
+def product_assignment(
+    left: Mapping[int, Fraction], right: Mapping[int, Fraction]
+) -> Joint:
+    return {(alpha, beta): left[alpha] * right[beta] for alpha in BITS for beta in BITS}
+
+
+def one_site_margins(joint: Mapping[tuple[int, int], Fraction]) -> tuple[dict[int, Fraction], dict[int, Fraction]]:
+    px = {alpha: joint[(alpha, 0)] + joint[(alpha, 1)] for alpha in BITS}
+    py = {beta: joint[(0, beta)] + joint[(1, beta)] for beta in BITS}
+    return px, py
+
+
+def is_product(joint: Mapping[tuple[int, int], Fraction]) -> bool:
+    """Identity-gate function: joint equals the product of its margins."""
+    px, py = one_site_margins(joint)
+    return all(joint[(alpha, beta)] == px[alpha] * py[beta] for alpha in BITS for beta in BITS)
+
+
+def independence_identity(joint: Mapping[tuple[int, int], Fraction]) -> bool:
+    return all(
+        joint[(alpha, beta)] * joint[(alpha_p, beta_p)]
+        == joint[(alpha, beta_p)] * joint[(alpha_p, beta)]
+        for alpha, beta, alpha_p, beta_p in cartesian(BITS, repeat=4)
+    )
+
+
+def fair_product() -> Joint:
+    dummy_eta = (0, 0, 0, 0, 0, 0)
+    other_eta = (1, 1, 1, 1, 1, 1)
+    return product_assignment(
+        one_site_law(Fraction(1, 2), dummy_eta),
+        one_site_law(Fraction(1, 2), other_eta),
+    )
+
+
+def correlated_fair() -> Joint:
+    return {
+        (0, 0): Fraction(1, 2),
+        (0, 1): Fraction(0),
+        (1, 0): Fraction(0),
+        (1, 1): Fraction(1, 2),
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current Lattice and Admissibility wording "
+        "are source-bound; no observational or fitted inputs"
+    )
+    print(
+        "integrity_reads: this runner, its paired note, and the axiom memo; "
+        "no other repository scientific inputs"
+    )
+    print(
+        "construction: spacing-3 disjoint NN 6-tuples; one-site product versus "
+        "the perfectly correlated fair joint"
+    )
+    print(
+        "negative_scope: a correlated joint is not a pair of one-site laws on "
+        "those tuples; not a no-go against all distant correlation"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/DISJOINT_NEIGHBOR_SUPPORT_ONE_SITE_LAWS_FACTORIZE_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    canonical_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    checks.check(
+        "source-lattice",
+        "the current Lattice nearest-neighbor sentence is pinned in the axiom memo and the note",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "the current distribution sentence is pinned in the axiom memo and the note",
+        canonical_sentence in normalize(axiom) and canonical_sentence in note,
+    )
+
+    two_e1 = scale(2, E1)
+    three_e1 = scale(3, E1)
+    six_e1 = scale(6, E1)
+    executed = (ORIGIN, two_e1, three_e1, six_e1)
+
+    expected_three = frozenset(
+        {two_e1, (4, 0, 0), (3, 1, 0), (3, -1, 0), (3, 0, 1), (3, 0, -1)}
+    )
+    expected_six = frozenset(
+        {(5, 0, 0), (7, 0, 0), (6, 1, 0), (6, -1, 0), (6, 0, 1), (6, 0, -1)}
+    )
+
+    checks.check(
+        "neighbors-type",
+        "neighbors(x) returns a frozenset of integer 3-tuples of size 6",
+        all(
+            isinstance(neighbors(site), frozenset)
+            and all(isinstance(point, tuple) and len(point) == 3 for point in neighbors(site))
+            and all(isinstance(coord, int) for point in neighbors(site) for coord in point)
+            and len(neighbors(site)) == 6
+            for site in executed
+        ),
+        residual=[(site, len(neighbors(site))) for site in executed],
+    )
+    checks.check(
+        "witness-N3e1",
+        "N(3e1) matches the listing and excludes the origin",
+        neighbors(three_e1) == expected_three and ORIGIN not in neighbors(three_e1),
+        residual=sorted(neighbors(three_e1)),
+    )
+    checks.check(
+        "witness-N6e1",
+        "N(6e1) matches the listing and excludes the origin",
+        neighbors(six_e1) == expected_six and ORIGIN not in neighbors(six_e1),
+        residual=sorted(neighbors(six_e1)),
+    )
+    checks.check(
+        "distances",
+        "d(0,3e1)=3, d(0,6e1)=6, d(3e1,6e1)=3",
+        graph_distance(ORIGIN, three_e1) == 3
+        and graph_distance(ORIGIN, six_e1) == 6
+        and graph_distance(three_e1, six_e1) == 3,
+    )
+
+    checks.check(
+        "theorem-1-disjoint-supports",
+        "N(3e1) ∩ N(6e1) is empty, and 0 lies in neither set",
+        disjoint_supports((three_e1, six_e1))
+        and neighbors(three_e1).isdisjoint(neighbors(six_e1))
+        and ORIGIN not in neighbors(three_e1)
+        and ORIGIN not in neighbors(six_e1),
+        residual=sorted(neighbors(three_e1) & neighbors(six_e1)),
+    )
+    checks.check(
+        "theorem-1-spacing2-contrast",
+        "spacing 2 is not disjoint-support: N(0) ∩ N(2e1) = {e1}",
+        not disjoint_supports((ORIGIN, two_e1))
+        and (neighbors(ORIGIN) & neighbors(two_e1)) == frozenset({E1}),
+        residual=sorted(neighbors(ORIGIN) & neighbors(two_e1)),
+    )
+
+    dummy_eta = (0, 0, 0, 0, 0, 0)
+    other_eta = (1, 0, 1, 0, 1, 0)
+    prod = fair_product()
+    biased = product_assignment(
+        one_site_law(Fraction(2, 3), dummy_eta),
+        one_site_law(Fraction(1, 3), other_eta),
+    )
+    corr = correlated_fair()
+    print(
+        "table: product_fair "
+        f"00={prod[(0, 0)]} 01={prod[(0, 1)]} 10={prod[(1, 0)]} 11={prod[(1, 1)]}"
+    )
+    print(
+        "table: correlated "
+        f"00={corr[(0, 0)]} 01={corr[(0, 1)]} 10={corr[(1, 0)]} 11={corr[(1, 1)]}"
+    )
+
+    checks.check(
+        "theorem-2-product-factorization",
+        "a pair of one-site laws is the product of its margins and obeys the independence identity",
+        prod[(0, 0)] == Fraction(1, 4)
+        and prod[(0, 1)] == Fraction(1, 4)
+        and prod[(1, 0)] == Fraction(1, 4)
+        and prod[(1, 1)] == Fraction(1, 4)
+        and is_product(prod)
+        and independence_identity(prod)
+        and is_product(biased)
+        and independence_identity(biased)
+        and biased[(0, 0)] == Fraction(1, 3) * Fraction(2, 3),
+        residual=(prod, biased),
+    )
+    checks.check(
+        "theorem-2-disjoint-conditions",
+        "the two executed 6-tuples live on disjoint neighbor supports",
+        disjoint_supports((three_e1, six_e1))
+        and len(dummy_eta) == 6
+        and len(other_eta) == 6
+        and neighbors(three_e1).isdisjoint(neighbors(six_e1)),
+    )
+
+    corr_px, corr_py = one_site_margins(corr)
+    checks.check(
+        "theorem-3-correlated-not-product",
+        "P_corr(00)P_corr(11)=1/4 and P_corr(01)P_corr(10)=0, so is_product fails",
+        corr[(0, 0)] * corr[(1, 1)] == Fraction(1, 4)
+        and corr[(0, 1)] * corr[(1, 0)] == Fraction(0)
+        and corr[(0, 0)] * corr[(1, 1)] != corr[(0, 1)] * corr[(1, 0)]
+        and not is_product(corr)
+        and not independence_identity(corr),
+        residual=(corr[(0, 0)] * corr[(1, 1)], corr[(0, 1)] * corr[(1, 0)]),
+    )
+    checks.check(
+        "theorem-3-fair-margins-do-not-imply-product",
+        "the correlated witness has fair margins yet is not the fair product",
+        corr_px[0] == Fraction(1, 2)
+        and corr_py[0] == Fraction(1, 2)
+        and corr[(0, 0)] != corr_px[0] * corr_py[0]
+        and corr[(0, 0)] != prod[(0, 0)]
+        and is_product(prod)
+        and not is_product(corr),
+    )
+
+    checks.check(
+        "theorem-4-not-supplied-by-one-site-pair",
+        "every executed one-site pair is a product; the correlated table is not",
+        is_product(prod)
+        and is_product(biased)
+        and not is_product(corr)
+        and disjoint_supports((three_e1, six_e1)),
+    )
+    checks.check(
+        "theorem-4-residuals-not-declared",
+        "path records and L_phys are recorded as extra residuals, not declared",
+        "intermediate records on a connecting path" in note
+        and "declared joint `L_phys`" in note
+        and "None is derived. None is declared." in note
+        and "no distant correlation is possible" not in note.lower(),
+    )
+    checks.check(
+        "theorem-5-not-global-nogo",
+        "the note refuses a global no-go and does not declare L_phys",
+        "not a no-go against all distant correlation" in note.lower()
+        and "not required as an axiom" in note
+        and "Do not declare `L_phys`" in note
+        and "we adopt" not in note.lower(),
+    )
+
+    checks.check(
+        "mutation-always-disjoint-fails",
+        "an always-disjoint predicate is true on (0,2e1) while neighbors() is not",
+        always_disjoint((ORIGIN, two_e1))
+        and not disjoint_supports((ORIGIN, two_e1))
+        and (neighbors(ORIGIN) & neighbors(two_e1)) == frozenset({E1})
+        and always_disjoint((ORIGIN, two_e1)) is not disjoint_supports((ORIGIN, two_e1)),
+    )
+    checks.check(
+        "mutation-product-fails-not-product",
+        "replacing the correlated witness by the fair product fails the not-a-product assertion",
+        not is_product(corr)
+        and is_product(prod)
+        and (not is_product(prod)) is False,
+    )
+
+    diagonal = add(E1, E2)
+    checks.check(
+        "mutation-moore-fails-distance2",
+        "replacing neighbors by the 26-site Moore neighborhood fails blanket distance-2 origin exclusion",
+        len(moore_neighbors(ORIGIN)) == 26
+        and len(moore_neighbors(two_e1)) == 26
+        and ORIGIN not in neighbors(two_e1)
+        and ORIGIN not in moore_neighbors(two_e1)
+        and graph_distance(ORIGIN, diagonal) == 2
+        and ORIGIN not in neighbors(diagonal)
+        and ORIGIN in moore_neighbors(diagonal),
+        residual=(
+            ORIGIN in moore_neighbors(two_e1),
+            ORIGIN in moore_neighbors(diagonal),
+        ),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                'hypothetical_axiom_status: "no edit"',
+                "trace_class: negative_route_pruning",
+                "target_claim_id: joint_law_l_phys",
+                'target_blocker_text: "a physical joint law on distant sites, including correlated bits"',
+                "reachability_to_target: prunes",
+                'next_trace_action: "One-site laws on disjoint neighbor supports factorize. A joint L_phys remains extra and must not be adopted until executable. Do not adopt axiom text."',
+                "N(3e1) ∩ N(6e1)",
+                "P_corr(00) P_corr(11)",
+                "authors no audit verdict",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "Block " not in note
+        and "toe-lphys" not in note,
+    )
+
+    n5_lines = (
+        "per_element: named sites 0, 2e1, 3e1, 6e1 and the four 2x2 atoms are recomputed by integer listing",
+        "per_site: one-site Bernoulli laws at 3e1 and 6e1 are site-local maps, not a composite arena",
+        "per_mode: nearest-neighbor 6-tuples and the independence identity are checked; no spectral mode is claimed",
+        "per_block: only disjointness, product factorization, and the correlated non-product are executed",
+        "lattice_wide: checked and not executed — no lattice-wide no-go against distant correlation is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

One-site Admissibility laws on disjoint neighbor supports factorize. N(3e1) and N(6e1) are disjoint; a correlated fair table with P(00)=P(11)=1/2 is not a product. A joint L_phys remains extra and is not adopted. Not a no-go against all distant correlation. No axiom edit.

## What changed

- Note: `docs/DISJOINT_NEIGHBOR_SUPPORT_ONE_SITE_LAWS_FACTORIZE_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py`
- Cache: `logs/runner-cache/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.txt`

## Verification

```bash
python3 scripts/disjoint_neighbor_support_one_site_laws_factorize_2026_08_13.py
# TOTAL: PASS=25 FAIL=0
```

## Trace

Negative route pruning for adopting a distant joint law from one-site Admissibility. Honest status: `bounded_theorem` / `bounded-support`. Independent audit required.

Campaign: `toe-lphys-20260812`.