### PR TITLE
[physics-loop] toe-lphys aspeed: bounded_theorem / bounded-support

### DIFF
--- a/docs/SPEED_PRESERVING_LINEAR_WICK_MAP_IS_UNIT_CLOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SPEED_PRESERVING_LINEAR_WICK_MAP_IS_UNIT_CLOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,478 @@
+---
+claim_id: speed_preserving_linear_wick_map_is_unit_clock_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Among linear Wick maps k4=i a ω of the Euclidean OS0 form (k4^2+k^2)/4, the declared extra matching that the Lorentzian null a^2 ω^2=k^2 coincide with Euclidean equal coefficients holds if and only if a^2=1, hence a∈{+1,-1} uniquely up to time-orientation; neither the four axioms nor c_t=c_s names that matching, and this note does not install a=1 or claim Lorentzian closure."
+upstream_dependencies:
+  - minimal_axioms
+  - kinetic_isotropy_primitive
+runner: scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py
+---
+
+# Speed-Preserving Linear Wick Map Is The Unit Clock
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact algebra of the linear Wick family of the Euclidean OS0
+TT form, under a declared extra speed-preservation matching.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py`](../scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py)
+
+## Result Up Front
+
+The approved kinetic-isotropy primitive
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+supplies one Euclidean kinetic-form equality,
+
+```text
+c_t = c_s,
+```
+
+equivalently the Osterwalder-Schrader OS0 kinetic normalization of the
+Euclidean regulator block `Z^3 x Z_tau`. In momentum space that is the
+declared Euclidean TT form
+
+```text
+Q_E(k4, k) = (k4^2 + k^2)/4,
+```
+
+where `k^2 = kx^2 + ky^2 + kz^2`. Both quadratic coefficients are `1/4`.
+That is the primitive's content. The four-axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+does not define a time metric and does not name a continuation parameter.
+
+A linear Wick clock map is a different object: the continuation
+
+```text
+k4 = i a ω,    a ∈ Q \ {0},
+```
+
+from Euclidean temporal momentum to a Lorentzian frequency. Substituting
+into the same `Q_E` produces the family
+
+```text
+Q_a(ω, k) = ((i a ω)^2 + k^2)/4 = (-a^2 ω^2 + k^2)/4.
+```
+
+The Euclidean polynomial never sees `a`. The coefficient of `ω^2` is
+`omega_coeff(a) = -a^2/4`. The spatial coefficient stays `1/4`.
+
+**Speed-preservation** is a declared extra matching, not an axiom and
+not a primitive sentence: the Lorentzian null `a^2 ω^2 = k^2` should
+be the same as the Euclidean equal-coefficient null written in `ω`,
+namely `ω^2 = k^2`. Equivalently `|omega_coeff(a)|` should equal the
+spatial coefficient. That matching is `|a|^2 = 1`. For `a ∈ Q \ {0}`
+one has `|a|^2 = a^2`, so
+
+```text
+speed_preserved(a)  ⇔  a^2 = 1  ⇔  a ∈ {+1, −1}.
+```
+
+The two solutions differ only by the sign of `k4 = i a ω`: they are
+the two time-orientations of one unit clock. The values `a = 1/2` and
+`a = 2` fail: they give `a^2 = 1/4` and `a^2 = 4`, with `ω^2`
+coefficients `-1/16` and `-1` against spatial `1/4`.
+
+Neither the four axioms nor `c_t = c_s` names speed-preservation across
+Wick continuation. The uniqueness is therefore conditional on that extra
+matching. This note does not install `a = 1` and does not claim Lorentzian closure.
+
+## Machine Status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The Euclidean TT polynomial is independent of a. Speed-preservation of that form across the linear Wick family is equivalent to a^2=1, hence a∈{+1,-1}. The matching is a declared extra condition: neither the four axioms nor c_t=c_s names it."
+trace_class: negative_route_pruning
+target_claim_id: speed_preserving_linear_wick_map_is_unit_clock
+target_blocker_text: "select the linear Wick clock map a that preserves the OS0 speed from axioms or the kinetic-isotropy primitive"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed Q_a family and the rational unit-clock solutions; the matching remains extra and Lorentzian closure remains open"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+next_trace_action: "Speed-preservation selects a=±1 uniquely among linear Wick maps. The matching is extra. Do not install a=1. Do not claim Lorentzian closure."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `k^2 := kx^2 + ky^2 + kz^2` for spatial Euclidean momentum. The
+**Euclidean TT form** is the quadratic polynomial
+
+```text
+Q_E(k4, kx, ky, kz) = (k4^2 + k^2)/4.
+```
+
+Its temporal and spatial coefficients are
+
+```text
+[k4^2] Q_E = 1/4,    [kx^2] Q_E = [ky^2] Q_E = [kz^2] Q_E = 1/4.
+```
+
+The OS0 sentence `c_t = c_s` is exactly that equality of coefficients.
+The overall `1/4` is the declared TT normalization; the primitive fixes
+the ratio, and the displayed polynomial is the isotropic representative
+with that normalization. The symbol `a` does not appear.
+
+A **linear Wick clock map** is a nonzero rational `a` together with the
+substitution `k4 = i a ω`. The **continued family** is
+
+```text
+Q_a(ω, k) := Q_E(i a ω, k) = (-a^2 ω^2 + k^2)/4.
+```
+
+The **Lorentzian `ω^2` coefficient** is
+
+```text
+omega_coeff(a) := [ω^2] Q_a = -a^2/4.
+```
+
+The **spatial coefficient** remains `1/4` on every row. The inverse
+substitution `ω = -i k4 / a`, available whenever `a ≠ 0`, returns the
+same Euclidean polynomial:
+
+```text
+Q_a(-i k4 / a, k) = (k4^2 + k^2)/4 = Q_E.
+```
+
+That recovery identity is independent of the particular nonzero `a`.
+
+The Euclidean equal-coefficient null of `Q_E` is `k4^2 = k^2`. After
+the linear substitution the Lorentzian null of `Q_a` is
+
+```text
+a^2 ω^2 = k^2.
+```
+
+**Speed-preservation** is the declared extra demand that this Lorentzian
+null be the same as the Euclidean equal-coefficient null written in `ω`,
+
+```text
+ω^2 = k^2.
+```
+
+Those two quadratic cones coincide if and only if `a^2 = 1`.
+Equivalently,
+
+```text
+speed_preserved(a) := (a * a == 1)
+                  ⇔  |omega_coeff(a)| = 1/4
+                  ⇔  a^2 / 4 = 1/4.
+```
+
+The identity gates of the companion runner are exactly
+`omega_coeff(a) = -a^2/4` and `speed_preserved(a) := (a*a==1)`.
+
+| `a` | `a^2` | `omega_coeff(a)` | spatial | `speed_preserved(a)` |
+|---|---|---|---|---|
+| `+1` | `1` | `-1/4` | `1/4` | true |
+| `-1` | `1` | `-1/4` | `1/4` | true |
+| `1/2` | `1/4` | `-1/16` | `1/4` | false |
+| `2` | `4` | `-1` | `1/4` | false |
+
+The two unit-clock rows share one quadratic form `Q_a`. They differ
+only by the sign of the linear map `k4 = i a ω`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Among linear Wick maps of the displayed OS0 TT form,
+decide which nonzero rationals preserve the Euclidean equal-coefficient
+speed, and decide whether that matching is already named by the four
+axioms or by `c_t = c_s`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin `c_t = c_s` and the OS0 Euclidean wording | premise | quoted from the primitive |
+| pin that the primitive does not add or amend an axiom | premise | quoted from the primitive |
+| pin that Admissibility does not define a time metric | premise | quoted from the axiom memo |
+| show `Q_E` has no `a` and is OS0 | Theorem 1 | coefficient comparison |
+| show speed-preservation ⇔ `a^2 = 1` ⇔ `a ∈ {+1, −1}` | Theorem 2 | rational square |
+| show `a = 1/2` and `a = 2` fail | Theorem 3 | `omega_coeff` versus spatial `1/4` |
+| show no source sentence names the extra matching | Theorem 4 | sentence pin |
+| install `a = 1` as an axiom or primitive | non-claim | not attempted |
+| claim Lorentzian closure | non-claim | not attempted |
+
+## Theorem 1 — The Euclidean Form Is Independent Of `a`
+
+The polynomial `Q_E = (k4^2 + k^2)/4` is written in the Euclidean
+momenta `(k4, kx, ky, kz)` alone. The symbol `a` does not appear. The
+four quadratic coefficients are
+
+```text
+[k4^2] Q_E = 1/4 = [kx^2] Q_E,
+```
+
+which is `c_t = c_s` at the declared TT normalization. That is the OS0
+statement.
+
+For each nonzero `a`, the Euclidean member of the family is the same
+polynomial: one obtains `Q_a` by substituting `k4 = i a ω`, and the
+inverse substitution displayed above returns `Q_E` with no residual `a`.
+Evaluating `Q_E` at any Euclidean point, for example
+`(k4, k^2) = (2, 9)`, returns the single rational `13/4`, independent of
+which continuation will later be used.
+
+Therefore every member of the linear family shares one Euclidean OS0
+form. The primitive, which speaks only about that Euclidean form,
+cannot distinguish the members.
+
+## Theorem 2 — Speed-Preservation Selects The Unit Clock
+
+Substitute `k4 = i a ω` into `Q_E`:
+
+```text
+(i a ω)^2 / 4 + k^2/4 = (i^2 a^2 ω^2)/4 + k^2/4
+                      = (-a^2 ω^2)/4 + k^2/4.
+```
+
+So `omega_coeff(a) = -a^2/4` and the spatial coefficient is `1/4`. The
+Lorentzian null is `a^2 ω^2 = k^2`. The Euclidean equal-coefficient
+null written in `ω` is `ω^2 = k^2`. These coincide if and only if
+`a^2 = 1`.
+
+Now `a ∈ Q \ {0}`. Write `a = p/q` in lowest terms with `q > 0`. Then
+`a^2 = 1` means `p^2 = q^2`, hence `|p| = q`, hence `a ∈ {+1, −1}`.
+Conversely both unit values satisfy `a^2 = 1`. Therefore
+
+```text
+speed_preserved(a)  ⇔  a * a == 1  ⇔  a ∈ {+1, −1}.
+```
+
+The two solutions give the same quadratic `Q_a = (-ω^2 + k^2)/4`. They
+are unique up to time-orientation: `a ↦ -a` reverses the sign of the
+linear clock map and leaves the quadratic form unchanged.
+
+A predicate that replaced `speed_preserved` by true-for-all-`a` would
+accept every nonzero rational, including `a = 1/2`. That replacement
+is not the identity gate.
+
+## Theorem 3 — The Maps `a = 1/2` And `a = 2` Fail
+
+Ordinary rational arithmetic on the identity gate yields
+
+```text
+omega_coeff(1/2) = -(1/4)/4 = -1/16,
+omega_coeff(2)   = -4/4     = -1.
+```
+
+Against spatial coefficient `1/4`:
+
+```text
+a = 1/2  ⇒  a^2 = 1/4 ≠ 1,   |-1/16| ≠ 1/4,
+a = 2    ⇒  a^2 = 4   ≠ 1,   |-1|   ≠ 1/4.
+```
+
+So `speed_preserved(1/2)` is false and `speed_preserved(2)` is false.
+The Lorentzian null at `a = 1/2` is `ω^2 = 4 k^2`. The Lorentzian
+null at `a = 2` is `4 ω^2 = k^2`. Neither is the Euclidean
+equal-coefficient cone `ω^2 = k^2`.
+
+These two rejectors are the same rationals that already distinguish
+members of the linear family by their `ω^2` coefficients. Speed-
+preservation retains only the unit-clock rows.
+
+## Theorem 4 — The Matching Is Extra; No Axiom Edit
+
+The primitive's load-bearing sentence is the Euclidean equality
+`c_t = c_s`, identified with OS0 hypercubic symmetry of `Z^3 x Z_tau`.
+It states that it supplies only that kinetic-form ratio, that it does
+not add or amend an axiom, and that it does not re-axiomatize time. Its
+only quantity-level uses of the letter `a` are the Lattice spatial
+adjacency `a_x = a_y = a_z` and the sibling scale-reference identity
+`a^{-1} = M_Pl`. It does not write `k4 = i a ω`, does not name
+speed-preservation across Wick continuation, and does not select
+`a ∈ {+1, −1}`. The wording "one tick is one edge in form, not only
+in spacing" is the same Euclidean OS0 statement. It is not a
+declaration that the continuation parameter equals `1`.
+
+The axiom memo names four premises: Lattice, Qubit, Admissibility, and
+Record. Lattice is the cubic lattice `Z^3`. Record locks content and
+supplies additive scalar readout `I` with `I(empty)=0`. Admissibility
+determines a nearest-neighbor distribution and, in the memo's own
+dynamics paragraph, does not define a time metric. No axiom sentence
+introduces a continuation parameter `a`, a Lorentzian `ω^2`
+coefficient, or a speed-preservation matching across Wick
+continuation.
+
+Therefore `|a| = 1` is conditional on the extra matching declared
+above. This note does not install `a = 1`. This note does not claim Lorentzian closure. If a later construction wants a definite clock
+map, it must declare the matching, or some other continuation rule,
+as a second object. That declaration is a live formal escape. It is
+not `c_t = c_s`, and it is not claimed here to be physical.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom or primitive, or argue that an axiom update is necessary;
+- install `a = 1` or any other continuation as a physical law;
+- claim Lorentzian reconstruction, boost generators, or OS reconstruction;
+- vary `c_t / c_s` or reopen the Euclidean isotropy primitive;
+- identify `omega_coeff(a)` with a mass ratio, coupling, or empirical fit;
+- exhaust nonlinear clock maps;
+- treat speed-preservation as already named by the four axioms.
+
+The scope is the exact gap: among linear Wick maps of the displayed
+OS0 form, speed-preservation selects the unit clock, and that matching
+is extra.
+
+## Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | Whether a speed-preserving linear Wick map of the OS0 form is unique, and whether the axioms or `c_t = c_s` already name that matching. |
+| V2 | Present on `origin/main`? | Search of `origin/main` for a uniqueness theorem that `|a|=1` is the unique linear Wick map preserving OS0 speed finds no such derivation. Existing Wick mentions are textbook or reconstruction conventions, not this matching. |
+| V3 | Textbook content? | Textbook Wick rotation is the convention `k4 = i ω` (equivalently `a = 1`). It does not isolate speed-preservation as an extra matching, and it does not prove uniqueness among nonzero rationals from `a^2 = 1`. |
+| V4 | Exact discriminating witnesses? | `omega_coeff(1/2)=-1/16` versus spatial `1/4`; `omega_coeff(2)=-1` versus spatial `1/4`; `a=±1` give `-1/4` versus `1/4`. |
+| V5 | Corollary of the primitive note? | No. The primitive supplies `c_t = c_s` only. Speed-preservation across Wick continuation is declared here and is not a primitive sentence. |
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to Theorem 4: neither the four
+axioms nor `c_t = c_s` names the extra matching, `|a|=1` remains
+conditional, `a = 1` is not installed, and Lorentzian closure is not
+claimed. Theorems 1–3 are positive algebra on the displayed family.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Euclidean OS0 as selector of `a` | read `a` from `Q_E` alone | Theorem 1: `Q_E` is `a`-free | closed here |
+| Speed-preservation matching | impose `a^2 ω^2 = k^2` equal to `ω^2 = k^2` | Theorem 2: unique unit clock `a = ±1` | closed here, extra |
+| Half-clock and double-clock | test `a = 1/2` and `a = 2` | Theorem 3: both fail | closed here |
+| Force `a = 1` from the primitive | treat "one tick is one edge" as Wick `a = 1` | that wording is Euclidean OS0 form, not a continuation | Theorem 4 |
+| Axiom edit | add a sentence naming `a = 1` | not executed; Theorem 4 records that no edit is performed or required | not required |
+| Lorentzian-closure import | import textbook `k4 = i ω` as a law | V3: textbooks do not isolate the extra matching; import is extra | not imported |
+
+Six routes. The first three are the algebra of this note. The last
+three remain formal escapes and are not used as claims.
+
+### N2 — wall independence
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---|---|---|
+| `Q_E` / `speed_preserved(a)` | no: an `a`-free Euclidean form does not impose `a^2 = 1` | no: a matching on `Q_a` does not change `Q_E` | independent |
+| `c_t = c_s` / `a = ±1` | no: Euclidean OS0 is `a`-free | no: the unit clock is a continuation statement | independent |
+| `a = 1/2` rejector / axiom edit | no: a failed matching does not write axiom text | an edit would be a different object | distinct types |
+| textbook `a = 1` / primitive sentence | no: `k4 = i ω` is not `c_t = c_s` | the primitive does not mention Wick | distinct types |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| linear family `k4 = i a ω` | declared class; nonlinear maps are out of scope |
+| `a ∈ Q \ {0}` | rational clock maps; the square equation `a^2 = 1` is solved in `Q` |
+| `Q_E = (k4^2+k^2)/4` | declared TT representative of `c_t = c_s`; reconstructed here |
+| speed-preservation | declared extra matching, not a source sentence |
+| family `{1/2, 1, 2, -1}` | unit-clock solutions plus two rejectors; not a classification of nonlinear maps |
+| observations or fitted values | none |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Lattice is `Z^3`; Admissibility does not define a time metric; Record supplies `I(empty)=0` | quoted; no Wick factor `a` is borrowed because none is present |
+| [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) | `c_t = c_s`; OS0 wording; no axiom amendment; `a` used only as spacing or scale | quoted; speed-preservation across Wick continuation is not supplied |
+
+No citation is used as authority for `omega_coeff` or for the
+equivalence `a^2 = 1 ⇔ a ∈ {+1, −1}`; those are computed here.
+
+### N5 — rhetoric and resolution audit (Theorem 4)
+
+Theorem 4 is the only negative claim. Its executed content is a
+sentence pin plus two non-installations.
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | each displayed `a` is tested by `speed_preserved(a) := (a*a==1)` | no classification of every real or complex `a` |
+| per site | statements are momentum-space quadratic forms | no composite carrier or formation-rate law |
+| per mode | quadratic TT form in momenta `(k4, k)` | no spectral-mode exhaustion |
+| per block | linear Wick family versus the extra speed matching | no Lorentzian closure |
+| lattice-wide | checked and not executed | no lattice-wide Wick reconstruction |
+
+Rhetoric that Theorem 4 does **not** license:
+
+- "the four axioms force `a = 1`";
+- "`c_t = c_s` already is Wick `a = 1`";
+- "speed-preservation is a primitive sentence";
+- "this note installs `a = 1`";
+- "Lorentzian physics is closed" or "Lorentzian physics is impossible";
+- "an axiom update is necessary."
+
+The runner emits the same five scoped-negative lines. Replacing
+`speed_preserved` by true-for-all-`a` must fail at `a = 1/2`; that
+mutation is a check that Theorem 4's extra matching is load-bearing,
+not a claim that every continuation is physical.
+
+### N6 — live partial-closure paths
+
+1. A separately declared speed-preservation matching would select
+   `a = ±1` among linear maps, by Theorem 2.
+2. A nonlinear clock map is outside the displayed family.
+3. An axiom or primitive sentence that named `a` would change the
+   Theorem 4 pin; no such sentence is present, and none is added.
+4. Textbook Wick `a = 1` remains a conventional import, not an OS0
+   derivation.
+5. Lorentzian closure, if ever reached, would have to supply its own
+   continuation rule. It is not imported here.
+
+None of these paths is claimed physical. An axiom edit is not required
+by the displayed algebra.
+
+### N7 — hostile steelman
+
+> Once `c_t = c_s` is granted, equal Euclidean coefficients already
+> mean unit speed, so the only possible Wick map is `a = 1`. Installing
+> that value is just spelling the primitive in Lorentzian language.
+
+This steelman is rejected as a derivation, not as a possible later
+declaration. The primitive's tick/edge wording is Euclidean OS0
+kinetic form. The continuation `k4 = i a ω` is a second map. The
+Euclidean polynomial is independent of `a` (Theorem 1). The values
+`a = 1/2` and `a = 2` share that polynomial and fail speed-preservation
+(Theorem 3). Accepting `a = 1` would be an extra declaration of the
+matching in Theorem 2. Theorem 4 records that the extra declaration
+is not a source sentence.
+
+### N8 — earlier-surface echo
+
+| Earlier surface | What it does | Echo here |
+|---|---|---|
+| kinetic-isotropy primitive | supplies `c_t = c_s` only | used as the Euclidean parent; not a selector of `a` |
+| axiom memo | four named axioms; Admissibility does not define a time metric | used as the axiom parent; no Wick factor is present |
+| textbook Wick convention | writes `k4 = i ω` | conventional `a = 1`, not a uniqueness proof from speed-preservation |
+
+Earlier surfaces supply Euclidean OS0 form. They do not name
+speed-preservation across Wick continuation, and they do not install
+`a = 1`.
+
+**Gate disposition:** the Euclidean-OS0-as-selector route fails. The
+speed-preservation route selects the unit clock and remains extra.
+Do not ship "Lorentzian physics is impossible," "an axiom update is
+necessary," or "this note installs `a = 1`."
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| primitive sentence `c_t = c_s` and OS0 wording | premise | quoted; no edit |
+| primitive non-amendment of the four axioms | premise | quoted; no edit |
+| axiom memo: `Z^3` Lattice; Admissibility does not define a time metric | premise | quoted; no edit |
+| Euclidean TT form `(k4^2+k^2)/4` and family `Q_a` | declared algebra | computed here |
+| speed-preservation matching | declared extra condition | not a source sentence |
+| physical Wick clock map `a` | escape route | live, not installed |
+
+The exact advance is a finite continuation-versus-matching theorem.
+Independent audit remains required before any effective status may
+change.
+
+## Primary Runner
+
+[`scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py`](../scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py)
+recomputes the Euclidean TT polynomial, the continuation `k4 = i a ω`,
+`omega_coeff(a) = -a^2/4`, and `speed_preserved(a) := (a*a==1)` in
+exact arithmetic, and re-reads the two source notes.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17121,6 +17121,10 @@
   "spectral_trajectory_theorem_2026-04-11": {
    "deps_hash": "db257ac283db",
    "out_degree": 7
+  },
+  "speed_preserving_linear_wick_map_is_unit_clock_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "0d988fd1ac07",
+   "out_degree": 2
   },
   "sphaleron_coefficient_28_79_from_sm_like_content_admission_bridge_note_2026-05-28": {
    "deps_hash": "7a3ee4490765",

--- a/logs/runner-cache/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.txt
+++ b/logs/runner-cache/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py
+runner_sha256: cfc5eca2e48a662bee021f2650fe382607d8147f32d7882bbf74411693a83149
+input_fingerprint_sha256: 0d33101bde93b045dcb87501f481760e7c103b57efa69771f5cacb4dcd7ad8eb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.32
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SPEED_PRESERVING_LINEAR_WICK_MAP_IS_UNIT_CLOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+  docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md
+cache_write: false
+external_scientific_inputs: axiom memo and kinetic-isotropy primitive; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: axioms and c_t = c_s as namers of speed-preservation are rejected; a declared matching remains a live formal escape
+PASS: audit-input-paths declared audit inputs exist and match the note, axiom memo, and primitive
+PASS: source-primitive-ct-cs the primitive supplies the Euclidean equality c_t = c_s
+PASS: source-primitive-os0 the primitive identifies that equality with OS0 kinetic normalization
+PASS: source-primitive-no-axiom-amend the primitive states that it does not add or amend an axiom
+PASS: source-axiom-lattice-z3 the axiom memo states that physical sites are the cubic lattice Z^3
+PASS: source-axiom-no-time-metric Admissibility is recorded as not defining a time metric
+PASS: theorem-1-euclidean-independent-of-a Q_E = (k4^2+k^2)/4 contains no continuation parameter a
+PASS: theorem-1-os0-equal-coefficients Euclidean coefficients of k4^2 and kx^2 are both 1/4, so c_t = c_s
+PASS: theorem-1-shared-euclidean displayed continuations recover the same Q_E; sample (k4,kx)=(2,3) is 13/4
+PASS: theorem-2-continuation substituting k4 = i a ω into Q_E yields (-a^2 ω^2 + k^2)/4
+PASS: identity-omega-coeff omega_coeff(a)=-a^2/4 equals the derived [ω^2] Q_a on every sample
+PASS: theorem-2-spatial-unchanged the spatial coefficient remains 1/4 for every displayed a
+PASS: theorem-2-speed-preservation-iff-square-one speed_preserved(a) iff a*a==1 on the rational sample
+PASS: theorem-2-unique-up-to-orientation among the samples only a=+1 and a=-1 preserve speed, unique up to time-orientation
+PASS: theorem-3-half a=1/2 gives a^2=1/4 ≠ 1 and omega_coeff=-1/16 versus spatial 1/4
+PASS: theorem-3-double a=2 gives a^2=4 ≠ 1 and omega_coeff=-1 versus spatial 1/4
+PASS: mutation-true-for-all-fails-at-half replacing speed_preserved by True-for-all-a wrongly accepts a=1/2
+PASS: identity-gates-present identity gates call omega_coeff(a)=-a^2/4 and speed_preserved(a):=(a*a==1)
+PASS: theorem-4-sources-do-not-name-matching neither source writes the continuation, omega_coeff, or speed_preserved
+PASS: theorem-4-primitive-does-not-force-a-1 the primitive is c_t = c_s only and does not force a=1
+PASS: canonical-nonmutation the continuation family is absent from the canonical axiom and primitive files
+PASS: note-preserves-ct-cs the note records c_t = c_s
+PASS: note-links-parents the note links the axiom memo and the kinetic-isotropy primitive
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: note-theorem-4-noninstall the note does not install a=1 and does not claim Lorentzian closure
+PASS: note-witnesses the note exhibits omega_coeff -1/16 versus 1/4 and unit-clock a=±1
+PASS: forbidden-rhetoric-absent the note avoids axiom-adoption, promotion, and executor-name rhetoric
+N5: Theorem 4 does not install a=1
+N5: Theorem 4 does not claim Lorentzian closure
+N5: speed-preservation is an extra matching, not an axiom sentence
+per_element: each displayed a is tested by speed_preserved(a):=(a*a==1)
+per_site: momentum-space quadratic forms; no composite carrier is asserted
+per_mode: quadratic TT form only; no spectral-mode exhaustion is claimed
+per_block: linear Wick family versus the extra speed matching
+lattice_wide: checked and not executed — no lattice-wide Lorentzian closure is claimed
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py
+++ b/scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Exact checks: speed-preserving linear Wick map is the unit clock.
+
+Q_E = (k4^2 + k^2)/4 is independent of a. Continuation k4 = i a ω
+produces Q_a = (-a^2 ω^2 + k^2)/4. Identity gates are
+omega_coeff(a) = -a^2/4 and speed_preserved(a) := (a*a==1).
+Speed-preservation holds iff a ∈ {+1, −1}. No cache is written.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+import sympy as sp
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SPEED_PRESERVING_LINEAR_WICK_MAP_IS_UNIT_CLOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+PRIMITIVE_REL = "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/SPEED_PRESERVING_LINEAR_WICK_MAP_IS_UNIT_CLOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+PRIMITIVE_PATH = ROOT / PRIMITIVE_REL
+
+A_SAMPLES = (
+    Fraction(1),
+    Fraction(-1),
+    Fraction(1, 2),
+    Fraction(2),
+    Fraction(-1, 2),
+    Fraction(-2),
+    Fraction(3),
+    Fraction(1, 3),
+    Fraction(3, 2),
+)
+UNIT_CLOCK = (Fraction(1), Fraction(-1))
+REJECTORS = (Fraction(1, 2), Fraction(2))
+SPEED_PHRASES = (
+    "speed_preserved",
+    "speed-preservation",
+    "k4 = i a ω",
+    "k4 = i a",
+    "i a ω",
+    "omega_coeff",
+    "Q_a",
+)
+
+
+def omega_coeff(a: Fraction) -> Fraction:
+    """Lorentzian ω^2 coefficient of Q_a: -a^2/4."""
+    return -(a * a) / Fraction(4)
+
+
+def speed_preserved(a: Fraction) -> bool:
+    """Declared extra matching: Lorentzian null coincides with ω^2 = k^2."""
+    return a * a == 1
+
+
+def speed_preserved_true_for_all(_a: Fraction) -> bool:
+    """Hostile mutation: replace speed_preserved by True for every a."""
+    return True
+
+
+def algebraic_unit_clock(a: Fraction) -> bool:
+    """a = p/q lowest terms, a^2 = 1 iff |p| = q, iff a ∈ {+1, −1}."""
+    return abs(a.numerator) == a.denominator
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def as_fraction(expr: sp.Expr) -> Fraction:
+    rat = sp.Rational(sp.simplify(expr))
+    return Fraction(int(rat.p), int(rat.q))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def build_family() -> dict[str, object]:
+    """Derive Q_E and Q_a by substitution. Coefficients are not preset."""
+    k4, omega, kx, ky, kz = sp.symbols("k4 omega kx ky kz")
+    a = sp.symbols("a", nonzero=True)
+    k2 = kx**2 + ky**2 + kz**2
+    q_e = (k4**2 + k2) / 4
+    q_a = sp.expand(q_e.subs(k4, sp.I * a * omega))
+    coeff = sp.expand(q_a).coeff(omega**2)
+    spatial = sp.expand(q_a).coeff(kx**2)
+    return {
+        "k4": k4,
+        "omega": omega,
+        "kx": kx,
+        "ky": ky,
+        "kz": kz,
+        "a": a,
+        "k2": k2,
+        "q_e": q_e,
+        "q_a": q_a,
+        "omega_coeff": coeff,
+        "spatial": spatial,
+    }
+
+
+def derived_omega_coeff(family: dict[str, object], a_val: Fraction) -> Fraction:
+    expr = family["omega_coeff"].subs(
+        family["a"], sp.Rational(a_val.numerator, a_val.denominator)
+    )
+    return as_fraction(expr)
+
+
+def inspect_identity_source() -> bool:
+    text = Path(__file__).read_text(encoding="utf-8")
+    return (
+        "def omega_coeff(" in text
+        and "def speed_preserved(" in text
+        and "-a^2/4" in text
+        and "a * a == 1" in text
+        and "omega_coeff(" in text
+        and "speed_preserved(" in text
+    )
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    primitive = PRIMITIVE_PATH.read_text(encoding="utf-8")
+    norm_axiom = normalize(axiom)
+    family = build_family()
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: axiom memo and kinetic-isotropy primitive; no observational or fitted inputs")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written")
+    print("negative_scope: axioms and c_t = c_s as namers of speed-preservation are rejected; a declared matching remains a live formal escape")
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, axiom memo, and primitive",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL, PRIMITIVE_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    checks.check(
+        "source-primitive-ct-cs",
+        "the primitive supplies the Euclidean equality c_t = c_s",
+        "c_t = c_s" in primitive,
+    )
+    checks.check(
+        "source-primitive-os0",
+        "the primitive identifies that equality with OS0 kinetic normalization",
+        "Osterwalder-Schrader OS0 kinetic normalization" in normalize(primitive.replace("`", "")),
+    )
+    checks.check(
+        "source-primitive-no-axiom-amend",
+        "the primitive states that it does not add or amend an axiom",
+        "It does not add or amend an axiom." in primitive,
+    )
+    checks.check(
+        "source-axiom-lattice-z3",
+        "the axiom memo states that physical sites are the cubic lattice Z^3",
+        "Physical sites are the points of the cubic lattice `Z^3`" in axiom,
+    )
+    time_metric_clause = (
+        "It does not choose a Hamiltonian or transfer operator, supply "
+        "transition-probability or weight values, select a scalar or nonzero "
+        "kinetic branch, assert a Dirac-square carrier, define a time metric"
+    )
+    checks.check(
+        "source-axiom-no-time-metric",
+        "Admissibility is recorded as not defining a time metric",
+        time_metric_clause in norm_axiom,
+    )
+
+    q_e = family["q_e"]
+    k4 = family["k4"]
+    a_sym = family["a"]
+    checks.check(
+        "theorem-1-euclidean-independent-of-a",
+        "Q_E = (k4^2+k^2)/4 contains no continuation parameter a",
+        a_sym not in q_e.free_symbols
+        and sp.simplify(q_e - (k4**2 + family["k2"]) / 4) == 0,
+        residual=q_e,
+    )
+    c_t = q_e.coeff(k4**2)
+    c_s = q_e.coeff(family["kx"] ** 2)
+    checks.check(
+        "theorem-1-os0-equal-coefficients",
+        "Euclidean coefficients of k4^2 and kx^2 are both 1/4, so c_t = c_s",
+        as_fraction(c_t) == Fraction(1, 4)
+        and as_fraction(c_s) == Fraction(1, 4)
+        and sp.simplify(c_t - c_s) == 0,
+        residual=(c_t, c_s),
+    )
+
+    recovered = []
+    for a_val in UNIT_CLOCK + REJECTORS:
+        q_cont = sp.expand(
+            family["q_a"].subs(a_sym, sp.Rational(a_val.numerator, a_val.denominator))
+        )
+        back = sp.expand(
+            q_cont.subs(
+                family["omega"],
+                -sp.I * k4 / sp.Rational(a_val.numerator, a_val.denominator),
+            )
+        )
+        recovered.append(sp.simplify(back - q_e) == 0)
+    sample = q_e.subs({k4: 2, family["kx"]: 3, family["ky"]: 0, family["kz"]: 0})
+    checks.check(
+        "theorem-1-shared-euclidean",
+        "displayed continuations recover the same Q_E; sample (k4,kx)=(2,3) is 13/4",
+        all(recovered) and as_fraction(sample) == Fraction(13, 4),
+        residual=(recovered, sample),
+    )
+
+    expanded = sp.expand(family["q_a"])
+    checks.check(
+        "theorem-2-continuation",
+        "substituting k4 = i a ω into Q_E yields (-a^2 ω^2 + k^2)/4",
+        sp.simplify(
+            expanded - ((-(a_sym**2) * family["omega"] ** 2 + family["k2"]) / 4)
+        )
+        == 0,
+        residual=expanded,
+    )
+
+    derived = [derived_omega_coeff(family, a_val) for a_val in A_SAMPLES]
+    identity = [omega_coeff(a_val) for a_val in A_SAMPLES]
+    checks.check(
+        "identity-omega-coeff",
+        "omega_coeff(a)=-a^2/4 equals the derived [ω^2] Q_a on every sample",
+        identity == derived
+        and omega_coeff(Fraction(1, 2)) == Fraction(-1, 16)
+        and omega_coeff(Fraction(1)) == Fraction(-1, 4)
+        and omega_coeff(Fraction(-1)) == Fraction(-1, 4)
+        and omega_coeff(Fraction(2)) == Fraction(-1),
+        residual=(identity, derived),
+    )
+
+    spatial_vals = [
+        as_fraction(
+            family["spatial"].subs(
+                a_sym, sp.Rational(a_val.numerator, a_val.denominator)
+            )
+        )
+        for a_val in UNIT_CLOCK + REJECTORS
+    ]
+    checks.check(
+        "theorem-2-spatial-unchanged",
+        "the spatial coefficient remains 1/4 for every displayed a",
+        spatial_vals == [Fraction(1, 4)] * 4,
+        residual=spatial_vals,
+    )
+
+    preserved = {a: speed_preserved(a) for a in A_SAMPLES}
+    checks.check(
+        "theorem-2-speed-preservation-iff-square-one",
+        "speed_preserved(a) iff a*a==1 on the rational sample",
+        all(speed_preserved(a) == (a * a == 1) for a in A_SAMPLES)
+        and preserved[Fraction(1)]
+        and preserved[Fraction(-1)]
+        and not preserved[Fraction(1, 2)]
+        and not preserved[Fraction(2)],
+        residual=preserved,
+    )
+    checks.check(
+        "theorem-2-unique-up-to-orientation",
+        "among the samples only a=+1 and a=-1 preserve speed, unique up to time-orientation",
+        tuple(a for a in A_SAMPLES if speed_preserved(a)) == UNIT_CLOCK
+        and all(algebraic_unit_clock(a) == speed_preserved(a) for a in A_SAMPLES)
+        and omega_coeff(Fraction(1)) == omega_coeff(Fraction(-1)),
+        residual=tuple(a for a in A_SAMPLES if speed_preserved(a)),
+    )
+
+    checks.check(
+        "theorem-3-half",
+        "a=1/2 gives a^2=1/4 ≠ 1 and omega_coeff=-1/16 versus spatial 1/4",
+        (Fraction(1, 2) * Fraction(1, 2) == Fraction(1, 4))
+        and omega_coeff(Fraction(1, 2)) == Fraction(-1, 16)
+        and abs(omega_coeff(Fraction(1, 2))) != Fraction(1, 4)
+        and not speed_preserved(Fraction(1, 2)),
+        residual=omega_coeff(Fraction(1, 2)),
+    )
+    checks.check(
+        "theorem-3-double",
+        "a=2 gives a^2=4 ≠ 1 and omega_coeff=-1 versus spatial 1/4",
+        (Fraction(2) * Fraction(2) == Fraction(4))
+        and omega_coeff(Fraction(2)) == Fraction(-1)
+        and abs(omega_coeff(Fraction(2))) != Fraction(1, 4)
+        and not speed_preserved(Fraction(2)),
+        residual=omega_coeff(Fraction(2)),
+    )
+
+    checks.check(
+        "mutation-true-for-all-fails-at-half",
+        "replacing speed_preserved by True-for-all-a wrongly accepts a=1/2",
+        speed_preserved_true_for_all(Fraction(1, 2)) is True
+        and speed_preserved(Fraction(1, 2)) is False
+        and Fraction(1, 2) * Fraction(1, 2) != 1,
+    )
+    checks.check(
+        "identity-gates-present",
+        "identity gates call omega_coeff(a)=-a^2/4 and speed_preserved(a):=(a*a==1)",
+        inspect_identity_source()
+        and omega_coeff(Fraction(2)) == Fraction(-1)
+        and speed_preserved(Fraction(1))
+        and not speed_preserved(Fraction(1, 2)),
+    )
+
+    primitive_speed = [phrase for phrase in SPEED_PHRASES if phrase in primitive]
+    axiom_speed = [phrase for phrase in SPEED_PHRASES if phrase in axiom]
+    checks.check(
+        "theorem-4-sources-do-not-name-matching",
+        "neither source writes the continuation, omega_coeff, or speed_preserved",
+        primitive_speed == [] and axiom_speed == [],
+        residual=(primitive_speed, axiom_speed),
+    )
+    primitive_forces_a_1 = (
+        "k4 = i" in primitive
+        or "k_4 = i" in primitive
+        or "forces a=1" in primitive
+        or "a = 1" in primitive
+    )
+    checks.check(
+        "theorem-4-primitive-does-not-force-a-1",
+        "the primitive is c_t = c_s only and does not force a=1",
+        "c_t = c_s" in primitive
+        and not primitive_forces_a_1
+        and "a_x = a_y = a_z" in primitive
+        and "a^{-1} = M_Pl" in primitive
+        and not speed_preserved(Fraction(1, 2)),
+        residual=primitive_forces_a_1,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the continuation family is absent from the canonical axiom and primitive files",
+        "Q_a" not in axiom
+        and "Q_a" not in primitive
+        and "omega_coeff" not in axiom
+        and "omega_coeff" not in primitive
+        and "speed_preserved" not in axiom
+        and "speed_preserved" not in primitive,
+    )
+
+    checks.check(
+        "note-preserves-ct-cs",
+        "the note records c_t = c_s",
+        "c_t = c_s" in note,
+    )
+    checks.check(
+        "note-links-parents",
+        "the note links the axiom memo and the kinetic-isotropy primitive",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "trace_class: negative_route_pruning",
+                "target_claim_id: speed_preserving_linear_wick_map_is_unit_clock",
+                "hypothetical_axiom_status: no edit",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "note-theorem-4-noninstall",
+        "the note does not install a=1 and does not claim Lorentzian closure",
+        "does not install `a = 1`" in note
+        and "does not claim Lorentzian closure" in note
+        and "N5" in note
+        and "Theorem 4" in note,
+    )
+    checks.check(
+        "note-witnesses",
+        "the note exhibits omega_coeff -1/16 versus 1/4 and unit-clock a=±1",
+        "-1/16" in note
+        and "omega_coeff(a) = -a^2/4" in note
+        and "a * a == 1" in note
+        and "a = 1/2" in note
+        and "a = 2" in note,
+    )
+
+    forbidden = ("new axiom", "we adopt", "promoted", "Codex")
+    retained_hits = [
+        line
+        for line in note.splitlines()
+        if "retained" in line
+        and "audit_required_before_effective_retained" not in line
+        and "bare_retained_allowed" not in line
+    ]
+    checks.check(
+        "forbidden-rhetoric-absent",
+        "the note avoids axiom-adoption, promotion, and executor-name rhetoric",
+        all(phrase not in note for phrase in forbidden) and retained_hits == [],
+        residual=retained_hits,
+    )
+
+    print("N5: Theorem 4 does not install a=1")
+    print("N5: Theorem 4 does not claim Lorentzian closure")
+    print("N5: speed-preservation is an extra matching, not an axiom sentence")
+    print("per_element: each displayed a is tested by speed_preserved(a):=(a*a==1)")
+    print("per_site: momentum-space quadratic forms; no composite carrier is asserted")
+    print("per_mode: quadratic TT form only; no spectral-mode exhaustion is claimed")
+    print("per_block: linear Wick family versus the extra speed matching")
+    print("lattice_wide: checked and not executed — no lattice-wide Lorentzian closure is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among linear Wick maps `k4 = i a ω` of the Euclidean OS0 form `(k4^2+k^2)/4`, the extra matching that the Lorentzian null coincide with Euclidean equal coefficients holds iff `a^2 = 1`, so `a ∈ {+1, −1}` uniquely up to time-orientation. Neither the four axioms nor `c_t = c_s` names that matching. The note does not install `a = 1` and does not claim Lorentzian closure.

## What this means for the TOE

Time still has a primitive clock (record count). Relativistic time needs a Wick factor. This block pins the unique linear clock that **keeps the Euclidean speed**. The remaining wall is a *reason* for speed-preservation, not another listing of the `a` family.

## What changed

- Note: `docs/SPEED_PRESERVING_LINEAR_WICK_MAP_IS_UNIT_CLOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py`
- Cache: `logs/runner-cache/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.txt`

## Verification

```bash
python3 scripts/speed_preserving_linear_wick_map_is_unit_clock_2026_08_13.py
# TOTAL: PASS=28 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.