### PR TITLE
[physics-loop] toe-lphys formsite: bounded_theorem / bounded-support

### DIFF
--- a/docs/PRODUCT_LAW_DOES_NOT_FORCE_FORMATION_AT_AUXILIARY_SITES_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/PRODUCT_LAW_DOES_NOT_FORCE_FORMATION_AT_AUXILIARY_SITES_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,454 @@
+---
+claim_id: product_law_does_not_force_formation_at_auxiliary_sites_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On Z^3, the sites 3e1 and 6e1 have disjoint nearest-neighbor 6-tuples, so a product of one-site laws on {0,1} is the same function of those 6-tuples whether or not records occupy the two sites; the histories H_form and H_empty share that product law and differ only in occupancy; a bit compiler that needs records at those sites requires H_form, but the axioms do not select H_form over H_empty."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py
+---
+
+# Product Law Does Not Force Formation At Auxiliary Sites
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact cubic nearest-neighbor listings for `3e1` and `6e1`; product
+of one-site laws as a function of those disjoint 6-tuples; occupancy-tagged
+histories `H_form` and `H_empty` sharing the same content law; a bit compiler
+that needs records at those sites is not selected by the axioms.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py`](../scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py)
+
+## Result Up Front
+
+A product of one-site Admissibility laws is a content law. Occupancy is a
+separate mark: whether a record is present at a named site. The two objects
+are not the same.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is quoted only
+as a premise and is not edited:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Lattice sentence is likewise quoted only as a premise:
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The Admissibility reading note is quoted only as a premise. The distribution
+concerns which possibility a forming record locks, conditional on formation at
+that site; it does not supply the formation site, probability, or rate.
+
+The current Record lock sentence is quoted only as a premise:
+
+When present, a record locks exactly one admissible local possibility.
+
+Five exact statements locate the split.
+
+1. **Disjoint supports.** The six-point sets `N(3e1)` and `N(6e1)` are
+   disjoint. Neither contains the origin. Neither site lies in its own
+   neighbor set.
+2. **Content law is not occurrence.** The product `P_x ⊗ P_y` is a function
+   of the two 6-tuples on `N(x)` and `N(y)`. Occupancy of `x` is not a
+   coordinate of either 6-tuple, and likewise for `y`. The product is the
+   same function of those 6-tuples whether `o(x)` is formed or unformed.
+3. **Two histories share the law.** The history `H_form` occupies both sites.
+   The history `H_empty` occupies neither. They carry the same product law
+   and differ only in occupancy. Both are compatible with the quoted
+   Admissibility reading (the distribution is conditional on formation) and
+   with the quoted Record lock sentence (“when present”).
+4. **Compiler demand is not an axiom selector.** A bit compiler that needs
+   records at those two sites requires `H_form`. The quoted axiom sentences
+   do not select `H_form` over `H_empty`.
+5. **Scoped negatives.** The note does not claim that no compiler exists.
+   It does not edit an axiom sentence to name a formation site. A
+   formation-site selector remains extra.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The neighbor listings, the occupancy-independence of the product as a function of the two 6-tuples, and the H_form versus H_empty split are proved by finite lattice enumeration and exact Fraction arithmetic; a formation-site selector remains extra."
+trace_class: negative_route_pruning
+target_claim_id: formation_at_auxiliary_compiler_sites
+target_blocker_text: "derive record formation at graph-separated auxiliary sites from a product of one-site laws"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "A bit compiler that needs records at those sites still requires a formation rule; the product law does not select H_form over H_empty. Do not adopt axiom text."
+conditional_surface_status: "exact for disjoint NN 6-tuples at spacing 3 and for the shared-law occupancy pair H_form, H_empty; formation-site selection remains extra"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work on the cubic lattice `Z^3` with the Lattice axiom's nearest-neighbor
+adjacency. Write
+
+`e1=(1,0,0)`, `e2=(0,1,0)`, `e3=(0,0,1)`, `0=(0,0,0)`.
+
+The neighbor set of a site `z` is the six-point set
+
+`N(z)={z±e1, z±e2, z±e3}`.
+
+Thus `|N(z)|=6` at every site, and `z ∉ N(z)`. Graph distance is the taxicab
+metric
+
+`d(a,b)=|a_1-b_1|+|a_2-b_2|+|a_3-b_3|`.
+
+The executed sites are `x=3e1=(3,0,0)` and `y=6e1=(6,0,0)`. Distances:
+`d(0,x)=3`, `d(0,y)=6`, `d(x,y)=3`.
+
+A **one-site law** at a site `z` is a map `P_z(· | η_z)` from 6-tuples of
+labels on `N(z)` to a probability distribution on a declared two-element
+possibility set `{0,1}`. The executed `{0,1}` is that declared finite menu.
+It is not a derivation that the Qubit one-site domain is binary. Executed
+margins are `p=1/2` and, as a non-fair control, `p=1/3`. Fairness is not
+derived.
+
+A **product law** on `{x,y}` is `P_x ⊗ P_y`, the joint
+
+`P(α,β) = P_x(α | η_x) P_y(β | η_y)`, `α,β ∈ {0,1}`.
+
+**Occupancy** at a site is a two-valued mark `o(z) ∈ {formed, unformed}`.
+It is not a coordinate of `η_z`. A forming record at `z` would lock a value
+in `{0,1}`; an unformed site carries no lock.
+
+A **history** is a pair `(law, occupancy)`. The two executed histories are
+
+- `H_form = (P_x ⊗ P_y, o(x)=formed, o(y)=formed)`,
+- `H_empty = (P_x ⊗ P_y, o(x)=unformed, o(y)=unformed)`.
+
+`H_empty` is emptiness of the two named auxiliary sites. It is not a claim
+that the whole lattice is empty. The Record occurrence sentence “Records
+form.” may be realized at other sites.
+
+Explicit neighbor lists used as witnesses:
+
+```text
+N(0)    = {(±1,0,0),(0,±1,0),(0,0,±1)}
+N(2e1)  = {(1,0,0),(3,0,0),(2,±1,0),(2,0,±1)}   — shares e1 with N(0)
+N(3e1)  = {(2,0,0),(4,0,0),(3,±1,0),(3,0,±1)}   — 0 ∉ N(3e1), 3e1 ∉ N(3e1)
+N(6e1)  = {(5,0,0),(7,0,0),(6,±1,0),(6,0,±1)}   — 0 ∉ N(6e1), 6e1 ∉ N(6e1)
+N(3e1) ∩ N(6e1) = empty
+```
+
+## Exact Target And Obligation Graph
+
+**Exact target.** On declared cubic nearest-neighbor objects, list `N(3e1)`
+and `N(6e1)`, prove those supports are disjoint, prove that the product of
+one-site laws is the same function of the two 6-tuples whether or not the
+two sites are occupied, exhibit `H_form` and `H_empty` as distinct
+occupancies of one product law, and record that a bit compiler needing
+records at those sites is not selected by the quoted axiom sentences.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin the Admissibility distribution sentence | premise | quoted; no edit |
+| pin the formation-site/rate reading note | premise | quoted; no edit |
+| pin Record “when present” | premise | quoted; no edit |
+| pin Lattice NN adjacency and `N(z)` | premise | quoted; `|N(z)|=6` listed |
+| show `N(3e1) ∩ N(6e1)=empty` and self-exclusion | Theorem 1 | listing |
+| show the product is the same function of the two 6-tuples at either occupancy | Theorem 2 | product of Fractions |
+| exhibit `H_form` and `H_empty` sharing the law | Theorem 3 | occupancy pair |
+| record that a compiler needing those records requires `H_form` | Theorem 4 | scoped residual |
+| record that no-compiler and axiom-edit claims are out of scope | Theorem 5 | scoped negative |
+| claim that no compiler exists | non-claim | not attempted |
+| edit an axiom sentence to name a formation site | non-claim | not attempted |
+
+## Theorem 1 — Disjoint Supports
+
+**Claim.** `N(3e1) ∩ N(6e1)=empty`. Also `0 ∉ N(3e1)`, `0 ∉ N(6e1)`,
+`3e1 ∉ N(3e1)`, and `6e1 ∉ N(6e1)`.
+
+**Proof.** The six neighbors of `3e1=(3,0,0)` are
+
+`(2,0,0)`, `(4,0,0)`, `(3,1,0)`, `(3,-1,0)`, `(3,0,1)`, `(3,0,-1)`.
+
+None is the origin. None is `(3,0,0)`. The six neighbors of `6e1=(6,0,0)`
+are
+
+`(5,0,0)`, `(7,0,0)`, `(6,1,0)`, `(6,-1,0)`, `(6,0,1)`, `(6,0,-1)`.
+
+None is the origin. None is `(6,0,0)`. The two six-point sets are disjoint
+by direct comparison.
+
+A one-line metric reason is available and is not a substitute for the
+listing. Distinct sites share a nearest neighbor if and only if `d≤2`,
+because a shared neighbor `z` would give `d(x,y)≤d(x,z)+d(z,y)=2`. Here
+`d(3e1,6e1)=3`, so a shared neighbor is impossible, matching the listing.
+
+The spacing-2 contrast used by the identity gate is the nonempty intersection
+
+`N(0) ∩ N(2e1)={(1,0,0)}={e1}`.
+
+A predicate that returns disjointness at every pair of sites is therefore
+false on `(0,2e1)`.
+
+## Theorem 2 — Content Law Is Not Occurrence
+
+**Claim.** The product `P_x ⊗ P_y` is the same function of the two 6-tuples
+`η_x` on `N(x)` and `η_y` on `N(y)` whether `o(x)` is formed or unformed,
+and whether `o(y)` is formed or unformed. Content law is not occurrence.
+
+**Proof.** By definition a one-site law at `x` is a function of a 6-tuple
+indexed by `N(x)` only. Theorem 1 gives `x ∉ N(x)` and `y ∉ N(y)`, and
+`N(x) ∩ N(y)=empty`. Therefore
+
+- occupancy of `x` is not a coordinate of `η_x` and not a coordinate of
+  `η_y`,
+- occupancy of `y` is not a coordinate of `η_x` and not a coordinate of
+  `η_y`.
+
+Two global configurations that differ only in `o(x)` or `o(y)` induce the
+same pair of 6-tuples. The product
+
+`P(α,β) = P_x(α | η_x) P_y(β | η_y)`
+
+is therefore the same function of those 6-tuples.
+
+The executed fair product has every atom equal to `1/4`. The executed
+non-fair control with both margins `1/3` has `P(00)=1/9`. Both tables are
+functions of the 6-tuples alone. Neither table names `o(x)` or `o(y)`.
+Fairness is not derived: `1/9 ≠ 1/4`.
+
+The Admissibility sentence determines, for each site, a distribution from
+that site's nearest-neighbor conditions. Occupancy of the site itself is
+not among those conditions.
+
+## Theorem 3 — Two Histories Share The Product Law
+
+**Claim.** The histories `H_form` (both sites formed) and `H_empty` (neither
+site formed) share the same product law and differ in occupancy. Both are
+compatible with Admissibility, whose distribution is conditional on
+formation, and with Record’s “when present” lock sentence.
+
+**Proof.** By definition both histories carry the same pair `(P_x, P_y)` and
+therefore the same product `P_x ⊗ P_y`. Theorem 2 says that product does
+not depend on `o(x)` or `o(y)`. The occupancy maps differ:
+
+| History | `o(x)` | `o(y)` | product law |
+|---|---|---|---|
+| `H_form` | formed | formed | `P_x ⊗ P_y` |
+| `H_empty` | unformed | unformed | `P_x ⊗ P_y` |
+
+Compatibility with Admissibility is the quoted reading note: the
+distribution concerns which possibility a forming record locks, conditional
+on formation at that site; it does not supply the formation site,
+probability, or rate. On `H_form` the product is the content law of the two
+forming records. On `H_empty` there is no forming record at `x` or at `y`,
+so the same content law is not asked to lock a value at those sites.
+
+Compatibility with Record is the quoted lock sentence. When present, a
+record locks exactly one admissible local possibility. On `H_form` each of
+`x` and `y` is present and locks one value in `{0,1}`. On `H_empty` neither
+record is present at those sites, so the lock sentence does not apply there.
+The sentence is a constraint on present records, not a selector that makes
+them present.
+
+`H_empty` does not contradict “Records form.” That sentence is a global
+occurrence mark. It may be realized at sites other than `{x,y}`. Emptiness
+of the two auxiliary sites is not emptiness of the lattice.
+
+## Theorem 4 — A Compiler Needing Those Records Requires `H_form`
+
+**Claim.** A bit compiler that needs records at `x` and `y` requires
+`H_form`. The quoted axiom sentences do not select `H_form` over `H_empty`.
+
+**Proof.** A bit compiler that reads locked possibilities at `x` and at `y`
+needs those records to be present. That is the occupancy of `H_form`.
+Theorem 3 supplies a second history `H_empty` with the same product law and
+the opposite occupancy at those sites. The Admissibility distribution
+sentence names a content law from nearest-neighbor conditions. The reading
+note says that distribution does not supply the formation site, probability,
+or rate. The Record lock sentence applies when a record is present. None of
+those sentences selects the occupancy of `H_form` over the occupancy of
+`H_empty`.
+
+The residual is therefore a formation-site selector at the two named sites.
+It is not supplied by the product law.
+
+A predicate that reads “the history carries a product law, therefore both
+sites are formed” fails on `H_empty`: that history carries the product and
+has both sites unformed.
+
+## Theorem 5 — Scoped Negatives
+
+**Claim.** Theorem 4 is a selection residual for occupancy at two named
+sites. It is not a claim that no compiler exists. It is not an invitation
+to edit an axiom sentence.
+
+**Scope.** The negatives are restricted to *forcing* occupancy of `{3e1,6e1}`
+from a product of one-site laws. They do not say that no bit compiler can
+ever be constructed. They do not say that records never form. They do not
+edit the four axiom sentences. A formation-site selector remains extra
+until it is derived from executable objects.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom sentence, or argue that an axiom-sentence change is
+  necessary;
+- claim that no compiler exists;
+- claim that records never form, or that `H_empty` is a completed empty
+  universe;
+- derive a fair binary margin (the `1/3` control is displayed exactly so
+  that fairness is not smuggled in);
+- replace nearest-neighbor adjacency by the 26-site Moore neighborhood;
+- identify the executed `{0,1}` menu with the full one-site possibility
+  domain `M_2(C)`;
+- construct a physical menu compiler of registered event partitions.
+
+The scope is the exact cubic split: disjoint 6-tuples at spacing 3, a
+product that is a function of those 6-tuples alone, and two occupancies of
+that product.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice NN sentence | premise | quoted; no edit |
+| current Admissibility distribution sentence | premise | quoted; no edit |
+| Admissibility reading note on formation site/rate | premise | quoted; no edit |
+| Record “when present” lock sentence | premise | quoted; no edit |
+| six-neighbor listings at `3e1` and `6e1` | Theorem 1 | computed here |
+| product of one-site Bernoulli laws | Theorem 2 | computed here |
+| occupancy pair `H_form`, `H_empty` | Theorems 3--4 | computed here |
+| formation-site selector at `{x,y}` | residual | extra; not derived |
+| observed frequencies or fitted occupancies | none | not used |
+
+The exact advance is a finite lattice-geometry theorem plus an occupancy
+tag on one product. Independent audit is required. This note authors no audit verdict.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | The current Admissibility reading note states that the distribution is conditional on formation and does not supply the formation site, probability, or rate. The named residual is a bit compiler that needs records at two graph-separated auxiliary sites. This note asks whether the product of the one-site laws already selects those records to form, and answers no. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for a product of one-site laws forcing occupancy at auxiliary sites, for histories `H_form`/`H_empty`, and for formation at `3e1` and `6e1`. Hits: the 2026-06-06 record-formation no-go is a general process/rule residual from the axiom baseline, not a spacing-3 occupancy pair; the 2026-07-04 AC-phi occupancy append is a different object; the 2026-08-10 type-separation note leaves physical construction of registered partitions open and does not tag occupancy of a product law. No landed `H_form`/`H_empty` split for a product of one-site laws on `N(3e1)` and `N(6e1)` appears on that commit. Unmerged neighbor-listing drafts are not premises. |
+| V3 | Independently checkable? | Textbook product measures do not mention nearest-neighbor 6-tuples, occupancy marks, or the Record “when present” sentence. The runner recomputes `N(x)` by integer shifts and the two histories by exact `Fraction` arithmetic. |
+| V4 | More than a restatement? | Yes. The discriminating witness is that `H_empty` carries the same product as `H_form` while both sites are unformed, together with the empty intersection `N(3e1) ∩ N(6e1)` and the self-exclusions `x ∉ N(x)`, `y ∉ N(y)`. Those identities are not restatements of the axiom sentence. |
+| V5 | One-step relabel? | No. The claim is not a corollary of the Admissibility sentence alone. That sentence names a per-site distribution determined by nearest-neighbor conditions; it does not name occupancy of the site, the pairing of two such maps, or the compiler demand for `H_form`. |
+
+## No-Go Discipline Gate (Theorems 4 and 5 only)
+
+The negative claims are restricted to: a product of one-site laws on the
+disjoint 6-tuples of `{3e1,6e1}` does not select occupancy of those sites;
+a bit compiler that needs those records therefore still needs a
+formation-site selector; this is not a claim that no compiler exists. The
+gate does not ship a global non-existence theorem against compilers.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| product forces occupancy | treat `P_x ⊗ P_y` as already selecting `o(x)=o(y)=formed` | Theorems 2--3: `H_empty` carries the same product with both sites unformed | **ATTEMPTED** |
+| Admissibility distribution forces the site | read the NN-determined law as a formation-site rule | reading note: the distribution is conditional on formation and does not supply the formation site, probability, or rate | **ATTEMPTED** |
+| “Records form.” forces `{x,y}` | treat global occurrence as occupancy of the two auxiliary sites | Theorem 3: occurrence may be realized at other sites; `H_empty` empties only `{x,y}` | **ATTEMPTED** |
+| “when present” forces presence | treat the lock sentence as a selector that makes the record present | the lock sentence constrains a present record; it does not create one | **ATTEMPTED** |
+| compiler demand | a bit compiler needs records at `{x,y}`, therefore the axioms do | Theorem 4: the compiler requires `H_form`; the axioms do not select it | **ATTEMPTED** |
+| axiom-sentence edit | add a formation-site sentence to close the residual | Theorem 5: the residual is extra; no axiom sentence is edited | **ATTEMPTED** |
+| 26-site Moore neighborhood | replace `N(z)` by the Chebyshev-1 26-set | different adjacency; not the Lattice neighbor set used by Theorem 1 | **ATTEMPTED** (mutation) |
+
+### N2 — wall independence
+
+Theorems 4 and 5 close only the route that reads occupancy of `{3e1,6e1}`
+off a product of one-site Admissibility maps. They do not close a later
+formation-site derivation, a later executable compiler, or a fair-margin
+selector. Those walls remain independent.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `Z^3` with six-neighbor `N(z)` | declared Lattice object |
+| one-site condition 6-tuple | declared domain of `η` |
+| sites `3e1`, `6e1` | explicit hypothesis of Theorems 1--4 |
+| declared menu `{0,1}` | executed possibility set; not the full `M_2(C)` domain |
+| product of one-site laws | declared pairing `P_x ⊗ P_y` |
+| occupancy mark `formed`/`unformed` | declared second coordinate of a history |
+| histories `H_form`, `H_empty` | executed occupancy pair of one product |
+| bit compiler needing those records | residual demand; not constructed |
+| formation-site selector | extra; not derived |
+| Moore adjacency | live mutation; not the Lattice adjacency |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Lattice NN sentence; Admissibility distribution sentence; formation-site/rate reading note; Record “when present” | quoted as premises only; no edit |
+| one-site pairing on disjoint 6-tuples | product as a function of those 6-tuples | computed here |
+| occupancy pair `H_form`, `H_empty` | shared law, distinct occupancy | computed here |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | named sites `0`, `2e1`, `3e1`, `6e1` and the four atoms of the product table | no classification of every map on `Z^3` |
+| per site | one-site laws at `3e1` and `6e1`, and occupancy marks at those two sites | no composite bonded-pair theorem |
+| per mode | nearest-neighbor condition 6-tuples and occupancy tags, not spectral modes | no harmonic-mode exhaustion |
+| per block | disjointness, occupancy-independence of the product, and the `H_form`/`H_empty` split only | no dynamics, formation rate, or compiler construction |
+| lattice-wide | checked and not executed | no lattice-wide no-go against compilers |
+
+The obstruction is per-site / declared axis pair; it is not lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. A later derivation that records form at the two named sites.
+2. A later executable bit compiler that constructs `H_form` from objects
+   already in the axioms, rather than reading it off the product law.
+3. A later selector for a fair binary margin, independent of occupancy.
+4. A different adjacency, including the 26-site Moore neighborhood, if and
+   when that adjacency is the Lattice object. It is not the present object.
+
+The quoted Admissibility sentence already names a per-site distribution
+determined by nearest-neighbor conditions. Pairing two such maps on disjoint
+supports is already a product. Occupancy of the two sites is a different
+coordinate. No axiom sentence is edited here. A later derivation is not
+forbidden.
+
+### N7 — hostile steelman
+
+> The product law is a law of records at `x` and `y`. If the law is present,
+> the records are present. Therefore `H_empty` is not a history of that law,
+> and the compiler is already selected.
+
+**Answer.** That identification is exactly the predicate “product law
+implies both sites formed.” Theorem 2 separates the product, a function of
+the two neighbor 6-tuples, from occupancy of `x` and `y`. Theorem 3 exhibits
+`H_empty` as a history that carries the product and leaves both sites
+unformed. The Admissibility reading note already types the distribution as
+conditional on formation. The discriminating fact remains that `H_form` and
+`H_empty` share one product and differ in occupancy.
+
+### N8 — cross-cycle echo
+
+The 2026-06-06 record-formation no-go and the 2026-07-04 formation-append
+notes prune routes that would force a formation *rule, site, or rate* from
+the axiom baseline. The 2026-08-10 type-separation note leaves a physical
+construction of registered partitions open. The present negatives face a
+narrower residual: even after a product of one-site laws is written on two
+graph-separated sites, occupancy of those sites is still not selected. The
+earlier notes are not cancelled. They remain notes about different
+premises.
+
+**Gate disposition.** PASS for the scoped occupancy split and the two
+negatives of Theorems 4 and 5. FAIL / DO NOT SHIP for “no compiler exists”
+or for editing an axiom sentence to name a formation site.
+
+## Primary Runner
+
+[`scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py`](../scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py)
+recomputes nearest-neighbor sets, the spacing-3 disjoint-support listing,
+the self-exclusions `x ∉ N(x)` and `y ∉ N(y)`, the product of one-site
+Bernoulli laws as a function of the two 6-tuples, and the occupancy pair
+`H_form`, `H_empty` in exact integer lattice geometry and `Fraction`
+arithmetic. Identity gates call `neighbors(x)` and `product_law`. A
+predicate “product law implies both sites formed” must fail on `H_empty`.
+Replacing spacing 3 by spacing 2 must fail disjoint-support.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -14665,6 +14665,10 @@
   "product_form_premise_weakens_to_outcome_factorization_bounded_note_2026-06-12": {
    "deps_hash": "cbe42f571241",
    "out_degree": 3
+  },
+  "product_law_does_not_force_formation_at_auxiliary_sites_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "program_content_order_attempt_cycle755_bounded_theorem_note_2026-07-28": {
    "deps_hash": "ec452f68be4a",

--- a/logs/runner-cache/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.txt
+++ b/logs/runner-cache/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py
+runner_sha256: 7c2bcec3f61627311183c679a492fd3e82f06b94390cf0cb72f49d9cb4b6838a
+input_fingerprint_sha256: 1cfe70c2b1438ea8caea1d0bedbfd7f9e9708d61ac0e33c0dc10a91ba71b8df4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record wording are source-bound; no observational or fitted inputs
+integrity_reads: this runner, its paired note, and the axiom memo; no other repository scientific inputs
+construction: spacing-3 disjoint NN 6-tuples; product law as a function of those tuples; H_form versus H_empty
+negative_scope: product law does not select occupancy at 3e1 and 6e1; not a no-go against all compilers
+PASS: audit-input-paths declared audit inputs exist and match the note and axiom memo
+PASS: source-lattice the current Lattice nearest-neighbor sentence is pinned in the axiom memo and the note
+PASS: source-admissibility the current distribution sentence is pinned in the axiom memo and the note
+PASS: source-formation-reading-note the Admissibility reading note on formation site/rate is pinned
+PASS: source-record-when-present the Record lock sentence When present is pinned in the axiom memo and the note
+PASS: neighbors-type neighbors(x) returns a frozenset of integer 3-tuples of size 6
+PASS: witness-N3e1 N(3e1) matches the listing, excludes the origin, and excludes itself
+PASS: witness-N6e1 N(6e1) matches the listing, excludes the origin, and excludes itself
+PASS: distances d(0,3e1)=3, d(0,6e1)=6, d(3e1,6e1)=3
+PASS: theorem-1-disjoint-supports N(3e1) ∩ N(6e1) is empty; neither set contains its own site
+PASS: theorem-1-spacing2-contrast spacing 2 is not disjoint-support: N(0) ∩ N(2e1) = {e1}
+table: product_half 00=1/4 01=1/4 10=1/4 11=1/4
+table: product_third 00=1/9 01=2/9 10=2/9 11=4/9
+PASS: theorem-2-same-function-of-6-tuples the product is the same function of the two 6-tuples at either occupancy tag
+PASS: theorem-2-content-not-occurrence occupancy of x or y is not a coordinate of either neighbor 6-tuple
+PASS: theorem-3-histories-share-law H_form and H_empty share the product law and differ in occupancy
+PASS: theorem-3-axiom-compatibility both histories are typed as compatible with conditional Admissibility and when-present Record
+PASS: theorem-4-compiler-requires-h-form a bit compiler that needs records at those sites requires H_form
+PASS: theorem-4-axioms-do-not-select the quoted axiom sentences do not select H_form over H_empty
+PASS: theorem-5-scoped-negatives the note refuses a no-compiler claim and does not edit an axiom sentence
+PASS: mutation-product-implies-formed-fails-on-h-empty the predicate product-law-implies-both-formed fails on H_empty and holds on H_form
+PASS: mutation-always-disjoint-fails an always-disjoint predicate is true on (0,2e1) while neighbors() is not
+PASS: mutation-moore-fails-distance2 replacing neighbors by the 26-site Moore neighborhood fails blanket distance-2 origin exclusion
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: named sites 0, 2e1, 3e1, 6e1 and the four product atoms are recomputed by integer listing
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: one-site laws and occupancy marks at 3e1 and 6e1 are site-local, not a composite arena
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: nearest-neighbor 6-tuples and occupancy tags are checked; no spectral mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only disjointness, occupancy-independence of the product, and H_form versus H_empty are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide no-go against compilers or formation rules is claimed
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py
+++ b/scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Exact cubic-lattice checks: a product law does not force occupancy.
+
+Spacing-3 disjoint 6-tuples, product of one-site Bernoulli laws as a
+function of those tuples, and histories H_form / H_empty sharing the law.
+Identity gates call neighbors(x) and product_law. A predicate
+"product law implies both sites formed" fails on H_empty. No cache is
+written.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import product as cartesian
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "PRODUCT_LAW_DOES_NOT_FORCE_FORMATION_AT_AUXILIARY_SITES_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/PRODUCT_LAW_DOES_NOT_FORCE_FORMATION_AT_AUXILIARY_SITES_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Joint = dict[tuple[int, int], Fraction]
+Occupancy = str
+
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN_SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+BITS = (0, 1)
+FORMED = "formed"
+UNFORMED = "unformed"
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def scale(coefficient: int, vector: Point) -> Point:
+    return (coefficient * vector[0], coefficient * vector[1], coefficient * vector[2])
+
+
+def graph_distance(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def neighbors(site: Point) -> frozenset[Point]:
+    """Identity-gate function: the six nearest neighbors of a cubic site."""
+    return frozenset(add(site, shift) for shift in NN_SHIFTS)
+
+
+def moore_neighbors(site: Point) -> frozenset[Point]:
+    """26-site Chebyshev-1 neighborhood; mutation of neighbors()."""
+    offsets = [
+        (i, j, k)
+        for i, j, k in cartesian((-1, 0, 1), repeat=3)
+        if (i, j, k) != (0, 0, 0)
+    ]
+    return frozenset(add(site, offset) for offset in offsets)
+
+
+def disjoint_supports(sites: Iterable[Point]) -> bool:
+    """Pairwise-empty nearest-neighbor supports, via neighbors()."""
+    listed = tuple(sites)
+    neighborhoods = [neighbors(site) for site in listed]
+    for index, left in enumerate(neighborhoods):
+        for right in neighborhoods[index + 1 :]:
+            if left & right:
+                return False
+    return True
+
+
+def always_disjoint(_sites: Iterable[Point]) -> bool:
+    """Mutation: declare every pair of neighbor supports disjoint."""
+    return True
+
+
+def one_site_law(margin: Fraction, eta: tuple[int, ...]) -> dict[int, Fraction]:
+    """Bernoulli law on {0,1}. Domain is the 6-tuple; value may ignore it."""
+    if len(eta) != 6:
+        raise ValueError("one-site condition must be a 6-tuple")
+    if margin < 0 or margin > 1:
+        raise ValueError("margin must lie in [0, 1]")
+    return {0: margin, 1: Fraction(1) - margin}
+
+
+def product_law(
+    left_margin: Fraction,
+    right_margin: Fraction,
+    eta_left: tuple[int, ...],
+    eta_right: tuple[int, ...],
+) -> Joint:
+    """Identity-gate function: product of two one-site laws on their 6-tuples."""
+    left = one_site_law(left_margin, eta_left)
+    right = one_site_law(right_margin, eta_right)
+    return {(alpha, beta): left[alpha] * right[beta] for alpha in BITS for beta in BITS}
+
+
+def is_product(joint: Mapping[tuple[int, int], Fraction]) -> bool:
+    px = {alpha: joint[(alpha, 0)] + joint[(alpha, 1)] for alpha in BITS}
+    py = {beta: joint[(0, beta)] + joint[(1, beta)] for beta in BITS}
+    return all(joint[(alpha, beta)] == px[alpha] * py[beta] for alpha in BITS for beta in BITS)
+
+
+@dataclass(frozen=True)
+class History:
+    """A history is a pair (law, occupancy) at the two auxiliary sites."""
+
+    law: Joint
+    occupancy_x: Occupancy
+    occupancy_y: Occupancy
+
+    def both_formed(self) -> bool:
+        return self.occupancy_x == FORMED and self.occupancy_y == FORMED
+
+    def neither_formed(self) -> bool:
+        return self.occupancy_x == UNFORMED and self.occupancy_y == UNFORMED
+
+
+def product_implies_both_formed(history: History) -> bool:
+    """Hostile predicate: carrying a product law forces both sites formed."""
+    if not is_product(history.law):
+        return True
+    return history.both_formed()
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current Lattice, Admissibility, and Record "
+        "wording are source-bound; no observational or fitted inputs"
+    )
+    print(
+        "integrity_reads: this runner, its paired note, and the axiom memo; "
+        "no other repository scientific inputs"
+    )
+    print(
+        "construction: spacing-3 disjoint NN 6-tuples; product law as a "
+        "function of those tuples; H_form versus H_empty"
+    )
+    print(
+        "negative_scope: product law does not select occupancy at 3e1 and 6e1; "
+        "not a no-go against all compilers"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/PRODUCT_LAW_DOES_NOT_FORCE_FORMATION_AT_AUXILIARY_SITES_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    canonical_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_note = "does not supply the formation site, probability, or rate"
+    conditional_note = "conditional on formation"
+    record_when_present = "When present, a record locks exactly one admissible local possibility."
+
+    checks.check(
+        "source-lattice",
+        "the current Lattice nearest-neighbor sentence is pinned in the axiom memo and the note",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "the current distribution sentence is pinned in the axiom memo and the note",
+        canonical_sentence in normalize(axiom) and canonical_sentence in note,
+    )
+    checks.check(
+        "source-formation-reading-note",
+        "the Admissibility reading note on formation site/rate is pinned",
+        formation_note in normalize(axiom)
+        and formation_note in note
+        and conditional_note in normalize(axiom)
+        and conditional_note in note,
+    )
+    checks.check(
+        "source-record-when-present",
+        "the Record lock sentence When present is pinned in the axiom memo and the note",
+        record_when_present in normalize(axiom) and record_when_present in note,
+    )
+
+    two_e1 = scale(2, E1)
+    three_e1 = scale(3, E1)
+    six_e1 = scale(6, E1)
+    executed = (ORIGIN, two_e1, three_e1, six_e1)
+
+    expected_three = frozenset(
+        {two_e1, (4, 0, 0), (3, 1, 0), (3, -1, 0), (3, 0, 1), (3, 0, -1)}
+    )
+    expected_six = frozenset(
+        {(5, 0, 0), (7, 0, 0), (6, 1, 0), (6, -1, 0), (6, 0, 1), (6, 0, -1)}
+    )
+
+    checks.check(
+        "neighbors-type",
+        "neighbors(x) returns a frozenset of integer 3-tuples of size 6",
+        all(
+            isinstance(neighbors(site), frozenset)
+            and all(isinstance(point, tuple) and len(point) == 3 for point in neighbors(site))
+            and all(isinstance(coord, int) for point in neighbors(site) for coord in point)
+            and len(neighbors(site)) == 6
+            for site in executed
+        ),
+        residual=[(site, len(neighbors(site))) for site in executed],
+    )
+    checks.check(
+        "witness-N3e1",
+        "N(3e1) matches the listing, excludes the origin, and excludes itself",
+        neighbors(three_e1) == expected_three
+        and ORIGIN not in neighbors(three_e1)
+        and three_e1 not in neighbors(three_e1),
+        residual=sorted(neighbors(three_e1)),
+    )
+    checks.check(
+        "witness-N6e1",
+        "N(6e1) matches the listing, excludes the origin, and excludes itself",
+        neighbors(six_e1) == expected_six
+        and ORIGIN not in neighbors(six_e1)
+        and six_e1 not in neighbors(six_e1),
+        residual=sorted(neighbors(six_e1)),
+    )
+    checks.check(
+        "distances",
+        "d(0,3e1)=3, d(0,6e1)=6, d(3e1,6e1)=3",
+        graph_distance(ORIGIN, three_e1) == 3
+        and graph_distance(ORIGIN, six_e1) == 6
+        and graph_distance(three_e1, six_e1) == 3,
+    )
+
+    checks.check(
+        "theorem-1-disjoint-supports",
+        "N(3e1) ∩ N(6e1) is empty; neither set contains its own site",
+        disjoint_supports((three_e1, six_e1))
+        and neighbors(three_e1).isdisjoint(neighbors(six_e1))
+        and three_e1 not in neighbors(three_e1)
+        and six_e1 not in neighbors(six_e1)
+        and ORIGIN not in neighbors(three_e1)
+        and ORIGIN not in neighbors(six_e1),
+        residual=sorted(neighbors(three_e1) & neighbors(six_e1)),
+    )
+    checks.check(
+        "theorem-1-spacing2-contrast",
+        "spacing 2 is not disjoint-support: N(0) ∩ N(2e1) = {e1}",
+        not disjoint_supports((ORIGIN, two_e1))
+        and (neighbors(ORIGIN) & neighbors(two_e1)) == frozenset({E1}),
+        residual=sorted(neighbors(ORIGIN) & neighbors(two_e1)),
+    )
+
+    dummy_eta = (0, 0, 0, 0, 0, 0)
+    other_eta = (1, 0, 1, 0, 1, 0)
+    half = Fraction(1, 2)
+    third = Fraction(1, 3)
+    prod_form = product_law(half, half, dummy_eta, dummy_eta)
+    prod_empty = product_law(half, half, dummy_eta, dummy_eta)
+    prod_other_eta = product_law(half, half, other_eta, other_eta)
+    prod_third = product_law(third, third, dummy_eta, dummy_eta)
+    print(
+        "table: product_half "
+        f"00={prod_form[(0, 0)]} 01={prod_form[(0, 1)]} "
+        f"10={prod_form[(1, 0)]} 11={prod_form[(1, 1)]}"
+    )
+    print(
+        "table: product_third "
+        f"00={prod_third[(0, 0)]} 01={prod_third[(0, 1)]} "
+        f"10={prod_third[(1, 0)]} 11={prod_third[(1, 1)]}"
+    )
+
+    checks.check(
+        "theorem-2-same-function-of-6-tuples",
+        "the product is the same function of the two 6-tuples at either occupancy tag",
+        prod_form == prod_empty
+        and prod_form == prod_other_eta
+        and is_product(prod_form)
+        and prod_form[(0, 0)] == Fraction(1, 4)
+        and prod_third[(0, 0)] == Fraction(1, 9)
+        and prod_third[(0, 0)] != Fraction(1, 4)
+        and three_e1 not in neighbors(three_e1)
+        and six_e1 not in neighbors(six_e1)
+        and disjoint_supports((three_e1, six_e1)),
+        residual=(prod_form, prod_third),
+    )
+    checks.check(
+        "theorem-2-content-not-occurrence",
+        "occupancy of x or y is not a coordinate of either neighbor 6-tuple",
+        three_e1 not in neighbors(three_e1)
+        and six_e1 not in neighbors(six_e1)
+        and three_e1 not in neighbors(six_e1)
+        and six_e1 not in neighbors(three_e1)
+        and "Content law is not occurrence" in note,
+    )
+
+    h_form = History(prod_form, FORMED, FORMED)
+    h_empty = History(prod_empty, UNFORMED, UNFORMED)
+    h_third_empty = History(prod_third, UNFORMED, UNFORMED)
+
+    checks.check(
+        "theorem-3-histories-share-law",
+        "H_form and H_empty share the product law and differ in occupancy",
+        h_form.law == h_empty.law
+        and h_form.both_formed()
+        and h_empty.neither_formed()
+        and not h_empty.both_formed()
+        and h_form.occupancy_x != h_empty.occupancy_x
+        and h_form.occupancy_y != h_empty.occupancy_y
+        and is_product(h_form.law)
+        and is_product(h_empty.law),
+    )
+    checks.check(
+        "theorem-3-axiom-compatibility",
+        "both histories are typed as compatible with conditional Admissibility and when-present Record",
+        formation_note in note
+        and conditional_note in note
+        and record_when_present in note
+        and "Both are compatible" in note
+        and h_form.law == h_empty.law,
+    )
+
+    checks.check(
+        "theorem-4-compiler-requires-h-form",
+        "a bit compiler that needs records at those sites requires H_form",
+        h_form.both_formed()
+        and not h_empty.both_formed()
+        and "requires `H_form`" in note
+        and "do not select `H_form` over `H_empty`" in note,
+    )
+    checks.check(
+        "theorem-4-axioms-do-not-select",
+        "the quoted axiom sentences do not select H_form over H_empty",
+        formation_note in note
+        and record_when_present in note
+        and h_form.law == h_empty.law
+        and h_empty.neither_formed(),
+    )
+    checks.check(
+        "theorem-5-scoped-negatives",
+        "the note refuses a no-compiler claim and does not edit an axiom sentence",
+        "does not claim that no compiler exists" in note.lower()
+        and "no compiler exists" in note
+        and "No axiom sentence is edited here" in note
+        and "formation-site selector remains extra" in note
+        and "we adopt" not in note.lower(),
+    )
+
+    checks.check(
+        "mutation-product-implies-formed-fails-on-h-empty",
+        "the predicate product-law-implies-both-formed fails on H_empty and holds on H_form",
+        is_product(h_empty.law)
+        and h_empty.neither_formed()
+        and product_implies_both_formed(h_empty) is False
+        and product_implies_both_formed(h_form) is True
+        and product_implies_both_formed(h_third_empty) is False,
+        residual=(product_implies_both_formed(h_empty), h_empty.neither_formed()),
+    )
+    checks.check(
+        "mutation-always-disjoint-fails",
+        "an always-disjoint predicate is true on (0,2e1) while neighbors() is not",
+        always_disjoint((ORIGIN, two_e1))
+        and not disjoint_supports((ORIGIN, two_e1))
+        and always_disjoint((ORIGIN, two_e1)) is not disjoint_supports((ORIGIN, two_e1)),
+    )
+
+    diagonal = add(E1, E2)
+    checks.check(
+        "mutation-moore-fails-distance2",
+        "replacing neighbors by the 26-site Moore neighborhood fails blanket distance-2 origin exclusion",
+        len(moore_neighbors(ORIGIN)) == 26
+        and ORIGIN not in neighbors(two_e1)
+        and ORIGIN not in neighbors(diagonal)
+        and ORIGIN in moore_neighbors(diagonal),
+        residual=(ORIGIN in moore_neighbors(two_e1), ORIGIN in moore_neighbors(diagonal)),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                'hypothetical_axiom_status: "no edit"',
+                "trace_class: negative_route_pruning",
+                "target_claim_id: formation_at_auxiliary_compiler_sites",
+                'target_blocker_text: "derive record formation at graph-separated auxiliary sites from a product of one-site laws"',
+                "reachability_to_target: prunes",
+                'next_trace_action: "A bit compiler that needs records at those sites still requires a formation rule; the product law does not select H_form over H_empty. Do not adopt axiom text."',
+                "N(3e1) ∩ N(6e1)",
+                "H_form",
+                "H_empty",
+                "authors no audit verdict",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "L_phys" not in note
+        and "Codex" not in note
+        and "Block " not in note
+        and "toe-lphys" not in note,
+    )
+
+    n5_lines = (
+        "per_element: named sites 0, 2e1, 3e1, 6e1 and the four product atoms are recomputed by integer listing",
+        "per_site: one-site laws and occupancy marks at 3e1 and 6e1 are site-local, not a composite arena",
+        "per_mode: nearest-neighbor 6-tuples and occupancy tags are checked; no spectral mode is claimed",
+        "per_block: only disjointness, occupancy-independence of the product, and H_form versus H_empty are executed",
+        "lattice_wide: checked and not executed — no lattice-wide no-go against compilers or formation rules is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On Z^3, sites 3e1 and 6e1 have disjoint NN 6-tuples. A product of one-site laws is the same function of those tuples whether the sites are occupied or not. Histories H_form and H_empty share that law. A bit compiler needs H_form; the axioms do not select it. No claim that no compiler exists. No axiom edit. L_phys not adopted.

## What this means for the TOE

Independence of auxiliary sites (the Born-compiler geometry) is not occurrence. Fair independent *laws* can sit on empty sites. Quantum mechanics still needs a formation rule before those sites become record bits.

## Verification

```bash
python3 scripts/product_law_does_not_force_formation_at_auxiliary_sites_2026_08_13.py
# TOTAL: PASS=27 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required.

Campaign: `toe-lphys-20260812`.