### PR TITLE
[physics-loop] toe-lphys nonaffine: bounded_theorem / bounded-support

### DIFF
--- a/docs/NONAFFINE_PURITY_WEIGHTED_KERNEL_IS_NOT_BARYCENTER_EVALUATION_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/NONAFFINE_PURITY_WEIGHTED_KERNEL_IS_NOT_BARYCENTER_EVALUATION_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,311 @@
+---
+claim_id: nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On finite-support measures on the density body, the purity-weighted kernel K(μ,E)=Tr(ρ_μ^2 E)/Tr(ρ_μ^2) is a well-defined menu-independent positive normalized kernel. It agrees with barycenter evaluation w_μ(E)=Tr(ρ_μ E) at I/2 and disagrees at diag(3/5,2/5) by 9/26 versus 3/10; it is not affine in μ. August 9 uniqueness of Born is among affine or similarly restricted kernels. The exhibit does not say Born is false, does not say that no uniqueness theorem exists in a larger class, and is not an axiom edit."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+  - admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10
+runner: scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py
+---
+
+# A Live Non-Affine Menu-Independent Kernel Is Not Barycenter Evaluation
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite-support kernels on the qubit density body; one
+purity-weighted exhibit compared with barycenter evaluation on `E0=(1/2)P(z)`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py`](../scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py)
+
+## Result Up Front
+
+Let `D` be the `2x2` density body. For a finite-support probability
+`μ=Σ_k p_k δ_{ρ_k}` on `D`, write `ρ_μ=Σ_k p_k ρ_k` for the barycenter and
+
+`w_μ(E)=Tr(ρ_μ E)`
+
+for barycenter evaluation. The purity-weighted kernel
+
+`K(μ,E) := Tr(ρ_μ^2 E) / Tr(ρ_μ^2)`
+
+is well-defined on `D`, depends on `μ` only through `ρ_μ`, and is therefore
+menu-independent. It satisfies `K(μ,I)=1`, `K(μ,0)=0`, and `K(μ,E)≥0` for
+every positive-semidefinite `E`.
+
+At `ρ=I/2` one has `Tr(ρ^2)=1/2` and `Tr(ρ^2 E0)=1/8`, so
+`K=1/4=w(E0)`. At `ρ=diag(3/5,2/5)` one has `w(E0)=3/10` while
+`Tr(ρ^2)=13/25`, `Tr(ρ^2 E0)=9/50`, and `K=(9/50)/(13/25)=9/26`. The
+rationals are distinct because `9/26=45/130` and `3/10=39/130`. The same
+biased law is the two-point mixture
+`μ=(3/5)δ_{P(z)}+(2/5)δ_{P(-z)}`; the affine mix of `K` at the pure atoms
+is `3/10`, not the barycenter value `9/26`, so `K` is not affine in `μ`.
+
+The August 9 frame-lift
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+unique-ifies a menu-independent low-arity grade as `Tr(ρ E)` for one density
+`ρ`. That is uniqueness among affine, or similarly restricted, kernels. The
+present `K` is a concrete non-affine menu-independent positive normalized
+kernel that is not `Tr(ρE)` in the barycenter state. This exhibit does not
+say Born is false. This exhibit does not say that no uniqueness theorem
+exists in a larger class.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) remains a
+quoted premise and is not edited:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+## Exact Objects And The Construction
+
+Write `P(n)=(I+n·σ)/2` for a unit Bloch vector `n`. The density body is
+
+`D={ρ∈M_2(C): ρ=ρ^†, ρ≥0, Tr(ρ)=1}`.
+
+A finite-support measure on `D` is `μ=Σ_k p_k δ_{ρ_k}` with `p_k>0`,
+`Σ_k p_k=1`, and each `ρ_k∈D`. The barycenter `ρ_μ=Σ_k p_k ρ_k` stays in
+`D` by convexity. Barycenter evaluation is `w_μ(E)=Tr(ρ_μ E)`.
+
+The purity-weighted kernel is the ratio
+
+`K(μ,E) := Tr(ρ_μ^2 E) / Tr(ρ_μ^2)`.
+
+On `D` one has `ρ≠0`, so `Tr(ρ^2)=‖ρ‖_HS^2>0` and the denominator never
+vanishes. For a qubit, `Tr(ρ^2)` lies in `[1/2,1]`.
+
+The shared effect is the August 10 object
+
+`E0=(1/2)P(z)=diag(1/2,0)`
+
+from
+[`ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md`](ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md).
+That parent records two hostile ternary menus sharing only `E0` and an
+atomic restriction witness with
+
+`K_ν(E0|M_A)=25/142`, `K_ν(E0|M_B)=2/11`.
+
+Restriction is a function of the menu. It is used here only as a hostile
+control: at `ρ=I/2` one has `K=1/4`, and `25/142≠1/4`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Exhibit one menu-independent positive normalized kernel on
+`(μ,E)` that is not barycenter evaluation, and scope August 9 uniqueness of
+Born to affine or similarly restricted kernels.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| well-definedness, endpoints, positivity, menu-independence | Theorem 1 | proved from `Tr(ρ^2)>0` and the pairing |
+| agreement with `w` at `I/2` | Theorem 2 | `K=1/4=w(E0)` |
+| disagreement at `diag(3/5,2/5)` | Theorem 3 | `9/26≠3/10` |
+| failure of affinity in `μ` | Theorem 4 | atom mix `3/10` versus barycenter `9/26` |
+| scope August 9 uniqueness | Theorem 5 | affine or similarly restricted class only |
+| declare Born false | non-claim | not attempted |
+| deny every larger uniqueness theorem | non-claim | not attempted |
+| edit an axiom sentence | non-claim | not attempted |
+
+## Theorem 1 — Well-Defined Menu-Independent Positive Normalized Kernel
+
+**Claim.** `K` is well-defined on `D`, depends on `μ` only through `ρ_μ`,
+satisfies `K(μ,I)=1` and `K(μ,0)=0`, and obeys `K(μ,E)≥0` whenever `E` is
+positive semidefinite.
+
+**Proof.** For `ρ∈D` the Hilbert--Schmidt identity `Tr(ρ^2)=‖ρ‖_HS^2` and
+the trace-one constraint give `ρ≠0`, hence `Tr(ρ^2)>0`. The ratio is
+therefore defined. It is a function of the pair `(ρ_μ,E)` and has no menu
+argument, so the same effect receives the same value in every menu: `K` is
+menu-independent.
+
+Linearity of the pairing in the second slot gives
+
+`K(μ,I)=Tr(ρ_μ^2)/Tr(ρ_μ^2)=1`, `K(μ,0)=0`.
+
+If `E≥0`, then `ρ_μ^2≥0` and `Tr(ρ_μ^2 E)≥0`, so `K(μ,E)≥0`.
+
+## Theorem 2 — Agreement With Barycenter Evaluation At The Mixed Point
+
+**Claim.** At `ρ=I/2` one has `Tr(ρ^2)=1/2`, `Tr(ρ^2 E0)=1/8`, and
+`K=1/4=w(E0)`.
+
+**Proof.** Direct matrix multiplication yields `ρ^2=I/4`, so
+`Tr(ρ^2)=Tr(I)/4=1/2`. Then
+
+`Tr(ρ^2 E0)=Tr((I/4)E0)=(1/4)Tr(E0)=(1/4)(1/2)=1/8`,
+
+and `K=(1/8)/(1/2)=1/4`. Barycenter evaluation is
+
+`w(E0)=Tr((I/2)E0)=1/4`.
+
+The two kernels agree at this mixed point. They still disagree with the
+August 10 restriction control: `25/142≠1/4`.
+
+## Theorem 3 — Disagreement At `ρ=diag(3/5,2/5)`
+
+**Claim.** At `ρ=diag(3/5,2/5)` one has `w(E0)=3/10` and `K=9/26`. These
+are unequal because `9/26=45/130` and `3/10=39/130`.
+
+**Proof.** Pairing against `E0=diag(1/2,0)` gives
+
+`w(E0)=Tr(ρ E0)=(3/5)(1/2)=3/10`.
+
+The square is `ρ^2=diag(9/25,4/25)`, so `Tr(ρ^2)=13/25` and
+
+`Tr(ρ^2 E0)=(9/25)(1/2)=9/50`.
+
+The purity-weighted value is the ratio
+
+`K=(9/50)/(13/25)=(9/50)·(25/13)=9/26`.
+
+Clearing a common denominator,
+
+`9/26=45/130`, `3/10=39/130`,
+
+and `45≠39`. Thus `K` is not `Tr(ρE)` at this state.
+
+## Theorem 4 — `K` Is Not Affine In `μ`
+
+**Claim.** For `μ=(3/5)δ_{P(z)}+(2/5)δ_{P(-z)}` the barycenter is
+`ρ_μ=diag(3/5,2/5)`. The affine mix of `K` at the atoms is `3/10`, while
+`K` at the barycenter is `9/26`.
+
+**Proof.** The atoms are pure, so `ρ^2=ρ` and `Tr(ρ^2)=1`. Therefore
+
+`K(δ_{P(z)},E0)=Tr(P(z) E0)=1/2`,
+`K(δ_{P(-z)},E0)=Tr(P(-z) E0)=0`.
+
+The affine mix of those values is
+
+`(3/5)·(1/2)+(2/5)·0=3/10`.
+
+Theorem 3 already computed `K(μ,E0)=9/26` at the barycenter of the same
+`μ`. Affinity in `μ` would force those two numbers to agree. They do not.
+
+## Theorem 5 — Scoped Uniqueness (N5)
+
+**Claim.** August 9 uniqueness of Born is among affine, or similarly
+restricted, kernels. The present `K` is a concrete non-affine
+menu-independent positive normalized kernel that is not `Tr(ρE)`. This
+exhibit does not say Born is false. This exhibit does not say that no
+uniqueness theorem exists in a larger class.
+
+**Proof.** The August 9 theorem states that a menu-independent grading on
+the scaled domain `S`, normalized on every binary and ternary nonzero
+resolution of `I`, has a unique density-matrix trace form
+`w(E)=Tr(ρ E)` on `S`. That hypothesis class is a restriction: the grade is
+a function of the effect alone, the eligible menus are the low-arity scaled
+family, and the representing state is unique. Equivalently, once a state is
+identified with a barycenter `ρ_μ`, uniqueness of `w_μ(E)=Tr(ρ_μ E)` is a
+statement about kernels affine in the Bloch coordinates of `ρ_μ`, or about
+kernels similarly restricted to a single trace pairing against that
+barycenter.
+
+The kernel `K` of Theorems 1--4 lies outside that class as a function of
+`μ`. It is menu-independent, positive on PSD effects, and normalized at
+`0` and `I`, yet Theorem 4 shows it is not affine in `μ`, and Theorem 3
+shows it is not barycenter evaluation. That is the executed exhibit.
+
+**Scope.** The negative is only that *this* live kernel is not barycenter
+evaluation and is not affine in `μ`, so uniqueness of Born cannot be quoted
+as if it applied to every menu-independent positive normalized kernel of
+`(μ,E)`. The negative does not say the Born trace form is false: at each
+fixed `μ` the map `E↦K(μ,E)` is still the pairing `Tr(σ_μ E)` against the
+density `σ_μ=ρ_μ^2/Tr(ρ_μ^2)`. The negative does not say that no uniqueness
+theorem exists among a larger class than the affine or similarly restricted
+kernels. No such larger theorem is claimed or denied here.
+
+**Steelman.** Because `K(μ,·)` still has a trace form, one might call `K`
+Born and conclude that the exhibit is empty. That reading changes the
+variable. The comparison target is barycenter evaluation `Tr(ρ_μ E)` as a
+kernel of the preparation measure. Theorems 3 and 4 separate `K` from that
+target. They do not attack the existence of some density against which `K`
+pairs.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom sentence;
+- say Born is false;
+- say that no uniqueness theorem exists in a larger class;
+- identify `M_2(C)` with the density body `D`;
+- register a physical menu or a Record readout;
+- exclude other non-affine kernels, or install `K` as a physical law.
+
+Restriction remains a hostile control (`25/142≠1/4` at the mixed point). It
+is not this kernel.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The purity-weighted kernel is an exact finite-matrix exhibit: well-defined, menu-independent, positive, and normalized, with K=9/26 versus barycenter evaluation 3/10 at diag(3/5,2/5). Uniqueness of Born is scoped to affine or similarly restricted kernels. The exhibit does not say Born is false."
+trace_class: negative_route_pruning
+target_claim_id: nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation
+target_blocker_text: "exhibit a live non-affine menu-independent kernel that is not barycenter evaluation"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Keep uniqueness claims inside the affine or similarly restricted class. Do not identify every menu-independent kernel with Tr(rho_mu E)."
+conditional_surface_status: "exact for the 9/26 versus 3/10 split and the affine-mix gap; physical registration and larger uniqueness theorems remain open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Admissibility distribution sentence | premise | quoted; no edit |
+| August 9 frame-lift uniqueness | scoped parent | uniqueness among restricted grades |
+| August 10 `E0` and restriction `25/142` | hostile control | recomputed from traces; not this kernel |
+| `K=Tr(ρ^2 E)/Tr(ρ^2)` and the `9/26` versus `3/10` split | Theorems 1--4 | computed here |
+| physical menu registration / Record identification | residual | open |
+| observed frequencies or fitted kernels | none | not used |
+
+The exact advance is a finite-matrix exhibit. Independent audit is required.
+This note authors no audit verdict.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | August 10 leaves barycenter/evaluation live after restriction fails, and August 9 unique-ifies a menu-independent low-arity grade. This note exhibits a live non-affine kernel that is not that barycenter evaluation. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` for `9/26`, `purity-weighted`, and `Tr(ρ^2 E)`. No landed purity-weighted versus barycenter-evaluation split appears on that commit. |
+| V3 | Independently checkable? | Yes. The runner recomputes `Tr(ρ^2)`, `Tr(ρ^2 E0)`, `K`, `w`, and the restriction control `25/142` by exact `Fraction` arithmetic. Identity gates call `purity_kernel`. |
+| V4 | More than a restatement? | Yes. `9/26≠3/10` and the atom-mix gap are not restatements of August 9 uniqueness or of August 10 restriction. |
+| V5 | One-step relabel? | No. Quoting “menu-independent grade” does not by itself produce the purity-weighted ratio or the `45/130` versus `39/130` comparison. |
+
+## No-Go Discipline Gate (Theorem 5)
+
+The negative claims are restricted to: this kernel is not barycenter
+evaluation; this kernel is not affine in `μ`; August 9 uniqueness is not a
+license to identify every menu-independent kernel with `Tr(ρ_μ E)`. The gate
+does not ship “Born is false” or “no uniqueness theorem exists in a larger
+class.”
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | `E0` at `I/2` and at `diag(3/5,2/5)`, with values `1/4`, `9/26`, `3/10`, and the control `25/142` | no classification of every map `(μ,E)→R` |
+| per site | one `M_2(C)` density-body site | no composite or intervention theorem |
+| per mode | the diagonal family `P(z)`, `P(-z)`, `I/2` | no spectral-mode exhaustion |
+| per block | Theorem 5 only scopes August 9 uniqueness to affine or similarly restricted kernels | no denial of every larger uniqueness theorem |
+| lattice-wide | checked and not executed | no lattice-wide Born no-go |
+
+**Gate disposition.** PASS for the `9/26` versus `3/10` exhibit and the
+Theorem 5 scope. FAIL / DO NOT SHIP for “Born is false” or “no uniqueness
+theorem exists in a larger class.”
+
+## Primary Runner
+
+[`scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py`](../scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py)
+recomputes `Tr(ρ^2)`, `Tr(ρ^2 E0)`, `K`, barycenter evaluation, and the
+restriction control `25/142` in exact `Fraction` arithmetic. Identity gates
+call `purity_kernel(rho, E)`, equivalently `K(rho, E)`. Replacing `K` by
+`Tr(ρE)` must fail `9/26` versus `3/10`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13105,6 +13105,10 @@
   "noether_source_current_classification_bounded_note_2026-07-08": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "ae792f44891f",
+   "out_degree": 3
   },
   "nonlabel_grown_basin_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.txt
+++ b/logs/runner-cache/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py
+runner_sha256: 21e0f039eae6f87a0bc2cd2c5bb81ba524d49e71b555b9841f7f5863b62614f8
+input_fingerprint_sha256: e1fa68c8fd52738752421c7f31299e56375b59985877bd9749e725807892293f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom wording and the August 10 type-separation note are source-bound; no observational or fitted inputs
+integrity_reads: this runner, its paired note, the axiom memo, and the August 10 parent; no cache is written
+kernel_formula: identity gates call purity_kernel(rho, E); born_kernel and restriction are hostile controls
+negative_scope: this kernel is not barycenter evaluation and is not affine in mu; Born is not declared false
+PASS: audit-input-paths declared audit inputs exist and match the note, August 10 note, and axiom memo
+PASS: source-admissibility the current distribution sentence is pinned in the axiom memo and the note
+PASS: source-aug10 August 10 supplies E0, the 25/142 restriction control, and menu-independence
+PASS: source-aug09-citation the note cites the August 9 frame-lift uniqueness parent
+PASS: theorem-1-well-defined Tr(rho^2)>0 on mixed, biased, and pure states; K(I)=1 and K(0)=0
+PASS: theorem-1-positive K is nonnegative on the PSD effects E0, I, P(z), and P(-z)
+PASS: theorem-1-menu-independent K depends on rho only, while restriction of E0 splits as 25/142 versus 2/11
+PASS: theorem-2-mixed at I/2, Tr(rho^2)=1/2, Tr(rho^2 E0)=1/8, and K=1/4=w(E0)
+PASS: theorem-3-intermediates at diag(3/5,2/5), Tr(rho^2)=13/25 and Tr(rho^2 E0)=9/50
+PASS: theorem-3-purity purity_kernel at the biased state is (9/50)/(13/25)=9/26
+PASS: theorem-3-born barycenter evaluation at the biased state is Tr(rho E0)=3/10
+PASS: theorem-3-disagree 9/26=45/130 and 3/10=39/130, so K is not Tr(rho E)
+PASS: theorem-4-atoms pure atoms give K(P(z),E0)=1/2 and K(P(-z),E0)=0
+PASS: theorem-4-not-affine affine mix of the atoms is 3/10, not the barycenter value 9/26
+PASS: restriction-hostile restriction of E0 on M_A recomputes as 25/142, which is not K(I/2,E0)=1/4
+PASS: mutation-born-fails replacing K by Tr(rho E) yields 3/10, not 9/26
+PASS: theorem-5-scope Theorem 5 scopes August 9 uniqueness and refuses the two banned overclaims
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: E0 at I/2 and diag(3/5,2/5) with values 1/4, 9/26, 3/10, and control 25/142
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: the exhibit is one M_2(C) density-body site; no composite carrier is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: the diagonal family P(z), P(-z), I/2 is checked; no spectral-mode exhaustion
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: Theorem 5 only scopes August 9 uniqueness to affine or similarly restricted kernels
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide Born no-go or uniqueness denial
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py
+++ b/scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Exact checks: purity-weighted kernel is not barycenter evaluation.
+
+Identity gates call purity_kernel(rho, E), equivalently K(rho, E).
+Replacing K by Tr(rho E) must fail 9/26 versus 3/10. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "NONAFFINE_PURITY_WEIGHTED_KERNEL_IS_NOT_BARYCENTER_EVALUATION_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+PARENT_AUG10_PATH = (
+    ROOT
+    / "docs"
+    / "ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/NONAFFINE_PURITY_WEIGHTED_KERNEL_IS_NOT_BARYCENTER_EVALUATION_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class H2:
+    """Real-symmetric 2x2 matrix over Fraction."""
+
+    p: Fraction
+    q: Fraction
+    r: Fraction
+
+    def __add__(self, other: "H2") -> "H2":
+        return H2(self.p + other.p, self.q + other.q, self.r + other.r)
+
+    def scale(self, value: Fraction) -> "H2":
+        return H2(self.p * value, self.q * value, self.r * value)
+
+    def mul(self, other: "H2") -> "H2":
+        return H2(
+            self.p * other.p + self.q * other.q,
+            self.p * other.q + self.q * other.r,
+            self.q * other.q + self.r * other.r,
+        )
+
+    def trace(self) -> Fraction:
+        return self.p + self.r
+
+    def pairing(self, other: "H2") -> Fraction:
+        return self.p * other.p + (self.q * other.q) * 2 + self.r * other.r
+
+
+ZERO = H2(Fraction(0), Fraction(0), Fraction(0))
+I2 = H2(Fraction(1), Fraction(0), Fraction(1))
+PZ = H2(Fraction(1), Fraction(0), Fraction(0))
+PMZ = H2(Fraction(0), Fraction(0), Fraction(1))
+MIXED = I2.scale(Fraction(1, 2))
+E0 = PZ.scale(Fraction(1, 2))
+BIASED = H2(Fraction(3, 5), Fraction(0), Fraction(2, 5))
+
+
+def purity_kernel(rho: H2, effect: H2) -> Fraction:
+    """K(rho, E) := Tr(rho^2 E) / Tr(rho^2). Identity gates call this."""
+    rho2 = rho.mul(rho)
+    denom = rho2.trace()
+    if denom == 0:
+        raise ZeroDivisionError("Tr(rho^2) vanished")
+    return rho2.pairing(effect) / denom
+
+
+def K(rho: H2, effect: H2) -> Fraction:
+    return purity_kernel(rho, effect)
+
+
+def born_kernel(rho: H2, effect: H2) -> Fraction:
+    """Hostile replacement: Tr(rho E). Substituting this for K fails 9/26 vs 3/10."""
+    return rho.pairing(effect)
+
+
+def restriction_weight(effect_trace: Fraction, menu_traces: tuple[Fraction, ...]) -> Fraction:
+    numerator = effect_trace * effect_trace
+    denominator = sum((trace * trace) for trace in menu_traces)
+    return numerator / denominator
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    parent_aug10 = PARENT_AUG10_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: axiom wording and the August 10 type-separation "
+        "note are source-bound; no observational or fitted inputs"
+    )
+    print(
+        "integrity_reads: this runner, its paired note, the axiom memo, and "
+        "the August 10 parent; no cache is written"
+    )
+    print(
+        "kernel_formula: identity gates call purity_kernel(rho, E); "
+        "born_kernel and restriction are hostile controls"
+    )
+    print(
+        "negative_scope: this kernel is not barycenter evaluation and is not "
+        "affine in mu; Born is not declared false"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, August 10 note, and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/NONAFFINE_PURITY_WEIGHTED_KERNEL_IS_NOT_BARYCENTER_EVALUATION_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    canonical_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    checks.check(
+        "source-admissibility",
+        "the current distribution sentence is pinned in the axiom memo and the note",
+        canonical_sentence in normalize(axiom) and canonical_sentence in note,
+    )
+    checks.check(
+        "source-aug10",
+        "August 10 supplies E0, the 25/142 restriction control, and menu-independence",
+        all(phrase in parent_aug10 for phrase in ("E_0=(1/2)P(z)", "25/142", "2/11", "menu-independent"))
+        and "25/142" in note
+        and "E0=(1/2)P(z)" in note.replace(" ", ""),
+    )
+    checks.check(
+        "source-aug09-citation",
+        "the note cites the August 9 frame-lift uniqueness parent",
+        "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+        in note
+        and "unique density-matrix trace form" in note,
+    )
+
+    mixed_denom = MIXED.mul(MIXED).trace()
+    biased_denom = BIASED.mul(BIASED).trace()
+    pure_denom = PZ.mul(PZ).trace()
+    checks.check(
+        "theorem-1-well-defined",
+        "Tr(rho^2)>0 on mixed, biased, and pure states; K(I)=1 and K(0)=0",
+        mixed_denom == Fraction(1, 2)
+        and biased_denom == Fraction(13, 25)
+        and pure_denom == Fraction(1)
+        and all(denom > 0 for denom in (mixed_denom, biased_denom, pure_denom))
+        and purity_kernel(MIXED, I2) == 1
+        and purity_kernel(BIASED, I2) == 1
+        and purity_kernel(PZ, I2) == 1
+        and purity_kernel(MIXED, ZERO) == 0
+        and purity_kernel(BIASED, ZERO) == 0
+        and K(BIASED, I2) == 1,
+        residual=(mixed_denom, biased_denom, pure_denom),
+    )
+    checks.check(
+        "theorem-1-positive",
+        "K is nonnegative on the PSD effects E0, I, P(z), and P(-z)",
+        all(
+            purity_kernel(state, effect) >= 0
+            for state in (MIXED, BIASED, PZ, PMZ)
+            for effect in (E0, I2, PZ, PMZ)
+        ),
+    )
+    checks.check(
+        "theorem-1-menu-independent",
+        "K depends on rho only, while restriction of E0 splits as 25/142 versus 2/11",
+        purity_kernel(MIXED, E0) == K(MIXED, E0)
+        and purity_kernel(BIASED, E0) == K(BIASED, E0)
+        and restriction_weight(Fraction(1, 2), (Fraction(1, 2), Fraction(9, 10), Fraction(3, 5)))
+        == Fraction(25, 142)
+        and restriction_weight(Fraction(1, 2), (Fraction(1, 2), Fraction(3, 4), Fraction(3, 4)))
+        == Fraction(2, 11)
+        and Fraction(25, 142) != Fraction(2, 11),
+    )
+
+    mixed_k = purity_kernel(MIXED, E0)
+    mixed_w = born_kernel(MIXED, E0)
+    mixed_rho2 = MIXED.mul(MIXED)
+    checks.check(
+        "theorem-2-mixed",
+        "at I/2, Tr(rho^2)=1/2, Tr(rho^2 E0)=1/8, and K=1/4=w(E0)",
+        mixed_rho2.trace() == Fraction(1, 2)
+        and mixed_rho2.pairing(E0) == Fraction(1, 8)
+        and mixed_k == Fraction(1, 4)
+        and mixed_w == Fraction(1, 4)
+        and mixed_k == mixed_w,
+        residual=(mixed_k, mixed_w),
+    )
+
+    biased_rho2 = BIASED.mul(BIASED)
+    tr_rho2 = biased_rho2.trace()
+    tr_rho2_e0 = biased_rho2.pairing(E0)
+    biased_k = purity_kernel(BIASED, E0)
+    biased_w = born_kernel(BIASED, E0)
+    checks.check(
+        "theorem-3-intermediates",
+        "at diag(3/5,2/5), Tr(rho^2)=13/25 and Tr(rho^2 E0)=9/50",
+        BIASED == H2(Fraction(3, 5), Fraction(0), Fraction(2, 5))
+        and tr_rho2 == Fraction(13, 25)
+        and tr_rho2_e0 == Fraction(9, 50),
+        residual=(tr_rho2, tr_rho2_e0),
+    )
+    checks.check(
+        "theorem-3-purity",
+        "purity_kernel at the biased state is (9/50)/(13/25)=9/26",
+        biased_k == tr_rho2_e0 / tr_rho2
+        and biased_k == Fraction(9, 26)
+        and K(BIASED, E0) == Fraction(9, 26),
+        residual=biased_k,
+    )
+    checks.check(
+        "theorem-3-born",
+        "barycenter evaluation at the biased state is Tr(rho E0)=3/10",
+        biased_w == Fraction(3, 10)
+        and BIASED.pairing(E0) == Fraction(3, 10),
+        residual=biased_w,
+    )
+    checks.check(
+        "theorem-3-disagree",
+        "9/26=45/130 and 3/10=39/130, so K is not Tr(rho E)",
+        Fraction(9, 26) == Fraction(45, 130)
+        and Fraction(3, 10) == Fraction(39, 130)
+        and biased_k == Fraction(45, 130)
+        and biased_w == Fraction(39, 130)
+        and biased_k != biased_w,
+        residual=(biased_k, biased_w),
+    )
+
+    k_plus = purity_kernel(PZ, E0)
+    k_minus = purity_kernel(PMZ, E0)
+    affine_mix = Fraction(3, 5) * k_plus + Fraction(2, 5) * k_minus
+    checks.check(
+        "theorem-4-atoms",
+        "pure atoms give K(P(z),E0)=1/2 and K(P(-z),E0)=0",
+        k_plus == Fraction(1, 2)
+        and k_minus == 0
+        and PZ.mul(PZ) == PZ
+        and PMZ.mul(PMZ) == PMZ,
+        residual=(k_plus, k_minus),
+    )
+    checks.check(
+        "theorem-4-not-affine",
+        "affine mix of the atoms is 3/10, not the barycenter value 9/26",
+        affine_mix == Fraction(3, 10)
+        and purity_kernel(BIASED, E0) == Fraction(9, 26)
+        and affine_mix != purity_kernel(BIASED, E0)
+        and (PZ.scale(Fraction(3, 5)) + PMZ.scale(Fraction(2, 5))) == BIASED,
+        residual=(affine_mix, purity_kernel(BIASED, E0)),
+    )
+
+    cond_a = restriction_weight(
+        E0.trace(), (E0.trace(), Fraction(9, 10), Fraction(3, 5))
+    )
+    checks.check(
+        "restriction-hostile",
+        "restriction of E0 on M_A recomputes as 25/142, which is not K(I/2,E0)=1/4",
+        E0.trace() == Fraction(1, 2)
+        and cond_a == Fraction(25, 142)
+        and purity_kernel(MIXED, E0) == Fraction(1, 4)
+        and cond_a != Fraction(1, 4)
+        and cond_a != purity_kernel(MIXED, E0)
+        and cond_a != purity_kernel(BIASED, E0),
+        residual=cond_a,
+    )
+
+    checks.check(
+        "mutation-born-fails",
+        "replacing K by Tr(rho E) yields 3/10, not 9/26",
+        born_kernel(BIASED, E0) == Fraction(3, 10)
+        and purity_kernel(BIASED, E0) == Fraction(9, 26)
+        and born_kernel(BIASED, E0) != purity_kernel(BIASED, E0)
+        and born_kernel(MIXED, E0) == purity_kernel(MIXED, E0),
+        residual=(born_kernel(BIASED, E0), purity_kernel(BIASED, E0)),
+    )
+
+    checks.check(
+        "theorem-5-scope",
+        "Theorem 5 scopes August 9 uniqueness and refuses the two banned overclaims",
+        "August 9 uniqueness of Born is among affine" in note
+        and "does not say Born is false" in note
+        and "does not say that no uniqueness theorem exists in a larger class" in note
+        and "not `Tr(ρE)`" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                'hypothetical_axiom_status: "no edit"',
+                "menu-independent",
+                "Tr(",
+                "3/10",
+                "9/26",
+                "25/142",
+                "45/130",
+                "39/130",
+                "authors no audit verdict",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "Block " not in note
+        and "toe-lphys" not in note,
+    )
+
+    n5_lines = (
+        "per_element: E0 at I/2 and diag(3/5,2/5) with values 1/4, 9/26, 3/10, and control 25/142",
+        "per_site: the exhibit is one M_2(C) density-body site; no composite carrier is claimed",
+        "per_mode: the diagonal family P(z), P(-z), I/2 is checked; no spectral-mode exhaustion",
+        "per_block: Theorem 5 only scopes August 9 uniqueness to affine or similarly restricted kernels",
+        "lattice_wide: checked and not executed — no lattice-wide Born no-go or uniqueness denial",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The purity-weighted kernel K(μ,E)=Tr(ρ_μ² E)/Tr(ρ_μ²) is menu-independent, positive, and normalized. It agrees with barycenter evaluation at I/2 (K=1/4) and disagrees at diag(3/5,2/5): K=9/26 versus Tr(ρE)=3/10. It is not affine in μ. August 9 uniqueness of Born is among affine kernels. This exhibit does not say Born is false. No axiom edit.

## What this means for the TOE

Quantum mechanics is not forced by “the unique nice kernel.” It is the unique *affine* nice kernel. A live non-affine alternative exists. Selecting Born still needs a reason (affinity, or a physical compiler that produces the barycenter evaluation).

## Verification

```bash
python3 scripts/nonaffine_purity_weighted_kernel_is_not_barycenter_evaluation_2026_08_13.py
# TOTAL: PASS=23 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required.

Campaign: `toe-lphys-20260812`.