### PR TITLE
[physics-loop] toe-lphys ranksplit: bounded_theorem / bounded-support

### DIFF
--- a/docs/INVOLUTION_RANK_SPLIT_SELECTS_TRACELESS_RATIO_AXIOMS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/INVOLUTION_RANK_SPLIT_SELECTS_TRACELESS_RATIO_AXIOMS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,525 @@
+---
+claim_id: involution_rank_split_selects_traceless_ratio_axioms_do_not_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "A second self-adjoint involution on C^8 has complementary projectors of ranks (4,4) and traceless ratio β=−α, so the May 2 identity for ranks (6,2) is not selected by Lattice, Qubit, Admissibility, or Record, and neither generator is U(1)_Y."
+upstream_dependencies:
+  - minimal_axioms
+  - LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md
+  - HYPERCHARGE_IDENTIFICATION_NOTE.md
+  - PHYSICAL_HYPERCHARGE_ALPHA_SCALE_FREEDOM_CYCLE692_NOTE_2026-07-25.md
+  - GRAPH_FIRST_SU3_INTEGRATION_NOTE.md
+runner: scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py
+---
+
+# Involution Rank Split Selects The Traceless Ratio; Axioms Do Not
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact rank-to-ratio mutation from one self-adjoint involution
+on `C^8` to another, and the residual that the four axiom sentences do
+not select `Y_0` over `Z_0`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py`](../scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py)
+
+## Result Up Front
+
+Work on `C^8` with the standard orthonormal basis `e_0,...,e_7`. Two
+self-adjoint involutions live on this same space. Their complementary
+projectors have different ranks, so tracelessness forces different
+eigenvalue ratios.
+
+The first involution is the already-landed rank pair. Write
+
+`Pi_+ = diag(I_6, 0_2)`, `Pi_- = diag(0_6, I_2)`.
+
+Those are complementary orthogonal projectors of ranks `(6,2)`. They are
+the spectral projectors of the involution `τ_Y = Pi_+ − Pi_-`. The May 2
+note
+[`LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md`](LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md)
+already records the identity
+
+`6 α + 2 β = 0  ⇒  β = −3 α`.
+
+That identity is recomputed here and is not claimed new.
+[`GRAPH_FIRST_SU3_INTEGRATION_NOTE.md`](GRAPH_FIRST_SU3_INTEGRATION_NOTE.md)
+supplies the same `(6,2)` multiplicities on the doubled weak-fiber
+surface. The name-free parent
+[`HYPERCHARGE_IDENTIFICATION_NOTE.md`](HYPERCHARGE_IDENTIFICATION_NOTE.md)
+writes the generator as `Y_0 = P_sym − 3 P_anti`. In the coordinates of
+this note that generator is
+
+`Y_0 := Pi_+ − 3 Pi_-`,
+
+with spectrum `{+1 × 6, −3 × 2}` and trace `6 − 6 = 0`.
+
+The second involution is extra. Define
+
+`σ = diag(+1,+1,+1,+1, −1,−1,−1,−1)`.
+
+Then `σ^2 = I` and `σ^* = σ`. The complementary projectors
+
+`Qi_+ = (I+σ)/2`, `Qi_- = (I−σ)/2`
+
+have ranks `(4,4)`. Tracelessness is now `4 α + 4 β = 0`, so `β = −α`.
+The generator
+
+`Z_0 := Qi_+ − Qi_-`
+
+has spectrum `{+1 × 4, −1 × 4}` and trace `0`. It is not a scalar
+multiple of `Y_0`: the eigenvalue multisets
+`{1,1,1,1,1,1,−3,−3}` and `{1,1,1,1,−1,−1,−1,−1}` differ.
+
+The four axiom sentences in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+are quoted only as premises and are not edited. Lattice names the sites
+of `Z^3`. Qubit names a one-site possibility domain with no privileged
+possibility. Admissibility names a nearest-neighbor-determined
+distribution. Record locks one admissible possibility and supplies an
+additive scalar `I` with `I(empty)=0`. None of those sentences name `τ`,
+`SWAP_23`, a `C^8` taste cube, or the rank pair `(6,2)` versus `(4,4)`.
+They do not select `Y_0` over `Z_0`.
+
+The scale `α = 1/3` is a convention. Cycle 692
+[`PHYSICAL_HYPERCHARGE_ALPHA_SCALE_FREEDOM_CYCLE692_NOTE_2026-07-25.md`](PHYSICAL_HYPERCHARGE_ALPHA_SCALE_FREEDOM_CYCLE692_NOTE_2026-07-25.md)
+already records that the tested mechanisms do not derive it. The
+rescaling `Y_like = Y_0/3` is that same convention and is not identified
+with `U(1)_Y`. P-HY and anomaly-complete `U(1)_Y` remain open.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "A second self-adjoint involution on C^8 has ranks (4,4) and ratio -1. Lattice, Qubit, Admissibility, and Record do not select the (6,2) generator Y_0 over Z_0."
+trace_class: negative_route_pruning
+target_claim_id: involution_rank_split_selects_traceless_ratio
+target_blocker_text: "axioms select the (6,2) LH split and the 1:(-3) ratio"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "The (6,2) split is an extra involution choice. Axioms do not select Y_0 over Z_0. Do not identify Y_like with U(1)_Y. Do not adopt axiom text."
+conditional_surface_status: "exact for the (4,4) involution mutation and the axiom non-selection; P-HY remains open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `H = C^8` with the standard orthonormal basis `e_0,...,e_7`. All
+operators below are diagonal in this basis, so adjoints are complex
+conjugates of the diagonal entries and every spectrum is read off the
+diagonal.
+
+The **landed rank pair** is the complementary pair of projectors
+
+`Pi_+ = diag(1,1,1,1,1,1,0,0)`,
+`Pi_- = diag(0,0,0,0,0,0,1,1)`.
+
+Equivalently, they are the spectral projectors of the self-adjoint
+involution
+
+`τ_Y := Pi_+ − Pi_- = diag(+1,+1,+1,+1,+1,+1,−1,−1)`,
+
+via `Pi_± = (I ± τ_Y)/2`. Ranks are `(6,2)`. A central two-value
+operator on this split is `Y(α,β) := α Pi_+ + β Pi_-`. Tracelessness
+is the linear equation `6α + 2β = 0`. The May 2 generator is the
+`α = 1` point of that line:
+
+`Y_0 := Pi_+ − 3 Pi_- = diag(1,1,1,1,1,1,−3,−3)`.
+
+The **mutated rank pair** is the complementary pair of projectors of a
+different self-adjoint involution on the same `H`:
+
+`σ = diag(+1,+1,+1,+1, −1,−1,−1,−1)`,
+`Qi_+ = (I+σ)/2 = diag(1,1,1,1,0,0,0,0)`,
+`Qi_- = (I−σ)/2 = diag(0,0,0,0,1,1,1,1)`.
+
+Ranks are `(4,4)`. A central two-value operator on this split is
+`Z(α,β) := α Qi_+ + β Qi_-`. Tracelessness is `4α + 4β = 0`. The
+normalized generator used here is the `α = 1` point of that line:
+
+`Z_0 := Qi_+ − Qi_- = σ = diag(1,1,1,1,−1,−1,−1,−1)`.
+
+Discriminating exact witnesses:
+
+```text
+tr(Y_0)=0, spec_multiset(Y_0) = {1,1,1,1,1,1,-3,-3}
+tr(Z_0)=0, spec_multiset(Z_0) = {1,1,1,1,-1,-1,-1,-1}
+4α+4β=0 ⇒ β=−α
+σ^2=I, σ^*=σ
+```
+
+The four axiom sentences used as premises, quoted and not edited:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+>
+> No possibility is privileged. Possibilities are distinguished by the supplied
+> algebraic structure alone.
+>
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+>
+> When present, a record locks exactly one admissible local possibility.
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Recompute the May 2 identity for ranks `(6,2)`, exhibit
+the involution `σ` of ranks `(4,4)` with ratio `−1`, and record that the
+quoted axiom sentences do not select `Y_0` over `Z_0`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin May 2 `6α+2β=0 ⇒ β=−3α` and its SM non-claim | premise | quoted; recomputed; not claimed new |
+| pin GRAPH_FIRST `(6,2)` multiplicities | premise | cited as the landed rank pair |
+| pin the four axiom sentences | premise | quoted from the axiom memo |
+| pin cycle 692 scale convention | premise | `α=1/3` is not derived |
+| exhibit `σ` and ranks `(4,4)` | Theorem 2 | computed here |
+| show the axiom sentences do not name the split | Theorem 3 | scoped residual |
+| identify `Y_like` with `U(1)_Y` | non-claim | open; Theorem 5 |
+| edit an axiom to name `τ` or `σ` | non-claim | not required |
+
+## Theorem 1 — Ranks (6,2) Force β=−3α (Recompute Only)
+
+**Claim.** `Pi_+` and `Pi_-` are complementary orthogonal projectors of
+ranks `6` and `2`. Tracelessness of `Y(α,β)=α Pi_+ + β Pi_-` is
+`6α+2β=0`, hence `β=−3α` whenever `α ≠ 0`. The generator `Y_0` has
+spectrum `{+1 × 6, −3 × 2}` and trace `0`. This is the May 2 identity.
+It is not claimed new.
+
+**Proof.** Each diagonal entry of `Pi_+` is `0` or `1`, and
+`Pi_+^2 = Pi_+`. The number of ones is `6`, so `rank(Pi_+)=6` and
+`tr(Pi_+)=6`. The complementary matrix `Pi_- = I − Pi_+` is likewise a
+projector of rank `2`. The product `Pi_+ Pi_-` is zero, so the pair is
+orthogonal. Self-adjointness is immediate from the real diagonal.
+
+On the six-dimensional plus sector `Y` acts by `α`. On the
+two-dimensional minus sector it acts by `β`. The trace is therefore
+`6α+2β`. Setting the trace to zero and dividing by `2` gives
+`3α+β=0`, so `β=−3α`. The same ratio is recovered for every nonzero
+sample `α` in `{1, 2, −5, 7/11}`: the solution line is one-dimensional.
+
+Substituting `(α,β)=(1,−3)` produces `Y_0=Pi_+−3 Pi_-`, whose diagonal
+is six ones followed by two copies of `−3`. The trace is
+`6·1 + 2·(−3) = 0`. The eigenvalue multiset is
+`{1,1,1,1,1,1,−3,−3}`.
+
+May 2 already states this identity and already excludes identification
+with Standard Model hypercharge `Y`. The present theorem only recomputes
+the same linear algebra on the same rank pair.
+
+## Theorem 2 — The Involution σ Has Ranks (4,4) And Ratio −1
+
+**Claim.** `σ = diag(+1^4, −1^4)` is a self-adjoint involution.
+`Qi_± = (I±σ)/2` are complementary orthogonal projectors of ranks
+`(4,4)`. Tracelessness of `Z(α,β)=α Qi_+ + β Qi_-` is `4α+4β=0`, hence
+`β=−α`. The generator `Z_0=Qi_+−Qi_-` has spectrum `{+1 × 4, −1 × 4}`
+and is not a scalar multiple of `Y_0`.
+
+**Proof.** Each diagonal entry of `σ` is `±1`, so `σ^2 = I`. The entries
+are real, so `σ^* = σ`. The standard involution calculus then gives
+
+`Qi_+ + Qi_- = I`, `Qi_+ Qi_- = 0`, `Qi_±^2 = Qi_±`, `Qi_±^* = Qi_±`.
+
+The plus projector is `diag(1,1,1,1,0,0,0,0)` and the minus projector is
+`diag(0,0,0,0,1,1,1,1)`. Each has four ones, so the ranks are `(4,4)`.
+
+The trace of `Z(α,β)` is `4α+4β`. Setting the trace to zero and dividing
+by `4` gives `α+β=0`, so `β=−α`. The same ratio is recovered for every
+nonzero sample `α` in `{1, 2, −5, 7/11}`.
+
+Substituting `(α,β)=(1,−1)` produces `Z_0=Qi_+−Qi_-`. That operator
+equals `σ` itself. Its diagonal is four ones followed by four copies of
+`−1`. The trace is `4−4=0`. The eigenvalue multiset is
+`{1,1,1,1,−1,−1,−1,−1}`.
+
+If `Y_0` were a scalar multiple of `Z_0`, there would exist `q` in `Q`
+with `Y_0 = q Z_0`. Both operators are diagonal and `Z_0` has no zero
+entries, so each ratio of corresponding eigenvalues would equal `q`.
+Those ratios are
+
+`1/1, 1/1, 1/1, 1/1, 1/(−1), 1/(−1), (−3)/(−1), (−3)/(−1)`,
+
+which evaluate to `1,1,1,1,−1,−1,3,3` and are not constant. The
+multisets `{1^6,(−3)^2}` and `{1^4,(−1)^4}` therefore distinguish the
+two generators.
+
+The mutation is the rank change. Replacing ranks `(6,2)` by `(4,4)`
+replaces the traceless ratio `−n_+/n_-` from `−3` to `−1`.
+
+## Theorem 3 — The Axiom Sentences Do Not Select Y_0 Over Z_0
+
+**Claim.** Lattice, Qubit, Admissibility, and Record, as quoted above,
+do not name `τ`, `SWAP_23`, a `C^8` taste cube, or the rank pair
+`(6,2)` versus `(4,4)`. They do not select `Y_0` over `Z_0`.
+
+**Proof.** Read each governing sentence against the named objects.
+
+Lattice says that physical sites are the points of the cubic lattice
+`Z^3`, with nearest-neighbor adjacency, translations, and proper cubic
+rotations, and that no site is privileged. That sentence names a
+spatial lattice. It does not name an eight-dimensional taste space, an
+involution on that space, or a rank pair of projectors.
+
+Qubit says that each site has a domain of local possibilities, that the
+full one-site domain has algebraic presentation `M_2(C)`, and that no
+possibility is privileged. A non-privileged `M_2(C)` does not name a
+preferred involution on `C^8` and does not name `SWAP_23`.
+
+Admissibility says that there is one fixed nearest-neighbor
+admissibility rule, and that for each site the probability distribution
+over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions. A nearest-neighbor distribution on `Z^3`
+does not name a taste-cube swap and does not fix ranks `(6,2)`.
+
+Record says that records form; that when present a record locks exactly
+one admissible local possibility; that only records are readable; that
+a readout value is determined by record content alone; and that for any
+finite collection of pairwise-disjoint records, scalar readout `I` is
+additive, with `I(empty)=0`. Additivity of a scalar on record
+collections does not name a projector rank and does not equate `6α+2β`
+with `4α+4β`.
+
+The objects that do name the landed split sit outside those sentences.
+GRAPH_FIRST supplies the `(6,2)` multiplicities from a residual
+complementary-axis swap on a taste cube. May 2 consumes that rank pair.
+`SWAP_23` is the involution used by the name-free parent to build
+`P_sym` and `P_anti`. Those are extra selectors. They are not Lattice,
+Qubit, Admissibility, or Record.
+
+Because both `Y_0` and `Z_0` are well-defined traceless operators on the
+same `C^8`, and because the axiom sentences do not mention either
+involution, those sentences do not select one generator over the other.
+
+## Theorem 4 — The Scale α=1/3 Is A Convention
+
+**Claim.** The value `α=1/3` is a convention. It is not derived here.
+The rescaling `Y_like = Y_0/3` is that convention and is not identified
+with `U(1)_Y`.
+
+**Proof.** Theorem 1 determines only the ratio `β/α`. The overall scale
+remains a free nonzero rational. Cycle 692 already tested a finite menu
+of scale-fixing mechanisms on the landed two-value surface and recorded
+that the only tested condition selecting `1/3` is the stipulation that
+the minus sector reads `−1`. That stipulation is a choice of unit, not
+a consequence of tracelessness.
+
+Dividing `Y_0` by `3` produces the diagonal
+`{1/3,1/3,1/3,1/3,1/3,1/3,−1,−1}`. That is the conventional
+normalization used by the May 23 left-handed abelian surface note. The
+present note does not re-derive that scale and does not identify the
+rescaled operator with physical hypercharge.
+
+## Theorem 5 — Scoped Residual
+
+**Claim.** `σ` is an extra involution. The quoted axiom sentences do
+not select `Y_0` over `Z_0`. This note does not identify either
+operator with anomaly-complete `U(1)_Y`, does not close P-HY, and does
+not edit an axiom.
+
+**Proof.** Theorems 1 and 2 compute two different traceless ratios from
+two different rank pairs on the same `C^8`. The hypotheses that produce
+those rank pairs — a choice of self-adjoint involution, equivalently a
+choice of complementary projectors — are not Lattice, Qubit,
+Admissibility, or Record. Theorem 3 reads those four sentences and finds
+none of the named objects.
+
+The attempted one-involution substitutes fail for independent reasons:
+
+- forcing ranks `(6,2)` from the axiom memo fails because the memo
+  never names a `C^8` involution;
+- forcing the same ranks from Record additivity fails because `I` is a
+  scalar on collections, not a projector rank;
+- forcing the same ranks from Admissibility fails because a
+  nearest-neighbor distribution does not name `τ` or `SWAP_23`;
+- identifying `Z_0` with `Y_0` fails because the eigenvalue multisets
+  differ;
+- naming either operator as anomaly-complete `U(1)_Y` is P-HY, which
+  remains open.
+
+Declaring `σ` makes the `(4,4)` split well-defined. That declaration is
+the extra object. It is not forced by the quoted axiom sentences. An
+axiom edit that named `τ`, `σ`, or the rank pair `(6,2)` is not required
+by the linear algebra of either split.
+
+The residual is scoped. It does not say that a later physical selector
+cannot prefer one involution, and it does not say that a later bridge
+cannot identify a named generator with physical hypercharge.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom, or argue that an axiom update is necessary;
+- claim uniqueness of `β=−3α` as a new result (May 2 already has it);
+- derive `α=1/3`;
+- identify `Y_0`, `Z_0`, or `Y_like` with `U(1)_Y`;
+- close P-HY, anomaly cancellation, or a charge formula
+  `Q = T_3 + Y/2`;
+- reopen two-plane uniqueness of a hypercharge-like generator;
+- exhaust every self-adjoint involution on `C^8`.
+
+The scope is the exact rank-to-ratio mutation from `(6,2)` to `(4,4)`,
+together with the residual that the four axiom sentences do not select
+`Y_0` over `Z_0`.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice, Qubit, Admissibility, and Record sentences | premise | quoted; no edit |
+| May 2 ratio `6α+2β=0 ⇒ β=−3α` and SM non-claim | scope pin | quoted; recomputed; not reversed |
+| GRAPH_FIRST `(6,2)` multiplicities | landed rank pair | cited; not re-derived as new |
+| name-free `Y_0 = P_sym − 3 P_anti` | landed generator | cited |
+| cycle 692 scale convention | scope pin | `α=1/3` not derived |
+| involution `σ` and generator `Z_0` | declared algebra | computed here |
+| axiom non-selection of `Y_0` over `Z_0` | Theorem 3 | computed here |
+| P-HY / anomaly-complete `U(1)_Y` | residual | live, not derived |
+
+The exact advance is a finite rank-to-ratio mutation on `C^8`. Independent
+audit remains required before any effective status may change.
+
+## Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | May 2 already forces `β=−3α` from ranks `(6,2)` and already excludes SM hypercharge identification. GRAPH_FIRST already supplies those ranks. The named residual is whether the four axiom sentences themselves select that rank pair and that ratio. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for involution rank-split, ranks `(4,4)` versus `(6,2)`, `σ=diag(+1^4,−1^4)`, `Qi_±`, and a `Z_0` generator on `C^8`. Hits: May 2 and the name-free parent ship the `(6,2)` identity `β=−3α`; May 23 constructs `Y_like` on the same `(6,2)` projectors; cycle 692 is scale freedom on that line; a CKM Brocard identity `β=−α` is a polynomial-coefficient alternative, not an involution on `C^8`. No landed theorem mutates the rank pair `(6,2)` to `(4,4)` and records the ratio change `−3 → −1`. Unmerged siblings are not premises. |
+| V3 | Independently checkable? | Textbook spectral calculus of a self-adjoint involution produces complementary projectors and does not mention Record or `Y_0`. The runner builds both involutions as exact diagonal operators, recomputes ranks by counting ones, and solves the two trace equations in `Fraction`. |
+| V4 | More than a restatement? | Yes. The witnesses `tr(Y_0)=0` with multiset `{1^6,(−3)^2}`, `tr(Z_0)=0` with multiset `{1^4,(−1)^4}`, and `4α+4β=0 ⇒ β=−α` are not restatements of the May 2 ratio sentence. |
+| V5 | One-step relabel? | No. The May 2 identity is the algebra of one rank pair. A mutation to a second involution with a different rank pair is not a relabel of that identity. |
+
+## No-Go Discipline Gate (Theorems 3–5 only)
+
+The negative claim is restricted to this: the quoted Lattice, Qubit,
+Admissibility, and Record sentences do not select `Y_0` over `Z_0`, the
+scale `α=1/3` is not derived, and neither operator is anomaly-complete
+`U(1)_Y`. The gate does not ship a global non-existence theorem against
+a later physical selector, and it does not ship a hypercharge
+identification.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| force `(6,2)` from the four axiom sentences | read Lattice, Qubit, Admissibility, and Record for a `C^8` involution or rank pair | Theorem 3: those sentences name `Z^3`, `M_2(C)`, a nearest-neighbor distribution, and an additive scalar `I` | **ATTEMPTED** |
+| force `(6,2)` from Record additivity | set projector ranks equal to a Record readout | `I` is a scalar on finite collections; `I(empty)=0` does not name `rank(Pi_+)` | **ATTEMPTED** |
+| force `(6,2)` from Admissibility | read the nearest-neighbor distribution as a taste-cube swap | Admissibility names a sitewise law on `Z^3`, not `τ` or `SWAP_23` | **ATTEMPTED** |
+| identify `Z_0` with `Y_0` | declare the two generators equal or scalar-equivalent | Theorem 2: eigenvalue multisets `{1^6,(−3)^2}` and `{1^4,(−1)^4}` differ | **ATTEMPTED** |
+| axiom edit naming `τ` or `(6,2)` | add an involution sentence to an axiom | not required by the linear algebra; see N6 | **ATTEMPTED** |
+| P-HY naming | call `Y_0` or `Y_like` anomaly-complete `U(1)_Y` | Theorem 5: identification remains open | **ATTEMPTED** |
+
+### N2 — wall independence
+
+Theorem 5 closes only the claim that the quoted axiom sentences select
+`Y_0`. It does not close the May 2 identity (Theorem 1, already landed),
+the `(4,4)` mutation (Theorem 2), a later physical selector among
+involutions, or P-HY. Those walls remain independent. Existence of two
+traceless generators on `C^8` does not by itself make either generator
+an axiom output.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| standard basis of `C^8` | declared working space |
+| `Pi_±` of ranks `(6,2)` | landed objects, recomputed |
+| involution `σ` and `Qi_±` | explicit construction |
+| tracelessness `n_+ α + n_- β = 0` | explicit linear algebra |
+| eigenvalue-multiset witnesses | explicit diagonals |
+| four axiom sentences | quoted premises |
+| axiom edit naming `τ` or `σ` | live governance path; not required |
+| P-HY / `U(1)_Y` identification | open; not assumed |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Lattice `Z^3`; Qubit non-privilege; Admissibility nearest-neighbor distribution; Record lock and `I(empty)=0` | quoted as premises only; no edit |
+| [`docs/LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md`](LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md) | `6α+2β=0 ⇒ β=−3α`; SM identification out of scope | recomputed only; not claimed new |
+| [`docs/HYPERCHARGE_IDENTIFICATION_NOTE.md`](HYPERCHARGE_IDENTIFICATION_NOTE.md) | `Y_0 = P_sym − 3 P_anti`; name-free two-value algebra | cited; not renamed as `U(1)_Y` |
+| [`docs/PHYSICAL_HYPERCHARGE_ALPHA_SCALE_FREEDOM_CYCLE692_NOTE_2026-07-25.md`](PHYSICAL_HYPERCHARGE_ALPHA_SCALE_FREEDOM_CYCLE692_NOTE_2026-07-25.md) | `α=1/3` not derived by the tested mechanisms | scale remains a convention |
+| [`docs/GRAPH_FIRST_SU3_INTEGRATION_NOTE.md`](GRAPH_FIRST_SU3_INTEGRATION_NOTE.md) | `(6,2)` multiplicities on the doubled weak-fiber surface | cited as the landed rank pair |
+
+No unmerged sibling is used as a parent. The `(4,4)` witnesses are
+computed here.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | diagonals of `Y_0` and `Z_0` and the two trace equations | no classification of every involution on `C^8` |
+| per site | one copy of `C^8`; no lattice site is assigned a taste cube | no spatial-lattice hypercharge field |
+| per mode | two-value central operators, not spectral modes of a Hamiltonian | no harmonic-mode exhaustion |
+| per split | ranks `(6,2)` versus `(4,4)` and the axiom residual | no `U(1)_Y` identification and no axiom edit |
+| lattice-wide | checked and not executed | no lattice-wide electroweak statement |
+
+The residual is an involution-selection gap. It is not lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. A later derivation that a physical selector on the taste cube prefers
+   one self-adjoint involution and that the preferred rank pair is
+   `(6,2)`.
+2. A later selector that uses more than the four axiom sentences — for
+   example a declared residual swap — to name `τ_Y` without editing an
+   axiom.
+3. A later dimensionless derivation of the unit choice `α=1/3`, which
+   cycle 692 left open.
+4. An owner-approved typed axiom addition that named an involution.
+   The linear algebra of either split does not require that addition.
+
+The quoted axiom sentences already name `Z^3` sites, a non-privileged
+possibility domain, a nearest-neighbor distribution, a lock, and an
+additive scalar `I`. They do not name `τ`, `σ`, or the rank pair. No
+axiom sentence is required by Theorem 5.
+
+### N7 — hostile steelman
+
+> The axioms already pick the graph-first taste cube, so they pick `τ`
+> and ranks `(6,2)`. Uniqueness of the traceless ratio on that split
+> then means the axioms selected `Y_0`.
+
+**Answer.** Uniqueness of `β=−3α` is conditional on the rank pair
+`(6,2)`. That rank pair is supplied by GRAPH_FIRST and consumed by
+May 2. Lattice names `Z^3` sites, not a `C^8` taste cube. Qubit names
+`M_2(C)` with no privileged possibility, not a preferred involution.
+Admissibility names a nearest-neighbor distribution. Record names a
+lock and an additive scalar. Theorem 2 exhibits a second involution on
+the same `C^8` whose traceless ratio is `−1`. Theorem 3 is exactly the
+gap between “unique if ranks are `(6,2)`” and “selected by the axiom
+sentences.”
+
+### N8 — cross-cycle echo
+
+May 2 already removed SM hypercharge identification from its
+load-bearing claim and already recorded `β=−3α` for ranks `(6,2)`.
+Cycle 692 already recorded that `α=1/3` is not derived by the tested
+mechanisms. The name-free parent already wrote `Y_0` without a physical
+species label. The present mutation does not reverse those non-claims.
+It answers a different question: among self-adjoint involutions on
+`C^8`, the traceless ratio tracks the rank pair; among axiom sentences,
+that rank pair is still extra.
+
+**Gate disposition.** PASS for the `(4,4)` rank-to-ratio mutation and
+for the scoped residual that the axiom sentences do not select `Y_0`
+over `Z_0`. FAIL / DO NOT SHIP for “`β=−3α` is new,” “`α=1/3` is
+derived,” “`Y_like` is `U(1)_Y`,” or “an axiom edit is required.”
+
+## Primary Runner
+
+[`scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py`](../scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py)
+rebuilds both involutions as exact diagonal operators, recomputes ranks
+by counting ones, solves the two trace equations in `Fraction`, checks
+that `Y_0` is not a scalar multiple of `Z_0`, and pins the May 2 ratio
+sentence together with the Admissibility and Record sentences. Identity
+gates call `ratio_from_ranks()` and `z0()`. Replacing ranks `(6,2)` by
+`(4,4)` must change the ratio `−3` to `−1`. Replacing `Z_0` by `Y_0`
+must fail the eigenvalue-multiset witness. A constant ratio `−3` must
+fail on ranks `(4,4)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15605,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10261,6 +10261,10 @@
   "inverse_problem_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "involution_rank_split_selects_traceless_ratio_axioms_do_not_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "f842b211d420",
+   "out_degree": 5
   },
   "irregular_directional_observable_note_2026-04-11": {
    "deps_hash": "07682cd2364f",

--- a/logs/runner-cache/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.txt
+++ b/logs/runner-cache/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py
+runner_sha256: 6b82652e30b3abc6046066b6f1d1336c2539ea3dbb04b487bed570525cd1aab5
+input_fingerprint_sha256: fd7510bbb44fb965ae026702f058a80825dd8acc88dfa7f46de5b933f627d3f3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: May 2 ratio identity, name-free Y_0, and the four axiom sentences are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: axioms do not select Y_0 over Z_0; ranks (4,4) force ratio -1; no U(1)_Y identification
+PASS: audit-input-paths declared audit inputs exist and match the note, May 2, name-free parent, and axiom memo
+PASS: source-may2-ratio May 2 states 6α+2β=0 ⇒ β=−3α and excludes SM identification
+PASS: source-hypercharge-y0 the name-free parent writes Y_0 = P_sym − 3 P_anti from 6α+2β=0
+PASS: source-lattice-sites the exact current Lattice Z^3 sentence is present in the axiom memo
+PASS: source-qubit-nonprivilege the exact current Qubit non-privilege sentence is present in the axiom memo
+PASS: source-admissibility the exact current Admissibility nearest-neighbor sentence is present in the axiom memo
+PASS: source-record-additivity the exact current Record additivity sentence is present in the axiom memo
+PASS: theorem-1-involution τ_Y is a self-adjoint involution and recovers the direct (6,2) projectors
+PASS: theorem-1-ranks Pi_+ and Pi_- have integer ranks 6 and 2
+PASS: theorem-1-ratio ranks (6,2) force β=−3α on the sample grid and Y_0 has spec {1^6,(-3)^2}
+PASS: theorem-2-involution σ is a self-adjoint involution with complementary (4,4) projectors
+PASS: theorem-2-ratio ranks (4,4) force β=−α and Z_0 equals σ with spec {1^4,(-1)^4}
+PASS: theorem-2-not-multiple Y_0 is not a scalar multiple of Z_0: eigenvalue ratios are not constant
+PASS: theorem-3-axioms-silent Lattice, Qubit, Admissibility, and Record do not name τ, SWAP_23, a C^8 taste cube, or the rank pairs
+PASS: theorem-3-not-selected the quoted axiom sentences appear in the note and do not select Y_0 over Z_0
+PASS: theorem-4-scale-convention α=1/3 remains a convention: Y_like=Y_0/3 is a rescaling, not a derived unit
+PASS: theorem-5-phy-open P-HY and anomaly-complete U(1)_Y remain open; Y_like is not identified
+PASS: mutation-ranks-change-ratio replacing ranks (6,2) by (4,4) changes the traceless ratio −3 to −1
+PASS: mutation-constant-ratio-fails freezing the ratio at −3 fails on ranks (4,4)
+PASS: mutation-identify-generators-fails replacing Z_0 by Y_0 fails the {1^4,(-1)^4} multiset witness
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: canonical-nonmutation the involution split and both generators are absent from the canonical axiom file
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: diagonals of Y_0 and Z_0 and both trace equations are recomputed in Fraction
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: one copy of C^8 is the only carrier; no spatial site is assigned a taste cube
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: two-value central operators are checked; no Hamiltonian mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only ranks (6,2) versus (4,4) and the axiom residual are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide electroweak or U(1)_Y claim
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py
+++ b/scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Exact checks: involution rank-split selects the traceless ratio.
+
+Ranks (6,2) recompute β=−3α (May 2; not claimed new). The involution
+σ=diag(+1^4,−1^4) has ranks (4,4) and ratio −1. Lattice, Qubit,
+Admissibility, and Record do not select Y_0 over Z_0. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "INVOLUTION_RANK_SPLIT_SELECTS_TRACELESS_RATIO_AXIOMS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+MAY2_PATH = (
+    ROOT
+    / "docs"
+    / "LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md"
+)
+HYPERCHARGE_PATH = ROOT / "docs" / "HYPERCHARGE_IDENTIFICATION_NOTE.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/INVOLUTION_RANK_SPLIT_SELECTS_TRACELESS_RATIO_AXIOMS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md",
+    "docs/HYPERCHARGE_IDENTIFICATION_NOTE.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Diagonal:
+    """Exact diagonal operator on C^8, entries in Q."""
+
+    entries: tuple[Fraction, ...]
+
+    def __add__(self, other: "Diagonal") -> "Diagonal":
+        return Diagonal(tuple(a + b for a, b in zip(self.entries, other.entries, strict=True)))
+
+    def __sub__(self, other: "Diagonal") -> "Diagonal":
+        return Diagonal(tuple(a - b for a, b in zip(self.entries, other.entries, strict=True)))
+
+    def __mul__(self, other: object) -> "Diagonal":
+        if isinstance(other, Diagonal):
+            return Diagonal(tuple(a * b for a, b in zip(self.entries, other.entries, strict=True)))
+        if isinstance(other, (int, Fraction)):
+            scale = Fraction(other)
+            return Diagonal(tuple(a * scale for a in self.entries))
+        return NotImplemented
+
+    def __rmul__(self, other: object) -> "Diagonal":
+        return self.__mul__(other)
+
+    def adj(self) -> "Diagonal":
+        return self
+
+    def trace(self) -> Fraction:
+        return sum(self.entries, Fraction(0))
+
+    def rank(self) -> int:
+        return sum(1 for entry in self.entries if entry != 0)
+
+    def spec_multiset(self) -> tuple[Fraction, ...]:
+        return tuple(sorted(self.entries))
+
+    def is_projector(self) -> bool:
+        return self * self == self and self.adj() == self
+
+    @staticmethod
+    def ones(dimension: int) -> "Diagonal":
+        return Diagonal(tuple(Fraction(1) for _ in range(dimension)))
+
+    @staticmethod
+    def from_signs(n_plus: int, n_minus: int) -> "Diagonal":
+        return Diagonal(tuple([Fraction(1)] * n_plus + [Fraction(-1)] * n_minus))
+
+
+def plus_projector(involution: Diagonal) -> Diagonal:
+    identity = Diagonal.ones(len(involution.entries))
+    return (identity + involution) * Fraction(1, 2)
+
+
+def minus_projector(involution: Diagonal) -> Diagonal:
+    identity = Diagonal.ones(len(involution.entries))
+    return (identity - involution) * Fraction(1, 2)
+
+
+def ratio_from_ranks(n_plus: int, n_minus: int) -> Fraction:
+    """Identity-gate function: traceless ratio β/α = −n_+/n_-."""
+    if n_minus == 0:
+        raise ValueError("minus rank must be positive")
+    return -Fraction(n_plus, n_minus)
+
+
+def traceless_beta(n_plus: int, n_minus: int, alpha: Fraction) -> Fraction:
+    """Solve n_+ α + n_- β = 0 for β."""
+    if n_minus == 0:
+        raise ValueError("minus rank must be positive")
+    return -Fraction(n_plus) * alpha / Fraction(n_minus)
+
+
+def y0() -> Diagonal:
+    """May 2 generator on ranks (6,2): Y_0 = Pi_+ − 3 Pi_-."""
+    tau = Diagonal.from_signs(6, 2)
+    return plus_projector(tau) + traceless_beta(6, 2, Fraction(1)) * minus_projector(tau)
+
+
+def z0() -> Diagonal:
+    """Identity-gate function: Z_0 = Qi_+ − Qi_- on ranks (4,4)."""
+    sigma = Diagonal.from_signs(4, 4)
+    return plus_projector(sigma) - minus_projector(sigma)
+
+
+def constant_minus_three(_n_plus: int, _n_minus: int) -> Fraction:
+    """Mutation: freeze the May 2 ratio on every rank pair."""
+    return Fraction(-3)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    may2 = MAY2_PATH.read_text(encoding="utf-8")
+    hypercharge = HYPERCHARGE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: May 2 ratio identity, name-free Y_0, "
+        "and the four axiom sentences are source-bound; no observational "
+        "or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; no runner cache is written"
+    )
+    print(
+        "negative_scope: axioms do not select Y_0 over Z_0; ranks (4,4) "
+        "force ratio -1; no U(1)_Y identification"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note, May 2, name-free parent, and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/INVOLUTION_RANK_SPLIT_SELECTS_TRACELESS_RATIO_AXIOMS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md",
+            "docs/HYPERCHARGE_IDENTIFICATION_NOTE.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    may2_identity = "6 · α + 2 · β = 0"
+    may2_ratio = "β = −3 α"
+    may2_nonclaim = "identification with Standard Model hypercharge Y"
+    checks.check(
+        "source-may2-ratio",
+        "May 2 states 6α+2β=0 ⇒ β=−3α and excludes SM identification",
+        may2_identity in may2 and may2_ratio in may2 and may2_nonclaim in may2,
+    )
+    checks.check(
+        "source-hypercharge-y0",
+        "the name-free parent writes Y_0 = P_sym − 3 P_anti from 6α+2β=0",
+        "6 alpha + 2 beta = 0" in hypercharge
+        and "so beta=-3 alpha." in hypercharge
+        and "Y_0 = P_sym - 3 P_anti." in hypercharge,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`"
+    qubit_sentence = "No possibility is privileged."
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_sentence = (
+        "For any finite collection of pairwise-disjoint records, scalar readout "
+        "`I` is additive, with `I(empty)=0`."
+    )
+    lock_sentence = "When present, a record locks exactly one admissible local possibility."
+    checks.check(
+        "source-lattice-sites",
+        "the exact current Lattice Z^3 sentence is present in the axiom memo",
+        lattice_sentence in axiom,
+    )
+    checks.check(
+        "source-qubit-nonprivilege",
+        "the exact current Qubit non-privilege sentence is present in the axiom memo",
+        qubit_sentence in axiom,
+    )
+    checks.check(
+        "source-admissibility",
+        "the exact current Admissibility nearest-neighbor sentence is present in the axiom memo",
+        admissibility_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-record-additivity",
+        "the exact current Record additivity sentence is present in the axiom memo",
+        record_sentence in normalized_axiom and lock_sentence in axiom,
+    )
+
+    tau = Diagonal.from_signs(6, 2)
+    pi_plus = plus_projector(tau)
+    pi_minus = minus_projector(tau)
+    pi_plus_direct = Diagonal(tuple([Fraction(1)] * 6 + [Fraction(0)] * 2))
+    pi_minus_direct = Diagonal(tuple([Fraction(0)] * 6 + [Fraction(1)] * 2))
+    checks.check(
+        "theorem-1-involution",
+        "τ_Y is a self-adjoint involution and recovers the direct (6,2) projectors",
+        tau * tau == Diagonal.ones(8)
+        and tau.adj() == tau
+        and pi_plus == pi_plus_direct
+        and pi_minus == pi_minus_direct
+        and pi_plus.is_projector()
+        and pi_minus.is_projector()
+        and pi_plus + pi_minus == Diagonal.ones(8)
+        and pi_plus * pi_minus == Diagonal(tuple(Fraction(0) for _ in range(8))),
+        residual=(pi_plus.entries, pi_minus.entries),
+    )
+    checks.check(
+        "theorem-1-ranks",
+        "Pi_+ and Pi_- have integer ranks 6 and 2",
+        pi_plus.rank() == 6
+        and pi_minus.rank() == 2
+        and pi_plus.trace() == Fraction(6)
+        and pi_minus.trace() == Fraction(2),
+        residual=(pi_plus.rank(), pi_minus.rank()),
+    )
+
+    sample_alphas = (Fraction(1), Fraction(2), Fraction(-5), Fraction(7, 11))
+    may2_line = all(
+        traceless_beta(pi_plus.rank(), pi_minus.rank(), alpha) == Fraction(-3) * alpha
+        and ratio_from_ranks(pi_plus.rank(), pi_minus.rank()) == Fraction(-3)
+        for alpha in sample_alphas
+    )
+    generator_62 = y0()
+    checks.check(
+        "theorem-1-ratio",
+        "ranks (6,2) force β=−3α on the sample grid and Y_0 has spec {1^6,(-3)^2}",
+        may2_line
+        and generator_62.trace() == Fraction(0)
+        and generator_62.spec_multiset()
+        == tuple([Fraction(-3)] * 2 + [Fraction(1)] * 6)
+        and generator_62 == pi_plus + Fraction(-3) * pi_minus,
+        residual=(generator_62.trace(), generator_62.spec_multiset()),
+    )
+
+    sigma = Diagonal.from_signs(4, 4)
+    qi_plus = plus_projector(sigma)
+    qi_minus = minus_projector(sigma)
+    checks.check(
+        "theorem-2-involution",
+        "σ is a self-adjoint involution with complementary (4,4) projectors",
+        sigma * sigma == Diagonal.ones(8)
+        and sigma.adj() == sigma
+        and qi_plus.is_projector()
+        and qi_minus.is_projector()
+        and qi_plus + qi_minus == Diagonal.ones(8)
+        and qi_plus * qi_minus == Diagonal(tuple(Fraction(0) for _ in range(8)))
+        and qi_plus.rank() == 4
+        and qi_minus.rank() == 4
+        and qi_plus.trace() == Fraction(4)
+        and qi_minus.trace() == Fraction(4),
+        residual=(qi_plus.rank(), qi_minus.rank()),
+    )
+
+    four_four_line = all(
+        traceless_beta(qi_plus.rank(), qi_minus.rank(), alpha) == Fraction(-1) * alpha
+        and ratio_from_ranks(qi_plus.rank(), qi_minus.rank()) == Fraction(-1)
+        for alpha in sample_alphas
+    )
+    generator_44 = z0()
+    checks.check(
+        "theorem-2-ratio",
+        "ranks (4,4) force β=−α and Z_0 equals σ with spec {1^4,(-1)^4}",
+        four_four_line
+        and generator_44.trace() == Fraction(0)
+        and generator_44 == sigma
+        and generator_44.spec_multiset()
+        == tuple([Fraction(-1)] * 4 + [Fraction(1)] * 4),
+        residual=(generator_44.trace(), generator_44.spec_multiset()),
+    )
+
+    eigenvalue_ratios = tuple(
+        y_entry / z_entry for y_entry, z_entry in zip(generator_62.entries, generator_44.entries, strict=True)
+    )
+    checks.check(
+        "theorem-2-not-multiple",
+        "Y_0 is not a scalar multiple of Z_0: eigenvalue ratios are not constant",
+        len(set(eigenvalue_ratios)) > 1
+        and generator_62.spec_multiset() != generator_44.spec_multiset()
+        and generator_62 != generator_44
+        and generator_62 != Fraction(-3) * generator_44,
+        residual=eigenvalue_ratios,
+    )
+
+    axiom_forbidden = ("τ", "SWAP_23", "C^8", "taste cube", "(6,2)", "(4,4)", "Y_0", "Z_0")
+    checks.check(
+        "theorem-3-axioms-silent",
+        "Lattice, Qubit, Admissibility, and Record do not name τ, SWAP_23, a C^8 taste cube, or the rank pairs",
+        all(token not in axiom for token in axiom_forbidden)
+        and lattice_sentence in axiom
+        and qubit_sentence in axiom
+        and admissibility_sentence in normalized_axiom
+        and record_sentence in normalized_axiom
+        and lock_sentence in axiom,
+    )
+    checks.check(
+        "theorem-3-not-selected",
+        "the quoted axiom sentences appear in the note and do not select Y_0 over Z_0",
+        lattice_sentence in note
+        and qubit_sentence in note
+        and admissibility_sentence in normalized_note
+        and record_sentence in normalized_note
+        and lock_sentence in note
+        and "I(empty)=0" in note
+        and generator_62.spec_multiset() != generator_44.spec_multiset(),
+    )
+
+    y_like = generator_62 * Fraction(1, 3)
+    checks.check(
+        "theorem-4-scale-convention",
+        "α=1/3 remains a convention: Y_like=Y_0/3 is a rescaling, not a derived unit",
+        "α=1/3" in note
+        and "convention" in note
+        and "not derived" in note.lower()
+        and "PHYSICAL_HYPERCHARGE_ALPHA_SCALE_FREEDOM_CYCLE692_NOTE_2026-07-25.md" in note
+        and y_like.spec_multiset()
+        == tuple([Fraction(-1)] * 2 + [Fraction(1, 3)] * 6)
+        and y_like.trace() == Fraction(0)
+        and ratio_from_ranks(6, 2) == Fraction(-3),
+        residual=y_like.spec_multiset(),
+    )
+    checks.check(
+        "theorem-5-phy-open",
+        "P-HY and anomaly-complete U(1)_Y remain open; Y_like is not identified",
+        "P-HY" in note
+        and "anomaly-complete" in note
+        and "U(1)_Y" in note
+        and "not identified" in note
+        and "Do not identify Y_like with U(1)_Y" in note,
+    )
+
+    checks.check(
+        "mutation-ranks-change-ratio",
+        "replacing ranks (6,2) by (4,4) changes the traceless ratio −3 to −1",
+        ratio_from_ranks(pi_plus.rank(), pi_minus.rank()) == Fraction(-3)
+        and ratio_from_ranks(qi_plus.rank(), qi_minus.rank()) == Fraction(-1)
+        and ratio_from_ranks(pi_plus.rank(), pi_minus.rank())
+        != ratio_from_ranks(qi_plus.rank(), qi_minus.rank()),
+        residual=(
+            ratio_from_ranks(pi_plus.rank(), pi_minus.rank()),
+            ratio_from_ranks(qi_plus.rank(), qi_minus.rank()),
+        ),
+    )
+    checks.check(
+        "mutation-constant-ratio-fails",
+        "freezing the ratio at −3 fails on ranks (4,4)",
+        constant_minus_three(4, 4) == Fraction(-3)
+        and ratio_from_ranks(4, 4) == Fraction(-1)
+        and constant_minus_three(4, 4) != ratio_from_ranks(4, 4)
+        and constant_minus_three(6, 2) == ratio_from_ranks(6, 2),
+        residual=(constant_minus_three(4, 4), ratio_from_ranks(4, 4)),
+    )
+    checks.check(
+        "mutation-identify-generators-fails",
+        "replacing Z_0 by Y_0 fails the {1^4,(-1)^4} multiset witness",
+        z0().spec_multiset() == tuple([Fraction(-1)] * 4 + [Fraction(1)] * 4)
+        and y0().spec_multiset() == tuple([Fraction(-3)] * 2 + [Fraction(1)] * 6)
+        and y0().spec_multiset() != z0().spec_multiset(),
+        residual=(y0().spec_multiset(), z0().spec_multiset()),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                'hypothetical_axiom_status: "no edit"',
+                "trace_class: negative_route_pruning",
+                "target_claim_id: involution_rank_split_selects_traceless_ratio",
+                "reachability_to_target: prunes",
+                'target_blocker_text: "axioms select the (6,2) LH split and the 1:(-3) ratio"',
+                'next_trace_action: "The (6,2) split is an extra involution choice. Axioms do not select Y_0 over Z_0. Do not identify Y_like with U(1)_Y. Do not adopt axiom text."',
+                "authors no audit verdict",
+                "I(empty)=0",
+                "not claimed new",
+                "MINIMAL_AXIOMS_2026-06-29.md",
+                "LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md",
+                "HYPERCHARGE_IDENTIFICATION_NOTE.md",
+                "GRAPH_FIRST_SU3_INTEGRATION_NOTE.md",
+            )
+        )
+        and may2_identity in note.replace("6 α + 2 β = 0", may2_identity)
+        and record_sentence in normalized_note
+        and admissibility_sentence in normalized_note
+        and "**Type:** bounded_theorem" in note
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "toe-lphys" not in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the involution split and both generators are absent from the canonical axiom file",
+        all(
+            phrase not in axiom
+            for phrase in ("Y_0", "Z_0", "Qi_+", "Pi_+", "SWAP_23", "taste cube", "β=−3α")
+        ),
+    )
+
+    n5_lines = (
+        "per_element: diagonals of Y_0 and Z_0 and both trace equations are recomputed in Fraction",
+        "per_site: one copy of C^8 is the only carrier; no spatial site is assigned a taste cube",
+        "per_mode: two-value central operators are checked; no Hamiltonian mode is claimed",
+        "per_block: only ranks (6,2) versus (4,4) and the axiom residual are executed",
+        "lattice_wide: checked and not executed — no lattice-wide electroweak or U(1)_Y claim",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

A second self-adjoint involution on `C^8` has complementary projectors of ranks `(4,4)` and traceless ratio `β=−α`. The May 2 identity `β=−3α` is the `(6,2)` case only. Lattice, Qubit, Admissibility, and Record do not name `τ`, a taste cube, or the rank pair, so they do not select `Y_0` over `Z_0`. `α=1/3` remains a convention. Neither generator is identified with `U(1)_Y`.

## What this means for the TOE

The 1:(−3) hypercharge-like ratio is a split, not an axiom. P-HY identification remains open.

## What changed

- Note: `docs/INVOLUTION_RANK_SPLIT_SELECTS_TRACELESS_RATIO_AXIOMS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py`
- Cache: `logs/runner-cache/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.txt`

## Verification

```bash
python3 scripts/involution_rank_split_selects_traceless_ratio_axioms_do_not_2026_08_13.py
# TOTAL: PASS=27 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
