### PR TITLE
[physics-loop] toe-lphys occuplock: bounded_theorem / bounded-support

### DIFF
--- a/docs/UNLOCKED_LABELS_ARE_INVISIBLE_OCCUPANCY_IS_NOT_LOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/UNLOCKED_LABELS_ARE_INVISIBLE_OCCUPANCY_IS_NOT_LOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,372 @@
+---
+claim_id: unlocked_labels_are_invisible_occupancy_is_not_lock_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the two-site star {x,y} with menu {A,B}, content-only readout sees only lock patterns: I(L_1)=1, I(L_2)=2, I(empty)=0, and I(ghost)=I(L_1)=1 because an unlocked label is not a record; the ghost is not a state; occupancy-without-lock is extra and is not axiom content."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py
+---
+
+# Unlocked Labels Are Invisible And Occupancy Is Not Lock
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact type split, on one two-site star and one two-point menu,
+between a Record lock pattern and a putative unlocked site-label.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py`](../scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py)
+
+## Result Up Front
+
+The current Record axiom in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies a
+content-only additive scalar on finite pairwise-disjoint record collections,
+and it identifies a state with a configuration of records. Those sentences
+are quoted only as premises and are not edited:
+
+> Only records are readable. A readout value is determined by record content alone.
+> For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+>
+> A state is a configuration of records.
+
+On the two-site star `{x,y}` with menu `{A,B}`, a **lock pattern** is a
+partial map `L: {x,y} ⇀ {A,B}`. Readout with unit strengths is the domain
+count `I(L)=|dom(L)|`. That count sees only locks:
+
+`I(L_1)=1`, `I(L_2)=2`, `I(empty)=0`.
+
+A **putative occupancy** is a total map `O: {x,y} → {A,B,∅}`. Decorating a
+site that carries no record with an unlocked menu label does not add a
+record. The ghost occupancy that locks `A` at `x` and writes unlocked `B` at
+`y` therefore has the same content-only readout as `L_1`:
+
+`I(ghost)=I(L_1)=1`.
+
+The unlocked `B` is invisible. The ghost is not a state. The two states in
+the comparison are the lock patterns `L_1` and `L_2`. Occupancy-without-lock
+is an extra label that the quoted sentences do not read. This note does not
+adopt that extra object, does not claim that no later occupancy compiler
+exists, and does not edit an axiom.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: negative_route_pruning
+target_claim_id: occupancy_versus_lock
+target_blocker_text: "identify site occupancy with Record lock, or read unlocked labels"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+next_trace_action: "Unlocked labels are invisible and are not states. Occupancy-without-lock is extra. Do not adopt axiom text."
+hypothetical_axiom_status: "no edit"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work on the two-site star `{x,y} ⊂ Z^3` with the single edge `xy`. The local
+possibility menu is the two-point set
+
+`X = {A, B}`.
+
+A **lock pattern** is a partial map
+
+`L: {x,y} ⇀ {A,B}`.
+
+Absence of a value means no record at that site. Record uniqueness makes the
+partial map at most single-valued. Each locked site is a unit-strength
+record. Scalar readout is the domain count
+
+`I(L) := |dom(L)|`,
+
+so `I(empty)=0` is the empty partial map. The three lock patterns used below
+are
+
+| pattern | lock at `x` | lock at `y` | `dom(L)` | `I(L)` |
+|---|---|---|---|---|
+| `empty` | empty | empty | `∅` | `0` |
+| `L_1` | `A` | empty | `{x}` | `1` |
+| `L_2` | `A` | `B` | `{x,y}` | `2` |
+
+A **putative occupancy** is a total map
+
+`O: {x,y} → {A,B,∅}`
+
+together with a distinguished subset of sites that actually lock. A nonempty
+occupancy value that is not a lock is an **unlocked label**. The ghost used
+below is
+
+| object | value at `x` | value at `y` | locked sites | `I` |
+|---|---|---|---|---|
+| `O_ghost` | `A` (locked) | `B` (unlocked) | `{x}` | `1` |
+
+The ghost and `L_1` have the same lock pattern. They differ only by the
+unlocked `B` at `y`.
+
+A declared content law on the menu is the probability
+
+`μ(A)=1/3`, `μ(B)=2/3`.
+
+Its support is `{A,B}`. A lock pattern is **lawful** for `μ` when every
+locked value lies in that support. Both `L_1` and `L_2` are lawful. The
+Admissibility reading note used only as a formation pin is that the
+distribution concerns which possibility a forming record locks, conditional
+on formation at that site; it does not supply the formation site,
+probability, or rate.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Prove that content-only readout sees only lock patterns,
+that a putative unlocked label is invisible and is not a Record state, and
+that occupancy-without-lock is extra.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin “Only records are readable” and content-only readout | premise | quoted from the axiom memo |
+| pin `I(empty)=0` | premise | quoted from the axiom memo |
+| pin “A state is a configuration of records.” | premise | quoted from the axiom memo |
+| compute `I(L_1)=1`, `I(L_2)=2`, `I(empty)=0` | Theorem 1 | unit-strength domain count |
+| compute `I(ghost)=I(L_1)=1` | Theorem 1 | unlocked label is not a record |
+| show the ghost is not a state | Theorem 2 | states are lock patterns |
+| show no readout of the ghost `B` exists | Theorem 3 | content-only |
+| show the same `μ` is compatible with `L_1` and `L_2` | Theorem 4 | formation still free |
+| record that occupancy-without-lock is extra | Theorem 5 | scoped residual |
+| identify occupancy with lock, or read unlocked labels | pruned route | Theorems 1--3 |
+| claim that no occupancy compiler exists | non-claim | not made |
+| edit an axiom to name occupancy-without-lock | non-claim | not required |
+
+## Theorem 1 — I Sees Only Locks
+
+**Claim.** `I(L_1)=1`, `I(L_2)=2`, and `I(empty)=0`. Adding an unlocked
+label does not change `I`: `I(ghost)=I(L_1)=1`.
+
+**Proof.** Each locked site is one unit-strength record. The empty lock
+pattern has empty domain, so `I(empty)=0` is the quoted identity. The domain
+of `L_1` is `{x}`, so `I(L_1)=1`. The domain of `L_2` is `{x,y}`, so
+`I(L_2)=2`. Additivity on the disjoint one-site records at `x` and at `y`
+recovers the same `2`:
+
+`I(L_2)=I(L_1)+I(y↦B)=1+1=2`.
+
+The ghost has the same lock pattern as `L_1`. Site `y` carries an unlocked
+`B`, which is not a record. Content-only readout is determined by record
+content alone, so the unlocked label does not enter `I`. Therefore
+`I(ghost)=I(L_1)=1`. In particular `I(ghost)≠I(L_2)`.
+
+## Theorem 2 — States Are Record Configurations
+
+**Claim.** Quote: “A state is a configuration of records.” The ghost
+occupancy is not a state. The two states in the comparison are `L_1` and
+`L_2`.
+
+**Proof.** A lock pattern is exactly a configuration of records on the star:
+each element of `dom(L)` is one record locking one menu value. Thus `L_1`
+and `L_2` are states, and the empty lock pattern is the empty configuration.
+The ghost is not a lock pattern. It carries an extra unlocked label at `y`
+that is not a record. That extra mark is not part of any configuration of
+records, so the ghost is not a state.
+
+The predicate `is_state` is true of a lock pattern and false of the ghost.
+Identifying the ghost with `L_2` would replace a non-state by a two-record
+state and would change `I` from `1` to `2`.
+
+## Theorem 3 — Content-Only Readout Sees No Ghost Label
+
+**Claim.** Quote: “Only records are readable. A readout value is determined
+by record content alone.” No readout of the ghost `B` exists.
+
+**Proof.** Readable content is the locked content. The readable set of
+`L_1` is the singleton record `(x,A)`. The readable set of the ghost is the
+same singleton: `y` carries no record, so the unlocked `B` is not readable.
+The readable set of `L_2` is `{(x,A),(y,B)}`. No content-only functional of
+the ghost returns the unlocked `B`, because that label is not record
+content. A readout that counted every nonempty occupancy value would return
+`2` on the ghost and would contradict `I(ghost)=1`.
+
+## Theorem 4 — Formation Still Free
+
+**Claim.** The same content law `μ` with support `{A,B}` is compatible with
+`L_1` and with `L_2`. Unlocking is not a third physical option supplied by
+the axioms; it is an extra label that the axioms do not read.
+
+**Proof.** Both locked values of `L_1` and of `L_2` lie in `supp(μ)={A,B}`,
+so both patterns are lawful. The same per-site law is therefore compatible
+with one lock and with two locks. The Admissibility reading note already
+says that the distribution does not supply the formation site, probability,
+or rate. Unlocking `y` while writing `B` there is not a third lawful lock
+pattern: it is not a lock pattern at all. The axioms read `L_1` or `L_2`.
+They do not read the ghost.
+
+## Theorem 5 — Scoped Residual
+
+**Claim.** Occupancy-without-lock is not derived and is not axiom content.
+A later occupancy rule would be extra. No axiom is edited. The note does
+not claim that no occupancy compiler exists.
+
+**Proof.** Theorems 1--3 show that the quoted Record sentences see lock
+patterns and do not see unlocked labels. Theorem 4 shows that those
+sentences still leave formation free between `L_1` and `L_2`. None of those
+facts produces a total occupancy map, and none of them reads an unlocked
+label. Declaring such a label makes a second object. That declaration is
+the extra structure.
+
+The residual is scoped. It does not say that a later compiler of occupancy
+from some further supplied structure is closed. It does not say that a
+later selector forcing a lock at every nonempty site is impossible. It says
+only that those objects are not the present Record readout and are not the
+present notion of state.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom, or argue that an axiom update is necessary;
+- identify site occupancy with Record lock;
+- treat an unlocked label as readable content;
+- force formation at every occupied site;
+- claim that no occupancy compiler exists;
+- derive a formation-rate law or a lattice-wide occupancy process;
+- replace the full one-site domain `M_2(C)` by the two-point menu.
+
+The scope is the exact type split on one two-site star: `I` sees only locks,
+the ghost is invisible and is not a state, and occupancy-without-lock is
+extra.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current content-only readout sentence and `I(empty)=0` | premise | quoted; no edit |
+| current “Only records are readable” sentence | premise | quoted; no edit |
+| current “A state is a configuration of records.” sentence | premise | quoted; no edit |
+| Admissibility reading note that the distribution does not supply site or rate | formation pin | quoted; not enlarged |
+| two-site star, menu `{A,B}`, `L_1`, `L_2`, ghost | declared algebra | computed here |
+| occupancy-without-lock as readable content | residual | live, not derived |
+
+The exact advance is a finite type-split theorem. Independent audit remains
+required before any effective status may change. An unmerged two-site
+support exhibit that used occupancy as a synonym for lock patterns is a
+sibling, not a premise; the lock patterns used here are reconstructed.
+
+## Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | The quoted Record sentences say “Only records are readable” and “A state is a configuration of records.” The obstruction is the identification of site occupancy with Record lock, or a readout of unlocked labels. This note splits those types on one star. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for unlocked labels, occupancy-versus-lock, putative occupancy, and “I sees only locks.” Hits: ACPHILAMBDA occupancy notes are orbit-grain statements (K/CPT 2-sector occupancy, `r=1/2` grain) and do not split lock from unlocked site-labels; Koide occupancy notes are statistical-slot or orbit-occupancy objects; the axiom memo never names occupancy. No landed type-split theorem that an unlocked label is invisible to `I` appears on that commit. An unmerged two-site support exhibit treats occupancy as a synonym for lock patterns and is a sibling, not a premise. |
+| V3 | Independently checkable? | Textbook partial maps (functions defined on a subset) do not mention Record, readout, or state. The runner recomputes `I` as a unit-strength domain count and checks `is_state` by absence of unlocked labels, in exact integer/`Fraction` arithmetic. |
+| V4 | More than a restatement? | Yes. The witnesses `I(L_1)=1`, `I(L_2)=2`, `I(empty)=0`, and `I(ghost)=I(L_1)=1` are not restatements of the quoted sentences. |
+| V5 | One-step relabel? | No. `I(empty)=0` alone says that the empty collection reads zero. It does not compare the ghost to `L_1` or separate `I=1` from `I=2`. The type split needs that pair. |
+
+## No-Go Discipline Gate (Theorems 4–5)
+
+The negative claim is restricted to this: occupancy-without-lock is extra,
+unlocking is not a third option supplied by the axioms, and the quoted
+sentences do not select a lock at every occupied site. The gate does not
+ship a global non-existence theorem against a later occupancy compiler.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| count unlocked labels | set `I` to the number of nonempty occupancy values | Theorem 1: `I(ghost)` would become `2`, but content-only `I` stays `1` | **ATTEMPTED** |
+| treat ghost as a state | declare `O_ghost` a Record state | Theorem 2: a state is a configuration of records; the ghost is not | **ATTEMPTED** |
+| force formation at every occupied site | lock every nonempty occupancy value | Theorem 4: that selector turns the ghost into `L_2` and changes `I` from `1` to `2`; it is extra | **ATTEMPTED** |
+| occupancy-lock synonym | identify every total occupancy map with its nonempty labels as locks | Theorems 1--3: the ghost would collapse to `L_2`, contradicting `I(ghost)=1` | **ATTEMPTED** |
+| axiom edit naming unlocked labels | add a sentence that unlocked labels are readable | not required by content-only readout; see N6 | **ATTEMPTED** |
+| `I(empty)=0` alone | derive the type split from the empty-collection identity | V5: the empty identity does not compare ghost to `L_1` | **ATTEMPTED** |
+
+### N2 — wall independence
+
+Theorems 4 and 5 close only the claim that the quoted sentences already
+supply occupancy-without-lock or force a lock at every occupied site. They
+do not close Theorem 1 (the count), Theorem 2 (the state predicate),
+Theorem 3 (content-only invisibility), a later occupancy compiler, or a
+later formation-rate law. Those walls remain independent. Invisibility of
+an unlocked label does not by itself forbid a later extra compiler.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| two-site star `{x,y}` and menu `{A,B}` | declared finite objects |
+| lock pattern as a partial map | declared Record configuration |
+| putative occupancy and unlocked labels | explicit extra marks |
+| unit-strength readout `I(L)=|dom(L)|` | explicit content-only count |
+| `μ(A)=1/3`, `μ(B)=2/3` | declared content law; support `{A,B}` |
+| axiom edit naming occupancy-without-lock | live governance path; not required |
+| later occupancy compiler | open; not assumed absent |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | “Only records are readable”; content-only readout; `I(empty)=0`; “A state is a configuration of records.” | quoted as premises only; no edit |
+
+No unmerged occupancy synonym exhibit is used as a parent. The lock
+patterns and the ghost are recomputed here.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | lock patterns `L_1`, `L_2`, `empty`, and the ghost occupancy | no classification of every site-label decoration |
+| per site | each star site is empty, locked, or carrying an unlocked label; `I` counts only locks | no composite carrier |
+| per mode | menu labels `{A,B}` are content; unlocked `B` is not a value of `I` | no spectral-mode exhaustion |
+| per block | type split on one star, plus the scoped residual that occupancy-without-lock is extra | no occupancy compiler and no axiom edit |
+| lattice-wide | checked and not executed | no lattice-wide occupancy process |
+
+The residual is a type-split gap. It is not lattice-wide.
+
+### N6 — live partial-closure paths
+
+1. A later occupancy compiler that uses more than Record content — for
+   example a declared total site-label — to name occupancy-without-lock
+   without editing an axiom.
+2. A later selector that forces a lock at every nonempty site, converting
+   a ghost into `L_2` by extra rule.
+3. A later readout that is not content-only and that treats unlocked
+   labels as readable.
+4. An owner-approved typed axiom addition that named occupancy-without-lock.
+   Content-only readout does not require that addition.
+
+The quoted Record sentences already name readable records, content-only
+`I`, `I(empty)=0`, and states as record configurations. They do not name
+unlocked labels. No axiom sentence is required by Theorem 5.
+
+### N7 — hostile steelman
+
+> Occupancy is just the lock pattern written as a total map with a blank
+> at empty sites. The ghost is then `L_2`, so `I` already counts occupancy.
+
+**Answer.** A total map that writes a menu value at a site with no record
+is not a lock pattern. Theorem 1 computes `I(ghost)=1` and `I(L_2)=2`.
+Theorem 2 refuses the ghost as a state. The synonym that collapses the
+ghost to `L_2` is exactly the identification this note prunes.
+
+### N8 — cross-cycle echo
+
+Orbit-grain occupancy notes on `origin/main` concern K/CPT sector weights
+and statistical slots. They do not read an unlocked site-label as a Record
+state. The present type split does not reverse those notes. It answers a
+different question: among Record readouts, only locks are visible; among
+putative site-labels, an unlocked mark is extra.
+
+**Gate disposition.** PASS for invisibility of unlocked labels, for the
+state/non-state split, and for the scoped residual that occupancy-without-lock
+is extra. FAIL / DO NOT SHIP for “no occupancy compiler exists,” “formation
+is forced at every occupied site,” or “an axiom edit is required.”
+
+## Primary Runner
+
+[`scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py`](../scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py)
+recomputes `I` from lock domains, the ghost comparison `I(ghost)=I(L_1)=1`,
+the state predicate, content-only readable sets, and the shared content law
+in exact rational arithmetic. Identity gates call `I_of_locks(L)` and
+`is_state(L)`. A predicate that `I` counts unlocked labels must fail (ghost
+still `I=1`). Replacing `L_1` by `L_2` must change `I` from `1` to `2`. A
+predicate that the ghost is a state must fail Theorem 2.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18765,6 +18765,10 @@
   "universality_classifier_note": {
    "deps_hash": "d8faf92865d3",
    "out_degree": 3
+  },
+  "unlocked_labels_are_invisible_occupancy_is_not_lock_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unordered_mass_multiset_registrability_bridge_narrow_theorem_note_2026-06-11": {
    "deps_hash": "78fbe012cf29",

--- a/logs/runner-cache/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.txt
+++ b/logs/runner-cache/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py
+runner_sha256: 91b06eeb0540ef87c54ca96a484532065b8782feeb51f6487f8b3568b755c832
+input_fingerprint_sha256: ced0e22676aaf1a7c4fc6be0b757d1ca55e060cac04eb3729ee46862b3c6afd2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record content-only readout, I(empty)=0, and the state-as-records sentence are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: unlocked labels are invisible and are not states; occupancy-without-lock is extra; no occupancy compiler is excluded
+PASS: audit-input-paths declared audit inputs exist and match the note and the axiom memo
+PASS: source-only-records-readable the exact current readable-records sentence is present in the axiom memo
+PASS: source-record-content-only the exact current content-only readout sentence is present in the axiom memo
+PASS: source-state-configuration the exact current state-as-records sentence is present in the axiom memo
+PASS: source-i-empty the exact current Record additivity sentence with I(empty)=0 is present
+PASS: empty-readout I(empty)=0
+PASS: theorem-1-lock-counts I(L_1)=1, I(L_2)=2, I(empty)=0 by unit-strength domain count
+PASS: theorem-1-ghost-invisible I(ghost)=I(L_1)=1; the unlocked B does not change I
+PASS: theorem-1-additivity I(L_2)=I(L_1)+I(y↦B)=1+1=2 on disjoint one-site records
+PASS: theorem-2-states-are-lock-patterns is_state is true of L_1 and L_2 and false of the ghost
+PASS: theorem-3-content-only readable content of the ghost equals L_1; no readout of unlocked B exists
+PASS: theorem-4-formation-free the same content law with support {A,B} is compatible with L_1 and L_2
+PASS: theorem-4-unlocking-not-third-option forcing a lock at every occupied site turns the ghost into L_2
+PASS: theorem-5-not-selected occupancy-without-lock remains a second object; I still sees only locks
+PASS: mutation-count-unlocked-fails a predicate that I counts unlocked labels fails; ghost still I=1
+PASS: mutation-replace-L1-by-L2 replacing L_1 by L_2 changes I from 1 to 2
+PASS: mutation-ghost-is-state-fails a predicate that the ghost is a state fails Theorem 2
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: canonical-nonmutation unlocked labels and occupancy-without-lock are absent from the axiom memo
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: lock patterns L_1, L_2, empty, and the ghost occupancy are recomputed as maps on {x,y}
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: each star site is empty, locked, or carrying an unlocked label; I counts only locks
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: menu labels {A,B} are content; unlocked B is not a value of I
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only the two-site star and unit-strength readout are executed; occupancy-without-lock stays extra
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no lattice-wide occupancy compiler or formation law is claimed
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py
+++ b/scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Exact checks: unlocked labels are invisible; occupancy is not lock.
+
+I sees only lock patterns. A putative unlocked label is invisible:
+I(ghost)=I(L_1)=1 versus I(L_2)=2. Identity gates call I_of_locks(L)
+and is_state(L). Occupancy-without-lock is extra. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "UNLOCKED_LABELS_ARE_INVISIBLE_OCCUPANCY_IS_NOT_LOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/UNLOCKED_LABELS_ARE_INVISIBLE_OCCUPANCY_IS_NOT_LOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+SITES = ("x", "y")
+MENU = ("A", "B")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class LockPattern:
+    """Partial map L: {x,y} ⇀ {A,B}."""
+
+    pairs: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for site, label in self.pairs:
+            if site not in SITES:
+                raise ValueError("lock site must lie on the star")
+            if label not in MENU:
+                raise ValueError("lock label must lie on the menu")
+            if site in seen:
+                raise ValueError("a site never carries more than one record")
+            seen.add(site)
+
+    def domain(self) -> frozenset[str]:
+        return frozenset(site for site, _ in self.pairs)
+
+    def content_at(self, site: str) -> str | None:
+        return dict(self.pairs).get(site)
+
+    def readable(self) -> frozenset[tuple[str, str]]:
+        return frozenset(self.pairs)
+
+
+@dataclass(frozen=True)
+class Occupancy:
+    """Total map O: {x,y} → {A,B,∅} plus which sites actually lock."""
+
+    labels: tuple[tuple[str, str | None], ...]
+    locked: frozenset[str]
+
+    def __post_init__(self) -> None:
+        sites = tuple(site for site, _ in self.labels)
+        if sites != SITES:
+            raise ValueError("occupancy must assign both star sites in order")
+        for site, label in self.labels:
+            if label is not None and label not in MENU:
+                raise ValueError("occupancy label must lie on the menu or be empty")
+        for site in self.locked:
+            if site not in SITES:
+                raise ValueError("locked site must lie on the star")
+            if dict(self.labels)[site] is None:
+                raise ValueError("a lock requires a nonempty label")
+
+    def as_lock_pattern(self) -> LockPattern:
+        pairs = tuple(
+            (site, label)
+            for site, label in self.labels
+            if site in self.locked and label is not None
+        )
+        return LockPattern(pairs)
+
+    def unlocked_labels(self) -> tuple[tuple[str, str], ...]:
+        return tuple(
+            (site, label)
+            for site, label in self.labels
+            if site not in self.locked and label is not None
+        )
+
+    def is_ghost(self) -> bool:
+        return len(self.unlocked_labels()) > 0
+
+
+def I_of_locks(pattern: LockPattern | Occupancy) -> Fraction:
+    """Identity-gate function: unit-strength count of locked sites only."""
+    locks = pattern.as_lock_pattern() if isinstance(pattern, Occupancy) else pattern
+    return sum((Fraction(1) for _ in locks.pairs), Fraction(0))
+
+
+def is_state(pattern: LockPattern | Occupancy) -> bool:
+    """Identity-gate function: true iff the object is a lock pattern, not a ghost."""
+    if isinstance(pattern, Occupancy):
+        return not pattern.is_ghost()
+    return isinstance(pattern, LockPattern)
+
+
+def I_counting_labels(pattern: Occupancy) -> Fraction:
+    """Mutation: count every nonempty occupancy value, locked or unlocked."""
+    return sum((Fraction(1) for _, label in pattern.labels if label is not None), Fraction(0))
+
+
+def force_lock_every_label(pattern: Occupancy) -> LockPattern:
+    """Mutation: treat every nonempty occupancy value as a lock."""
+    pairs = tuple((site, label) for site, label in pattern.labels if label is not None)
+    return LockPattern(pairs)
+
+
+def predicate_i_counts_unlocked(pattern: Occupancy) -> bool:
+    """Mutation predicate: I counts unlocked labels."""
+    return I_of_locks(pattern) == I_counting_labels(pattern)
+
+
+def predicate_ghost_is_state(pattern: Occupancy) -> bool:
+    """Mutation predicate: declare any occupancy, including a ghost, a state."""
+    return True
+
+
+def support_of(measure: dict[str, Fraction]) -> frozenset[str]:
+    return frozenset(label for label, mass in measure.items() if mass > 0)
+
+
+def lawful(pattern: LockPattern, measure: dict[str, Fraction]) -> bool:
+    allowed = support_of(measure)
+    return all(label in allowed for _, label in pattern.pairs)
+
+
+def occupancy_from(locks: LockPattern, unlocked: dict[str, str] | None = None) -> Occupancy:
+    unlocked = unlocked or {}
+    labels: list[tuple[str, str | None]] = []
+    locked_sites = locks.domain()
+    for site in SITES:
+        if site in locked_sites:
+            labels.append((site, locks.content_at(site)))
+        elif site in unlocked:
+            labels.append((site, unlocked[site]))
+        else:
+            labels.append((site, None))
+    return Occupancy(tuple(labels), locked_sites)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current Record content-only readout, "
+        "I(empty)=0, and the state-as-records sentence are source-bound; no "
+        "observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; no runner cache is written"
+    )
+    print(
+        "negative_scope: unlocked labels are invisible and are not states; "
+        "occupancy-without-lock is extra; no occupancy compiler is excluded"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/UNLOCKED_LABELS_ARE_INVISIBLE_OCCUPANCY_IS_NOT_LOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    readable_sentence = "Only records are readable."
+    content_sentence = "A readout value is determined by record content alone."
+    state_sentence = "A state is a configuration of records."
+    additivity_sentence = (
+        "For any finite collection of pairwise-disjoint records, scalar readout "
+        "`I` is additive, with `I(empty)=0`."
+    )
+    checks.check(
+        "source-only-records-readable",
+        "the exact current readable-records sentence is present in the axiom memo",
+        readable_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-record-content-only",
+        "the exact current content-only readout sentence is present in the axiom memo",
+        content_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-state-configuration",
+        "the exact current state-as-records sentence is present in the axiom memo",
+        state_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-i-empty",
+        "the exact current Record additivity sentence with I(empty)=0 is present",
+        additivity_sentence in normalized_axiom,
+    )
+
+    empty = LockPattern()
+    lock_1 = LockPattern((("x", "A"),))
+    lock_2 = LockPattern((("x", "A"), ("y", "B")))
+    ghost = occupancy_from(lock_1, unlocked={"y": "B"})
+    ghost_as_occupancy_of_lock_1 = occupancy_from(lock_1)
+
+    checks.check(
+        "empty-readout",
+        "I(empty)=0",
+        I_of_locks(empty) == Fraction(0),
+        residual=I_of_locks(empty),
+    )
+    checks.check(
+        "theorem-1-lock-counts",
+        "I(L_1)=1, I(L_2)=2, I(empty)=0 by unit-strength domain count",
+        I_of_locks(lock_1) == Fraction(1)
+        and I_of_locks(lock_2) == Fraction(2)
+        and I_of_locks(empty) == Fraction(0)
+        and lock_1.domain() == frozenset({"x"})
+        and lock_2.domain() == frozenset({"x", "y"})
+        and empty.domain() == frozenset(),
+        residual=(I_of_locks(empty), I_of_locks(lock_1), I_of_locks(lock_2)),
+    )
+    checks.check(
+        "theorem-1-ghost-invisible",
+        "I(ghost)=I(L_1)=1; the unlocked B does not change I",
+        I_of_locks(ghost) == I_of_locks(lock_1) == Fraction(1)
+        and I_of_locks(ghost) != I_of_locks(lock_2)
+        and ghost.unlocked_labels() == (("y", "B"),)
+        and ghost.as_lock_pattern() == lock_1,
+        residual=(I_of_locks(ghost), I_of_locks(lock_1), I_of_locks(lock_2)),
+    )
+    lock_at_y = LockPattern((("y", "B"),))
+    checks.check(
+        "theorem-1-additivity",
+        "I(L_2)=I(L_1)+I(y↦B)=1+1=2 on disjoint one-site records",
+        lock_1.domain().isdisjoint(lock_at_y.domain())
+        and I_of_locks(lock_1) + I_of_locks(lock_at_y) == I_of_locks(lock_2) == Fraction(2),
+        residual=I_of_locks(lock_1) + I_of_locks(lock_at_y),
+    )
+
+    checks.check(
+        "theorem-2-states-are-lock-patterns",
+        "is_state is true of L_1 and L_2 and false of the ghost",
+        is_state(lock_1)
+        and is_state(lock_2)
+        and is_state(empty)
+        and is_state(ghost_as_occupancy_of_lock_1)
+        and not is_state(ghost)
+        and ghost.is_ghost(),
+        residual=(is_state(lock_1), is_state(lock_2), is_state(ghost)),
+    )
+    checks.check(
+        "theorem-3-content-only",
+        "readable content of the ghost equals L_1; no readout of unlocked B exists",
+        lock_1.readable() == frozenset({("x", "A")})
+        and ghost.as_lock_pattern().readable() == lock_1.readable()
+        and lock_2.readable() == frozenset({("x", "A"), ("y", "B")})
+        and ("y", "B") not in ghost.as_lock_pattern().readable()
+        and content_sentence in normalized_note
+        and readable_sentence in normalized_note,
+        residual=ghost.as_lock_pattern().readable(),
+    )
+
+    measure = {"A": Fraction(1, 3), "B": Fraction(2, 3)}
+    checks.check(
+        "theorem-4-formation-free",
+        "the same content law with support {A,B} is compatible with L_1 and L_2",
+        support_of(measure) == frozenset({"A", "B"})
+        and sum(measure.values(), Fraction(0)) == 1
+        and lawful(lock_1, measure)
+        and lawful(lock_2, measure)
+        and I_of_locks(lock_1) != I_of_locks(lock_2)
+        and not is_state(ghost),
+        residual=(support_of(measure), I_of_locks(lock_1), I_of_locks(lock_2)),
+    )
+    forced = force_lock_every_label(ghost)
+    checks.check(
+        "theorem-4-unlocking-not-third-option",
+        "forcing a lock at every occupied site turns the ghost into L_2",
+        forced == lock_2
+        and I_of_locks(forced) == Fraction(2)
+        and I_of_locks(ghost) == Fraction(1),
+        residual=I_of_locks(forced),
+    )
+    checks.check(
+        "theorem-5-not-selected",
+        "occupancy-without-lock remains a second object; I still sees only locks",
+        readable_sentence in note
+        and state_sentence in note
+        and "I(empty)=0" in note
+        and additivity_sentence in normalized_note
+        and I_of_locks(ghost) == I_of_locks(lock_1)
+        and not is_state(ghost)
+        and I_counting_labels(ghost) != I_of_locks(ghost),
+    )
+
+    checks.check(
+        "mutation-count-unlocked-fails",
+        "a predicate that I counts unlocked labels fails; ghost still I=1",
+        I_of_locks(ghost) == Fraction(1)
+        and I_counting_labels(ghost) == Fraction(2)
+        and predicate_i_counts_unlocked(ghost) is False
+        and I_of_locks(ghost) != I_counting_labels(ghost),
+        residual=(I_of_locks(ghost), I_counting_labels(ghost)),
+    )
+    checks.check(
+        "mutation-replace-L1-by-L2",
+        "replacing L_1 by L_2 changes I from 1 to 2",
+        I_of_locks(lock_1) == Fraction(1)
+        and I_of_locks(lock_2) == Fraction(2)
+        and I_of_locks(lock_1) != I_of_locks(lock_2),
+        residual=(I_of_locks(lock_1), I_of_locks(lock_2)),
+    )
+    checks.check(
+        "mutation-ghost-is-state-fails",
+        "a predicate that the ghost is a state fails Theorem 2",
+        is_state(ghost) is False
+        and predicate_ghost_is_state(ghost) is True
+        and predicate_ghost_is_state(ghost) != is_state(ghost)
+        and is_state(lock_1)
+        and is_state(lock_2),
+        residual=(is_state(ghost), predicate_ghost_is_state(ghost)),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                'hypothetical_axiom_status: "no edit"',
+                "trace_class: negative_route_pruning",
+                "target_claim_id: occupancy_versus_lock",
+                "reachability_to_target: prunes",
+                'target_blocker_text: "identify site occupancy with Record lock, or read unlocked labels"',
+                'next_trace_action: "Unlocked labels are invisible and are not states. Occupancy-without-lock is extra. Do not adopt axiom text."',
+                "Only records are readable",
+                "A state is a configuration of records.",
+                "I(empty)=0",
+                "I(L_1)=1",
+                "I(L_2)=2",
+                "I(ghost)=I(L_1)=1",
+                "authors no audit verdict",
+            )
+        )
+        and additivity_sentence in normalized_note
+        and content_sentence in note
+        and "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and "**Type:** bounded_theorem" in note
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "Codex" not in note
+        and "toe-lphys" not in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "unlocked labels and occupancy-without-lock are absent from the axiom memo",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "unlocked label",
+                "occupancy-without-lock",
+                "putative occupancy",
+                "O_ghost",
+            )
+        )
+        and readable_sentence in axiom
+        and state_sentence in axiom,
+    )
+
+    n5_lines = (
+        "per_element: lock patterns L_1, L_2, empty, and the ghost occupancy are recomputed as maps on {x,y}",
+        "per_site: each star site is empty, locked, or carrying an unlocked label; I counts only locks",
+        "per_mode: menu labels {A,B} are content; unlocked B is not a value of I",
+        "per_block: only the two-site star and unit-strength readout are executed; occupancy-without-lock stays extra",
+        "lattice_wide: checked and not executed — no lattice-wide occupancy compiler or formation law is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-site star `{x,y}` with menu `{A,B}`, content-only readout sees only lock patterns: `I(L_1)=1`, `I(L_2)=2`, `I(empty)=0`, and `I(ghost)=I(L_1)=1` because an unlocked label is not a record. The ghost is not a state. Occupancy-without-lock is extra and is not axiom content.

## What this means for the TOE

Occupancy is not lock. A later occupancy compiler would be extra. This does not claim that no occupancy compiler exists.

## What changed

- Note: `docs/UNLOCKED_LABELS_ARE_INVISIBLE_OCCUPANCY_IS_NOT_LOCK_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py`
- Cache: `logs/runner-cache/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.txt`

## Verification

```bash
python3 scripts/unlocked_labels_are_invisible_occupancy_is_not_lock_2026_08_13.py
# TOTAL: PASS=24 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
