### PR TITLE
[physics-loop] toe-lphys green: bounded_theorem / bounded-support

### DIFF
--- a/docs/LATTICE_GREEN_ON_Z3_IS_NOT_CONTINUUM_ONE_OVER_R_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/LATTICE_GREEN_ON_Z3_IS_NOT_CONTINUUM_ONE_OVER_R_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,233 @@
+---
+claim_id: lattice_green_on_z3_is_not_continuum_one_over_r_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the cube {-2..2}^3 of Z^3 the graph reciprocal 1/d is not nn-harmonic at e1, so G_cont∘d is not a lattice Green function; Record additivity does not select a kernel; the Newton packet is not retired."
+upstream_dependencies:
+  - minimal_axioms
+  - newton_law_derived_note
+runner: scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py
+---
+
+# Discrete Z^3 Graph-Distance Reciprocal Is Not a Continuum 1/r Lattice Green Trial
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Claim type:** bounded_theorem
+**Claim scope:** exact Fraction / integer-lattice comparison of the formal
+continuum Newton-packet kernel symbol with the 6-nearest-neighbor graph
+reciprocal on a finite cube of `Z^3`. The continuum symbol composed with
+graph distance is not a lattice Green function. Record additivity does
+not select a kernel. The Newton packet is not retired.
+**Status authority:** independent audit lane only. This source note does
+not set, predict, or estimate an audit verdict.
+**Primary runner:**
+[`scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py`](../scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py)
+
+Parents (the only load-bearing textual inputs):
+
+- [`NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) — formal
+  continuum kernel symbol and already-isolated source-linear product
+  pairing.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — Lattice
+  (`Z^3`, nearest-neighbor adjacency) and Record (including additivity of
+  scalar readout on pairwise-disjoint records).
+
+No axiom is edited. No gravitational coupling, no `G_N`, and no physical
+Newton force law is imported or claimed. The continuum kernel is not
+installed on the lattice.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "1/d fails nn-harmonicity at e1 by exact Fraction; G_cont∘d is not a lattice Green; Record additivity does not pick a kernel."
+trace_class: negative_route_pruning
+target_claim_id: discrete_z3_green_versus_one_over_r
+target_blocker_text: "derive a 1/r kernel from the lattice after the product pairing is isolated"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "The remaining Newton object is a lattice Green, not G_cont∘d. Do not install 1/r. Do not retire the Newton packet."
+hypothetical_axiom_status: "no edit"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Objects
+
+The Newton packet uses, as a formal symbol for `r > 0`,
+
+```text
+G_cont(r) = 1/(4 π r).
+```
+
+That symbol is not constructed here. It is quoted from the parent packet
+as a formal radial expression. This note does not identify it with a
+lattice function and does not install `1/r` on `Z^3`.
+
+Let `Z^3` carry the 6-nearest-neighbor adjacency of the Lattice axiom.
+Graph distance from the origin is
+
+```text
+d(x, 0) = |x_1| + |x_2| + |x_3|.
+```
+
+Write `d(x)` for `d(x, 0)`. On the punctured cube
+
+```text
+C* = {-2, …, 2}^3 \ {0}
+```
+
+the graph reciprocal is the `Q`-valued function `x ↦ 1/d(x)`. The
+composition `G_cont ∘ d` is the formal multiple `(1/(4 π)) · (1/d)` on
+`C*`. Neither function is assigned a finite reciprocal at the origin:
+`d(0) = 0`.
+
+The 6-nearest-neighbor Laplacian (continuum sign) is
+
+```text
+(Δ_nn g)(x) = Σ_{y ~ x} (g(y) − g(x)) = (Σ_{y ~ x} g(y)) − 6 g(x).
+```
+
+A **graph Green trial** on the closed cube `C = {-2, …, 2}^3` is a
+`Q`-valued function `g: C → Q` satisfying the lattice Poisson identities
+
+```text
+(Δ_nn g)(0) = −1,
+(Δ_nn g)(x) = 0    for all x with 0 < |x|_∞ ≤ 1.
+```
+
+The already-isolated product pairing of the Newton packet is the
+source-linear map
+
+```text
+π(M, G) := M · G,
+```
+
+the formal rule `phi = M G` recorded in the parent packet. This note
+does not enlarge, replace, or re-derive `π`.
+
+## Theorem 1
+
+At the executed sites `e_1 = (1,0,0)`, `2 e_1 = (2,0,0)`, and
+`e_1 + e_2 = (1,1,0)`,
+
+```text
+d(e_1) = 1,     d(2 e_1) = 2,     d(e_1 + e_2) = 2,
+1/d(e_1) = 1,   1/d(2 e_1) = 1/2, 1/d(e_1 + e_2) = 1/2.
+```
+
+The six 6-nearest-neighbor sites of `e_1` and the corresponding
+`1/d` values are
+
+```text
+(0,0,0)   : 1/d undefined (not a finite lattice value),
+(2,0,0)   : 1/2,
+(1, 1,0)  : 1/2,
+(1,-1,0)  : 1/2,
+(1,0, 1)  : 1/2,
+(1,0,-1)  : 1/2.
+```
+
+The center value is `1/d(e_1) = 1`. The nn-Laplacian of `1/d` at `e_1`
+is therefore not the zero element of `Q`: the stencil meets the origin,
+where `1/d` is not a finite lattice value, so the predicate
+“`1/d` is nn-harmonic off `0`” fails at `e_1`.
+
+Under the unique `Q`-valued extension that agrees with `1/d` on `C*` and
+places `0` at the undefined origin (the only integer that is not a
+reciprocal of a positive graph distance on `C`), the same stencil
+evaluates to the explicit nonzero Fraction
+
+```text
+(Δ_nn f)(e_1) = 0 + 5 · (1/2) − 6 · 1 = −7/2 ≠ 0.
+```
+
+## Theorem 2
+
+Consequently `G_cont ∘ d` is not a lattice Green function.
+
+On `C*` the composition is a positive formal multiple of `1/d`. A
+positive multiple of a function that fails to be nn-harmonic at `e_1`
+cannot satisfy `(Δ_nn g)(e_1) = 0`. Even if the origin value is left
+free in `Q`, no extension of `1/d` is a graph Green trial: Poisson at
+the origin forces one origin value, and harmonicity at `e_1` forces
+another.
+
+Let `g(0) = c ∈ Q` and `g = 1/d` on `C*`. The six neighbors of the
+origin are `± e_i`, each with `1/d = 1`, so
+
+```text
+(Δ_nn g)(0) = 6 · 1 − 6 c = 6(1 − c).
+```
+
+The identity `(Δ_nn g)(0) = −1` forces `c = 7/6`. The stencil at `e_1`
+gives
+
+```text
+(Δ_nn g)(e_1) = c + 5 · (1/2) − 6 = c − 7/2,
+```
+
+and `(Δ_nn g)(e_1) = 0` forces `c = 7/2`. These are distinct elements of
+`Q`. Therefore no function that equals `1/d` at every executed site of
+`C*` satisfies the lattice Poisson identities, and the formal
+composition `G_cont ∘ d` is not a lattice Green function.
+
+The same non-harmonicity is visible at a site whose stencil never meets
+the origin: at `e_1 + e_2`,
+
+```text
+(Δ_nn (1/d))(e_1 + e_2) = 2 · 1 + 4 · (1/3) − 6 · (1/2) = 1/3 ≠ 0.
+```
+
+## Theorem 3
+
+Record additivity does not pick either kernel.
+
+The Record axiom of the parent memo states that records form; that a
+present record locks exactly one admissible local possibility; that a
+site never carries more than one record; that records are permanent;
+and that for any finite collection of pairwise-disjoint records, scalar
+readout `I` is additive, with `I(empty) = 0`.
+
+That additivity is a statement about scalar readout of disjoint records.
+It does not name a Green function, a Laplacian, a radial kernel, graph
+distance, `1/d`, or `G_cont`. It therefore does not select
+`G_cont ∘ d` over a graph Green trial, nor the reverse.
+
+## Theorem 4
+
+This note does not retire the Newton packet. It splits the remaining
+kernel object from the already-isolated product pairing `π`.
+
+The parent packet still records the formal algebra `G(r) = 1/(4 π r)`,
+`phi = M G`, `|grad phi| = M/(4 π r^2)` as bounded-support
+potential-kernel algebra, and it still refuses a physical force law.
+The product pairing `π(M, G) := M · G` is already isolated there as
+source-linearity. What remains unidentified is the kernel object
+itself: the formal continuum symbol is not the 6-nn graph reciprocal,
+and the graph reciprocal is not a lattice Green function. Separating
+those objects does not delete the packet.
+
+## Non-claims
+
+This row does not prove, install, or claim:
+
+- a physical Newton force law, a gravitational coupling, or `G_N`;
+- that `1/r` or `G_cont` is the lattice Green function on `Z^3`;
+- that a graph Green function on `Z^3` has been constructed;
+- that Record additivity produces a pairing of sources or a kernel;
+- retirement, replacement, or promotion of the Newton parent packet;
+- any axiom edit or new primitive.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py
+```
+
+Expected closeout: `PASS >= 10`, `FAIL = 0`, and the mutation predicate
+“`1/d` is nn-harmonic off `0`” fails at `e_1`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11777,6 +11777,10 @@
   "lattice_green_function_zero_argument_narrow_theorem_note_2026-05-17": {
    "deps_hash": "620cf6af7381",
    "out_degree": 1
+  },
+  "lattice_green_on_z3_is_not_continuum_one_over_r_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "7ea010b16c05",
+   "out_degree": 2
   },
   "lattice_greens_1_over_r_from_heat_kernel_resolvent_theorem_note_2026-06-07": {
    "deps_hash": "2b11e69fd3cb",

--- a/logs/runner-cache/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.txt
+++ b/logs/runner-cache/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py
+runner_sha256: d098f182e858fc0db3eea5cff099058ec3d9ab97551dd5f099c919d778848d7c
+input_fingerprint_sha256: 18a1ccce6610740447d8810a51c7bb76f37bacd2fffdfc60f8536550c59a0561
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+PASS AUDIT_INPUT_PATHS has the new note, Newton note, axiom memo
+PASS T1 graph distances at e1, 2e1, e1+e2 are 1, 2, 2
+PASS T1 reciprocals at e1, 2e1, e1+e2 are 1, 1/2, 1/2
+PASS T1 six neighbors of e1: origin undefined, five halves
+PASS T1 zero-extended nn-Laplacian of 1/d at e1 is -7/2
+PASS mutation: 1/d is nn-harmonic off 0 fails at e1
+PASS T2 no origin value makes 1/d a Green trial (7/6 != 7/2)
+PASS T2 1/d Laplacian at e1+e2 is 1/3 (stencil avoids origin)
+PASS executed cube {-2..2}^3\{0} has 124 Fraction values 1/d
+PASS T2 G_cont∘d is not a lattice Green: 1/d fails Poisson/harmonicity
+PASS T3 axiom memo states Record readout additivity on disjoint records
+PASS T3 Record additivity text does not name either kernel
+PASS T4 Newton packet still isolates phi = M G and formal G(r)
+PASS T4 this note does not retire Newton and splits kernel from π
+PASS note states Theorems 1–4 and refuses gravity / G_N / 1/r install
+PASS no G_N import and no force-law derivation in this pair
+PASS n5 per_element: graph dista
+per_element: graph distances and 1/d values at e1, 2e1, e1+e2 are exact Fractions
+PASS n5 per_site: the nn-Laplaci
+per_site: the nn-Laplacian is evaluated at e1 and e1+e2 only
+PASS n5 per_mode: 6-nn graph Lap
+per_mode: 6-nn graph Laplacian is checked; no continuum mode is claimed
+PASS n5 per_block: only the 1/d 
+per_block: only the 1/d versus Green-trial split and the additivity residual are executed
+PASS n5 lattice_wide: checked an
+lattice_wide: checked and not executed — no lattice-wide gravity or G_N is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py
+++ b/scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Exact Fraction / integer-lattice checks: 1/d is not a 6-nn Green trial.
+
+Parents read as AUDIT_INPUT_PATHS only: this note, the Newton packet, and
+the current axiom memo. No cache write, no G_N, no continuum 1/r install.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/LATTICE_GREEN_ON_Z3_IS_NOT_CONTINUUM_ONE_OVER_R_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/NEWTON_LAW_DERIVED_NOTE.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE = ROOT / AUDIT_INPUT_PATHS[0]
+NEWTON = ROOT / AUDIT_INPUT_PATHS[1]
+AXIOM = ROOT / AUDIT_INPUT_PATHS[2]
+
+NN = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+E1 = (1, 0, 0)
+TWO_E1 = (2, 0, 0)
+E1_E2 = (1, 1, 0)
+ORIGIN = (0, 0, 0)
+
+
+def add(x, y):
+    return (x[0] + y[0], x[1] + y[1], x[2] + y[2])
+
+
+def graph_distance(x):
+    return abs(x[0]) + abs(x[1]) + abs(x[2])
+
+
+def one_over_d(x):
+    dist = graph_distance(x)
+    if dist == 0:
+        return None
+    return Fraction(1, dist)
+
+
+def one_over_d_zero_at_origin(x):
+    value = one_over_d(x)
+    return Fraction(0) if value is None else value
+
+
+def nn_laplacian(func, x):
+    center = func(x)
+    return sum(func(add(x, shift)) for shift in NN) - 6 * center
+
+
+def one_over_d_is_nn_harmonic_off_0(site) -> bool:
+    """Predicate: 1/d is nn-harmonic off 0 at `site`.
+
+    The origin is outside the domain of 1/d. If the 6-nn stencil meets the
+    origin, the predicate is false. Otherwise it is true only if the
+    Laplacian Fraction is exactly zero.
+    """
+    if site == ORIGIN:
+        return False
+    for shift in NN:
+        if add(site, shift) == ORIGIN:
+            return False
+    return nn_laplacian(one_over_d_zero_at_origin, site) == 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+            print(f"PASS {label}")
+        else:
+            self.failed += 1
+            print(f"FAIL {label}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return 0 if self.failed == 0 and self.passed >= 10 else 1
+
+
+def main() -> int:
+    checks = Checks()
+    note_text = NOTE.read_text(encoding="utf-8")
+    newton_text = NEWTON.read_text(encoding="utf-8")
+    axiom_text = AXIOM.read_text(encoding="utf-8")
+
+    checks.check("AUDIT_INPUT_PATHS has the new note, Newton note, axiom memo",
+                 AUDIT_INPUT_PATHS == (
+                     "docs/LATTICE_GREEN_ON_Z3_IS_NOT_CONTINUUM_ONE_OVER_R_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+                     "docs/NEWTON_LAW_DERIVED_NOTE.md",
+                     "docs/MINIMAL_AXIOMS_2026-06-29.md",
+                 ) and NOTE.is_file() and NEWTON.is_file() and AXIOM.is_file())
+
+    checks.check("T1 graph distances at e1, 2e1, e1+e2 are 1, 2, 2",
+                 graph_distance(E1) == 1
+                 and graph_distance(TWO_E1) == 2
+                 and graph_distance(E1_E2) == 2)
+
+    checks.check("T1 reciprocals at e1, 2e1, e1+e2 are 1, 1/2, 1/2",
+                 one_over_d(E1) == 1
+                 and one_over_d(TWO_E1) == Fraction(1, 2)
+                 and one_over_d(E1_E2) == Fraction(1, 2))
+
+    neighbor_values = tuple(one_over_d(add(E1, shift)) for shift in NN)
+    checks.check("T1 six neighbors of e1: origin undefined, five halves",
+                 neighbor_values.count(None) == 1
+                 and neighbor_values.count(Fraction(1, 2)) == 5)
+
+    lap_e1 = nn_laplacian(one_over_d_zero_at_origin, E1)
+    checks.check("T1 zero-extended nn-Laplacian of 1/d at e1 is -7/2",
+                 lap_e1 == Fraction(-7, 2))
+
+    checks.check("mutation: 1/d is nn-harmonic off 0 fails at e1",
+                 one_over_d_is_nn_harmonic_off_0(E1) is False
+                 and lap_e1 != 0)
+
+    poisson_c = Fraction(7, 6)
+    harmonic_c = Fraction(7, 2)
+    lap_origin_at_poisson = (
+        6 * Fraction(1) - 6 * poisson_c
+    )
+    lap_e1_at_poisson = poisson_c + 5 * Fraction(1, 2) - 6
+    checks.check("T2 no origin value makes 1/d a Green trial (7/6 != 7/2)",
+                 poisson_c != harmonic_c
+                 and lap_origin_at_poisson == Fraction(-1)
+                 and lap_e1_at_poisson == poisson_c - Fraction(7, 2)
+                 and lap_e1_at_poisson != 0)
+
+    lap_diag = nn_laplacian(one_over_d_zero_at_origin, E1_E2)
+    checks.check("T2 1/d Laplacian at e1+e2 is 1/3 (stencil avoids origin)",
+                 one_over_d_is_nn_harmonic_off_0(E1_E2) is False
+                 and lap_diag == Fraction(1, 3))
+
+    cube_star = [
+        (x, y, z)
+        for x in range(-2, 3)
+        for y in range(-2, 3)
+        for z in range(-2, 3)
+        if (x, y, z) != ORIGIN
+    ]
+    checks.check("executed cube {-2..2}^3\\{0} has 124 Fraction values 1/d",
+                 len(cube_star) == 124
+                 and all(isinstance(one_over_d(site), Fraction) for site in cube_star))
+
+    # G_cont o d is a formal positive multiple of 1/d on C*, so it inherits
+    # the failed harmonicity. The multiple 1/(4π) is never instantiated.
+    checks.check("T2 G_cont∘d is not a lattice Green: 1/d fails Poisson/harmonicity",
+                 lap_e1 != 0 and poisson_c != harmonic_c)
+
+    checks.check("T3 axiom memo states Record readout additivity on disjoint records",
+                 "pairwise-disjoint records, scalar readout" in axiom_text
+                 and "I(empty)=0" in axiom_text.replace(" ", ""))
+
+    kernel_needles = (
+        "lattice Green",
+        "G_cont",
+        "1/d",
+        "1/r",
+        "graph distance",
+        "Poisson",
+    )
+    checks.check("T3 Record additivity text does not name either kernel",
+                 all(needle not in axiom_text.split("### Record / Fixed Reality")[1]
+                     .split("## Qualification")[0]
+                     for needle in kernel_needles))
+
+    checks.check("T4 Newton packet still isolates phi = M G and formal G(r)",
+                 "G(r) = 1/(4 pi r)" in newton_text
+                 and "phi(r) = M G(r)" in newton_text
+                 and "source-linearity" in newton_text)
+
+    checks.check("T4 this note does not retire Newton and splits kernel from π",
+                 "does not retire the Newton packet" in note_text
+                 and "already-isolated product pairing" in note_text
+                 and "π(M, G) := M · G" in note_text)
+
+    checks.check("note states Theorems 1–4 and refuses gravity / G_N / 1/r install",
+                 "Theorem 1" in note_text
+                 and "Theorem 2" in note_text
+                 and "Theorem 3" in note_text
+                 and "Theorem 4" in note_text
+                 and "No gravitational coupling, no `G_N`" in note_text
+                 and "does not install `1/r`" in note_text
+                 and "G_N" not in newton_text.split("## In-Scope Theorem")[0])
+
+    forbidden = ("G_N =", "import G_N", "Newton force law is derived")
+    checks.check("no G_N import and no force-law derivation in this pair",
+                 all(token not in note_text for token in forbidden)
+                 and "G_N" not in Path(__file__).read_text(encoding="utf-8").split(
+                     'no G_N, no continuum'
+                 )[0])
+
+    n5_lines = (
+        "per_element: graph distances and 1/d values at e1, 2e1, e1+e2 are exact Fractions",
+        "per_site: the nn-Laplacian is evaluated at e1 and e1+e2 only",
+        "per_mode: 6-nn graph Laplacian is checked; no continuum mode is claimed",
+        "per_block: only the 1/d versus Green-trial split and the additivity residual are executed",
+        "lattice_wide: checked and not executed — no lattice-wide gravity or G_N is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            f"n5 {line[:24]}",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+        )
+        print(line)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the cube `{-2,…,2}³ ⊂ Z³` the 6-nn graph reciprocal `1/d` fails to be nn-harmonic at `e1` (`Δ_nn=−7/2` with zero at the origin). No origin value makes `1/d` a lattice Green trial: Poisson at `0` forces `c=7/6` and harmonicity at `e1` forces `c=7/2`. Therefore `G_cont∘d` is not a lattice Green function. Record additivity does not pick either kernel. The Newton packet is not retired; the remaining object is split from the already-isolated product pairing `π`.

## What this means for the TOE

This is the last Newton type-split this campaign. π-selection stays blocked until a Record-typed reason exists. Do not install `1/r`.

## What changed

- Note: `docs/LATTICE_GREEN_ON_Z3_IS_NOT_CONTINUUM_ONE_OVER_R_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py`
- Cache: `logs/runner-cache/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.txt`

## Verification

```bash
python3 scripts/lattice_green_on_z3_is_not_continuum_one_over_r_2026_08_13.py
# TOTAL: PASS=21 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
