### PR TITLE
[physics-loop] toe-lphys cubebianchi: bounded_theorem / bounded-support

### DIFF
--- a/docs/Z2_UNIT_CUBE_FACE_HOLONOMIES_OBEY_BIANCHI_MONOPOLE_IMPOSSIBLE_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/Z2_UNIT_CUBE_FACE_HOLONOMIES_OBEY_BIANCHI_MONOPOLE_IMPOSSIBLE_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,189 @@
+---
+claim_id: z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the unit cube, every Z2 link field has even face-holonomy sum (Bianchi / 2-cocycle). The odd 6-tuple (1,0,0,0,0,0) is therefore not a holonomy image, so a one-cube magnetic monopole is impossible for a link field. The identity uses an extra edge 1-form that Lattice and Admissibility do not name. The six face bits are not independent plaquettes and are not the June 10 4D SU(3) ln Z_L count."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py
+---
+
+# Z2 Unit-Cube Face Holonomies Obey Bianchi; a Monopole 6-Tuple Is Impossible
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact `Z2` arithmetic on the twelve edges and six faces of one unit cube.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py`](../scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+A link field on the unit cube is an assignment `θ ∈ {0,1}^12` to the twelve
+edges. Each face holonomy is the sum of its four edge bits modulo 2. Because
+every edge lies in exactly two faces, the six holonomies always sum to `0`
+modulo 2. The 6-tuple `m = (1,0,0,0,0,0)` has odd weight, so it is not in the
+image of the holonomy map. A magnetic monopole supported on one cube is
+impossible for a link field.
+
+This is a 2-cocycle identity on an extra object — `θ` on the twelve edges —
+not a one-site Admissibility 6-tuple of possibilities. The cube is not six independent plaquette bits.
+The count `N_p = 6` on this cube is not
+`N_p(L=2) = 96` of 4D `SU(3)`. The groups `Z2` and `SU(3)` are different.
+This note does not treat the June 10 `ln Z_L` object as a lemma.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The Bianchi identity and the missing monopole 6-tuple are proved by exact Z2 linear algebra on one cube. Lattice and Admissibility do not name the link field, so the identity is extra structure, not axiom content."
+trace_class: negative_route_pruning
+artifact_role: theorem
+conditional_surface_status: "exact for every Z2 link field on one unit cube; no 4D SU(3) or continuum claim"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Vertices of the unit cube are `{0,1}^3`. The twelve edges are labeled:
+
+- x-edges `0..3` at `(y,z) ∈ {0,1}^2` in order `(0,0)`, `(1,0)`, `(0,1)`, `(1,1)`
+- y-edges `4..7` at `(x,z)` in the same order
+- z-edges `8..11` at `(x,y)` in the same order
+
+The six faces are the unordered 4-edge sets (orientation does not matter over
+`Z2`):
+
+```text
+z=0: {0,5,1,4}
+z=1: {2,7,3,6}
+y=0: {0,9,2,8}
+y=1: {1,11,3,10}
+x=0: {4,10,6,8}
+x=1: {5,11,7,9}
+```
+
+A link field is `θ ∈ {0,1}^12`. Face holonomy is
+
+```text
+H_f(θ) = (sum of the four edges of f)  (mod 2).
+```
+
+Write `H(θ) = (H_{z=0}, H_{z=1}, H_{y=0}, H_{y=1}, H_{x=0}, H_{x=1})`.
+The Bianchi sum is `∑_{f=1..6} H_f(θ) (mod 2)`.
+
+The extra object used by the identity is `θ` on the twelve edges. It is a
+`Z2` 1-cochain on the 1-skeleton. Face holonomies are the coboundary
+2-cochain on the six faces.
+
+## Quoted Axiom Content
+
+The parent memo names Lattice as the cubic lattice `Z^3` with nearest-neighbor
+adjacency, and Admissibility as one fixed nearest-neighbor rule that determines,
+for each site, the probability distribution over local possibilities from the
+nearest-neighbor conditions. Those two sentences do not name a link 1-form, a
+closed 2-cochain, or a six-component face-holonomy tuple. The identity below
+therefore uses extra structure.
+
+## Theorem 1 — Bianchi Identity On Every Link Field
+
+For every `θ ∈ {0,1}^12`,
+
+```text
+∑_{f=1..6} H_f(θ) ≡ 0  (mod 2).
+```
+
+Proof. Each edge lies in exactly two faces, so the six face sums count every
+edge twice. Twice any `Z2` bit is `0`. Hence the total is `0`.
+
+Witnesses. The zero field `θ = 0` has `H = 0^6`. Flipping a single edge
+changes the holonomy of exactly the two faces that contain that edge, so the
+Bianchi sum stays `0`. The runner enumerates all `2^{12}` fields through
+`face_holonomies(θ)` and `bianchi_sum(H)`.
+
+## Theorem 2 — A One-Cube Monopole 6-Tuple Is Not In The Image
+
+Let `m = (1,0,0,0,0,0)`. Then `∑ m_f ≡ 1 (mod 2)`. By Theorem 1, `m` is not
+`H(θ)` for any link field `θ`. A magnetic monopole on one cube — a single
+nonzero face holonomy with the other five faces flat — is impossible for a
+link field.
+
+The image of `H` is exactly the even-weight subspace of `{0,1}^6`, of size
+`2^5 = 32`. The runner builds that image by enumerating every `θ`.
+
+## Theorem 3 — The Cube Is Not Six Independent Plaquettes
+
+Six independent `Z2` plaquette bits would be the full cube `{0,1}^6`, which
+contains `m`. The holonomy map lands only in the Bianchi hyperplane. The six
+face bits are therefore not independent. Bianchi is a 2-cocycle constraint on
+the coboundary of `θ`, not a one-site Admissibility 6-tuple of possibilities.
+
+The mutation predicate “every 6-tuple in `{0,1}^6` is a face-holonomy image”
+fails on `m`.
+
+## Theorem 4 — The Identity Uses Extra Structure
+
+Lattice names `Z^3` with nearest-neighbor adjacency. Admissibility names a
+nearest-neighbor distribution over one-site possibilities. Neither sentence
+names a link 1-form or a closed 2-cochain. The extra object required for
+Theorems 1–3 is `θ` on the twelve edges of this cube.
+
+This note does not edit an axiom and does not claim that the identity is
+already axiom content.
+
+## Theorem 5 — This Cube Is Not The June 10 `ln Z_L` Object
+
+The unit cube has `N_p = 6` faces. The June 10 4D `SU(3)` count
+`N_p(L=2) = 96` is a different integer. Group `Z2` ≠ `SU(3)`.
+The identity is not that `ln Z_L` object. The runner compares the two
+integers and the two group names only as a non-identification check. It does
+not treat the June 10 note as a lemma.
+
+## No-Go Discipline Gate
+
+**Result:** exact Bianchi identity and missing monopole 6-tuple on one `Z2`
+unit cube. No 4D gauge axiom, no continuum monopole theorem, and no change to
+the four-axiom memo.
+
+**N1 alternative routes.**
+
+1. Independent six-bit plaquette assignment: ruled out on this cube by
+   Theorems 1–3.
+2. A monopole 6-tuple as a holonomy image: ruled out by Theorem 2.
+3. Reading the identity as one-site Admissibility content: blocked by
+   Theorem 4; the extra object is the edge field.
+4. Identifying this cube with the June 10 `ln Z_L` 4D `SU(3)` count: blocked
+   by Theorem 5.
+
+**N2 wall independence.** The double-counting identity, the missing odd
+6-tuple, the independent-plaquette mismatch, the extra-object gap, and the
+`N_p`/`SU(3)` non-identification are distinct statements.
+
+**N3 hidden-wall scan.** The note uses no observed masses, no fitted
+selector, and no axiom edit.
+
+**N4 residual matching.** The residual is the Bianchi parity of six `Z2` face
+holonomies on one cube. It is not a 4D Wilson free-energy residual.
+
+**N5 rhetoric audit.** The negative statement is at the one-cube `Z2` link
+field. It is not a claim that every continuum monopole is impossible, and it
+is not a claim that Lattice or Admissibility already contain a gauge 1-form.
+
+## Imports And Claim Boundary
+
+- **Imported:** the 2026-06-29 Lattice and Admissibility sentences, quoted
+  only to show that they do not name `θ`.
+- **Computed here:** edge-face incidence, `H(θ)`, Bianchi sums, the image of
+  `H`, and the failure of the independent-plaquette predicate on `m`.
+- **Quoted count only, not a lemma:** `N_p(L=2) = 96`.
+- **Not imported:** unmerged work, a gauge axiom, or any identification of
+  this cube with 4D `SU(3)` plaquettes.
+
+## Review Record
+
+Source proposal only. The independent audit lane grades.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -21925,6 +21925,10 @@
   "z2_hw1_mass_matrix_parametrization_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "z3_character_isomorphism_color_generation_open_gate_note_2026-05-10": {
    "deps_hash": "9df4bd04ea8c",

--- a/logs/runner-cache/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.txt
+++ b/logs/runner-cache/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py
+runner_sha256: 2ca3fea79c395af4bedbb41ed94f99c4c0fae9ec4540571e48d5bf370c02b037
+input_fingerprint_sha256: 9f8146a2e9b98c446e9dbe0df33e8d6f90cdadd0b60078a90502f5fc5436198b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+PASS: inputs-exist declared note and axiom memo are present
+PASS: axiom-lattice Lattice names Z^3 with nearest-neighbor adjacency
+PASS: axiom-admissibility Admissibility names the nearest-neighbor distribution sentence
+PASS: axiom-no-link-form the axiom memo does not name a link 1-form or closed 2-cochain
+PASS: face-arity face (0, 5, 1, 4) has four distinct edges
+PASS: face-arity face (2, 7, 3, 6) has four distinct edges
+PASS: face-arity face (0, 9, 2, 8) has four distinct edges
+PASS: face-arity face (1, 11, 3, 10) has four distinct edges
+PASS: face-arity face (4, 10, 6, 8) has four distinct edges
+PASS: face-arity face (5, 11, 7, 9) has four distinct edges
+PASS: edge-incidence each of the 12 edges lies in exactly two faces
+PASS: identity-call-zero identity_zero_link_field calls face_holonomies and bianchi_sum
+PASS: identity-call-flip identity_single_edge_flip calls face_holonomies and bianchi_sum
+PASS: identity-call-field identity_bianchi_on_field calls face_holonomies and bianchi_sum
+PASS: identity-call-all identity_bianchi_all_fields calls face_holonomies and bianchi_sum
+PASS: identity-zero theta=0 maps to H=0^6 with even Bianchi sum
+PASS: identity-single-flip each single-edge flip changes exactly two faces and preserves Bianchi
+PASS: identity-sample a mixed field has even Bianchi sum
+PASS: identity-enumerate every one of the 4096 link fields has even Bianchi sum
+PASS: identity-calls-fired enumeration invoked face_holonomies and bianchi_sum
+PASS: image-even holonomy image equals the 32 even-weight 6-tuples
+PASS: monopole-odd m=(1,0,0,0,0,0) has odd Bianchi weight
+PASS: monopole-missing m is not a face-holonomy image
+PASS: mutation-independent-plaquettes the predicate that every 6-tuple is a holonomy image fails on m
+PASS: np-not-june10 N_p(this cube)=6 is not N_p(L=2)=96
+PASS: group-not-su3 the cube group is Z2, not SU(3)
+PASS: note-theorems the note states Bianchi, monopole impossibility, and extra edge object
+PASS: hygiene note carries no fitted-plaquette input and no axiom-adoption language
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: twelve edge bits and six face holonomies are Z2 sums
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: one unit cube; no lattice-wide gauge field is sampled
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: Z2 coboundary is checked; no SU(3) mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only Bianchi even-sum and the missing monopole 6-tuple are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no 4D SU(3) ln Z_L claim
+TOTAL: PASS=33 FAIL=0
+
+----- stderr -----
+

--- a/scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py
+++ b/scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Exact Z2 Bianchi identity on the unit cube; monopole 6-tuple is impossible.
+
+Identity gates call face_holonomies(theta) and bianchi_sum(H). Arithmetic is
+integers modulo 2. No fitted scalar is used as an input.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/Z2_UNIT_CUBE_FACE_HOLONOMIES_OBEY_BIANCHI_MONOPOLE_IMPOSSIBLE_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+# Face order: z=0, z=1, y=0, y=1, x=0, x=1.
+FACES: tuple[tuple[int, ...], ...] = (
+    (0, 5, 1, 4),
+    (2, 7, 3, 6),
+    (0, 9, 2, 8),
+    (1, 11, 3, 10),
+    (4, 10, 6, 8),
+    (5, 11, 7, 9),
+)
+
+MONOPOLE = (1, 0, 0, 0, 0, 0)
+N_P_CUBE = 6
+N_P_L2_SU3 = 96
+
+_FACE_CALLS = 0
+_BIANCHI_CALLS = 0
+
+
+def _mod2(value: int) -> int:
+    return int(value) & 1
+
+
+def face_holonomies(theta: tuple[int, ...] | list[int]) -> tuple[int, ...]:
+    global _FACE_CALLS
+    _FACE_CALLS += 1
+    bits = tuple(_mod2(bit) for bit in theta)
+    if len(bits) != 12:
+        raise ValueError("theta must have 12 edge bits")
+    return tuple(_mod2(sum(bits[edge] for edge in face)) for face in FACES)
+
+
+def bianchi_sum(H: tuple[int, ...] | list[int]) -> int:
+    global _BIANCHI_CALLS
+    _BIANCHI_CALLS += 1
+    bits = tuple(_mod2(bit) for bit in H)
+    if len(bits) != 6:
+        raise ValueError("H must have 6 face bits")
+    return _mod2(sum(bits))
+
+
+def identity_zero_link_field() -> bool:
+    theta = (0,) * 12
+    H = face_holonomies(theta)
+    return H == (0, 0, 0, 0, 0, 0) and bianchi_sum(H) == 0
+
+
+def identity_single_edge_flip(edge: int) -> bool:
+    theta0 = (0,) * 12
+    H0 = face_holonomies(theta0)
+    theta1 = list(theta0)
+    theta1[edge] = 1
+    H1 = face_holonomies(tuple(theta1))
+    flipped = sum(a != b for a, b in zip(H0, H1))
+    return flipped == 2 and bianchi_sum(H1) == 0
+
+
+def identity_bianchi_on_field(theta: tuple[int, ...]) -> bool:
+    H = face_holonomies(theta)
+    return bianchi_sum(H) == 0
+
+
+def identity_bianchi_all_fields() -> tuple[bool, set[tuple[int, ...]]]:
+    image: set[tuple[int, ...]] = set()
+    ok = True
+    for bits in product((0, 1), repeat=12):
+        H = face_holonomies(bits)
+        if bianchi_sum(H) != 0:
+            ok = False
+            break
+        image.add(H)
+    return ok, image
+
+
+def every_six_tuple_is_face_holonomy_image(image: set[tuple[int, ...]]) -> bool:
+    return all(h in image for h in product((0, 1), repeat=6))
+
+
+def _calls_named(fn, names: tuple[str, ...]) -> bool:
+    tree = ast.parse(inspect.getsource(fn))
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    return all(name in called for name in names)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    axiom_flat = " ".join(axiom.split())
+
+    checks.check(
+        "inputs-exist",
+        "declared note and axiom memo are present",
+        NOTE_PATH.is_file() and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "axiom-lattice",
+        "Lattice names Z^3 with nearest-neighbor adjacency",
+        "cubic lattice `Z^3`, with nearest-neighbor adjacency" in axiom_flat,
+    )
+    checks.check(
+        "axiom-admissibility",
+        "Admissibility names the nearest-neighbor distribution sentence",
+        "the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions"
+        in axiom_flat,
+    )
+    checks.check(
+        "axiom-no-link-form",
+        "the axiom memo does not name a link 1-form or closed 2-cochain",
+        "link 1-form" not in axiom and "2-cochain" not in axiom,
+    )
+
+    incidence = [0] * 12
+    for face in FACES:
+        checks.check(
+            "face-arity",
+            f"face {face} has four distinct edges",
+            len(face) == 4 and len(set(face)) == 4 and all(0 <= e < 12 for e in face),
+        )
+        for edge in face:
+            incidence[edge] += 1
+    checks.check(
+        "edge-incidence",
+        "each of the 12 edges lies in exactly two faces",
+        incidence == [2] * 12,
+    )
+
+    required = ("face_holonomies", "bianchi_sum")
+    checks.check(
+        "identity-call-zero",
+        "identity_zero_link_field calls face_holonomies and bianchi_sum",
+        _calls_named(identity_zero_link_field, required),
+    )
+    checks.check(
+        "identity-call-flip",
+        "identity_single_edge_flip calls face_holonomies and bianchi_sum",
+        _calls_named(identity_single_edge_flip, required),
+    )
+    checks.check(
+        "identity-call-field",
+        "identity_bianchi_on_field calls face_holonomies and bianchi_sum",
+        _calls_named(identity_bianchi_on_field, required),
+    )
+    checks.check(
+        "identity-call-all",
+        "identity_bianchi_all_fields calls face_holonomies and bianchi_sum",
+        _calls_named(identity_bianchi_all_fields, required),
+    )
+
+    checks.check(
+        "identity-zero",
+        "theta=0 maps to H=0^6 with even Bianchi sum",
+        identity_zero_link_field(),
+    )
+    flip_ok = all(identity_single_edge_flip(edge) for edge in range(12))
+    checks.check(
+        "identity-single-flip",
+        "each single-edge flip changes exactly two faces and preserves Bianchi",
+        flip_ok,
+    )
+    sample = (1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0)
+    checks.check(
+        "identity-sample",
+        "a mixed field has even Bianchi sum",
+        identity_bianchi_on_field(sample),
+    )
+
+    before_face = _FACE_CALLS
+    before_bianchi = _BIANCHI_CALLS
+    all_ok, image = identity_bianchi_all_fields()
+    checks.check(
+        "identity-enumerate",
+        "every one of the 4096 link fields has even Bianchi sum",
+        all_ok and len(image) > 0,
+    )
+    checks.check(
+        "identity-calls-fired",
+        "enumeration invoked face_holonomies and bianchi_sum",
+        _FACE_CALLS - before_face >= 4096 and _BIANCHI_CALLS - before_bianchi >= 4096,
+    )
+
+    even = {h for h in product((0, 1), repeat=6) if _mod2(sum(h)) == 0}
+    checks.check(
+        "image-even",
+        "holonomy image equals the 32 even-weight 6-tuples",
+        image == even and len(image) == 32,
+    )
+    checks.check(
+        "monopole-odd",
+        "m=(1,0,0,0,0,0) has odd Bianchi weight",
+        bianchi_sum(MONOPOLE) == 1,
+    )
+    checks.check(
+        "monopole-missing",
+        "m is not a face-holonomy image",
+        MONOPOLE not in image,
+    )
+    checks.check(
+        "mutation-independent-plaquettes",
+        "the predicate that every 6-tuple is a holonomy image fails on m",
+        (not every_six_tuple_is_face_holonomy_image(image)) and MONOPOLE not in image,
+    )
+
+    checks.check(
+        "np-not-june10",
+        "N_p(this cube)=6 is not N_p(L=2)=96",
+        N_P_CUBE == len(FACES) and N_P_CUBE != N_P_L2_SU3,
+    )
+    checks.check(
+        "group-not-su3",
+        "the cube group is Z2, not SU(3)",
+        "Z2" in note and "SU(3)" in note and "Z2` ≠ `SU(3)" in note,
+    )
+    checks.check(
+        "note-theorems",
+        "the note states Bianchi, monopole impossibility, and extra edge object",
+        all(
+            needle in note
+            for needle in (
+                "H_f",
+                "(1,0,0,0,0,0)",
+                "not six independent",
+                "on the twelve edges",
+                "N_p(L=2) = 96",
+            )
+        ),
+    )
+    forbidden_scalar = "0." + "5934"
+    runner_src = Path(__file__).read_text(encoding="utf-8")
+    checks.check(
+        "hygiene",
+        "note carries no fitted-plaquette input and no axiom-adoption language",
+        forbidden_scalar not in note
+        and "we adopt" not in note.lower()
+        and "L_phys" not in note
+        and " = " + forbidden_scalar not in runner_src
+        and "N_P_L2_SU3 = 96" in runner_src,
+    )
+
+    n5_lines = (
+        "per_element: twelve edge bits and six face holonomies are Z2 sums",
+        "per_site: one unit cube; no lattice-wide gauge field is sampled",
+        "per_mode: Z2 coboundary is checked; no SU(3) mode is claimed",
+        "per_block: only Bianchi even-sum and the missing monopole 6-tuple are executed",
+        "lattice_wide: checked and not executed — no 4D SU(3) ln Z_L claim",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+        )
+        print(line)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the unit cube every Z2 link field has even face-holonomy sum (Bianchi). The odd 6-tuple `m=(1,0,0,0,0,0)` is not a holonomy image, so a one-cube magnetic monopole is impossible for a link field. The identity uses an extra edge 1-form that Lattice and Admissibility do not name. `N_p=6 ≠ 96`. Group Z2 ≠ SU(3).

## What this means for the TOE

A 3D 2-cocycle is now an executable extra object. It is not June 10 ln Z_L.

## What changed

- Note: `docs/Z2_UNIT_CUBE_FACE_HOLONOMIES_OBEY_BIANCHI_MONOPOLE_IMPOSSIBLE_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py`
- Cache: `logs/runner-cache/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.txt`

## Verification

```bash
python3 scripts/z2_unit_cube_face_holonomies_obey_bianchi_monopole_impossible_2026_08_13.py
# TOTAL: PASS=33 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
