### PR TITLE
[physics-loop] toe-lphys stencil6: bounded_theorem / bounded-support

### DIFF
--- a/docs/LATTICE_NN_ADJACENCY_KILLS_EDGE_DIAGONAL_STENCIL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/LATTICE_NN_ADJACENCY_KILLS_EDGE_DIAGONAL_STENCIL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,419 @@
+---
+claim_id: lattice_nn_adjacency_kills_edge_diagonal_stencil_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On Z^3 at the origin, the unnormalized six-neighbor stencil of φ(x)=x1²+x2²+x3² equals 6 and the twelve-site edge-diagonal stencil equals 24, so the two O_h classes are distinct operators; Lattice names nearest-neighbor adjacency, which is the 6-NN cubic graph of graph distance 1, not the 18-neighbor graph; inside the two-parameter family Δ_{α,β}=α Δ_NN + β Δ_edge a later graph-Laplacian supplier of the named adjacency forces β=0 and a rational multiple of Δ_NN; that supplier is extra; no Green function, 1/r kernel, product M_s M_t, Newton constant, or Laplacian axiom is selected."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py
+---
+
+# Lattice NN Adjacency Kills The Edge-Diagonal Stencil Coefficient
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact integer stencil arithmetic on `Z^3` at the origin; two
+`O_h`-invariant neighbor classes; the two-parameter family
+`Δ_{α,β}=α Δ_NN + β Δ_edge` with `α,β ∈ Q`; Lattice nearest-neighbor
+adjacency as the six-neighbor cubic graph.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py`](../scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py)
+
+## Result Up Front
+
+The current Lattice sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is quoted only
+as a premise and is not edited:
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The named adjacency phrase is **nearest-neighbor adjacency**. That phrase is
+the six-neighbor cubic graph, not the eighteen-neighbor graph that would add
+the edge-diagonals.
+
+The axioms do not name a field operator. This note does not install one.
+
+Five exact statements locate the split.
+
+1. **The two stencils disagree on `φ`.** With `φ(x)=x1²+x2²+x3²` one has
+   `(Δ_NN φ)(0)=6` and `(Δ_edge φ)(0)=24`. Hence `Δ_NN ≠ Δ_edge` as
+   operators.
+2. **Edge-diagonals are not nearest neighbors.** Every edge-diagonal site
+   has graph distance `2` from the origin on the named six-neighbor graph.
+   Those twelve sites are not nearest neighbors.
+3. **Named-adjacency Laplacian kills `β`.** If a later supplier says the
+   field operator is a graph Laplacian of the *named* adjacency, then
+   `β=0` and the operator is a rational multiple of `Δ_NN`. That supplier
+   is extra. Lattice kills only the edge-diagonal coefficient inside this
+   two-parameter class.
+4. **No kernel, no Newton product, no constant.** The note does not select
+   a Green function, a 1/r kernel, a product `M_s M_t`, or Newton’s
+   constant.
+5. **No Laplacian axiom.** The note does not adopt a Laplacian axiom. It
+   does not claim that `Δ_NN` is the only `O_h`-invariant operator on all
+   of `ℓ²(Z^3)`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The integer identities (Δ_NN φ)(0)=6 and (Δ_edge φ)(0)=24, the graph-distance-2 listing of the twelve edge-diagonals, and the β=0 restriction inside Δ_{α,β} are proved by exact integer arithmetic on declared Z^3 neighbor classes; a field-operator supplier remains extra."
+trace_class: negative_route_pruning
+target_claim_id: lattice_nn_adjacency_kills_edge_diagonal_stencil
+target_blocker_text: "derive an O_h field-operator stencil with a nonzero edge-diagonal coefficient from Lattice nearest-neighbor adjacency"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "If a later supplier names the field operator as the graph Laplacian of the named adjacency, then β=0 and the operator is a rational multiple of Δ_NN. That supplier is extra. Do not adopt axiom text."
+conditional_surface_status: "exact for the 6-versus-24 split, graph distance 2, and β=0 inside the named two-parameter family; a field operator, Green function, and Laplacian axiom remain open"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at the origin of `Z^3`. Write `e1=(1,0,0)`, `e2=(0,1,0)`, `e3=(0,0,1)`.
+Graph distance is the `ℓ¹` path metric of the six-neighbor cubic graph.
+
+Two `O_h`-invariant neighbor classes:
+
+- NN (`6`): `±e1`, `±e2`, `±e3`. Graph distance `1`.
+- Edge-diagonal (`12`): `±e_i ± e_j` for `i<j`. Graph distance `2`.
+
+The twelve edge-diagonal sites are
+
+```text
+( 1, 1, 0), ( 1,-1, 0), (-1, 1, 0), (-1,-1, 0),
+( 1, 0, 1), ( 1, 0,-1), (-1, 0, 1), (-1, 0,-1),
+( 0, 1, 1), ( 0, 1,-1), ( 0,-1, 1), ( 0,-1,-1).
+```
+
+The eighteen-neighbor set is the disjoint union of these two classes. It is
+not the named adjacency.
+
+Two unnormalized stencils act on a test function `φ` by
+
+```text
+(Δ_NN φ)(0)   = Σ_{x NN}   (φ(x) − φ(0))
+(Δ_edge φ)(0) = Σ_{x edge} (φ(x) − φ(0))
+```
+
+A two-parameter `O_h` stencil is
+
+`Δ_{α,β} = α Δ_NN + β Δ_edge`, `α,β ∈ Q`.
+
+The executed test function is the integer quadratic
+
+`φ(x) = x1² + x2² + x3²`.
+
+Then `φ(0)=0`, `φ=1` on every NN site, and `φ=2` on every edge-diagonal
+site.
+
+`O_h` is the signed-permutation group on the three axes (order `48`). It
+preserves the cubic lattice, the six-neighbor graph, and each of the two
+classes. Proper cubic rotations about a site are the index-two rotation
+subgroup; the full `O_h` orbit decomposition is used only to name the
+classes.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** At the origin of `Z^3`, evaluate the two unnormalized
+`O_h` stencils on `φ`; prove they disagree; prove every edge-diagonal has
+graph distance `2` on the named adjacency; and record that a later
+graph-Laplacian supplier of that adjacency forces `β=0` inside
+`Δ_{α,β}`, without installing a field operator, a Green function, or a
+Laplacian axiom.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| pin the Lattice nearest-neighbor sentence | premise | quoted; no edit |
+| evaluate `(Δ_NN φ)(0)` and `(Δ_edge φ)(0)` | Theorem 1 | exact integers `6` and `24` |
+| conclude `Δ_NN ≠ Δ_edge` as operators | Theorem 1 | they disagree on `φ` |
+| list graph distances of the twelve edge sites | Theorem 2 | each equals `2` |
+| identify the named graph as `6`-NN, not `18` | Theorem 2 | Lattice phrase |
+| restrict `Δ_{α,β}` under a named-adjacency Laplacian supplier | Theorem 3 | `β=0`; rational multiple of `Δ_NN` |
+| record that the supplier is extra | Theorem 3 | axioms name no field operator |
+| refuse Green, `1/r`, `M_s M_t`, Newton constant | Theorem 4 | scoped negative |
+| refuse a Laplacian axiom and `ℓ²` uniqueness | Theorem 5 | scoped negative |
+| adopt a Laplacian axiom or install `1/r` | non-claim | not attempted |
+
+## Theorem 1 — The Two Stencils Disagree On `φ`
+
+**Claim.** `(Δ_NN φ)(0) = 6` and `(Δ_edge φ)(0) = 24`. Hence
+`Δ_NN ≠ Δ_edge` as operators: they disagree on this `φ`.
+
+**Proof.** The origin value is `φ(0,0,0)=0`. Each of the six NN sites is a
+standard basis vector or its negative, so `φ(NN)=1+0+0=1`. The unnormalized
+NN stencil is therefore
+
+`(Δ_NN φ)(0) = 6 · (1 − 0) = 6`.
+
+Each of the twelve edge-diagonal sites has two coordinates in `{±1}` and
+one coordinate `0`, so `φ(edge)=1+1+0=2`. The unnormalized edge stencil is
+therefore
+
+`(Δ_edge φ)(0) = 12 · (2 − 0) = 24`.
+
+If the two operators were equal they would agree on every test function, in
+particular on `φ`. They do not: `6 ≠ 24`. A predicate
+“`Δ_NN φ = Δ_edge φ` at `0`” fails.
+
+The arithmetic is integer. No continuum limit is used.
+
+## Theorem 2 — Edge-Diagonals Are Not Nearest Neighbors
+
+**Claim.** The graph distance of an edge-diagonal from the origin is `2`,
+so those twelve sites are not nearest neighbors. The named adjacency graph
+is the `6`-NN cubic graph, not the `18`-neighbor graph.
+
+**Proof.** The Lattice sentence names **nearest-neighbor adjacency** on the
+cubic lattice `Z^3`. The unique translation-invariant cubic graph whose
+degree-`6` star at the origin is `{±e1, ±e2, ±e3}` is the six-neighbor
+cubic graph. Its graph distance from the origin is the `ℓ¹` norm
+`d(x)=|x1|+|x2|+|x3|`.
+
+On that graph, every listed edge-diagonal satisfies
+
+`d(±e_i ± e_j)=1+1+0=2`.
+
+A nearest neighbor is a site at graph distance `1`. The twelve
+edge-diagonals are therefore not nearest neighbors. A predicate
+“edge-diagonals are nearest neighbors” fails.
+
+The eighteen-neighbor set is the disjoint union of the six NN sites and the
+twelve edge-diagonals. Using that set as the adjacency would name a
+different graph. Lattice does not name it.
+
+Proper cubic rotations permute the six NN sites among themselves and the
+twelve edge-diagonals among themselves. They do not mix the two classes,
+and they do not move an edge-diagonal onto the NN star.
+
+## Theorem 3 — Named-Adjacency Laplacian Forces `β=0`
+
+**Claim.** If a later supplier says the field operator is a graph Laplacian
+of the *named* adjacency, then `β=0` and the operator is a rational
+multiple of `Δ_NN`. That supplier is extra: the axioms do not name a field
+operator. Lattice kills only the edge-diagonal coefficient inside this
+two-parameter class.
+
+**Proof.** The two-parameter family is
+
+`Δ_{α,β} = α Δ_NN + β Δ_edge`, `α,β ∈ Q`.
+
+A graph Laplacian of an undirected graph with no loops acts at the origin
+by a rational multiple of `Σ_{x ∼ 0} (φ(x)−φ(0))`, where `∼` is the named
+adjacency. Theorem 2 identifies that adjacency with the six-neighbor cubic
+graph. The twelve edge-diagonals are not adjacent to the origin, so they
+do not appear in the sum. Therefore `β=0` and
+
+`Δ_{α,0} = α Δ_NN`.
+
+That is a rational multiple of `Δ_NN`.
+
+The supplier that *identifies* a field operator with that graph Laplacian
+is extra. The Lattice sentence names sites, nearest-neighbor adjacency,
+translations, and proper cubic rotations. It does not name a field
+operator, a Laplacian, or a coefficient `β`. Admissibility names a
+nearest-neighbor probability rule, not a stencil. Record names locking and
+readout, not a stencil. Inside the declared class `Δ_{α,β}`, the Lattice
+nearest-neighbor clause is enough to kill `β`. It is not enough to install
+the operator.
+
+## Theorem 4 — No Green Function, No `1/r`, No Newton Product
+
+**Claim.** This does not select a Green function, a 1/r kernel, a product
+`M_s M_t`, or Newton’s constant.
+
+**Proof.** Theorems 1--3 are statements about two unnormalized stencils on
+one quadratic test function, and about which of those stencils can appear
+in a later named-adjacency Laplacian. A Green function is an inverse of an
+operator. No inverse is constructed. A `1/r` kernel is a pointwise function
+of Euclidean radius. No such function is written, fitted, or installed. A
+product `M_s M_t` is a two-argument pairing of readout scalars. No pairing
+is written. Newton’s constant is a dimensionful coupling. It is not
+imported and not named as a derived value.
+
+Selecting the operator class is not selecting a kernel, a pairing, or a
+constant. The note does not claim gravity.
+
+## Theorem 5 — No Laplacian Axiom, No `ℓ²` Uniqueness
+
+**Claim.** Do not adopt a Laplacian axiom. Do not claim that `Δ_NN` is the
+only `O_h`-invariant operator on all of `ℓ²(Z^3)` — only that, inside this two-parameter stencil family, Lattice’s NN clause forces `β=0`.
+
+**Proof.** An axiom-sentence change that named a Laplacian would be a
+different document. This note quotes the current Lattice sentence and does
+not edit it.
+
+`O_h`-invariant operators on `ℓ²(Z^3)` include, among others, longer-range
+radial stencils, polynomials in `Δ_NN`, and Fourier multipliers constant
+on `O_h` orbits in the Brillouin zone. None of those objects is classified
+here. The executed family is the two-parameter stencil `Δ_{α,β}`. Inside
+that family, Theorem 3 gives `β=0` once the named adjacency is used as the
+graph. That is the whole uniqueness claim.
+
+## Boundary And Non-Claims
+
+The note does not:
+
+- edit an axiom sentence, or argue that an axiom-sentence change is
+  necessary;
+- adopt a Laplacian axiom;
+- claim that `Δ_NN` is the only `O_h`-invariant operator on all of
+  `ℓ²(Z^3)`;
+- select a Green function, install a 1/r kernel, write a product
+  `M_s M_t`, or import Newton’s constant;
+- claim gravity;
+- replace nearest-neighbor adjacency by the eighteen-neighbor graph;
+- assert that the axioms already name a field operator.
+
+The scope is the exact cubic split: `6` versus `24` on `φ`, graph
+distance `2` for the edge class, and `β=0` inside `Δ_{α,β}` under a
+named-adjacency Laplacian supplier.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice NN sentence | premise | quoted; no edit |
+| six NN sites and twelve edge-diagonals | Theorem 1--2 | listed here |
+| `(Δ_NN φ)(0)=6`, `(Δ_edge φ)(0)=24` | Theorem 1 | computed here |
+| graph distance `2` on the named graph | Theorem 2 | computed here |
+| `β=0` inside `Δ_{α,β}` under a named-adjacency Laplacian | Theorem 3 | computed here |
+| field-operator supplier | residual | extra; not derived |
+| Green function, `1/r`, `M_s M_t`, Newton constant | none | not selected |
+| observed or fitted kernels | none | not used |
+
+The exact advance is a finite lattice-geometry theorem about two stencil
+coefficients. Independent audit is required. This note authors no audit verdict.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | A later field-operator construction on `Z^3` may be tempted to mix the twelve edge-diagonals into an `O_h` stencil. The named Lattice adjacency is nearest-neighbor. This note asks whether that clause already kills the edge-diagonal coefficient inside `Δ_{α,β}`, and answers yes, while leaving the operator itself uninstalled. |
+| V2 | New content? | Searched `origin/main` at `c45dd5ab30` by `git grep` for `Δ_NN`, `delta_nn`, edge-diagonal stencil coefficients, and a `6`-versus-`24` split of unnormalized `O_h` stencils on `φ(x)=‖x‖²`. Hits: `LATTICE_LAPLACIAN_SHELL_LOCALIZATION_IDENTITY_BOUNDED_THEOREM_NOTE_2026-06-16.md` is a shell-localization identity, not this coefficient split; the `LATTICE_NN_*` notes are continuum, RG, light-cone, or distance-law surfaces. No landed note that `(Δ_NN φ)(0)=6 ≠ 24=(Δ_edge φ)(0)` forces `β=0` inside `Δ_{α,β}` appears on that commit. Unmerged drafts are not premises. |
+| V3 | Independently checkable? | Textbook cubic graph distance and the integer quadratic `φ` do not mention a field operator, a Green function, or Newton’s constant. The runner recomputes both stencils by summing `φ(x)−φ(0)` over the listed sites. |
+| V4 | More than a restatement? | Yes. The discriminating witnesses are the integers `6` and `24` and the graph-distance-`2` listing. The Lattice sentence names nearest-neighbor adjacency; it does not evaluate either stencil. |
+| V5 | One-step relabel? | No. The claim is not a corollary of the Lattice sentence alone. That sentence names the adjacency graph. The two-parameter family, the test function `φ`, and the coefficient `β` are declared objects of this note. |
+
+## No-Go Discipline Gate (Theorems 4 and 5 only)
+
+The negative claims are restricted to: this block does not select a Green
+function, a `1/r` kernel, a product `M_s M_t`, or Newton’s constant; it
+does not adopt a Laplacian axiom; it does not claim `ℓ²(Z^3)` uniqueness
+for `Δ_NN`. The gate does not ship a global non-existence theorem against
+later operators.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| equate the two stencils | treat `Δ_NN φ = Δ_edge φ` at the origin | Theorem 1: `6 ≠ 24` | **ATTEMPTED** |
+| treat edge-diagonals as NN | read graph distance `2` as nearest | Theorem 2: `d=2` | **ATTEMPTED** |
+| use the `18`-neighbor graph | add the twelve edge sites to the adjacency | Theorem 2: that graph is not named | **ATTEMPTED** |
+| keep `β` with a named-adjacency Laplacian | write `Δ_{α,β}` with `β≠0` as the graph Laplacian of the named graph | Theorem 3: `β=0` | **ATTEMPTED** |
+| read Lattice as already naming the operator | treat the adjacency sentence as a Laplacian axiom | Theorem 3: the supplier is extra | **ATTEMPTED** |
+| install `1/r` or a Green function | pass from the stencil to a kernel | Theorem 4: no inverse, no kernel | **ATTEMPTED** |
+| claim `ℓ²` uniqueness or adopt a Laplacian axiom | treat `Δ_NN` as the only `O_h` operator | Theorem 5: family-internal only | **ATTEMPTED** |
+
+### N2 — wall independence
+
+Theorems 4 and 5 close only the route that would read a Green function, a
+`1/r` kernel, a Newton product, a Laplacian axiom, or `ℓ²` uniqueness off
+the `6`-versus-`24` split. They do not close a later field-operator
+derivation that supplies `Δ_NN` by other means, nor a later kernel
+analysis of that operator.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `Z^3` with six-neighbor adjacency | declared Lattice object |
+| origin evaluation point | explicit hypothesis |
+| NN class of size `6` | listed; graph distance `1` |
+| edge-diagonal class of size `12` | listed; graph distance `2` |
+| test function `φ(x)=x1²+x2²+x3²` | declared integer quadratic |
+| family `Δ_{α,β}` | declared two-parameter stencil |
+| named-adjacency Laplacian supplier | extra; not derived |
+| Green function, `1/r`, `M_s M_t`, Newton constant | not selected |
+| Laplacian axiom | not adopted |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Lattice nearest-neighbor adjacency sentence | quoted as premise only; no edit |
+| two `O_h` neighbor classes | `6` versus `12` sites | listed here |
+| stencil evaluations on `φ` | `6` versus `24` | computed here |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | origin, six NN sites, twelve edge-diagonals, integers `6` and `24` | no classification of every map on `Z^3` |
+| per site | stencils evaluated at the origin; `O_h` orbits that site’s neighbor classes | no composite multi-site operator |
+| per mode | unnormalized graph stencils on one quadratic; no Green function | no harmonic-mode exhaustion |
+| per block | the `6`-versus-`24` split, graph distance `2`, and `β=0` inside `Δ_{α,β}` | no dynamics, kernel, or Newton constant |
+| lattice-wide | checked and not executed | no uniqueness of `Δ_NN` on all of `ℓ²(Z^3)` |
+
+The obstruction is per-origin / declared stencil family; it is not
+lattice-wide uniqueness.
+
+### N6 — live partial-closure paths
+
+1. A later supplier that names a field operator by other executable
+   objects, including a named-adjacency Laplacian, in which case Theorem 3
+   already forces `β=0` inside this family.
+2. A later analysis of a Green function of whatever operator is supplied.
+3. A later pairing of readout scalars, independent of this stencil split.
+4. A different adjacency, including the eighteen-neighbor graph, if and
+   when that adjacency is the Lattice object. It is not the present object.
+
+The quoted Lattice sentence already names nearest-neighbor adjacency.
+Killing `β` inside `Δ_{α,β}` uses that clause. No axiom sentence is edited
+here. A later derivation of an operator is not forbidden.
+
+### N7 — hostile steelman
+
+> The two `O_h` classes are just the same Laplacian at different ranges.
+> On a quadratic they must agree up to a constant, so `Δ_edge` is a
+> multiple of `Δ_NN` and the eighteen-neighbor stencil is still
+> nearest-neighbor in the only sense that matters.
+
+**Answer.** That identification is exactly the predicate
+“`Δ_NN φ = Δ_edge φ` at `0`,” or the predicate “edge-diagonals are
+nearest neighbors.” Theorem 1 gives `6 ≠ 24`, so the operators disagree
+on this quadratic. Theorem 2 gives graph distance `2` on the named graph,
+so the twelve sites are not nearest neighbors. A constant multiple would
+require `24=c·6` together with operator equality; operator equality already
+fails on `φ`. The eighteen-neighbor graph is a different adjacency.
+
+### N8 — cross-cycle echo
+
+The 2026-06-16 lattice-Laplacian shell-localization note and the landed
+`LATTICE_NN_*` continuum and RG notes treat other objects: shells of a
+already-chosen Laplacian, or continuum/RG diagnostics of a nearest-neighbor
+surface. They do not evaluate `(Δ_NN φ)(0)` against `(Δ_edge φ)(0)` or kill
+`β` inside `Δ_{α,β}`. The present negatives face a narrower residual: the
+named adjacency does not include the edge-diagonal coefficient. The earlier
+notes are not cancelled.
+
+**Gate disposition.** PASS for the `6`-versus-`24` split, the
+graph-distance-`2` listing, and the scoped negatives of Theorems 4 and 5.
+FAIL / DO NOT SHIP for installing `1/r`, claiming gravity, or editing an
+axiom sentence to name a Laplacian.
+
+## Primary Runner
+
+[`scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py`](../scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py)
+recomputes the six NN sites, the twelve edge-diagonals, the integer values
+`(Δ_NN φ)(0)=6` and `(Δ_edge φ)(0)=24`, and the graph-distance-`2` listing
+in exact integer arithmetic on `Z^3`. Identity gates call `delta_nn_phi()`
+and `delta_edge_phi()`. A predicate “`Δ_NN φ = Δ_edge φ` at `0`” must fail
+(`6 ≠ 24`). A predicate “edge-diagonals are nearest neighbors” must fail
+(graph distance `2`).

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11805,6 +11805,10 @@
   "lattice_laplacian_shell_localization_identity_bounded_theorem_note_2026-06-16": {
    "deps_hash": "22da0f98116f",
    "out_degree": 2
+  },
+  "lattice_nn_adjacency_kills_edge_diagonal_stencil_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "lattice_nn_continuum_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.txt
+++ b/logs/runner-cache/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py
+runner_sha256: 07cfdc708d0aed2805807b31cdb552366c21127f3c56702331be687d9aabf185
+input_fingerprint_sha256: 97c0d2eea75ed6bae8a5afaccbe907e4a2a8a157d80fe25f47a0c83d49f89b93
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice wording is source-bound; no observational or fitted inputs
+integrity_reads: this runner, its paired note, and the axiom memo; no other repository scientific inputs
+construction: six NN sites, twelve edge-diagonals, unnormalized stencils of φ at the origin, graph distance on the 6-NN cubic graph
+negative_scope: Lattice kills β inside Δ_{α,β}; no field operator, Green function, 1/r kernel, M_s M_t, Newton constant, or Laplacian axiom
+PASS: audit-input-paths declared audit inputs exist and match the note and axiom memo
+PASS: source-lattice the current Lattice nearest-neighbor sentence is pinned in the axiom memo and the note
+PASS: classes-cardinalities the NN class has 6 sites and the edge-diagonal class has 12 distinct sites
+PASS: classes-are-oh-orbits NN is the O_h orbit of e1 and the edge class is the O_h orbit of e1+e2
+table: delta_nn_phi=6 delta_edge_phi=24
+PASS: theorem-1-delta-nn-phi (Δ_NN φ)(0)=6 by summing φ(x)-φ(0) over the six NN sites
+PASS: theorem-1-delta-edge-phi (Δ_edge φ)(0)=24 by summing φ(x)-φ(0) over the twelve edge sites
+PASS: theorem-1-operators-disagree Δ_NN ≠ Δ_edge as operators because they disagree on this φ
+PASS: theorem-2-nn-graph-distance every NN site has graph distance 1 from the origin
+PASS: theorem-2-edge-graph-distance every edge-diagonal has graph distance 2, so those sites are not nearest neighbors
+PASS: theorem-2-named-graph-is-6-not-18 the named adjacency is the 6-NN cubic graph, not the 18-neighbor graph
+PASS: theorem-3-beta-zero a named-adjacency Laplacian is a rational multiple of Δ_NN, so β=0
+PASS: theorem-3-axioms-name-no-field-operator the axioms do not name a field operator; Lattice kills only β inside the class
+PASS: theorem-4-no-kernel-no-newton the note refuses a Green function, a 1/r kernel, M_s M_t, and Newton’s constant
+PASS: theorem-5-no-laplacian-axiom the note refuses a Laplacian axiom and ℓ² uniqueness for Δ_NN
+PASS: mutation-equal-stencils-fails the predicate Δ_NN φ = Δ_edge φ at 0 fails because 6 ≠ 24
+PASS: mutation-edge-are-nn-fails the predicate that edge-diagonals are nearest neighbors fails at graph distance 2
+PASS: note-contract machine-status fields, required phrases, and forbidden-word hygiene hold
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_element: origin, six NN sites, twelve edge-diagonal sites, and the integer values 6 and 24 are recomputed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_site: the stencils are evaluated at the origin of Z^3; O_h merely orbits that site's neighbor classes
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_mode: unnormalized graph stencils on one quadratic test function; no Green function or harmonic mode is claimed
+PASS: n5-length each N5 resolution line is at least 40 characters
+per_block: only the 6-versus-24 split, graph distance 2, and β=0 inside the named 2-parameter family are executed
+PASS: n5-length each N5 resolution line is at least 40 characters
+lattice_wide: checked and not executed — no uniqueness of Δ_NN on all of l2(Z^3) and no Laplacian axiom is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py
+++ b/scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Exact checks: Lattice NN adjacency kills the edge-diagonal coefficient.
+
+Unnormalized O_h stencils of φ(x)=x1²+x2²+x3² at the origin of Z^3.
+Identity gates call delta_nn_phi() and delta_edge_phi(). A predicate
+“Δ_NN φ = Δ_edge φ at 0” fails (6 ≠ 24). A predicate “edge-diagonals are
+nearest neighbors” fails (graph distance 2). No cache is written.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import permutations, product as cartesian
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/LATTICE_NN_ADJACENCY_KILLS_EDGE_DIAGONAL_STENCIL_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/LATTICE_NN_ADJACENCY_KILLS_EDGE_DIAGONAL_STENCIL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def scale(coefficient: int, vector: Point) -> Point:
+    return (coefficient * vector[0], coefficient * vector[1], coefficient * vector[2])
+
+
+def graph_distance(left: Point, right: Point) -> int:
+    """ℓ¹ path metric of the six-neighbor cubic graph."""
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def phi(site: Point) -> int:
+    """Integer quadratic φ(x)=x1²+x2²+x3²."""
+    return site[0] * site[0] + site[1] * site[1] + site[2] * site[2]
+
+
+def edge_sites() -> tuple[Point, ...]:
+    """The twelve edge-diagonals ±e_i ± e_j for i<j."""
+    axes = (E1, E2, E3)
+    listed: list[Point] = []
+    for i in range(3):
+        for j in range(i + 1, 3):
+            for sign_i, sign_j in cartesian((1, -1), repeat=2):
+                listed.append(add(scale(sign_i, axes[i]), scale(sign_j, axes[j])))
+    return tuple(listed)
+
+
+def delta_nn_phi() -> int:
+    """Identity-gate: unnormalized NN stencil of φ at the origin."""
+    return sum(phi(site) - phi(ORIGIN) for site in NN)
+
+
+def delta_edge_phi() -> int:
+    """Identity-gate: unnormalized edge-diagonal stencil of φ at the origin."""
+    return sum(phi(site) - phi(ORIGIN) for site in edge_sites())
+
+
+def stencil(alpha: Fraction, beta: Fraction) -> Fraction:
+    """Two-parameter O_h stencil Δ_{α,β} φ at the origin."""
+    return alpha * delta_nn_phi() + beta * delta_edge_phi()
+
+
+def oh_apply(site: Point, perm: tuple[int, int, int], signs: tuple[int, int, int]) -> Point:
+    coords = (site[0], site[1], site[2])
+    return (
+        signs[0] * coords[perm[0]],
+        signs[1] * coords[perm[1]],
+        signs[2] * coords[perm[2]],
+    )
+
+
+def oh_orbit(seed: Point) -> frozenset[Point]:
+    """O_h as signed permutations of the three axes."""
+    orbit: set[Point] = set()
+    for perm in permutations((0, 1, 2)):
+        for signs in cartesian((1, -1), repeat=3):
+            orbit.add(oh_apply(seed, perm, signs))
+    return frozenset(orbit)
+
+
+def nn_equals_edge_at_origin() -> bool:
+    """Hostile predicate: Δ_NN φ = Δ_edge φ at 0."""
+    return delta_nn_phi() == delta_edge_phi()
+
+
+def edge_diagonals_are_nearest_neighbors() -> bool:
+    """Hostile predicate: edge-diagonals are nearest neighbors."""
+    return all(graph_distance(ORIGIN, site) == 1 for site in edge_sites())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current Lattice wording is source-bound; "
+        "no observational or fitted inputs"
+    )
+    print(
+        "integrity_reads: this runner, its paired note, and the axiom memo; "
+        "no other repository scientific inputs"
+    )
+    print(
+        "construction: six NN sites, twelve edge-diagonals, unnormalized "
+        "stencils of φ at the origin, graph distance on the 6-NN cubic graph"
+    )
+    print(
+        "negative_scope: Lattice kills β inside Δ_{α,β}; no field operator, "
+        "Green function, 1/r kernel, M_s M_t, Newton constant, or Laplacian axiom"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs exist and match the note and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/LATTICE_NN_ADJACENCY_KILLS_EDGE_DIAGONAL_STENCIL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    lattice_phrase = "nearest-neighbor adjacency"
+    checks.check(
+        "source-lattice",
+        "the current Lattice nearest-neighbor sentence is pinned in the axiom memo and the note",
+        lattice_sentence in normalize(axiom)
+        and lattice_sentence in note
+        and lattice_phrase in normalize(axiom)
+        and lattice_phrase in note,
+    )
+
+    edges = edge_sites()
+    checks.check(
+        "classes-cardinalities",
+        "the NN class has 6 sites and the edge-diagonal class has 12 distinct sites",
+        len(NN) == 6
+        and len(edges) == 12
+        and len(set(NN)) == 6
+        and len(set(edges)) == 12
+        and set(NN).isdisjoint(edges),
+        residual=(len(NN), len(edges), len(set(edges))),
+    )
+    checks.check(
+        "classes-are-oh-orbits",
+        "NN is the O_h orbit of e1 and the edge class is the O_h orbit of e1+e2",
+        oh_orbit(E1) == frozenset(NN)
+        and oh_orbit(add(E1, E2)) == frozenset(edges)
+        and len(oh_orbit(E1)) == 6
+        and len(oh_orbit(add(E1, E2))) == 12,
+    )
+
+    nn_value = delta_nn_phi()
+    edge_value = delta_edge_phi()
+    print(f"table: delta_nn_phi={nn_value} delta_edge_phi={edge_value}")
+    checks.check(
+        "theorem-1-delta-nn-phi",
+        "(Δ_NN φ)(0)=6 by summing φ(x)-φ(0) over the six NN sites",
+        nn_value == 6
+        and phi(ORIGIN) == 0
+        and all(phi(site) == 1 for site in NN)
+        and delta_nn_phi() == 6 * (1 - 0),
+        residual=nn_value,
+    )
+    checks.check(
+        "theorem-1-delta-edge-phi",
+        "(Δ_edge φ)(0)=24 by summing φ(x)-φ(0) over the twelve edge sites",
+        edge_value == 24
+        and all(phi(site) == 2 for site in edges)
+        and delta_edge_phi() == 12 * (2 - 0),
+        residual=edge_value,
+    )
+    checks.check(
+        "theorem-1-operators-disagree",
+        "Δ_NN ≠ Δ_edge as operators because they disagree on this φ",
+        delta_nn_phi() != delta_edge_phi()
+        and delta_nn_phi() == 6
+        and delta_edge_phi() == 24
+        and "6 ≠ 24" in note,
+        residual=(delta_nn_phi(), delta_edge_phi()),
+    )
+
+    checks.check(
+        "theorem-2-nn-graph-distance",
+        "every NN site has graph distance 1 from the origin",
+        all(graph_distance(ORIGIN, site) == 1 for site in NN)
+        and set(NN) == {site for site in NN if graph_distance(ORIGIN, site) == 1},
+    )
+    checks.check(
+        "theorem-2-edge-graph-distance",
+        "every edge-diagonal has graph distance 2, so those sites are not nearest neighbors",
+        all(graph_distance(ORIGIN, site) == 2 for site in edges)
+        and all(graph_distance(ORIGIN, site) != 1 for site in edges)
+        and "graph distance `2`" in note,
+        residual=sorted({graph_distance(ORIGIN, site) for site in edges}),
+    )
+    checks.check(
+        "theorem-2-named-graph-is-6-not-18",
+        "the named adjacency is the 6-NN cubic graph, not the 18-neighbor graph",
+        len(NN) == 6
+        and len(set(NN) | set(edges)) == 18
+        and "not the `18`-neighbor graph" in note
+        and "nearest-neighbor adjacency" in note,
+    )
+
+    named_operator = stencil(Fraction(1), Fraction(0))
+    mixed_operator = stencil(Fraction(1), Fraction(1))
+    checks.check(
+        "theorem-3-beta-zero",
+        "a named-adjacency Laplacian is a rational multiple of Δ_NN, so β=0",
+        named_operator == Fraction(delta_nn_phi())
+        and named_operator == Fraction(6)
+        and mixed_operator == Fraction(6 + 24)
+        and stencil(Fraction(2), Fraction(0)) == Fraction(2) * Fraction(delta_nn_phi())
+        and "β=0" in note
+        and "rational multiple of `Δ_NN`" in note
+        and "That supplier is extra" in note,
+        residual=(named_operator, mixed_operator),
+    )
+    checks.check(
+        "theorem-3-axioms-name-no-field-operator",
+        "the axioms do not name a field operator; Lattice kills only β inside the class",
+        "axioms do not name a field operator" in note
+        and "field operator" not in axiom.lower()
+        and "Laplacian" not in axiom
+        and "kills only the edge-diagonal coefficient" in note,
+    )
+
+    checks.check(
+        "theorem-4-no-kernel-no-newton",
+        "the note refuses a Green function, a 1/r kernel, M_s M_t, and Newton’s constant",
+        "does not select a Green function" in note
+        and "1/r kernel" in note
+        and "`M_s M_t`" in note
+        and "Newton’s constant" in note
+        and "does not claim gravity" in note
+        and "G_N" not in note,
+    )
+    checks.check(
+        "theorem-5-no-laplacian-axiom",
+        "the note refuses a Laplacian axiom and ℓ² uniqueness for Δ_NN",
+        "does not adopt a Laplacian axiom" in note
+        and "only `O_h`-invariant operator on all of" in note
+        and "inside this two-parameter stencil family" in note
+        and 'hypothetical_axiom_status: "no edit"' in note,
+    )
+
+    checks.check(
+        "mutation-equal-stencils-fails",
+        "the predicate Δ_NN φ = Δ_edge φ at 0 fails because 6 ≠ 24",
+        nn_equals_edge_at_origin() is False
+        and delta_nn_phi() == 6
+        and delta_edge_phi() == 24
+        and delta_nn_phi() != delta_edge_phi(),
+        residual=(delta_nn_phi(), delta_edge_phi(), nn_equals_edge_at_origin()),
+    )
+    checks.check(
+        "mutation-edge-are-nn-fails",
+        "the predicate that edge-diagonals are nearest neighbors fails at graph distance 2",
+        edge_diagonals_are_nearest_neighbors() is False
+        and all(graph_distance(ORIGIN, site) == 2 for site in edges)
+        and all(graph_distance(ORIGIN, site) == 1 for site in NN),
+        residual=sorted({graph_distance(ORIGIN, site) for site in edges}),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    retained_ok = all(line in note for line in allowed_retained)
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine-status fields, required phrases, and forbidden-word hygiene hold",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                'hypothetical_axiom_status: "no edit"',
+                "trace_class: negative_route_pruning",
+                "target_claim_id: lattice_nn_adjacency_kills_edge_diagonal_stencil",
+                'target_blocker_text: "derive an O_h field-operator stencil with a nonzero edge-diagonal coefficient from Lattice nearest-neighbor adjacency"',
+                "reachability_to_target: prunes",
+                'next_trace_action: "If a later supplier names the field operator as the graph Laplacian of the named adjacency, then β=0 and the operator is a rational multiple of Δ_NN. That supplier is extra. Do not adopt axiom text."',
+                "(Δ_NN φ)(0)=6",
+                "(Δ_edge φ)(0)=24",
+                "authors no audit verdict",
+                "Identity gates call `delta_nn_phi()`",
+                "`delta_edge_phi()`",
+            )
+        )
+        and retained_ok
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "L_phys" not in note
+        and "Codex" not in note
+        and "Block " not in note
+        and "toe-lphys" not in note,
+    )
+
+    n5_lines = (
+        "per_element: origin, six NN sites, twelve edge-diagonal sites, and the integer values 6 and 24 are recomputed",
+        "per_site: the stencils are evaluated at the origin of Z^3; O_h merely orbits that site's neighbor classes",
+        "per_mode: unnormalized graph stencils on one quadratic test function; no Green function or harmonic mode is claimed",
+        "per_block: only the 6-versus-24 split, graph distance 2, and β=0 inside the named 2-parameter family are executed",
+        "lattice_wide: checked and not executed — no uniqueness of Δ_NN on all of l2(Z^3) and no Laplacian axiom is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            "n5-length",
+            "each N5 resolution line is at least 40 characters",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+            residual=(len(line), line[:40]),
+        )
+        print(line)
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On Z^3 at the origin, `(Δ_NN φ)(0)=6` and `(Δ_edge φ)(0)=24` for `φ=|x|²`. Edge-diagonals have graph distance 2, so they are not nearest neighbors. Inside `Δ_{α,β}=α Δ_NN + β Δ_edge`, a later graph-Laplacian supplier of the *named* adjacency forces `β=0`. That supplier is extra. No Green, 1/r, product, or Laplacian axiom is selected.

## What this means for the TOE

Lattice kills the edge-diagonal stencil coefficient inside this 2-parameter class. It does not install a Newton kernel.

## What changed

- Note: `docs/LATTICE_NN_ADJACENCY_KILLS_EDGE_DIAGONAL_STENCIL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py`
- Cache: `logs/runner-cache/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.txt`

## Verification

```bash
python3 scripts/lattice_nn_adjacency_kills_edge_diagonal_stencil_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
