### PR TITLE
[physics-loop] toe-lphys c8carrier: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_BLOCK_CARRIER_IS_C8_NOT_ONE_SITE_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_BLOCK_CARRIER_IS_C8_NOT_ONE_SITE_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,283 @@
+---
+claim_id: two_block_carrier_is_c8_not_one_site_m2_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The May 2 two-block ranks (6,2) reconstruct an 8x8 self-adjoint operator Y_0 = Pi_+ - 3 Pi_- on C^8 with spectrum {+1 x6, -3 x2}. That eigenvalue multiset has length 8, so the smallest Hilbert-space dimension that can carry it is 8. No spectrum-preserving *-embedding of (C^8, Y_0) into the one-site pair (C^2, M_2(C)) exists, because 8 > 2. The current Qubit sentence presents the one-site possibility domain as M_2(C); the current Lattice sentence presents sites of Z^3 with no site privileged. Neither sentence names a C^8 taste cube, a 3-factor tensor, or ranks (6,2). The 8-dimensional carrier is therefore a displayed missing input relative to one-site Qubit. This note does not identify Y_0 with U(1)_Y, does not select (6,2) over (4,4), does not derive alpha = 1/3, and does not claim that no later 8-carrier compiler exists."
+upstream_dependencies:
+  - minimal_axioms
+  - lh_doublet_traceless_abelian_eigenvalue_ratio_narrow_theorem_note_2026-05-02
+runner: scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py
+---
+
+# The Two-Block Carrier Is C^8, Not One-Site M_2(C)
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite-dimensional comparison of the reconstructed two-block
+operator `Y_0` on `C^8` with the one-site Qubit algebra `M_2(C)`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py`](../scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py)
+
+## Result Up Front
+
+The one-site Qubit domain is the pair `(C^2, M_2(C))`. Any self-adjoint
+element of that algebra has at most two eigenvalues, counting multiplicity.
+
+The May 2 two-block ranks `(6,2)` live on an eight-dimensional space. This
+note reconstructs, and does not import Standard Model names for, the
+complementary projectors
+
+```text
+Pi_+ = diag(I_6, 0_2),
+Pi_- = diag(0_6, I_2),
+```
+
+and the ratio representative
+
+```text
+Y_0 := Pi_+ − 3 Pi_-.
+```
+
+The spectrum of `Y_0` is `{+1 × 6, −3 × 2}`. The trace is `6 − 6 = 0`. The
+ratio `β = −3α` is used only as the cited May 2 identity
+`6α + 2β = 0`. The scale choice here is the representative `α = 1`, not a
+derivation of `α = 1/3`.
+
+Five bounded statements follow.
+
+1. `Y_0` is self-adjoint on `C^8` and has eight eigenvalues with
+   multiplicity. The smallest Hilbert-space dimension that can carry that
+   multiset is 8.
+2. No `*`-embedding of `(C^8, Y_0)` into `(C^2, M_2(C))` can preserve the
+   spectrum, because `8 > 2`. Therefore `Y_0` is not an element of the
+   one-site algebra.
+3. The current Qubit sentence and the current Lattice sentence do not name a
+   `C^8` taste cube, a 3-factor tensor, or ranks `(6,2)`.
+4. Any operator with spectrum `{1^6, (−3)^2}` requires an 8-dimensional
+   carrier. That carrier is extra relative to one-site Qubit. The carrier is
+   displayed; this note does not adopt a taste-cube axiom.
+5. This note does not identify `Y_0` with `U(1)_Y`, does not select the
+   `(6,2)` split over `(4,4)`, and does not claim that no later 8-carrier
+   compiler exists.
+
+The predicates "`Y_0` acts on `C^2`" and "one-site `M_2` contains `Y_0`"
+are therefore false.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The dimension comparison is exact integer-linear algebra on a reconstructed 8x8 operator and the one-site M_2(C) presentation. The (6,2) ranks and the ratio beta = -3 alpha are cited May 2 inputs, not axiom consequences. No physical identification, split selection, or later compiler existence claim is made."
+trace_class: missing_input_display
+artifact_role: theorem
+hypothetical_axiom_status: "display only; no canonical axiom edit and no taste-cube adoption"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+One-site Qubit data, quoted from the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+The underlying one-site Hilbert space is therefore `H_2 = C^2`, and the
+one-site operator algebra is `End(H_2) = M_2(C)`. Write `site_dim()` for
+that Hilbert-space dimension. The unique positive integer `n` with
+`n^2 = dim_C M_2(C) = 4` is `n = 2`, so `site_dim() = 2`.
+
+Lattice data, quoted from the same memo:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with
+> nearest-neighbor adjacency, standard translations, and proper cubic
+> rotations about each site.
+>
+> No site is privileged.
+
+May 2 two-block ranks, cited from
+[`LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md`](LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md)
+and not re-derived here: a traceless two-block operator with multiplicities
+`6` and `2` satisfies
+
+```text
+6 · α + 2 · β = 0
+⇒ β = −3 α.
+```
+
+This note uses that identity only as a cited May 2 fact. It reconstructs one
+ratio representative on `H_8 = C^8` by the block projectors above. It does
+not import Standard Model names for the two blocks.
+
+Let `I_k` and `0_k` be the `k × k` identity and zero matrices over the
+rationals. Define
+
+```text
+Pi_+ := diag(I_6, 0_2) ∈ M_8(Q),
+Pi_- := diag(0_6, I_2) ∈ M_8(Q),
+Y_0  := Pi_+ − 3 Pi_-.
+```
+
+These are explicit `8 × 8` matrices. All arithmetic below is exact over
+`Q` (equivalently Python `Fraction`).
+
+Write `spectrum_multiset(T)` for the eigenvalue multiset of a self-adjoint
+operator `T`, counted with algebraic multiplicity and ordered
+non-increasingly.
+
+## Theorem 1 — Eight eigenvalues on C^8
+
+`Y_0` is self-adjoint on `C^8`. Its spectrum is `{+1 × 6, −3 × 2}`. The
+smallest Hilbert-space dimension that can carry that multiset is 8.
+
+**Proof.** Each of `Pi_+` and `Pi_-` is real symmetric, hence self-adjoint,
+and `Y_0` is an integer-linear combination of them, hence self-adjoint.
+Direct matrix multiplication gives
+
+```text
+Pi_+^2 = Pi_+,   Pi_-^2 = Pi_-,   Pi_+ Pi_- = 0 = Pi_- Pi_+,
+Pi_+ + Pi_- = I_8.
+```
+
+In the same block basis, `Y_0` is diagonal with six entries `+1` and two
+entries `−3`. Therefore
+
+```text
+spectrum_multiset(Y_0) = (1, 1, 1, 1, 1, 1, −3, −3).
+```
+
+The length of that multiset is 8. For any self-adjoint operator the length
+of the eigenvalue multiset equals the dimension of the Hilbert space on
+which it acts. A space that carries eight eigenvalues, counted with
+multiplicity, therefore has dimension at least 8. The constructed space has
+dimension 8, so 8 is the smallest such dimension.
+
+The trace is the sum of the multiset:
+
+```text
+Tr(Y_0) = 6 · 1 + 2 · (−3) = 0,
+```
+
+which is the same identity as `6α + 2β = 0` at the cited May 2
+representative `α = 1`, `β = −3`.
+
+## Theorem 2 — No spectrum-preserving embedding into one-site M_2(C)
+
+There is no `*`-embedding of the pair `(C^8, Y_0)` into the one-site pair
+`(C^2, M_2(C))` that preserves `spectrum_multiset(Y_0)`. In particular
+`Y_0` is not an element of the one-site algebra.
+
+**Proof.** A self-adjoint element of `M_2(C)` acts on a Hilbert space of
+dimension `site_dim() = 2`, so it has at most two eigenvalues counting
+multiplicity. A spectrum-preserving `*`-embedding would send `Y_0` to such
+an element, forcing
+
+```text
+len(spectrum_multiset(Y_0)) ≤ site_dim().
+```
+
+The left side is 8 and the right side is 2. The inequality `8 ≤ 2` is
+false. Equivalently, there is no injective linear map `C^8 → C^2`.
+
+Therefore the predicate "`Y_0` acts on `C^2`" fails, and the predicate
+"one-site `M_2` contains `Y_0`" fails.
+
+## Theorem 3 — Current axiom sentences do not name the carrier
+
+Quote Qubit: the full one-site possibility domain has algebraic
+presentation `M_2(C)`. Quote Lattice: sites of `Z^3`, no site privileged.
+
+Neither sentence names a `C^8` taste cube, a 3-factor tensor, or ranks
+`(6,2)`.
+
+**Proof.** The quoted sentences are the current axiom-memo wording. Direct
+inspection of that wording shows that the phrases "`C^8` taste cube",
+"3-factor tensor", and "ranks `(6,2)`" do not occur there. The one-site
+algebra named by Qubit is `M_2(C)`, whose carrier dimension is
+`site_dim() = 2`. Lattice names the site set `Z^3` and states that no site
+is privileged; it does not add an internal eight-dimensional fiber.
+
+## Theorem 4 — Missing input, displayed not adopted
+
+Any operator with spectrum `{1^6, (−3)^2}` requires an 8-dimensional
+carrier. That carrier is extra relative to one-site Qubit. This note
+displays the carrier. It does not adopt a taste-cube axiom.
+
+**Proof.** Theorem 1 supplies the dimension count. Theorem 2 supplies the
+comparison with one-site `M_2(C)`. Theorem 3 supplies that the current
+axiom sentences do not already name the eight-dimensional object. The
+conjunction is a missing-input statement: the reconstructed operator is
+not an output of the one-site Qubit presentation. Displaying
+`(C^8, Y_0)` records the extra carrier. Recording a missing input is not
+an axiom edit and is not an adoption of a taste-cube axiom.
+
+## Theorem 5 — Explicit non-claims
+
+This note does not identify `Y_0` with `U(1)_Y`. It does not select the
+`(6,2)` split over `(4,4)`. It does not claim that no later 8-carrier
+compiler exists. It does not derive `α = 1/3`. It does not force `r = 1/2`.
+
+The `(6,2)` ranks enter only as the cited May 2 two-block data. A different
+two-block split of an eight-dimensional space, such as `(4,4)`, would give
+a different traceless ratio and is not compared or eliminated here. The
+representative `Y_0 = Pi_+ − 3 Pi_-` fixes the May 2 ratio at scale
+`α = 1`; that is a reconstruction choice, not a derivation of the
+normalization `α = 1/3`. A later construction that compiles an
+eight-dimensional carrier from already retained data would be a different
+claim and is not ruled out by `8 > 2`.
+
+## What This Note Does Not Close
+
+- Identification of `Y_0` with Standard Model hypercharge `U(1)_Y`.
+- Selection of ranks `(6,2)` over `(4,4)` or any other split of 8.
+- A derivation of the normalization `α = 1/3`.
+- Any claim about `r = 1/2`.
+- Existence or non-existence of a later 8-carrier compiler.
+- Adoption of a `C^8` taste cube, a 3-factor tensor, or any new axiom.
+- Anomaly cancellation, charge formulae, or any Standard Model renaming.
+
+## Dependencies
+
+Load-bearing one-hop sources:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  the current Qubit presentation `M_2(C)` and the current Lattice wording
+  that sites are the points of `Z^3` with no site privileged.
+- [`LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md`](LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md)
+  supplies the two-block ranks `(6,2)` and the cited identity
+  `6α + 2β = 0 ⇒ β = −3α`. That parent already places Standard Model
+  hypercharge identification, the normalization `α = 1/3`, and the charge
+  formula outside its load-bearing chain.
+
+No other scientific source is load-bearing. Unmerged pull requests are not
+cited.
+
+## No-Go Discipline Gate
+
+The negative fragment is only the spectrum-preserving embedding obstruction
+of Theorem 2 and the two failed predicates of the identity gates.
+
+| Item | Statement |
+|---|---|
+| Exact negative | no spectrum-preserving `*`-embedding of `(C^8, Y_0)` into `(C^2, M_2(C))`; `Y_0` is not an element of one-site `M_2(C)` |
+| Mechanism | eigenvalue-multiset length 8 exceeds `site_dim() = 2` |
+| Live remainder | a later 8-carrier compiler, a different split of 8, and any physical identification of `Y_0` remain open |
+| Not claimed | axiom necessity, taste-cube adoption, uniqueness of ranks `(6,2)`, non-existence of every 8-dimensional construction |
+
+The obstruction is a finite dimension count on named matrices. It is not a
+global no-go against every future eight-dimensional object.
+
+## Verification
+
+```bash
+PYTHONPATH=scripts python3 scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py
+```
+
+The runner reconstructs `Pi_+`, `Pi_-`, and `Y_0` over `Fraction`, computes
+`spectrum_multiset(Y_0)` from the matrix, computes `site_dim()` from
+`dim M_2(C) = 4`, and evaluates the two identity predicates by calling
+those two functions. Both predicates must fail. The runner binds
+`AUDIT_INPUT_PATHS` to this note, the May 2 parent, and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18381,6 +18381,10 @@
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
    "out_degree": 1
+  },
+  "two_block_carrier_is_c8_not_one_site_m2_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "61e9d69bb3fe",
+   "out_degree": 2
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {
    "deps_hash": "bd71c5f30cb7",

--- a/logs/runner-cache/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.txt
+++ b/logs/runner-cache/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py
+runner_sha256: d9b1f1191debac2e2e2825aa08350baef482c2a07c695b67df460f0980fdb4fc
+input_fingerprint_sha256: 431c2b60ae1f2d552f310af6e141541a5dd32791ce749e5b5d00626a5b2e8eb4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+PASS: audit-input-present:TWO_BLOCK_CARRIER_IS_C8_NOT_ONE_SITE_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md (f270fb2d6156)
+PASS: audit-input-present:LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md (3039740f093a)
+PASS: audit-input-present:MINIMAL_AXIOMS_2026-06-29.md (53175250f045)
+PASS: axiom-qubit-sentence
+PASS: axiom-lattice-sites
+PASS: axiom-lattice-unprivileged
+PASS: note-quotes-qubit
+PASS: note-quotes-lattice-privilege
+PASS: axiom-does-not-name-taste-cube-or-ranks
+PASS: may2-cited-identity
+PASS: note-cites-may2-identity
+PASS: note-reconstructs-y0
+PASS: note-states-min-dim-8
+PASS: note-does-not-identify-u1y
+PASS: note-does-not-select-62-over-44
+PASS: note-does-not-derive-alpha-one-third
+PASS: note-does-not-force-r-half
+PASS: note-does-not-adopt-taste-cube
+PASS: note-forbids-adoption-language
+PASS: note-does-not-cite-unmerged-prs
+PASS: pi-plus-projector
+PASS: pi-minus-projector
+PASS: pi-plus-minus-orthogonal
+PASS: pi-sum-identity
+PASS: y0-self-adjoint
+PASS: y0-is-diagonal
+PASS: spectrum-multiset-reconstructed (1,1,1,1,1,1,-3,-3)
+PASS: spectrum-length-eight
+PASS: trace-zero (0)
+PASS: cited-may2-ratio-at-alpha-one
+PASS: trace-matches-cited-may2
+PASS: site-dim-is-two (2)
+PASS: carrier-dim-is-eight
+PASS: min-dim-is-len-spectrum
+PASS: eight-exceeds-two
+PASS: predicate-y0-acts-on-c2-fails
+PASS: predicate-one-site-m2-contains-y0-fails
+PASS: identity-gates-call-spectrum-and-site-dim
+PASS: n5 per_element: eight e
+per_element: eight eigenvalues of Y_0 and site_dim=2 are recomputed
+PASS: n5 per_site: one C^8 ca
+per_site: one C^8 carrier versus one M_2(C) site; no lattice of taste cubes
+PASS: n5 per_mode: only the t
+per_mode: only the two-block spectrum is checked; no U(1)_Y mode
+PASS: n5 per_block: only the 
+per_block: only the 8-versus-2 dimension split and the display residual are executed
+PASS: n5 lattice_wide: checke
+lattice_wide: checked and not executed — no lattice-wide hypercharge law is claimed
+TOTAL: PASS=43 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py
+++ b/scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Exact checks: the two-block carrier is C^8, not one-site M_2(C).
+
+Reconstructs Y_0 = Pi_+ - 3 Pi_- on C^8 over Fraction, computes
+spectrum_multiset(Y_0) from the matrix, computes site_dim() from
+dim M_2(C) = 4, and requires the predicates
+  'Y_0 acts on C^2'
+  'one-site M_2 contains Y_0'
+to fail after calling those two functions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BLOCK_CARRIER_IS_C8_NOT_ONE_SITE_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+MAY2_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[2]
+
+Matrix = tuple[tuple[Fraction, ...], ...]
+
+
+def file_sha256(relpath: str) -> str:
+    return hashlib.sha256((ROOT / relpath).read_bytes()).hexdigest()
+
+
+def eye(n: int) -> Matrix:
+    return tuple(
+        tuple(Fraction(1 if row == col else 0) for col in range(n))
+        for row in range(n)
+    )
+
+
+def zero(n: int) -> Matrix:
+    return tuple(tuple(Fraction(0) for _ in range(n)) for _ in range(n))
+
+
+def block_diag(left: Matrix, right: Matrix) -> Matrix:
+    n = len(left)
+    m = len(right)
+    rows = []
+    for i in range(n + m):
+        row = []
+        for j in range(n + m):
+            if i < n and j < n:
+                row.append(left[i][j])
+            elif i >= n and j >= n:
+                row.append(right[i - n][j - n])
+            else:
+                row.append(Fraction(0))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def mat_add(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[i][j] + right[i][j] for j in range(len(left)))
+        for i in range(len(left))
+    )
+
+
+def mat_scale(coeff: Fraction, mat: Matrix) -> Matrix:
+    return tuple(tuple(coeff * mat[i][j] for j in range(len(mat))) for i in range(len(mat)))
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    n = len(left)
+    out = []
+    for i in range(n):
+        row = []
+        for j in range(n):
+            acc = Fraction(0)
+            for k in range(n):
+                acc += left[i][k] * right[k][j]
+            row.append(acc)
+        out.append(tuple(row))
+    return tuple(out)
+
+
+def mat_adj(mat: Matrix) -> Matrix:
+    n = len(mat)
+    return tuple(tuple(mat[j][i] for j in range(n)) for i in range(n))
+
+
+def is_self_adjoint(mat: Matrix) -> bool:
+    return mat == mat_adj(mat)
+
+
+def is_diagonal(mat: Matrix) -> bool:
+    n = len(mat)
+    return all(mat[i][j] == Fraction(0) for i in range(n) for j in range(n) if i != j)
+
+
+def trace(mat: Matrix) -> Fraction:
+    return sum((mat[i][i] for i in range(len(mat))), Fraction(0))
+
+
+def pi_plus() -> Matrix:
+    return block_diag(eye(6), zero(2))
+
+
+def pi_minus() -> Matrix:
+    return block_diag(zero(6), eye(2))
+
+
+def construct_y0() -> Matrix:
+    return mat_add(pi_plus(), mat_scale(Fraction(-3), pi_minus()))
+
+
+def site_dim() -> int:
+    """One-site Hilbert dimension: End(C^n) = M_2(C) forces n^2 = 4."""
+    algebra_dim = 2 * 2
+    n = 1
+    while n * n < algebra_dim:
+        n += 1
+    if n * n != algebra_dim:
+        raise ValueError("one-site algebra dimension is not a square")
+    return n
+
+
+def spectrum_multiset(op: Matrix) -> tuple[Fraction, ...]:
+    """Eigenvalue multiset of a self-adjoint diagonalizable-by-construction operator.
+
+    Off-diagonal vanishing is checked, then the diagonal is the spectrum.
+    """
+    if not is_self_adjoint(op):
+        raise ValueError("spectrum_multiset requires a self-adjoint operator")
+    if not is_diagonal(op):
+        raise ValueError("spectrum_multiset expects the reconstructed diagonal form")
+    values = [op[i][i] for i in range(len(op))]
+    values.sort(reverse=True)
+    return tuple(values)
+
+
+def predicate_y0_acts_on_c2(y0: Matrix) -> bool:
+    """Identity gate: 'Y_0 acts on C^2'. Must fail (8 eigenvalues, dim 2)."""
+    return len(spectrum_multiset(y0)) <= site_dim()
+
+
+def predicate_one_site_m2_contains_y0(y0: Matrix) -> bool:
+    """Identity gate: 'one-site M_2 contains Y_0'. Must fail."""
+    return len(y0) == site_dim() and len(spectrum_multiset(y0)) <= site_dim()
+
+
+def cited_may2_beta(alpha: Fraction) -> Fraction:
+    """Cited May 2 identity 6α + 2β = 0, solved over Fraction."""
+    return -Fraction(6) * alpha / Fraction(2)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        if ok:
+            self.passed += 1
+        else:
+            self.failed += 1
+        extra = f" ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{extra}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    may2 = MAY2_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    for relpath in AUDIT_INPUT_PATHS:
+        digest = file_sha256(relpath)
+        checks.check(
+            f"audit-input-present:{Path(relpath).name}",
+            (ROOT / relpath).is_file() and len(digest) == 64,
+            digest[:12],
+        )
+
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    lattice_sites = "Physical sites are the points of the cubic lattice `Z^3`"
+    lattice_privilege = "No site is privileged."
+    checks.check("axiom-qubit-sentence", qubit_sentence in axiom)
+    checks.check("axiom-lattice-sites", lattice_sites in axiom)
+    checks.check("axiom-lattice-unprivileged", lattice_privilege in axiom)
+    checks.check("note-quotes-qubit", qubit_sentence in note)
+    checks.check("note-quotes-lattice-privilege", "no site privileged" in note)
+    checks.check(
+        "axiom-does-not-name-taste-cube-or-ranks",
+        all(
+            phrase not in axiom
+            for phrase in ("taste cube", "3-factor tensor", "ranks (6,2)")
+        ),
+    )
+
+    checks.check(
+        "may2-cited-identity",
+        "6 · α + 2 · β = 0" in may2 and "β = −3 α" in may2,
+    )
+    checks.check("note-cites-may2-identity", "6α + 2β = 0" in note)
+    checks.check(
+        "note-reconstructs-y0",
+        "Y_0 := Pi_+ − 3 Pi_-" in note or "Y_0 := Pi_+ - 3 Pi_-" in note,
+    )
+    checks.check("note-states-min-dim-8", "smallest Hilbert-space dimension" in note)
+    checks.check("note-does-not-identify-u1y", "does not identify `Y_0` with `U(1)_Y`" in note)
+    checks.check("note-does-not-select-62-over-44", "does not select the" in note and "(4,4)" in note)
+    checks.check("note-does-not-derive-alpha-one-third", "does not derive `α = 1/3`" in note)
+    checks.check("note-does-not-force-r-half", "does not force `r = 1/2`" in note)
+    checks.check(
+        "note-does-not-adopt-taste-cube",
+        "does not adopt a taste-cube axiom" in note,
+    )
+    lowered = note.lower()
+    checks.check(
+        "note-forbids-adoption-language",
+        "we adopt" not in lowered and "adopt a new axiom" not in lowered,
+    )
+    checks.check(
+        "note-does-not-cite-unmerged-prs",
+        all(token not in note.lower() for token in ("ranksplit", "phyanom", "ylike")),
+    )
+
+    plus = pi_plus()
+    minus = pi_minus()
+    identity8 = eye(8)
+    zero8 = zero(8)
+    y0 = construct_y0()
+
+    checks.check("pi-plus-projector", mat_mul(plus, plus) == plus and is_self_adjoint(plus))
+    checks.check("pi-minus-projector", mat_mul(minus, minus) == minus and is_self_adjoint(minus))
+    checks.check("pi-plus-minus-orthogonal", mat_mul(plus, minus) == zero8)
+    checks.check("pi-sum-identity", mat_add(plus, minus) == identity8)
+    checks.check("y0-self-adjoint", is_self_adjoint(y0))
+    checks.check("y0-is-diagonal", is_diagonal(y0))
+
+    spec = spectrum_multiset(y0)
+    expected = tuple([Fraction(1)] * 6 + [Fraction(-3)] * 2)
+    checks.check(
+        "spectrum-multiset-reconstructed",
+        spec == expected,
+        ",".join(str(v) for v in spec),
+    )
+    checks.check("spectrum-length-eight", len(spec) == 8)
+    checks.check("trace-zero", trace(y0) == Fraction(0), str(trace(y0)))
+    checks.check(
+        "cited-may2-ratio-at-alpha-one",
+        cited_may2_beta(Fraction(1)) == Fraction(-3),
+    )
+    checks.check(
+        "trace-matches-cited-may2",
+        Fraction(6) * Fraction(1) + Fraction(2) * Fraction(-3) == Fraction(0),
+    )
+
+    dim = site_dim()
+    checks.check("site-dim-is-two", dim == 2, str(dim))
+    checks.check("carrier-dim-is-eight", len(y0) == 8)
+    checks.check("min-dim-is-len-spectrum", len(spec) == 8 and len(spec) > dim)
+    checks.check("eight-exceeds-two", len(spec) > dim)
+
+    acts = predicate_y0_acts_on_c2(y0)
+    contains = predicate_one_site_m2_contains_y0(y0)
+    checks.check("predicate-y0-acts-on-c2-fails", acts is False)
+    checks.check("predicate-one-site-m2-contains-y0-fails", contains is False)
+
+    acts_src = inspect.getsource(predicate_y0_acts_on_c2)
+    contains_src = inspect.getsource(predicate_one_site_m2_contains_y0)
+    checks.check(
+        "identity-gates-call-spectrum-and-site-dim",
+        "spectrum_multiset" in acts_src
+        and "site_dim" in acts_src
+        and "spectrum_multiset" in contains_src
+        and "site_dim" in contains_src,
+    )
+
+    n5_lines = (
+        "per_element: eight eigenvalues of Y_0 and site_dim=2 are recomputed",
+        "per_site: one C^8 carrier versus one M_2(C) site; no lattice of taste cubes",
+        "per_mode: only the two-block spectrum is checked; no U(1)_Y mode",
+        "per_block: only the 8-versus-2 dimension split and the display residual are executed",
+        "lattice_wide: checked and not executed — no lattice-wide hypercharge law is claimed",
+    )
+    for line in n5_lines:
+        checks.check(
+            f"n5 {line[:20]}",
+            line.startswith(("per_element:", "per_site:", "per_mode:", "per_block:", "lattice_wide:"))
+            and len(line) >= 40,
+        )
+        print(line)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The May 2 two-block operator `Y_0=Pi_+−3 Pi_-` is self-adjoint on `C^8` with spectrum `{+1×6, −3×2}`. The smallest Hilbert-space dimension carrying that multiset is 8. No spectrum-preserving `*`-embedding into one-site `M_2(C)` exists (`8>2`). Qubit and Lattice do not name a `C^8` taste cube. The 8-carrier is displayed, not adopted. `Y_0` is not identified with `U(1)_Y`.

## What this means for the TOE

The two-block ratio lives on an extra Hilbert space relative to one-site Qubit.

## What changed

- Note: `docs/TWO_BLOCK_CARRIER_IS_C8_NOT_ONE_SITE_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py`
- Cache: `logs/runner-cache/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.txt`

## Verification

```bash
python3 scripts/two_block_carrier_is_c8_not_one_site_m2_2026_08_13.py
# TOTAL: PASS=43 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
