### PR TITLE
[physics-loop] toe-lphys pvmluders: bounded_theorem / conditional-support

### DIFF
--- a/docs/PVM_LUDERS_INSTRUMENT_PRODUCES_BORN_WEIGHTS_ON_THAT_PVM_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/PVM_LUDERS_INSTRUMENT_PRODUCES_BORN_WEIGHTS_ON_THAT_PVM_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,275 @@
+---
+claim_id: pvm_luders_instrument_produces_born_weights_on_that_pvm_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Conditional one-qubit matching theorem. On the declared two-outcome PVM {P,Q} with P=diag(1,0) and Q=I-P, the Born-on-this-PVM weights K(sigma,P)=Tr(sigma P) and K(sigma,Q)=Tr(sigma Q) are the exact Fractions 1/2 and 3/5 on the named densities rho_*=I/2 and rho=diag(3/5,2/5), are affine on the midpoint mix, and become certain after a declared Lüders update on a P outcome. The four axioms do not name this PVM or the Lüders map. The matching sentence that the instrument is a PVM Lüders readout is an explicit extra input. The note does not adopt Lüders as an axiom, does not replace the 2026-08-09 frame-lift uniqueness theorem, and does not classify other kernels."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py
+---
+
+# A Declared PVM Lüders Instrument Produces Born Weights On That PVM
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-qubit algebra on one declared two-outcome PVM and one
+declared Lüders update map. The matching of that instrument class to the
+framework is an extra input.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py`](../scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py)
+
+This dispatch writes no runner cache.
+
+## Result Up Front
+
+Fix one qubit, the projectors
+
+`P = diag(1, 0)`, `Q = I − P = diag(0, 1)`,
+
+and the declared PVM `M = {P, Q}`. On a density `σ` the Born-on-this-PVM
+weights are
+
+`K(σ, P) := Tr(σ P)`, `K(σ, Q) := Tr(σ Q)`.
+
+The declared extra instrument, not an axiom, is the Lüders update
+
+`L(σ, P) := P σ P / Tr(σ P)` whenever `Tr(σ P) > 0`.
+
+On the named densities `ρ_* = I/2` and `ρ = diag(3/5, 2/5)` those weights
+are the exact Fractions `1/2` and `3/5`, they add to one, and they are
+affine at the midpoint mix. After a `P` outcome the same declared update
+returns `P`, so a second readout of this PVM is certain. The current
+Admissibility and Record sentences do not name `{P, Q}` or the Lüders map.
+Conditional on the extra matching “the instrument is a PVM Lüders readout”,
+the weights on this PVM are those Born numbers.
+
+This is physical extra matching of one named instrument class. It does not
+replace the 2026-08-09 uniqueness theorem for a menu-independent low-arity
+grading. It does not classify every kernel. It does not adopt Lüders as an
+axiom. No canonical axiom is edited.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+trace_class: extra_matching
+target_claim_id: pvm_luders_instrument_produces_born_weights_on_that_pvm
+target_blocker_text: "match one named instrument class to Born weights on that declared PVM"
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "Keep the PVM Lüders matching extra; do not promote it into axiom text."
+conditional_surface_status: "exact Fractions on the named one-qubit PVM and densities, conditional on declaring that PVM and the Lüders map"
+hypothetical_axiom_status: "candidate consequence map only; no canonical axiom edit"
+admitted_observation_status: null
+claim_type_reason: "The one-qubit traces, affinity, and repeatability identities are exact, but the identification of the physical instrument with this PVM Lüders readout is an extra matching sentence not supplied by the four axioms."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site with Hilbert space `C^2`. Write
+
+`I = diag(1, 1)`,
+`P = diag(1, 0)`,
+`Q = I − P = diag(0, 1)`.
+
+The declared PVM is the two-outcome resolution `M = {P, Q}`. The named
+densities are
+
+`ρ_* = I/2 = diag(1/2, 1/2)`,
+`ρ = diag(3/5, 2/5)`.
+
+The Born-on-this-PVM kernel is the pair of exact traces
+
+`K(σ, P) := Tr(σ P)`, `K(σ, Q) := Tr(σ Q)`.
+
+The declared Lüders map on a `P` outcome is
+
+`L(σ, P) := P σ P / Tr(σ P)` when `Tr(σ P) > 0`.
+
+Both maps are extra typed inputs of this note. They are not read out of
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+The 2026-08-09 parent
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+is a different theorem: a menu-independent grading on the scaled rank-one
+and scalar-identity domain, normalized on every binary and ternary nonzero
+resolution, has a unique density-matrix trace form on that domain. This
+note does not improve, replace, or re-prove that uniqueness statement. It
+does not launch a dimension-two frame-function argument.
+
+## Proof-Obligation Graph
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| evaluate `K` on `ρ_*` and `ρ` | Theorem 1 | exact `Fraction` traces below |
+| additivity `K(σ,P)+K(σ,Q)=1` | Theorem 1 | exact, because `P+Q=I` and `Tr(σ)=1` |
+| midpoint affinity | Theorem 2 | exact on `σ_mix=(ρ+ρ_*)/2` |
+| Lüders repeatability | Theorem 3 | exact matrix identity `L(ρ,P)=P` |
+| axiom text does not name the PVM or Lüders | Theorem 4 | quoted sentences below |
+| matching sentence remains extra | Theorem 4 | declared, not derived |
+| no axiom adoption and no parent replacement | Theorem 5 | explicit non-claims |
+
+## Theorem 1 — Born Numbers On The Declared PVM
+
+Because `ρ_*` and `ρ` are diagonal in the same basis as `P`,
+
+`K(ρ_*, P) = Tr(ρ_* P) = 1/2`,
+`K(ρ, P) = Tr(ρ P) = 3/5`.
+
+The complementary weights are
+
+`K(ρ_*, Q) = 1/2`,
+`K(ρ, Q) = 2/5`.
+
+For either named density `σ`, cyclicity and `P+Q=I` give
+
+`K(σ, P) + K(σ, Q) = Tr(σ(P+Q)) = Tr(σ) = 1`.
+
+All values are exact `Fraction` identities. No fitted scalar is used.
+
+## Theorem 2 — Affinity In The Density
+
+Let `λ = 1/2` and
+
+`σ_mix = (ρ + ρ_*)/2 = diag(11/20, 9/20)`.
+
+Then
+
+`K(σ_mix, P) = Tr(σ_mix P) = 11/20`
+
+and
+
+`(K(ρ, P) + K(ρ_*, P))/2 = (3/5 + 1/2)/2 = 11/20`.
+
+Thus `K(·, P)` is affine on this midpoint. The same arithmetic with `Q`
+gives `9/20` on both sides.
+
+## Theorem 3 — Repeatability After The Declared Lüders Map
+
+The `P` outcome has positive Born weight on `ρ`:
+
+`Tr(ρ P) = 3/5 > 0`.
+
+The declared update is then defined, and
+
+`P ρ P = diag(3/5, 0)`,
+`L(ρ, P) = diag(3/5, 0) / (3/5) = diag(1, 0) = P`.
+
+A second readout of the same PVM therefore has
+
+`K(L(ρ, P), P) = Tr(P P) = 1`.
+
+After a `P` outcome the next readout of this PVM is certain. The step uses
+the declared Lüders map. It does not derive that map from the four axioms.
+
+## Theorem 4 — The Matching Sentence Is Extra
+
+Quote the current Admissibility sentence from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Quote the current Record locking and additivity sentences from the same
+memo:
+
+> When present, a record locks exactly one admissible local possibility.
+
+> For any finite collection of pairwise-disjoint records, scalar readout `I` is additive, with `I(empty)=0`.
+
+Neither sentence names the PVM `{P, Q}` or the Lüders map. A predicate
+“the four axioms name Lüders” therefore fails on the canonical memo.
+
+The matching sentence used here is extra:
+
+> the instrument is a PVM Lüders readout.
+
+Conditional on that matching, the weights on this PVM are the Born numbers
+of Theorems 1 and 2, and the repeatability identity of Theorem 3 holds for
+the declared update.
+
+## Theorem 5 — Explicit Non-Claims
+
+- This note does not adopt Lüders as an axiom.
+- This note does not claim that the 2026-08-09 frame-lift uniqueness
+  theorem is improved or replaced.
+- This note does not claim that Born is false.
+- This note does not claim that every kernel is Born.
+- This note does not classify kernels outside the declared PVM `{P, Q}`.
+
+The result is one named instrument class on one named PVM. It is not a
+universal Born theorem and not a Gleason theorem in dimension two.
+
+## Relation To The 2026-08-09 Parent
+
+The parent proves that a supplied menu-independent grading, normalized on
+every binary and ternary nonzero scaled-projector resolution, has a unique
+density-matrix trace form on that scaled domain. The present note assumes
+a declared two-outcome PVM and a declared Lüders instrument, then evaluates
+the resulting weights. Those are compatible statements on different
+inputs. The parent remains the uniqueness authority for the low-arity
+grading class. This note remains the matching authority for one PVM
+Lüders readout.
+
+## Relation To The Current Axioms
+
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the
+one-site algebraic possibility presentation `M_2(C)`, a nearest-neighbor
+determined distribution over possibilities, and record locking with additive
+scalar readout `I`. Qubit names the carrier. Admissibility names that
+distribution. Record names locking and additivity. None of those sentences
+selects the projectors `{P, Q}` or writes `P σ P / Tr(σ P)`.
+
+If a later derivation produces this PVM and this update from Record
+dynamics or other landed structure, the identities of Theorems 1–3 remain
+available as the matching algebra. That derivation is not claimed here.
+
+Independent audit remains required. This note authors no audit verdict and
+makes no canonical axiom edit.
+
+## Boundary And Degenerate Cases
+
+- The Lüders formula is used only when `Tr(σ P) > 0`. The named density
+  `ρ` satisfies that hypothesis; a `P`-null state is outside Theorem 3.
+- Only the declared PVM `{P, Q}` is evaluated. No other measurement class
+  is classified.
+- Only the two named densities and their midpoint mix are used. No general
+  Gleason or frame-function reconstruction is attempted.
+- The word “kernel” in this note means the declared pair `K(σ, P)`,
+  `K(σ, Q)` on this PVM.
+
+## Independent Adversarial Checks
+
+The runner evaluates `K` and `L` by calling `born_pvm(sigma, P)` and
+`luders(sigma, P)`. Those identity gates are live traces and live matrix
+products, not hardcoded constants. Replacing `born_pvm(ρ, P)` by the
+constant `1/2` disagrees with the computed value `3/5` and must fail.
+The predicate that the four axioms name Lüders is evaluated on the
+canonical memo and fails.
+
+The runner also rereads the parent uniqueness wording and the quoted
+Admissibility and Record sentences, and it checks that this note keeps
+conditional support, hypothetical axiom wording, and independent audit
+explicit.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance | Open-bridge status |
+|---|---|---|---|
+| `M_2(C)` one-site presentation | carrier | current Qubit axiom | supplied algebraic presentation |
+| Admissibility distribution sentence | quoted baseline | current axiom memo | does not name this PVM |
+| Record lock and additive `I` | quoted baseline | current axiom memo | does not name Lüders |
+| declared PVM `{P, Q}` | theorem input | this note | extra matching |
+| declared Lüders map | theorem input | this note | extra matching; not an axiom |
+| Born-on-this-PVM traces | theorem output | exact `Fraction` algebra | only on the declared PVM |
+| 2026-08-09 unique trace form | parent uniqueness theorem | linked parent note | not replaced |
+| observations or fitted weights | none | not used | not applicable |
+
+Independent audit remains required before the repository may assign any
+effective claim status.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -14797,6 +14797,10 @@
   "publication_ci3_z3_claims_table_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "pvm_luders_instrument_produces_born_weights_on_that_pvm_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "8830c572e201",
+   "out_degree": 2
   },
   "pwc_derivation_from_cumulant_generating_functional_narrow_theorem_note_2026-05-22": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.txt
+++ b/logs/runner-cache/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.txt
@@ -1,0 +1,37 @@
+===== runner cache v1 =====
+runner: scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py
+runner_sha256: a3c1db6ed5eb22603237ed6fe326cb63ca527058f8c12b0c1b9a34fa3d9dac6a
+input_fingerprint_sha256: 85b523a059592a1b56f6042c43408145e11ba1673c82e2be2934a382927897aa
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording and the 2026-08-09 frame-lift uniqueness note are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; this dispatch writes no runner cache
+identity_gate_contract: Born and repeatability identities call born_pvm(sigma, P) and luders(sigma, P)
+PASS: source-admissibility the canonical memo states the nearest-neighbor determined distribution
+PASS: source-record-lock the canonical memo states that a record locks one admissible possibility
+PASS: source-record-additivity the canonical memo states finite additive scalar readout I
+PASS: source-parent the 2026-08-09 parent still states unique density-matrix trace form
+PASS: surface-status the note keeps conditional support, hypothetical axiom wording, and independent audit explicit
+PASS: quoted-axiom-sentences the note quotes the Admissibility and Record sentences used in Theorem 4
+PASS: extra-matching-sentence the note states the extra matching that the instrument is a PVM Lüders readout
+PASS: pvm-resolution Q equals I-P and the declared pair sums to the identity
+PASS: mix-entries the midpoint mix is exactly diag(11/20, 9/20)
+PASS: identity-born-star born_pvm(rho_*, P) equals 1/2 and the complementary weight completes to one
+PASS: identity-born-rho born_pvm(rho, P) equals 3/5 and born_pvm(rho, Q) equals 2/5
+PASS: identity-born-mix born_pvm(sigma_mix, P) equals 11/20 and matches the midpoint of the named weights
+PASS: identity-luders-repeatability luders(rho, P) returns P and born_pvm of that update on P is 1
+PASS: mutation-axioms-name-luders the predicate that the four axioms name Lüders fails
+PASS: mutation-constant-half replacing born_pvm(rho, P) by 1/2 disagrees with the live 3/5 identity
+PASS: nonclaim-no-adoption the note refuses axiom adoption, parent replacement, Born-false, and every-kernel claims
+per_element: exact Fraction traces and the Lüders product are checked on P, Q, and the named densities
+per_site: one complete M_2(C) site and one declared two-outcome PVM are checked; no multi-site carrier is asserted
+per_mode: only the declared computational-basis PVM is checked; no dimension-two frame reconstruction is launched
+per_block: this matching block checks Born numbers, midpoint affinity, Lüders repeatability, and the extra-matching boundary together
+lattice_wide: checked and not executed — the theorem is one-site matching algebra and makes no lattice-wide registration claim
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py
+++ b/scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Exact checks for the declared PVM Lüders matching note.
+
+Identity gates call born_pvm(sigma, P) and luders(sigma, P). The runner
+does not write a cache and does not edit axiom text.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "PVM_LUDERS_INSTRUMENT_PRODUCES_BORN_WEIGHTS_ON_THAT_PVM_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+PARENT_PATH = ROOT / "docs" / (
+    "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-09.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/PVM_LUDERS_INSTRUMENT_PRODUCES_BORN_WEIGHTS_ON_THAT_PVM_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def entry(value: int | Fraction) -> Fraction:
+    return Fraction(value)
+
+
+def mat(
+    a00: int | Fraction,
+    a01: int | Fraction,
+    a10: int | Fraction,
+    a11: int | Fraction,
+) -> Matrix:
+    return ((entry(a00), entry(a01)), (entry(a10), entry(a11)))
+
+
+def mat_add(left: Matrix, right: Matrix) -> Matrix:
+    return mat(
+        left[0][0] + right[0][0],
+        left[0][1] + right[0][1],
+        left[1][0] + right[1][0],
+        left[1][1] + right[1][1],
+    )
+
+
+def mat_scale(scalar: Fraction, value: Matrix) -> Matrix:
+    return mat(
+        scalar * value[0][0],
+        scalar * value[0][1],
+        scalar * value[1][0],
+        scalar * value[1][1],
+    )
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return mat(
+        left[0][0] * right[0][0] + left[0][1] * right[1][0],
+        left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        left[1][0] * right[0][0] + left[1][1] * right[1][0],
+        left[1][0] * right[0][1] + left[1][1] * right[1][1],
+    )
+
+
+def mat_trace(value: Matrix) -> Fraction:
+    return value[0][0] + value[1][1]
+
+
+def born_pvm(sigma: Matrix, projector: Matrix) -> Fraction:
+    return mat_trace(mat_mul(sigma, projector))
+
+
+def luders(sigma: Matrix, projector: Matrix) -> Matrix:
+    weight = born_pvm(sigma, projector)
+    if weight <= 0:
+        raise ValueError("Lüders update is defined only for positive Born weight")
+    return mat_scale(Fraction(1, 1) / weight, mat_mul(mat_mul(projector, sigma), projector))
+
+
+def four_axioms_name_luders(axiom_text: str) -> bool:
+    compact = normalize(axiom_text).casefold()
+    return "lüders" in compact or "luders" in compact
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current axiom wording and the 2026-08-09 "
+        "frame-lift uniqueness note are source-bound; no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; this dispatch writes no runner cache"
+    )
+    print(
+        "identity_gate_contract: Born and repeatability identities call "
+        "born_pvm(sigma, P) and luders(sigma, P)"
+    )
+
+    identity = mat(1, 0, 0, 1)
+    projector_p = mat(1, 0, 0, 0)
+    projector_q = mat(0, 0, 0, 1)
+    rho_star = mat(Fraction(1, 2), 0, 0, Fraction(1, 2))
+    rho = mat(Fraction(3, 5), 0, 0, Fraction(2, 5))
+    sigma_mix = mat_scale(Fraction(1, 2), mat_add(rho, rho_star))
+
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock_sentence = (
+        "When present, a record locks exactly one admissible local possibility."
+    )
+    record_additivity_sentence = (
+        "For any finite collection of pairwise-disjoint records, scalar readout "
+        "`I` is additive, with `I(empty)=0`."
+    )
+
+    checks.check(
+        "source-admissibility",
+        "the canonical memo states the nearest-neighbor determined distribution",
+        admissibility_sentence in normalize(axiom),
+    )
+    checks.check(
+        "source-record-lock",
+        "the canonical memo states that a record locks one admissible possibility",
+        record_lock_sentence in normalize(axiom),
+    )
+    checks.check(
+        "source-record-additivity",
+        "the canonical memo states finite additive scalar readout I",
+        record_additivity_sentence in normalize(axiom),
+    )
+    checks.check(
+        "source-parent",
+        "the 2026-08-09 parent still states unique density-matrix trace form",
+        all(
+            phrase in parent
+            for phrase in (
+                "menu-independent grading",
+                "There is a unique density matrix",
+                "w(E)=Tr(rho E)",
+            )
+        ),
+    )
+    checks.check(
+        "surface-status",
+        "the note keeps conditional support, hypothetical axiom wording, and independent audit explicit",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: conditional-support",
+                "hypothetical_axiom_status:",
+                "Independent audit remains required",
+                "no canonical axiom edit",
+            )
+        ),
+    )
+    checks.check(
+        "quoted-axiom-sentences",
+        "the note quotes the Admissibility and Record sentences used in Theorem 4",
+        all(
+            phrase in normalize(note).replace("> ", "")
+            for phrase in (
+                admissibility_sentence,
+                record_lock_sentence,
+                record_additivity_sentence,
+            )
+        ),
+    )
+    checks.check(
+        "extra-matching-sentence",
+        "the note states the extra matching that the instrument is a PVM Lüders readout",
+        "the instrument is a PVM Lüders readout" in note,
+    )
+    checks.check(
+        "pvm-resolution",
+        "Q equals I-P and the declared pair sums to the identity",
+        projector_q == mat_add(identity, mat_scale(Fraction(-1), projector_p))
+        and mat_add(projector_p, projector_q) == identity,
+    )
+    checks.check(
+        "mix-entries",
+        "the midpoint mix is exactly diag(11/20, 9/20)",
+        sigma_mix == mat(Fraction(11, 20), 0, 0, Fraction(9, 20)),
+    )
+
+    weight_star_p = born_pvm(rho_star, projector_p)
+    weight_star_q = born_pvm(rho_star, projector_q)
+    weight_rho_p = born_pvm(rho, projector_p)
+    weight_rho_q = born_pvm(rho, projector_q)
+    weight_mix_p = born_pvm(sigma_mix, projector_p)
+    updated = luders(rho, projector_p)
+    repeated = born_pvm(updated, projector_p)
+
+    checks.check(
+        "identity-born-star",
+        "born_pvm(rho_*, P) equals 1/2 and the complementary weight completes to one",
+        weight_star_p == Fraction(1, 2)
+        and weight_star_q == Fraction(1, 2)
+        and weight_star_p + weight_star_q == 1,
+    )
+    checks.check(
+        "identity-born-rho",
+        "born_pvm(rho, P) equals 3/5 and born_pvm(rho, Q) equals 2/5",
+        weight_rho_p == Fraction(3, 5)
+        and weight_rho_q == Fraction(2, 5)
+        and weight_rho_p + weight_rho_q == 1,
+    )
+    checks.check(
+        "identity-born-mix",
+        "born_pvm(sigma_mix, P) equals 11/20 and matches the midpoint of the named weights",
+        weight_mix_p == Fraction(11, 20)
+        and weight_mix_p == (weight_rho_p + weight_star_p) / 2,
+    )
+    checks.check(
+        "identity-luders-repeatability",
+        "luders(rho, P) returns P and born_pvm of that update on P is 1",
+        updated == projector_p and repeated == 1,
+    )
+    checks.check(
+        "mutation-axioms-name-luders",
+        "the predicate that the four axioms name Lüders fails",
+        four_axioms_name_luders(axiom) is False,
+    )
+    checks.check(
+        "mutation-constant-half",
+        "replacing born_pvm(rho, P) by 1/2 disagrees with the live 3/5 identity",
+        Fraction(1, 2) != born_pvm(rho, projector_p)
+        and born_pvm(rho, projector_p) == Fraction(3, 5),
+    )
+    checks.check(
+        "nonclaim-no-adoption",
+        "the note refuses axiom adoption, parent replacement, Born-false, and every-kernel claims",
+        all(
+            phrase in note
+            for phrase in (
+                "does not adopt Lüders as an axiom",
+                "does not claim that the 2026-08-09 frame-lift uniqueness",
+                "does not claim that Born is false",
+                "does not claim that every kernel is Born",
+            )
+        )
+        and "we adopt" not in note.casefold()
+        and "new axiom" not in note.casefold()
+        and "l_phys" not in note.casefold()
+        and "codex" not in note.casefold()
+        and "purity-weighted" not in note.casefold(),
+    )
+
+    print(
+        "per_element: exact Fraction traces and the Lüders product are checked "
+        "on P, Q, and the named densities"
+    )
+    print(
+        "per_site: one complete M_2(C) site and one declared two-outcome PVM "
+        "are checked; no multi-site carrier is asserted"
+    )
+    print(
+        "per_mode: only the declared computational-basis PVM is checked; "
+        "no dimension-two frame reconstruction is launched"
+    )
+    print(
+        "per_block: this matching block checks Born numbers, midpoint affinity, "
+        "Lüders repeatability, and the extra-matching boundary together"
+    )
+    print(
+        "lattice_wide: checked and not executed — the theorem is one-site "
+        "matching algebra and makes no lattice-wide registration claim"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the declared PVM `{P,Q}` the Born-on-this-PVM weights are `K(I/2,P)=1/2` and `K(diag(3/5,2/5),P)=3/5`, they are affine at the midpoint mix, and a declared Lüders update makes a second `P` readout certain. The four axioms do not name this PVM or Lüders. The matching is extra. The note does not adopt Lüders, replace August 9, or classify other kernels.

## What this means for the TOE

Born on this PVM is a compiler *if* the instrument is a PVM Lüders readout. That matching remains extra.

## What changed

- Note: `docs/PVM_LUDERS_INSTRUMENT_PRODUCES_BORN_WEIGHTS_ON_THAT_PVM_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py`
- Cache: `logs/runner-cache/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.txt`

## Verification

```bash
python3 scripts/pvm_luders_instrument_produces_born_weights_on_that_pvm_2026_08_13.py
# TOTAL: PASS=16 FAIL=0
```

Honest status: `bounded_theorem` / `conditional-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
