### PR TITLE
[physics-loop] toe-lphys volsign: bounded_theorem / bounded-support

### DIFF
--- a/docs/CL3_VOLUME_ELEMENTS_PLUS_MINUS_NOT_AXIOM_SELECTED_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/CL3_VOLUME_ELEMENTS_PLUS_MINUS_NOT_AXIOM_SELECTED_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,190 @@
+# Cl(3) Volume Elements +ω and −ω Are Not Axiom-Selected
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Claim scope:** on the real Clifford algebra `Cl(3,0)`, the two opposite
+volume elements `ω := e1 e2 e3` and `ω' := e3 e2 e1` satisfy `ω' = −ω`,
+are both odd and central, and are square-equal (`ω² = (−ω)² = −I`). Proper
+cubic rotations preserve both signs. No axiom-selected structure on the
+current Lattice/Qubit wording distinguishes `+ω` from `−ω`. The extra
+object for an orientation is a displayed choice `s ∈ {+1, −1}` with
+oriented volume `s ω`. This note does not add a chirality axiom and does
+not reopen the parent odd-`d_t` restriction.
+**Status authority:** independent audit lane only. This source note does
+not set or predict an audit outcome.
+**Primary runner:**
+[`scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py`](../scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py)
+
+This block is the orientation `Z2` on `Cl(3,0)`. It is independent of the
+May 10 chirality-existence statement (a square-normalized anticommuting
+element exists iff total dimension `n` is even) and of any in-flight
+carrier work. The only parent algebra reused here is the May 10 odd-`n`
+centrality rule, applied at `n = 3`.
+
+## Parents
+
+- [`CLIFFORD_VOLUME_CHIRALITY_EVEN_DIMENSION_NARROW_THEOREM_NOTE_2026-05-10.md`](CLIFFORD_VOLUME_CHIRALITY_EVEN_DIMENSION_NARROW_THEOREM_NOTE_2026-05-10.md)
+  — volume-element (anti)commutation rule `(V)` and the odd-`n` centrality
+  of `ω`.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — Lattice
+  proper cubic rotations; Qubit `Cl(3,0)`-compatible real-algebra
+  presentation.
+
+## Algebra
+
+Let `Cl(3,0)` be the real Clifford algebra on generators `e1, e2, e3`
+satisfying
+
+```text
+{ ei, ej }  =  2 δ_{ij} I.
+```
+
+Define the volume element and the opposite-order volume element by
+
+```text
+ω   :=  e1 e2 e3,
+ω'  :=  e3 e2 e1.
+```
+
+All identities below are exact integer Clifford arithmetic: abstract
+anticommutators on the eight-dimensional integer span, with a 2×2 Pauli
+model exhibited as a faithful check.
+
+## Theorem 1
+
+`ω' = −ω`.
+
+**Proof.** Three adjacent transpositions, each from `{ei, ej} = 0` for
+`i ≠ j`:
+
+```text
+ω'  =  e3 e2 e1
+    =  − e2 e3 e1          (swap e3 past e2)
+    =    e2 e1 e3          (swap e3 past e1)
+    =  − e1 e2 e3          =  −ω.
+```
+
+The same identity is the explicit product `e3 e2 e1` in the integer
+basis.
+
+Both products are grade-odd (three generators). The parent May 10 rule
+`(V)` says `ω γ_μ = (−1)^{n−1} γ_μ ω`. At `n = 3` (odd),
+`(−1)^{n−1} = +1`, so `ω` is central: it commutes with every generator.
+Then `ω' = −ω` is the other central orientation. Direct check for `e1`:
+
+```text
+ω e1  =  e1 e2 e3 e1  =  e1 e2 (− e1 e3)  =  − e1 (e2 e1) e3
+      =  − e1 (− e1 e2) e3  =  (e1 e1) e2 e3  =  e2 e3,
+e1 ω  =  e1 e1 e2 e3  =  e2 e3.
+```
+
+The `e2` and `e3` calculations are cyclic. Centrality of `−ω` is
+immediate.
+
+## Theorem 2
+
+On this real `Cl(3,0)` convention, `ω² = −I`. Consequently
+`(−ω)² = ω² = −I`. The two orientations are square-equal. Neither is
+distinguished by the value of the square.
+
+**Proof.** Move generators through by the same anticommutators:
+
+```text
+ω²  =  e1 e2 e3 e1 e2 e3
+    =  e1 e2 (− e1 e3) e2 e3
+    =  − e1 (e2 e1) e3 e2 e3
+    =  − e1 (− e1 e2) e3 e2 e3
+    =  e1 e1 e2 e3 e2 e3
+    =  e2 (e3 e2) e3
+    =  e2 (− e2 e3) e3
+    =  − (e2 e2) (e3 e3)
+    =  − I.
+```
+
+Then `(−ω)² = ω² = −I`.
+
+**Pauli model.** The standard 2×2 Pauli matrices `e_i = σ_i` realize the
+same relations over `Z[i]`:
+
+```text
+σ1 σ2 σ3  =  i I,     (σ1 σ2 σ3)²  =  i² I  =  −I,
+(− σ1 σ2 σ3)²  =  (−i I)²  =  i² I  =  −I.
+```
+
+The model confirms the abstract square. It does not add a sign
+selection: both `+i I` and `−i I` square to `−I`.
+
+## Theorem 3
+
+Qubit states: “A `Cl(3,0)`-compatible real-algebra presentation may be
+used equivalently and adds no further primitive structure.” Lattice
+supplies proper cubic rotations (orientation-preserving) about each
+site. A proper rotation `R` (det `=+1`) acts on the volume by
+
+```text
+R(ω)   =  R(e1) R(e2) R(e3)  =  (det R) ω  =  +ω,
+R(−ω)  =  − R(ω)             =  −ω.
+```
+
+Proper cubic rotations therefore preserve `ω` and also preserve `−ω`.
+Covariance under the supplied Lattice symmetry does not pick the sign.
+(An improper map with det `= −1` exchanges the two signs; the axiom
+wording names only proper cubic rotations.)
+
+## Theorem 4 (missing-input)
+
+The extra object for an orientation is a choice `s ∈ {+1, −1}` with
+oriented volume `s ω`. This note displays that pair. It does not add a
+chirality axiom.
+
+The May 10 parent already forces odd `d_t` for a spacetime volume that
+admits a square-normalized anticommuting chirality element. This note
+does not reopen `d_t`. The present `Z2` is the residual sign of the
+spatial `Cl(3,0)` volume after that parent dichotomy is granted.
+
+## Theorem 5
+
+Do not identify `s` with the sign of weak hypercharge, with a gravity
+orientation, or with a fifth framework axiom. Those identifications are
+outside the algebra checked here. The displayed pair `{+ω, −ω}` is only
+the orientation `Z2` of `Cl(3,0)`.
+
+## What this claims
+
+- Identity: `ω' = −ω` by three transpositions.
+- Both volume elements are odd and central at `n = 3`.
+- Square identity: `ω² = (−ω)² = −I` on real `Cl(3,0)`; the Pauli model
+  exhibits the same square.
+- Proper cubic rotations preserve both signs, so Lattice covariance does
+  not select `s`.
+- Qubit adds no further primitive that would select `s`.
+- The missing input is the displayed choice `s ∈ {+1, −1}`.
+
+## What this does not claim
+
+- Does not add, propose, or adopt a chirality axiom or any fifth axiom.
+- Does not identify `s` with weak hypercharge sign or gravity
+  orientation.
+- Does not reopen `d_t`, does not claim `d_t = 1`, and does not reuse
+  the May 10 chirality-existence theorem beyond odd-`n` centrality.
+- Does not select a preferred faithful irrep (`χ = +i` versus `χ = −i`)
+  and does not identify the spatial volume sign with staggered
+  `ε(x)`, generation handedness, or a spacetime `γ5`.
+- Does not edit the axiom memo.
+
+## Forbidden imports check
+
+- No PDG values, fitted selectors, or unit conventions.
+- No unmerged-PR citations.
+- No observational inputs.
+
+## Validation
+
+Primary runner:
+[`scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py`](../scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py)
+
+The runner uses exact integer Clifford arithmetic (abstract
+anticommutators on `Z^8`, plus a 2×2 Pauli model over Gaussian
+integers). Identity gates call `volume()` and `volume_opp()`. A
+predicate `ω' ≠ −ω` fails. A predicate `ω² ≠ (−ω)²` fails. Declared
+inputs are this note, the May 10 parent, and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2257,6 +2257,10 @@
   "cl3_to_cl31_spinor_extension_narrow_theorem_note_2026-05-27": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "cl3_volume_elements_plus_minus_not_axiom_selected_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "eb898ddaed75",
+   "out_degree": 2
   },
   "claude_branch_retainability_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.txt
+++ b/logs/runner-cache/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py
+runner_sha256: 2e91163f7f3c3ef1111570b07f71b1859e03a2ba1bfa4c1d46bf7fe58ec2840f
+input_fingerprint_sha256: 75bbd5aa6a566227b7375f8bbb8477ba6bd36fcfbf83985439e95a86914d4944
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact Cl(3,0) anticommutators and the declared axiom/parent wording
+audit_input_paths: docs/CL3_VOLUME_ELEMENTS_PLUS_MINUS_NOT_AXIOM_SELECTED_BOUNDED_THEOREM_NOTE_2026-08-13.md, docs/CLIFFORD_VOLUME_CHIRALITY_EVEN_DIMENSION_NARROW_THEOREM_NOTE_2026-05-10.md, docs/MINIMAL_AXIOMS_2026-06-29.md
+PASS: audit-inputs-exist declared note, May 10 parent, and axiom memo are readable
+PASS: car {ei, ej} = 2 δ_ij I on the integer generators
+PASS: identity-opp-minus volume_opp() equals -volume()
+PASS: identity-squares volume()^2 equals volume_opp()^2
+PASS: mutation-opp-neq-minus the predicate ω' ≠ −ω fails
+PASS: mutation-squares-unequal the predicate ω² ≠ (−ω)² fails
+PASS: odd-grade both volume elements are grade-odd
+PASS: central n=3 odd: ω and ω' commute with every generator
+PASS: square-minus-one ω² = (−ω)² = −I
+PASS: pauli-volume σ1 σ2 σ3 = i I and the opposite product is −i I
+PASS: pauli-squares (σ1 σ2 σ3)² = (−σ1 σ2 σ3)² = −I
+PASS: proper-rotations-preserve-both all 24 proper cubic rotations preserve ω and −ω
+PASS: improper-flips the sample det=−1 map exchanges the two volume signs
+PASS: source-qubit axiom memo carries the Qubit Cl(3,0) equivalence sentence
+PASS: source-lattice axiom memo names proper cubic rotations
+PASS: source-parent-odd-central May 10 parent states the odd-n centrality rule
+PASS: source-note-missing-input this note displays s in {+1, −1} and does not add a chirality axiom
+PASS: source-note-no-identifications this note refuses hypercharge, gravity-orientation, and fifth-axiom identifications
+PASS: source-note-no-reopen-dt this note does not reopen d_t
+PASS: source-note-hygiene this note avoids we-adopt / new-axiom / Codex language
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py
+++ b/scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Exact integer checks: Cl(3,0) volume elements +ω and −ω are not axiom-selected.
+
+Identity gates call volume() and volume_opp(). The predicates
+ω' ≠ −ω and ω² ≠ (−ω)² are required to fail.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/CL3_VOLUME_ELEMENTS_PLUS_MINUS_NOT_AXIOM_SELECTED_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/CLIFFORD_VOLUME_CHIRALITY_EVEN_DIMENSION_NARROW_THEOREM_NOTE_2026-05-10.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+PARENT_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[2]
+
+
+class Cl3:
+    """Integer span of Cl(3,0) in the ordered basis 1, e1, e2, e3, e12, e13, e23, e123."""
+
+    __slots__ = ("c",)
+
+    def __init__(self, coeffs: tuple[int, ...] | list[int]) -> None:
+        values = tuple(int(value) for value in coeffs)
+        if len(values) != 8:
+            raise ValueError("Cl(3,0) vectors have eight integer coefficients")
+        self.c = values
+
+    def __add__(self, other: "Cl3") -> "Cl3":
+        return Cl3(tuple(a + b for a, b in zip(self.c, other.c)))
+
+    def __sub__(self, other: "Cl3") -> "Cl3":
+        return Cl3(tuple(a - b for a, b in zip(self.c, other.c)))
+
+    def __neg__(self) -> "Cl3":
+        return Cl3(tuple(-value for value in self.c))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Cl3) and self.c == other.c
+
+    def __mul__(self, other: "Cl3") -> "Cl3":
+        acc = [0, 0, 0, 0, 0, 0, 0, 0]
+        for mask_a, coeff_a in enumerate(self.c):
+            if coeff_a == 0:
+                continue
+            for mask_b, coeff_b in enumerate(other.c):
+                if coeff_b == 0:
+                    continue
+                sign, mask = _blade_mul(mask_a, mask_b)
+                acc[mask] += sign * coeff_a * coeff_b
+        return Cl3(tuple(acc))
+
+    def grade_parity(self) -> int | None:
+        parities = {
+            bin(mask).count("1") % 2
+            for mask, coeff in enumerate(self.c)
+            if coeff
+        }
+        if len(parities) != 1:
+            return None
+        return next(iter(parities))
+
+    def is_scalar(self, value: int) -> bool:
+        return self.c == (value, 0, 0, 0, 0, 0, 0, 0)
+
+
+def _blade_mul(mask_a: int, mask_b: int) -> tuple[int, int]:
+    """Euclidean Cl(3,0) product of two basis blades. Returns (sign, mask)."""
+    sign = 1
+    mask = mask_a
+    for index in range(3):
+        if ((mask_b >> index) & 1) == 0:
+            continue
+        higher = 0
+        for other in range(index + 1, 3):
+            if (mask >> other) & 1:
+                higher += 1
+        if higher % 2:
+            sign = -sign
+        mask ^= 1 << index
+    return sign, mask
+
+
+def basis(mask: int) -> Cl3:
+    coeffs = [0] * 8
+    coeffs[mask] = 1
+    return Cl3(tuple(coeffs))
+
+
+SCALAR = basis(0)
+E1 = basis(1)
+E2 = basis(2)
+E3 = basis(4)
+GENERATORS = (E1, E2, E3)
+
+
+def volume() -> Cl3:
+    return E1 * E2 * E3
+
+
+def volume_opp() -> Cl3:
+    return E3 * E2 * E1
+
+
+def identity_opposite_is_minus() -> bool:
+    return volume_opp() == -volume()
+
+
+def identity_squares_equal() -> bool:
+    return (volume() * volume()) == (volume_opp() * volume_opp())
+
+
+def mutation_opp_neq_minus() -> bool:
+    """Predicate ω' ≠ −ω. Must fail on the live algebra."""
+    return volume_opp() != -volume()
+
+
+def mutation_squares_unequal() -> bool:
+    """Predicate ω² ≠ (−ω)². Must fail on the live algebra."""
+    minus = -volume()
+    return (volume() * volume()) != (minus * minus)
+
+
+class Gauss:
+    __slots__ = ("re", "im")
+
+    def __init__(self, re: int, im: int = 0) -> None:
+        self.re = int(re)
+        self.im = int(im)
+
+    def __add__(self, other: "Gauss") -> "Gauss":
+        return Gauss(self.re + other.re, self.im + other.im)
+
+    def __neg__(self) -> "Gauss":
+        return Gauss(-self.re, -self.im)
+
+    def __mul__(self, other: "Gauss") -> "Gauss":
+        return Gauss(
+            self.re * other.re - self.im * other.im,
+            self.re * other.im + self.im * other.re,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Gauss) and self.re == other.re and self.im == other.im
+
+
+class Mat2:
+    """2×2 matrices over Z[i], used only for the Pauli exhibit."""
+
+    __slots__ = ("a",)
+
+    def __init__(self, entries: tuple[tuple[Gauss, Gauss], tuple[Gauss, Gauss]]) -> None:
+        self.a = entries
+
+    def __neg__(self) -> "Mat2":
+        return Mat2(tuple(tuple(-entry for entry in row) for row in self.a))  # type: ignore[arg-type]
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Mat2) and self.a == other.a
+
+    def __mul__(self, other: "Mat2") -> "Mat2":
+        out = []
+        for row in range(2):
+            out_row = []
+            for col in range(2):
+                acc = Gauss(0)
+                for mid in range(2):
+                    acc = acc + self.a[row][mid] * other.a[mid][col]
+                out_row.append(acc)
+            out.append(tuple(out_row))
+        return Mat2((out[0], out[1]))
+
+
+ZERO_G = Gauss(0)
+ONE_G = Gauss(1)
+I_G = Gauss(0, 1)
+SIGMA1 = Mat2(((ZERO_G, ONE_G), (ONE_G, ZERO_G)))
+SIGMA2 = Mat2(((ZERO_G, Gauss(0, -1)), (I_G, ZERO_G)))
+SIGMA3 = Mat2(((ONE_G, ZERO_G), (ZERO_G, Gauss(-1))))
+PAULI_I = Mat2(((ONE_G, ZERO_G), (ZERO_G, ONE_G)))
+
+
+def pauli_volume() -> Mat2:
+    return volume_from(SIGMA1, SIGMA2, SIGMA3)
+
+
+def pauli_volume_opp() -> Mat2:
+    return volume_opp_from(SIGMA1, SIGMA2, SIGMA3)
+
+
+def volume_from(e1, e2, e3):
+    return e1 * e2 * e3
+
+
+def volume_opp_from(e1, e2, e3):
+    return e3 * e2 * e1
+
+
+def apply_linear(matrix: tuple[tuple[int, ...], ...], vectors: tuple[Cl3, Cl3, Cl3]) -> tuple[Cl3, Cl3, Cl3]:
+    images = []
+    for col in range(3):
+        acc = Cl3((0, 0, 0, 0, 0, 0, 0, 0))
+        for row in range(3):
+            coeff = matrix[row][col]
+            if coeff == 1:
+                acc = acc + vectors[row]
+            elif coeff == -1:
+                acc = acc - vectors[row]
+        images.append(acc)
+    return images[0], images[1], images[2]
+
+
+def permutation_sign(perm: tuple[int, ...]) -> int:
+    sign = 1
+    values = list(perm)
+    for i in range(3):
+        for j in range(i + 1, 3):
+            if values[i] > values[j]:
+                sign = -sign
+    return sign
+
+
+def proper_cubic_rotations() -> list[tuple[tuple[int, ...], ...]]:
+    rotations = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            det = permutation_sign(perm) * signs[0] * signs[1] * signs[2]
+            if det != 1:
+                continue
+            matrix = []
+            for row in range(3):
+                row_entries = []
+                for col in range(3):
+                    row_entries.append(signs[row] if perm[row] == col else 0)
+                matrix.append(tuple(row_entries))
+            rotations.append(tuple(matrix))
+    return rotations
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_n = normalize(note)
+    parent_n = normalize(parent)
+    axiom_n = normalize(axiom)
+
+    print("external_scientific_inputs: none; exact Cl(3,0) anticommutators and the declared axiom/parent wording")
+    print("audit_input_paths: " + ", ".join(AUDIT_INPUT_PATHS))
+
+    checks.check(
+        "audit-inputs-exist",
+        "declared note, May 10 parent, and axiom memo are readable",
+        NOTE_PATH.is_file() and PARENT_PATH.is_file() and AXIOM_PATH.is_file(),
+    )
+
+    car_ok = True
+    for i, ei in enumerate(GENERATORS):
+        for j, ej in enumerate(GENERATORS):
+            anti = ei * ej + ej * ei
+            expected = SCALAR + SCALAR if i == j else Cl3((0, 0, 0, 0, 0, 0, 0, 0))
+            car_ok = car_ok and anti == expected
+    checks.check("car", "{ei, ej} = 2 δ_ij I on the integer generators", car_ok)
+
+    checks.check(
+        "identity-opp-minus",
+        "volume_opp() equals -volume()",
+        identity_opposite_is_minus(),
+    )
+    checks.check(
+        "identity-squares",
+        "volume()^2 equals volume_opp()^2",
+        identity_squares_equal(),
+    )
+    checks.check(
+        "mutation-opp-neq-minus",
+        "the predicate ω' ≠ −ω fails",
+        mutation_opp_neq_minus() is False,
+    )
+    checks.check(
+        "mutation-squares-unequal",
+        "the predicate ω² ≠ (−ω)² fails",
+        mutation_squares_unequal() is False,
+    )
+
+    omega = volume()
+    omega_opp = volume_opp()
+    checks.check("odd-grade", "both volume elements are grade-odd", omega.grade_parity() == 1 and omega_opp.grade_parity() == 1)
+    central = all(omega * gen == gen * omega and omega_opp * gen == gen * omega_opp for gen in GENERATORS)
+    checks.check("central", "n=3 odd: ω and ω' commute with every generator", central)
+    checks.check("square-minus-one", "ω² = (−ω)² = −I", (omega * omega).is_scalar(-1) and ((-omega) * (-omega)).is_scalar(-1))
+
+    pauli_w = pauli_volume()
+    pauli_w_opp = pauli_volume_opp()
+    i_times_id = Mat2(((I_G, ZERO_G), (ZERO_G, I_G)))
+    checks.check(
+        "pauli-volume",
+        "σ1 σ2 σ3 = i I and the opposite product is −i I",
+        pauli_w == i_times_id and pauli_w_opp == -i_times_id,
+    )
+    checks.check(
+        "pauli-squares",
+        "(σ1 σ2 σ3)² = (−σ1 σ2 σ3)² = −I",
+        pauli_w * pauli_w == -PAULI_I and pauli_w_opp * pauli_w_opp == -PAULI_I,
+    )
+
+    rotations = proper_cubic_rotations()
+    gens = (E1, E2, E3)
+    preserve = True
+    for matrix in rotations:
+        images = apply_linear(matrix, gens)
+        rotated = volume_from(*images)
+        rotated_opp = volume_opp_from(*images)
+        if rotated != omega or rotated_opp != omega_opp:
+            preserve = False
+            break
+    checks.check(
+        "proper-rotations-preserve-both",
+        "all 24 proper cubic rotations preserve ω and −ω",
+        len(rotations) == 24 and preserve,
+    )
+
+    reflection = ((-1, 0, 0), (0, 1, 0), (0, 0, 1))
+    reflected = volume_from(*apply_linear(reflection, gens))
+    checks.check(
+        "improper-flips",
+        "the sample det=−1 map exchanges the two volume signs",
+        reflected == -omega,
+    )
+
+    qubit_quote = (
+        "A `Cl(3,0)`-compatible real-algebra presentation may be used equivalently and "
+        "adds no further primitive structure."
+    )
+    checks.check(
+        "source-qubit",
+        "axiom memo carries the Qubit Cl(3,0) equivalence sentence",
+        normalize(qubit_quote) in axiom_n,
+    )
+    checks.check(
+        "source-lattice",
+        "axiom memo names proper cubic rotations",
+        "proper cubic rotations about each site" in axiom_n,
+    )
+    checks.check(
+        "source-parent-odd-central",
+        "May 10 parent states the odd-n centrality rule",
+        "If `n` is odd, `omega` **commutes** with every generator" in parent
+        or "If n is odd, omega commutes with every generator" in parent_n,
+    )
+    checks.check(
+        "source-note-missing-input",
+        "this note displays s in {+1, −1} and does not add a chirality axiom",
+        "s ∈ {+1, −1}" in note and "does not add a chirality axiom" in note_n,
+    )
+    checks.check(
+        "source-note-no-identifications",
+        "this note refuses hypercharge, gravity-orientation, and fifth-axiom identifications",
+        "weak hypercharge" in note_n and "gravity orientation" in note_n and "fifth framework axiom" in note_n,
+    )
+    checks.check(
+        "source-note-no-reopen-dt",
+        "this note does not reopen d_t",
+        "does not reopen `d_t`" in note or "does not reopen d_t" in note_n,
+    )
+    checks.check(
+        "source-note-hygiene",
+        "this note avoids we-adopt / new-axiom / Codex language",
+        "we adopt" not in note_n.lower()
+        and "new axiom" not in note_n.lower()
+        and "codex" not in note_n.lower(),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On real `Cl(3,0)`, `ω'=e3 e2 e1` equals `−ω`, and `ω²=(−ω)²=−I`. Proper cubic rotations preserve both signs. The axioms do not select `+ω` over `−ω`. The extra object is a displayed choice `s∈{+1,−1}`. No chirality axiom is adopted. May 10 `d_t` is not reopened.

## What this means for the TOE

Orientation is a Z2 missing input, not axiom content.

## What changed

- Note: `docs/CL3_VOLUME_ELEMENTS_PLUS_MINUS_NOT_AXIOM_SELECTED_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py`
- Cache: `logs/runner-cache/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.txt`

## Verification

```bash
python3 scripts/cl3_volume_elements_plus_minus_not_axiom_selected_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
