### PR TITLE
[physics-loop] toe-lphys cubic24: bounded_theorem / bounded-support

### DIFF
--- a/docs/PROPER_CUBIC_GROUP_IS_24_AND_CONTAINS_NO_BOOST_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/PROPER_CUBIC_GROUP_IS_24_AND_CONTAINS_NO_BOOST_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,267 @@
+---
+claim_id: proper_cubic_group_is_24_and_contains_no_boost_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The Lattice named symmetry on Z^3 is the 24-element group G of 3x3 monomial signed-permutation matrices with det=+1. Enumeration gives |G|=24. Every R in G satisfies R^T R = I_3 and preserves x1^2+x2^2+x3^2, hence is orthogonal for diag(1,1,1) and not for diag(1,1,-1). A 1+1 boost prototype L=[[2,1],[1,2]], and its 3D block embedding diag(L,1), is not a proper cubic matrix. Lattice and the kinetic-isotropy primitive name Euclidean cubic rotations and one Euclidean tick c_t=c_s; neither sentence names a boost. A Lorentzian boost would require a fourth direction plus a (3,1) form; those extras are displayed and not adopted. The note does not claim Lorentz closure is impossible, does not install a=1, and does not identify G with SO(3)."
+upstream_dependencies:
+  - minimal_axioms
+  - kinetic_isotropy_primitive
+runner: scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py
+---
+
+# Proper Cubic Group Is 24 Matrices In SO(3); None Is A Boost
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact integer 3×3 named-symmetry algebra of the Lattice proper
+cubic rotations. No Wick parameter, no fourth-direction form, and no
+axiom edit.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py`](../scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py)
+
+Parents on `origin/main`:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — current axiom memo
+- [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+
+## Result Up Front
+
+Lattice supplies a finite named symmetry: the proper cubic rotations of the
+spatial lattice `Z^3`. That named object is a set `G` of exact integer 3×3
+matrices. It is not a Lorentz boost, and it is not the continuous group
+`SO(3)`.
+
+Five exact statements locate the object.
+
+1. There are `3! × 2^3 = 48` signed-permutation matrices. Exactly half have
+   `det = +1`, so `|G| = 24`.
+2. Every `R ∈ G` preserves the Euclidean form: `R^T R = I_3`, and
+   `x ↦ R x` preserves `x_1^2 + x_2^2 + x_3^2`. In particular every `R` is
+   orthogonal with respect to `diag(1,1,1)`, not `diag(1,1,-1)`.
+3. A 1+1 boost prototype `L = [[2,1],[1,2]]` is not a 3×3 cubic matrix. Its
+   block embedding `diag(L,1)` fails the monomial ±1 test.
+4. The axiom memo names “standard translations, and proper cubic rotations
+   about each site.” Kinetic isotropy supplies one Euclidean tick
+   `c_t = c_s`, not a Lorentz theorem. Neither sentence names a boost.
+5. The extra object for a Lorentzian boost is a fourth direction plus a
+   `(3,1)` form. That extra is displayed below and is not adopted. This note
+   does not claim Lorentz closure is impossible, does not install `a = 1`,
+   and does not say that the cubic 24 is `SO(3)`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 24-element count, Euclidean orthogonality, and non-membership of the boost prototype are proved on declared integer 3x3 matrices. A fourth direction, a (3,1) form, Lorentz closure, and identification of G with SO(3) remain outside the claim."
+trace_class: named_symmetry_localization
+target_claim_id: proper_cubic_named_symmetry_is_24_euclidean_matrices
+target_blocker_text: "name the Lattice cubic symmetry as a finite Euclidean rotation group and separate it from a Lorentz boost"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for |G|=24, Euclidean preservation, and non-membership of diag(L,1); Lorentzian extras remain displayed-only"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+A **signed-permutation matrix** of size 3 is a 3×3 integer matrix with
+exactly one nonzero entry in each row and each column, and with every
+nonzero entry in `{+1, −1}`.
+
+A **proper cubic matrix** is a signed-permutation matrix with `det = +1`.
+Write `G` for the set of all proper cubic matrices. Identity gates in the
+runner call `proper_cubic_count()` and `is_proper_cubic(M)` on these objects.
+
+The Euclidean spatial form is
+
+```text
+q_E(x) = x_1^2 + x_2^2 + x_3^2,
+```
+
+equivalently the matrix `diag(1,1,1)`. The Minkowski 2-form used only as a
+rejector contrast is `η_2 = diag(1,−1)`. The 3×3 contrast form that `G` does
+not preserve as its defining form is `diag(1,1,−1)`.
+
+The 1+1 boost prototype is the integer matrix
+
+```text
+L = [[2, 1],
+     [1, 2]].
+```
+
+Its 3-dimensional block embedding is
+
+```text
+diag(L, 1) = [[2, 1, 0],
+              [1, 2, 0],
+              [0, 0, 1]].
+```
+
+## Theorem 1 — `|G| = 24`
+
+Every signed-permutation matrix is uniquely a pair `(σ, s)` with `σ ∈ S_3`
+and `s ∈ {±1}^3`: the unique nonzero in column `j` sits in row `σ(j)` and
+equals `s_j`. There are `3! = 6` permutations and `2^3 = 8` sign patterns,
+hence `48` signed-permutation matrices.
+
+The determinant of that matrix is
+
+```text
+det = sign(σ) · s_1 s_2 s_3 ∈ {±1}.
+```
+
+Flipping one sign sends the determinant to its opposite and is a bijection of
+the 48-element set onto itself. Exactly half the signed-permutation matrices
+therefore have `det = +1`, so
+
+```text
+|G| = 48 / 2 = 24.
+```
+
+The runner enumerates the 48 matrices over exact integers and counts the
+`det = +1` subset by `proper_cubic_count()`. A predicate `|G| ≠ 24` fails.
+
+## Theorem 2 — every `R ∈ G` preserves the Euclidean form
+
+Let `R` be a proper cubic matrix. Each column is a signed standard-basis
+vector, the three columns are pairwise orthogonal as integer vectors, and
+each has Euclidean length squared `1`. Hence
+
+```text
+R^T R = I_3
+```
+
+as an exact integer matrix identity. For every integer (or real) column
+`x = (x_1, x_2, x_3)`,
+
+```text
+q_E(R x) = (R x)^T (R x) = x^T (R^T R) x = x^T x = q_E(x).
+```
+
+The same matrices are therefore orthogonal for `diag(1,1,1)`. They are not
+defined as the orthogonal group of `diag(1,1,−1)`: that form has signature
+`(2,1)`, while every `R ∈ G` is a Euclidean rotation matrix (an element of
+the compact group `SO(3)`, not a parametrization of that whole group).
+
+## Theorem 3 — a boost prototype is not a proper cubic matrix
+
+The prototype `L = [[2,1],[1,2]]` fails to be a proper cubic matrix for three
+independent reasons, each already visible before any continuum Lorentz
+discussion:
+
+1. `L` is 2×2, not 3×3.
+2. `L` is not monomial with entries in `{±1}` only: the entry `2` is not
+   `±1`.
+3. `L` does not preserve the Euclidean plane form. On `(1,0)` one has
+   `L(1,0) = (2,1)` and `2^2 + 1^2 = 5 ≠ 1`.
+
+Embed the same prototype as a 3×3 block `M = diag(L, 1)`. The `(1,2)` entry
+is `1`, but the first row is `(2, 1, 0)` and therefore contains two nonzero
+entries. So `M` is not a signed-permutation matrix, and
+`is_proper_cubic(M)` is false. A predicate “`diag(L, 1)` is a proper cubic
+matrix” fails.
+
+The same rejection applies to any integer 2×2 matrix that preserves
+`η_2 = diag(1,−1)` other than the Euclidean-type elements `±I` and the
+swap-with-signs that remain in `O(1,1)` of Euclidean type: those matrices
+are still 2×2, and a nontrivial boost-like integer block still fails the
+3×3 monomial ±1 test after `diag(·, 1)` embedding.
+
+## Theorem 4 — the parent sentences name no boost
+
+The current axiom memo states the Lattice named symmetry as:
+
+> standard translations, and proper cubic rotations about each site.
+
+That is a 3-dimensional cubic rotation statement on `Z^3`. It does not name
+a boost, a fourth axis, or a `(3,1)` form.
+
+The kinetic-isotropy primitive supplies one structural graining equality
+
+```text
+c_t = c_s,
+```
+
+one Euclidean tick equal in form to one spatial edge. It is a regulator
+normalization on a Euclidean block, not a Lorentz theorem. The primitive
+states that full Lorentz restoration remains a separate claim and is not
+supplied by the declaration. Neither parent sentence names a boost.
+
+## Theorem 5 — extra Lorentzian object, displayed only
+
+A Lorentzian boost is not an element of `G`. The extra object that would
+make a boost well-typed is:
+
+- a **fourth direction**, so that linear maps act on a 4-component
+  `(t, x_1, x_2, x_3)` rather than on the three Lattice coordinates;
+- a **`(3,1)` form**, for example `η = diag(1,1,1,−1)` or
+  `η = diag(−1,1,1,1)`, whose preservation — not preservation of
+  `x_1^2+x_2^2+x_3^2` — would define the boost.
+
+Those two extras are displayed so the type gap is explicit. They are not
+adopted. No fourth lattice direction is added to Lattice. No `(3,1)` form
+is installed. No Wick parameter is chosen. In particular this note does not
+install `a = 1`.
+
+The 24 matrices of `G` sit inside `SO(3)` as exact rotation matrices. This
+note does not say that the cubic 24 is `SO(3)`. The continuous group
+`SO(3)` is larger than `G`.
+
+This note does not claim that Lorentz closure is impossible. A later
+construction may introduce a fourth direction and a `(3,1)` form by a
+separate theorem. That construction is outside the present named-symmetry
+count.
+
+## What This Does Not Claim
+
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not add a primitive, and it does not adopt the displayed
+  fourth-direction or `(3,1)` extras.
+- It does not install `a = 1` or any other Wick parameter.
+- It does not identify `G` with `SO(3)`.
+- It does not claim that Lorentz closure is impossible.
+- It does not derive kinetic isotropy, and it does not promote
+  `c_t = c_s` to a Lorentz theorem.
+- It does not cite unmerged work.
+
+## No-Go Gate
+
+Shipping any of the following would be a failure of this note:
+
+- asserting `|G| ≠ 24` after the enumeration above;
+- asserting that `diag(L, 1)` is a proper cubic matrix;
+- asserting that the Lattice cubic rotations are boosts;
+- asserting that the cubic 24 is `SO(3)`;
+- installing `a = 1`;
+- claiming Lorentz closure is impossible;
+- editing an axiom or adopting the displayed `(3,1)` extra.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Name the Lattice proper cubic symmetry as the 24-element
+integer matrix group `G`, prove Euclidean preservation, and reject the
+boost prototype as a member of `G`, without closing or forbidding a later
+Lorentzian construction.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| count signed-permutation matrices | Theorem 1 | proved: `3! × 2^3 = 48` |
+| split by `det = +1` | Theorem 1 | proved: `|G| = 24` |
+| Euclidean form preservation | Theorem 2 | proved: `R^T R = I_3` |
+| reject `diag(1,1,−1)` as the defining form | Theorem 2 | proved as signature contrast |
+| reject `L` and `diag(L,1)` | Theorem 3 | proved by size, entries, and monomial test |
+| quote Lattice and kinetic isotropy | Theorem 4 | quoted; neither names a boost |
+| display fourth direction and `(3,1)` form | Theorem 5 | displayed, not adopted |
+
+The runner identity gates call `proper_cubic_count()` and
+`is_proper_cubic(M)`. Those functions, not a hardcoded banner, decide the
+order and membership checks.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -14677,6 +14677,10 @@
   "proper_cubic_finite_support_linear_kernel_classification_bounded_theorem_note_2026-07-25": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
+  },
+  "proper_cubic_group_is_24_and_contains_no_boost_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "0d988fd1ac07",
+   "out_degree": 2
   },
   "proper_cubic_local_admission_relations_conditional_port_finite_grade_block_bounded_theorem_note_2026-07-23": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.txt
+++ b/logs/runner-cache/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py
+runner_sha256: 84a6efd423779dbad7a03c1fec4c143889c73a2b7a3154896eaf36e6a960e6fe
+input_fingerprint_sha256: dad69337ace03998821abfbe2f907f57aee931a35ff1b8837ee3b80e467f3ede
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording and the kinetic-isotropy primitive are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+measure_boundary: the runner checks exact integer 3x3 algebra; it does not install a Wick parameter or a (3,1) form
+negative_scope: only |G|!=24 and membership of diag(L,1) are rejected; Lorentz closure remains live
+PASS: source-lattice the axiom memo names translations and proper cubic rotations
+PASS: source-kinetic-tick kinetic isotropy supplies the Euclidean equality c_t = c_s
+PASS: source-kinetic-not-lorentz kinetic isotropy leaves full Lorentz restoration as a separate claim
+PASS: source-note-quotes the note quotes Lattice and states one Euclidean tick, not a Lorentz theorem
+PASS: signed-permutation-census there are exactly 3! x 2^3 = 48 signed-permutation matrices
+PASS: identity-count-gate identity gate calls proper_cubic_count() and obtains 24
+PASS: proper-det every counted matrix has det=+1 and passes is_proper_cubic
+PASS: half-split exactly half of the 48 signed-permutation matrices have det=+1
+PASS: euclidean-form every R in G satisfies R^T R = I_3
+PASS: euclidean-quadratic x |-> R x preserves x1^2+x2^2+x3^2 on the first basis vector
+PASS: not-minkowski-3 the note distinguishes diag(1,1,1) from diag(1,1,-1)
+PASS: identity-membership-gate identity gate calls is_proper_cubic on I_3 and a proper rotation
+PASS: boost-prototype-not-cubic L is 2x2, has entry 2, and does not preserve x^2+y^2
+PASS: embedded-boost-not-cubic diag(L,1) has two nonzeros in the first row and fails is_proper_cubic
+PASS: mutation-order predicate |G|!=24 fails
+PASS: mutation-embedded-boost predicate diag(L,1) is a proper cubic matrix fails
+PASS: extra-object-displayed a fourth direction and a (3,1) form are displayed and not adopted
+PASS: boundary-phrases the note does not claim Lorentz impossibility, a=1, G=SO(3), or axiom adoption
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: canonical-nonmutation the axiom memo is not edited by this block
+per_element: all 48 signed-permutation matrices and the 24 det=+1 subset are counted exactly
+per_site: named symmetry is the Lattice site rotation; no composite carrier is asserted
+per_mode: Euclidean q_E is checked; the (3,1) form is displayed only
+per_block: the boost prototype and its 3D embedding are the only rejected block
+lattice_wide: checked and not executed — no lattice-wide dynamics or Lorentz no-go is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py
+++ b/scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Exact integer checks for the proper cubic group of 24 matrices.
+
+The runner enumerates 3x3 signed-permutation matrices, counts the det=+1
+subset through proper_cubic_count(), and rejects the 1+1 boost prototype
+through is_proper_cubic(). Identity gates must call those two functions.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "PROPER_CUBIC_GROUP_IS_24_AND_CONTAINS_NO_BOOST_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PARENT_PATH = ROOT / "docs" / "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/PROPER_CUBIC_GROUP_IS_24_AND_CONTAINS_NO_BOOST_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+)
+
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def _shape_ok(matrix: object) -> bool:
+    if not isinstance(matrix, tuple) or len(matrix) != 3:
+        return False
+    return all(isinstance(row, tuple) and len(row) == 3 for row in matrix)
+
+
+def _det3(matrix: Matrix) -> int:
+    a, b, c = matrix
+    return (
+        a[0] * (b[1] * c[2] - b[2] * c[1])
+        - a[1] * (b[0] * c[2] - b[2] * c[0])
+        + a[2] * (b[0] * c[1] - b[1] * c[0])
+    )
+
+
+def _matmul(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(sum(left[i][k] * right[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )  # type: ignore[return-value]
+
+
+def _transpose(matrix: Matrix) -> Matrix:
+    return tuple(tuple(matrix[j][i] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def _is_signed_permutation(matrix: object) -> bool:
+    if not _shape_ok(matrix):
+        return False
+    rows = matrix  # type: ignore[assignment]
+    for row in rows:
+        if any(entry not in (-1, 0, 1) for entry in row):
+            return False
+        if sum(entry != 0 for entry in row) != 1:
+            return False
+    for column in range(3):
+        if sum(rows[row][column] != 0 for row in range(3)) != 1:
+            return False
+    return True
+
+
+def is_proper_cubic(matrix: object) -> bool:
+    """True iff matrix is a 3x3 monomial signed-permutation matrix with det=+1."""
+    if not _is_signed_permutation(matrix):
+        return False
+    return _det3(matrix) == 1  # type: ignore[arg-type]
+
+
+def signed_permutation_matrices() -> tuple[Matrix, ...]:
+    matrices: list[Matrix] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for column, row in enumerate(perm):
+                rows[row][column] = signs[column]
+            matrices.append(tuple(tuple(entry) for entry in rows))  # type: ignore[arg-type]
+    return tuple(matrices)
+
+
+def proper_cubic_matrices() -> tuple[Matrix, ...]:
+    return tuple(matrix for matrix in signed_permutation_matrices() if is_proper_cubic(matrix))
+
+
+def proper_cubic_count() -> int:
+    return sum(1 for matrix in signed_permutation_matrices() if is_proper_cubic(matrix))
+
+
+def identity_count_gate() -> bool:
+    """Identity gate: order is read from proper_cubic_count()."""
+    return proper_cubic_count() == 24
+
+
+def identity_membership_gate(matrix: object) -> bool:
+    """Identity gate: membership is read from is_proper_cubic(M)."""
+    return is_proper_cubic(matrix)
+
+
+IDENTITY: Matrix = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+BOOST_L = ((2, 1), (1, 2))
+EMBEDDED_BOOST: Matrix = ((2, 1, 0), (1, 2, 0), (0, 0, 1))
+ROT90_Z: Matrix = ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_parent = normalize(parent)
+
+    print(
+        "external_scientific_inputs: current axiom wording and the kinetic-isotropy "
+        "primitive are source-bound; no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+    print(
+        "measure_boundary: the runner checks exact integer 3x3 algebra; it does "
+        "not install a Wick parameter or a (3,1) form"
+    )
+    print(
+        "negative_scope: only |G|!=24 and membership of diag(L,1) are rejected; "
+        "Lorentz closure remains live"
+    )
+
+    lattice_quote = "standard translations, and proper cubic rotations about each site."
+    checks.check(
+        "source-lattice",
+        "the axiom memo names translations and proper cubic rotations",
+        lattice_quote in normalized_axiom,
+    )
+    checks.check(
+        "source-kinetic-tick",
+        "kinetic isotropy supplies the Euclidean equality c_t = c_s",
+        "c_t = c_s" in parent,
+    )
+    checks.check(
+        "source-kinetic-not-lorentz",
+        "kinetic isotropy leaves full Lorentz restoration as a separate claim",
+        "full Lorentz restoration remain separate" in normalized_parent,
+    )
+    checks.check(
+        "source-note-quotes",
+        "the note quotes Lattice and states one Euclidean tick, not a Lorentz theorem",
+        lattice_quote in normalized_note
+        and "one Euclidean tick" in normalized_note
+        and "c_t = c_s" in note
+        and "not a Lorentz theorem" in normalized_note,
+    )
+
+    signed = signed_permutation_matrices()
+    unique_signed = set(signed)
+    checks.check(
+        "signed-permutation-census",
+        "there are exactly 3! x 2^3 = 48 signed-permutation matrices",
+        len(signed) == 48 and len(unique_signed) == 48,
+    )
+
+    group = proper_cubic_matrices()
+    count = proper_cubic_count()
+    checks.check(
+        "identity-count-gate",
+        "identity gate calls proper_cubic_count() and obtains 24",
+        identity_count_gate() and count == 24 and len(group) == 24,
+    )
+    checks.check(
+        "proper-det",
+        "every counted matrix has det=+1 and passes is_proper_cubic",
+        all(_det3(matrix) == 1 and is_proper_cubic(matrix) for matrix in group),
+    )
+    half = sum(1 for matrix in signed if _det3(matrix) == 1)
+    checks.check(
+        "half-split",
+        "exactly half of the 48 signed-permutation matrices have det=+1",
+        half == 24 and 2 * half == len(signed),
+    )
+
+    euclidean_ok = all(_matmul(_transpose(matrix), matrix) == IDENTITY for matrix in group)
+    checks.check(
+        "euclidean-form",
+        "every R in G satisfies R^T R = I_3",
+        euclidean_ok,
+    )
+
+    sample = (1, 0, 0)
+    preserved = True
+    for matrix in group:
+        image = tuple(sum(matrix[i][j] * sample[j] for j in range(3)) for i in range(3))
+        if sum(value * value for value in image) != 1:
+            preserved = False
+            break
+    checks.check(
+        "euclidean-quadratic",
+        "x |-> R x preserves x1^2+x2^2+x3^2 on the first basis vector",
+        preserved,
+    )
+    checks.check(
+        "not-minkowski-3",
+        "the note distinguishes diag(1,1,1) from diag(1,1,-1)",
+        "diag(1,1,1)" in note and "diag(1,1,-1)" in note,
+    )
+
+    checks.check(
+        "identity-membership-gate",
+        "identity gate calls is_proper_cubic on I_3 and a proper rotation",
+        identity_membership_gate(IDENTITY)
+        and identity_membership_gate(ROT90_Z)
+        and is_proper_cubic(IDENTITY)
+        and is_proper_cubic(ROT90_Z),
+    )
+
+    boost_plane = BOOST_L[0][0] ** 2 + BOOST_L[1][0] ** 2
+    checks.check(
+        "boost-prototype-not-cubic",
+        "L is 2x2, has entry 2, and does not preserve x^2+y^2",
+        len(BOOST_L) == 2
+        and len(BOOST_L[0]) == 2
+        and BOOST_L[0][0] == 2
+        and 2 not in (-1, 1)
+        and boost_plane == 5
+        and not is_proper_cubic(BOOST_L),
+    )
+    first_row_nonzeros = sum(entry != 0 for entry in EMBEDDED_BOOST[0])
+    embedded_is_cubic = is_proper_cubic(EMBEDDED_BOOST)
+    checks.check(
+        "embedded-boost-not-cubic",
+        "diag(L,1) has two nonzeros in the first row and fails is_proper_cubic",
+        EMBEDDED_BOOST[0][1] == 1
+        and first_row_nonzeros == 2
+        and identity_membership_gate(EMBEDDED_BOOST) is False
+        and embedded_is_cubic is False,
+    )
+
+    order_neq_24 = proper_cubic_count() != 24
+    checks.check(
+        "mutation-order",
+        "predicate |G|!=24 fails",
+        order_neq_24 is False,
+    )
+    checks.check(
+        "mutation-embedded-boost",
+        "predicate diag(L,1) is a proper cubic matrix fails",
+        embedded_is_cubic is False,
+    )
+
+    checks.check(
+        "extra-object-displayed",
+        "a fourth direction and a (3,1) form are displayed and not adopted",
+        "fourth direction" in normalized_note
+        and "(3,1) form" in normalized_note
+        and "not adopted" in normalized_note,
+    )
+    checks.check(
+        "boundary-phrases",
+        "the note does not claim Lorentz impossibility, a=1, G=SO(3), or axiom adoption",
+        "we adopt" not in normalized_note.lower()
+        and "new axiom" not in normalized_note
+        and "Codex" not in note
+        and "does not install `a = 1`" in normalized_note
+        and "does not say that the cubic 24 is `SO(3)`" in normalized_note
+        and "does not claim that Lorentz closure is impossible" in normalized_note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo is not edited by this block",
+        lattice_quote in axiom and "diag(L, 1)" not in axiom,
+    )
+
+    print("per_element: all 48 signed-permutation matrices and the 24 det=+1 subset are counted exactly")
+    print("per_site: named symmetry is the Lattice site rotation; no composite carrier is asserted")
+    print("per_mode: Euclidean q_E is checked; the (3,1) form is displayed only")
+    print("per_block: the boost prototype and its 3D embedding are the only rejected block")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics or Lorentz no-go is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The Lattice named symmetry is the 24-element group of 3×3 monomial signed-permutation matrices with `det=+1`. Every such `R` preserves the Euclidean form, not `diag(1,1,−1)`. The boost prototype `L=[[2,1],[1,2]]` and `diag(L,1)` are not proper cubic matrices. Neither Lattice nor kinetic isotropy names a boost. The extra for a Lorentzian boost is a fourth direction plus a `(3,1)` form; it is displayed, not adopted. `a=1` is not installed.

## What this means for the TOE

Named cubic symmetry is not a Lorentz boost.

## What changed

- Note: `docs/PROPER_CUBIC_GROUP_IS_24_AND_CONTAINS_NO_BOOST_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py`
- Cache: `logs/runner-cache/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.txt`

## Verification

```bash
python3 scripts/proper_cubic_group_is_24_and_contains_no_boost_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
