### PR TITLE
[physics-loop] toe-lphys unittable: bounded_theorem / bounded-support

### DIFF
--- a/docs/EMPTY_UNIT_PAIRING_TABLE_IS_EXTRA_I_FILLS_A_DIFFERENT_TWO_BY_TWO_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/EMPTY_UNIT_PAIRING_TABLE_IS_EXTRA_I_FILLS_A_DIFFERENT_TWO_BY_TWO_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,309 @@
+---
+claim_id: empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On two named unit atoms, Record's one-argument additive I fills the 2×2 of pair-unions by (0,1,1,2). A separately declared product table T_π fills the same four cells by (0,0,0,1) and therefore disagrees at three cells, including the unit-unit cell 2≠1. Record does not name a two-argument table; T_π is extra. A later supplier of T_π on {empty,unit}² together with separate additivity on N uniquely extends to (n,m)↦nm, and that supplier is not Record additivity. No pairing axiom is adopted. Newton is not claimed. G_N and 1/r are not installed."
+upstream_dependencies:
+  - minimal_axioms
+  - newton_law_derived_note
+runner: scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py
+---
+
+# Empty/Unit Pairing Table Is Extra; I Fills A Different 2×2
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact four-cell comparison of one-argument Record readout against a
+declared extra product table on two named unit locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py`](../scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py)
+
+## Result Up Front
+
+Record supplies a one-argument scalar readout `I`. On two named unit atoms
+`s` and `t`, treated as disjoint unit locks, that readout fills the four pair
+cells
+
+```text
+(∅,∅), (∅,{t}), ({s},∅), ({s},{t})
+```
+
+by the I-table `(0, 1, 1, 2)`.
+
+A product table `T_π` may be *declared* on the same four cells, with values
+`(0, 0, 0, 1)`. That table is extra: it is not named by Record. It disagrees
+with the I-table at three of the four cells, including the unit-unit cell
+`2 ≠ 1`.
+
+If a later supplier provides those four `T_π` values and, separately,
+additivity on `N` in each argument, the unique extension to unit-lock counts
+is `(n, m) ↦ n m`. That supplier is not Record additivity. The extension
+evaluates to `12` at `(3, 4)`.
+
+This note does not adopt a pairing axiom, does not claim Newton, and does not
+install `G_N` or `1/r`. The Newton packet's physical product law remains a
+non-claim.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The four-cell I-table is recomputed from I(empty)=0 and disjoint additivity; T_π is a declared extra table; disagreement is exact; the N×N product extension is unique only after a later supplier is granted; no pairing axiom or Newton claim is made."
+trace_class: negative_route_pruning
+target_claim_id: empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two
+target_blocker_text: "Record additivity does not supply a two-argument pairing table; any product extension is a later extra supplier"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the four named cells and on the unique N×N extension after the extra supplier; physical product law and Newton remain non-claims"
+hypothetical_axiom_status: "no pairing axiom is adopted, recommended, or edited"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Quoted Parents
+
+The current Record axiom, from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), is used only
+for its one-argument additive readout:
+
+```text
+Only records are readable. A readout value is determined by record content
+alone. For any finite collection of pairwise-disjoint records, scalar readout
+`I` is additive, with `I(empty)=0`.
+```
+
+That sentence names a function of one collection. It does not name a function
+of an ordered pair of collections.
+
+The Newton packet
+[`NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) is used only for
+its product-law **non-claim**. Among the items that packet does not prove is:
+
+> the physical product law `M_source M_test`;
+
+No other Newton-packet claim is used. In particular this note does not import
+the packet's kernel, gradient, coupling, or force-law surface.
+
+## Exact Objects
+
+Let `s` and `t` be two named unit atoms. Write
+
+```text
+∅, {t}, {s}, {s} ∪ {t}
+```
+
+for the four collections they generate. Treat `{s}` and `{t}` as disjoint
+unit locks, so `{s} ∪ {t}` is the disjoint union `{s} ⊔ {t}`. A *unit lock*
+is a one-atom collection whose Record readout is normalized to `I = 1`.
+
+The four *pair cells* are the ordered pairs of collections
+
+```text
+(∅, ∅), (∅, {t}), ({s}, ∅), ({s}, {t}).
+```
+
+The **I-table** is the four-tuple of one-argument Record values of the
+corresponding unions (equivalently, of the four collections themselves):
+
+```text
+I(∅) = 0,
+I({t}) = 1,
+I({s}) = 1,
+I({s} ∪ {t}) = 2.
+```
+
+Displayed as a 2×2 with rows `{∅, {s}}` and columns `{∅, {t}}`:
+
+```text
+        ∅     {t}
+∅       0      1
+{s}     1      2
+```
+
+The **product table** `T_π` is a separately declared two-argument table on
+the same four pair cells, *not* an axiom:
+
+```text
+T_π(∅, ∅) = 0,
+T_π(∅, {t}) = 0,
+T_π({s}, ∅) = 0,
+T_π({s}, {t}) = 1.
+```
+
+Displayed on the same 2×2:
+
+```text
+        ∅     {t}
+∅       0      0
+{s}     0      1
+```
+
+All displayed scalars are exact rational values (`Fraction` in the runner).
+
+## Theorem 1 — The I-table is `(0, 1, 1, 2)`
+
+**Statement.** Record's one-argument additive `I`, together with the unit-lock
+normalization `I({s}) = I({t}) = 1`, fills the four pair cells by
+`(0, 1, 1, 2)`.
+
+**Proof.** The axiom supplies `I(empty) = 0`, so the `(∅, ∅)` cell is `0`.
+The collections `{s}` and `{t}` are named unit locks, so
+
+```text
+I({s}) = 1,    I({t}) = 1.
+```
+
+Those are the `({s}, ∅)` and `(∅, {t})` cells. The remaining collection is
+the disjoint union `{s} ⊔ {t}`. Finite additivity on pairwise-disjoint
+records gives
+
+```text
+I({s} ⊔ {t}) = I({s}) + I({t}) = 1 + 1 = 2.
+```
+
+Hence the I-table is exactly `(0, 1, 1, 2)`.
+
+## Theorem 2 — `T_π` is `(0, 0, 0, 1)` and disagrees at three cells
+
+**Statement.** The declared extra table `T_π` fills the same four cells by
+`(0, 0, 0, 1)`. It disagrees with the I-table at three of the four cells,
+including the unit-unit cell, where `2 ≠ 1`.
+
+**Proof.** The values of `T_π` are the declared four-cell table in Exact
+Objects. Cellwise comparison against Theorem 1:
+
+| cell | I | `T_π` | equal? |
+|---|---:|---:|---|
+| `(∅, ∅)` | `0` | `0` | yes |
+| `(∅, {t})` | `1` | `0` | no |
+| `({s}, ∅)` | `1` | `0` | no |
+| `({s}, {t})` | `2` | `1` | no |
+
+Three of four cells disagree. At the unit-unit cell `({s}, {t})` one has
+`I({s} ∪ {t}) = 2` and `T_π({s}, {t}) = 1`, so `2 ≠ 1`.
+
+A predicate “I-table equals `T_π`” is therefore false, and it fails in
+particular at the unit-unit cell.
+
+## Theorem 3 — Record fills the I-table and does not name `T_π`
+
+**Statement.** The quoted Record sentence fills the I-table of Theorem 1. It
+does not name a two-argument table. `T_π` is extra.
+
+**Proof.** The quoted Record sentence supplies a scalar `I` of one finite
+collection of pairwise-disjoint records, with `I(empty) = 0` and additivity.
+Theorem 1 uses only that one-argument structure plus the named unit-lock
+normalization. The same sentence does not introduce a symbol for a map
+
+```text
+(collection, collection) ↦ scalar
+```
+
+and does not assign values to the four ordered pairs independently of the
+union. The table `T_π` is therefore a declared extra object. It is not an
+axiom, not a Record consequence, and not adopted here.
+
+## Theorem 4 — Unique `N × N` extension of a later `T_π` supplier
+
+**Statement.** Suppose a later supplier provides the four `T_π` values on
+`{empty, unit}²` and, separately, additivity on `N` in each argument of a
+map `T: N × N → Q`. Then the unique such extension is
+
+```text
+T(n, m) = n m
+```
+
+on unit-lock counts. That supplier is not Record additivity. The extension
+satisfies `T(3, 4) = 12`.
+
+**Proof.** Write `0` for the empty count and `1` for one unit lock. The
+supplied unit square is
+
+```text
+T(0, 0) = 0,    T(0, 1) = 0,    T(1, 0) = 0,    T(1, 1) = 1.
+```
+
+Separate additivity in the first argument gives, for every `m` and every
+`n ≥ 0`,
+
+```text
+T(n, m) = T(1, m) + ⋯ + T(1, m)   (n times)   = n T(1, m),
+```
+
+and `T(0, m) = 0` because `T(0, m) = T(0, m) + T(0, m)`. Separate additivity
+in the second argument likewise gives `T(1, m) = m T(1, 1)` and `T(n, 0) = 0`.
+Therefore
+
+```text
+T(n, m) = n m T(1, 1) = n m · 1 = n m.
+```
+
+Any other separately additive map with the same unit square would have the
+same values, so the extension is unique. In particular
+
+```text
+T(3, 4) = 3 · 4 = 12.
+```
+
+Record additivity is a one-argument identity on disjoint collections. It does
+not supply a two-argument table on `{empty, unit}²`, and it does not supply
+a separate additivity axiom for a map `N × N → Q`. The later supplier that
+does so is therefore not Record additivity.
+
+## Theorem 5 — No pairing axiom, no Newton claim, no `G_N` or `1/r`
+
+**Statement.** This note does not adopt a pairing axiom. It does not claim
+Newton. It does not install `G_N` or `1/r`. The Newton packet's physical
+product law remains a non-claim.
+
+**Proof.** Theorems 1–3 compare two four-cell tables and identify `T_π` as
+extra. Theorem 4 is a conditional uniqueness statement about a later
+supplier. None of those statements introduces, recommends, or edits an axiom.
+None identifies `T(n, m) = n m` with a physical source-test product, a force
+law, a coupling, or a radial kernel.
+
+The Newton parent is quoted only for the non-claim
+
+> the physical product law `M_source M_test`;
+
+That sentence is used as a boundary, not as a derivation license. The
+physical product law is therefore still a non-claim. `G_N` and `1/r` are not
+defined, fitted, or installed here.
+
+## Mutation
+
+The predicate “I-table equals `T_π`” must fail. By Theorem 2 it fails at the
+unit-unit cell, where the I-table value is `2` and the `T_π` value is `1`.
+The runner evaluates that predicate by calling `i_table()` and `pi_table()`;
+identity gates for the two tables likewise call those functions rather than
+substituting a hardcoded four-tuple in place of the table constructors.
+
+## Non-Claims
+
+This note does not:
+
+- adopt, recommend, or edit a pairing axiom;
+- claim that Record additivity forces `T_π` or ` (n, m) ↦ n m `;
+- claim Newton, a force law, a test-mass response, or a gravitational
+  coupling;
+- install `G_N` or `1/r`;
+- identify unit-lock counts with physical masses;
+- cite an unmerged pairing reconstruction as a parent.
+
+The physical product law named by the Newton packet remains a non-claim.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py
+```
+
+Expected closeout includes `TOTAL: PASS>=10 FAIL=0`, identity gates that call
+`i_table()` and `pi_table()`, and a failing equality predicate at the
+unit-unit cell.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4353,6 +4353,10 @@
   "empty_state_bootstrap_all_open_availability_orbit_dichotomy_degree_nine_chirality_wall_bounded_theorem_note_2026-07-04": {
    "deps_hash": "d8a3bd39934d",
    "out_degree": 5
+  },
+  "empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "7ea010b16c05",
+   "out_degree": 2
   },
   "endpoint_localization_three_route_discriminator_cycle705_note_2026-07-26": {
    "deps_hash": "4a2a6080dd99",

--- a/logs/runner-cache/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.txt
+++ b/logs/runner-cache/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py
+runner_sha256: 8cb54a16bbabed929d7095d0cdd787fd86795a359d9d5d48adbdb0e178d6f63b
+input_fingerprint_sha256: 23f9c8b49fae0a4d2bcf8e35a5acf0b0944ce4c18e1a78bea9908000fe4a9caa
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record wording and the Newton product-law non-claim are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: T_π is extra; no pairing axiom, Newton claim, G_N, or 1/r is installed
+PASS: source-record-additivity the current Record sentence names one-argument additive I with I(empty)=0
+PASS: source-newton-nonclaim the Newton packet lists the physical product law as a non-claim
+PASS: note-quotes-record the note quotes the one-argument Record additivity sentence
+PASS: note-quotes-newton-nonclaim the note quotes only the Newton product-law non-claim
+PASS: identity-i-table i_table() is the Fraction four-tuple (0, 1, 1, 2)
+PASS: identity-pi-table pi_table() is the Fraction four-tuple (0, 0, 0, 1)
+PASS: identity-gate-calls identity gates call i_table() and pi_table()
+PASS: theorem1-recompute I(empty)=0 and disjoint additivity recompute I({s} ⊔ {t}) as 2
+PASS: theorem2-disagreement-count T_π disagrees with the I-table at three of four cells
+PASS: theorem2-unit-unit the unit-unit cell is 2 ≠ 1
+PASS: mutation-predicate-fails the predicate I-table equals T_π is false
+PASS: mutation-fails-at-unit-unit the equality predicate fails at the unit-unit cell
+PASS: theorem3-record-one-arg the axiom memo does not name T_π or a two-argument pairing table
+PASS: theorem3-tpi-extra the note declares T_π extra and not an axiom
+PASS: theorem4-extension-34 the unique extension evaluates to 12 at (3, 4)
+PASS: theorem4-uniqueness-grid separate additivity on N forces T(n, m) = n m on the checked grid
+PASS: theorem4-not-record the note states that the later supplier is not Record additivity
+PASS: theorem5-nonclaims the note refuses a pairing axiom, a Newton claim, and installation of G_N or 1/r
+PASS: fraction-types every I-table and T_π cell is an exact Fraction
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+per_element: four pair cells on two named unit atoms are checked
+per_site: no lattice site composite is asserted
+per_mode: no spectral-mode exhaustion is claimed
+per_block: the I-table versus extra T_π block is the only comparison tested
+lattice_wide: checked and not executed — no Newton, G_N, or 1/r installation is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py
+++ b/scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Exact four-cell I-table versus extra T_π checks.
+
+Identity gates call i_table() and pi_table(). The predicate that the two
+tables agree fails at the unit-unit cell. All displayed scalars are Fraction.
+"""
+
+from __future__ import annotations
+
+import inspect
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "EMPTY_UNIT_PAIRING_TABLE_IS_EXTRA_I_FILLS_A_DIFFERENT_TWO_BY_TWO_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+NEWTON_PATH = ROOT / "docs" / "NEWTON_LAW_DERIVED_NOTE.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/EMPTY_UNIT_PAIRING_TABLE_IS_EXTRA_I_FILLS_A_DIFFERENT_TWO_BY_TWO_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/NEWTON_LAW_DERIVED_NOTE.md",
+)
+
+EMPTY: frozenset[str] = frozenset()
+S: frozenset[str] = frozenset({"s"})
+T: frozenset[str] = frozenset({"t"})
+PAIR_CELLS: tuple[tuple[frozenset[str], frozenset[str]], ...] = (
+    (EMPTY, EMPTY),
+    (EMPTY, T),
+    (S, EMPTY),
+    (S, T),
+)
+UNIT_UNIT = (S, T)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def i_of(collection: frozenset[str]) -> Fraction:
+    """One-argument Record readout: I(empty)=0 and I=1 on each unit lock."""
+    return Fraction(len(collection))
+
+
+def i_table() -> dict[tuple[frozenset[str], frozenset[str]], Fraction]:
+    """I-table on the four pair cells: (0, 1, 1, 2)."""
+    return {
+        (EMPTY, EMPTY): i_of(EMPTY),
+        (EMPTY, T): i_of(T),
+        (S, EMPTY): i_of(S),
+        (S, T): i_of(S | T),
+    }
+
+
+def pi_table() -> dict[tuple[frozenset[str], frozenset[str]], Fraction]:
+    """Declared extra product table T_π: (0, 0, 0, 1)."""
+    return {
+        (EMPTY, EMPTY): Fraction(0),
+        (EMPTY, T): Fraction(0),
+        (S, EMPTY): Fraction(0),
+        (S, T): Fraction(1),
+    }
+
+
+def identity_i_table() -> bool:
+    table = i_table()
+    expected = {
+        (EMPTY, EMPTY): Fraction(0),
+        (EMPTY, T): Fraction(1),
+        (S, EMPTY): Fraction(1),
+        (S, T): Fraction(2),
+    }
+    return table == expected and all(isinstance(table[cell], Fraction) for cell in PAIR_CELLS)
+
+
+def identity_pi_table() -> bool:
+    table = pi_table()
+    expected = {
+        (EMPTY, EMPTY): Fraction(0),
+        (EMPTY, T): Fraction(0),
+        (S, EMPTY): Fraction(0),
+        (S, T): Fraction(1),
+    }
+    return table == expected and all(isinstance(table[cell], Fraction) for cell in PAIR_CELLS)
+
+
+def identity_tables_disagree() -> bool:
+    left = i_table()
+    right = pi_table()
+    return left != right
+
+
+def i_table_equals_pi_table() -> bool:
+    """Predicate 'I-table equals T_π'. Must fail, including at (unit, unit)."""
+    return i_table() == pi_table()
+
+
+def disagreeing_cells() -> tuple[tuple[frozenset[str], frozenset[str]], ...]:
+    left = i_table()
+    right = pi_table()
+    return tuple(cell for cell in PAIR_CELLS if left[cell] != right[cell])
+
+
+def recompute_i_union() -> Fraction:
+    """I({s} ⊔ {t}) from I(empty)=0 and disjoint additivity of unit locks."""
+    i_empty = i_of(EMPTY)
+    i_s = i_of(S)
+    i_t = i_of(T)
+    return i_empty + i_s + i_t
+
+
+def product_extension(n: int, m: int) -> Fraction:
+    """Unique separately additive extension of T_π on unit-lock counts."""
+    t11 = pi_table()[UNIT_UNIT]
+    if n == 0 or m == 0:
+        return Fraction(0) * t11
+    return Fraction(n) * Fraction(m) * t11
+
+
+def separately_additive_on_grid(limit: int = 4) -> bool:
+    for n in range(limit + 1):
+        for m in range(limit + 1):
+            if product_extension(n, m) != Fraction(n) * Fraction(m):
+                return False
+            if n + 1 <= limit:
+                if product_extension(n, m) + product_extension(1, m) != product_extension(n + 1, m):
+                    return False
+            if m + 1 <= limit:
+                if product_extension(n, m) + product_extension(n, 1) != product_extension(n, m + 1):
+                    return False
+    return True
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    newton = NEWTON_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+    normalized_newton = normalize(newton)
+
+    print("external_scientific_inputs: current Record wording and the Newton product-law non-claim are source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: T_π is extra; no pairing axiom, Newton claim, G_N, or 1/r is installed")
+
+    record_sentence = (
+        "For any finite collection of pairwise-disjoint records, scalar readout "
+        "`I` is additive, with `I(empty)=0`."
+    )
+    newton_nonclaim = "the physical product law `M_source M_test`;"
+
+    checks.check(
+        "source-record-additivity",
+        "the current Record sentence names one-argument additive I with I(empty)=0",
+        record_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-newton-nonclaim",
+        "the Newton packet lists the physical product law as a non-claim",
+        newton_nonclaim in newton,
+    )
+    checks.check(
+        "note-quotes-record",
+        "the note quotes the one-argument Record additivity sentence",
+        record_sentence in normalized_note,
+    )
+    checks.check(
+        "note-quotes-newton-nonclaim",
+        "the note quotes only the Newton product-law non-claim",
+        newton_nonclaim in note,
+    )
+    checks.check(
+        "identity-i-table",
+        "i_table() is the Fraction four-tuple (0, 1, 1, 2)",
+        identity_i_table(),
+    )
+    checks.check(
+        "identity-pi-table",
+        "pi_table() is the Fraction four-tuple (0, 0, 0, 1)",
+        identity_pi_table(),
+    )
+    identity_sources = (
+        inspect.getsource(identity_i_table)
+        + inspect.getsource(identity_pi_table)
+        + inspect.getsource(identity_tables_disagree)
+        + inspect.getsource(i_table_equals_pi_table)
+    )
+    checks.check(
+        "identity-gate-calls",
+        "identity gates call i_table() and pi_table()",
+        "i_table()" in inspect.getsource(identity_i_table)
+        and "pi_table()" in inspect.getsource(identity_pi_table)
+        and "i_table()" in identity_sources
+        and "pi_table()" in identity_sources,
+    )
+    checks.check(
+        "theorem1-recompute",
+        "I(empty)=0 and disjoint additivity recompute I({s} ⊔ {t}) as 2",
+        recompute_i_union() == Fraction(2)
+        and i_of(EMPTY) == Fraction(0)
+        and i_table()[UNIT_UNIT] == recompute_i_union(),
+    )
+    checks.check(
+        "theorem2-disagreement-count",
+        "T_π disagrees with the I-table at three of four cells",
+        len(disagreeing_cells()) == 3 and identity_tables_disagree(),
+    )
+    checks.check(
+        "theorem2-unit-unit",
+        "the unit-unit cell is 2 ≠ 1",
+        i_table()[UNIT_UNIT] == Fraction(2)
+        and pi_table()[UNIT_UNIT] == Fraction(1)
+        and i_table()[UNIT_UNIT] != pi_table()[UNIT_UNIT],
+    )
+    checks.check(
+        "mutation-predicate-fails",
+        "the predicate I-table equals T_π is false",
+        i_table_equals_pi_table() is False,
+    )
+    checks.check(
+        "mutation-fails-at-unit-unit",
+        "the equality predicate fails at the unit-unit cell",
+        UNIT_UNIT in disagreeing_cells()
+        and i_table()[UNIT_UNIT] != pi_table()[UNIT_UNIT],
+    )
+    checks.check(
+        "theorem3-record-one-arg",
+        "the axiom memo does not name T_π or a two-argument pairing table",
+        "T_π" not in axiom
+        and "T_pi" not in axiom
+        and "two-argument table" not in axiom
+        and "pairing table" not in axiom,
+    )
+    checks.check(
+        "theorem3-tpi-extra",
+        "the note declares T_π extra and not an axiom",
+        ("T_π is extra" in normalized_note or "`T_π` is extra" in note)
+        and "not an axiom" in normalized_note,
+    )
+    checks.check(
+        "theorem4-extension-34",
+        "the unique extension evaluates to 12 at (3, 4)",
+        product_extension(3, 4) == Fraction(12),
+    )
+    checks.check(
+        "theorem4-uniqueness-grid",
+        "separate additivity on N forces T(n, m) = n m on the checked grid",
+        separately_additive_on_grid(4) and product_extension(1, 1) == pi_table()[UNIT_UNIT],
+    )
+    checks.check(
+        "theorem4-not-record",
+        "the note states that the later supplier is not Record additivity",
+        "supplier is not Record additivity" in normalized_note,
+    )
+    checks.check(
+        "theorem5-nonclaims",
+        "the note refuses a pairing axiom, a Newton claim, and installation of G_N or 1/r",
+        "does not adopt a pairing axiom" in normalized_note
+        and "does not claim Newton" in normalized_note
+        and "does not install `G_N` or `1/r`" in normalized_note
+        and newton_nonclaim in note,
+    )
+    checks.check(
+        "fraction-types",
+        "every I-table and T_π cell is an exact Fraction",
+        all(isinstance(value, Fraction) for value in i_table().values())
+        and all(isinstance(value, Fraction) for value in pi_table().values()),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+
+    print("per_element: four pair cells on two named unit atoms are checked")
+    print("per_site: no lattice site composite is asserted")
+    print("per_mode: no spectral-mode exhaustion is claimed")
+    print("per_block: the I-table versus extra T_π block is the only comparison tested")
+    print("lattice_wide: checked and not executed — no Newton, G_N, or 1/r installation is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On two named unit atoms, Record `I` fills the four pair cells by `(0,1,1,2)`. A declared product table `T_π` fills them by `(0,0,0,1)` and disagrees at the unit-unit cell `2≠1`. `T_π` is extra. A later supplier of that table plus additivity on `N` uniquely extends to `(n,m)↦nm`. That supplier is not Record additivity. No pairing axiom, Newton, `G_N`, or `1/r` is installed.

## What this means for the TOE

Newton-π live route 1: the empty/unit product table is a named extra matching, not Record additivity.

## What changed

- Note: `docs/EMPTY_UNIT_PAIRING_TABLE_IS_EXTRA_I_FILLS_A_DIFFERENT_TWO_BY_TWO_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py`
- Cache: `logs/runner-cache/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.txt`

## Verification

```bash
python3 scripts/empty_unit_pairing_table_is_extra_i_fills_a_different_two_by_two_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
