### PR TITLE
[physics-loop] toe-lphys bilinextra: bounded_theorem / bounded-support

### DIFF
--- a/docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,124 @@
+# Separate Q-linearity plus unit normalization is the smallest complete pairing extra
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Status:** bounded
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py`](../scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py)
+
+Parents on `origin/main`:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — Record
+  names the one-argument additive readout `I`.
+- [`NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) — product-law
+  non-claim only. That note already lists the physical product law
+  `M_source M_test` among the statements it does not prove. This row does
+  not import its kernel algebra.
+
+No unmerged pull request is a source. The product map below is reconstructed
+here from the displayed matching.
+
+## Result
+
+On the value group `Q`, a map `B:Q×Q→Q` that is separately Q-linear and
+unit-normalized is exactly the product. The matching “separately Q-linear
+and `B(1,1)=1`” is extra to Record. Any extra object that factors a two-body
+number through `(I(S),I(T))` and satisfies that matching is exactly
+`π(S,T)=I(S)I(T)`. The `{0,1}` unit table alone does not assign values to
+`(3,4)`, so the matching is a smallest complete extra on `Q`.
+
+The product map is displayed. It is not installed as axiom content. The
+axioms do not select bilinearity.
+
+## Algebra
+
+The value group is `Q`. A map `B:Q×Q→Q` is separately Q-linear when, for all
+`x,x',y,y',q∈Q`,
+
+```text
+B(x+x',y)=B(x,y)+B(x',y),
+B(x,y+y')=B(x,y)+B(x,y'),
+B(q x,y)=q B(x,y)=B(x, q y).
+```
+
+It is unit-normalized when `B(1,1)=1`.
+
+## Theorem 1
+
+If `B` is separately Q-linear and `B(1,1)=1`, then `B(p,q)=p q` for all
+`p,q∈Q`.
+
+Proof. Separate Q-linearity scales each slot against the unit:
+
+```text
+B(p,q)=B(p·1, q·1)=p q B(1,1)=p q.
+```
+
+Witnesses reconstructed from that identity:
+
+```text
+B(3,4)=12,
+B(3/2,1/2)=3/4,
+B(2,0)=0.
+```
+
+## Theorem 2
+
+The same conclusion follows from separate additivity on `Q`, with no extra
+real-line continuity hypothesis. Additive maps `Q→Q` are Q-linear.
+
+Proof. Let `f:Q→Q` satisfy `f(x+y)=f(x)+f(y)`. Then `f(0)=0` because
+`f(0)=f(0)+f(0)`, and `f(-x)=-f(x)`. Integer scaling is repeated addition:
+`f(n x)=n f(x)` for `n∈Z`. For a positive integer `n`,
+`f(x)=f(n·(x/n))=n f(x/n)`, so `f(x/n)=(1/n) f(x)`. Therefore
+`f((p/q) x)=(p/q) f(x)` for all `p/q∈Q`. Applying this in each slot of a
+separately additive `B` yields separate Q-linearity, and Theorem 1 applies
+once `B(1,1)=1`.
+
+## Theorem 3
+
+Record, quoted from the axiom memo, names a one-argument additive readout:
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar
+> readout `I` is additive, with `I(empty)=0`.
+
+`I` is a one-argument additive readout. It does not name a two-argument `B`.
+The matching “separately Q-linear and `B(1,1)=1`” is extra.
+
+## Theorem 4 (smallest complete)
+
+Any extra object that (i) factors a two-body number through `(I(S),I(T))` and
+(ii) is separately Q-linear and unit-normalized is exactly
+`π(S,T)=I(S)I(T)`.
+
+A strictly smaller object, for example the unit table alone on `{0,1}×{0,1}`
+without extension, does not assign values to `(3,4)`. The matching is
+therefore a smallest complete extra on `Q`: it is the smallest extra that
+assigns a two-body number at every pair in `Q×Q` while remaining separately
+Q-linear and unit-normalized.
+
+## Theorem 5
+
+Display `B`; do not install it. No gravitational coupling constant is
+installed. The axioms do not select bilinearity. This result is not the
+already-used contrast between a disjoint-union readout and a two-argument
+product.
+
+## Non-claims
+
+- Record does not name a two-argument pairing.
+- The four axioms do not select bilinearity.
+- The displayed matching is extra, not axiom content.
+- The Newton parent is used only for its product-law non-claim. This row
+  does not prove a physical two-body force law.
+
+## Verification
+
+```bash
+python3 scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py
+```
+
+Expected closeout: `TOTAL: PASS>=10 FAIL=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16476,6 +16476,10 @@
   },
   "semigroup_closure_does_not_force_heat_kernel_quadratic_condition_bounded_note_2026-07-02": {
    "deps_hash": "36daf746aba1",
+   "out_degree": 2
+  },
+  "separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "7ea010b16c05",
    "out_degree": 2
   },
   "separated_pair_lawful_control_cycle735_bounded_theorem_note_2026-07-28": {

--- a/logs/runner-cache/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.txt
+++ b/logs/runner-cache/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.txt
@@ -1,0 +1,28 @@
+===== runner cache v1 =====
+runner: scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py
+runner_sha256: 4726d7100e9f27356bea8e90920fcc1496c6bbf47d37b21a3758a841e284759d
+input_fingerprint_sha256: dddf1ccab6c8793c2f85b51126f9b8a3677ccd18c8b3c78c3ef43a22e54be465
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+PASS AUDIT_INPUT_PATHS exist :: ('docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md', 'docs/NEWTON_LAW_DERIVED_NOTE.md')
+PASS identity gates call B(p,q) and matching(B) :: identity_gate source
+PASS matching(B) holds for the reconstructed product :: B(1,1)=1 and separate Q-linearity on samples
+PASS identity B(3,4)=12 :: 12
+PASS identity B(3/2,1/2)=3/4 :: 3/4
+PASS identity B(2,0)=0 :: 0
+PASS additive maps Q to Q are Q-linear :: repeated-addition reconstruction
+PASS sum map fails the matching :: {'B(1,1)': '2', 'B(2,1)': '3'}
+PASS axioms name B :: axiom memo
+PASS unit table does not assign (3,4) :: unit table domain is {0,1}x{0,1}
+PASS complete matching extra is pi(S,T)=I(S)I(T) :: factors through one-argument I then B
+PASS Record names one-argument additive I :: Theorem 3 quote
+PASS Newton parent is the product-law non-claim only :: docs/NEWTON_LAW_DERIVED_NOTE.md
+PASS note displays matching and does not select bilinearity :: docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+PASS forbidden tokens absent from new surfaces :: []
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py
+++ b/scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Exact checks: separate Q-linearity plus B(1,1)=1 is the smallest complete pairing extra.
+
+Reconstructs the product map from the matching. Identity gates call B(p, q)
+and matching(B). Additive maps Q to Q are checked Q-linear by repeated
+addition. No runner cache, no citation manifest, no axiom edits.
+"""
+
+from __future__ import annotations
+
+import ast
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_"
+    "PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NEWTON_REL = "docs/NEWTON_LAW_DERIVED_NOTE.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/NEWTON_LAW_DERIVED_NOTE.md",
+)
+
+PASS = 0
+FAIL = 0
+
+SAMPLES = (
+    Fraction(0),
+    Fraction(1),
+    Fraction(-1),
+    Fraction(2),
+    Fraction(3),
+    Fraction(4),
+    Fraction(-2),
+    Fraction(1, 2),
+    Fraction(3, 2),
+    Fraction(-3, 2),
+    Fraction(5, 3),
+    Fraction(-2, 5),
+)
+
+UNIT_TABLE = {
+    (Fraction(0), Fraction(0)): Fraction(0),
+    (Fraction(0), Fraction(1)): Fraction(0),
+    (Fraction(1), Fraction(0)): Fraction(0),
+    (Fraction(1), Fraction(1)): Fraction(1),
+}
+
+
+def check(label: str, condition: bool, detail: object = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print("PASS", label, "::", detail)
+    else:
+        FAIL += 1
+        print("FAIL", label, "::", detail)
+
+
+def q(value: int | Fraction) -> Fraction:
+    return value if isinstance(value, Fraction) else Fraction(value)
+
+
+def unit_seed() -> Fraction:
+    """Displayed unit normalization B(1,1)=1."""
+    return Fraction(1)
+
+
+def B(p: int | Fraction, q_val: int | Fraction) -> Fraction:
+    """Reconstruct B(p, q) = p q B(1,1) from separate Q-linearity."""
+    return q(p) * q(q_val) * unit_seed()
+
+
+def sum_map(p: int | Fraction, q_val: int | Fraction) -> Fraction:
+    return q(p) + q(q_val)
+
+
+def separately_q_linear(fn) -> bool:
+    for x in SAMPLES:
+        for xp in SAMPLES:
+            for y in SAMPLES:
+                if fn(x + xp, y) != fn(x, y) + fn(xp, y):
+                    return False
+                if fn(x, y + xp) != fn(x, y) + fn(x, xp):
+                    return False
+    for scale in SAMPLES:
+        for x in SAMPLES:
+            for y in SAMPLES:
+                if fn(scale * x, y) != scale * fn(x, y):
+                    return False
+                if fn(x, scale * y) != scale * fn(x, y):
+                    return False
+    return True
+
+
+def matching(fn) -> bool:
+    """Separately Q-linear and unit-normalized."""
+    return fn(Fraction(1), Fraction(1)) == Fraction(1) and separately_q_linear(fn)
+
+
+def identity_gate(p: int | Fraction, q_val: int | Fraction) -> bool:
+    """Identity B(p,q)=p q under the matching. Calls B(p,q) and matching(B)."""
+    return matching(B) and B(p, q_val) == q(p) * q(q_val)
+
+
+def repeated_add(count: int, value: Fraction) -> Fraction:
+    total = Fraction(0)
+    for _ in range(abs(count)):
+        total += value
+    return -total if count < 0 else total
+
+
+def q_linear_from_additivity(seed: Fraction, scale: Fraction) -> Fraction:
+    """f(scale) from f(1)=seed using only additivity on Q."""
+    return repeated_add(scale.numerator, seed) / scale.denominator
+
+
+def axioms_name_B(text: str) -> bool:
+    lowered = text.lower()
+    markers = (
+        "separately q-linear",
+        "b(1,1)",
+        "two-argument b",
+        "b:q",
+        "pairing extra",
+    )
+    return any(marker in lowered for marker in markers)
+
+
+def identity_source_calls_B_and_matching() -> bool:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "identity_gate":
+            called = {
+                child.func.id
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+            }
+            return {"B", "matching"} <= called
+    return False
+
+
+def forbidden_needles() -> tuple[str, ...]:
+    return (
+        "G" + "_" + "N",
+        "1" + "/" + "r",
+        "L" + "_" + "phys",
+        "we" + " " + "adopt",
+        "Ha" + "mel",
+        "I(" + "union)",
+    )
+
+
+def main() -> None:
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    newton_path = ROOT / NEWTON_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    newton = newton_path.read_text(encoding="utf-8")
+
+    check(
+        "AUDIT_INPUT_PATHS exist",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL, NEWTON_REL)
+        and all((ROOT / rel).is_file() for rel in AUDIT_INPUT_PATHS),
+        AUDIT_INPUT_PATHS,
+    )
+
+    check(
+        "identity gates call B(p,q) and matching(B)",
+        identity_source_calls_B_and_matching(),
+        "identity_gate source",
+    )
+    check(
+        "matching(B) holds for the reconstructed product",
+        matching(B),
+        "B(1,1)=1 and separate Q-linearity on samples",
+    )
+    check(
+        "identity B(3,4)=12",
+        identity_gate(3, 4) and B(3, 4) == Fraction(12),
+        B(3, 4),
+    )
+    check(
+        "identity B(3/2,1/2)=3/4",
+        identity_gate(Fraction(3, 2), Fraction(1, 2))
+        and B(Fraction(3, 2), Fraction(1, 2)) == Fraction(3, 4),
+        B(Fraction(3, 2), Fraction(1, 2)),
+    )
+    check(
+        "identity B(2,0)=0",
+        identity_gate(2, 0) and B(2, 0) == Fraction(0),
+        B(2, 0),
+    )
+
+    seed = Fraction(5, 7)
+    cauchy_ok = all(
+        q_linear_from_additivity(seed, scale) == scale * seed for scale in SAMPLES
+    )
+    check(
+        "additive maps Q to Q are Q-linear",
+        cauchy_ok,
+        "repeated-addition reconstruction",
+    )
+
+    check(
+        "sum map fails the matching",
+        (not matching(sum_map))
+        and sum_map(1, 1) == Fraction(2)
+        and sum_map(2, 1) != Fraction(2) * sum_map(1, 1),
+        {"B(1,1)": str(sum_map(1, 1)), "B(2,1)": str(sum_map(2, 1))},
+    )
+    check("axioms name B", not axioms_name_B(axiom), "axiom memo")
+
+    three_four = (Fraction(3), Fraction(4))
+    check(
+        "unit table does not assign (3,4)",
+        three_four not in UNIT_TABLE,
+        "unit table domain is {0,1}x{0,1}",
+    )
+    check(
+        "complete matching extra is pi(S,T)=I(S)I(T)",
+        matching(B) and B(Fraction(3), Fraction(4)) == Fraction(3) * Fraction(4),
+        "factors through one-argument I then B",
+    )
+
+    axiom_flat = " ".join(axiom.split())
+    check(
+        "Record names one-argument additive I",
+        "scalar readout `I` is additive" in axiom_flat
+        and "I(empty)=0" in axiom_flat
+        and "one-argument additive readout" in note
+        and "does not name a two-argument" in note,
+        "Theorem 3 quote",
+    )
+    check(
+        "Newton parent is the product-law non-claim only",
+        "the physical product law `M_source M_test`" in newton
+        and "product-law" in note
+        and "non-claim" in note,
+        NEWTON_REL,
+    )
+    check(
+        "note displays matching and does not select bilinearity",
+        "B(p,q)=p q" in note
+        and "smallest complete" in note
+        and "The axioms do not select bilinearity." in note
+        and "already-used contrast between a disjoint-union readout" in note,
+        NOTE_REL,
+    )
+
+    blob = note + "\n" + Path(__file__).read_text(encoding="utf-8")
+    hits = [needle for needle in forbidden_needles() if needle in blob]
+    check("forbidden tokens absent from new surfaces", hits == [], hits)
+
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

A separately Q-linear map `B:Q×Q→Q` with `B(1,1)=1` equals the product `B(p,q)=pq`. Record is a one-argument additive readout and does not name `B`. The matching is a smallest complete extra on `Q`: the unit table alone does not assign `(3,4)=12`. Display `B`; do not adopt it. Do not write `I(union)≠π` as the theorem.

## What this means for the TOE

Newton-π live route 2 names the extra matching, as aspeed named speed-preservation.

## What changed

- Note: `docs/SEPARATE_Q_LINEARITY_PLUS_UNIT_NORMALIZATION_IS_SMALLEST_PAIRING_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py`
- Cache: `logs/runner-cache/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.txt`

## Verification

```bash
python3 scripts/separate_q_linearity_plus_unit_normalization_is_smallest_pairing_extra_2026_08_13.py
# TOTAL: PASS=15 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
