### PR TITLE
[physics-loop] toe-lphys pvmselect: bounded_theorem / bounded-support

### DIFF
--- a/docs/AXIOMS_DO_NOT_SELECT_WHICH_PVM_A_LUDERS_INSTRUMENT_READS_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/AXIOMS_DO_NOT_SELECT_WHICH_PVM_A_LUDERS_INSTRUMENT_READS_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,331 @@
+---
+claim_id: axioms_do_not_select_which_pvm_a_luders_instrument_reads_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "At one M_2(C) site, the Born weights on two declared rank-one projective menus disagree at an explicit polarized density matrix. The current Qubit and Admissibility sentences name the possibility domain and a nearest-neighbor-determined distribution; they do not name P_z versus P_x. A later compiler that returns Born weights still consumes a declared PVM. The result does not replace the August 9 frame-lift theorem, does not deny Born form, does not select n=z by cubic covariance, does not force r=1/2, and does not adopt a PVM axiom."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py
+---
+
+# Axioms Do Not Select Which PVM A Lüders Instrument Reads
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site menu-declaration hygiene under the current
+`M_2(C)` possibility-domain wording.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py`](../scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py)
+
+## Result Up Front
+
+Born weights on a declared projector-valued menu are the ordinary trace
+kernel. That kernel does not pick the menu.
+
+Two explicit rank-one menus at one qubit site already disagree on an explicit
+polarized density matrix. The current Qubit and Admissibility sentences do
+not name either menu. A later Lüders compiler that returns those Born
+weights still consumes a declared projector, or an equivalent unit Bloch
+vector. The menu is extra structure.
+
+This note does not improve or replace
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md).
+It does not say Born is false. It does not select `n=z` by cubic covariance:
+a polarized density matrix is allowed. It does not force `r=1/2`. It does
+not adopt a PVM axiom. Both menus
+
+`{P_z, I-P_z}` and `{P_x, I-P_x}`
+
+are displayed; neither is adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two-menu Born disagreement and the textual non-selection of P_z versus P_x are exact on declared one-site objects, while a later instrument compiler, physical menu registration, and any PVM-selecting law remain extra or open."
+trace_class: negative_route_pruning
+target_claim_id: axioms_select_luders_pvm_menu
+target_blocker_text: "show that the four axioms do not name which declared PVM a later Lüders compiler reads"
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed two-menu kernel values and the quoted axiom sentences; physical compilation of a preferred menu remains open"
+hypothetical_axiom_status: "no PVM-selecting clause is displayed, recommended, or adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site, with `H=C^2`. Write `I` for the `2x2` identity and
+
+`P_z = diag(1,0)`,
+`P_x = (I+sigma_x)/2 = [[1/2,1/2],[1/2,1/2]]`,
+`rho = diag(3/5, 2/5)`.
+
+Both pairs `{P_z, I-P_z}` and `{P_x, I-P_x}` are rank-one resolutions of
+`I`. They are the two declared projective menus used below.
+
+On a declared projector `P`, the Born kernel is the exact trace
+
+`K(sigma,P)=Tr(sigma P)`.
+
+The same kernel evaluated on `I-P` is `1-K(sigma,P)` whenever
+`Tr(sigma)=1`. The kernel is a function of a supplied pair `(sigma,P)`. It
+does not invent `P`.
+
+The Bloch form of the displayed state is
+
+`rho = (I + (1/5) sigma_z)/2`.
+
+Its Bloch radius is `1/5`, not `1/2`. The state is polarized and positive
+with trace one.
+
+## Theorem 1 — The Two Declared Menus Disagree
+
+`K(rho, P_z)=Tr(rho P_z)=3/5`.
+
+`K(rho, P_x)=Tr(rho P_x)=(3/5)(1/2)+(2/5)(1/2)=1/2`.
+
+Therefore
+
+`3/5 != 1/2`,
+
+so the predicate `K(rho, P_z)=K(rho, P_x)` fails at this `rho`. The two
+declared menus are not interchangeable as readout data for the same state.
+The complementary weights are `2/5` on `I-P_z` and `1/2` on `I-P_x`.
+
+This is ordinary finite-matrix arithmetic. No continuity, measurability, or
+frame-function hypothesis is used.
+
+## Theorem 2 — The Current Axiom Sentences Do Not Name Either Menu
+
+The current Qubit sentences in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) are:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+>
+> No possibility is privileged. Possibilities are distinguished by the
+> supplied algebraic structure alone.
+
+The current Admissibility distribution sentence is:
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+Neither sentence names `P_z` versus `P_x`. Neither sentence names a unit
+Bloch vector `n`, a distinguished rank-one projector, or a preferred
+projective menu. The predicate "axioms name `P_z`" therefore fails on the
+canonical text.
+
+Qubit supplies the carrier on which both projectors live. Admissibility
+supplies a nearest-neighbor-determined distribution over possibilities. Those
+are not a declared PVM.
+
+## Theorem 3 — A Later Lüders Compiler Still Needs A Declared PVM
+
+Suppose a later compiler is given a projector `P` and returns the two-outcome
+Lüders instrument that reads `{P, I-P}` with Born weights `K(sigma,P)` and
+`1-K(sigma,P)`. The output of that compiler is then exactly the kernel of
+Theorem 1.
+
+The compiler still consumes the declared menu. The declaration may be written
+as a projector `P` or as a unit vector `n` with `P=(I+n·sigma)/2`. Either
+form is extra relative to the sentences quoted in Theorem 2.
+
+Both displayed menus are well-formed inputs to such a compiler:
+
+- `{P_z, I-P_z}` yields weights `{3/5, 2/5}` at `rho`;
+- `{P_x, I-P_x}` yields weights `{1/2, 1/2}` at `rho`.
+
+Neither menu is adopted here. The later compiler, if written, remains a
+downstream map from a declared PVM to an instrument. It is not a selector of
+which PVM the current axioms already named.
+
+## Theorem 4 — August 9, Born Form, And Cubic Covariance Are Untouched
+
+This note does not improve or replace the August 9 parent. That parent forces
+the trace form on the scaled-projector domain after a menu-independent
+low-arity grading is supplied. The present note does not revisit that
+forcing, does not weaken it, and does not enlarge its menu family.
+
+This note does not say Born is false. The kernel `K(sigma,P)=Tr(sigma P)` is
+used as the declared-menu evaluation rule. The disagreement in Theorem 1 is a
+disagreement between two menus, not a failure of the trace formula.
+
+This note does not select `n=z` by cubic covariance. Lattice and
+Admissibility are covariant under proper cubic rotations about a site. A
+90-degree rotation about the `y`-axis exchanges the `z` and `x` axes and
+therefore exchanges `P_z` with `P_x`. A cubic-covariant rule cannot privilege
+the `z` menu over the `x` menu. A polarized density matrix remains allowed:
+`rho` above is positive, has trace one, and is not `I/2`. Covariance of the
+rule is not isotropy of every state.
+
+## Theorem 5 — No Forced Radius And No PVM Axiom
+
+This note does not force `r=1/2`. The displayed Bloch radius is `1/5`. The
+`x`-menu weight `1/2` at this `rho` is a matrix identity, not a requirement
+that every state or every selector sit at radius `1/2`.
+
+This note does not adopt a PVM axiom. No fifth axiom naming a distinguished
+projector, a distinguished Bloch axis, or a preferred Lüders menu is stated,
+recommended, or inserted into the canonical memo.
+
+## Relation To The Current Axioms And To August 9
+
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) already records,
+among the open gates outside the axioms, context selection and measurement
+basis selection. Theorem 2 is the one-site matrix reading of that gate:
+`P_z` versus `P_x` is a basis-selection datum, not axiom content.
+
+The August 9 parent remains the bounded theorem for the trace form on a
+supplied low-arity grading. The present note answers a different question:
+once that form is granted on a declared projector, which projector is read.
+The four axioms do not answer that question. Displaying two disagreeing
+menus keeps the residual visible.
+
+No inference of impossibility is made about a later derivation that would
+construct a physical menu from neighboring records, from a contact compiler,
+or from another landed structure. Such a derivation would supply the missing
+declaration. It would not show that the present axiom sentences already named
+`P_z`.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to (i) equality of the two displayed
+Born weights at this `rho` and (ii) the claim that the current axiom
+sentences already name `P_z` or otherwise select a PVM. The gate does not
+certify a global non-derivability theorem about instruments.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Identify the two menus | require `K(rho,P_z)=K(rho,P_x)` | Theorem 1 gives the exact values `3/5 != 1/2` | **ATTEMPTED** |
+| Read `P_z` off Qubit | treat `M_2(C)` plus "no possibility is privileged" as naming a projector | Theorem 2: the quoted sentences do not name `P_z` or `P_x` | **ATTEMPTED** |
+| Read `P_z` off Admissibility | treat the nearest-neighbor distribution sentence as a PVM declaration | Theorem 2: that sentence names no projector | **ATTEMPTED** |
+| Let cubic covariance pick `n=z` | invoke proper cubic rotations to privilege the `z` axis | Theorem 4: those rotations exchange `P_z` with `P_x`; a polarized `rho` remains allowed | **ATTEMPTED** |
+| Force `r=1/2` to erase the disagreement | specialize the Bloch radius until the menus agree | Theorem 5: the displayed radius is `1/5`; the disagreement is the point | **ATTEMPTED** |
+| Hide the menu inside a later compiler | treat a Lüders compiler as selecting `P` by itself | Theorem 3: the compiler consumes a declared `P` or `n` | **ATTEMPTED** |
+| Replace August 9 | treat menu non-selection as a defect of the trace form | Theorem 4: August 9 is untouched and Born is not denied | **ATTEMPTED** |
+
+The last route is a misreading rather than a live construction. Constructive
+routes that *supply* a declared menu from other structure remain open.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| declared PVM / Born kernel on that PVM | no: a projector does not evaluate itself | no: `K(sigma,P)=Tr(sigma P)` names no distinguished `P` | independent |
+| Qubit carrier / distinguished projector | no: `M_2(C)` contains every rank-one projector | no: naming `P_z` does not supply the possibility domain | independent |
+| Admissibility distribution / distinguished projector | no: a distribution over possibilities names no menu | no: a declared menu does not determine the nearest-neighbor law | independent |
+| cubic covariance of the rule / isotropic states | no: a covariant rule may still admit polarized states | no: one polarized state does not break rule covariance | independent |
+| August 9 trace form / PVM selection | no: the parent consumes a supplied grading, not a preferred axis | no: displaying two menus does not revisit the frame lift | independent |
+
+The missing declaration is one wall. It is not collapsed into the Born kernel,
+the August 9 parent, or a cubic-isotropy demand.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `P_z`, `P_x`, `rho` | explicit finite matrices, written before Theorem 1 |
+| `K(sigma,P)=Tr(sigma P)` | declared-menu evaluation rule, not a hidden state-to-menu map |
+| "Lüders compiler" | later map from a declared PVM to a two-outcome instrument; not present in the axioms and not adopted |
+| "declared PVM" | explicit extra input: a projector or a unit vector `n` |
+| cubic rotation about `y` | explicit proper cubic rotation exchanging the two displayed axes |
+| Bloch radius `1/5` | exact identity for the displayed `rho` |
+| August 9 parent | explicit dependency for the untouched trace-form boundary only |
+| observations or fitted radii | none |
+
+No dim-2 frame theorem, hidden preferred axis, or axiom edit is used.
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | one-site `M_2(C)` domain; no possibility privileged; nearest-neighbor-determined distribution; measurement-basis selection listed among open gates | quoted wording only; no projector conclusion borrowed |
+| [`docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md) | unique trace form after a menu-independent low-arity grading is supplied | used only as the untouched parent; not improved or replaced |
+
+No citation is used as authority for the `3/5` versus `1/2` arithmetic; that
+identity is proved here and checked by the runner.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | two rank-one projectors and one polarized density matrix | no classification of every instrument |
+| per site | one `M_2(C)` site | no composite or multi-site instrument theorem |
+| per mode | the `z` and `x` axes, plus the cubic rotation that exchanges them | no exhaustion of every Bloch direction |
+| per block | PVM declaration versus Born evaluation | no complete Record/update closure |
+| lattice-wide | cubic covariance is invoked only to refuse a privileged axis | no lattice-wide dynamics or Born denial |
+
+The risky sentence family is "the axioms cannot produce a Lüders instrument."
+This note uses the narrower form: the current sentences do not name which
+declared PVM such an instrument would read.
+
+### N6 — live partial-closure paths
+
+1. A neighboring-record encoding of an apparatus could derive a declared
+   projector from landed content.
+2. A contact compiler could supply one physical menu, after which Theorem 1's
+   kernel evaluates that menu.
+3. An operational equivalence theorem could identify two laboratory
+   implementations as the same projector without privileging `z` in the
+   axioms.
+4. The August 9 parent remains available once a menu-independent grading on
+   a declared family is supplied.
+
+None of these paths is closed here. None is a reason to adopt a PVM axiom.
+
+### N7 — hostile steelman
+
+> Cubic covariance plus a unique nearest-neighbor rule might still pick a
+> preferred local axis once a polarized neighbor configuration is given, and
+> a later Lüders compiler could then read that axis. In that reading the
+> axioms already select the PVM, up to an implicit function of the neighbors.
+
+The steelman is a constructive program, not a present derivation. A neighbor
+configuration can be polarized, as `rho` itself shows. The current sentences
+still do not name the map from those neighbors to `{P_z, I-P_z}` rather than
+`{P_x, I-P_x}`. Until that map is derived, the menu remains extra.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Later movement | Echo here |
+|---|---|---|
+| August 9 forces Born form on a supplied low-arity grading | the grading and eligible menus remain explicit inputs | this note does not reopen or replace that forcing |
+| Admissibility names a distribution over possibilities | August 10 separates that global measure from a menu kernel | the present note separates the same kernel from the choice of PVM |
+| open gates already list measurement basis selection | no later landed sentence names `P_z` versus `P_x` | Theorem 2 is the matrix reading of that existing gate |
+
+**Gate disposition:** PASS for (i) `K(rho,P_z)!=K(rho,P_x)` at the displayed
+state, (ii) failure of the predicate that the current axiom sentences name
+`P_z`, and (iii) the statement that a later Lüders compiler still consumes a
+declared PVM. FAIL / DO NOT SHIP for "Born is false," "August 9 is replaced,"
+"`n=z` is selected by cubic covariance," "`r=1/2` is forced," or "a PVM axiom is adopted."
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Qubit and Admissibility sentences | exact semantic baseline | supplied; no edit |
+| `P_z`, `P_x`, `rho` | Theorem 1 witnesses | constructed here |
+| `K(sigma,P)=Tr(sigma P)` | declared-menu evaluation | definition-level mathematics |
+| later Lüders compiler | Theorem 3 consumer of a declared PVM | not current authority; not adopted |
+| August 9 frame-lift theorem | untouched parent | explicit non-replacement |
+| PVM-selecting axiom | forbidden closure in this note | not stated and not adopted |
+| observed frequencies or fitted axes | none | not used |
+
+The exact advance is a menu-declaration theorem. It does not move the
+August 9 trace-form residual. It makes the next instrument question
+testable: derive a declared PVM from landed structure, or leave the menu
+explicit. Do not read `P_z` off the present axiom sentences.
+
+## Review Record
+
+Independent audit remains required before any effective status may change.
+No `review-loop` was invoked in producing or self-reviewing this artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1197,6 +1197,10 @@
   "axiom_stack_minimality_cl4c_no_go_theorem_note_2026-04-29": {
    "deps_hash": "43bbfd6e9fc5",
    "out_degree": 5
+  },
+  "axioms_do_not_select_which_pvm_a_luders_instrument_reads_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "8830c572e201",
+   "out_degree": 2
   },
   "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2a26c7562e24",

--- a/logs/runner-cache/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.txt
+++ b/logs/runner-cache/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py
+runner_sha256: c06aa44251bf654d44cd0fb1039f3dcffc708ba2ad70651faf0a15182e7ad439
+input_fingerprint_sha256: 652192db6f92608a967aaa9472ba50e3004f3576977a1e0601952db6011b3010
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording and the August 9 parent are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency against the declared parents
+negative_scope: only equality of the two displayed Born weights and the claim that the axioms name P_z are rejected
+PASS: identity-born-z born(rho, Pz) equals the exact weight 3/5
+PASS: identity-born-x born(rho, Px) equals the exact weight 1/2
+PASS: binary-menu-resolutions each displayed pair sums exactly to the identity
+PASS: complement-weights the complementary Born weights are 2/5 and 1/2
+PASS: mutation-equal-weights the predicate K(rho, P_z)=K(rho, P_x) fails
+PASS: polarized-state rho is a polarized density matrix with Bloch radius 1/5, not r=1/2
+PASS: source-qubit Qubit names M_2(C) and that no possibility is privileged
+PASS: source-admissibility Admissibility names a nearest-neighbor-determined distribution
+PASS: mutation-axioms-name-pz the predicate that the axioms name P_z fails
+PASS: source-parent the August 9 parent supplies the unique trace form after a supplied grading
+PASS: note-theorems the note records the two-menu disagreement, the un-named menus, and the extra declaration
+PASS: note-hygiene-theorems the note refuses August 9 replacement, Born denial, n=z selection, r=1/2, and a PVM axiom
+PASS: forbidden-closures the note avoids we adopt, a Lüders axiom, L_phys, dim-2 Gleason, and unmerged PR citations
+PASS: identity-gates-call-born the identity gates in this runner literally call born(rho, Pz) and born(rho, Px)
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support and negative-route-pruning fields
+PASS: no-go-gate all N1-N8 sections and the forbidden-closure rejection are source-visible
+PASS: declared-inputs-exist AUDIT_INPUT_PATHS resolve to the new note, the August 9 parent, and the axiom memo
+per_element: two rank-one projectors and one polarized density matrix are evaluated by the exact Born kernel
+per_site: the disagreement and the axiom-text check are one-site statements; no composite carrier is asserted
+per_mode: the z and x axes are checked, together with the refusal to force r=1/2; no exhaustion of Bloch directions is claimed
+per_block: only PVM declaration versus declared-menu Born evaluation is the negative block tested
+lattice_wide: checked and not executed — cubic covariance is used only to refuse a privileged axis; no lattice-wide dynamics is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py
+++ b/scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Exact checks: axioms do not select which PVM a Lüders instrument reads.
+
+Identity gates call born(rho, Pz) and born(rho, Px). The equality predicate
+K(rho, Pz) = K(rho, Px) is required to fail, as is the predicate that the
+canonical axiom memo names P_z.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/AXIOMS_DO_NOT_SELECT_WHICH_PVM_A_LUDERS_INSTRUMENT_READS_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+PARENT_REL = (
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-09.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/AXIOMS_DO_NOT_SELECT_WHICH_PVM_A_LUDERS_INSTRUMENT_READS_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+PARENT_PATH = ROOT / PARENT_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def mat_add(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def trace(matrix: Matrix) -> Fraction:
+    return matrix[0][0] + matrix[1][1]
+
+
+def born(sigma: Matrix, projector: Matrix) -> Fraction:
+    return trace(mat_mul(sigma, projector))
+
+
+def k_rho_pz_equals_k_rho_px(sigma: Matrix, p_z: Matrix, p_x: Matrix) -> bool:
+    return born(sigma, p_z) == born(sigma, p_x)
+
+
+def axioms_name_pz(axiom_text: str) -> bool:
+    compact = normalize(axiom_text)
+    needles = (
+        "P_z",
+        "P_x",
+        "diag(1,0)",
+        "sigma_x",
+        "sigma_z",
+        "Lüders",
+        "Luders",
+        "projector-valued",
+    )
+    return any(needle in compact for needle in needles)
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current axiom wording and the August 9 "
+        "parent are source-bound; no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency against the declared parents"
+    )
+    print(
+        "negative_scope: only equality of the two displayed Born weights and "
+        "the claim that the axioms name P_z are rejected"
+    )
+
+    I = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(1)),
+    )
+    Pz = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(0)),
+    )
+    Px = (
+        (Fraction(1, 2), Fraction(1, 2)),
+        (Fraction(1, 2), Fraction(1, 2)),
+    )
+    I_minus_Pz = (
+        (Fraction(0), Fraction(0)),
+        (Fraction(0), Fraction(1)),
+    )
+    I_minus_Px = (
+        (Fraction(1, 2), Fraction(-1, 2)),
+        (Fraction(-1, 2), Fraction(1, 2)),
+    )
+    rho = (
+        (Fraction(3, 5), Fraction(0)),
+        (Fraction(0), Fraction(2, 5)),
+    )
+
+    checks.check(
+        "identity-born-z",
+        "born(rho, Pz) equals the exact weight 3/5",
+        born(rho, Pz) == Fraction(3, 5),
+    )
+    checks.check(
+        "identity-born-x",
+        "born(rho, Px) equals the exact weight 1/2",
+        born(rho, Px) == Fraction(1, 2),
+    )
+    checks.check(
+        "binary-menu-resolutions",
+        "each displayed pair sums exactly to the identity",
+        mat_add(Pz, I_minus_Pz) == I and mat_add(Px, I_minus_Px) == I,
+    )
+    checks.check(
+        "complement-weights",
+        "the complementary Born weights are 2/5 and 1/2",
+        born(rho, I_minus_Pz) == Fraction(2, 5)
+        and born(rho, I_minus_Px) == Fraction(1, 2),
+    )
+    checks.check(
+        "mutation-equal-weights",
+        "the predicate K(rho, P_z)=K(rho, P_x) fails",
+        not k_rho_pz_equals_k_rho_px(rho, Pz, Px),
+    )
+    checks.check(
+        "polarized-state",
+        "rho is a polarized density matrix with Bloch radius 1/5, not r=1/2",
+        trace(rho) == 1
+        and rho[0][0] - rho[1][1] == Fraction(1, 5)
+        and rho[0][0] - rho[1][1] != Fraction(1, 2)
+        and rho != (
+            (Fraction(1, 2), Fraction(0)),
+            (Fraction(0), Fraction(1, 2)),
+        ),
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit names M_2(C) and that no possibility is privileged",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "No possibility is privileged." in axiom,
+    )
+    checks.check(
+        "source-admissibility",
+        "Admissibility names a nearest-neighbor-determined distribution",
+        (
+            "For each site, the probability distribution over the possibilities is "
+            "determined by, and varies with, the nearest-neighbor conditions."
+        )
+        in normalize(axiom),
+    )
+    checks.check(
+        "mutation-axioms-name-pz",
+        "the predicate that the axioms name P_z fails",
+        not axioms_name_pz(axiom),
+    )
+    checks.check(
+        "source-parent",
+        "the August 9 parent supplies the unique trace form after a supplied grading",
+        all(
+            phrase in parent
+            for phrase in (
+                "menu-independent grading",
+                "There is a unique density matrix",
+                "w(E)=Tr(rho E)",
+            )
+        ),
+    )
+    checks.check(
+        "note-theorems",
+        "the note records the two-menu disagreement, the un-named menus, and the extra declaration",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "K(rho, P_z)=Tr(rho P_z)=3/5",
+                "K(rho, P_x)=Tr(rho P_x)=(3/5)(1/2)+(2/5)(1/2)=1/2",
+                "3/5 != 1/2",
+                "Neither sentence names `P_z` versus `P_x`",
+                "A later Lüders compiler that returns those Born weights still consumes a declared projector",
+                "`{P_z, I-P_z}` and `{P_x, I-P_x}`",
+            )
+        ),
+    )
+    checks.check(
+        "note-hygiene-theorems",
+        "the note refuses August 9 replacement, Born denial, n=z selection, r=1/2, and a PVM axiom",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "This note does not improve or replace",
+                "It does not say Born is false",
+                "It does not select `n=z` by cubic covariance",
+                "a polarized density matrix is allowed",
+                "It does not force `r=1/2`",
+                "It does not adopt a PVM axiom",
+                "neither is adopted",
+            )
+        ),
+    )
+    checks.check(
+        "forbidden-closures",
+        "the note avoids we adopt, a Lüders axiom, L_phys, dim-2 Gleason, and unmerged PR citations",
+        all(
+            phrase not in note
+            for phrase in (
+                "we adopt",
+                "Lüders axiom",
+                "Luders axiom",
+                "L_phys",
+                "dim-2 Gleason",
+                "dimension-two Gleason",
+                "dimension 2 Gleason",
+                "pvmluders",
+                "github.com/",
+                "/pull/",
+            )
+        ),
+    )
+    checks.check(
+        "identity-gates-call-born",
+        "the identity gates in this runner literally call born(rho, Pz) and born(rho, Px)",
+        "born(rho, Pz)" in source and "born(rho, Px)" in source,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support and negative-route-pruning fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "claim_type_reason:",
+                "trace_class: negative_route_pruning",
+                "source_of_blocker_text: handoff",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+                "hypothetical_axiom_status: \"no PVM-selecting clause is displayed, recommended, or adopted\"",
+            )
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the forbidden-closure rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "a PVM axiom is adopted" in note,
+    )
+    checks.check(
+        "declared-inputs-exist",
+        "AUDIT_INPUT_PATHS resolve to the new note, the August 9 parent, and the axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, PARENT_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    print(
+        "per_element: two rank-one projectors and one polarized density matrix "
+        "are evaluated by the exact Born kernel"
+    )
+    print(
+        "per_site: the disagreement and the axiom-text check are one-site "
+        "statements; no composite carrier is asserted"
+    )
+    print(
+        "per_mode: the z and x axes are checked, together with the refusal to "
+        "force r=1/2; no exhaustion of Bloch directions is claimed"
+    )
+    print(
+        "per_block: only PVM declaration versus declared-menu Born evaluation "
+        "is the negative block tested"
+    )
+    print(
+        "lattice_wide: checked and not executed — cubic covariance is used only "
+        "to refuse a privileged axis; no lattice-wide dynamics is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

At `ρ=diag(3/5,2/5)`, `K(ρ,P_z)=3/5` and `K(ρ,P_x)=1/2`. The two PVMs disagree. Qubit and Admissibility do not name `P_z` versus `P_x`. A later Lüders compiler still needs a declared menu. August 9 is not replaced. `r=1/2` is not forced.

## What this means for the TOE

Even after a Lüders matching, which PVM is extra.

## What changed

- Note: `docs/AXIOMS_DO_NOT_SELECT_WHICH_PVM_A_LUDERS_INSTRUMENT_READS_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py`
- Cache: `logs/runner-cache/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.txt`

## Verification

```bash
python3 scripts/axioms_do_not_select_which_pvm_a_luders_instrument_reads_2026_08_13.py
# TOTAL: PASS=18 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
