### PR TITLE
[physics-loop] toe-lphys clockscale: bounded_theorem / bounded-support

### DIFF
--- a/docs/SCALE_REFERENCE_A_INVERSE_IS_NOT_WICK_CLOCK_PARAMETER_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SCALE_REFERENCE_A_INVERSE_IS_NOT_WICK_CLOCK_PARAMETER_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,231 @@
+---
+claim_id: scale_reference_a_inverse_is_not_wick_clock_parameter_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The scale-reference conversion a_sr^{-1}=M_Pl and the Wick clock parameter a_w in k4=i a_w omega are unequal types. The Euclidean OS0 form Q_E=(k4^2+k^2)/4 does not contain a_w; after substitution, omega_coeff(a_w)=-a_w^2/4 and |omega_coeff|/spatial_coeff=a_w^2 is a dimensionless ratio of quadratic coefficients. Scale-reference carries no dimensionless content and cannot select a_w in {1/2,1,2}. Kinetic isotropy is the Euclidean equality c_t=c_s, not a Wick parameter. The shared letter a is not an identification. This note does not install a_w=1, does not replace speed-preservation, and does not claim Lorentz closure."
+upstream_dependencies:
+  - minimal_axioms
+  - scale_reference_primitive
+  - kinetic_isotropy_primitive
+runner: scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py
+---
+
+# Scale-Reference `a^{-1}` Is Not The Wick Clock Parameter `a`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact type split between the dimensionful scale-reference conversion
+and the dimensionless Wick clock ratio among quadratic coefficients.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py`](../scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py)
+
+## Result Up Front
+
+The framework writes two different objects with the letter `a`. They are not
+the same type, and the scale-reference primitive does not fix the Wick clock.
+
+1. **Scale-reference `a_sr` is dimensionful.** The registered primitive is the
+   single units conversion `a_sr^{-1} = M_Pl`. It carries no dimensionless
+   content.
+2. **Wick clock `a_w` is dimensionless.** The linear Wick map is
+   `k4 = i a_w omega` with `a_w in Q\{0}`. The Euclidean OS0 form
+   `Q_E = (k4^2 + k^2)/4` does not contain `a_w`. After substitution,
+   `omega_coeff(a_w) = -a_w^2/4` and
+   `|omega_coeff|/spatial_coeff = a_w^2` is a dimensionless ratio of quadratic
+   coefficients.
+3. **The types are unequal.** A units conversion cannot be identified with a
+   ratio of quadratic coefficients. In particular it cannot select
+   `a_w in {1/2, 1, 2}`. The value `a_w = 1/2` remains a legal dimensionless
+   Wick parameter, with `omega_coeff(1/2) = -1/16`.
+4. **Kinetic isotropy is not a Wick parameter.** The registered statement
+   `c_t = c_s` is Euclidean coefficient equality. It is already encoded by
+   `Q_E` and does not name `a_w`.
+5. **This is only a type split.** Speed-preservation among linear Wick maps
+   remains extra. The note does not install `a_w = 1`, does not claim that
+   Planck units fix the Wick map, and does not claim Lorentz closure.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Fraction algebra on the OS0 quadratic and the registered primitive wordings separates a_sr from a_w; speed-preservation, a_w=1, and Lorentz closure remain unclaimed."
+trace_class: negative_route_pruning
+target_claim_id: scale_reference_a_inverse_is_not_wick_clock_parameter
+target_blocker_text: "do not treat the shared letter a as an identification of the scale-reference conversion with the Wick clock parameter"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the type split and the displayed omega_coeff identities; Wick-parameter selection and Lorentz closure remain open"
+hypothetical_axiom_status: "no edit, adoption, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `a_sr` for the scale-reference conversion of
+[`SCALE_REFERENCE_PRIMITIVE_NOTE.md`](SCALE_REFERENCE_PRIMITIVE_NOTE.md):
+
+```text
+a_sr^{-1} = M_Pl.
+```
+
+That note states that this is a units conversion, not a physics axiom, and
+that it carries zero dimensionless content.
+
+Write `a_w` for the Wick clock parameter in the linear map
+
+```text
+k4 = i a_w omega,    a_w in Q\{0}.
+```
+
+The Euclidean OS0 quadratic used here is the `a_w`-free form
+
+```text
+Q_E(k4, k) = (k4^2 + k^2)/4.
+```
+
+Substitute the Wick map. Because `i^2 = -1`,
+
+```text
+Q_E(i a_w omega, k) = (-a_w^2 omega^2 + k^2)/4
+                    = omega_coeff(a_w) omega^2 + spatial_coeff k^2,
+```
+
+with the exact identities
+
+```text
+omega_coeff(a_w) = -a_w^2 / 4,
+spatial_coeff    = 1/4,
+|omega_coeff(a_w)| / spatial_coeff = a_w^2.
+```
+
+The displayed reconstructions used below are
+
+```text
+omega_coeff(1/2) = -1/16,
+omega_coeff(2)   = -1,
+spatial_coeff    = 1/4.
+```
+
+The ratio `a_w^2` is a dimensionless rational. The conversion `a_sr` is not.
+
+Kinetic isotropy, from
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md),
+is the Euclidean coefficient equality `c_t = c_s`. In the form `Q_E` that
+equality is already the shared prefactor `1/4` on `k4^2` and `k^2`. It is not
+a value of `a_w`.
+
+The axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+names Lattice, Qubit, Admissibility, and Record. It does not identify `a_sr`
+with a Wick clock parameter and does not install `a_w = 1`.
+
+Identity gates in the companion runner call `omega_coeff(a)` and
+`is_dimensionless_ratio`. They do not compare a hardcoded constant to itself.
+
+## Theorem 1 — Unequal Types
+
+`a_sr` is dimensionful: it is the units conversion `a_sr^{-1} = M_Pl`.
+
+`a_w` is a dimensionless ratio of quadratic coefficients: after the Wick
+substitution into `Q_E`,
+
+```text
+|omega_coeff(a_w)| / spatial_coeff = a_w^2 in Q_{>0}.
+```
+
+These are unequal types. Reconstructing the coefficients does not require
+choosing a preferred `a_w`:
+
+```text
+omega_coeff(1/2) = -1/16,
+omega_coeff(2)   = -1,
+spatial_coeff    = 1/4.
+```
+
+A dimensionful ruler and a dimensionless quadratic ratio cannot be the same
+object.
+
+## Theorem 2 — Scale-Reference Cannot Select The Wick Clock
+
+The scale-reference primitive states that it carries no dimensionless
+content: no mass ratio, coupling, mixing angle, phase, selector, readout
+bridge, or empirical fit is supplied by it.
+
+The legal sample `{1/2, 1, 2}` consists of distinct nonzero rationals. Each
+gives a distinct `omega_coeff`:
+
+```text
+omega_coeff(1/2) = -1/16,
+omega_coeff(1)   = -1/4,
+omega_coeff(2)   = -1.
+```
+
+A conversion with no dimensionless content cannot select among those values.
+In particular it cannot select `a_w = 1`.
+
+## Theorem 3 — Kinetic Isotropy Is Euclidean, Not A Wick Parameter
+
+The kinetic-isotropy primitive states `c_t = c_s`: the Osterwalder-Schrader
+OS0 kinetic normalization of the Euclidean regulator. That is equality of
+the Euclidean quadratic coefficients of `k4^2` and `k^2`.
+
+`Q_E = (k4^2 + k^2)/4` already encodes that equality and does not contain
+`a_w`. The Wick parameter appears only after the substitution
+`k4 = i a_w omega`. Therefore `c_t = c_s` is not a selection of `a_w`.
+
+## Theorem 4 — What This Does Not Replace
+
+This type split does not replace speed-preservation among linear Wick maps.
+Speed-preservation remains an extra condition, not supplied by `a_sr` and
+not supplied by `c_t = c_s`.
+
+This note does not install `a_w = 1`.
+
+This note does not claim Lorentz closure.
+
+This note does not claim that Planck units fix the Wick map.
+
+## Theorem 5 — Shared Letter Is Not Identification
+
+The scale-reference note writes `a^{-1} = M_Pl`. The Wick clock writes
+`k4 = i a_w omega`. The shared letter `a` is notation, not a theorem.
+
+Do not treat the shared letter as an identification of `a_sr` with `a_w`.
+
+## Mutation
+
+The predicate "`a_sr` selects `a_w = 1`" must fail. The value `a_w = 1/2`
+remains a legal dimensionless Wick parameter, and
+
+```text
+omega_coeff(1/2) = -1/16
+```
+
+is the exact quadratic coefficient of that legal value.
+
+Any identity gate that reconstructs `omega_coeff` or tests the type of the
+quadratic ratio must call `omega_coeff(a)` and `is_dimensionless_ratio`.
+
+## What This Does Not Do
+
+- It does not add or amend an axiom. The axiom memo remains
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+- It does not edit a registered primitive.
+- It does not install `a_w = 1` or any other preferred Wick clock value.
+- It does not claim that the Planck-mass conversion fixes the Wick map.
+- It does not claim Lorentz closure or replace speed-preservation.
+- It does not change any audit verdict.
+
+## Dependencies
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — current
+  axiom memo; four named axioms, no Wick-clock identification.
+- [`SCALE_REFERENCE_PRIMITIVE_NOTE.md`](SCALE_REFERENCE_PRIMITIVE_NOTE.md) —
+  dimensionful units conversion `a^{-1} = M_Pl` with no dimensionless content.
+- [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) —
+  Euclidean OS0 equality `c_t = c_s`, not a Wick parameter.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16401,6 +16401,10 @@
   "scalar_trace_tensor_record_invariance_companion_note_2026-06-04": {
    "deps_hash": "02deca191ed1",
    "out_degree": 2
+  },
+  "scale_reference_a_inverse_is_not_wick_clock_parameter_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "872a440eb583",
+   "out_degree": 3
   },
   "scale_reference_primitive": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.txt
+++ b/logs/runner-cache/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.txt
@@ -1,0 +1,30 @@
+===== runner cache v1 =====
+runner: scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py
+runner_sha256: fa33ed5063e39a0bbcdcd438eae091220c9d1cacf8c23aa60960754dd1bc1c39
+input_fingerprint_sha256: 15bb934fd8da9e60b1bc16a04f21076a157536dbb4d9a7b035b90ec29fcd0292
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none; algebra is exact Fraction substitution into Q_E
+package_local_integrity_reads: new note, scale-reference primitive, kinetic isotropy, axiom memo
+negative_scope: type split only; a_w=1 is not installed; speed-preservation and Lorentz remain extra
+PASS: identity-omega-half omega_coeff(1/2) reconstructs -1/16
+PASS: identity-omega-two omega_coeff(2) reconstructs -1
+PASS: identity-spatial spatial_coeff reconstructs 1/4 from Q_E
+PASS: identity-ratio-half is_dimensionless_ratio(|omega_coeff(1/2)|, spatial_coeff) and the ratio is (1/2)^2
+PASS: identity-ratio-two is_dimensionless_ratio(|omega_coeff(2)|, spatial_coeff) and the ratio is 2^2
+PASS: identity-ratio-one-not-installed omega_coeff(1)=-1/4 is legal but is_dimensionless_ratio does not install a_w=1
+PASS: q-e-independent-of-aw Q_E(k4^2, k^2) has no a_w argument and is unchanged across Wick samples
+PASS: types-unequal a_sr is dimensionful; a_w ratios are dimensionless
+PASS: mutation-selects-one-fails predicate a_sr selects a_w=1 fails; a_w=1/2 remains legal
+PASS: source-scale-reference scale-reference is a_sr^{-1}=M_Pl with no dimensionless content
+PASS: source-kinetic-isotropy kinetic isotropy is Euclidean c_t=c_s, not a Wick parameter
+PASS: source-axiom-memo axiom memo names the four axioms and does not install a Wick clock
+PASS: note-theorems-and-gates note records Theorems 1-5, the mutation, and the required identity-gate names
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py
+++ b/scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Exact type split: scale-reference a_sr is not the Wick clock parameter a_w.
+
+Identity gates call omega_coeff(a) and is_dimensionless_ratio. Values are
+derived by substituting k4 = i a_w omega into Q_E = (k4^2 + k^2)/4 using
+exact Fraction arithmetic. The runner does not install a_w = 1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "SCALE_REFERENCE_A_INVERSE_IS_NOT_WICK_CLOCK_PARAMETER_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+SCALE_PATH = ROOT / "docs" / "SCALE_REFERENCE_PRIMITIVE_NOTE.md"
+KINETIC_PATH = ROOT / "docs" / "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/SCALE_REFERENCE_A_INVERSE_IS_NOT_WICK_CLOCK_PARAMETER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/SCALE_REFERENCE_PRIMITIVE_NOTE.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def q_e(k4_sq: Fraction, k_sq: Fraction) -> Fraction:
+    """Euclidean OS0 form Q_E = (k4^2 + k^2)/4. No Wick parameter."""
+    return (k4_sq + k_sq) / Fraction(4)
+
+
+def wick_k4_squared(a_w: Fraction, omega: Fraction) -> Fraction:
+    """k4 = i a_w omega implies k4^2 = -a_w^2 omega^2."""
+    return -(a_w * a_w) * (omega * omega)
+
+
+def omega_coeff(a: Fraction) -> Fraction:
+    """Coefficient of omega^2 after substituting k4 = i a omega into Q_E."""
+    return q_e(wick_k4_squared(a, Fraction(1)), Fraction(0))
+
+
+def spatial_coeff() -> Fraction:
+    """Coefficient of k^2 in Q_E. Independent of a_w."""
+    return q_e(Fraction(0), Fraction(1))
+
+
+@dataclass(frozen=True)
+class TypedQuantity:
+    value: Fraction
+    dimensionful: bool
+
+
+def is_dimensionless_ratio(
+    numerator: Fraction | TypedQuantity,
+    denominator: Fraction | TypedQuantity | None = None,
+) -> bool:
+    """True iff the argument is a nonzero rational ratio of quadratic coefficients."""
+    if denominator is None:
+        if isinstance(numerator, TypedQuantity):
+            return (not numerator.dimensionful) and numerator.value != 0
+        return False
+    if isinstance(numerator, TypedQuantity) or isinstance(denominator, TypedQuantity):
+        left = numerator if isinstance(numerator, TypedQuantity) else TypedQuantity(Fraction(numerator), False)
+        right = (
+            denominator
+            if isinstance(denominator, TypedQuantity)
+            else TypedQuantity(Fraction(denominator), False)
+        )
+        if left.dimensionful or right.dimensionful or right.value == 0:
+            return False
+        return left.value != 0
+    if denominator == 0:
+        return False
+    return Fraction(numerator) != 0
+
+
+def scale_reference_selects_wick_clock(target: Fraction) -> bool:
+    """Predicate 'a_sr selects a_w = target'. Must fail for target = 1."""
+    del target
+    a_sr = TypedQuantity(Fraction(1), dimensionful=True)
+    if is_dimensionless_ratio(a_sr):
+        return True
+    return False
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    scale = SCALE_PATH.read_text(encoding="utf-8")
+    kinetic = KINETIC_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    scale_n = normalize(scale)
+    kinetic_n = normalize(kinetic)
+    axiom_n = normalize(axiom)
+
+    print("external_scientific_inputs: none; algebra is exact Fraction substitution into Q_E")
+    print("package_local_integrity_reads: new note, scale-reference primitive, kinetic isotropy, axiom memo")
+    print("negative_scope: type split only; a_w=1 is not installed; speed-preservation and Lorentz remain extra")
+
+    half = Fraction(1, 2)
+    one = Fraction(1)
+    two = Fraction(2)
+    a_sr = TypedQuantity(Fraction(1), dimensionful=True)
+
+    checks.check(
+        "identity-omega-half",
+        "omega_coeff(1/2) reconstructs -1/16",
+        omega_coeff(half) == Fraction(-1, 16),
+    )
+    checks.check(
+        "identity-omega-two",
+        "omega_coeff(2) reconstructs -1",
+        omega_coeff(two) == Fraction(-1),
+    )
+    checks.check(
+        "identity-spatial",
+        "spatial_coeff reconstructs 1/4 from Q_E",
+        spatial_coeff() == Fraction(1, 4),
+    )
+    checks.check(
+        "identity-ratio-half",
+        "is_dimensionless_ratio(|omega_coeff(1/2)|, spatial_coeff) and the ratio is (1/2)^2",
+        is_dimensionless_ratio(abs(omega_coeff(half)), spatial_coeff())
+        and abs(omega_coeff(half)) / spatial_coeff() == half * half,
+    )
+    checks.check(
+        "identity-ratio-two",
+        "is_dimensionless_ratio(|omega_coeff(2)|, spatial_coeff) and the ratio is 2^2",
+        is_dimensionless_ratio(abs(omega_coeff(two)), spatial_coeff())
+        and abs(omega_coeff(two)) / spatial_coeff() == two * two,
+    )
+    checks.check(
+        "identity-ratio-one-not-installed",
+        "omega_coeff(1)=-1/4 is legal but is_dimensionless_ratio does not install a_w=1",
+        omega_coeff(one) == Fraction(-1, 4)
+        and is_dimensionless_ratio(abs(omega_coeff(one)), spatial_coeff())
+        and abs(omega_coeff(one)) / spatial_coeff() == one
+        and {half, one, two} != {one},
+    )
+    checks.check(
+        "q-e-independent-of-aw",
+        "Q_E(k4^2, k^2) has no a_w argument and is unchanged across Wick samples",
+        q_e(Fraction(4), Fraction(9)) == Fraction(13, 4)
+        and q_e.__code__.co_argcount == 2,
+    )
+    checks.check(
+        "types-unequal",
+        "a_sr is dimensionful; a_w ratios are dimensionless",
+        a_sr.dimensionful
+        and not is_dimensionless_ratio(a_sr)
+        and is_dimensionless_ratio(abs(omega_coeff(half)), spatial_coeff()),
+    )
+    checks.check(
+        "mutation-selects-one-fails",
+        "predicate a_sr selects a_w=1 fails; a_w=1/2 remains legal",
+        scale_reference_selects_wick_clock(one) is False
+        and omega_coeff(half) == Fraction(-1, 16)
+        and is_dimensionless_ratio(abs(omega_coeff(half)), spatial_coeff()),
+    )
+    checks.check(
+        "source-scale-reference",
+        "scale-reference is a_sr^{-1}=M_Pl with no dimensionless content",
+        "a^{-1} = M_Pl" in scale_n
+        and "carries zero dimensionless content" in scale_n,
+    )
+    checks.check(
+        "source-kinetic-isotropy",
+        "kinetic isotropy is Euclidean c_t=c_s, not a Wick parameter",
+        "c_t = c_s" in kinetic_n
+        and "Osterwalder-Schrader OS0 kinetic" in kinetic_n,
+    )
+    checks.check(
+        "source-axiom-memo",
+        "axiom memo names the four axioms and does not install a Wick clock",
+        all(name in axiom_n for name in ("Lattice", "Qubit", "Admissibility", "Record"))
+        and "a_w" not in axiom
+        and "Wick clock" not in axiom,
+    )
+    checks.check(
+        "note-theorems-and-gates",
+        "note records Theorems 1-5, the mutation, and the required identity-gate names",
+        all(
+            phrase in note
+            for phrase in (
+                "Theorem 1",
+                "Theorem 2",
+                "Theorem 3",
+                "Theorem 4",
+                "Theorem 5",
+                "omega_coeff(1/2) = -1/16",
+                "omega_coeff(2)   = -1",
+                "does not install `a_w = 1`",
+                "omega_coeff(a)",
+                "is_dimensionless_ratio",
+                "Shared Letter Is Not Identification",
+            )
+        ),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Scale-reference `a_sr^{-1}=M_Pl` is dimensionful and carries no dimensionless content. The Wick parameter `a_w` in `k4=i a_w ω` is a dimensionless ratio of quadratic coefficients (`omega_coeff(1/2)=−1/16`). Scale-reference cannot select `a_w`. Kinetic isotropy is Euclidean `c_t=c_s`, not a Wick map. The shared letter `a` is not an identification. `a_w=1` is not installed.

## What this means for the TOE

Planck units do not fix the Wick clock.

## What changed

- Note: `docs/SCALE_REFERENCE_A_INVERSE_IS_NOT_WICK_CLOCK_PARAMETER_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py`
- Cache: `logs/runner-cache/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.txt`

## Verification

```bash
python3 scripts/scale_reference_a_inverse_is_not_wick_clock_parameter_2026_08_13.py
# TOTAL: PASS=14 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
