### PR TITLE
[physics-loop] toe-lphys source3: bounded_theorem / bounded-support

### DIFF
--- a/docs/CUBE_GAUSS_SOURCE_IS_A_3_COCHAIN_NOT_RECORD_I_AT_A_VERTEX_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/CUBE_GAUSS_SOURCE_IS_A_3_COCHAIN_NOT_RECORD_I_AT_A_VERTEX_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,190 @@
+---
+claim_id: cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On one unit cube with a Z2 link field, the unique 3-cochain forced by summing the six face holonomies is identically zero. Vertex Record lock count I is a content-only domain cardinality on the eight vertices and is not that 3-cochain. The cube Gauss source, if written at all, is the displayed 3-cell value rho. The row does not install Newton, a coupling, an inverse-distance kernel, a mass identification, a new Bianchi theorem, or 4D color."
+upstream_dependencies:
+  - minimal_axioms
+  - newton_law_derived_note
+runner: scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py
+---
+
+# Cube Gauss source is a 3-cochain, not Record I at a vertex
+
+> **Key terms used in this doc** are indexed A-Z at
+> [docs/KEY_TERMINOLOGY.md](KEY_TERMINOLOGY.md); each row points to the
+> canonical source-of-truth doc.
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** one unit cube; exact `Z2` link algebra; vertex Record lock patterns.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py`](../scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py)
+
+## Result Up Front
+
+A putative cube Gauss source forced by a `Z2` link field is a 3-cochain `ρ`
+on the cube. Face holonomies sum to `0` for every link field, because each of
+the twelve edges lies in exactly two faces. Hence `ρ=0` identically.
+
+Record scalar readout `I` on a vertex lock pattern is the number of locked
+vertices. There exist patterns with `I=1`. That value is not the cube source
+`ρ`. Record names a content-only count of locks. It does not name a 3-cochain
+on cubes. The extra object for a lattice Gauss source is `ρ` on 3-cells.
+
+Display `ρ`; do not adopt it.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two-count identity and the I-versus-rho type split are exact on one cube. Newton, mass, coupling, and any lattice-wide Gauss law remain uninstalled."
+trace_class: negative_route_pruning
+target_claim_id: cube_gauss_source_type
+target_blocker_text: "name the cube Gauss source type without identifying vertex Record I with a 3-cochain"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the one-cube Z2 source type; physical Gauss law and Newton remain open"
+hypothetical_axiom_status: "no axiom edit, adoption, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Load-Bearing Inputs
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  Lattice sites as points of `Z^3` and the Record wording quoted below. The
+  axiom memo chain-satisfies as an approved premise; it is not a source of
+  bounded status.
+- [`NEWTON_LAW_DERIVED_NOTE.md`](NEWTON_LAW_DERIVED_NOTE.md) is cited only
+  for its source-linearity non-claim: that packet does not promote
+  source-linearity to a physical Newton law. This row does not import that
+  packet's kernel algebra.
+- The unit-cube edge and face listing below is reconstructed in this note. It
+  is not taken as a lemma from any other row.
+
+## Exact Objects
+
+Label the twelve edges of the unit cube by
+
+```text
+x-edges 0,1,2,3
+y-edges 4,5,6,7
+z-edges 8,9,10,11
+```
+
+Reconstruct the six faces as four-edge sets so that each edge lies in exactly
+two faces:
+
+```text
+z=0  {0,5,1,4}
+z=1  {2,7,3,6}
+y=0  {0,9,2,8}
+y=1  {1,11,3,10}
+x=0  {4,10,6,8}
+x=1  {5,11,7,9}
+```
+
+A link field is `θ ∈ {0,1}^12`. The face holonomy of face `f` is the exact
+`Z2` sum of its four edges,
+
+```text
+H_f = (sum_{e in f} θ_e) mod 2.
+```
+
+A putative Gauss source is a 3-cochain `ρ ∈ {0,1}` on the cube obeying
+
+```text
+(sum_f H_f) mod 2 ≡ ρ.
+```
+
+A vertex Record lock pattern is a partial map `L` from the eight vertices to
+`{A,B}`. Unlocked vertices lie outside `dom(L)`. The Record count on that
+pattern is the content-only domain cardinality
+
+```text
+I(L) = |dom(L)| ∈ {0,…,8}.
+```
+
+## Theorem 1
+
+For every link field `θ`,
+
+```text
+sum_f H_f ≡ 0 (mod 2).
+```
+
+Proof. Expand the left-hand side as a sum of edge values. Each of the twelve
+edges appears in exactly two reconstructed faces, so each `θ_e` is counted
+twice. Twice any `Z2` value is `0`. Therefore any Gauss `ρ` forced by a link
+field is `0`.
+
+This two-count is the entire identity. It is not a new Bianchi theorem beyond
+the two-count of each edge.
+
+## Theorem 2
+
+There exist lock patterns with `I=1`: lock one vertex and leave the other
+seven unlocked. For every link field the forced source is `ρ=0`. Hence
+
+```text
+I=1 ≠ 0 = ρ.
+```
+
+Vertex Record `I` is not the cube source.
+
+## Theorem 3
+
+Quote Record
+([`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)):
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+So `I` is a content-only count of locks. It does not name a 3-cochain on
+cubes. The extra object for a lattice Gauss source is `ρ` on 3-cells.
+
+## Theorem 4
+
+This does not install Newton, a gravitational coupling, or an inverse-distance
+kernel. It does not identify `I` with mass. Display `ρ`; do not adopt it.
+
+The Newton parent is used only as a source-linearity non-claim. That parent
+already records that source-linearity is not a physical Newton force law.
+Nothing here enlarges that non-claim into a derivation.
+
+## Theorem 5
+
+Do not cite the two-count as a new Bianchi theorem beyond the two-count of
+each edge. Do not claim 4D color.
+
+## What This Does Not Claim
+
+- It does not install Newton or identify `I` with mass.
+- It does not adopt `ρ` as a primitive, an axiom edit, or a lattice-wide law.
+- It does not derive a physical Gauss law off this one cube.
+- It does not claim 4D color.
+- It does not cite any unmerged pull request.
+
+The safe downstream use is only the type split: the cube source forced by a
+link field is the displayed 3-cochain `ρ=0`, and vertex Record `I` is a
+different object.
+
+## Runner Certificate
+
+The paired runner reconstructs the six face lists, checks the two-count,
+evaluates `bianchi_sum(theta)` on every `Z2` link field, evaluates
+`record_I(locks)` on lock patterns including `I=1`, and checks that the
+hostile predicate "`I=1` equals Gauss `ρ`" fails. Identity gates call
+`bianchi_sum(theta)` and `record_I(locks)`.
+
+Run:
+
+```bash
+python3 scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15603,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2753,6 +2753,10 @@
   "cte_rconn_spatial_tensor_color_bridge_is_a_cross_domain_coincidence_narrow_no_go_note_2026-06-08": {
    "deps_hash": "825a4024d61b",
    "out_degree": 4
+  },
+  "cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "2e55076cdcb9",
+   "out_degree": 3
   },
   "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
    "deps_hash": "04fc7d8812c4",

--- a/logs/runner-cache/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.txt
+++ b/logs/runner-cache/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py
+runner_sha256: 396242bd247a01074ca5e58e2d6e1dea4e2218ace386b8210e090359eec3391f
+input_fingerprint_sha256: ab6a2e4a1c0f41271edb7794699524aa276f551a88506cf8e56cb7d1f529ad9e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom Record wording and the Newton source-linearity non-claim are source-bound; no observational inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency against AUDIT_INPUT_PATHS
+PASS: audit-inputs declared inputs are the new note, the axiom memo, and the Newton note
+PASS: face-reconstruction six faces, each a 4-edge set, cover twelve edges
+PASS: two-count each edge lies in exactly two faces
+PASS: identity-bianchi-zero identity_link_field_rho calls bianchi_sum and returns 0 on sample fields
+PASS: theorem-1-all-fields bianchi_sum(theta) is 0 for every Z2 link field, so forced rho is 0
+PASS: identity-record-I identity_vertex_I calls record_I and counts the lock domain
+PASS: theorem-2-type-split I=1 exists and is not the forced cube source rho=0
+PASS: mutation-i-equals-rho the predicate I=1 equals Gauss rho fails
+PASS: source-record Record I is quoted as content-only additive readout
+PASS: source-newton-nonclaim Newton is cited only as a source-linearity non-claim
+PASS: display-not-adopt rho is displayed and not adopted
+PASS: theorem-5-scope two-count is not a new Bianchi theorem and 4D color is not claimed
+PASS: forbidden-tokens note stays off coupling, inverse-distance, and physical-length tokens
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+per_element: twelve edges and six faces are reconstructed; every Z2 link field is summed
+per_site: Record I is a vertex lock-domain count on the eight cube vertices
+per_block: the only negative block is the I=1 versus rho=0 type split
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py
+++ b/scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Exact Z2 checks: cube Gauss source is a 3-cochain, not vertex Record I.
+
+The runner reconstructs the six unit-cube faces, checks the two-count of each
+edge, evaluates bianchi_sum(theta) on every link field, and evaluates
+record_I(locks) on vertex lock patterns. Identity gates call those two
+functions. The hostile predicate that I=1 equals Gauss rho must fail.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from itertools import product
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "CUBE_GAUSS_SOURCE_IS_A_3_COCHAIN_NOT_RECORD_I_AT_A_VERTEX_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+NEWTON_PATH = ROOT / "docs" / "NEWTON_LAW_DERIVED_NOTE.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CUBE_GAUSS_SOURCE_IS_A_3_COCHAIN_NOT_RECORD_I_AT_A_VERTEX_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/NEWTON_LAW_DERIVED_NOTE.md",
+)
+
+FACES: tuple[frozenset[int], ...] = (
+    frozenset({0, 5, 1, 4}),   # z=0
+    frozenset({2, 7, 3, 6}),   # z=1
+    frozenset({0, 9, 2, 8}),   # y=0
+    frozenset({1, 11, 3, 10}),  # y=1
+    frozenset({4, 10, 6, 8}),  # x=0
+    frozenset({5, 11, 7, 9}),  # x=1
+)
+
+Lock = str | None
+Locks = tuple[Lock, ...]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def holonomy(theta: tuple[int, ...], face: frozenset[int]) -> int:
+    return sum(theta[edge] for edge in face) % 2
+
+
+def bianchi_sum(theta: tuple[int, ...]) -> int:
+    """Z2 sum of the six face holonomies; this is the forced cube source rho."""
+    return sum(holonomy(theta, face) for face in FACES) % 2
+
+
+def record_I(locks: Locks) -> int:
+    """Content-only count of locked vertices."""
+    return sum(lock is not None for lock in locks)
+
+
+def identity_link_field_rho(theta: tuple[int, ...]) -> int:
+    """Identity gate for the link-field source. Must call bianchi_sum(theta)."""
+    return bianchi_sum(theta)
+
+
+def identity_vertex_I(locks: Locks) -> int:
+    """Identity gate for vertex Record count. Must call record_I(locks)."""
+    return record_I(locks)
+
+
+def predicate_i_one_equals_gauss_rho(theta: tuple[int, ...], locks: Locks) -> bool:
+    """Hostile identification: a one-vertex lock equals the cube Gauss source."""
+    return identity_vertex_I(locks) == 1 and identity_vertex_I(locks) == identity_link_field_rho(theta)
+
+
+def edge_face_counts() -> tuple[int, ...]:
+    counts = [0] * 12
+    for face in FACES:
+        for edge in face:
+            counts[edge] += 1
+    return tuple(counts)
+
+
+def function_calls(name: str) -> set[str]:
+    source = inspect.getsource(globals()[name])
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            names.add(node.func.id)
+    return names
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    newton = NEWTON_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_newton = normalize(newton)
+
+    print(
+        "external_scientific_inputs: axiom Record wording and the Newton "
+        "source-linearity non-claim are source-bound; no observational inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency against AUDIT_INPUT_PATHS"
+    )
+
+    checks.check(
+        "audit-inputs",
+        "declared inputs are the new note, the axiom memo, and the Newton note",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CUBE_GAUSS_SOURCE_IS_A_3_COCHAIN_NOT_RECORD_I_AT_A_VERTEX_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/NEWTON_LAW_DERIVED_NOTE.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and NEWTON_PATH.is_file(),
+    )
+    checks.check(
+        "face-reconstruction",
+        "six faces, each a 4-edge set, cover twelve edges",
+        len(FACES) == 6 and all(len(face) == 4 for face in FACES) and set().union(*FACES) == set(range(12)),
+    )
+    checks.check(
+        "two-count",
+        "each edge lies in exactly two faces",
+        edge_face_counts() == (2,) * 12,
+    )
+
+    zero_field = (0,) * 12
+    one_edge = (1,) + (0,) * 11
+    all_ones = (1,) * 12
+    all_rho_zero = all(identity_link_field_rho(theta) == 0 for theta in product((0, 1), repeat=12))
+    checks.check(
+        "identity-bianchi-zero",
+        "identity_link_field_rho calls bianchi_sum and returns 0 on sample fields",
+        "bianchi_sum" in function_calls("identity_link_field_rho")
+        and identity_link_field_rho(zero_field) == 0
+        and identity_link_field_rho(one_edge) == 0
+        and identity_link_field_rho(all_ones) == 0,
+    )
+    checks.check(
+        "theorem-1-all-fields",
+        "bianchi_sum(theta) is 0 for every Z2 link field, so forced rho is 0",
+        all_rho_zero and bianchi_sum(one_edge) == 0,
+    )
+
+    unlocked: Locks = (None,) * 8
+    one_lock: Locks = ("A",) + (None,) * 7
+    other_one_lock: Locks = (None,) * 3 + ("B",) + (None,) * 4
+    full_lock: Locks = ("A", "B", "A", "B", "A", "B", "A", "B")
+    checks.check(
+        "identity-record-I",
+        "identity_vertex_I calls record_I and counts the lock domain",
+        "record_I" in function_calls("identity_vertex_I")
+        and identity_vertex_I(unlocked) == 0
+        and identity_vertex_I(one_lock) == 1
+        and identity_vertex_I(other_one_lock) == 1
+        and identity_vertex_I(full_lock) == 8,
+    )
+    checks.check(
+        "theorem-2-type-split",
+        "I=1 exists and is not the forced cube source rho=0",
+        record_I(one_lock) == 1 and bianchi_sum(zero_field) == 0 and record_I(one_lock) != bianchi_sum(zero_field),
+    )
+    checks.check(
+        "mutation-i-equals-rho",
+        "the predicate I=1 equals Gauss rho fails",
+        predicate_i_one_equals_gauss_rho(zero_field, one_lock) is False
+        and predicate_i_one_equals_gauss_rho(one_edge, other_one_lock) is False
+        and record_I(one_lock) == 1,
+    )
+    checks.check(
+        "source-record",
+        "Record I is quoted as content-only additive readout",
+        "A readout value is determined by record content alone." in normalized_axiom
+        and "scalar readout `I` is additive, with `I(empty)=0`." in normalized_axiom
+        and "`I` is a content-only count of locks" in normalized_note
+        and "does not name a 3-cochain on cubes" in normalized_note
+        and "The extra object for a lattice Gauss source is `ρ` on 3-cells." in note,
+    )
+    checks.check(
+        "source-newton-nonclaim",
+        "Newton is cited only as a source-linearity non-claim",
+        "source-linearity" in normalized_newton
+        and "Newton's law as an unconditional framework output" in newton
+        and "source-linearity non-claim" in normalized_note
+        and "does not install Newton" in normalized_note
+        and "does not identify `I` with mass" in note,
+    )
+    checks.check(
+        "display-not-adopt",
+        "rho is displayed and not adopted",
+        "Display `ρ`; do not adopt it." in note
+        and "we adopt" not in note.lower(),
+    )
+    checks.check(
+        "theorem-5-scope",
+        "two-count is not a new Bianchi theorem and 4D color is not claimed",
+        "not a new Bianchi theorem beyond the two-count" in normalized_note
+        and "Do not claim 4D color." in note
+        and "SU(3)" not in note
+        and "cubebianchi" not in note.lower()
+        and "unittable" not in note.lower(),
+    )
+    forbidden = ("G" + "_N", "1" + "/r", "L" + "_phys")
+    runner_text = Path(__file__).read_text(encoding="utf-8")
+    checks.check(
+        "forbidden-tokens",
+        "note stays off coupling, inverse-distance, and physical-length tokens",
+        all(token not in note for token in forbidden)
+        and all(token not in runner_text for token in forbidden),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+
+    print("per_element: twelve edges and six faces are reconstructed; every Z2 link field is summed")
+    print("per_site: Record I is a vertex lock-domain count on the eight cube vertices")
+    print("per_block: the only negative block is the I=1 versus rho=0 type split")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On one unit cube every Z2 link field has face-holonomy sum 0, so a Gauss 3-cochain forced by links is identically 0. Vertex Record `I` can be 1. `I` is not the cube source. Display `ρ`; do not adopt it. No Newton, `G_N`, or `1/r`.

## What this means for the TOE

A lattice Gauss source is a 3-cell extra, not vertex Record count.

## What changed

- Note: `docs/CUBE_GAUSS_SOURCE_IS_A_3_COCHAIN_NOT_RECORD_I_AT_A_VERTEX_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py`
- Cache: `logs/runner-cache/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.txt`

## Verification

```bash
python3 scripts/cube_gauss_source_is_a_3_cochain_not_record_i_at_a_vertex_2026_08_13.py
# TOTAL: PASS=14 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
