### PR TITLE
[physics-loop] toe-lphys oneweight: bounded_theorem / bounded-support

### DIFF
--- a/docs/ONE_BORN_WEIGHT_DOES_NOT_DETERMINE_THE_DENSITY_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/ONE_BORN_WEIGHT_DOES_NOT_DETERMINE_THE_DENSITY_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,161 @@
+---
+claim_id: one_born_weight_does_not_determine_the_density_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "At one M_2(C) site, a single Born weight Tr(ρP) on one fixed rank-one projector does not recover the density matrix. An exact two-density witness with a=3/5 shares that weight and differs in the off-diagonal. Reconstructing a state needs the full density or enough independent weights. A Record lock of a P-outcome is not either density, and an Admissibility distribution over possibilities is not a density matrix without an identification. The note does not claim the Born form is false, does not replace the 2026-08-09 low-arity uniqueness theorem, and does not adopt ρ as axiom content."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py
+---
+
+# One Born Weight Does Not Determine The Density
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site finite-dimensional algebra on one projector and two
+explicit densities. No frame-function uniqueness argument is launched.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py`](../scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py)
+
+## Result Up Front
+
+A single number `Tr(ρ P)` does not pick `ρ`.
+
+On `H=C^2`, the rank-one projector `P=diag(1,0)` returns only the `(0,0)`
+entry of a density. Two distinct positive trace-one operators share the value
+`3/5` and differ by a nonzero off-diagonal. Therefore a predicate
+“`Tr(ρ P)` recovers `ρ`” fails on that pair.
+
+This is independent of which projector is later selected as a menu member and
+independent of any update map on a declared resolution of the identity. The
+August 9 parent already gives uniqueness after a menu-independent grading on
+every binary and ternary scaled-projector menu. That parent is left in place.
+The present block only displays that one weight on one projector is not that
+input.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: negative_route_pruning
+target_claim_id: one_born_weight_does_not_determine_the_density
+target_blocker_text: "a single number Tr(ρP) does not pick ρ"
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "Keep the extra reconstruction object as the full density or enough independent weights; do not treat one lock or one weight as ρ."
+conditional_surface_status: "exact two-density witness on one projector; uniqueness on a full low-arity menu family remains the August 9 parent"
+hypothetical_axiom_status: "no axiom edit; density is not adopted as axiom content"
+admitted_observation_status: null
+claim_type_reason: "The two-density witness is exact finite algebra; it does not derive a physical identification of Admissibility with a density matrix."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site, with `H=C^2`. Fix the rank-one projector
+
+`P = diag(1, 0)`.
+
+A density has the Hermitian trace-one form
+
+`ρ = [[a, c], [c̄, 1−a]]`
+
+with `a` rational, `0 ≤ a ≤ 1`, and `|c|² ≤ a(1−a)`. The last inequality is
+the principal-minor form of positive semidefiniteness.
+
+Direct multiplication gives
+
+`Tr(ρ P) = a`.
+
+The extra object for a state is the full density (or enough independent weights).
+One diagonal entry does not determine the off-diagonal.
+
+## Theorem 1 — Two Densities, One Weight
+
+Take `a = 3/5`. Display the two-density witness
+
+- `ρ0 = diag(3/5, 2/5)`, off-diagonal `0`. Then `|0|² = 0 ≤ 6/25`, so `ρ0`
+  is positive semidefinite. Its principal minors are `3/5 > 0` and
+  `det(ρ0) = 6/25 ≥ 0`.
+- `ρ1 = [[3/5, 1/5], [1/5, 2/5]]`. Then `|1/5|² = 1/25 ≤ 6/25`, so `ρ1` is
+  positive semidefinite. Its principal minors are `3/5 > 0` and
+  `det(ρ1) = (3/5)(2/5) − 1/25 = 6/25 − 1/25 = 1/5 > 0`.
+
+Both are Hermitian and have trace one. Therefore both are densities. The
+Born weights on the fixed projector agree and the matrices do not:
+
+`Tr(ρ0 P) = Tr(ρ1 P) = 3/5`, and `ρ0 ≠ ρ1` (off-diagonal).
+
+## Theorem 2 — One Weight Does Not Recover The Density
+
+A single Born weight on one projector does not recover `ρ`.
+
+Any map that sends the number `Tr(ρ P)` to a unique density fails on
+`{ρ0, ρ1}`: both inputs produce `3/5`, and the outputs differ. Recovering a
+state on this algebra requires the full density matrix or a list of
+independent weights large enough to fix the remaining Hermitian parameters.
+That reconstruction statement is not an axiom change.
+
+## Theorem 3 — A Lock And A Distribution Are The Wrong Types
+
+The current Record wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+states that a record locks exactly one admissible local possibility, and that
+for any finite collection of pairwise-disjoint records the scalar readout `I`
+is additive with `I(empty)=0`. In that wording, a lock is one admissible
+possibility; `I` is a count.
+
+A lock of a P-outcome is not `ρ0` or `ρ1`. The locked object is one
+admissible possibility. The two displayed densities are candidate operators
+used to form Born weights. They are not that locked possibility.
+
+The current Admissibility wording states that for each site the probability
+distribution over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions, and that the distribution is a probability
+measure on the local possibility domain. A distribution over possibilities is not a density matrix without an identification.
+This note supplies no such identification.
+
+## Theorem 4 — Born, August 9, And The Axiom Surface Stay Put
+
+This note does not claim the Born form is false. The witness uses the Born
+weight `Tr(ρ P)` as the evaluation map and shows only that one such number
+underdetermines `ρ`.
+
+This note does not replace
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md).
+That parent still supplies uniqueness of a density after a menu-independent
+grading on every binary and ternary scaled-projector menu. The present
+hypothesis is one weight on one projector, which is a strictly smaller input.
+
+This note does not adopt `ρ` as axiom content. The four axioms are unchanged.
+The two-density witness is displayed only as finite algebra on supplied
+matrices.
+
+## Theorem 5 — No Half-Trace Specialization And No Frame Relaunch
+
+The witness uses `a = 3/5`, not `1/2`. This note does not force `r=1/2`.
+
+This note does not launch a frame-function uniqueness on all projectors.
+Gleason and the August 9 low-arity lift already live elsewhere. Their
+hypotheses are a nonnegative normalized frame function, or a menu-independent
+grading on every binary and ternary scaled menu. One number `Tr(ρ P)` is not
+that input, and this block does not re-prove those theorems.
+
+## Mutation
+
+Let `R` be the predicate “`Tr(ρ P)` recovers `ρ`” on a finite family of
+densities: `R` holds when each Born weight on the fixed `P` is produced by
+exactly one member of the family. Then `R` fails on `{ρ0, ρ1}`.
+
+## Cited Surfaces
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — Record lock
+  and count; Admissibility distribution on the local possibility domain.
+- [`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+  — uniqueness after a full low-arity grading; not replaced here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13348,6 +13348,10 @@
   },
   "omega_lambda_matter_bridge_theorem_note_2026-04-22": {
    "deps_hash": "f4f3f6286756",
+   "out_degree": 2
+  },
+  "one_born_weight_does_not_determine_the_density_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "8830c572e201",
    "out_degree": 2
   },
   "one_generation_anomaly_singlet_completion_narrow_theorem_note_2026-05-10": {

--- a/logs/runner-cache/one_born_weight_does_not_determine_the_density_2026_08_13.txt
+++ b/logs/runner-cache/one_born_weight_does_not_determine_the_density_2026_08_13.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py
+runner_sha256: d719b6be39250e03e51775af5286055cca49a9ef0830cae5558a1128f5ce65c9
+input_fingerprint_sha256: ead76d67c9501def8c63d4ad895e49c590806beed12f0aa3d439308b58f824ac
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom wording and the August 9 parent are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+PASS: projector-idempotent P is exactly P squared
+PASS: projector-hermitian P equals its adjoint
+PASS: rho0-density rho0 is Hermitian, trace one, and positive semidefinite
+PASS: rho1-density rho1 is Hermitian, trace one, and positive semidefinite
+PASS: psd-witness-bound the off-diagonal of rho1 saturates 1/25 of the 6/25 product bound
+PASS: born-rho0 born(rho0, P) equals 3/5
+PASS: born-rho1 born(rho1, P) equals 3/5
+PASS: same-weight the two densities share one Born weight on P
+PASS: distinct-rho equal_rho(rho0, rho1) is false because the off-diagonals differ
+PASS: diagonal-entry born(rho, P) returns the (0,0) entry for this P
+PASS: not-half-trace the witness diagonal is 3/5, not 1/2
+PASS: mutation-recovers the predicate Tr(rho P) recovers rho fails on {rho0, rho1}
+PASS: source-record the axiom memo names a lock as one possibility and I as an additive count
+PASS: source-admissibility the axiom memo names a neighbor-determined possibility distribution
+PASS: source-parent the August 9 parent still states unique density after low-arity grading
+PASS: note-witness the note displays Tr(ρ0 P)=Tr(ρ1 P)=3/5 and ρ0 ≠ ρ1
+PASS: note-reconstruction the note states that one projector weight does not recover ρ
+PASS: note-types the note quotes lock/count and refuses the distribution-to-density identification
+PASS: note-negative-scope the note keeps Born, August 9, and the axiom surface unmutated
+PASS: note-no-relaunch the note does not force r=1/2 and does not launch frame uniqueness
+PASS: note-forbidden-surface the note has no adoption phrasing and cites no unmerged pull request
+PASS: canonical-nonmutation the displayed witness matrices are absent from the canonical axiom file
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: parent-not-overwritten the parent uniqueness sentence remains in the August 9 file
+per_element: two exact densities and one rank-one projector are checked
+per_site: the underdetermination statement is one-site algebra on M_2(C)
+per_mode: a=3/5 is the only diagonal used; r=1/2 is not forced
+per_block: the rejected block is the predicate that one weight recovers rho
+lattice_wide: checked and not executed — no lattice-wide claim is made
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py
+++ b/scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Exact two-density witness: one Born weight does not recover the density.
+
+Identity gates are born(rho, P) and equal_rho(rho0, rho1). Every same-weight
+or distinct-density check calls those functions. The mutation predicate
+“Tr(ρP) recovers ρ” is required to fail on the displayed pair.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "ONE_BORN_WEIGHT_DOES_NOT_DETERMINE_THE_DENSITY_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+PARENT_PATH = ROOT / "docs" / "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/ONE_BORN_WEIGHT_DOES_NOT_DETERMINE_THE_DENSITY_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def matmul(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def trace(matrix: Matrix) -> Fraction:
+    return matrix[0][0] + matrix[1][1]
+
+
+def det(matrix: Matrix) -> Fraction:
+    return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0]
+
+
+def adjoint(matrix: Matrix) -> Matrix:
+    return (
+        (matrix[0][0], matrix[1][0]),
+        (matrix[0][1], matrix[1][1]),
+    )
+
+
+def born(rho: Matrix, projector: Matrix) -> Fraction:
+    return trace(matmul(rho, projector))
+
+
+def equal_rho(rho0: Matrix, rho1: Matrix) -> bool:
+    return rho0 == rho1
+
+
+def density(diagonal: Fraction, off_diagonal: Fraction) -> Matrix:
+    return (
+        (diagonal, off_diagonal),
+        (off_diagonal, Fraction(1) - diagonal),
+    )
+
+
+def recovers_rho(family: tuple[Matrix, ...], projector: Matrix) -> bool:
+    """Predicate “Tr(ρP) recovers ρ”: each weight comes from exactly one density."""
+    for rho in family:
+        matches = [
+            other
+            for other in family
+            if born(other, projector) == born(rho, projector)
+        ]
+        if len(matches) != 1:
+            return False
+    return True
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_parent = normalize(parent)
+
+    print(
+        "external_scientific_inputs: axiom wording and the August 9 parent "
+        "are source-bound; no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+
+    projector: Matrix = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(0)),
+    )
+    diagonal = Fraction(3, 5)
+    rho0 = density(diagonal, Fraction(0))
+    rho1 = density(diagonal, Fraction(1, 5))
+    family = (rho0, rho1)
+
+    checks.check(
+        "projector-idempotent",
+        "P is exactly P squared",
+        matmul(projector, projector) == projector,
+    )
+    checks.check(
+        "projector-hermitian",
+        "P equals its adjoint",
+        adjoint(projector) == projector,
+    )
+    checks.check(
+        "rho0-density",
+        "rho0 is Hermitian, trace one, and positive semidefinite",
+        adjoint(rho0) == rho0
+        and trace(rho0) == 1
+        and rho0[0][0] > 0
+        and det(rho0) == Fraction(6, 25)
+        and det(rho0) >= 0
+        and rho0[0][1] * rho0[0][1] <= rho0[0][0] * rho0[1][1],
+    )
+    checks.check(
+        "rho1-density",
+        "rho1 is Hermitian, trace one, and positive semidefinite",
+        adjoint(rho1) == rho1
+        and trace(rho1) == 1
+        and rho1[0][0] > 0
+        and det(rho1) == Fraction(1, 5)
+        and det(rho1) > 0
+        and rho1[0][1] * rho1[0][1] <= rho1[0][0] * rho1[1][1],
+    )
+    checks.check(
+        "psd-witness-bound",
+        "the off-diagonal of rho1 saturates 1/25 of the 6/25 product bound",
+        rho1[0][1] * rho1[0][1] == Fraction(1, 25)
+        and rho0[0][0] * rho0[1][1] == Fraction(6, 25),
+    )
+    checks.check(
+        "born-rho0",
+        "born(rho0, P) equals 3/5",
+        born(rho0, projector) == Fraction(3, 5),
+    )
+    checks.check(
+        "born-rho1",
+        "born(rho1, P) equals 3/5",
+        born(rho1, projector) == Fraction(3, 5),
+    )
+    checks.check(
+        "same-weight",
+        "the two densities share one Born weight on P",
+        born(rho0, projector) == born(rho1, projector),
+    )
+    checks.check(
+        "distinct-rho",
+        "equal_rho(rho0, rho1) is false because the off-diagonals differ",
+        not equal_rho(rho0, rho1) and rho0[0][1] != rho1[0][1],
+    )
+    checks.check(
+        "diagonal-entry",
+        "born(rho, P) returns the (0,0) entry for this P",
+        born(rho0, projector) == rho0[0][0] and born(rho1, projector) == rho1[0][0],
+    )
+    checks.check(
+        "not-half-trace",
+        "the witness diagonal is 3/5, not 1/2",
+        diagonal == Fraction(3, 5) and diagonal != Fraction(1, 2),
+    )
+    checks.check(
+        "mutation-recovers",
+        "the predicate Tr(rho P) recovers rho fails on {rho0, rho1}",
+        recovers_rho(family, projector) is False,
+    )
+
+    record_lock = "a record locks exactly one admissible local possibility"
+    record_count = "`I` is additive, with `I(empty)=0`"
+    admissibility = (
+        "the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions"
+    )
+    checks.check(
+        "source-record",
+        "the axiom memo names a lock as one possibility and I as an additive count",
+        record_lock in normalized_axiom and record_count in axiom,
+    )
+    checks.check(
+        "source-admissibility",
+        "the axiom memo names a neighbor-determined possibility distribution",
+        admissibility in normalized_axiom,
+    )
+    checks.check(
+        "source-parent",
+        "the August 9 parent still states unique density after low-arity grading",
+        all(
+            phrase in parent
+            for phrase in (
+                "menu-independent grading",
+                "There is a unique density matrix",
+                "w(E)=Tr(rho E)",
+            )
+        ),
+    )
+    checks.check(
+        "note-witness",
+        "the note displays Tr(ρ0 P)=Tr(ρ1 P)=3/5 and ρ0 ≠ ρ1",
+        "Tr(ρ0 P) = Tr(ρ1 P) = 3/5" in normalized_note
+        and "ρ0 ≠ ρ1" in note,
+    )
+    checks.check(
+        "note-reconstruction",
+        "the note states that one projector weight does not recover ρ",
+        "A single Born weight on one projector does not recover `ρ`" in note
+        and "The extra object for a state is the full density (or enough independent weights)"
+        in normalized_note,
+    )
+    checks.check(
+        "note-types",
+        "the note quotes lock/count and refuses the distribution-to-density identification",
+        "a lock is one admissible possibility; `I` is a count" in normalized_note
+        and "A lock of a P-outcome is not `ρ0` or `ρ1`" in note
+        and "A distribution over possibilities is not a density matrix without an identification"
+        in normalized_note,
+    )
+    checks.check(
+        "note-negative-scope",
+        "the note keeps Born, August 9, and the axiom surface unmutated",
+        "does not claim the Born form is false" in note
+        and "does not replace" in note
+        and "does not adopt `ρ` as axiom content" in note
+        and "two-density witness" in note,
+    )
+    checks.check(
+        "note-no-relaunch",
+        "the note does not force r=1/2 and does not launch frame uniqueness",
+        "does not force `r=1/2`" in note
+        and "does not launch a frame-function uniqueness on all projectors" in note,
+    )
+    checks.check(
+        "note-forbidden-surface",
+        "the note has no adoption phrasing and cites no unmerged pull request",
+        "we adopt" not in note.lower()
+        and "pvmluders" not in note.lower()
+        and "pvmselect" not in note.lower()
+        and "bloch0" not in note.lower()
+        and "nonaffine" not in note.lower()
+        and "PR #" not in note
+        and "github.com" not in note.lower(),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the displayed witness matrices are absent from the canonical axiom file",
+        all(phrase not in axiom for phrase in ("ρ0", "ρ1", "3/5", "oneweight")),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "parent-not-overwritten",
+        "the parent uniqueness sentence remains in the August 9 file",
+        "rho` is unique" in parent or "ρ is unique" in normalized_parent,
+    )
+
+    print("per_element: two exact densities and one rank-one projector are checked")
+    print("per_site: the underdetermination statement is one-site algebra on M_2(C)")
+    print("per_mode: a=3/5 is the only diagonal used; r=1/2 is not forced")
+    print("per_block: the rejected block is the predicate that one weight recovers rho")
+    print("lattice_wide: checked and not executed — no lattice-wide claim is made")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`Tr(ρ0 P)=Tr(ρ1 P)=3/5` for two distinct PSD densities `ρ0=diag(3/5,2/5)` and `ρ1` with off-diagonal `1/5`. One Born weight does not recover `ρ`. A lock of a P-outcome is not a density. August 9 is not replaced. `r=1/2` is not forced.

## What this means for the TOE

A single Born number is not a state.

## What changed

- Note: `docs/ONE_BORN_WEIGHT_DOES_NOT_DETERMINE_THE_DENSITY_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py`
- Cache: `logs/runner-cache/one_born_weight_does_not_determine_the_density_2026_08_13.txt`

## Verification

```bash
python3 scripts/one_born_weight_does_not_determine_the_density_2026_08_13.py
# TOTAL: PASS=24 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
