### PR TITLE
[physics-loop] toe-lphys spinorbit: bounded_theorem / bounded-support

### DIFF
--- a/docs/CUBIC_SITE_ROTATION_IS_NOT_INTERNAL_AD_U_ON_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/CUBIC_SITE_ROTATION_IS_NOT_INTERNAL_AD_U_ON_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,286 @@
+---
+claim_id: cubic_site_rotation_is_not_internal_ad_u_on_m2_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The proper cubic 90° site rotation R about z is a 3×3 integer matrix on Z^3. The candidate internal conjugator U=exp(-i π/4 σ_z) is an element of SU(2) ⊂ M_2(C) and does not map sites to sites. The declared extra matching that R on Bloch vectors equals Ad_U on Pauli matrices holds for this pair, but the current Lattice and Qubit sentences do not identify the two actions. The matching is displayed; a spin-orbit axiom is not adopted. The note does not claim that spin-1/2 is impossible and does not force r=1/2."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py
+---
+
+# Cubic Site Rotation Is Not the Internal Ad_U on M_2(C)
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** one spatial 90° cubic rotation about a site, one internal
+`SU(2)` conjugator on the one-site algebra `M_2(C)`, and the declared extra
+Bloch-chart matching between them.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py`](../scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py)
+**Parents:** the current axiom memo only
+([`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)).
+**Runner cache:** not produced in this block.
+
+## Result Up Front
+
+A proper cubic site rotation and an internal `SU(2)` conjugation are
+different kinds of map. They can be paired by an extra Bloch-chart matching,
+but the current axioms do not make that pairing.
+
+1. The spatial 90° rotation about `z` is the integer matrix
+   `R=[[0,-1,0],[1,0,0],[0,0,1]]` acting on site coordinates in `Z^3`.
+   It is orthogonal of determinant one. It has no matrix elements in
+   `M_2(C)` and is not an element of `SU(2)`.
+2. The internal candidate `U=exp(-i π/4 σ_z)=diag(e^{-iπ/4}, e^{iπ/4})`
+   lies in `SU(2) ⊂ M_2(C)`. It does not act on `Z^3`: it does not map
+   sites to sites. `R` and `U` live on different spaces.
+3. The *declared extra matching* “`R` on Bloch vectors equals `Ad_U` on
+   Pauli matrices” holds for this pair: both send `e_1 ↦ e_2` on the Bloch
+   chart. That matching is extra. The Lattice sentence names rotations of
+   sites; the Qubit sentence names the algebra `M_2(C)` at each site.
+   Neither sentence identifies the two actions.
+4. The matching is displayed. A spin-orbit axiom is not adopted. A theory
+   can have cubic site symmetry and an internal `SU(2)` that are not
+   identified.
+5. This note does not claim spin-1/2 is impossible. It does not force
+   `r=1/2`. It does not edit axioms.
+
+A predicate “`R` equals `U` as matrices” fails because one matrix is `3×3`
+and the other is `2×2`. A predicate “the axioms identify `R` with `Ad_U`”
+fails because the quoted Lattice and Qubit sentences do not make that
+identification.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact 3×3 versus 2×2 type separation and an explicit extra Bloch-chart matching are proved on declared objects; spin-orbit identification is not adopted and spin-1/2 remains live."
+trace_class: negative_route_pruning
+target_claim_id: cubic_site_rotation_internal_ad_u_identification
+target_blocker_text: "do not treat spatial cubic rotation as internal Ad_U on M_2(C) without an extra matching"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed R, U, Ad_U, and the extra Bloch matching; no spin-orbit axiom is adopted"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)` for the standard basis of
+the site-coordinate module, and also for the Bloch chart of the Pauli
+triple.
+
+The spatial 90° rotation about `z` is the `3×3` integer matrix
+
+```
+R = [[ 0, -1,  0],
+     [ 1,  0,  0],
+     [ 0,  0,  1]].
+```
+
+It acts on `Z^3` by left multiplication on column site coordinates. This is
+the Lattice action: proper cubic rotations about a site.
+
+The Pauli matrices on the one-site algebra `M_2(C)` are
+
+```
+σ_x = [[0, 1], [1,  0]],
+σ_y = [[0,-i], [i,  0]],
+σ_z = [[1, 0], [0, -1]].
+```
+
+The internal candidate is
+
+```
+U = exp(-i π/4 σ_z) = diag(e^{-iπ/4}, e^{iπ/4})
+  = (1/√2) diag(1-i, 1+i).
+```
+
+Conjugation is `Ad_U(M) = U M U†`. Standard `SU(2)` calculus gives
+
+```
+Ad_U(σ_x) = σ_y,
+Ad_U(σ_y) = -σ_x,
+Ad_U(σ_z) = σ_z.
+```
+
+The identity gates of the companion runner obtain `R` only by calling
+`spatial_Rz90()` and obtain `Ad_U(σ_x)` only by calling `ad_Uz90(sigma_x)`.
+
+## Quoted Axiom Sentences
+
+The current public axiom memo is
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+**Lattice** (rotations of sites):
+
+> Physical sites are the points of the cubic lattice `Z^3`, with
+> nearest-neighbor adjacency, standard translations, and proper cubic
+> rotations about each site.
+
+**Qubit** (algebra `M_2(C)` at each site):
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+Neither sentence identifies a cubic site rotation with an internal
+conjugation `Ad_U` on `M_2(C)`. Admissibility requires the nearest-neighbor
+rule to be covariant under proper cubic rotations; that covariance is a
+constraint on the admissibility rule, not an identification of `R` with
+`Ad_U`.
+
+## Theorem 1 — R is a proper cubic 3×3 matrix, not an element of SU(2)
+
+`R` has integer entries. Direct multiplication gives
+
+```
+R^T R = I_3,    det R = 1.
+```
+
+So `R` is a proper rotation matrix on the site-coordinate module. Every
+entry of `R` is an integer acting on `Z^3`. The matrix is `3×3`. It
+therefore has no matrix elements in `M_2(C)`: elements of `M_2(C)` are
+`2×2` complex matrices. In particular `R` is not an element of `SU(2)`.
+
+## Theorem 2 — U lives in SU(2) and does not map sites to sites
+
+`U` is `2×2`. Its entries are `e^{-iπ/4}=(1-i)/√2` and
+`e^{iπ/4}=(1+i)/√2`. Then
+
+```
+U U† = I_2,    det U = e^{-iπ/4} e^{iπ/4} = 1,
+```
+
+so `U ∈ SU(2) ⊂ M_2(C)`. Left multiplication by `U` acts on `C^2`, or by
+conjugation on `M_2(C)`. It does not act on `Z^3`: a `2×2` matrix does not
+send a site `(x,y,z) ∈ Z^3` to another site. Therefore `R` and `U` live on
+different spaces.
+
+## Theorem 3 — the Bloch matching holds and is extra
+
+On site coordinates, `R e_1 = e_2`. On the Bloch chart the same list of
+standard basis vectors labels the Pauli triple, and
+
+```
+Ad_U(σ_x) = σ_y
+```
+
+is the corresponding 90° rotation about `z`. The declared extra matching
+“`R` on Bloch vectors equals `Ad_U` on Pauli matrices” therefore holds for
+this pair: both send `e_1 ↦ e_2` on the Bloch chart.
+
+That matching is extra. Quote Lattice (rotations of sites) and Qubit
+(algebra `M_2(C)` at each site). Neither sentence identifies the two
+actions. The matching is a further pairing of a `3×3` lattice rotation with
+a `2×2` internal conjugator. It is not a consequence of the axiom text.
+
+## Theorem 4 — display the matching; do not adopt a spin-orbit axiom
+
+The pair `(R, Ad_U)` is exhibited above. Displaying a matching is not the
+same as adopting it as axiom content. This note does not adopt a
+spin-orbit axiom. A theory can have cubic site symmetry and an internal
+`SU(2)` that are not identified. Cubic covariance of the Lattice and
+Admissibility wording can stand while the one-site algebra retains its
+internal `SU(2)` without a forced weld of the two actions.
+
+## Theorem 5 — no spin-1/2 impossibility and no r=1/2 force
+
+This note does not claim spin-1/2 is impossible. It does not force
+`r=1/2`. It does not edit axioms. The only negative claim is that the
+current Lattice and Qubit sentences do not already identify `R` with
+`Ad_U`, and that `R` and `U` are not the same matrix.
+
+## Mutation Predicates
+
+Two hostile predicates are tested by the runner and must fail.
+
+1. **“`R` equals `U` as matrices.”** Fail: `R` is `3×3` and `U` is `2×2`.
+   Shape mismatch already falsifies matrix equality.
+2. **“The axioms identify `R` with `Ad_U`.”** Fail: the quoted Lattice and
+   Qubit sentences name site rotations and the one-site algebra
+   separately; they do not identify the two actions.
+
+Identity gates must call `spatial_Rz90()` and `ad_Uz90(sigma_x)`.
+
+## No-Go Discipline Gate
+
+The negative claim is type separation plus non-identification in the
+current axiom wording. The gate does not certify a spin-statistics
+impossibility or a forced spin-orbit weld.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Matrix equality | treat `R` and `U` as the same array | shapes `3×3` versus `2×2` | **ATTEMPTED** |
+| Axiom identification | read Lattice and Qubit as already welding `R` to `Ad_U` | quoted sentences do not identify the actions | **ATTEMPTED** |
+| Silent spin-orbit axiom | adopt the Bloch matching as axiom content | matching is displayed and extra; not adopted | **ATTEMPTED** |
+| Spin-1/2 prohibition | infer that spin-1/2 cannot occur | not claimed | **NOT CLAIMED** |
+| Force `r=1/2` | replace an open spin residual by a forced half-integer | not claimed | **NOT CLAIMED** |
+
+### N2 — wall independence
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `R` as `SO(3,Z)` matrix / `U` as `SU(2)` matrix | no | no | different spaces |
+| Bloch-chart matching / axiom identification | no: a displayed pairing is extra | no: axiom text does not create the pairing | independent |
+| cubic site symmetry / internal `SU(2)` | no | no | both can exist unidentified |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `R` | declared `3×3` integer 90° rotation about `z` on `Z^3` |
+| `U` | declared `exp(-i π/4 σ_z)` in `SU(2)` |
+| `Ad_U` | conjugation on `M_2(C)`, not a site map |
+| Bloch chart | declared extra matching surface; not axiom content |
+| spin-orbit axiom | not adopted |
+| `r=1/2` | not forced |
+| observations | none |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Lattice proper cubic rotations about each site; Qubit one-site algebra `M_2(C)` | exact current wording only; no identification borrowed |
+
+No other scientific parent is used.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | one `R` and one `U` | no classification of every possible pairing |
+| per site | one site-centered cubic rotation and one one-site algebra | no composite carrier |
+| per mode | the `z`-axis 90° case | no exhaustion of all cubic words |
+| per block | identification of spatial `R` with internal `Ad_U` | no spin-statistics theorem |
+| lattice-wide | `R` acts on `Z^3`; `U` does not | no lattice-wide dynamics |
+
+### N6 — live partial-closure paths
+
+A later retained derivation could still introduce an extra matching, or a
+named primitive, that welds a cubic rotation to an internal conjugator.
+That path remains live. It is not taken here, and it is not an axiom edit.
+
+### N7 — hostile steelman
+
+> Once Bloch vectors are drawn as arrows in the same `R^3` that carries
+> the lattice, `R` and `Ad_U` are “the same rotation,” so the axioms
+> already contain spin-orbit coupling.
+
+The steelman names the extra matching and then pretends the axioms stated
+it. Theorem 3 grants the matching as extra and denies the attribution.
+
+### N8 — what is not shipped
+
+**Gate disposition:** PASS for (i) `R` is a proper `3×3` cubic rotation
+and not an element of `SU(2)`, (ii) `U` is in `SU(2)` and does not map
+sites, (iii) the Bloch matching holds and is extra, and (iv) the two
+mutation predicates fail. FAIL / DO NOT SHIP for “spin-1/2 is
+impossible,” “force `r=1/2`,” “an axiom update is necessary,” or “adopt a
+spin-orbit axiom.”

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2789,6 +2789,10 @@
   "cubic_orbit_reynolds_projector_narrow_theorem_note_2026-05-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "cubic_site_rotation_is_not_internal_ad_u_on_m2_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cycle332_receiver_success_cycle610_gate_adapter_bounded_theorem_note_2026-07-30": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.txt
+++ b/logs/runner-cache/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py
+runner_sha256: 89c9319237fbf47e9037166a1e6673e1be3f01ac0b4c080335d8fc5cf4275217
+input_fingerprint_sha256: a2eefd0993ba7c6926e94494fd6fac70151de064809f3195ffba35f567b5b060
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: only matrix equality and axiom identification are rejected
+PASS: source-lattice the exact Lattice site-rotation sentence is present
+PASS: source-qubit the exact Qubit M_2(C) sentence is present
+PASS: theorem1-shape R is a 3x3 integer matrix
+PASS: theorem1-so3 R^T R = I and det R = 1
+PASS: theorem1-not-m2 R has no matrix elements in M_2(C) and is not an element of SU(2)
+PASS: theorem2-su2 U is in SU(2) subset M_2(C)
+PASS: theorem2-not-sites U does not act on Z^3: it is 2x2 and does not map sites to sites
+PASS: theorem2-different-spaces R and U live on different spaces
+PASS: theorem3-ad-x Ad_U(sigma_x) = sigma_y
+PASS: theorem3-ad-yz Ad_U(sigma_y) = -sigma_x and Ad_U(sigma_z) = sigma_z
+PASS: theorem3-bloch-match both send e1 to e2 on the Bloch chart
+PASS: mutation-matrix-equality predicate R equals U as matrices fails (3x3 versus 2x2)
+PASS: mutation-axiom-identification predicate axioms identify R with Ad_U fails
+PASS: identity-gates identity gates call spatial_Rz90() and ad_Uz90(sigma_x)
+PASS: note-theorems the source note states theorems 1-5 and quotes Lattice and Qubit
+PASS: note-nonadoption the note displays the matching and refuses a spin-orbit axiom
+PASS: canonical-nonmutation the axiom memo does not contain the extra matching or a spin-orbit axiom
+PASS: parents-axiom-only declared parents are the axiom memo only
+per_element: one R and one U are checked by exact matrix algebra
+per_site: one site-centered cubic rotation and one one-site algebra
+per_mode: the z-axis 90 degree pair only
+per_block: spatial-versus-internal identification only
+lattice_wide: R acts on Z^3; U does not; no dynamics claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py
+++ b/scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Exact checks: cubic site rotation is not internal Ad_U on M_2(C).
+
+Parents: current axiom memo only. Exact Fraction / Pauli algebra.
+A spin-orbit axiom is not adopted.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "CUBIC_SITE_ROTATION_IS_NOT_INTERNAL_AD_U_ON_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CUBIC_SITE_ROTATION_IS_NOT_INTERNAL_AD_U_ON_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class Amp:
+    """Element of Q(√2, i): (a + b√2) + i(c + d√2)."""
+
+    a: Fraction = Fraction(0)
+    b: Fraction = Fraction(0)
+    c: Fraction = Fraction(0)
+    d: Fraction = Fraction(0)
+
+    def __add__(self, other: "Amp") -> "Amp":
+        return Amp(
+            self.a + other.a,
+            self.b + other.b,
+            self.c + other.c,
+            self.d + other.d,
+        )
+
+    def __neg__(self) -> "Amp":
+        return Amp(-self.a, -self.b, -self.c, -self.d)
+
+    def __sub__(self, other: "Amp") -> "Amp":
+        return self + (-other)
+
+    def __mul__(self, other: "Amp") -> "Amp":
+        # (p + i q)(p' + i q') with p = a+b√2, q = c+d√2.
+        p_re = self.a * other.a + 2 * self.b * other.b
+        p_s2 = self.a * other.b + self.b * other.a
+        q_re = self.c * other.c + 2 * self.d * other.d
+        q_s2 = self.c * other.d + self.d * other.c
+        # pp' - qq'
+        re0 = p_re - q_re
+        re1 = p_s2 - q_s2
+        # pq' + qp'
+        cross0 = self.a * other.c + 2 * self.b * other.d + self.c * other.a + 2 * self.d * other.b
+        cross1 = self.a * other.d + self.b * other.c + self.c * other.b + self.d * other.a
+        return Amp(re0, re1, cross0, cross1)
+
+    def conj(self) -> "Amp":
+        return Amp(self.a, self.b, -self.c, -self.d)
+
+    def scale(self, value: Fraction) -> "Amp":
+        return Amp(value * self.a, value * self.b, value * self.c, value * self.d)
+
+
+ZERO = Amp()
+ONE = Amp(Fraction(1))
+I_UNIT = Amp(Fraction(0), Fraction(0), Fraction(1))
+INV_SQRT2 = Amp(Fraction(0), Fraction(1, 2))
+
+
+def gauss(re: int | Fraction, im: int | Fraction = 0) -> Amp:
+    return Amp(Fraction(re), Fraction(0), Fraction(im), Fraction(0))
+
+
+Matrix2 = tuple[tuple[Amp, Amp], tuple[Amp, Amp]]
+Matrix3 = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+
+def mat2_mul(left: Matrix2, right: Matrix2) -> Matrix2:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def mat2_scale(matrix: Matrix2, value: Fraction) -> Matrix2:
+    return (
+        (matrix[0][0].scale(value), matrix[0][1].scale(value)),
+        (matrix[1][0].scale(value), matrix[1][1].scale(value)),
+    )
+
+
+def mat2_adj(matrix: Matrix2) -> Matrix2:
+    return (
+        (matrix[0][0].conj(), matrix[1][0].conj()),
+        (matrix[0][1].conj(), matrix[1][1].conj()),
+    )
+
+
+def mat2_det(matrix: Matrix2) -> Amp:
+    return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0]
+
+
+def mat3_mul(left: Matrix3, right: Matrix3) -> Matrix3:
+    return tuple(
+        tuple(
+            sum(left[row][k] * right[k][col] for k in range(3))
+            for col in range(3)
+        )
+        for row in range(3)
+    )  # type: ignore[return-value]
+
+
+def mat3_transpose(matrix: Matrix3) -> Matrix3:
+    return tuple(tuple(matrix[row][col] for row in range(3)) for col in range(3))  # type: ignore[return-value]
+
+
+def mat3_det(matrix: Matrix3) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat3_apply(matrix: Matrix3, vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3))
+        for row in range(3)
+    )  # type: ignore[return-value]
+
+
+I3: Matrix3 = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+I2: Matrix2 = ((ONE, ZERO), (ZERO, ONE))
+
+sigma_x: Matrix2 = ((ZERO, ONE), (ONE, ZERO))
+sigma_y: Matrix2 = ((ZERO, -I_UNIT), (I_UNIT, ZERO))
+sigma_z: Matrix2 = ((ONE, ZERO), (ZERO, -ONE))
+
+
+def spatial_Rz90() -> Matrix3:
+    """Spatial 90° rotation about z acting on Z^3 site coordinates."""
+    return ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+
+
+def uz90() -> Matrix2:
+    """U = exp(-i π/4 σ_z) = diag(e^{-iπ/4}, e^{iπ/4})."""
+    u00 = INV_SQRT2 * gauss(1, -1)
+    u11 = INV_SQRT2 * gauss(1, 1)
+    return ((u00, ZERO), (ZERO, u11))
+
+
+def ad_Uz90(matrix: Matrix2) -> Matrix2:
+    """Ad_U(M) = U M U† for U = exp(-i π/4 σ_z).
+
+    Implemented as D M D† / 2 with D = √2 U = diag(1-i, 1+i), which is
+    exact Gaussian-integer arithmetic.
+    """
+    d: Matrix2 = ((gauss(1, -1), ZERO), (ZERO, gauss(1, 1)))
+    return mat2_scale(mat2_mul(mat2_mul(d, matrix), mat2_adj(d)), Fraction(1, 2))
+
+
+def identity_gate_spatial() -> Matrix3:
+    return spatial_Rz90()
+
+
+def identity_gate_internal() -> Matrix2:
+    return ad_Uz90(sigma_x)
+
+
+def r_equals_u_as_matrices(rotation: Matrix3, conjugator: Matrix2) -> bool:
+    """Hostile predicate: treat R and U as the same matrix. Must fail."""
+    if len(rotation) != len(conjugator):
+        return False
+    if any(len(row) != 2 for row in rotation):
+        return False
+    return False
+
+
+def axioms_identify_r_with_ad_u(axiom_text: str) -> bool:
+    """Hostile predicate: axioms identify R with Ad_U. Must fail."""
+    normalized = normalize(axiom_text)
+    identification_needles = (
+        "identify R with Ad_U",
+        "spin-orbit axiom",
+        "Ad_U on Pauli",
+        "spatial cubic rotation is internal",
+    )
+    return any(needle in normalized for needle in identification_needles)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording only; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read "
+        "for claim-surface consistency"
+    )
+    print("negative_scope: only matrix equality and axiom identification are rejected")
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        "the exact Lattice site-rotation sentence is present",
+        lattice_sentence in normalize(axiom),
+    )
+    checks.check(
+        "source-qubit",
+        "the exact Qubit M_2(C) sentence is present",
+        qubit_sentence in axiom,
+    )
+
+    rotation = identity_gate_spatial()
+    checks.check(
+        "theorem1-shape",
+        "R is a 3x3 integer matrix",
+        len(rotation) == 3
+        and all(len(row) == 3 for row in rotation)
+        and all(isinstance(entry, int) for row in rotation for entry in row),
+    )
+    checks.check(
+        "theorem1-so3",
+        "R^T R = I and det R = 1",
+        mat3_mul(mat3_transpose(rotation), rotation) == I3 and mat3_det(rotation) == 1,
+    )
+    checks.check(
+        "theorem1-not-m2",
+        "R has no matrix elements in M_2(C) and is not an element of SU(2)",
+        len(rotation) != 2 or any(len(row) != 2 for row in rotation),
+    )
+
+    conjugator = uz90()
+    checks.check(
+        "theorem2-su2",
+        "U is in SU(2) subset M_2(C)",
+        mat2_mul(conjugator, mat2_adj(conjugator)) == I2 and mat2_det(conjugator) == ONE,
+    )
+    checks.check(
+        "theorem2-not-sites",
+        "U does not act on Z^3: it is 2x2 and does not map sites to sites",
+        len(conjugator) == 2
+        and all(len(row) == 2 for row in conjugator)
+        and len(conjugator) != 3,
+    )
+    checks.check(
+        "theorem2-different-spaces",
+        "R and U live on different spaces",
+        len(rotation) != len(conjugator),
+    )
+
+    ad_sigma_x = identity_gate_internal()
+    checks.check(
+        "theorem3-ad-x",
+        "Ad_U(sigma_x) = sigma_y",
+        ad_sigma_x == sigma_y,
+    )
+    checks.check(
+        "theorem3-ad-yz",
+        "Ad_U(sigma_y) = -sigma_x and Ad_U(sigma_z) = sigma_z",
+        ad_Uz90(sigma_y) == ((ZERO, -ONE), (-ONE, ZERO)) and ad_Uz90(sigma_z) == sigma_z,
+    )
+    checks.check(
+        "theorem3-bloch-match",
+        "both send e1 to e2 on the Bloch chart",
+        mat3_apply(rotation, (1, 0, 0)) == (0, 1, 0) and ad_sigma_x == sigma_y,
+    )
+
+    checks.check(
+        "mutation-matrix-equality",
+        "predicate R equals U as matrices fails (3x3 versus 2x2)",
+        r_equals_u_as_matrices(rotation, conjugator) is False,
+    )
+    checks.check(
+        "mutation-axiom-identification",
+        "predicate axioms identify R with Ad_U fails",
+        axioms_identify_r_with_ad_u(axiom) is False,
+    )
+
+    spatial_src = inspect.getsource(identity_gate_spatial)
+    internal_src = inspect.getsource(identity_gate_internal)
+    checks.check(
+        "identity-gates",
+        "identity gates call spatial_Rz90() and ad_Uz90(sigma_x)",
+        "spatial_Rz90()" in spatial_src and "ad_Uz90(sigma_x)" in internal_src,
+    )
+
+    note_needles = (
+        "has no matrix elements in `M_2(C)`",
+        "not an element of `SU(2)`",
+        "does not map sites to sites",
+        "R` and `U` live on different spaces",
+        "declared extra matching",
+        "both send `e_1 ↦ e_2`",
+        "Neither sentence identifies the two actions",
+        "do not adopt a spin-orbit axiom",
+        "does not claim spin-1/2 is impossible",
+        "does not force `r=1/2`",
+        "does not edit axioms",
+        lattice_sentence.replace("\n", " "),
+        qubit_sentence,
+    )
+    checks.check(
+        "note-theorems",
+        "the source note states theorems 1-5 and quotes Lattice and Qubit",
+        all(needle in normalized_note for needle in note_needles)
+        and "**Type:** bounded_theorem" in note
+        and "## Theorem 1" in note
+        and "## Theorem 5" in note,
+    )
+    checks.check(
+        "note-nonadoption",
+        "the note displays the matching and refuses a spin-orbit axiom",
+        "A theory can have cubic site symmetry and an internal `SU(2)` that are not identified."
+        in normalized_note
+        and "spin-orbit axiom" in note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo does not contain the extra matching or a spin-orbit axiom",
+        all(
+            phrase not in axiom
+            for phrase in ("Ad_U", "spin-orbit", "spatial_Rz90", "e_1 ↦ e_2")
+        ),
+    )
+    checks.check(
+        "parents-axiom-only",
+        "declared parents are the axiom memo only",
+        "minimal_axioms" in note
+        and "upstream_dependencies:" in note
+        and "Parents:** the current axiom memo only" in note,
+    )
+
+    print("per_element: one R and one U are checked by exact matrix algebra")
+    print("per_site: one site-centered cubic rotation and one one-site algebra")
+    print("per_mode: the z-axis 90 degree pair only")
+    print("per_block: spatial-versus-internal identification only")
+    print("lattice_wide: R acts on Z^3; U does not; no dynamics claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Spatial `R` is a 3×3 cubic rotation on `Z^3`. Internal `U=exp(-iπ/4 σ_z)` lives in `SU(2)⊂M_2(C)` and does not map sites. They are unequal types. The Bloch matching `R·e1=e2` vs `Ad_U(σ_x)=σ_y` is extra. No spin-orbit axiom. `r=1/2` is not forced.

## What this means for the TOE

Lattice cubic rotations are not identified with internal `Ad_U`.

## What changed

- Note: `docs/CUBIC_SITE_ROTATION_IS_NOT_INTERNAL_AD_U_ON_M2_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py`
- Cache: `logs/runner-cache/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.txt`

## Verification

```bash
python3 scripts/cubic_site_rotation_is_not_internal_ad_u_on_m2_2026_08_13.py
# TOTAL: PASS=18 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
