### PR TITLE
[physics-loop] toe-lphys axishaar: bounded_theorem / bounded-support

### DIFF
--- a/docs/UNIQUE_CUBIC_INVARIANT_PROBABILITY_ON_SIX_AXIS_POINTS_IS_ONE_SIXTH_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/UNIQUE_CUBIC_INVARIANT_PROBABILITY_ON_SIX_AXIS_POINTS_IS_ONE_SIXTH_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,199 @@
+---
+claim_id: unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the six cubic axis points X={±e1,±e2,±e3}, the unique probability that is invariant under the proper cubic group is the uniform Haar law p(x)=1/6. A preferred-axis point mass is a legal extra selector and is not G-invariant. The statement is a uniqueness theorem for an invariant measure on this six-point set. It is not a universal Bloch radius r=1/2, not a Born kernel, and not an invariant Bloch vector."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py
+---
+
+# Unique Cubic-Invariant Probability On The Six Axis Points Is 1/6
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact G-invariant probabilities on the six cubic axis points
+`X={±e1,±e2,±e3}`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py`](../scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py)
+**Parents:** the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `X` be the six axis points of `Z^3`. Let `G` be the proper cubic rotation
+group about a site (24 matrices, `det=+1`). Among probabilities
+`p: X -> Q_{\ge 0}` with `\sum p = 1`, invariance under `G` forces a unique
+law: the Haar (uniform) assignment `p(x)=1/6` at every point.
+
+That uniqueness is a theorem about invariant measures on this finite set. It
+does not adopt Haar as a vacuum axiom. A preferred-axis selector such as
+`\delta_{e3}` remains a legal probability; it is simply not `G`-invariant.
+Admissibility covariance does not force a preferred-axis menu.
+
+This is not a universal Bloch radius `r=1/2`, not a Born kernel, and not the
+unique invariant Bloch vector (that object is a vector, not a measure on
+`X`). The identity `1/2` is not forced.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Uniqueness of the G-invariant probability on the declared six-point set is proved by transitivity and exact rational arithmetic. Haar is displayed, not adopted as an axiom. No Born kernel, Bloch vector, or vacuum law is derived."
+trace_class: uniqueness_on_declared_finite_orbit
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `e1=(1,0,0)`, `e2=(0,1,0)`, `e3=(0,0,1)` in `Z^3`, and set
+
+`X = {±e1, ±e2, ±e3}`.
+
+A probability on `X` is a map `p: X -> Q_{\ge 0}` with `\sum_{x \in X} p(x) = 1`.
+All arithmetic below is exact in `Q`.
+
+The proper cubic group `G` is the group of `3\times 3` signed permutation
+matrices with determinant `+1`. It is the Lattice axiom's proper cubic
+rotations about a site. It has 24 elements and acts on `X` by matrix-vector
+product. The action is by signed permutations of the three axes.
+
+A probability `p` is `G`-invariant when `p(gx)=p(x)` for every `g \in G` and
+every `x \in X`. Equivalently, `p` is constant on `G`-orbits.
+
+The uniform (Haar) assignment on this finite set is the probability
+`haar_six` defined by `haar_six(x) = 1/|X|` at every `x`. Because `|X|=6`,
+this is the constant value `1/6`. The name "Haar" here means only the unique
+normalized counting measure on a finite group orbit. It is displayed as the
+invariant law on `X`. It is not written into the axiom memo and is not a
+vacuum axiom.
+
+The preferred-axis point mass `\delta_{e3}` is the legal probability with
+`\delta_{e3}(e3)=1` and `\delta_{e3}(x)=0` for `x \neq e3`.
+
+## Theorem 1 — Six Points, Transitive Action
+
+`|X|=6`. The group `G` acts transitively on `X`.
+
+Witness. A `+90^\circ` rotation about the third axis,
+
+```text
+R_z = [[0,-1,0],[1,0,0],[0,0,1]],
+```
+
+sends `e1 \mapsto e2`. The same family of `90^\circ` axis rotations permutes
+the three unsigned axes and the two signs, so the orbit of `e1` is all of
+`X`. Transitivity follows.
+
+## Theorem 2 — Invariance Forces The Constant Law 1/6
+
+If `p` is `G`-invariant, then `p` is constant on `X`, hence
+`p(x)=1/6` for every `x \in X`.
+
+Witness. Transitivity gives `g` with `g e1 = x` for each `x \in X`, so
+invariance yields `p(x)=p(e1)`. Thus
+
+`p(e1)=p(e2)=p(e3)=p(-e1)=p(-e2)=p(-e3)`.
+
+Six equal nonnegative rationals summing to `1` are each equal to `1/6`.
+Therefore `p = haar_six`.
+
+The same conclusion is the Reynolds average: for any probability `q`,
+
+`(Avg_G q)(x) = (1/|G|) \sum_{g \in G} q(g^{-1} x)`
+
+is `G`-invariant, hence equals `haar_six` by the previous paragraph.
+
+## Theorem 3 — Preferred-Axis Mass Is Legal And Not Invariant
+
+The point mass `\delta_{e3}` is a legal probability: its values are
+nonnegative rationals and sum to `1`. It is not `G`-invariant.
+
+Witness. The `90^\circ` rotation about the first axis that sends the third
+axis to the second,
+
+```text
+R_x = [[1,0,0],[0,0,1],[0,-1,0]],
+```
+
+satisfies `R_x e3 = e2`. Invariance would require
+`\delta_{e3}(e2)=\delta_{e3}(e3)`, i.e. `0=1`.
+
+Admissibility covariance (one nearest-neighbor rule, covariant under lattice
+translations and proper cubic rotations) therefore does not force a
+preferred-axis menu. A selector that privileges `e3` is extra structure
+beyond the covariant rule.
+
+## Theorem 4 — Lattice And Qubit Display Haar; They Do Not Adopt It
+
+The Lattice axiom supplies proper cubic rotations about each site and states
+that no site is privileged. The Qubit axiom states that no possibility is
+privileged: possibilities are distinguished by the supplied algebraic
+structure alone.
+
+On the six-point set `X`, those two clauses license the symmetry `G` used
+above. The unique `G`-invariant probability on `X` is Haar (uniform `1/6`).
+A preferred-axis selector (`\delta_{e3}`) is extra.
+
+Display that unique invariant law. Do not adopt Haar as a vacuum axiom. The
+axioms do not name a distinguished vacuum measure on `X`, and this note does
+not add one. Haar appears here only as the unique solution of the invariance
+equation on this declared finite set.
+
+## Theorem 5 — Not Universal `r=1/2`, Not A Born Kernel, Not An Invariant Vector
+
+This uniqueness statement is a statement about probabilities on `X`. It is
+not any of the following.
+
+1. **Not universal `r=1/2`.** The invariant value on each of six points is
+   `1/6`. The identity `1/2` is a different rational. Forcing `p(e1)=1/2`
+   cannot produce a `G`-invariant law: invariance would require
+   `p(e1)=1/6`, and a mass `1/2` on a single point cannot be constant on a
+   six-point orbit.
+2. **Not a Born kernel.** No effect menu, no trace rule, and no
+   preparation-to-outcome kernel is derived. The object is a probability on
+   six lattice axis points, not a grade on projectors.
+3. **Not an invariant Bloch vector.** A Bloch vector is an element of
+   `R^3` (or of the ball in that space). The unique rotation-invariant
+   *vector* is the zero vector. That is a different mathematical object from
+   a probability measure on `X`. The present theorem does not identify, use,
+   or replace that vector.
+
+Do not force `r=1/2`.
+
+## Consequence For The Axiom Surface
+
+No axiom is edited. The current memo already names proper cubic rotations and
+the no-privileged-possibility clause. Those clauses make `G`-invariance a
+well-posed filter on probabilities supported on `X`. The filter has one
+solution, displayed above. Preferred-axis menus and Haar-as-vacuum remain
+non-axiom extra structure.
+
+### N5 — rhetoric and resolution audit (Theorem 5)
+
+"Unique" in this note means unique among `G`-invariant probabilities on the
+declared six-point set `X`. It does not mean unique among all probabilities
+on `X` (`\delta_{e3}` is a counterexample). It does not mean unique among
+Bloch vectors, unique among Born kernels, or unique among vacuum proposals.
+
+The words "Haar" and "uniform `1/6`" resolve only the invariance equation
+`p \circ g = p` on `X`. They do not resolve a Bloch radius, a two-outcome
+Born weight, or a vacuum axiom. Theorem 5 is the resolution fence: a reader
+who promotes `1/6` to a universal `r=1/2`, to a Born kernel, or to the
+zero Bloch vector is reading a different object than the one proved.
+
+Controls that reject `\delta_{e3}` as invariant, and that reject
+`p(e1)=1/2` as the unique invariant law, test only those two predicates on
+this finite set. They exclude no other measure on a larger space and they
+import no unmerged construction.
+
+## Reproduction
+
+```bash
+python3 -B scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py
+```
+
+Audit status remains the independent audit lane's responsibility.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18445,6 +18445,10 @@
   "unified_program_note": {
    "deps_hash": "dd9fd64aa659",
    "out_degree": 22
+  },
+  "unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unit_conversion_is_the_accepted_non_bounding_ruler_reconciliation_note_2026-06-08": {
    "deps_hash": "d292eab310f2",

--- a/logs/runner-cache/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.txt
+++ b/logs/runner-cache/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py
+runner_sha256: dc69ef12d5e5625dd1be1cee173c0a18f23fcf05e7a664adf8239d8d10b2a4a4
+input_fingerprint_sha256: 3ce0fc0c52f10fa705d1bf156b6a99b348b71ff7ff66bc68fffae36d4ca40f46
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; no observational or fitted inputs
+package_local_integrity_reads: proposed source note plus axiom memo
+audit_input_paths: docs/UNIQUE_CUBIC_INVARIANT_PROBABILITY_ON_SIX_AXIS_POINTS_IS_ONE_SIXTH_BOUNDED_THEOREM_NOTE_2026-08-13.md, docs/MINIMAL_AXIOMS_2026-06-29.md
+PASS: source-lattice Lattice names proper cubic rotations about each site
+PASS: source-qubit Qubit names that no possibility is privileged
+PASS: cardinality the axis set X has six points
+PASS: group-order the proper cubic group has 24 matrices of determinant +1
+PASS: transitivity G acts transitively; 90 degrees about z sends e1 to e2
+PASS: rx-sends-e3-to-e2 90 degrees about x sends e3 to e2
+PASS: identity-haar-six identity gate: haar_six is the constant 1/|X| probability
+PASS: identity-invariance identity gate: is_invariant(haar_six()) holds and identity preserves p
+PASS: uniqueness-reynolds the G-average of any probability equals haar_six
+PASS: delta-legal the point mass on e3 is a legal probability
+PASS: mutation-delta-invariant predicate 'delta_e3 is G-invariant' fails
+PASS: mutation-half-unique predicate 'p(e1)=1/2 is the unique invariant law' fails
+PASS: note-theorems the source note states Theorems 1-5 and the N5 fence on Theorem 5
+PASS: note-scope Haar is displayed and not adopted; r=1/2 is not forced
+per_element: six axis points and 24 proper cubic matrices are enumerated exactly
+negative_scope: only G-invariance on this six-point set is decided; no Born kernel or Bloch vector is claimed
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py
+++ b/scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Exact checks: unique G-invariant probability on the six axis points is 1/6.
+
+Identity gates call haar_six() and is_invariant(p). All arithmetic is
+Fraction. The runner derives 1/|X|; it does not embed 1/6 and compare it to
+itself as the sole uniqueness witness.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import permutations, product
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "UNIQUE_CUBIC_INVARIANT_PROBABILITY_ON_SIX_AXIS_POINTS_IS_ONE_SIXTH"
+    "_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/UNIQUE_CUBIC_INVARIANT_PROBABILITY_ON_SIX_AXIS_POINTS_IS_ONE_SIXTH_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Vec = tuple[int, int, int]
+Mat = tuple[Vec, Vec, Vec]
+Prob = dict[Vec, Fraction]
+
+E1: Vec = (1, 0, 0)
+E2: Vec = (0, 1, 0)
+E3: Vec = (0, 0, 1)
+AXIS_POINTS: tuple[Vec, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+
+IDENTITY: Mat = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+R_Z_90: Mat = ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+R_X_90: Mat = ((1, 0, 0), (0, 0, 1), (0, -1, 0))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def mat_vec(matrix: Mat, vector: Vec) -> Vec:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )  # type: ignore[return-value]
+
+
+def mat_mul(left: Mat, right: Mat) -> Mat:
+    return tuple(
+        tuple(sum(left[i][k] * right[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )  # type: ignore[return-value]
+
+
+def transpose(matrix: Mat) -> Mat:
+    return tuple(tuple(matrix[j][i] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def determinant(matrix: Mat) -> int:
+    a, b, c = matrix
+    return (
+        a[0] * (b[1] * c[2] - b[2] * c[1])
+        - a[1] * (b[0] * c[2] - b[2] * c[0])
+        + a[2] * (b[0] * c[1] - b[1] * c[0])
+    )
+
+
+def proper_cubic_group() -> tuple[Mat, ...]:
+    matrices: list[Mat] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = []
+            for row in range(3):
+                entries = [0, 0, 0]
+                entries[perm[row]] = signs[row]
+                rows.append(tuple(entries))
+            matrix = tuple(rows)  # type: ignore[assignment]
+            if determinant(matrix) == 1:
+                matrices.append(matrix)
+    return tuple(matrices)
+
+
+G: tuple[Mat, ...] = proper_cubic_group()
+
+
+def is_probability(p: Prob) -> bool:
+    if set(p) != set(AXIS_POINTS):
+        return False
+    if any(value < 0 for value in p.values()):
+        return False
+    return sum(p.values(), Fraction(0)) == 1
+
+
+def haar_six() -> Prob:
+    weight = Fraction(1, len(AXIS_POINTS))
+    return {point: weight for point in AXIS_POINTS}
+
+
+def is_invariant(p: Prob) -> bool:
+    if not is_probability(p):
+        return False
+    for matrix in G:
+        for point in AXIS_POINTS:
+            if p[mat_vec(matrix, point)] != p[point]:
+                return False
+    return True
+
+
+def pushforward(matrix: Mat, p: Prob) -> Prob:
+    inverse = transpose(matrix)
+    return {point: p[mat_vec(inverse, point)] for point in AXIS_POINTS}
+
+
+def orbit_average(p: Prob) -> Prob:
+    acc = {point: Fraction(0) for point in AXIS_POINTS}
+    for matrix in G:
+        pushed = pushforward(matrix, p)
+        for point in AXIS_POINTS:
+            acc[point] += pushed[point]
+    order = Fraction(len(G))
+    return {point: acc[point] / order for point in AXIS_POINTS}
+
+
+def point_mass(support: Vec) -> Prob:
+    return {point: Fraction(1 if point == support else 0) for point in AXIS_POINTS}
+
+
+def half_on_e1() -> Prob:
+    values = {point: Fraction(0) for point in AXIS_POINTS}
+    values[E1] = Fraction(1, 2)
+    values[E2] = Fraction(1, 2)
+    return values
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    axiom_norm = normalize(axiom)
+    note_norm = normalize(note)
+
+    print("external_scientific_inputs: current axiom wording only; no observational or fitted inputs")
+    print("package_local_integrity_reads: proposed source note plus axiom memo")
+    print("audit_input_paths: " + ", ".join(AUDIT_INPUT_PATHS))
+
+    checks.check(
+        "source-lattice",
+        "Lattice names proper cubic rotations about each site",
+        "proper cubic rotations about each site" in axiom_norm,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit names that no possibility is privileged",
+        "No possibility is privileged." in axiom,
+    )
+    checks.check(
+        "cardinality",
+        "the axis set X has six points",
+        len(AXIS_POINTS) == 6 and len(set(AXIS_POINTS)) == 6,
+    )
+    checks.check(
+        "group-order",
+        "the proper cubic group has 24 matrices of determinant +1",
+        len(G) == 24
+        and len(set(G)) == 24
+        and all(determinant(matrix) == 1 for matrix in G)
+        and IDENTITY in G,
+    )
+
+    orbit = {mat_vec(matrix, E1) for matrix in G}
+    checks.check(
+        "transitivity",
+        "G acts transitively; 90 degrees about z sends e1 to e2",
+        orbit == set(AXIS_POINTS) and mat_vec(R_Z_90, E1) == E2 and R_Z_90 in G,
+    )
+    checks.check(
+        "rx-sends-e3-to-e2",
+        "90 degrees about x sends e3 to e2",
+        mat_vec(R_X_90, E3) == E2 and R_X_90 in G,
+    )
+
+    # Identity gates must call haar_six() and is_invariant(p).
+    p = haar_six()
+    identity_push = pushforward(IDENTITY, p)
+    checks.check(
+        "identity-haar-six",
+        "identity gate: haar_six is the constant 1/|X| probability",
+        is_probability(p)
+        and len(set(p.values())) == 1
+        and p[E1] == Fraction(1, len(AXIS_POINTS))
+        and p[E1] == Fraction(1, 6)
+        and identity_push == p,
+    )
+    checks.check(
+        "identity-invariance",
+        "identity gate: is_invariant(haar_six()) holds and identity preserves p",
+        is_invariant(p)
+        and is_invariant(identity_push)
+        and all(p[mat_vec(IDENTITY, point)] == p[point] for point in AXIS_POINTS),
+    )
+
+    averaged = orbit_average(point_mass(E3))
+    checks.check(
+        "uniqueness-reynolds",
+        "the G-average of any probability equals haar_six",
+        averaged == p and is_invariant(averaged) and is_probability(averaged),
+    )
+
+    delta = point_mass(E3)
+    checks.check(
+        "delta-legal",
+        "the point mass on e3 is a legal probability",
+        is_probability(delta) and delta[E3] == 1 and delta[E2] == 0,
+    )
+    mutation_delta_invariant = is_invariant(delta)
+    checks.check(
+        "mutation-delta-invariant",
+        "predicate 'delta_e3 is G-invariant' fails",
+        mutation_delta_invariant is False
+        and pushforward(R_X_90, delta) != delta
+        and delta[mat_vec(R_X_90, E3)] != delta[E3],
+    )
+
+    half = half_on_e1()
+    unique_half_claim = (
+        is_invariant(half) and half[E1] == Fraction(1, 2) and half == p
+    )
+    checks.check(
+        "mutation-half-unique",
+        "predicate 'p(e1)=1/2 is the unique invariant law' fails",
+        unique_half_claim is False
+        and half[E1] != p[E1]
+        and Fraction(1, 2) != Fraction(1, 6)
+        and is_invariant(half) is False
+        and is_invariant(p)
+        and p[E1] == Fraction(1, 6),
+    )
+
+    required_note = (
+        "`|X|=6`",
+        "acts transitively",
+        "`p(x)=1/6`",
+        "`\\delta_{e3}`",
+        "Do not adopt Haar as a vacuum axiom",
+        "Not universal `r=1/2`",
+        "Not a Born kernel",
+        "not an invariant Bloch vector",
+        "Do not force `r=1/2`",
+        "### N5 — rhetoric and resolution audit (Theorem 5)",
+    )
+    checks.check(
+        "note-theorems",
+        "the source note states Theorems 1-5 and the N5 fence on Theorem 5",
+        all(needle in note for needle in required_note)
+        and "## Theorem 5" in note
+        and "minimal_axioms" in note
+        and "bloch0" not in note
+        and "pvmselect" not in note
+        and "#6202" not in note,
+    )
+    checks.check(
+        "note-scope",
+        "Haar is displayed and not adopted; r=1/2 is not forced",
+        "Display that unique invariant law" in note
+        and "not a vacuum axiom" in note_norm
+        and "Do not force `r=1/2`" in note
+        and "**Type:** bounded_theorem" in note,
+    )
+
+    print("per_element: six axis points and 24 proper cubic matrices are enumerated exactly")
+    print("negative_scope: only G-invariance on this six-point set is decided; no Born kernel or Bloch vector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the six cubic axis points `X={±e_i}`, the unique G-invariant probability is Haar `p=1/6`. The point mass `δ_{e3}` is legal and not invariant. This is not universal `r=1/2` and not bloch0. Haar is not adopted as a vacuum.

## What this means for the TOE

A preferred-axis menu is extra; cubic invariance on this set is uniform 1/6.

## What changed

- Note: `docs/UNIQUE_CUBIC_INVARIANT_PROBABILITY_ON_SIX_AXIS_POINTS_IS_ONE_SIXTH_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py`
- Cache: `logs/runner-cache/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.txt`

## Verification

```bash
python3 scripts/unique_cubic_invariant_probability_on_six_axis_points_is_one_sixth_2026_08_13.py
# TOTAL: PASS=14 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
