### PR TITLE
[physics-loop] toe-lphys emptyvac: bounded_theorem / bounded-support

### DIFF
--- a/docs/I_EMPTY_ZERO_IS_NOT_A_VACUUM_ENERGY_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/I_EMPTY_ZERO_IS_NOT_A_VACUUM_ENERGY_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,150 @@
+---
+claim_id: i_empty_zero_is_not_a_vacuum_energy_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The Record sentence I(empty)=0 is the additive identity of the readout, a count of locks in the empty collection. A putative vacuum energy is a law-level rational E0 attached to the empty history and is not that count: the trial values E0=1 and E0=1/2 are well-defined and unequal to I(empty). Realized-state evaluation is pointwise with no averaging, so a history-independent law-level vacuum number is not a Record readout of the empty collection. The extra object is displayed at E0=1 and is not adopted; it is not identified with r, w, or G_N, and no cosmological claim is made."
+upstream_dependencies:
+  - minimal_axioms
+  - realized_state_primitive_note_2026-06-11
+runner: scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py
+---
+
+# I(empty)=0 Is Not A Vacuum Energy
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact additive identity of the Record readout versus a law-level
+constant attached to the empty history. No cosmological constant is installed.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py`](../scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py)
+
+## Result Up Front
+
+`I(empty)=0` is a count identity, not a law-level energy.
+
+The current Record wording supplies a finitely additive scalar readout of
+pairwise-disjoint record collections and names the empty collection as the
+additive identity. That number is the number of locks in the empty collection.
+It is not a selectable vacuum energy sitting in every history.
+
+A putative vacuum energy is a different object: a law-level rational `E0`
+attached to the empty history, constant rather than a count of locks. The
+trial values `E0=1` and `E0=1/2` are well-defined rationals and are not equal
+to `I(empty)`. The extra object is displayed at `E0=1` and is not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: negative_route_pruning
+target_claim_id: i_empty_zero_is_not_a_vacuum_energy
+target_blocker_text: "I(empty)=0 is a count identity, not a law-level vacuum energy"
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+next_trace_action: "Keep E0 as an extra law-level constant if it is displayed; do not identify it with I(empty), r, w, or G_N, and do not install a cosmological constant."
+conditional_surface_status: "exact additive-identity algebra on the empty collection; no vacuum-energy law is derived or adopted"
+hypothetical_axiom_status: "no axiom edit; E0 is not adopted as axiom content"
+admitted_observation_status: null
+claim_type_reason: "The identity I(empty)=0 is the Record additive identity recomputed from empty ∪ empty; unequal trial constants are exact rationals. No cosmological identification is claimed."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work with finite collections of pairwise-disjoint records. The current Record
+wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+states that a readout value is determined by record content alone, and that
+for any finite collection of pairwise-disjoint records the scalar readout `I`
+is additive, with `I(empty)=0`.
+
+Write `empty` for the empty collection. Then `empty ∪ empty = empty`, and
+the two copies are pairwise disjoint, so additivity applies.
+
+A putative vacuum energy is a law-level number `E0 ∈ Q` attached to the empty
+history: a constant, not a count of locks. Two trial values are used:
+
+- `E0 = 1`
+- `E0 = 1/2`
+
+The value `E0 = 0` is also a well-defined rational. Numerical equality of
+that one trial with the count `I(empty)` does not make `E0` a Record readout.
+
+## Theorem 1 — I(empty)=0 By The Axiom Sentence
+
+The axiom sentence already states `I(empty)=0`. The same value is the unique
+solution of the additivity identity on the empty collection.
+
+Recompute only:
+
+`I(empty ∪ empty) = I(empty) + I(empty)`.
+
+Because `empty ∪ empty = empty`, this is `I(empty) = I(empty) + I(empty)`,
+hence `I(empty) = 0` in `Q`.
+
+That is the additive identity of the readout. It is a count of locks in the
+empty collection.
+
+## Theorem 2 — Trial Constants Are Not I(empty)
+
+A constant `E0 = 1` is a well-defined rational and is not equal to
+`I(empty)`. A constant `E0 = 1/2` is likewise unequal to `0`.
+
+So
+
+`E0 = 1 ≠ I(empty) = 0`,
+
+and
+
+`E0 = 1/2 ≠ I(empty) = 0`.
+
+Both trial values are extra numbers. Neither is the additive identity of `I`.
+
+## Theorem 3 — A History-Independent Law Number Is Not The Empty Readout
+
+The realized-state primitive in
+[`REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md`](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md)
+states that derivations may evaluate at the realized state, pointwise, and
+that nothing more is supplied: no averaging over alternatives, no typical or
+generic claim, and no quoting a number that would differ had another
+law-admissible state been realized.
+
+A law-level vacuum number that would be the same in every history is not a
+Record readout of the empty collection. That readout is `0`, a count
+identity, not a selectable energy. Pointwise evaluation at a realized empty
+collection still returns the count identity. Averaging is not used.
+
+## Theorem 4 — Display E0=1 As Extra; Do Not Adopt It
+
+The extra object for a vacuum energy is a law-level constant `E0`,
+independent of `I`. Display `E0=1` as extra. Do not adopt it.
+
+This note does not install a cosmological constant. It does not claim cosmology.
+The four axioms are unchanged. The displayed constant is not axiom content.
+
+## Theorem 5 — Do Not Identify E0 With r, w, Or G_N
+
+Do not identify `E0` with `r`, `w`, or `G_N`.
+
+Those symbols are already in use as a registered sector dial, a formation
+weight, and Newton's constant. The trial constant `E0` is a separate extra
+object. This note does not force `r=1/2`.
+
+## Mutation
+
+Let `P1` be the predicate “`I(empty)=1`”. Then `P1` fails: `I(empty)=0`.
+
+Let `P½` be the predicate “`I(empty)` selects `E0=1/2`”. Then `P½` fails:
+the empty readout is the count identity `0` and does not select the trial
+constant `1/2`.
+
+## Cited Surfaces
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — Record
+  additivity and the sentence `I(empty)=0`.
+- [`REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md`](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md)
+  — pointwise evaluation; no averaging over alternatives.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10165,6 +10165,10 @@
   "i3_zero_exact_theorem_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "i_empty_zero_is_not_a_vacuum_energy_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "7b707271a9a8",
+   "out_degree": 2
   },
   "impact_parameter_lensing_note": {
    "deps_hash": "bbfa07daa875",

--- a/logs/runner-cache/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.txt
+++ b/logs/runner-cache/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py
+runner_sha256: f3b5c43cee3d155ccf5f7b49ec08e84cdc55d783e46e70e578a89f141c0f771a
+input_fingerprint_sha256: 6644deb13d6aa994d69c2c5a6e35ea837a0b202294dd2a057896ed36e67fcbd9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom wording and the realized-state primitive are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+PASS: i-empty-zero I_empty() equals 0 as the lock count of the empty collection
+PASS: additivity-empty-union I(empty ∪ empty) equals I_empty() + I_empty()
+PASS: additive-identity-unique I_empty() = I_empty() + I_empty() forces the unique rational 0
+PASS: trial-e0-one trial_E0(1) is the well-defined rational 1 and is not I_empty()
+PASS: trial-e0-half trial_E0(1/2) is the well-defined rational 1/2 and is not 0
+PASS: trial-e0-zero-is-still-extra trial_E0(0) equals I_empty() as a rational and remains an extra object
+PASS: mutation-equals-one the predicate I(empty)=1 fails
+PASS: mutation-selects-half the predicate I(empty) selects E0=1/2 fails
+PASS: identity-gates-present identity gates I_empty() and trial_E0() are defined and called
+PASS: source-record the axiom memo states finite additivity with I(empty)=0
+PASS: source-realized-state the realized-state primitive states pointwise evaluation and no averaging
+PASS: note-theorem-1 the note recomputes I(empty ∪ empty)=I(empty)+I(empty) ⇒ I(empty)=0
+PASS: note-theorem-2 the note states E0=1 and E0=1/2 are unequal to I(empty)
+PASS: note-theorem-3 the note quotes pointwise evaluation and refuses a selectable vacuum readout
+PASS: note-theorem-4 the note displays E0=1 as extra, does not adopt it, and claims no cosmology
+PASS: note-theorem-5 the note does not identify E0 with r, w, or G_N and does not force r=1/2
+PASS: note-mutation the note requires I(empty)=1 and I(empty) selects E0=1/2 to fail
+PASS: note-forbidden-surface the note has no adoption phrasing and cites no unmerged pull request
+PASS: canonical-nonmutation the displayed trial constant E0 is absent from the canonical axiom file
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: parents-unmutated the axiom identity and the realized-state pointwise sentence remain
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the new note, axiom memo, and realized-state primitive
+per_element: I_empty() and trial_E0() are the only identity gates
+per_site: the empty collection is the only record collection used
+per_mode: trial values are 1 and 1/2; r=1/2 is not forced
+per_block: rejected blocks are I(empty)=1 and I(empty) selects E0=1/2
+lattice_wide: checked and not executed — no lattice-wide claim is made
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py
+++ b/scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Exact checks: I(empty)=0 is a count identity, not a vacuum energy.
+
+Identity gates are I_empty() and trial_E0(). Every identity or trial-constant
+check calls those functions. The predicates “I(empty)=1” and “I(empty)
+selects E0=1/2” are required to fail.
+"""
+
+from __future__ import annotations
+
+import ast
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "I_EMPTY_ZERO_IS_NOT_A_VACUUM_ENERGY_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PRIMITIVE_PATH = ROOT / "docs" / "REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/I_EMPTY_ZERO_IS_NOT_A_VACUUM_ENERGY_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md",
+)
+
+Collection = frozenset[object]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def I(collection: Collection) -> Fraction:
+    """Scalar readout: number of locks in a finite record collection."""
+    return Fraction(len(collection))
+
+
+def I_empty() -> Fraction:
+    """Additive identity of the Record readout.
+
+    empty ∪ empty = empty, so additivity forces I(empty) = I(empty)+I(empty).
+    The readout itself is the lock count of the empty collection.
+    """
+    empty: Collection = frozenset()
+    unioned = empty.union(empty)
+    if unioned != empty:
+        raise RuntimeError("empty ∪ empty is not empty")
+    value = I(empty)
+    if I(unioned) != value + value:
+        raise RuntimeError("additivity failed on empty ∪ empty")
+    # Unique solution of x = x + x in Q is 0: (2-1)x = 0.
+    if (Fraction(2) - Fraction(1)) * value != Fraction(0):
+        raise RuntimeError("additive identity is not 0")
+    return value
+
+
+def trial_E0(value: Fraction | int = 1) -> Fraction:
+    """Law-level constant attached to the empty history; not a lock count."""
+    return Fraction(value)
+
+
+def predicate_I_empty_equals_one() -> bool:
+    return I_empty() == Fraction(1)
+
+
+def predicate_I_empty_selects_half() -> bool:
+    return I_empty() == trial_E0(Fraction(1, 2))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def _identity_gate_calls(source: str) -> tuple[bool, bool]:
+    tree = ast.parse(source)
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    called: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            called.add(node.func.id)
+    return "I_empty" in defined and "I_empty" in called, (
+        "trial_E0" in defined and "trial_E0" in called
+    )
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    primitive = PRIMITIVE_PATH.read_text(encoding="utf-8")
+    runner_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_primitive = normalize(primitive)
+
+    print(
+        "external_scientific_inputs: axiom wording and the realized-state "
+        "primitive are source-bound; no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+
+    empty: Collection = frozenset()
+    empty_value = I_empty()
+    extra_one = trial_E0(1)
+    extra_half = trial_E0(Fraction(1, 2))
+    extra_zero = trial_E0(0)
+
+    checks.check(
+        "i-empty-zero",
+        "I_empty() equals 0 as the lock count of the empty collection",
+        empty_value == Fraction(0) and I(empty) == I_empty(),
+    )
+    checks.check(
+        "additivity-empty-union",
+        "I(empty ∪ empty) equals I_empty() + I_empty()",
+        I(empty.union(empty)) == I_empty() + I_empty(),
+    )
+    checks.check(
+        "additive-identity-unique",
+        "I_empty() = I_empty() + I_empty() forces the unique rational 0",
+        I_empty() == I_empty() + I_empty()
+        and (Fraction(2) - Fraction(1)) * I_empty() == Fraction(0),
+    )
+    checks.check(
+        "trial-e0-one",
+        "trial_E0(1) is the well-defined rational 1 and is not I_empty()",
+        extra_one == Fraction(1) and extra_one != I_empty(),
+    )
+    checks.check(
+        "trial-e0-half",
+        "trial_E0(1/2) is the well-defined rational 1/2 and is not 0",
+        extra_half == Fraction(1, 2)
+        and extra_half != I_empty()
+        and extra_half != Fraction(0),
+    )
+    checks.check(
+        "trial-e0-zero-is-still-extra",
+        "trial_E0(0) equals I_empty() as a rational and remains an extra object",
+        extra_zero == I_empty() and extra_zero == Fraction(0),
+    )
+    checks.check(
+        "mutation-equals-one",
+        "the predicate I(empty)=1 fails",
+        predicate_I_empty_equals_one() is False,
+    )
+    checks.check(
+        "mutation-selects-half",
+        "the predicate I(empty) selects E0=1/2 fails",
+        predicate_I_empty_selects_half() is False,
+    )
+    checks.check(
+        "identity-gates-present",
+        "identity gates I_empty() and trial_E0() are defined and called",
+        all(_identity_gate_calls(runner_source)),
+    )
+
+    record_sentence = "`I` is additive, with `I(empty)=0`"
+    checks.check(
+        "source-record",
+        "the axiom memo states finite additivity with I(empty)=0",
+        record_sentence in axiom
+        and "pairwise-disjoint records" in axiom
+        and "A readout value is determined by record content" in axiom,
+    )
+    checks.check(
+        "source-realized-state",
+        "the realized-state primitive states pointwise evaluation and no averaging",
+        "evaluate at the realized state, pointwise" in primitive
+        and "no averaging over alternatives" in primitive
+        and "pointwise" in normalized_primitive,
+    )
+    checks.check(
+        "note-theorem-1",
+        "the note recomputes I(empty ∪ empty)=I(empty)+I(empty) ⇒ I(empty)=0",
+        "I(empty ∪ empty) = I(empty) + I(empty)" in note
+        and "empty ∪ empty = empty" in note
+        and "`I(empty) = 0`" in note,
+    )
+    checks.check(
+        "note-theorem-2",
+        "the note states E0=1 and E0=1/2 are unequal to I(empty)",
+        "E0 = 1 ≠ I(empty) = 0" in normalized_note
+        and "E0 = 1/2 ≠ I(empty) = 0" in normalized_note,
+    )
+    checks.check(
+        "note-theorem-3",
+        "the note quotes pointwise evaluation and refuses a selectable vacuum readout",
+        "evaluate at the realized state, pointwise" in note
+        and "no averaging over alternatives" in note
+        and "count identity, not a selectable energy" in normalized_note,
+    )
+    checks.check(
+        "note-theorem-4",
+        "the note displays E0=1 as extra, does not adopt it, and claims no cosmology",
+        "Display `E0=1` as extra" in note
+        and "Do not adopt it" in note
+        and "does not install a cosmological constant" in normalized_note
+        and "does not claim cosmology" in normalized_note,
+    )
+    checks.check(
+        "note-theorem-5",
+        "the note does not identify E0 with r, w, or G_N and does not force r=1/2",
+        "Do not identify `E0` with `r`, `w`, or `G_N`" in note
+        and "does not force `r=1/2`" in note,
+    )
+    checks.check(
+        "note-mutation",
+        "the note requires I(empty)=1 and I(empty) selects E0=1/2 to fail",
+        "I(empty)=1" in note
+        and "I(empty)` selects `E0=1/2" in note
+        and "P1` fails" in note
+        and "P½` fails" in note,
+    )
+    checks.check(
+        "note-forbidden-surface",
+        "the note has no adoption phrasing and cites no unmerged pull request",
+        "we adopt" not in note.lower()
+        and "new axiom" not in note.lower()
+        and "codex" not in note.lower()
+        and "energy dictionary" not in note.lower()
+        and "clockscale" not in note.lower()
+        and "PR #" not in note
+        and "github.com" not in note.lower(),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the displayed trial constant E0 is absent from the canonical axiom file",
+        all(phrase not in axiom for phrase in ("E0=1", "trial_E0", "emptyvac")),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "parents-unmutated",
+        "the axiom identity and the realized-state pointwise sentence remain",
+        "`I` is additive, with `I(empty)=0`" in axiom
+        and "Derivations may evaluate at the realized state, pointwise."
+        in primitive,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the new note, axiom memo, and realized-state primitive",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/I_EMPTY_ZERO_IS_NOT_A_VACUUM_ENERGY_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    print("per_element: I_empty() and trial_E0() are the only identity gates")
+    print("per_site: the empty collection is the only record collection used")
+    print("per_mode: trial values are 1 and 1/2; r=1/2 is not forced")
+    print("per_block: rejected blocks are I(empty)=1 and I(empty) selects E0=1/2")
+    print("lattice_wide: checked and not executed — no lattice-wide claim is made")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`I(empty)=0` is Record additivity on the empty collection. It is a count identity, not a law-level vacuum energy or cosmological constant. No vacuum axiom is adopted.

## What this means for the TOE

Empty readout is not vacuum energy.

## What changed

- Note: `docs/I_EMPTY_ZERO_IS_NOT_A_VACUUM_ENERGY_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py`
- Cache: `logs/runner-cache/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.txt`

## Verification

```bash
python3 scripts/i_empty_zero_is_not_a_vacuum_energy_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
