### PR TITLE
[physics-loop] toe-lphys trvsi: bounded_theorem / bounded-support

### DIFF
--- a/docs/BORN_WEIGHT_IN_UNIT_INTERVAL_IS_NOT_RECORD_COUNT_I_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/BORN_WEIGHT_IN_UNIT_INTERVAL_IS_NOT_RECORD_COUNT_I_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,185 @@
+---
+claim_id: born_weight_in_unit_interval_is_not_record_count_i_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "At one M_2(C) site, the supplied-grading Born pairing Tr(rho P) takes the exact value 3/5 on the displayed diagonal witness, which lies in (0,1) and is not an integer. A unit-lock Record pattern has I in Z_>=0 with I(empty)=0 and I(one lock)=1, so I is a cardinality. These are different types: a Q-valued pairing versus a Z-valued count. Identifying them requires an extra dictionary that this note displays and does not adopt. The result does not say the Born form is false, does not force r=1/2, and does not adopt L_phys."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py
+---
+
+# Born Weight In The Unit Interval Is Not Record Count I
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site type comparison of a supplied-grading Born pairing
+with a unit-lock Record count.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py`](../scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py)
+
+## Result Up Front
+
+Take the exact one-site matrices
+
+`P = diag(1, 0)`, `rho = diag(3/5, 2/5)`.
+
+Then
+
+`Tr(rho P) = 3/5`.
+
+The value `3/5` lies in the open unit interval and is not an integer. A
+unit-lock Record pattern has `I in Z_>=0`, with `I(empty)=0` and
+`I(one lock)=1`. Therefore `Tr(rho P)` is not equal to any unit-lock `I`.
+
+The August 9 parent supplies a Born form `Tr(rho E)` on a supplied grading.
+The current Record axiom supplies a scalar readout that is additive on
+pairwise-disjoint records with `I(empty)=0`. On unit locks that readout is a
+cardinality. These are different types: a `Q`-valued pairing versus a
+`Z`-valued count. Identifying them requires an extra dictionary. This note
+displays the mismatch and does not adopt the dictionary.
+
+The argument uses only exact rational matrix arithmetic and the unit-lock
+cardinality convention. It does not use Bessel functions, Haar measure, or
+four-dimensional plaquettes. It does not say that the Born form is false. It
+does not force `r=1/2` and does not adopt `L_phys`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The witness Tr(rho P)=3/5 is exact, 3/5 is not an integer, and unit-lock I is a cardinality; the extra identification dictionary is displayed and not adopted."
+trace_class: type_separation
+target_claim_id: born_weight_in_unit_interval_is_not_record_count_i
+target_blocker_text: "a Born weight in (0,1) is not a Record count I"
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed witness and the unit-lock cardinality reading; no dictionary is adopted"
+hypothetical_axiom_status: "none; no axiom edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site with possibility presentation `M_2(C)` from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+Let
+
+`P = diag(1, 0)`, `rho = diag(3/5, 2/5)`.
+
+Both matrices are Hermitian. `P` is a rank-one projector. `rho` is a density
+matrix: it is positive semidefinite and `Tr(rho)=1`. The Born pairing on this
+pair is the exact rational
+
+`Tr(rho P) = 3/5`.
+
+The parent
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+supplies, on a supplied grading `w` and an eligible low-arity menu family, a
+unique density matrix with
+
+`w(E) = Tr(rho E)`
+
+on the scaled-projector domain. The present note uses only that typed pairing.
+It does not re-prove the parent theorem and does not add a grading-selection
+law.
+
+The current Record axiom states that records form, that a present record locks
+exactly one admissible local possibility, and that
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+A **unit-lock Record pattern** is a finite collection of pairwise-disjoint
+records in which each lock is assigned the same unit increment. Additivity and
+`I(empty)=0` then make `I` a cardinality: `I in Z_>=0`, `I(empty)=0`, and
+`I(one lock)=1`. This is a reading of the existing additive readout on unit
+locks, not an axiom edit.
+
+## Theorem 1 — The displayed pairing is not an integer
+
+`Tr(rho P) = 3/5`. The integer condition `q in Z` for a rational `q=a/b` in
+lowest terms is `b=1`. Here `b=5`, so
+
+`3/5 notin Z`.
+
+A unit-lock `I` takes values in `Z_>=0`. Therefore `Tr(rho P)` is not equal to
+any unit-lock `I`. In particular the predicate "`Tr(rho P)` is an integer"
+fails on this witness.
+
+## Theorem 2 — The two objects have different types
+
+Quote Record: `I` is additive on pairwise-disjoint records with `I(empty)=0`.
+For unit locks it is a cardinality.
+
+Quote August 9: the Born form is `Tr(rho E)` on a supplied grading.
+
+The first object is `Z`-valued. The second is a `Q`-valued pairing of a
+density matrix with an effect. They are different types. The displayed values
+are
+
+`born(rho, P) = 3/5`, `record_I(0) = 0`, `record_I(1) = 1`.
+
+The predicate "`I(one lock)=3/5`" fails.
+
+## Theorem 3 — Identification requires an extra dictionary
+
+Any identification of `Tr(rho P)` with `I` must supply an extra dictionary
+that converts a pairing in `[0,1]` into a count in `Z_>=0`, or that converts
+a count into a pairing. The witness `3/5` versus `{0,1,2,...}` is already a
+type mismatch, so no such dictionary is implied by the current objects.
+
+This note displays the mismatch. It does not adopt a dictionary, a rounding
+rule, a frequency typicality map, or a large-`N` replacement of `I` by
+`N Tr(rho P)`.
+
+## Theorem 4 — Independence and non-refutation
+
+The argument does not use Bessel functions, Haar measure, or four-dimensional
+plaquettes. Those constructions are outside this block.
+
+The argument does not say that the Born form is false. The parent pairing
+`Tr(rho E)` remains the typed Born object on a supplied grading. The claim is
+only that this pairing is not the unit-lock Record count.
+
+## Theorem 5 — No forced equal weight and no `L_phys`
+
+The witness uses `rho = diag(3/5, 2/5)`, not a forced equal-weight
+`r=1/2` mixture. The note does not force `r=1/2`.
+
+The note does not adopt `L_phys`. No physical length, cell scale, or continuum
+path length is introduced.
+
+## Mutation Predicates
+
+The following hostile predicates fail on the displayed objects:
+
+1. "`Tr(rho P)` is an integer" fails, because `born(rho, P)=3/5`.
+2. "`I(one lock)=3/5`" fails, because `record_I(1)=1`.
+
+Identity gates for those objects call `born(rho, P)` and `record_I(nlocks)`.
+
+## What Is Not Claimed
+
+- No canonical axiom is edited.
+- The parent low-arity uniqueness theorem is not re-proved.
+- No physical registration of the displayed `P` or `rho` is claimed.
+- Born is not declared false.
+- Bessel, Haar, and four-dimensional plaquette constructions are not used.
+- `r=1/2` is not forced.
+- `L_phys` is not adopted.
+- No extra dictionary from pairing to count is adopted.
+
+## Runner Contract
+
+The companion runner computes `Tr(rho P)` by exact `Fraction` matrix
+arithmetic, evaluates `record_I` as the unit-lock cardinality, and checks the
+two mutation predicates. It reads this note, the August 9 parent, and the
+axiom memo. It writes no runner cache.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1460,6 +1460,10 @@
   },
   "born_scattering_comparison_note": {
    "deps_hash": "9cf8e0d23288",
+   "out_degree": 2
+  },
+  "born_weight_in_unit_interval_is_not_record_count_i_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "8830c572e201",
    "out_degree": 2
   },
   "bougerol_lacroix_oseledets_met_external_narrow_theorem_note_2026-05-10": {

--- a/logs/runner-cache/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.txt
+++ b/logs/runner-cache/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py
+runner_sha256: ba7c50b0f8139dca3af324e68615630e93e6e83b8282e718072eee31a561a912
+input_fingerprint_sha256: dd66a03f4a370eec2a2201d60d0d20cbf8cd9d4f91dc69cb8ac6f33172030051
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: axiom Record wording and the August 9 supplied-grading Born form are source-bound; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note, the August 9 parent, and the axiom memo are read for claim-surface consistency
+arithmetic: exact Fraction matrix pairing and integer unit-lock cardinality
+PASS: source-record the axiom memo states additive I with I(empty)=0
+PASS: source-parent the August 9 parent supplies the unique trace form on a supplied grading
+PASS: identity-born identity gate born(rho, P) returns the exact pairing 3/5
+PASS: identity-record identity gate record_I(nlocks) is the unit-lock cardinality
+PASS: identity-gate-calls identity gates call born(rho, P) and record_I(nlocks)
+PASS: record-additivity unit-lock I is additive on disjoint locks
+PASS: projector-and-density P is a projector and rho is a trace-one positive diagonal density
+PASS: mutation-integer-born the predicate Tr(rho P) is an integer fails on 3/5
+PASS: mutation-one-lock-fraction the predicate I(one lock)=3/5 fails
+PASS: type-separation the pairing is rational non-integral and the unit-lock values are integers
+PASS: note-theorems the note states the five theorems, the extra dictionary, and the two failed predicates
+PASS: independence-surface the note excludes Bessel functions, Haar measure, and four-dimensional plaquettes
+PASS: forbidden-imports-absent the note does not cite Gleason, the decimal 0.5934, or unmerged block names
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: audit-input-paths declared audit inputs are the new note, the August 9 parent, and the axiom memo
+PASS: canonical-nonmutation the axiom memo is not edited by this block
+per_element: one exact projector-density pairing and the unit-lock counts 0,1,2
+dictionary: displayed mismatch only; no pairing-to-count map is adopted
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py
+++ b/scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Exact type checks: a Born weight in (0, 1) is not a unit-lock Record count.
+
+The runner computes Tr(rho P) by Fraction matrix arithmetic and evaluates
+record_I as a unit-lock cardinality. It does not approximate, fit, or cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "BORN_WEIGHT_IN_UNIT_INTERVAL_IS_NOT_RECORD_COUNT_I_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+PARENT_PATH = ROOT / "docs" / "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/BORN_WEIGHT_IN_UNIT_INTERVAL_IS_NOT_RECORD_COUNT_I_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def matmul(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def trace(matrix: Matrix) -> Fraction:
+    return matrix[0][0] + matrix[1][1]
+
+
+def born(rho: Matrix, P: Matrix) -> Fraction:
+    return trace(matmul(rho, P))
+
+
+def record_I(nlocks: int) -> int:
+    if nlocks < 0:
+        raise ValueError("unit-lock count is nonnegative")
+    return nlocks
+
+
+def identity_born_gate(rho: Matrix, P: Matrix) -> Fraction:
+    return born(rho, P)
+
+
+def identity_record_gate(nlocks: int) -> int:
+    return record_I(nlocks)
+
+
+def predicate_born_weight_is_integer(value: Fraction) -> bool:
+    return value.denominator == 1
+
+
+def predicate_one_lock_equals_three_fifths(nlocks: int) -> bool:
+    return record_I(nlocks) == Fraction(3, 5)
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_src = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+
+    print(
+        "external_scientific_inputs: axiom Record wording and the August 9 "
+        "supplied-grading Born form are source-bound; no observational or fitted inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note, the August 9 "
+        "parent, and the axiom memo are read for claim-surface consistency"
+    )
+    print("arithmetic: exact Fraction matrix pairing and integer unit-lock cardinality")
+
+    P: Matrix = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(0)),
+    )
+    rho: Matrix = (
+        (Fraction(3, 5), Fraction(0)),
+        (Fraction(0), Fraction(2, 5)),
+    )
+
+    weight = identity_born_gate(rho, P)
+    empty_count = identity_record_gate(0)
+    one_lock = identity_record_gate(1)
+    two_locks = identity_record_gate(2)
+
+    checks.check(
+        "source-record",
+        "the axiom memo states additive I with I(empty)=0",
+        "`I` is additive, with `I(empty)=0`" in axiom,
+    )
+    checks.check(
+        "source-parent",
+        "the August 9 parent supplies the unique trace form on a supplied grading",
+        all(
+            phrase in parent
+            for phrase in (
+                "w(E)=Tr(rho E)",
+                "unique density matrix",
+                "explicitly supplied grading",
+            )
+        ),
+    )
+    checks.check(
+        "identity-born",
+        "identity gate born(rho, P) returns the exact pairing 3/5",
+        weight == Fraction(3, 5) and Fraction(0) < weight < Fraction(1),
+    )
+    checks.check(
+        "identity-record",
+        "identity gate record_I(nlocks) is the unit-lock cardinality",
+        empty_count == 0 and one_lock == 1 and two_locks == 2,
+    )
+    checks.check(
+        "identity-gate-calls",
+        "identity gates call born(rho, P) and record_I(nlocks)",
+        "born(rho, P)" in runner_src and "record_I(nlocks)" in runner_src,
+    )
+    checks.check(
+        "record-additivity",
+        "unit-lock I is additive on disjoint locks",
+        record_I(2) == record_I(1) + record_I(1)
+        and record_I(1) == record_I(0) + record_I(1),
+    )
+    checks.check(
+        "projector-and-density",
+        "P is a projector and rho is a trace-one positive diagonal density",
+        matmul(P, P) == P
+        and P[0][1] == P[1][0] == Fraction(0)
+        and trace(rho) == Fraction(1)
+        and rho[0][0] > 0
+        and rho[1][1] > 0,
+    )
+    checks.check(
+        "mutation-integer-born",
+        "the predicate Tr(rho P) is an integer fails on 3/5",
+        not predicate_born_weight_is_integer(born(rho, P)),
+    )
+    checks.check(
+        "mutation-one-lock-fraction",
+        "the predicate I(one lock)=3/5 fails",
+        not predicate_one_lock_equals_three_fifths(1),
+    )
+    checks.check(
+        "type-separation",
+        "the pairing is rational non-integral and the unit-lock values are integers",
+        weight.denominator != 1
+        and isinstance(empty_count, int)
+        and isinstance(one_lock, int)
+        and isinstance(two_locks, int),
+    )
+    checks.check(
+        "note-theorems",
+        "the note states the five theorems, the extra dictionary, and the two failed predicates",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "3/5 notin Z",
+                "not equal to any unit-lock",
+                "different types",
+                "extra dictionary",
+                "does not adopt the dictionary",
+                "does not say that the Born form is false",
+                "does not force `r=1/2`",
+                "does not adopt `L_phys`",
+                "`Tr(rho P)` is an integer",
+                "`I(one lock)=3/5`",
+            )
+        ),
+    )
+    checks.check(
+        "independence-surface",
+        "the note excludes Bessel functions, Haar measure, and four-dimensional plaquettes",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "Bessel functions",
+                "Haar measure",
+                "four-dimensional plaquettes",
+            )
+        ),
+    )
+    checks.check(
+        "forbidden-imports-absent",
+        "the note does not cite Gleason, the decimal 0.5934, or unmerged block names",
+        all(
+            token not in note
+            for token in ("Gleason", "0.5934", "realens", "oneweight", "pvmluders")
+        ),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs are the new note, the August 9 parent, and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/BORN_WEIGHT_IN_UNIT_INTERVAL_IS_NOT_RECORD_COUNT_I_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo is not edited by this block",
+        "unit-lock Record pattern" not in axiom,
+    )
+
+    print("per_element: one exact projector-density pairing and the unit-lock counts 0,1,2")
+    print("dictionary: displayed mismatch only; no pairing-to-count map is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`Tr(ρP)` at `ρ=diag(3/5,2/5)` is `3/5`, which is not an integer. Record `I` is an integer count. A Born weight in `(0,1)` is not `I`. Independent of realens (Haar mean) and oneweight (one weight ⇏ ρ).

## What this means for the TOE

Born numbers and Record counts are different types.

## What changed

- Note: `docs/BORN_WEIGHT_IN_UNIT_INTERVAL_IS_NOT_RECORD_COUNT_I_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py`
- Cache: `logs/runner-cache/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.txt`

## Verification

```bash
python3 scripts/born_weight_in_unit_interval_is_not_record_count_i_2026_08_13.py
# TOTAL: PASS=16 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
