### PR TITLE
[physics-loop] toe-lphys istrength: bounded_theorem / bounded-support

### DIFF
--- a/docs/UNIT_LOCK_I_IS_A_CARDINALITY_Q_STRENGTH_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/UNIT_LOCK_I_IS_A_CARDINALITY_Q_STRENGTH_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,238 @@
+---
+claim_id: unit_lock_i_is_a_cardinality_q_strength_is_extra_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a finite window, a unit-lock pattern is a partial map from sites to a menu of admissible local possibilities. The Record scalar I of that pattern, read as the count of locked sites, is the nonnegative integer cardinality of the domain. A Q-valued per-lock strength sum is a separately displayed extra dictionary: it recovers the cardinal readout when every strength is 1, and it differs from that readout on one lock when every strength is 3/2. The axiom memo names content-only additive I and does not name a rational strength. The extra dictionary is displayed, not adopted, not installed as Newton mass, and not used to force r=1/2 or adopt L_phys."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py
+---
+
+# Unit-Lock I Is A Cardinality; A Q-Valued Strength Is Extra
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite-window readout typing for unit locks under the
+current Record wording.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py`](../scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py)
+
+## Result Up Front
+
+The current Record axiom supplies a scalar readout `I` of record *content*,
+additive on finite pairwise-disjoint collections, with `I(empty)=0`. A record
+locks exactly one admissible local possibility.
+
+On a finite window that fact is a cardinality. A unit-lock pattern is a
+partial map from sites to a menu. The cardinal readout
+
+`I_#(L) := |dom(L)|`
+
+is a nonnegative integer. One lock has `I_#=1`. Two disjoint locks have
+`I_#=2`. The empty pattern has `I_#=0`.
+
+A per-lock rational strength
+
+`I_q(L) := sum_{x in dom(L)} q_x`, `q_x in Q_{>0}`,
+
+is an extra dictionary. The trial `q_x=1` recovers `I_#`. The trial `q_x=3/2`
+gives `3/2` on one lock and `3` on two locks, so `I_q != I_#` already at one
+lock. The axiom memo does not name that dictionary.
+
+This note displays `I_q`. It does not adopt `I_q`, does not install it as
+Newton mass, and does not claim that `I_#` is insufficient for a later
+dictionary. It does not force `r=1/2` and does not adopt `L_phys`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The cardinal identities and the 3/2 strength mismatch are exact finite-set arithmetic on declared lock patterns. The Q-valued strength remains a displayed extra dictionary, not an adopted primitive or a Newton-mass identification."
+trace_class: negative_route_pruning
+target_claim_id: record_unit_lock_cardinal_readout
+target_blocker_text: "a Q-valued per-lock strength is extra to axiom I"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for I_# on finite unit-lock patterns and for the displayed I_q trials; adoption remains open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `W` be a finite window of lattice sites and let `M` be a finite menu of
+admissible local possibilities. A **unit-lock pattern** is a partial map
+
+`L : W ⇀ M`.
+
+The domain `dom(L)` is the finite set of sites that carry a record. Each value
+`L(x)` is the unique locked menu entry at that site. This is the Record
+sentence that a record locks exactly one admissible local possibility, read on
+a finite window: one site, one lock, one menu entry.
+
+The **cardinal readout** is
+
+`I_#(L) := |dom(L)| ∈ Z_{>=0}`.
+
+A **strength assignment** is a family `q_x ∈ Q_{>0}` indexed by `dom(L)`. The
+**strength readout** is
+
+`I_q(L) := sum_{x in dom(L)} q_x ∈ Q_{>0} ∪ {0}`,
+
+with the empty sum equal to `0`. Two trials are used below:
+
+1. `q_x = 1` for every `x` in `dom(L)`, which recovers `I_#(L)`;
+2. `q_x = 3/2` for every `x` in `dom(L)`, which multiplies the cardinality by
+   `3/2`.
+
+Two patterns are **disjoint** when their domains are disjoint. Their
+disjoint union is the partial map whose domain is the set-union of the
+domains and whose values agree with each summand on that summand's domain.
+
+The current Record wording, quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), is:
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+>
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+That is the entire load-bearing parent. No pairing table, Born weight, Newton
+kernel, or unmerged branch is used.
+
+## Theorem 1 — Cardinal `I` On Unit Locks
+
+Let `L_1` be a pattern with `|dom(L_1)|=1` and let `L_2` be a pattern with
+`|dom(L_2)|=1` whose domain is disjoint from `dom(L_1)`. Let `L_emptyset` be
+the empty partial map.
+
+Then
+
+`I_#(L_1) = 1`,
+
+`I_#(L_1 ⊔ L_2) = |dom(L_1) ∪ dom(L_2)| = 1 + 1 = 2`,
+
+and
+
+`I_#(L_emptyset) = 0`.
+
+If `L` and `L'` are any two disjoint unit-lock patterns on the same window,
+
+`I_#(L ⊔ L') = |dom(L)| + |dom(L')| = I_#(L) + I_#(L')`.
+
+So finite additivity and `I(empty)=0` hold for `I_#`. For unit locks the
+Record scalar is the cardinality of the locked-site set.
+
+## Theorem 2 — The `q=3/2` Strength Trial Differs From `I_#`
+
+Keep the same one-lock and two-lock patterns. Assign the constant strength
+`q_x = 3/2`. Then
+
+`I_q(L_1) = 3/2`,
+
+`I_q(L_1 ⊔ L_2) = 3/2 + 3/2 = 3`.
+
+In particular
+
+`I_q(L_1) = 3/2 ≠ 1 = I_#(L_1)`.
+
+The same strength dictionary with every `q_x=1` recovers the cardinal
+readout:
+
+`I_{q=1}(L) = sum_{x in dom(L)} 1 = |dom(L)| = I_#(L)`.
+
+The two trials therefore separate a displayed extra dictionary from the
+integer count. The hostile predicate
+
+`I_q(one lock) = I_#(one lock)` for `q=3/2`
+
+is false.
+
+## Theorem 3 — Record Names Content-Additive `I`, Not A Per-Lock Strength
+
+The quoted Record sentences name:
+
+- formation and unit locking of one admissible local possibility;
+- one-record-per-site uniqueness and permanence;
+- readability of records only;
+- content-only determination of a readout value;
+- finite additivity of a scalar `I` on pairwise-disjoint records, with
+  `I(empty)=0`.
+
+They do not name a family `q_x ∈ Q_{>0}`, a sum of those values, or any other
+Q-valued per-lock strength. The axioms state only their named primitive
+content. Therefore `I_q` is extra to the axiom memo. It is a separately
+written dictionary on the same finite patterns, not a clause of Record.
+
+## Theorem 4 — Display `I_q`; Do Not Adopt It
+
+The `q=3/2` trial is exhibited so that the extra dictionary is visible as a
+distinct rational-valued map. Displaying it is not adopting it.
+
+This note does not:
+
+- register `I_q` as an approved primitive;
+- replace axiom `I` by `I_q`;
+- install `I_q` as Newton mass, a source coefficient, or a force-law weight;
+- claim that `I_#` is insufficient for a later dictionary.
+
+A later retained dictionary may or may not use a rational strength. That
+decision is not made here. Cardinal `I_#` remains a well-defined Record
+readout of unit-lock content.
+
+## Theorem 5 — Do Not Force `r=1/2`; Do Not Adopt `L_phys`
+
+Nothing in Theorems 1--4 selects a radial exponent, a continuum length, or a
+physical-path parameter. In particular this note does not force `r=1/2` and
+does not adopt `L_phys`. Those symbols, if they appear in other rows, remain
+outside this claim.
+
+## What This Does Not Claim
+
+- It does not edit the axiom memo.
+- It does not identify Born weights with `I`.
+- It does not construct a pairing table or a two-argument product on `I`.
+- It does not claim that every later dictionary must stay integer-valued.
+- It does not claim that `I_#` is insufficient for a later dictionary.
+- It does not install a Newton mass, a force law, `r=1/2`, or `L_phys`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** On finite unit-lock patterns, identify axiom `I` with the
+domain cardinality and exhibit a Q-valued strength as an extra dictionary
+that is recovered at `q=1` and that differs from the cardinality at `q=3/2`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| one lock has `I_#=1` | Theorem 1 | proved by `|dom|=1` |
+| two disjoint locks have `I_#=2` | Theorem 1 | proved by disjoint-union cardinality |
+| `I_#(empty)=0` and additivity | Theorem 1 | empty set and disjoint union |
+| `I_q` at `q=3/2` is `3/2` and `3` | Theorem 2 | exact rational sum |
+| `3/2 ≠ 1` at one lock | Theorem 2 | exact inequality |
+| `q=1` recovers `I_#` | Theorem 2 | counting sum |
+| axiom does not name `q_x` | Theorem 3 | quoted Record wording |
+| display without adoption | Theorems 4--5 | explicit non-claims |
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Record sentences | parent | quoted from the axiom memo |
+| finite partial maps and disjoint union | Theorem 1 | definition-level mathematics |
+| `Q_{>0}` sums with `Fraction` | Theorem 2 | exact arithmetic here |
+| per-lock strength dictionary `I_q` | displayed extra | not axiom content; not adopted |
+| Newton mass, `r=1/2`, `L_phys` | non-claims | not used, not forced, not adopted |
+| observations or fitted couplings | none | not used |
+
+## Review Record
+
+Independent audit remains required before any effective status may change.
+No axiom file is edited. No runner cache, citation manifest, or ledger
+surface is written by this row.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18449,6 +18449,10 @@
   "unit_conversion_is_the_accepted_non_bounding_ruler_reconciliation_note_2026-06-08": {
    "deps_hash": "d292eab310f2",
    "out_degree": 2
+  },
+  "unit_lock_i_is_a_cardinality_q_strength_is_extra_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unit_singlet_overlap_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.txt
+++ b/logs/runner-cache/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py
+runner_sha256: 5f5dbc8a69cb61d5d98ebad5b1c5c86f78fd05d2a724f1c75391e15415ce8864
+input_fingerprint_sha256: 1611401504257f0b0bb060c174e6e5b5d41e75945e5e8eee3404a92afc422097
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency against the axiom memo
+PASS: source-record-lock the axiom names unit locking of one admissible local possibility
+PASS: source-record-content the axiom determines readout by record content alone
+PASS: source-record-additivity the axiom names additive scalar I with I(empty)=0
+PASS: source-no-strength-dictionary the axiom memo does not name a Q-valued per-lock strength
+PASS: pattern-disjoint-union two singleton domains are disjoint and union to cardinality two
+PASS: theorem1-one-lock I_#(one lock)=1
+PASS: theorem1-two-locks I_#(two disjoint locks)=2
+PASS: theorem1-empty I_#(empty)=0
+PASS: theorem1-additivity I_# is additive on disjoint unit locks
+PASS: theorem2-unit-strength-recovers-card I_q with every q_x=1 recovers I_#
+PASS: theorem2-three-halves-one I_q(one lock)=3/2 at q=3/2
+PASS: theorem2-three-halves-two I_q(two locks)=3 at q=3/2
+PASS: theorem2-mismatch I_q differs from I_# at one lock when q=3/2
+PASS: mutation-strength-equals-card the predicate I_q(one lock)=I_#(one lock) for q=3/2 fails
+PASS: identity-gates-call-card-and-strength identity gates call I_card(n) and I_strength(n, q)
+PASS: note-cardinal-definition the note defines I_# as the domain cardinality
+PASS: note-strength-definition the note defines I_q as a positive-rational domain sum
+PASS: note-display-not-adopt the note displays I_q and refuses adoption, Newton mass, and insufficiency rhetoric
+PASS: note-theorem5-nonclaims the note refuses r=1/2 and L_phys
+PASS: note-parent-is-axiom-memo the only named parent is the current axiom memo
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+per_element: one lock, two disjoint locks, and the empty pattern are checked
+per_site: each lock occupies one site and one menu entry
+per_mode: two strength trials q=1 and q=3/2 are compared to I_#
+per_block: the extra-dictionary block is I_q versus cardinal I_#
+lattice_wide: checked and not executed — no lattice-wide dynamics is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py
+++ b/scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Exact checks: unit-lock I is a cardinality; Q-valued strength is extra.
+
+Identity gates call I_card(n) and I_strength(n, q). The hostile predicate
+that I_q(one lock) equals I_#(one lock) at q=3/2 must fail. Arithmetic uses
+exact Fraction. No Newton coupling, no runner cache, no axiom edit.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "UNIT_LOCK_I_IS_A_CARDINALITY_Q_STRENGTH_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/UNIT_LOCK_I_IS_A_CARDINALITY_Q_STRENGTH_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+MENU = ("plus", "minus")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def unit_lock_pattern(n: int, label: str = "plus") -> dict[int, str]:
+    if n < 0:
+        raise ValueError("lock count must be nonnegative")
+    if label not in MENU:
+        raise ValueError("label is not on the menu")
+    return {site: label for site in range(n)}
+
+
+def I_hash(pattern: dict[int, str]) -> int:
+    return len(pattern)
+
+
+def I_q_sum(pattern: dict[int, str], strengths: dict[int, Fraction]) -> Fraction:
+    return sum((strengths[site] for site in pattern), start=Fraction(0))
+
+
+def I_card(n: int) -> int:
+    return I_hash(unit_lock_pattern(n))
+
+
+def I_strength(n: int, q: Fraction) -> Fraction:
+    q = Fraction(q)
+    if q <= 0:
+        raise ValueError("per-lock strength must be a positive rational")
+    pattern = unit_lock_pattern(n)
+    strengths = {site: q for site in pattern}
+    return I_q_sum(pattern, strengths)
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def identity_gates(checks: Checks) -> None:
+    one = I_card(1)
+    two = I_card(2)
+    empty = I_card(0)
+    q = Fraction(3, 2)
+    one_strength = I_strength(1, q)
+    two_strength = I_strength(2, q)
+    recovered_one = I_strength(1, Fraction(1))
+    recovered_two = I_strength(2, Fraction(1))
+
+    checks.check(
+        "theorem1-one-lock",
+        "I_#(one lock)=1",
+        one == 1,
+    )
+    checks.check(
+        "theorem1-two-locks",
+        "I_#(two disjoint locks)=2",
+        two == 2,
+    )
+    checks.check(
+        "theorem1-empty",
+        "I_#(empty)=0",
+        empty == 0,
+    )
+    checks.check(
+        "theorem1-additivity",
+        "I_# is additive on disjoint unit locks",
+        one + one == two,
+    )
+    checks.check(
+        "theorem2-unit-strength-recovers-card",
+        "I_q with every q_x=1 recovers I_#",
+        recovered_one == Fraction(one) and recovered_two == Fraction(two),
+    )
+    checks.check(
+        "theorem2-three-halves-one",
+        "I_q(one lock)=3/2 at q=3/2",
+        one_strength == Fraction(3, 2),
+    )
+    checks.check(
+        "theorem2-three-halves-two",
+        "I_q(two locks)=3 at q=3/2",
+        two_strength == Fraction(3),
+    )
+    checks.check(
+        "theorem2-mismatch",
+        "I_q differs from I_# at one lock when q=3/2",
+        one_strength != Fraction(one),
+    )
+
+
+def mutation_strength_equals_card() -> bool:
+    """Hostile predicate: I_q(one lock)=I_#(one lock) for q=3/2."""
+    return I_strength(1, Fraction(3, 2)) == I_card(1)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_norm = normalize(note)
+    axiom_norm = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current Record wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency against the axiom memo"
+    )
+
+    checks.check(
+        "source-record-lock",
+        "the axiom names unit locking of one admissible local possibility",
+        "a record locks exactly one admissible local possibility" in axiom_norm,
+    )
+    checks.check(
+        "source-record-content",
+        "the axiom determines readout by record content alone",
+        "A readout value is determined by record content alone." in axiom_norm,
+    )
+    checks.check(
+        "source-record-additivity",
+        "the axiom names additive scalar I with I(empty)=0",
+        "scalar readout `I` is additive, with `I(empty)=0`" in axiom_norm,
+    )
+    checks.check(
+        "source-no-strength-dictionary",
+        "the axiom memo does not name a Q-valued per-lock strength",
+        all(
+            needle not in axiom
+            for needle in ("per-lock", "I_q", "q_x", "I_#", "lock strength")
+        ),
+    )
+
+    one_lock = unit_lock_pattern(1)
+    other_lock = {site + 10: label for site, label in unit_lock_pattern(1).items()}
+    empty_lock: dict[int, str] = {}
+    union_lock = {**one_lock, **other_lock}
+    checks.check(
+        "pattern-disjoint-union",
+        "two singleton domains are disjoint and union to cardinality two",
+        set(one_lock).isdisjoint(other_lock)
+        and I_hash(union_lock) == I_hash(one_lock) + I_hash(other_lock)
+        and I_hash(empty_lock) == 0,
+    )
+
+    identity_gates(checks)
+
+    checks.check(
+        "mutation-strength-equals-card",
+        "the predicate I_q(one lock)=I_#(one lock) for q=3/2 fails",
+        mutation_strength_equals_card() is False,
+    )
+
+    identity_source = inspect.getsource(identity_gates)
+    checks.check(
+        "identity-gates-call-card-and-strength",
+        "identity gates call I_card(n) and I_strength(n, q)",
+        "I_card(" in identity_source and "I_strength(" in identity_source,
+    )
+
+    checks.check(
+        "note-cardinal-definition",
+        "the note defines I_# as the domain cardinality",
+        "`I_#(L) := |dom(L)|`" in note,
+    )
+    checks.check(
+        "note-strength-definition",
+        "the note defines I_q as a positive-rational domain sum",
+        "`I_q(L) := sum_{x in dom(L)} q_x`" in note
+        and "`q_x ∈ Q_{>0}`" in note,
+    )
+    checks.check(
+        "note-display-not-adopt",
+        "the note displays I_q and refuses adoption, Newton mass, and insufficiency rhetoric",
+        all(
+            phrase in note_norm
+            for phrase in (
+                "This note displays `I_q`.",
+                "does not adopt `I_q`",
+                "does not install it as Newton mass",
+                "does not claim that `I_#` is insufficient for a later dictionary",
+            )
+        ),
+    )
+    checks.check(
+        "note-theorem5-nonclaims",
+        "the note refuses r=1/2 and L_phys",
+        "does not force `r=1/2`" in note_norm and "does not adopt `L_phys`" in note_norm,
+    )
+    checks.check(
+        "note-parent-is-axiom-memo",
+        "the only named parent is the current axiom memo",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and "That is the entire load-bearing parent." in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "claim_type_reason:",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+
+    print("per_element: one lock, two disjoint locks, and the empty pattern are checked")
+    print("per_site: each lock occupies one site and one menu entry")
+    print("per_mode: two strength trials q=1 and q=3/2 are compared to I_#")
+    print("per_block: the extra-dictionary block is I_q versus cardinal I_#")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Unit-lock Record `I` is the cardinality `|dom L|`. A Q-valued per-lock strength `I_q` with `q=3/2` gives `3/2` on one lock, not `1`. That dictionary is extra. It is not Newton mass. Not adopted. `r=1/2` is not forced.

## What this means for the TOE

Mass-like lock strengths are an extra dictionary, not axiom `I`.

## What changed

- Note: `docs/UNIT_LOCK_I_IS_A_CARDINALITY_Q_STRENGTH_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py`
- Cache: `logs/runner-cache/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.txt`

## Verification

```bash
python3 scripts/unit_lock_i_is_a_cardinality_q_strength_is_extra_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
