### PR TITLE
[physics-loop] toe-lphys adjnn: bounded_theorem / bounded-support

### DIFF
--- a/docs/ADMISSIBILITY_CONDITION_IS_SIX_NN_NOT_EIGHTEEN_NEIGHBOR_STAR_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/ADMISSIBILITY_CONDITION_IS_SIX_NN_NOT_EIGHTEEN_NEIGHBOR_STAR_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,155 @@
+---
+claim_id: admissibility_condition_is_six_nn_not_eighteen_neighbor_star_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On Z^3 with nearest-neighbor adjacency, the Admissibility condition tuple is the six graph-distance-1 neighbor sites, not the eighteen-site star that adjoins the twelve edge-diagonal sites of graph distance 2. A law that depends on an edge-diagonal occupancy uses extra data. The note does not select the values of any six-neighbor law, does not adopt L_phys, and does not claim gravity or a Laplacian."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py
+---
+
+# Admissibility Condition Is The Six-Neighbor Star, Not The Eighteen-Neighbor Star
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact neighbor-set cardinalities and graph distances on `Z^3`,
+read against the current Lattice and Admissibility wording.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py`](../scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py)
+**Parents:** the live axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Lattice names nearest-neighbor adjacency on `Z^3`. Admissibility names one
+fixed nearest-neighbor rule whose distribution at a site is determined by,
+and varies with, the nearest-neighbor conditions. The nearest-neighbor set
+of the origin is the six-point star
+
+`S6 = {±e1, ±e2, ±e3}`.
+
+The twelve edge-diagonal displacements
+
+`D = {±e_i ± e_j : i < j}`
+
+sit at graph distance 2. The eighteen-point union `S18 = S6 ∪ D` is therefore
+not the named condition domain. A law `μ18` that depends on an occupancy in
+`D` uses extra data. The axioms name the domain of a six-neighbor law `μ6`,
+not the values of `μ6` and not the larger domain of `μ18`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer cardinalities and graph distances for the declared Z^3 neighbor sets, plus a displayed extra-data pair of laws. No selection of law values, no L_phys adoption, no gravity or Laplacian claim."
+trace_class: negative_route_pruning
+target_claim_id: admissibility_condition_tuple_is_six_nn
+target_blocker_text: "decide whether Admissibility's named condition is the six nearest-neighbor sites or an eighteen-site star"
+source_of_blocker_text: frontier_question
+reachability_to_target: closes
+artifact_role: theorem
+conditional_surface_status: "exact for the neighbor-set theorem and the extra-data pair; values of any six-neighbor law remain open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `e1 = (1,0,0)`, `e2 = (0,1,0)`, `e3 = (0,0,1)` for the standard
+generators of `Z^3`. Graph distance is the nearest-neighbor path metric: the
+graph distance of a displacement `v` from the origin is the `l^1` norm
+`|v1| + |v2| + |v3|`.
+
+Define
+
+```text
+S6 = {±e1, ±e2, ±e3},
+D  = {±e_i ± e_j : 1 ≤ i < j ≤ 3},
+S18 = S6 ∪ D.
+```
+
+An occupancy of the eighteen-star is a map `ω : S18 → {0,1}`. Two integer
+laws of occupancy are displayed below: `μ6` reads only `S6`, and `μ18` reads
+one edge-diagonal slot.
+
+## Theorem 1
+
+`|S6| = 6`, `|D| = 12`, and `|S18| = 18`. The three axis pairs that generate
+`S6` are disjoint, so the six signed generators are distinct. The three
+coordinate planes each contribute four signed sums `±e_i ± e_j`, and those
+twelve vectors are distinct from one another and from every element of `S6`
+because every vector in `D` has two nonzero coordinates. Therefore
+`S6 ∩ D = ∅` and `|S18| = 6 + 12 = 18`.
+
+Every `v ∈ S6` has graph distance 1. Every `w ∈ D` has graph distance 2.
+Edge-diagonal sites are not nearest neighbors of the origin.
+
+## Theorem 2
+
+The Lattice axiom states that physical sites are the points of the cubic
+lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and
+proper cubic rotations about each site.
+
+The Admissibility axiom states that there is one fixed nearest-neighbor
+admissibility rule, and that for each site the probability distribution over
+the possibilities is determined by, and varies with, the nearest-neighbor
+conditions.
+
+Nearest-neighbor adjacency is exactly the graph-distance-1 relation. At the
+origin that relation names the six-site tuple with slots in `S6`, not the
+eighteen-site tuple with slots in `S18`. The named condition is a 6-tuple,
+not an 18-tuple.
+
+## Theorem 3
+
+A law of occupancy that depends on an edge-diagonal slot is extra relative
+to the named condition.
+
+Define integer laws
+
+```text
+μ6(ω)  = Σ_{v ∈ S6} ω(v),
+μ18(ω) = μ6(ω) + ω(e1 + e2).
+```
+
+`μ6` ignores `D`. `μ18` depends on the single edge-diagonal occupancy
+`ω(e1 + e2)`.
+
+Display the pair of occupancies that agree on `S6` and differ on `D`:
+
+- `ω0` occupies `e1` only;
+- `ω1` occupies `e1` and `e1 + e2` only.
+
+Then `μ6(ω0) = μ6(ω1) = 1`, while `μ18(ω0) = 1` and `μ18(ω1) = 2`. The
+axioms name the domain of `μ6`, not the domain of `μ18`.
+
+## Theorem 4
+
+This note does not select the values of `μ6`. The displayed pair is a
+domain witness, not a proposed physical law. The note does not adopt
+`L_phys`. It does not claim gravity. It does not claim a Laplacian.
+
+## Theorem 5
+
+The note does not force a distinguished half-weight `r = 1/2`. The displayed
+integer values of `μ6` and `μ18` on `{ω0, ω1}` are `1` and `2`. Neither
+witness is a half-weight, and no later selector is forbidden from choosing
+some other six-neighbor table.
+
+## Hostile Predicates
+
+The predicate "edge-diagonals are nearest neighbors" fails: every vector in
+`D` has graph distance 2. The predicate "`|S6| = 18`" fails: `nn_count()`
+returns 6. Identity gates call `nn_count()` and `graph_distance(e1+e2)` and
+read `6` and `2` respectively.
+
+## Negative Scope
+
+The result is a condition-domain theorem. It does not derive a unique
+Admissibility table, a kinetic operator, a continuum Laplacian coefficient,
+a gravitational identification, or a physical law `L_phys`. It does not
+edit an axiom.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -345,6 +345,10 @@
   "adm2_global_su3_symmetry_reduces_action_form_bi_invariance_narrow_theorem_note_2026-06-08": {
    "deps_hash": "17b0cde87f4c",
    "out_degree": 3
+  },
+  "admissibility_condition_is_six_nn_not_eighteen_neighbor_star_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10": {
    "deps_hash": "8830c572e201",

--- a/logs/runner-cache/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.txt
+++ b/logs/runner-cache/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py
+runner_sha256: b6037a71e8a20c7d7e99a33f54926930c6783c8f2fcbd18731fe4e5996012654
+input_fingerprint_sha256: b601cf3050e6c6dccf1096cbe63f952496086ae8dcb1493c42c8f8fa147e39eb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: values of mu6, L_phys, gravity, and any Laplacian remain unselected
+PASS: audit-inputs declared inputs are the new note and the axiom memo
+PASS: theorem-1-cardinalities constructed |S6|=6, |D|=12, |S18|=18 with empty intersection
+PASS: theorem-1-s6-distance every vector in S6 has graph distance 1
+PASS: theorem-1-d-distance every edge-diagonal has graph distance 2
+PASS: theorem-2-lattice-quote Lattice names nearest-neighbor adjacency
+PASS: theorem-2-admissibility-quote Admissibility names nearest-neighbor conditions as the distribution's domain
+PASS: theorem-2-six-tuple the named condition is a 6-tuple, not an 18-tuple
+PASS: theorem-3-mu6-ignores-d mu6 is unchanged when only an edge-diagonal occupancy flips
+PASS: theorem-3-mu18-depends-on-d mu18 depends on the occupancy of e1+e2
+PASS: theorem-3-domain the displayed pair names mu6's domain, not mu18
+PASS: theorem-4-nonclaims note does not adopt L_phys and does not claim gravity or a Laplacian
+PASS: theorem-5-no-half-weight displayed integer laws are not forced to r=1/2
+PASS: mutation-edge-diagonals-are-nn predicate 'edge-diagonals are nearest neighbors' fails
+PASS: mutation-s6-eq-18 predicate '|S6|=18' fails
+PASS: identity-nn-count identity gate calls nn_count() and reads 6
+PASS: identity-graph-distance identity gate calls graph_distance(e1+e2) and reads 2
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py
+++ b/scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Exact neighbor-set checks: Admissibility names the 6-NN star, not S18.
+
+The runner builds S6, D, and S18 from the standard generators of Z^3, counts
+them, and computes graph distances. Identity gates call nn_count() and
+graph_distance(e1+e2). Two hostile predicates are required to fail. A displayed
+pair of occupancy laws shows that dependence on an edge-diagonal slot is extra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "ADMISSIBILITY_CONDITION_IS_SIX_NN_NOT_EIGHTEEN_NEIGHBOR_STAR_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_CONDITION_IS_SIX_NN_NOT_EIGHTEEN_NEIGHBOR_STAR_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+class Vec(tuple):
+    """Integer lattice vector with componentwise addition."""
+
+    def __new__(cls, xs):
+        return super().__new__(cls, tuple(int(x) for x in xs))
+
+    def __add__(self, other: object) -> "Vec":
+        if not isinstance(other, tuple):
+            return NotImplemented
+        return Vec(a + b for a, b in zip(self, other))
+
+    def __neg__(self) -> "Vec":
+        return Vec(-a for a in self)
+
+    def __mul__(self, scalar: object) -> "Vec":
+        if not isinstance(scalar, int):
+            return NotImplemented
+        return Vec(scalar * a for a in self)
+
+    def __rmul__(self, scalar: object) -> "Vec":
+        return self.__mul__(scalar)
+
+
+e1 = Vec((1, 0, 0))
+e2 = Vec((0, 1, 0))
+e3 = Vec((0, 0, 1))
+
+
+def graph_distance(displacement: tuple[int, ...]) -> int:
+    """Nearest-neighbor path length from the origin on Z^3."""
+    return sum(abs(int(component)) for component in displacement)
+
+
+def s6_set() -> frozenset[Vec]:
+    axes = (e1, e2, e3)
+    return frozenset(sign * axis for axis in axes for sign in (1, -1))
+
+
+def d_set() -> frozenset[Vec]:
+    axes = (e1, e2, e3)
+    out: set[Vec] = set()
+    for i in range(3):
+        for j in range(i + 1, 3):
+            for si in (1, -1):
+                for sj in (1, -1):
+                    out.add((si * axes[i]) + (sj * axes[j]))
+    return frozenset(out)
+
+
+def s18_set() -> frozenset[Vec]:
+    return s6_set() | d_set()
+
+
+def nn_count() -> int:
+    return len(s6_set())
+
+
+def mu6(occupancy: dict[Vec, int]) -> int:
+    return sum(int(occupancy[site]) for site in s6_set())
+
+
+def mu18(occupancy: dict[Vec, int]) -> int:
+    return mu6(occupancy) + int(occupancy[e1 + e2])
+
+
+def occupancy(occupied: frozenset[Vec]) -> dict[Vec, int]:
+    return {site: 1 if site in occupied else 0 for site in s18_set()}
+
+
+def identity_nn_count() -> int:
+    return nn_count()
+
+
+def identity_edge_diagonal_distance() -> int:
+    return graph_distance(e1+e2)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_n = normalize(note)
+    axiom_n = normalize(axiom)
+
+    s6 = s6_set()
+    d = d_set()
+    s18 = s18_set()
+
+    print("external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: values of mu6, L_phys, gravity, and any Laplacian remain unselected")
+
+    checks.check(
+        "audit-inputs",
+        "declared inputs are the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_CONDITION_IS_SIX_NN_NOT_EIGHTEEN_NEIGHBOR_STAR_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    checks.check(
+        "theorem-1-cardinalities",
+        "constructed |S6|=6, |D|=12, |S18|=18 with empty intersection",
+        nn_count() == 6
+        and len(d) == 12
+        and len(s18) == 18
+        and s6.isdisjoint(d)
+        and s18 == s6 | d,
+    )
+    checks.check(
+        "theorem-1-s6-distance",
+        "every vector in S6 has graph distance 1",
+        all(graph_distance(site) == 1 for site in s6) and len(s6) == nn_count(),
+    )
+    checks.check(
+        "theorem-1-d-distance",
+        "every edge-diagonal has graph distance 2",
+        all(graph_distance(site) == 2 for site in d) and len(d) == 12,
+    )
+
+    lattice_phrase = "nearest-neighbor adjacency"
+    admissibility_sentence = (
+        "the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions"
+    )
+    checks.check(
+        "theorem-2-lattice-quote",
+        "Lattice names nearest-neighbor adjacency",
+        lattice_phrase in axiom_n and lattice_phrase in note_n,
+    )
+    checks.check(
+        "theorem-2-admissibility-quote",
+        "Admissibility names nearest-neighbor conditions as the distribution's domain",
+        admissibility_sentence in axiom_n and admissibility_sentence in note_n,
+    )
+    checks.check(
+        "theorem-2-six-tuple",
+        "the named condition is a 6-tuple, not an 18-tuple",
+        "named condition is a 6-tuple, not an 18-tuple" in note_n
+        and nn_count() != 18
+        and len(s18) == 18,
+    )
+
+    omega0 = occupancy(frozenset({e1}))
+    omega1 = occupancy(frozenset({e1, e1 + e2}))
+    checks.check(
+        "theorem-3-mu6-ignores-d",
+        "mu6 is unchanged when only an edge-diagonal occupancy flips",
+        mu6(omega0) == mu6(omega1) == 1
+        and omega0[e1 + e2] != omega1[e1 + e2],
+    )
+    checks.check(
+        "theorem-3-mu18-depends-on-d",
+        "mu18 depends on the occupancy of e1+e2",
+        mu18(omega0) == 1 and mu18(omega1) == 2 and mu18(omega0) != mu18(omega1),
+    )
+    checks.check(
+        "theorem-3-domain",
+        "the displayed pair names mu6's domain, not mu18",
+        "Axioms name the domain of `μ6`, not the domain of `μ18`" in note
+        or "axioms name the domain of `μ6`, not the domain of `μ18`" in note_n,
+    )
+
+    checks.check(
+        "theorem-4-nonclaims",
+        "note does not adopt L_phys and does not claim gravity or a Laplacian",
+        "does not adopt `L_phys`" in note_n
+        and "does not claim gravity" in note_n
+        and "does not claim a Laplacian" in note_n
+        and "does not select the values of `μ6`" in note_n,
+    )
+    checks.check(
+        "theorem-5-no-half-weight",
+        "displayed integer laws are not forced to r=1/2",
+        mu6(omega0) != 1 / 2
+        and mu18(omega1) != 1 / 2
+        and "does not force a distinguished half-weight `r = 1/2`" in note_n,
+    )
+
+    edge_diagonals_are_nearest_neighbors = all(
+        graph_distance(site) == 1 for site in d
+    )
+    s6_has_eighteen = nn_count() == 18
+    checks.check(
+        "mutation-edge-diagonals-are-nn",
+        "predicate 'edge-diagonals are nearest neighbors' fails",
+        edge_diagonals_are_nearest_neighbors is False,
+    )
+    checks.check(
+        "mutation-s6-eq-18",
+        "predicate '|S6|=18' fails",
+        s6_has_eighteen is False,
+    )
+
+    checks.check(
+        "identity-nn-count",
+        "identity gate calls nn_count() and reads 6",
+        identity_nn_count() == 6,
+    )
+    checks.check(
+        "identity-graph-distance",
+        "identity gate calls graph_distance(e1+e2) and reads 2",
+        identity_edge_diagonal_distance() == 2,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On `Z^3`, nearest neighbors are the six sites at graph distance 1. The twelve edge-diagonals sit at distance 2. Admissibility's named condition is a 6-tuple, not an 18-tuple. A law that depends on edge-diagonal occupancy is extra. Law *values* are not selected. No L_phys, no Laplacian claim.

## What this means for the TOE

The law's condition domain is the 6-NN star.

## What changed

- Note: `docs/ADMISSIBILITY_CONDITION_IS_SIX_NN_NOT_EIGHTEEN_NEIGHBOR_STAR_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py`
- Cache: `logs/runner-cache/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.txt`

## Verification

```bash
python3 scripts/admissibility_condition_is_six_nn_not_eighteen_neighbor_star_2026_08_13.py
# TOTAL: PASS=16 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
