### PR TITLE
[physics-loop] toe-lphys phycomp: bounded_theorem / bounded-support

### DIFF
--- a/docs/SECOND_C8_WITH_MINUS_Y0_CANCELS_CUBIC_AND_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SECOND_C8_WITH_MINUS_Y0_CANCELS_CUBIC_AND_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,182 @@
+---
+claim_id: second_c8_with_minus_y0_cancels_cubic_and_is_extra_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a displayed C^8 the operator Y_0 = Pi_+ - 3 Pi_- has exact cubic trace 6 - 54 = -48. On the extra direct sum H = C^8 ⊕ C^8 the complementary block -Y_0 cancels that cubic, Tr(Y_⊕^3) = 0, while the first block keeps the parent (6,2) eigenvalue ratio 1 : (-3). The resulting 16-dimensional object is strictly larger than one-site Qubit M_2(C) and larger than one C^8. The displayed pair is not adopted as an axiom, not named as two generations, and is not identified with U(1)_Y or PDG hypercharge. Physical-hypercharge closure is not claimed."
+upstream_dependencies:
+  - minimal_axioms
+  - lh_doublet_traceless_abelian_eigenvalue_ratio_narrow_theorem_note_2026-05-02
+runner: scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py
+---
+
+# A Second C^8 With −Y_0 Cancels the Two-Block Cubic and Is Extra
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact integer traces of one displayed pair of 8-by-8 diagonal
+operators and their 16-by-16 direct sum. No observational input.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py`](../scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py)
+
+Parents used as source text only:
+
+- [`LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md`](LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_NARROW_THEOREM_NOTE_2026-05-02.md)
+  supplies the structural multiplicity pair `(6, 2)` and the traceless
+  eigenvalue ratio `1 : (−3)`. That parent does not identify the ratio with
+  Standard Model hypercharge.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the
+  Qubit sentence that the full one-site possibility domain has algebraic
+  presentation `M_2(C)`. Neither a second `C^8` nor `Y_⊕` is named there.
+
+The cubic integer `6 − 54 = −48` is reconstructed here from the displayed
+diagonal. It is not imported from any other row.
+
+## Result Up Front
+
+Let `Pi_+ = diag(I_6, 0_2)` and `Pi_- = diag(0_6, I_2)` act on `C^8`, and set
+
+```text
+Y_0 = Pi_+ − 3 Pi_- = diag(1,1,1,1,1,1,−3,−3).
+```
+
+The first block therefore keeps the parent ratio `1 : (−3)` on the
+multiplicities `(6, 2)`. The exact cubic is
+
+```text
+Tr(Y_0^3) = 6 · (1)^3 + 2 · (−3)^3 = 6 − 54 = −48 ≠ 0.
+```
+
+On the extra space `H = C^8 ⊕ C^8` define the complementary block `−Y_0` and
+
+```text
+Y_⊕ = Y_0 ⊕ (−Y_0).
+```
+
+Then
+
+```text
+Tr(Y_⊕^3) = Tr(Y_0^3) + Tr((−Y_0)^3) = −48 + 48 = 0.
+```
+
+The complementary 8-carrier with opposite `Y` is the smallest extra object
+that keeps the `(6, 2)` ratio on the first block and meets the extra matching
+condition `Tr(Y^3) = 0`: the opposite spectrum of `Y_0` is six copies of
+`−1` and two copies of `+3`, which occupies eight eigenvalues and cannot sit
+in a strictly smaller complementary carrier. The displayed `Y_⊕` is an extra
+algebraic object. It is not adopted as an axiom and is not named as two
+generations.
+
+`dim H = 16` is strictly larger than `dim C^2 = 2` (the one-site Hilbert
+space whose endomorphism algebra is the Qubit domain `M_2(C)`) and strictly
+larger than `8`. A predicate that one-site `M_2(C)` already contains `Y_⊕`
+is therefore false.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer traces on a displayed pair of carriers. The pair is extra relative to Qubit and is not adopted. No physical-hypercharge identification and no generation axiom."
+trace_class: negative_route_pruning
+target_claim_id: complementary_c8_cancels_cubic
+target_blocker_text: "the (6,2) cubic Tr(Y_0^3)=-48 is not cancelled on one C^8"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed pair and the cubic identities; P-HY identification remains open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+On `C^8` the complementary projectors are
+
+```text
+Pi_+ = diag(I_6, 0_2),     Pi_- = diag(0_6, I_2),
+Pi_+^2 = Pi_+,             Pi_-^2 = Pi_-,
+Pi_+ Pi_- = 0,             Pi_+ + Pi_- = I_8,
+rank(Pi_+) = 6,            rank(Pi_-) = 2.
+```
+
+The displayed abelian operator is
+
+```text
+Y_0 = Pi_+ − 3 Pi_-.
+```
+
+Its spectrum is `1` with multiplicity `6` and `−3` with multiplicity `2`.
+Tracelessness `6 · 1 + 2 · (−3) = 0` is the parent ratio identity with
+scale `α = 1`. The cubic is recomputed only from this diagonal:
+
+```text
+Tr(Y_0^3) = 6 − 54 = −48.
+```
+
+A predicate `Tr(Y_0^3) = 0` is therefore false.
+
+On `H = C^8 ⊕ C^8` the complementary block is `−Y_0` and
+
+```text
+Y_⊕ = Y_0 ⊕ (−Y_0)
+    = diag(1,1,1,1,1,1,−3,−3,−1,−1,−1,−1,−1,−1,+3,+3).
+```
+
+The first eight eigenvalues are exactly those of `Y_0`, so the first block
+keeps the `(6, 2)` ratio. The last eight are the opposite spectrum, so the
+extra matching cubic vanishes:
+
+```text
+Tr(Y_⊕^3) = (−48) + 48 = 0.
+```
+
+Identity gates in the runner call `cubic_Y0()` and `cubic_Yplus()`; those
+functions compute the traces from the constructed matrices. They do not
+return a stored target constant.
+
+## Theorems
+
+**Theorem 1.** `Tr(Y_0^3) = −48 ≠ 0`. Recomputed from
+`6 · (1)^3 + 2 · (−3)^3 = 6 − 54`.
+
+**Theorem 2.** `Tr(Y_⊕^3) = 0`. The complementary block cancels the cubic.
+
+**Theorem 3.** `dim H = 16 > 2 = dim C^2` (one-site Qubit) and `16 > 8`.
+The Qubit axiom states that the full one-site possibility domain has
+algebraic presentation `M_2(C)`. Neither a second `C^8` nor `Y_⊕` is named
+in that axiom memo.
+
+**Theorem 4.** The smallest extra object that keeps the `(6, 2)` ratio on
+the first block and satisfies the extra matching `Tr(Y^3) = 0` is a
+complementary 8-carrier with opposite `Y`. The note displays `Y_⊕`. It does
+not adopt that operator as an axiom and does not call the pair two
+generations.
+
+**Theorem 5.** Do not identify `Y_⊕` with Standard Model hypercharge. Do not
+import PDG values. Do not claim that physical hypercharge (P-HY) is closed.
+
+## What this note does not close
+
+- Identification of `Y_0` or `Y_⊕` with `U(1)_Y` or with any PDG
+  hypercharge assignment.
+- Adoption of a generation axiom, a two-generation reading of `H`, or any
+  extra axiom.
+- Closure of physical hypercharge (P-HY).
+- Anomaly cancellation for any Standard Model fermion census.
+- A claim that one-site `M_2(C)` already contains `Y_⊕`.
+
+## Audit-lane disposition (proposed)
+
+```yaml
+target_claim_type: bounded_theorem
+proposed_claim_scope: |
+  exact integer reconstruction Tr(Y_0^3) = 6 - 54 = -48 on one C^8;
+  complementary -Y_0 on a second C^8 cancels the cubic; the 16-dimensional
+  pair is extra relative to one-site M_2(C); no U(1)_Y, PDG, generation
+  axiom, or P-HY closure.
+audit_status_authority: independent audit lane only
+audit_required_before_effective_retained: true
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16421,6 +16421,10 @@
   "science_3plus1_line_law_known_limits_note_2026-04-20": {
    "deps_hash": "3e19d7b5d628",
    "out_degree": 6
+  },
+  "second_c8_with_minus_y0_cancels_cubic_and_is_extra_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "61e9d69bb3fe",
+   "out_degree": 2
   },
   "second_grown_family_complex_boundary_note": {
    "deps_hash": "3ba1a856c176",

--- a/logs/runner-cache/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.txt
+++ b/logs/runner-cache/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py
 runner_sha256: 9fd72ce94451ca242a2143fc70543adc279171635fd9c971f4b58a3effa9edf9
-input_fingerprint_sha256: 3c320a71a7a6f756d09e67020902abb63dea4220f9a91b32c5803cde98c8ab32
+input_fingerprint_sha256: 93a07c36d25b4ab44d893a581b8ea08ed76390c468090cf8f32d1fb54a399f50
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.05
+elapsed_sec: 0.04
 status: ok
 ----- stdout -----
 PASS: source-parent-ratio May 2 parent states the 1 : (-3) multiplicity ratio

--- a/logs/runner-cache/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.txt
+++ b/logs/runner-cache/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.txt
@@ -1,0 +1,28 @@
+===== runner cache v1 =====
+runner: scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py
+runner_sha256: 9fd72ce94451ca242a2143fc70543adc279171635fd9c971f4b58a3effa9edf9
+input_fingerprint_sha256: 3c320a71a7a6f756d09e67020902abb63dea4220f9a91b32c5803cde98c8ab32
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+PASS: source-parent-ratio May 2 parent states the 1 : (-3) multiplicity ratio
+PASS: source-parent-no-sm-y May 2 parent keeps SM hypercharge identification out of scope
+PASS: source-qubit-m2 Qubit one-site domain is M_2(C) and names neither second C^8 nor Y_oplus
+PASS: source-note-theorems note states the five theorems and the extra-object bound
+PASS: source-note-negative-scope note adopts no generation axiom and does not close P-HY
+PASS: projectors Pi_+ and Pi_- are complementary rank-(6,2) projectors on C^8
+PASS: first-block-ratio Y_0 keeps the parent (6,2) spectrum 1 x6 and -3 x2
+PASS: identity-cubic-Y0 Tr(Y_0^3) equals reconstructed 6*(1)^3 + 2*(-3)^3
+PASS: identity-cubic-Yplus Tr(Y_oplus^3) vanishes by the complementary block
+PASS: dim-extra dim H = 16 exceeds one-site C^2 and one C^8
+PASS: minimality-opposite-octet opposite spectrum of Y_0 occupies eight eigenvalues
+PASS: mutation-cubic-zero predicate Tr(Y_0^3)=0 fails because the cubic is 6-54
+PASS: mutation-m2-contains-yplus predicate one-site M_2 contains Y_oplus fails (dim 16 vs 2)
+PASS: identity-gates-call-cubics identity gates call cubic_Y0() and cubic_Yplus()
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the new note, the May 2 note, and the axiom memo
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py
+++ b/scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Exact integer traces: second C^8 with -Y_0 cancels the cubic and is extra.
+
+Identity gates call cubic_Y0() and cubic_Yplus(). Those functions compute
+traces from constructed integer matrices. They do not return a stored target.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SECOND_C8_WITH_MINUS_Y0_CANCELS_CUBIC_AND_IS_EXTRA_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+PARENT_REL = (
+    "docs/LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_"
+    "NARROW_THEOREM_NOTE_2026-05-02.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/SECOND_C8_WITH_MINUS_Y0_CANCELS_CUBIC_AND_IS_EXTRA_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/LH_DOUBLET_TRACELESS_ABELIAN_EIGENVALUE_RATIO_"
+    "NARROW_THEOREM_NOTE_2026-05-02.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def diag(values: tuple[int, ...]) -> tuple[tuple[int, ...], ...]:
+    n = len(values)
+    return tuple(tuple(values[i] if i == j else 0 for j in range(n)) for i in range(n))
+
+
+def mat_add(
+    left: tuple[tuple[int, ...], ...],
+    right: tuple[tuple[int, ...], ...],
+) -> tuple[tuple[int, ...], ...]:
+    n = len(left)
+    return tuple(tuple(left[i][j] + right[i][j] for j in range(n)) for i in range(n))
+
+
+def mat_scale(
+    scalar: int,
+    matrix: tuple[tuple[int, ...], ...],
+) -> tuple[tuple[int, ...], ...]:
+    n = len(matrix)
+    return tuple(tuple(scalar * matrix[i][j] for j in range(n)) for i in range(n))
+
+
+def matmul(
+    left: tuple[tuple[int, ...], ...],
+    right: tuple[tuple[int, ...], ...],
+) -> tuple[tuple[int, ...], ...]:
+    n = len(left)
+    return tuple(
+        tuple(sum(left[i][k] * right[k][j] for k in range(n)) for j in range(n))
+        for i in range(n)
+    )
+
+
+def mat_pow3(matrix: tuple[tuple[int, ...], ...]) -> tuple[tuple[int, ...], ...]:
+    return matmul(matmul(matrix, matrix), matrix)
+
+
+def trace(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return sum(matrix[i][i] for i in range(len(matrix)))
+
+
+def rank_diag_projector(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return sum(1 for i in range(len(matrix)) if matrix[i][i] != 0)
+
+
+def direct_sum(
+    left: tuple[tuple[int, ...], ...],
+    right: tuple[tuple[int, ...], ...],
+) -> tuple[tuple[int, ...], ...]:
+    n = len(left)
+    m = len(right)
+    size = n + m
+    rows = []
+    for i in range(size):
+        row = []
+        for j in range(size):
+            if i < n and j < n:
+                row.append(left[i][j])
+            elif i >= n and j >= n:
+                row.append(right[i - n][j - n])
+            else:
+                row.append(0)
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def spectrum(matrix: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
+    return tuple(matrix[i][i] for i in range(len(matrix)))
+
+
+def pi_plus() -> tuple[tuple[int, ...], ...]:
+    return diag((1, 1, 1, 1, 1, 1, 0, 0))
+
+
+def pi_minus() -> tuple[tuple[int, ...], ...]:
+    return diag((0, 0, 0, 0, 0, 0, 1, 1))
+
+
+def Y_0() -> tuple[tuple[int, ...], ...]:
+    return mat_add(pi_plus(), mat_scale(-3, pi_minus()))
+
+
+def minus_Y_0() -> tuple[tuple[int, ...], ...]:
+    return mat_scale(-1, Y_0())
+
+
+def Y_plus() -> tuple[tuple[int, ...], ...]:
+    return direct_sum(Y_0(), minus_Y_0())
+
+
+def reconstructed_cubic_Y0() -> int:
+    return 6 * (1**3) + 2 * ((-3) ** 3)
+
+
+def cubic_Y0() -> int:
+    return trace(mat_pow3(Y_0()))
+
+
+def cubic_Yplus() -> int:
+    return trace(mat_pow3(Y_plus()))
+
+
+def dim_H() -> int:
+    return len(Y_plus())
+
+
+def onesite_qubit_dim() -> int:
+    return 2
+
+
+def predicate_single_block_cubic_vanishes() -> bool:
+    return cubic_Y0() == 0
+
+
+def predicate_onesite_M2_contains_Yplus() -> bool:
+    return dim_H() <= onesite_qubit_dim()
+
+
+def opposite_spectrum_length() -> int:
+    return len(tuple(-value for value in spectrum(Y_0())))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def identity_gates_call_required_functions(source: str) -> bool:
+    tree = ast.parse(source)
+    required = {"cubic_Y0", "cubic_Yplus"}
+    seen: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in required:
+            seen.add(func.id)
+    return seen == required
+
+
+def audit_paths_literal(source: str) -> tuple[str, ...] | None:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if node.targets[0].id != "AUDIT_INPUT_PATHS":
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        paths: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            paths.append(elt.value)
+        return tuple(paths)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    source = Path(__file__).read_text(encoding="utf-8")
+    note = (ROOT / NOTE_REL).read_text(encoding="utf-8")
+    parent = (ROOT / PARENT_REL).read_text(encoding="utf-8")
+    axiom = (ROOT / AXIOM_REL).read_text(encoding="utf-8")
+    note_n = normalize(note)
+    parent_n = normalize(parent)
+    axiom_n = normalize(axiom)
+
+    plus = pi_plus()
+    minus = pi_minus()
+    y0 = Y_0()
+    yplus = Y_plus()
+    rebuilt = reconstructed_cubic_Y0()
+
+    checks.check(
+        "source-parent-ratio",
+        "May 2 parent states the 1 : (-3) multiplicity ratio",
+        "1 : (−3)" in parent or "1 : (-3)" in parent,
+    )
+    checks.check(
+        "source-parent-no-sm-y",
+        "May 2 parent keeps SM hypercharge identification out of scope",
+        "identification with Standard Model hypercharge Y" in parent
+        and "out of scope" in parent_n,
+    )
+    checks.check(
+        "source-qubit-m2",
+        "Qubit one-site domain is M_2(C) and names neither second C^8 nor Y_oplus",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "Y_⊕" not in axiom
+        and "Y_oplus" not in axiom_n
+        and "second C^8" not in axiom,
+    )
+    checks.check(
+        "source-note-theorems",
+        "note states the five theorems and the extra-object bound",
+        all(
+            phrase in note
+            for phrase in (
+                "Tr(Y_0^3) = −48 ≠ 0",
+                "The complementary block cancels the cubic",
+                "dim H = 16 > 2 = dim C^2",
+                "complementary 8-carrier with opposite",
+                "Do not identify `Y_⊕` with Standard Model hypercharge",
+            )
+        ),
+    )
+    checks.check(
+        "source-note-negative-scope",
+        "note adopts no generation axiom and does not close P-HY",
+        "does not adopt that operator as an axiom" in note_n
+        and "does not call the pair two generations" in note_n
+        and "Do not claim that physical hypercharge (P-HY) is closed" in note
+        and "Do not import PDG" in note_n
+        and "phyanom" not in note
+        and "c8carrier" not in note
+        and "ranksplit" not in note,
+    )
+    checks.check(
+        "projectors",
+        "Pi_+ and Pi_- are complementary rank-(6,2) projectors on C^8",
+        plus == matmul(plus, plus)
+        and minus == matmul(minus, minus)
+        and matmul(plus, minus) == diag((0,) * 8)
+        and mat_add(plus, minus) == diag((1,) * 8)
+        and rank_diag_projector(plus) == 6
+        and rank_diag_projector(minus) == 2,
+    )
+    checks.check(
+        "first-block-ratio",
+        "Y_0 keeps the parent (6,2) spectrum 1 x6 and -3 x2",
+        spectrum(y0) == (1, 1, 1, 1, 1, 1, -3, -3)
+        and y0 == mat_add(plus, mat_scale(-3, minus))
+        and trace(y0) == 0,
+    )
+    checks.check(
+        "identity-cubic-Y0",
+        "Tr(Y_0^3) equals reconstructed 6*(1)^3 + 2*(-3)^3",
+        cubic_Y0() == rebuilt and rebuilt == 6 - 54 and cubic_Y0() != 0,
+    )
+    checks.check(
+        "identity-cubic-Yplus",
+        "Tr(Y_oplus^3) vanishes by the complementary block",
+        cubic_Yplus() == 0
+        and cubic_Yplus() == cubic_Y0() + trace(mat_pow3(minus_Y_0()))
+        and spectrum(yplus)
+        == (1, 1, 1, 1, 1, 1, -3, -3, -1, -1, -1, -1, -1, -1, 3, 3),
+    )
+    checks.check(
+        "dim-extra",
+        "dim H = 16 exceeds one-site C^2 and one C^8",
+        dim_H() == 16 and dim_H() > onesite_qubit_dim() and dim_H() > 8,
+    )
+    checks.check(
+        "minimality-opposite-octet",
+        "opposite spectrum of Y_0 occupies eight eigenvalues",
+        opposite_spectrum_length() == 8
+        and tuple(-value for value in spectrum(y0)[:8]) == spectrum(yplus)[8:],
+    )
+    checks.check(
+        "mutation-cubic-zero",
+        "predicate Tr(Y_0^3)=0 fails because the cubic is 6-54",
+        predicate_single_block_cubic_vanishes() is False and cubic_Y0() == 6 - 54,
+    )
+    checks.check(
+        "mutation-m2-contains-yplus",
+        "predicate one-site M_2 contains Y_oplus fails (dim 16 vs 2)",
+        predicate_onesite_M2_contains_Yplus() is False
+        and dim_H() == 16
+        and onesite_qubit_dim() == 2,
+    )
+    checks.check(
+        "identity-gates-call-cubics",
+        "identity gates call cubic_Y0() and cubic_Yplus()",
+        identity_gates_call_required_functions(source),
+    )
+    literal = audit_paths_literal(source)
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the new note, the May 2 note, and the axiom memo",
+        literal == AUDIT_INPUT_PATHS
+        and AUDIT_INPUT_PATHS
+        == (
+            NOTE_REL,
+            PARENT_REL,
+            AXIOM_REL,
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`Tr(Y_0^3)=6-54=-48`. On `C^8⊕C^8`, `Y_⊕=Y_0⊕(-Y_0)` has cubic `0`. `dim H=16` exceeds one-site `M_2(C)`. The complementary 8-carrier is extra. Not adopted as two generations. Not identified with `U(1)_Y` or PDG. P-HY is not closed.

## What this means for the TOE

Cubic cancellation needs an extra second `C^8`. That is not axiom content.

## What changed

- Note: `docs/SECOND_C8_WITH_MINUS_Y0_CANCELS_CUBIC_AND_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py`
- Cache: `logs/runner-cache/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.txt`

## Verification

```bash
python3 scripts/second_c8_with_minus_y0_cancels_cubic_and_is_extra_2026_08_13.py
# TOTAL: PASS=15 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
