### PR TITLE
[physics-loop] toe-lphys varyrule: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_NN_VARYING_LAWS_ARE_ADMISSIBILITY_SHAPED_AXIOMS_PICK_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_NN_VARYING_LAWS_ARE_ADMISSIBILITY_SHAPED_AXIOMS_PICK_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,286 @@
+---
+claim_id: two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On one center site with binary menu {A,B} and occupancy coarse-grain n of the six nearest-neighbor records, two distinct full-support-on-interior laws mu1(A|n) and mu2(A|n) are each functions of nearest-neighbor data and each vary with n. Both therefore fit the current Admissibility shape. The four axioms name neither function, adopt neither as a physical law, and do not force mu(A)=1/2 at every n. The result does not claim that no later selector exists."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py
+---
+
+# Two NN-Varying Laws Are Admissibility-Shaped; Axioms Pick Neither
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site occupancy coarse-grain of the six nearest-neighbor
+conditions; function-selection only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py`](../scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py)
+
+## Result Up Front
+
+Admissibility supplies one fixed nearest-neighbor rule and requires that, for
+each site, the probability distribution over the possibilities is determined
+by, and varies with, the nearest-neighbor conditions. That sentence constrains
+the *type* of the law. It does not name the extensional function.
+
+Two explicit occupancy laws on the same window both fit the type and disagree
+at a legal interior point. Neither is adopted as a physical law. The uniform
+value `mu(A)=1/2` is not forced: `mu1(A|2)=1/3` is a legal value of a
+varying nearest-neighbor law. A later selector is not ruled out.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two explicit occupancy laws are proved to vary with a nearest-neighbor coarse-grain and to disagree, while Admissibility names the type and not the function; adoption as a physical law, a universal half-weight, and nonexistence of a later selector remain outside the claim."
+trace_class: negative_route_pruning
+target_claim_id: admissibility_nn_rule_extensional_function
+target_blocker_text: "determined by and varies with the nearest-neighbor 6-tuple does not select the function"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed occupancy pair and the axiom-type reading; later selectors remain open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Fix one center site. The local menu is the two-point set `{A,B}`. The six
+nearest-neighbor sites of the cubic lattice are the condition window. Let
+`n in {0,1,...,6}` be the number of those neighbor sites locked to a declared
+label `A`. This `n` is a coarse-grain of the nearest-neighbor 6-tuple: every
+value of `n` is realized by some 6-tuple, and distinct 6-tuples may share a
+value of `n`.
+
+A binary occupancy law is a function
+
+`mu(A|n) in [0,1]`, `mu(B|n)=1-mu(A|n)`.
+
+The first displayed law is piecewise
+
+`mu1(A|0)=1/2`, `mu1(A|n)=n/6` for `n=1,...,6`.
+
+So `mu1(A|1)=1/6`, `mu1(A|2)=1/3`, `mu1(A|6)=1`. The `n=0` clause is full
+support on `{A,B}`; without it the occupancy fraction would be `0`. At `n=6`
+the same occupancy fraction is certain `A`.
+
+The second displayed law is
+
+`mu2(A|n)=(n+1)/8` for `n=0,...,6`.
+
+So `mu2(A|0)=1/8`, `mu2(A|1)=2/8=1/4`, `mu2(A|2)=3/8`, `mu2(A|6)=7/8`. Every
+value lies in `{1/8,...,7/8}` and is therefore neither `0` nor `1`.
+
+A discarded alternative `1/(1+n)` also varies with `n`, but at `n=0` it is
+certain `A`. It is not used below. The displayed `mu2` is the full-support
+replacement.
+
+Neither `mu1` nor `mu2` is adopted as a physical law. They are witnesses that
+the Admissibility type is inhabited by more than one function.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether the current Admissibility wording, read on
+this occupancy coarse-grain, selects one extensional function of `n`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| exhibit one law that varies with `n` | type inhabitance | [Theorem 1](#theorem-1--both-laws-vary-with-n) for `mu1` |
+| exhibit a second law that varies with `n` | type inhabitance | [Theorem 1](#theorem-1--both-laws-vary-with-n) for `mu2` |
+| show the two laws disagree | non-uniqueness | [Theorem 2](#theorem-2--the-two-laws-disagree) at `n=2` |
+| quote the axiom type and observe that it names neither function | axiom reading | [Theorem 3](#theorem-3--admissibility-names-the-type-not-the-function) |
+| refuse adoption and refuse a universal half-weight | claim boundary | [Theorem 4](#theorem-4--display-both-adopt-neither-do-not-force-a-universal-half-weight) |
+| refuse a nonexistence claim about later selectors | claim boundary | [Theorem 5](#theorem-5--a-later-selector-is-not-ruled-out) |
+
+The occupancy coarse-grain is load-bearing for the witnesses and is not a
+claim that Admissibility reduces to a function of `n` alone. A law of the
+full 6-tuple remains inside the axiom type. That larger domain still does
+not, by itself, name one function.
+
+## Theorem 1 — Both Laws Vary With `n`
+
+Direct evaluation of the displayed formulas gives
+
+`mu1(A|1)=1/6`, `mu1(A|2)=1/3`.
+
+These are unequal, so `mu1` varies with `n`. The same evaluation gives
+
+`mu2(A|1)=2/8=1/4`, `mu2(A|2)=3/8`.
+
+These are unequal, so `mu2` varies with `n`.
+
+Each law is a function of a nearest-neighbor coarse-grain. Combined with
+variation, both inhabit the Admissibility type on this window.
+
+## Theorem 2 — The Two Laws Disagree
+
+At the common interior point `n=2`,
+
+`mu1(A|2)=1/3` and `mu2(A|2)=3/8`.
+
+These fractions are unequal: `1/3=8/24` and `3/8=9/24`. Therefore `mu1` and
+`mu2` are distinct laws. A predicate that they are the same function fails at
+`n=2`.
+
+## Theorem 3 — Admissibility Names The Type, Not The Function
+
+The current Admissibility axiom states that there is one fixed nearest-neighbor
+admissibility rule, covariant under lattice translations and proper cubic
+rotations, and that for each site the probability distribution over the
+possibilities is determined by, and varies with, the nearest-neighbor
+conditions.
+
+Both `mu1` and `mu2` are functions of a nearest-neighbor coarse-grain and both
+vary with that coarse-grain. The axiom sentence is therefore satisfied by
+either witness. The same memo states that the distribution's extensional form
+and values are not specified by the axiom text, and that a choice not fixed by
+the supplied structure remains a named conditional or open dependency.
+
+The axiom does not name `mu1` versus `mu2`.
+
+## Theorem 4 — Display Both; Adopt Neither; Do Not Force A Universal Half-Weight
+
+The two laws are displayed as type-inhabiting witnesses. This note
+does not adopt either as `L_phys`. Neither witness is a physical law.
+
+The note also does not force `mu(A)=1/2` at every `n`. The value
+`mu1(A|2)=1/3` is a legal value of a varying nearest-neighbor law. A predicate
+that the axioms force `mu(A)=1/2` for all `n` therefore fails at `n=2`.
+
+No ratio dictionary is introduced, and `r=1/2` is not forced.
+
+### N5 — resolution and rhetoric audit (Theorem 4)
+
+Theorem 4 is a display-and-boundary statement, not a selection of values.
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | the two displayed functions of `n`, evaluated at `n=1` and `n=2` | no classification of every function of the full 6-tuple |
+| per site | one center site with menu `{A,B}` | no composite, multi-site, or formation-site theorem |
+| per mode | occupancy classes `n=0,...,6` as a coarse-grain of the six nearest neighbors | no spectral-mode or harmonic exhaustion |
+| per block | function-selection and non-adoption; `mu1(A|2)=1/3` is legal | no adoption of `L_phys`, no universal half-weight, no ratio dictionary |
+| lattice-wide | covariance is the axiom's already-named constraint on the *rule*, not a unique value table | no lattice-wide dynamics, gravity, or Laplacian claim |
+
+Rhetoric that "the axioms pick a fair coin," "the axioms pick `mu1`," or "the
+axioms pick `mu2`" is outside this resolution. Rhetoric that "no physical law
+can ever be selected" is likewise outside this resolution; see Theorem 5.
+
+## Theorem 5 — A Later Selector Is Not Ruled Out
+
+Nothing above claims that no later selector exists. Extra derived structure,
+an approved primitive, a finer reading of the 6-tuple, or a later bridge could
+still name one function. The present result is only that the current four
+axiom sentences, read on this window, do not already do so.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to: (i) non-uniqueness of the displayed
+occupancy pair, (ii) the axiom text not naming that pair, (iii) non-adoption
+of either witness as a physical law, and (iv) failure of a universal
+half-weight. The gate does not certify that no selector can exist.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Unique-function reading | treat "determined by" as naming one extensional map | Theorems 1--3: two distinct varying maps inhabit the type | **ATTEMPTED** |
+| Occupancy-fraction `n/6` | take `mu1` as forced | Theorem 2: `mu2` is another varying law; Theorem 3: the axiom does not name `mu1` | **ATTEMPTED** |
+| Universal half-weight | set `mu(A|n)=1/2` for every `n` | fails the vary clause at distinct `n`, and `mu1(A|2)=1/3` remains legal | **ATTEMPTED** |
+| Inverse-count `1/(1+n)` | take the discarded alternative as forced | not used; `n=0` is certain `A`, and the axiom still names no values | **ATTEMPTED** |
+| Record additivity | lift scalar readout additivity to a unique menu weight | Record names locking and additive readout of disjoint records, not nearest-neighbor values | **ATTEMPTED** |
+| Cubic covariance as a value table | treat translation/rotation covariance as selecting `mu(A|n)` | covariance constrains the *rule* to be a nearest-neighbor covariant law; it does not pick `mu1` versus `mu2` | **ATTEMPTED** |
+| Later selector | derive or register a function from extra structure | [Theorem 5](#theorem-5--a-later-selector-is-not-ruled-out) keeps the route live | **LIVE** |
+
+The broad statement "the axioms can never select a nearest-neighbor law" is
+not shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| type inhabitance / numerical disagreement | no: many distinct functions can vary | no: disagreement does not by itself quote the axiom | independent |
+| type inhabitance / non-adoption | no: displaying a type-fit is not adoption | no: refusing adoption does not prove variation | independent |
+| disagreement / universal half-weight | no: `1/3 != 3/8` does not mention `1/2` | no: rejecting a constant `1/2` does not separate `mu1` from `mu2` | independent |
+| axiom-type reading / later selector | no: "not named now" is not "unlistable later" | no: a future selector would be extra structure | independent |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| menu `{A,B}` | declared finite possibility menu for the center site |
+| occupancy count `n` | coarse-grain of the six nearest-neighbor records; not claimed to be the only legal condition |
+| `mu1`, `mu2` | displayed witnesses; not axiom content and not adopted as a physical law |
+| `L_phys` | unused adoption slot; neither witness is placed in it |
+| `r=1/2` | not introduced and not forced |
+| "legal value" | means compatible with the axiom type and with `0<=mu<=1`; not an empirical claim |
+| observations or fitted frequencies | none |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | one fixed nearest-neighbor rule; distribution determined by and varying with nearest-neighbor conditions; form and values not specified | exact current wording; no function is borrowed |
+
+No other scientific parent is used. The two occupancy formulas and the
+fraction comparison `1/3 != 3/8` are proved here and checked by the runner.
+
+### N6 — live partial-closure paths
+
+1. A later derivation could select one covariant function of the full 6-tuple.
+2. A later derivation could select a function of occupancy `n` from extra
+   structure not present in the four axiom sentences.
+3. An approved primitive could name a specific nearest-neighbor law.
+4. A retained bridge from Record formation or from a later kinetic structure
+   could constrain values without editing an axiom.
+
+None of these paths is closed here. None is claimed exhausted.
+
+### N7 — hostile steelman
+
+> "Determined by the nearest-neighbor conditions" already means there is one
+> physical rule. Displaying two formulas only shows that the English sentence
+> is loose. Once covariance and a binary menu are read carefully, a unique
+> function will drop out, so the axioms do pick a law.
+
+This steelman is accepted as a *program*, not as a present theorem. Covariance
+and a binary menu are already on the table, and they still leave both `mu1`
+and `mu2` standing. If a later argument names further structure and derives
+one function, that argument is the selector. It is not supplied by the current
+axiom text.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Later movement | Echo here |
+|---|---|---|
+| Admissibility as availability only | August 5 named a genuine nearest-neighbor-varying distribution | the type is now explicit; the function is still unnamed |
+| form and values left unspecified | the current axiom memo keeps that residual | Theorems 3--5 repeat the residual rather than filling it |
+
+**Gate disposition:** PASS for (i) both displayed laws vary with `n`, (ii) they
+disagree at `n=2`, (iii) the axiom type does not name either function, and
+(iv) neither is adopted and a universal half-weight is not forced.
+FAIL / DO NOT SHIP for "an axiom update is necessary," "no later selector exists,"
+"the axioms force `mu(A)=1/2` for all `n`," or "either displayed law is the
+physical law."
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current four axiom sentences | type baseline | supplied; no edit |
+| occupancy coarse-grain `n` | witness domain | constructed here |
+| `mu1`, `mu2` | type-inhabiting witnesses | constructed here; not adopted |
+| later selector | possible extra structure | open |
+| `L_phys` | unused adoption slot | not adopted |
+| `r=1/2` | unused dictionary | not introduced and not forced |
+| observations or fits | none | not used |
+
+## Review Record
+
+The only scientific parent is the current axiom memo. Independent audit
+remains required before any effective status may change.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18393,6 +18393,10 @@
   "two_field_retarded_probe_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_seam_forest_gauge_polyakov_holonomy_preservation_bounded_theorem_note_2026-07-12": {
    "deps_hash": "5fc9a31251f2",

--- a/logs/runner-cache/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.txt
+++ b/logs/runner-cache/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py
+runner_sha256: d59f77117058b33484ca0ba5e71e30e3ed87300cd30c9222768f22a71a313c15
+input_fingerprint_sha256: 7a1516a65860c38f148750a6a7982e82817dffbe909ca67f7219705859a6ad5b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: function-selection on one occupancy coarse-grain; later selectors remain live
+PASS: source-admissibility the exact current distribution sentence is present
+PASS: source-one-fixed-rule Admissibility names one fixed nearest-neighbor rule
+PASS: source-form-values-open the axiom memo leaves the distribution form and values unspecified
+PASS: identity-mu1-at-1 mu1(n) equals 1/6 at n=1
+PASS: identity-mu2-at-1 mu2(n) equals 1/4 at n=1
+PASS: identity-mu1-at-2 mu1(n) equals 1/3 at n=2
+PASS: identity-mu2-at-2 mu2(n) equals 3/8 at n=2
+PASS: identity-gates-call-mu identity gates call mu1(n) and mu2(n)
+PASS: theorem-1-variation both laws vary with n
+PASS: theorem-2-disagreement the two laws disagree at n=2
+PASS: mutation-mu1-equals-mu2-fails-at-n2 the predicate mu1=mu2 fails at n=2 because 1/3 != 3/8
+PASS: mutation-axioms-force-half-fails-at-n2 the predicate axioms force mu(A)=1/2 for all n fails at n=2
+PASS: mu2-full-support mu2(n) stays in (0,1) for every occupancy class
+PASS: mu1-zero-clause mu1 uses the full-support n=0 clause and the occupancy fraction thereafter
+PASS: note-theorem-surface the note records both identities, non-adoption, no universal half-weight, and an open later selector
+PASS: note-n5-theorem-4 N5 is attached to Theorem 4 and refuses L_phys adoption and a universal half-weight
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: canonical-nonmutation the displayed occupancy laws are absent from the canonical axiom file
+PASS: no-go-gate all N1-N8 sections and the broad-claim rejection are source-visible
+PASS: audit-input-paths declared inputs are the new note and the axiom memo only
+PASS: no-unmerged-pr-citation the note cites no unmerged pull-request numbers
+per_element: identity gates evaluate mu1(n) and mu2(n) at n=1 and n=2
+per_site: one center site with menu {A,B}; no composite carrier
+per_mode: occupancy classes n=0,...,6 are the declared coarse-grain
+per_block: function-selection only; neither law is adopted as L_phys
+lattice_wide: checked and not executed — no lattice-wide dynamics claim
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py
+++ b/scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Exact checks: two NN-varying occupancy laws inhabit Admissibility; axioms pick neither.
+
+Identity gates call mu1(n) and mu2(n). Mutation predicates that the laws
+agree, or that the axioms force mu(A)=1/2 for every n, must fail at n=2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_NN_VARYING_LAWS_ARE_ADMISSIBILITY_SHAPED_AXIOMS_PICK_NEITHER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_NN_VARYING_LAWS_ARE_ADMISSIBILITY_SHAPED_AXIOMS_PICK_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def mu1(n: int) -> Fraction:
+    if n == 0:
+        return Fraction(1, 2)
+    return Fraction(n, 6)
+
+
+def mu2(n: int) -> Fraction:
+    return Fraction(n + 1, 8)
+
+
+@dataclass(frozen=True)
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> "Checks":
+        result = bool(condition)
+        if result:
+            object.__setattr__(self, "passed", self.passed + 1)
+        else:
+            object.__setattr__(self, "failed", self.failed + 1)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        return self
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_src = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print("external_scientific_inputs: current axiom wording only; no observational or fitted inputs")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: function-selection on one occupancy coarse-grain; later selectors remain live")
+
+    canonical_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    checks.check(
+        "source-admissibility",
+        "the exact current distribution sentence is present",
+        canonical_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-one-fixed-rule",
+        "Admissibility names one fixed nearest-neighbor rule",
+        "one fixed nearest-neighbor admissibility rule" in normalized_axiom,
+    )
+    checks.check(
+        "source-form-values-open",
+        "the axiom memo leaves the distribution form and values unspecified",
+        "distribution's extensional form and values are not specified" in normalized_axiom,
+    )
+
+    n = 1
+    checks.check(
+        "identity-mu1-at-1",
+        "mu1(n) equals 1/6 at n=1",
+        mu1(n) == Fraction(1, 6),
+    )
+    checks.check(
+        "identity-mu2-at-1",
+        "mu2(n) equals 1/4 at n=1",
+        mu2(n) == Fraction(1, 4),
+    )
+    n = 2
+    checks.check(
+        "identity-mu1-at-2",
+        "mu1(n) equals 1/3 at n=2",
+        mu1(n) == Fraction(1, 3),
+    )
+    checks.check(
+        "identity-mu2-at-2",
+        "mu2(n) equals 3/8 at n=2",
+        mu2(n) == Fraction(3, 8),
+    )
+    checks.check(
+        "identity-gates-call-mu",
+        "identity gates call mu1(n) and mu2(n)",
+        "mu1(n)" in runner_src and "mu2(n)" in runner_src,
+    )
+
+    n = 1
+    left_mu1 = mu1(n)
+    left_mu2 = mu2(n)
+    n = 2
+    checks.check(
+        "theorem-1-variation",
+        "both laws vary with n",
+        left_mu1 != mu1(n) and left_mu2 != mu2(n),
+    )
+    checks.check(
+        "theorem-2-disagreement",
+        "the two laws disagree at n=2",
+        mu1(n) != mu2(n) and mu1(n) == Fraction(1, 3) and mu2(n) == Fraction(3, 8),
+    )
+
+    predicate_laws_equal = mu1(n) == mu2(n)
+    checks.check(
+        "mutation-mu1-equals-mu2-fails-at-n2",
+        "the predicate mu1=mu2 fails at n=2 because 1/3 != 3/8",
+        predicate_laws_equal is False,
+    )
+    predicate_force_half = mu1(n) == Fraction(1, 2)
+    checks.check(
+        "mutation-axioms-force-half-fails-at-n2",
+        "the predicate axioms force mu(A)=1/2 for all n fails at n=2",
+        predicate_force_half is False and mu1(n) == Fraction(1, 3),
+    )
+
+    occupancy = range(7)
+    checks.check(
+        "mu2-full-support",
+        "mu2(n) stays in (0,1) for every occupancy class",
+        all(Fraction(0) < mu2(n) < Fraction(1) for n in occupancy),
+    )
+    checks.check(
+        "mu1-zero-clause",
+        "mu1 uses the full-support n=0 clause and the occupancy fraction thereafter",
+        mu1(0) == Fraction(1, 2) and mu1(6) == Fraction(1),
+    )
+
+    note_needles = (
+        "mu1(A|1)=1/6",
+        "mu1(A|2)=1/3",
+        "mu2(A|1)=2/8=1/4",
+        "mu2(A|2)=3/8",
+        "The axiom does not name `mu1` versus `mu2`.",
+        "does not adopt either as `L_phys`",
+        "does not force `mu(A)=1/2`",
+        "Nothing above claims that no later selector exists",
+        "`r=1/2` is not forced",
+    )
+    checks.check(
+        "note-theorem-surface",
+        "the note records both identities, non-adoption, no universal half-weight, and an open later selector",
+        all(needle in note for needle in note_needles),
+    )
+    checks.check(
+        "note-n5-theorem-4",
+        "N5 is attached to Theorem 4 and refuses L_phys adoption and a universal half-weight",
+        "### N5 — resolution and rhetoric audit (Theorem 4)" in note
+        and "no adoption of `L_phys`, no universal half-weight, no ratio dictionary" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "trace_class: negative_route_pruning",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the displayed occupancy laws are absent from the canonical axiom file",
+        all(phrase not in axiom for phrase in ("mu1(A|n)", "mu2(A|n)", "L_phys")),
+    )
+    checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note
+        and "no later selector exists" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the new note and the axiom memo only",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_NN_VARYING_LAWS_ARE_ADMISSIBILITY_SHAPED_AXIOMS_PICK_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "no-unmerged-pr-citation",
+        "the note cites no unmerged pull-request numbers",
+        "PR #" not in note and "#6185" not in note and "#6202" not in note,
+    )
+
+    print("per_element: identity gates evaluate mu1(n) and mu2(n) at n=1 and n=2")
+    print("per_site: one center site with menu {A,B}; no composite carrier")
+    print("per_mode: occupancy classes n=0,...,6 are the declared coarse-grain")
+    print("per_block: function-selection only; neither law is adopted as L_phys")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics claim")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two NN-varying full-support laws `μ1(A|n)=n/6` (with `μ1(A|0)=1/2`) and `μ2(A|n)=(n+1)/8` both vary with the 6-tuple coarse-grain `n`. At `n=2`, `1/3≠3/8`. Admissibility names a function of NN conditions, not which function. Neither is adopted as `L_phys`. Universal `μ=1/2` is not forced.

## What this means for the TOE

“Varies with NN” does not select the law.

## What changed

- Note: `docs/TWO_NN_VARYING_LAWS_ARE_ADMISSIBILITY_SHAPED_AXIOMS_PICK_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py`
- Cache: `logs/runner-cache/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.txt`

## Verification

```bash
python3 scripts/two_nn_varying_laws_are_admissibility_shaped_axioms_pick_neither_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
