### PR TITLE
[physics-loop] toe-lphys covarlaw: bounded_theorem / bounded-support

### DIFF
--- a/docs/CUBIC_COVARIANCE_FORBIDS_PREFERRED_NEIGHBOR_CONTENT_LAW_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/CUBIC_COVARIANCE_FORBIDS_PREFERRED_NEIGHBOR_CONTENT_LAW_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,237 @@
+---
+claim_id: cubic_covariance_forbids_preferred_neighbor_content_law_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "A nearest-neighbor content law that reads only the +e3 neighbor is not covariant under a proper cubic rotation, so it is not an Admissibility-shaped law. The result excludes preferred-axis neighbor dependence only. It does not select a unique covariant rule, does not force mu=1/2, does not adopt a law, and does not claim that no later selector exists."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py
+---
+
+# Cubic Covariance Forbids a Preferred-Neighbor Content Law
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite algebra on six-neighbor content 6-tuples and one
+hostile preferred-axis law; no dynamics, no unique-rule selection, and no
+axiom edit.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py`](../scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py)
+
+## Result Up Front
+
+Admissibility requires one fixed nearest-neighbor rule that is covariant
+under proper cubic rotations. A law that looks only at the `+e3` neighbor is
+not that kind of rule.
+
+Fix a site at the origin and a two-letter menu `{A,B}`. A 6-tuple is a map
+
+`n : {±e1, ±e2, ±e3} → {A,B}`
+
+recording the neighbor content in each of the six cubic directions. The
+hostile preferred-axis law is
+
+`μ_z(A | n) = 1` if `n(+e3)=A`, else `1/3`.
+
+Those two values are exact `Fraction` assignments of the hostile example.
+This note does not force `μ = 1/2`.
+
+The standard 90° rotation about the `x`-axis is the coordinate map
+
+`(x,y,z) ↦ (x, −z, y)`.
+
+It is a proper cubic rotation. Acting on 6-tuples by
+`(R·n)(d) = n(R^{-1} d)` moves the `+e3` slot onto a different cubic
+direction. There exist 6-tuples `n` and `R·n` with
+
+`μ_z(A|n)=1` and `μ_z(A|R·n)=1/3`.
+
+So `μ_z` is not invariant under `R`. Quoting Admissibility, the rule is
+covariant under proper cubic rotations. Therefore `μ_z` is not an
+Admissibility-shaped law.
+
+This is a positive constraint: preferred-axis neighbor dependence is
+excluded. The note does not adopt a law. It does not select the unique
+covariant rule. Many maps that still depend on the full 6-tuple can remain
+covariant. The result does not claim that no later selector exists.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The hostile preferred-axis law is exhibited as non-invariant under one proper cubic rotation, using only the current Admissibility covariance sentence. Unique covariant-rule selection, a numerical law, and later selectors remain open."
+trace_class: negative_route_pruning
+target_claim_id: preferred_neighbor_content_law_forbidden
+target_blocker_text: "preferred-axis neighbor dependence is not Admissibility-shaped"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed hostile law and the displayed rotation; unique-rule selection remains open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `e1=(1,0,0)`, `e2=(0,1,0)`, `e3=(0,0,1)` for the standard cubic
+generators. The six nearest-neighbor directions at the origin are
+`{±e1, ±e2, ±e3}`.
+
+A **content 6-tuple** is a function `n` from that six-element set into the
+menu `{A,B}`. No physical identification of `A` or `B` is used. They are
+labels.
+
+The **hostile law** `μ_z` assigns, for each 6-tuple `n`,
+
+`μ_z(A | n) = 1` if `n(+e3) = A`, and `μ_z(A | n) = 1/3` otherwise.
+
+Equivalently, `μ_z(B | n) = 0` if `n(+e3)=A`, and `2/3` otherwise. Both
+values are exact rationals. The law depends on `n` only through the single
+slot `n(+e3)`.
+
+Let `R` be the linear map
+
+`R(x,y,z) = (x, −z, y)`,
+
+with matrix (rows)
+
+```
+[[ 1,  0,  0],
+ [ 0,  0, -1],
+ [ 0,  1,  0]].
+```
+
+This is the standard 90° rotation about the positive `x`-axis (right-hand
+sense: `e2 ↦ e3` and `e3 ↦ −e2`). The signed image of `+e3` is `−e2`, which
+is a neighbor direction on the `e2` axis, not the original `+e3` slot.
+
+The induced action on 6-tuples is
+
+`(R·n)(d) = n(R^{-1} d)`
+
+for each cubic direction `d`. Because `R` is orthogonal, `R^{-1}=R^{T}`.
+
+A law `μ` is **invariant under `R`** when `μ(A | n) = μ(A | R·n)` for every
+6-tuple `n`. Admissibility-shaped laws are required to be covariant under
+every proper cubic rotation, hence in particular under this `R`.
+
+## Theorem 1 — The Displayed Map Is A Proper Cubic Rotation
+
+`R` satisfies `R^{T} R = I` and `det R = 1`. Explicitly,
+
+`R^{T} = [[1,0,0],[0,0,1],[0,-1,0]]`,
+
+so
+
+`R^{T} R = I`,
+
+and the determinant expansion along the first row is
+
+`det R = det([[0,-1],[1,0]]) = 1`.
+
+`R` permutes the six nearest-neighbor directions:
+
+`R(+e1)=+e1`, `R(−e1)=−e1`, `R(+e2)=+e3`, `R(−e2)=−e3`,
+`R(+e3)=−e2`, `R(−e3)=+e2`.
+
+It therefore maps the cubic nearest-neighbor shell to itself and is a
+proper cubic rotation about the origin, in the sense of the Lattice axiom
+(standard translations and proper cubic rotations about each site).
+
+## Theorem 2 — The Hostile Law Is Not Invariant Under `R`
+
+Let `n` be the 6-tuple with `n(+e3)=A` and `n(d)=B` for every other
+direction `d`. Then `μ_z(A | n) = 1` by definition.
+
+The inverse image of the `+e3` slot is
+
+`R^{-1}(+e3) = R^{T}(+e3) = −e2`.
+
+Hence
+
+`(R·n)(+e3) = n(−e2) = B`,
+
+and `μ_z(A | R·n) = 1/3`.
+
+The two values `1` and `1/3` are unequal, so `μ_z` is not invariant under
+`R`. The same mismatch is the failure of the predicate “`μ_z` is
+cubic-covariant” on this pair `(n, R·n)`.
+
+The constant 6-tuple with every slot equal to `A` is invariant, as is the
+constant-`B` 6-tuple. Invariance on a proper subset of 6-tuples is not
+covariance of the law.
+
+## Theorem 3 — `μ_z` Is Not An Admissibility-Shaped Law
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under
+> lattice translations and proper cubic rotations.
+
+The same memo continues that, for each site, the probability distribution
+over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions.
+
+`μ_z` is a nearest-neighbor content rule on the six-direction shell, but
+Theorem 2 shows it fails covariance under the proper cubic rotation `R` of
+Theorem 1. Therefore `μ_z` is not an Admissibility-shaped law.
+
+The conclusion uses only the named covariance requirement and the explicit
+hostile dependence on the single `+e3` slot. It does not use any unmerged
+work, any numerical fit, or any axiom edit.
+
+## Theorem 4 — Preferred-Axis Dependence Is Killed; A Unique Rule Is Not Selected
+
+The argument excludes laws whose value depends on a preferred cubic
+direction in the way `μ_z` depends on `+e3`. Any rule that assigns
+different probabilities to a 6-tuple and to a proper-cubic rotate of that
+6-tuple fails the same test.
+
+The argument does not select a unique covariant rule. Covariance is a
+constraint, not a uniqueness theorem. Many maps that still depend on the
+full 6-tuple — rather than on one preferred neighbor — can be invariant
+under every proper cubic rotation. This note does not enumerate them, rank
+them, or adopt one of them.
+
+In particular, this note does not force `μ = 1/2`. The values `1` and
+`1/3` belong only to the hostile example. Equal-probability `1/2` is one
+covariant candidate on a two-letter menu, not a consequence of killing
+`μ_z`. The note does not adopt a law.
+
+## Theorem 5 — A Later Selector Is Not Ruled Out
+
+Nothing here claims that no later selector exists. A subsequent derivation
+may still impose further Admissibility-compatible constraints and select a
+specific covariant rule, or prove that several covariant rules remain.
+Those are later questions. The present theorem only removes
+preferred-neighbor content laws from the Admissibility-shaped class.
+
+## What This Does Not Claim
+
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not register a primitive and does not import a numerical value.
+- It does not identify `{A,B}` with a physical species, Bloch state, or
+  record-lock value beyond being a two-letter menu of local possibilities.
+- It does not force `μ = 1/2` and does not adopt a law.
+- It does not claim uniqueness of the covariant rule.
+- It does not claim that no later selector exists.
+- It does not cite, depend on, or close any unmerged work.
+
+## Parents
+
+The only parent on `origin/main` is the current axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Runner
+
+[`scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py`](../scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py)
+checks the exact `Fraction` identities for `R^{T} R = I` and `det R = 1`,
+constructs the witness 6-tuple, and evaluates `μ_z` only by calling
+`mu_z(n)` and `rotate_x90_tuple(n)`. The mutation predicate “`μ_z` is
+cubic-covariant” fails on that witness. All probabilities are exact
+`Fraction` values. The runner does not force `μ = 1/2`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2757,6 +2757,10 @@
   "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
    "deps_hash": "04fc7d8812c4",
    "out_degree": 3
+  },
+  "cubic_covariance_forbids_preferred_neighbor_content_law_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cubic_coxeter_edge_lengths_from_matter_correlation_decay_narrow_theorem_note_2026-06-10": {
    "deps_hash": "cb078be0ad0c",

--- a/logs/runner-cache/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.txt
+++ b/logs/runner-cache/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py
+runner_sha256: be35860a921707e7bf9aabaa9a92fca5d0e03ba57fb921729f2616223cc7fd58
+input_fingerprint_sha256: 35f42fe056cb03186a6e5f1c62553935023bac108ecd6693168df6ec5a21d562
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: only preferred-axis neighbor dependence is excluded; unique covariant selection remains open
+PASS: audit-inputs declared audit inputs are the new note and the axiom memo
+PASS: source-admissibility the axiom memo states proper-cubic covariance of the rule
+PASS: source-note-theorems the note states Theorems 1 through 5 on the hostile law
+PASS: source-note-no-half the note does not force μ = 1/2
+PASS: source-note-no-adoption the note does not adopt a law
+PASS: source-note-no-selector-ban the note does not claim that no later selector exists
+PASS: theorem-1-orthogonal R^T R equals the identity with exact Fraction entries
+PASS: theorem-1-det det R equals 1
+PASS: theorem-1-cubic-shell R permutes the six nearest-neighbor directions
+PASS: theorem-1-moves-plus-e3 R sends +e3 to a different cubic direction
+PASS: identity-mu-z identity gate calls mu_z on the +e3=A witness and on a +e3=B tuple
+PASS: identity-rotate identity gate calls rotate_x90_tuple and moves the +e3 slot off A
+PASS: values-not-half the hostile values are exact 1 and 1/3, not 1/2
+PASS: theorem-2-witness there exist n and R·n with mu_z(A|n)=1 and mu_z(A|R·n)=1/3
+PASS: mutation-covariant-predicate the predicate 'μ_z is cubic-covariant' fails on the witness
+PASS: constant-tuple-invariance constant 6-tuples are invariant, so the mutation is not a broken equality
+PASS: rotate-order-four four applications of rotate_x90_tuple return the original 6-tuple
+PASS: identity-gate-source the runner source contains live calls to mu_z(n) and rotate_x90_tuple(n)
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py
+++ b/scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Exact checks: cubic covariance forbids a preferred-neighbor content law.
+
+A 6-tuple maps the six cubic neighbor directions to a two-letter menu {A,B}.
+The hostile law mu_z reads only the +e3 slot. Identity gates call mu_z(n)
+and rotate_x90_tuple(n). All scalars are exact Fraction values.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "CUBIC_COVARIANCE_FORBIDS_PREFERRED_NEIGHBOR_CONTENT_LAW_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CUBIC_COVARIANCE_FORBIDS_PREFERRED_NEIGHBOR_CONTENT_LAW_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+A = "A"
+B = "B"
+
+PLUS_E1 = (1, 0, 0)
+MINUS_E1 = (-1, 0, 0)
+PLUS_E2 = (0, 1, 0)
+MINUS_E2 = (0, -1, 0)
+PLUS_E3 = (0, 0, 1)
+MINUS_E3 = (0, 0, -1)
+
+AXES = (PLUS_E1, MINUS_E1, PLUS_E2, MINUS_E2, PLUS_E3, MINUS_E3)
+
+# Standard 90° rotation about +x: (x, y, z) ↦ (x, −z, y).
+R = (
+    (Fraction(1), Fraction(0), Fraction(0)),
+    (Fraction(0), Fraction(0), Fraction(-1)),
+    (Fraction(0), Fraction(1), Fraction(0)),
+)
+
+I3 = (
+    (Fraction(1), Fraction(0), Fraction(0)),
+    (Fraction(0), Fraction(1), Fraction(0)),
+    (Fraction(0), Fraction(0), Fraction(1)),
+)
+
+NeighborTuple = tuple[str, str, str, str, str, str]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def transpose(matrix):
+    return tuple(tuple(matrix[row][column] for row in range(3)) for column in range(3))
+
+
+def mat_mul(left, right):
+    return tuple(
+        tuple(
+            sum((left[i][k] * right[k][j] for k in range(3)), Fraction(0))
+            for j in range(3)
+        )
+        for i in range(3)
+    )
+
+
+def det3(matrix) -> Fraction:
+    a, b, c = matrix[0]
+    d, e, f = matrix[1]
+    g, h, i = matrix[2]
+    return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+
+
+def apply_matrix(matrix, vector):
+    coords = tuple(Fraction(component) for component in vector)
+    image = tuple(
+        sum((matrix[i][j] * coords[j] for j in range(3)), Fraction(0))
+        for i in range(3)
+    )
+    if any(entry.denominator != 1 for entry in image):
+        raise ValueError("rotation left the integer lattice")
+    return tuple(int(entry) for entry in image)
+
+
+def labels_of(n: NeighborTuple) -> dict[tuple[int, int, int], str]:
+    return dict(zip(AXES, n))
+
+
+def tuple_from_labels(labels: dict[tuple[int, int, int], str]) -> NeighborTuple:
+    return tuple(labels[axis] for axis in AXES)  # type: ignore[return-value]
+
+
+def mu_z(n: NeighborTuple) -> Fraction:
+    """Hostile preferred-axis law: depends only on the +e3 neighbor."""
+    if labels_of(n)[PLUS_E3] == A:
+        return Fraction(1)
+    return Fraction(1, 3)
+
+
+def rotate_x90_tuple(n: NeighborTuple) -> NeighborTuple:
+    """Act by (R·n)(d) = n(R^{-1} d) with R the standard 90° rotation about x."""
+    labels = labels_of(n)
+    r_inv = transpose(R)
+    rotated = {axis: labels[apply_matrix(r_inv, axis)] for axis in AXES}
+    return tuple_from_labels(rotated)
+
+
+def is_mu_z_cubic_covariant(n: NeighborTuple) -> bool:
+    """Predicate 'μ_z is cubic-covariant' on one 6-tuple: μ_z(n) = μ_z(R·n)."""
+    return mu_z(n) == mu_z(rotate_x90_tuple(n))
+
+
+def identity_mu_z_gate(n: NeighborTuple) -> Fraction:
+    return mu_z(n)
+
+
+def identity_rotate_gate(n: NeighborTuple) -> NeighborTuple:
+    return rotate_x90_tuple(n)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording only; no observational or fitted inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for claim-surface consistency"
+    )
+    print(
+        "negative_scope: only preferred-axis neighbor dependence is excluded; unique covariant selection remains open"
+    )
+
+    checks.check(
+        "audit-inputs",
+        "declared audit inputs are the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CUBIC_COVARIANCE_FORBIDS_PREFERRED_NEIGHBOR_CONTENT_LAW_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    covariance_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    checks.check(
+        "source-admissibility",
+        "the axiom memo states proper-cubic covariance of the rule",
+        covariance_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-note-theorems",
+        "the note states Theorems 1 through 5 on the hostile law",
+        all(
+            phrase in note
+            for phrase in (
+                "Theorem 1 — The Displayed Map Is A Proper Cubic Rotation",
+                "Theorem 2 — The Hostile Law Is Not Invariant Under `R`",
+                "Theorem 3 — `μ_z` Is Not An Admissibility-Shaped Law",
+                "Theorem 4 — Preferred-Axis Dependence Is Killed; A Unique Rule Is Not Selected",
+                "Theorem 5 — A Later Selector Is Not Ruled Out",
+            )
+        ),
+    )
+    checks.check(
+        "source-note-no-half",
+        "the note does not force μ = 1/2",
+        "does not force `μ = 1/2`" in normalized_note
+        and "This note does not force `μ = 1/2`" in normalized_note,
+    )
+    checks.check(
+        "source-note-no-adoption",
+        "the note does not adopt a law",
+        "does not adopt a law" in normalized_note,
+    )
+    checks.check(
+        "source-note-no-selector-ban",
+        "the note does not claim that no later selector exists",
+        "does not claim that no later selector exists" in normalized_note,
+    )
+
+    r_t = transpose(R)
+    checks.check(
+        "theorem-1-orthogonal",
+        "R^T R equals the identity with exact Fraction entries",
+        mat_mul(r_t, R) == I3,
+    )
+    checks.check(
+        "theorem-1-det",
+        "det R equals 1",
+        det3(R) == Fraction(1),
+    )
+    rotated_axes = tuple(apply_matrix(R, axis) for axis in AXES)
+    checks.check(
+        "theorem-1-cubic-shell",
+        "R permutes the six nearest-neighbor directions",
+        set(rotated_axes) == set(AXES),
+    )
+    checks.check(
+        "theorem-1-moves-plus-e3",
+        "R sends +e3 to a different cubic direction",
+        apply_matrix(R, PLUS_E3) != PLUS_E3 and apply_matrix(R, PLUS_E3) in AXES,
+    )
+
+    all_b: NeighborTuple = (B, B, B, B, B, B)
+    plus_e3_a_labels = {axis: B for axis in AXES}
+    plus_e3_a_labels[PLUS_E3] = A
+    witness: NeighborTuple = tuple_from_labels(plus_e3_a_labels)
+    constant_a: NeighborTuple = (A, A, A, A, A, A)
+
+    mu_witness = identity_mu_z_gate(witness)
+    mu_all_b = identity_mu_z_gate(all_b)
+    rotated_witness = identity_rotate_gate(witness)
+    mu_rotated = identity_mu_z_gate(rotated_witness)
+
+    checks.check(
+        "identity-mu-z",
+        "identity gate calls mu_z on the +e3=A witness and on a +e3=B tuple",
+        mu_witness == Fraction(1) and mu_all_b == Fraction(1, 3),
+    )
+    checks.check(
+        "identity-rotate",
+        "identity gate calls rotate_x90_tuple and moves the +e3 slot off A",
+        labels_of(rotated_witness)[PLUS_E3] == B
+        and labels_of(rotated_witness)[apply_matrix(R, PLUS_E3)] == A,
+    )
+    checks.check(
+        "values-not-half",
+        "the hostile values are exact 1 and 1/3, not 1/2",
+        mu_witness != Fraction(1, 2)
+        and mu_rotated != Fraction(1, 2)
+        and mu_all_b != Fraction(1, 2)
+        and mu_witness == Fraction(1)
+        and mu_rotated == Fraction(1, 3),
+    )
+    checks.check(
+        "theorem-2-witness",
+        "there exist n and R·n with mu_z(A|n)=1 and mu_z(A|R·n)=1/3",
+        mu_witness == Fraction(1) and mu_rotated == Fraction(1, 3),
+    )
+    checks.check(
+        "mutation-covariant-predicate",
+        "the predicate 'μ_z is cubic-covariant' fails on the witness",
+        is_mu_z_cubic_covariant(witness) is False,
+    )
+    checks.check(
+        "constant-tuple-invariance",
+        "constant 6-tuples are invariant, so the mutation is not a broken equality",
+        is_mu_z_cubic_covariant(constant_a)
+        and is_mu_z_cubic_covariant(all_b)
+        and mu_z(constant_a) == Fraction(1)
+        and mu_z(all_b) == Fraction(1, 3),
+    )
+    fourth = witness
+    for _ in range(4):
+        fourth = rotate_x90_tuple(fourth)
+    checks.check(
+        "rotate-order-four",
+        "four applications of rotate_x90_tuple return the original 6-tuple",
+        fourth == witness,
+    )
+    checks.check(
+        "identity-gate-source",
+        "the runner source contains live calls to mu_z(n) and rotate_x90_tuple(n)",
+        "return mu_z(n)" in runner_source
+        and "return rotate_x90_tuple(n)" in runner_source
+        and "identity_mu_z_gate(witness)" in runner_source
+        and "identity_rotate_gate(witness)" in runner_source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

A nearest-neighbor content law that reads only the `+e3` neighbor is not covariant under the standard 90° rotation about `x`. Witness: `μ_z(A|n)=1` and `μ_z(A|R·n)=1/3`. Preferred-axis dependence is excluded. A unique covariant rule is not selected. `μ=1/2` is not forced. Neither law is adopted. A later selector is not ruled out.

## What this means for the TOE

Admissibility covariance is a positive cut: preferred-neighbor laws are not shaped.

## What changed

- Note: `docs/CUBIC_COVARIANCE_FORBIDS_PREFERRED_NEIGHBOR_CONTENT_LAW_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py`
- Cache: `logs/runner-cache/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.txt`

## Verification

```bash
python3 scripts/cubic_covariance_forbids_preferred_neighbor_content_law_2026_08_13.py
# TOTAL: PASS=18 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
