### PR TITLE
[physics-loop] toe-lphys color3: bounded_theorem / bounded-support

### DIFF
--- a/docs/M3_DOES_NOT_EMBED_IN_ONE_SITE_M2_COLOR_ALGEBRA_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/M3_DOES_NOT_EMBED_IN_ONE_SITE_M2_COLOR_ALGEBRA_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,164 @@
+---
+claim_id: m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The trial color algebra A3 = M_3(C) is nine-dimensional over C. The one-site axiom algebra A2 = M_2(C) is four-dimensional over C. There is therefore no injective C-linear map A3 → A2, and in particular no injective *-homomorphism. Qubit names M_2(C) and does not name M_3(C) or SU(3). A color algebra is an extra displayed object of dimension at least 9, not an axiom and not QCD. The result does not retire June 10, does not identify N_p with ln Z_L, does not import 0.5934, does not force r=1/2, and does not claim a later multi-site tensor obstruction."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py
+---
+
+# `M_3(C)` Does Not Embed In One-Site `M_2(C)`; A Color Algebra Is Extra
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact complex dimensions of the one-site axiom algebra and a
+displayed trial color algebra. No QCD import. No axiom edit.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py`](../scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py)
+**Parents:** the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write
+
+```text
+A2 = M_2(C)     dim_C(A2) = 4
+A3 = M_3(C)     dim_C(A3) = 9
+```
+
+for the full one-site possibility algebra named by Qubit, and for a displayed
+trial color algebra. The integer comparison `9 > 4` is exact. There is no
+injective `C`-linear map `A3 → A2`, hence no injective unital `*`-homomorphism.
+Qubit names `M_2(C)` and does not name `M_3(C)` or `SU(3)`. A color algebra is
+therefore extra: at least a nine-dimensional unital `*`-algebra, equivalently
+displayable as operators on a `C^3` Hilbert space. This note displays `A3`. It
+does not adopt a color axiom and does not identify `A3` with QCD.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer dimensions of M_2(C) and M_3(C) give a one-site linear-injection obstruction. Multi-site tensors, later color constructions, June 10 objects, and QCD identification remain outside the claim."
+trace_class: negative_route_pruning
+target_claim_id: one_site_m2_does_not_host_m3_color_algebra
+target_blocker_text: "decide whether a color algebra injects into the one-site Qubit algebra"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for one-site C-linear and *-algebra injection; multi-site tensors remain open"
+hypothetical_axiom_status: "A3 is displayed only; no color axiom is adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `M_n(C)` be the unital `*`-algebra of `n × n` complex matrices, with the
+standard adjoint. As a complex vector space it has the matrix-unit basis
+
+```text
+{ E_{ij} : 1 <= i,j <= n }
+```
+
+so the exact integer dimension is
+
+```text
+dim_C(M_n(C)) = n^2.
+```
+
+The one-site algebra is the Qubit presentation
+
+```text
+A2 := M_2(C),    dim_C(A2) = 2^2 = 4.
+```
+
+The displayed trial color algebra is
+
+```text
+A3 := M_3(C),    dim_C(A3) = 3^2 = 9.
+```
+
+Equivalently, `A3 ≅ B(C^3)` as a unital `*`-algebra, so the same extra object
+may be displayed as a three-dimensional complex Hilbert space. Neither display
+is an axiom.
+
+The Qubit sentence used below is the current axiom-memo wording, quoted
+verbatim:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+That sentence does not name `M_3(C)` and does not name `SU(3)`.
+
+## Theorem 1 — No One-Site Linear Injection
+
+There is no injective `C`-linear map `A3 → A2`.
+
+**Proof.** Any injective linear map of finite-dimensional vector spaces
+satisfies `dim(domain) ≤ dim(codomain)`. The dimensions are the exact integers
+`9` and `4`. The comparison `9 ≤ 4` is false, so no such injection exists.
+
+In particular there is no injective unital `*`-homomorphism `A3 → A2`: every
+unital `*`-homomorphism of these matrix algebras is `C`-linear.
+
+The same comparison is the required mutation predicate. The statement
+`dim_C(M_3(C)) ≤ dim_C(M_2(C))` is the false integer predicate `9 ≰ 4`.
+
+## Theorem 2 — Qubit Names `M_2(C)` Only
+
+The current Qubit axiom states that the full one-site possibility domain has
+algebraic presentation `M_2(C)`. It does not name `M_3(C)` and does not name
+`SU(3)`. The one-site algebra available as axiom content is therefore `A2`,
+not `A3`.
+
+This is a quotation of the axiom memo, not an axiom edit.
+
+## Theorem 3 — A Color Algebra Is Extra
+
+Any algebra isomorphic to `A3` is extra relative to one-site Qubit content.
+The extra object is at least a nine-dimensional unital `*`-algebra, or a
+`C^3` Hilbert space on which that algebra acts. This note displays `A3`.
+
+The note does not adopt a color axiom. It does not identify `A3` with QCD,
+does not import a QCD Lagrangian, gauge coupling, or confinement statement,
+and does not treat `SU(3)` as axiom content.
+
+## Theorem 4 — June 10 Is Not Retired
+
+This dimension comparison does not retire June 10. The objects `N_p` and
+`ln Z_L` are different: `N_p` is a plaquette count, while `ln Z_L` is a
+finite-volume log partition function. They are not identified here.
+
+The number `0.5934` is not used, not imported, and not derived.
+
+## Theorem 5 — No Forced `r = 1/2` And No Multi-Site Claim
+
+This note does not force `r = 1/2`.
+
+The obstruction is one-site. For a multi-site tensor `A2^{⊗k}` one has the
+exact integer dimension `4^k`, which already exceeds `9` at `k ≥ 2`. Dimension
+counting on one site therefore does not claim that a color algebra is
+impossible later on a multi-site tensor.
+
+## Explicit Non-Claims
+
+- No axiom is edited, added, or proposed.
+- No color axiom is adopted.
+- `A3` is displayed, not identified with QCD.
+- Unmerged work, including independent carrier and composition lanes, is not
+  cited and is not a parent.
+- June 10 is not retired. `N_p` is not `ln Z_L`. The value `0.5934` is not
+  imported.
+- `r = 1/2` is not selected.
+- A later multi-site or composite construction is not ruled out.
+
+## Runner Contract
+
+The companion runner checks exact integer dimensions through the identity
+gates `dim_m2()` and `dim_m3()`, rejects the mutation predicate
+`dim M_3 ≤ dim M_2`, quotes the Qubit sentence, and records the non-claims
+above. Declared audit inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12189,6 +12189,10 @@
   "m2_tensor_d4_dimension_256_bounded_note_2026-05-26": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "m_dm_nsites_v_integer_16_factorization_enumeration_narrow_theorem_note_2026-05-28": {
    "deps_hash": "cce9e6a23a29",

--- a/logs/runner-cache/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.txt
+++ b/logs/runner-cache/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py
+runner_sha256: ae86fdbc3bc195a0d0a79f5e177396c64914890624114a6b2c6714f0a5b94491
+input_fingerprint_sha256: 2b98d934c08ccbc523769dd22c635f4830a7d91087f5c229fe8e27f05460a933
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact integer dimensions only
+package_local_integrity_reads: new note and current axiom memo
+negative_scope: one-site injection only; multi-site tensors remain open
+PASS: identity-dim-m2 dim_C(M_2(C)) = 4 via dim_m2()
+PASS: identity-dim-m3 dim_C(M_3(C)) = 9 via dim_m3()
+PASS: exact-integers both dimensions are exact Python ints
+PASS: theorem-1-strict 9 > 4 so no injective C-linear map A3 → A2
+PASS: mutation-dim-m3-leq-dim-m2-fails predicate dim M_3 <= dim M_2 fails (9 ≰ 4)
+PASS: no-injective-star-hom an injective *-hom would be an injective C-linear map, already impossible
+PASS: theorem-2-qubit-quote axiom memo names the one-site algebra as M_2(C)
+PASS: theorem-2-no-m3 axiom memo does not name M_3(C)
+PASS: theorem-2-no-su3 axiom memo does not name SU(3)
+PASS: theorem-3-display-a3 note displays A3 = M_3(C) as an extra object
+PASS: theorem-3-no-color-axiom note does not adopt a color axiom
+PASS: theorem-3-not-qcd note does not identify A3 with QCD
+PASS: theorem-3-min-dim-or-c3 extra object is at least 9-dimensional or a C^3 Hilbert space
+PASS: theorem-4-june-10-not-retired note does not retire June 10
+PASS: theorem-4-np-not-lnzl N_p and ln Z_L are different objects
+PASS: theorem-4-no-05934 0.5934 is not imported
+PASS: theorem-5-no-r-half note does not force r=1/2
+PASS: theorem-5-no-multisite-impossibility note does not claim color is impossible later on a multi-site tensor
+PASS: audit-inputs-axiom-and-note-only declared audit inputs are the new note and the axiom memo
+PASS: no-unmerged-pr-citation note does not cite unmerged PR numbers or c8carrier/phycomp
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py
+++ b/scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Exact integer checks: M_3(C) does not embed in one-site M_2(C).
+
+Identity gates call dim_m2() and dim_m3(). The mutation predicate
+dim M_3 <= dim M_2 must fail (9 ≰ 4). Parents: axiom memo only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "M3_DOES_NOT_EMBED_IN_ONE_SITE_M2_COLOR_ALGEBRA_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/M3_DOES_NOT_EMBED_IN_ONE_SITE_M2_COLOR_ALGEBRA_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def dim_matrix_algebra(n: int) -> int:
+    """Exact complex dimension of M_n(C): n^2."""
+    return n * n
+
+
+def dim_m2() -> int:
+    return dim_matrix_algebra(2)
+
+
+def dim_m3() -> int:
+    return dim_matrix_algebra(3)
+
+
+def dim_m3_leq_dim_m2() -> bool:
+    """Mutation predicate: dim M_3 <= dim M_2. Must fail (9 ≰ 4)."""
+    return dim_m3() <= dim_m2()
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_n = normalize(note)
+    axiom_n = normalize(axiom)
+
+    print("external_scientific_inputs: none; exact integer dimensions only")
+    print("package_local_integrity_reads: new note and current axiom memo")
+    print("negative_scope: one-site injection only; multi-site tensors remain open")
+
+    # Identity gates MUST call dim_m2() and dim_m3().
+    checks.check(
+        "identity-dim-m2",
+        "dim_C(M_2(C)) = 4 via dim_m2()",
+        dim_m2() == 4,
+    )
+    checks.check(
+        "identity-dim-m3",
+        "dim_C(M_3(C)) = 9 via dim_m3()",
+        dim_m3() == 9,
+    )
+    checks.check(
+        "exact-integers",
+        "both dimensions are exact Python ints",
+        isinstance(dim_m2(), int) and isinstance(dim_m3(), int),
+    )
+    checks.check(
+        "theorem-1-strict",
+        "9 > 4 so no injective C-linear map A3 → A2",
+        dim_m3() > dim_m2(),
+    )
+    checks.check(
+        "mutation-dim-m3-leq-dim-m2-fails",
+        "predicate dim M_3 <= dim M_2 fails (9 ≰ 4)",
+        dim_m3_leq_dim_m2() is False,
+    )
+    checks.check(
+        "no-injective-star-hom",
+        "an injective *-hom would be an injective C-linear map, already impossible",
+        not dim_m3_leq_dim_m2(),
+    )
+
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "theorem-2-qubit-quote",
+        "axiom memo names the one-site algebra as M_2(C)",
+        qubit_sentence in axiom,
+    )
+    checks.check(
+        "theorem-2-no-m3",
+        "axiom memo does not name M_3(C)",
+        "M_3(C)" not in axiom and "M_3(\\mathrm{C})" not in axiom,
+    )
+    checks.check(
+        "theorem-2-no-su3",
+        "axiom memo does not name SU(3)",
+        "SU(3)" not in axiom and "SU3" not in axiom,
+    )
+
+    checks.check(
+        "theorem-3-display-a3",
+        "note displays A3 = M_3(C) as an extra object",
+        "A3 = M_3(C)" in note or "A3 := M_3(C)" in note,
+    )
+    checks.check(
+        "theorem-3-no-color-axiom",
+        "note does not adopt a color axiom",
+        "does not adopt a color axiom" in note_n.lower(),
+    )
+    checks.check(
+        "theorem-3-not-qcd",
+        "note does not identify A3 with QCD",
+        "does not identify" in note_n.lower() and "QCD" in note,
+    )
+    checks.check(
+        "theorem-3-min-dim-or-c3",
+        "extra object is at least 9-dimensional or a C^3 Hilbert space",
+        "nine-dimensional" in note_n.lower() and "C^3" in note,
+    )
+
+    checks.check(
+        "theorem-4-june-10-not-retired",
+        "note does not retire June 10",
+        "does not retire June 10" in note,
+    )
+    checks.check(
+        "theorem-4-np-not-lnzl",
+        "N_p and ln Z_L are different objects",
+        "N_p" in note and "ln Z_L" in note and "different" in note_n,
+    )
+    checks.check(
+        "theorem-4-no-05934",
+        "0.5934 is not imported",
+        "0.5934" not in axiom
+        and "`0.5934` is not used, not imported" in note
+        and "`0.5934` is not imported" in note_n,
+    )
+
+    checks.check(
+        "theorem-5-no-r-half",
+        "note does not force r=1/2",
+        "does not force" in note_n and "r = 1/2" in note,
+    )
+    checks.check(
+        "theorem-5-no-multisite-impossibility",
+        "note does not claim color is impossible later on a multi-site tensor",
+        "does not claim" in note_n and "multi-site tensor" in note,
+    )
+
+    checks.check(
+        "audit-inputs-axiom-and-note-only",
+        "declared audit inputs are the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/M3_DOES_NOT_EMBED_IN_ONE_SITE_M2_COLOR_ALGEBRA_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "no-unmerged-pr-citation",
+        "note does not cite unmerged PR numbers or c8carrier/phycomp",
+        "c8carrier" not in note_n.lower()
+        and "phycomp" not in note_n.lower()
+        and "PR #" not in note
+        and "#6198" not in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`M_3(C)` is 9-dimensional. One-site `M_2(C)` is 4-dimensional. There is no injective C-linear map, hence no injective *-homomorphism. Qubit names `M_2(C)` and does not name `M_3(C)` or `SU(3)`. A color algebra is extra. Not adopted as QCD. June 10 is not retired. `0.5934` is not imported. `r=1/2` is not forced. Multi-site tensors remain open.

## What this means for the TOE

Color does not sit inside one-site Qubit. It is extra structure.

## What changed

- Note: `docs/M3_DOES_NOT_EMBED_IN_ONE_SITE_M2_COLOR_ALGEBRA_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py`
- Cache: `logs/runner-cache/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.txt`

## Verification

```bash
python3 scripts/m3_does_not_embed_in_one_site_m2_color_algebra_is_extra_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
