### PR TITLE
[physics-loop] toe-lphys povmvs: bounded_theorem / bounded-support

### DIFF
--- a/docs/SCALED_EFFECT_IS_NOT_A_PROJECTOR_AXIOMS_PICK_NEITHER_INSTRUMENT_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SCALED_EFFECT_IS_NOT_A_PROJECTOR_AXIOMS_PICK_NEITHER_INSTRUMENT_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,313 @@
+---
+claim_id: scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "At one M_2(C) site, the August 10 shared effect E0=(1/2)P with P=diag(1,0) fails to be a projector, and the Born traces of P and E0 against rho=diag(3/5,2/5) disagree. Admissibility and Record name a distribution over possibilities and the lock of one possibility; neither sentence names P versus cP. A later Born compiler must still declare the scale of each effect. The two binary menus {P,I-P} and {E0,I-E0} are displayed; neither is adopted. August 9 and August 10 are not replaced, and r=1/2 is not forced."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10
+runner: scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py
+---
+
+# A Scaled Effect `cP` Is Not A Projector; Axioms Pick Neither Instrument
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site algebra on the pair `P` versus `(1/2)P`; instrument
+selection only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py`](../scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py)
+
+## Result Up Front
+
+The August 10 shared effect `E_0=(1/2)P` is a scaled rank-one matrix, not a
+projector. Against a single density `rho=diag(3/5,2/5)` the two candidate first
+outcomes disagree: `Tr(rho P)=3/5` and `Tr(rho E_0)=3/10`.
+
+Admissibility names a nearest-neighbor-determined distribution over
+possibilities. Record names the lock of one admissible possibility. Neither
+sentence names `P` versus `cP`. A later Born compiler that evaluates effects
+must still declare the scale of each effect. This note displays the two binary
+menus `{P,I-P}` and `{E_0,I-E_0}` and does not adopt either.
+
+The result does not replace the August 9 frame-lift theorem or the August 10
+type-separation theorem. It does not force `r=1/2`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The projector identity, the exact Born-trace split 3/5 versus 3/10, and the axiom-text reading that neither sentence names P versus cP are proved on declared one-site matrices. Menu adoption, a later scale-declaring compiler, replacement of August 9/10, and a forced r=1/2 remain outside the claim."
+trace_class: negative_route_pruning
+target_claim_id: scaled_effect_versus_projector_instrument_selection
+target_blocker_text: "declare the scale of each effect; axioms name neither P nor cP as the instrument"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for P versus E0=(1/2)P on the displayed density; later compilers remain open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site with `H=C^2`. Fix the rank-one diagonal projector
+
+`P=diag(1,0)`
+
+and the August 10 object
+
+`E_0=(1/2)P=diag(1/2,0)`.
+
+The complementary matrices are
+
+`I-P=diag(0,1)`, `I-E_0=diag(1/2,1)`.
+
+The displayed density is
+
+`rho=diag(3/5,2/5)`.
+
+A matrix `E` is a projector when `E^2=E`. The Born evaluation used below is
+the ordinary trace pairing
+
+`Tr(rho E)`.
+
+Two binary resolutions of the identity are displayed, not adopted:
+
+`M_P={P,I-P}`, `M_{E_0}={E_0,I-E_0}`.
+
+The first is a projective menu. The second is a two-outcome effect menu whose
+first member is the scaled matrix `E_0`. The complement `I-E_0` is a valid
+effect (`0 <= I-E_0 <= I`) but is not itself a rank-one scaled projector.
+
+This block is `P` versus `(1/2)P`. It is not a comparison of two distinct
+projective bases, and it does not assume a Lüders update.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether `E_0` is already a projector, whether the two
+first-outcome evaluations agree on the displayed density, and whether the
+current Admissibility and Record sentences already name `P` versus `cP`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| test the projector identity on `P` and on `E_0` | type split | [Theorem 1](#theorem-1--e0-is-not-a-projector) |
+| evaluate both first outcomes on `rho` | numerical split | [Theorem 2](#theorem-2--the-two-instruments-disagree) |
+| quote Admissibility and Record | axiom reading | [Theorem 3](#theorem-3--admissibility-and-record-name-neither-p-nor-cp) |
+| display both menus and refuse adoption | claim boundary | [Theorem 4](#theorem-4--a-later-compiler-must-declare-scale-display-both-adopt-neither) |
+| refuse replacement of August 9/10 and refuse `r=1/2` | claim boundary | [Theorem 5](#theorem-5--august-910-are-not-replaced-r12-is-not-forced) |
+
+The fixed matrices are load-bearing witnesses. A different scale `c`, a
+different density, or a later physical compiler is outside Theorems 1--2.
+
+## Theorem 1 — `E_0` Is Not A Projector
+
+Direct matrix multiplication gives
+
+`P^2=diag(1,0)=P`
+
+and
+
+`E_0^2=diag(1/4,0)`.
+
+The right-hand side is not `E_0`, because `1/4 != 1/2`. Therefore `E_0` is
+not a projector. A predicate "`E_0` is a projector" fails.
+
+The same identity confirms that `P` itself is a projector. Scaling a projector
+by `1/2` leaves the August 10 object, which is an effect and not a projection.
+
+## Theorem 2 — The Two Instruments Disagree
+
+The trace pairing on the displayed density is
+
+`Tr(rho P)=3/5`, `Tr(rho E_0)=3/10`.
+
+These fractions are unequal. The two first-outcome instruments therefore
+disagree at this `rho`. A predicate `Tr(rho P)=Tr(rho E_0)` fails because
+`3/5 != 3/10`.
+
+The complementary evaluations are `Tr(rho(I-P))=2/5` and
+`Tr(rho(I-E_0))=7/10`. Each displayed pair sums to `1`, so the disagreement
+is a genuine split of one and the same probability, not a normalization
+error.
+
+## Theorem 3 — Admissibility And Record Name Neither `P` Nor `cP`
+
+The current Admissibility axiom states that, for each site, the probability
+distribution over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions.
+
+The current Record axiom states that, when present, a record locks exactly
+one admissible local possibility.
+
+The first sentence names a distribution over possibilities. The second
+sentence names the lock of one possibility. Neither sentence names `P` versus `cP`.
+Neither sentence names the menus `{P,I-P}` or `{E_0,I-E_0}`,
+the scale of an effect, or the trace pairing of Theorem 2.
+
+The axiom memo also records that context selection, measurement basis
+selection, Born weight values, probability rules beyond the distribution
+clause, and update laws remain outside axiom content.
+
+## Theorem 4 — A Later Compiler Must Declare Scale; Display Both; Adopt Neither
+
+A later Born compiler that consumes effects must still declare the scale of
+each effect. The pair `P` and `E_0=(1/2)P` is the exact witness: they share a
+support ray and they are not interchangeable as first outcomes.
+
+This note displays
+
+`{P,I-P}` and `{E_0,I-E_0}`
+
+and does not adopt either. Neither menu is installed as a physical instrument.
+Neither is named `L_phys`.
+
+### N5 — resolution and rhetoric audit (Theorem 4)
+
+Theorem 4 is a display-and-boundary statement, not a selection of an
+instrument.
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | the two displayed first outcomes `P` and `E_0`, with exact squares and traces | no classification of every effect or every POVM |
+| per site | one `M_2(C)` site and one displayed density | no composite, multi-site, or formation-site theorem |
+| per mode | the rank-one ray of `P` and its scale `c=1/2` | no spectral-mode or harmonic exhaustion |
+| per block | scale declaration and non-adoption of either binary menu | no adoption of `L_phys`, no forced `r=1/2`, no Lüders map |
+| lattice-wide | not executed | no lattice-wide dynamics, gravity, or measurement-process claim |
+
+Rhetoric that "the axioms pick the projector menu," "the axioms pick the
+scaled menu," or "the two first outcomes are the same instrument" is outside
+this resolution.
+
+## Theorem 5 — August 9/10 Are Not Replaced; `r=1/2` Is Not Forced
+
+Nothing above claims that the August 9 binary/ternary frame-lift theorem or
+the August 10 global-measure / menu-kernel type-separation theorem is
+replaced, improved, or withdrawn. The August 10 parent remains the source of
+the shared object `E_0=(1/2)P(z)`. The present block only compares that
+object with the unscaled projector `P` as two candidate first outcomes.
+
+The note does not force `r=1/2`. No ratio dictionary is introduced. A later
+selector of scale, or a later physical compiler, is not ruled out.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to: (i) `E_0` is not a projector, (ii) the
+two first-outcome traces disagree, (iii) Admissibility and Record do not name
+`P` versus `cP`, and (iv) neither displayed menu is adopted and `r=1/2` is
+not forced. The gate does not certify that no later compiler can declare a
+scale.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Treat `E_0` as a projector | demand `E_0^2=E_0` | [Theorem 1](#theorem-1--e0-is-not-a-projector): `E_0^2=diag(1/4,0)` | **ATTEMPTED** |
+| Identify the two first outcomes | demand `Tr(rho P)=Tr(rho E_0)` | [Theorem 2](#theorem-2--the-two-instruments-disagree): `3/5 != 3/10` | **ATTEMPTED** |
+| Read scale off Admissibility | treat "distribution over possibilities" as naming `P` or `cP` | [Theorem 3](#theorem-3--admissibility-and-record-name-neither-p-nor-cp): the sentence names neither | **ATTEMPTED** |
+| Read scale off Record | treat "locks one possibility" as selecting a projector menu | Theorem 3: lock is not an effect scale | **ATTEMPTED** |
+| Adopt a displayed menu | install `{P,I-P}` or `{E_0,I-E_0}` as `L_phys` | [Theorem 4](#theorem-4--a-later-compiler-must-declare-scale-display-both-adopt-neither) refuses adoption | **ATTEMPTED** |
+| Force `r=1/2` | take the scale `1/2` as a universal dictionary | [Theorem 5](#theorem-5--august-910-are-not-replaced-r12-is-not-forced) refuses the force | **ATTEMPTED** |
+| Replace August 9/10 | treat this split as a successor theorem | Theorem 5: those standing results are not replaced | **ATTEMPTED** |
+| Later scale-declaring compiler | derive a physical rule that names `c` for each effect | Theorem 4 keeps the obligation live; Theorem 5 does not exhaust it | **LIVE** |
+
+The broad statement "the axioms can never supply an instrument" is not
+shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| projector identity / Born-trace split | no: a non-projector can still share a trace with `P` on some states | no: unequal traces do not compute `E_0^2` | independent |
+| Born-trace split / axiom-text reading | no: `3/5 != 3/10` does not quote Admissibility or Record | no: unnamed menus do not evaluate traces | independent |
+| axiom-text reading / non-adoption | no: "not named now" is not "unlistable later" | no: refusing adoption does not quote the axiom sentences | independent |
+| non-adoption / August 9/10 non-replacement | no: displaying two menus does not touch those theorems | no: leaving August 9/10 in place does not adopt a menu | independent |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `P=diag(1,0)` | declared rank-one projector; not axiom content |
+| `E_0=(1/2)P` | August 10 shared-effect object, reused here as a scale witness |
+| `rho=diag(3/5,2/5)` | declared one-site density; not derived and not adopted |
+| `{P,I-P}`, `{E_0,I-E_0}` | displayed binary resolutions; not adopted instruments |
+| `L_phys` | unused adoption slot; neither menu is placed in it |
+| `r=1/2` | not introduced and not forced |
+| Lüders update | not used |
+| observations or fitted frequencies | none |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | Admissibility distribution sentence; Record lock of one admissible possibility; Born weights and update laws outside axiom content | exact current wording; no instrument is borrowed |
+| [`docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md`](ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md) | the shared object `E_0=(1/2)P(z)` | object identity only; the August 10 type-separation theorems are not reused as premises and are not replaced |
+
+No other scientific parent is used. The identities `P^2=P`,
+`E_0^2=diag(1/4,0)`, `Tr(rho P)=3/5`, and `Tr(rho E_0)=3/10` are proved here
+and checked by the runner.
+
+### N6 — live partial-closure paths
+
+1. A later physical compiler could declare a scale `c` for each registered
+   effect and then evaluate the trace pairing on that declared effect.
+2. A later derivation could restrict eligible menus to projective resolutions
+   and thereby exclude `E_0` as a first outcome.
+3. A later derivation could keep the full scaled domain and treat `c` as part
+   of the registered effect, as the August 10 kernel interface already types.
+4. An approved primitive could name one of the displayed menus. None is
+   adopted here.
+
+None of these paths is closed here. None is claimed exhausted.
+
+### N7 — hostile steelman
+
+> Once a rank-one ray is fixed, the only idempotent on that ray is `P`, so
+> the axioms already pick the projector. The matrix `E_0` is just a rescaled
+> label for the same outcome. Displaying `{E_0,I-E_0}` is bookkeeping, not a
+> second instrument.
+
+This steelman is accepted as a *program*, not as a present theorem. Theorem 1
+agrees that only `P` is idempotent. Theorem 2 shows that the rescaled label
+is not bookkeeping: the Born numbers differ. If a later argument derives that
+only idempotents are eligible first outcomes, that argument is the selector.
+It is not supplied by the current Admissibility or Record sentences.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Later movement | Echo here |
+|---|---|---|
+| August 10 used `E_0=(1/2)P(z)` as a shared ternary effect | that object remains live and is not a projector | Theorem 1 records the projector failure on the same matrix |
+| August 10 separated a global measure from a menu kernel | the kernel still consumes a declared effect | Theorem 4 repeats that the scale must be declared |
+| August 9 forced a unique trace form after a grade is supplied | the grade still needs an effect, not a bare ray | this note does not replace that implication |
+
+**Gate disposition:** PASS for (i) `E_0` is not a projector, (ii) the two
+first-outcome traces disagree, (iii) Admissibility and Record do not name
+`P` versus `cP`, and (iv) both menus are displayed and neither is adopted.
+FAIL / DO NOT SHIP for "an axiom update is necessary," "August 9/10 are
+replaced," "the axioms force `r=1/2`," "either displayed menu is the
+physical instrument," or "no later compiler can declare a scale."
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current four axiom sentences | semantic baseline | supplied; no edit |
+| August 10 shared effect `E_0` | object identity | reused; theorems not replaced |
+| `P`, `rho`, both binary menus | witnesses | constructed here; not adopted |
+| later scale-declaring compiler | possible extra structure | open |
+| `L_phys` | unused adoption slot | not adopted |
+| `r=1/2` | unused dictionary | not introduced and not forced |
+| August 9 frame-lift theorem | standing neighbor | not replaced and not a premise |
+| observations or fits | none | not used |
+
+## Review Record
+
+The scientific parents are the current axiom memo and the August 10
+type-separation note, used only for the shared object `E_0` and the standing
+claim that a menu kernel consumes a declared effect. Independent audit
+remains required before any effective status may change.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16405,6 +16405,10 @@
   "scale_reference_primitive": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
+  },
+  "scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "e8920a7a8b6a",
+   "out_degree": 2
   },
   "scaling_failure_mechanisms": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.txt
+++ b/logs/runner-cache/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py
+runner_sha256: f0a81005ab384ac243c0cf4ef65ff44985538760763a9eeec3ce92b724412c1d
+input_fingerprint_sha256: 6be3f92cd70454c7acacb4e0e2a34138851eefa95dc381317a1e841dc86e6765
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording and the August 10 E0 object; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: projector identity and first-outcome scale on one site; later compilers remain live
+PASS: source-admissibility the exact current distribution sentence is present
+PASS: source-record the exact current lock sentence is present
+PASS: source-parent-e0 the August 10 parent supplies the shared object E0=(1/2)P(z)
+PASS: identity-is-projector-P is_projector(P) holds
+PASS: identity-is-projector-E0 is_projector(E0) fails
+PASS: identity-born-rho-P born(rho,P) equals 3/5
+PASS: identity-born-rho-E0 born(rho, E0) equals 3/10
+PASS: identity-gates-call-born-and-is-projector identity gates call born(rho,P) and is_projector(E0)
+PASS: theorem-1-projector-split P^2=P and E0^2=diag(1/4,0) so E0 is not a projector
+PASS: theorem-2-instruments-disagree Tr(rho P)=3/5 and Tr(rho E0)=3/10 disagree
+PASS: mutation-e0-is-projector-fails the predicate E0 is a projector fails
+PASS: mutation-traces-equal-fails the predicate Tr(rho P)=Tr(rho E0) fails because 3/5 != 3/10
+PASS: binary-menus-resolve-identity both displayed menus sum exactly to I
+PASS: complements-born-normalize each menu's Born weights sum to one
+PASS: note-theorem-surface the note records both identities, non-adoption, no forced half-scale, and non-replacement
+PASS: note-n5-theorem-4 N5 is attached to Theorem 4 and refuses L_phys adoption and a forced r=1/2
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: canonical-nonmutation the displayed instruments are absent from the canonical axiom file
+PASS: no-go-gate all N1-N8 sections and the broad-claim rejection are source-visible
+PASS: audit-input-paths declared inputs are the new note, the August 10 note, and the axiom memo
+PASS: no-unmerged-pr-citation the note cites no unmerged pull-request numbers
+PASS: no-gleason the note does not invoke Gleason
+PASS: august-standing-not-replaced August 9 and August 10 are left standing
+PASS: theorem-3-axiom-quotes the note quotes the distribution sentence and the lock sentence
+per_element: identity gates call born(rho,P) and is_projector(E0)
+per_site: one M_2(C) site; P versus (1/2)P only
+per_mode: the rank-one ray of P and the scale c=1/2
+per_block: instrument selection only; neither menu is adopted
+lattice_wide: checked and not executed — no lattice-wide dynamics claim
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py
+++ b/scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Exact checks: a scaled effect cP is not a projector; axioms pick neither instrument.
+
+Identity gates call born(rho,P) and is_projector(E0). Mutation predicates that
+E0 is a projector, or that Tr(rho P) equals Tr(rho E0), must fail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "SCALED_EFFECT_IS_NOT_A_PROJECTOR_AXIOMS_PICK_NEITHER_INSTRUMENT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+PARENT_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-10.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/SCALED_EFFECT_IS_NOT_A_PROJECTOR_AXIOMS_PICK_NEITHER_INSTRUMENT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def entry(value: int | Fraction) -> Fraction:
+    return Fraction(value)
+
+
+def diag(a: int | Fraction, b: int | Fraction) -> Matrix:
+    zero = entry(0)
+    return ((entry(a), zero), (zero, entry(b)))
+
+
+def matmul(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(
+            left[row][0] * right[0][column] + left[row][1] * right[1][column]
+            for column in range(2)
+        )
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def matadd(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][column] + right[row][column] for column in range(2))
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def matsub(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][column] - right[row][column] for column in range(2))
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def trace(matrix: Matrix) -> Fraction:
+    return matrix[0][0] + matrix[1][1]
+
+
+def is_projector(effect: Matrix) -> bool:
+    return matmul(effect, effect) == effect
+
+
+def born(state: Matrix, effect: Matrix) -> Fraction:
+    return trace(matmul(state, effect))
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_src = Path(__file__).read_text(encoding="utf-8")
+    normalized_axiom = normalize(axiom)
+    normalized_note = normalize(note)
+
+    print("external_scientific_inputs: current axiom wording and the August 10 E0 object; no observational or fitted inputs")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: projector identity and first-outcome scale on one site; later compilers remain live")
+
+    identity = diag(1, 1)
+    P = diag(1, 0)
+    E0 = diag(Fraction(1, 2), 0)
+    rho = diag(Fraction(3, 5), Fraction(2, 5))
+    I_minus_P = matsub(identity, P)
+    I_minus_E0 = matsub(identity, E0)
+
+    canonical_admissibility = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    canonical_record = "When present, a record locks exactly one admissible local possibility."
+    checks.check(
+        "source-admissibility",
+        "the exact current distribution sentence is present",
+        canonical_admissibility in normalized_axiom,
+    )
+    checks.check(
+        "source-record",
+        "the exact current lock sentence is present",
+        canonical_record in normalized_axiom,
+    )
+    checks.check(
+        "source-parent-e0",
+        "the August 10 parent supplies the shared object E0=(1/2)P(z)",
+        "E_0=(1/2)P(z)" in parent,
+    )
+
+    checks.check(
+        "identity-is-projector-P",
+        "is_projector(P) holds",
+        is_projector(P) is True,
+    )
+    checks.check(
+        "identity-is-projector-E0",
+        "is_projector(E0) fails",
+        is_projector(E0) is False,
+    )
+    checks.check(
+        "identity-born-rho-P",
+        "born(rho,P) equals 3/5",
+        born(rho,P) == Fraction(3, 5),
+    )
+    checks.check(
+        "identity-born-rho-E0",
+        "born(rho, E0) equals 3/10",
+        born(rho, E0) == Fraction(3, 10),
+    )
+    checks.check(
+        "identity-gates-call-born-and-is-projector",
+        "identity gates call born(rho,P) and is_projector(E0)",
+        "born(rho,P)" in runner_src and "is_projector(E0)" in runner_src,
+    )
+
+    e0_square = matmul(E0, E0)
+    checks.check(
+        "theorem-1-projector-split",
+        "P^2=P and E0^2=diag(1/4,0) so E0 is not a projector",
+        matmul(P, P) == P
+        and e0_square == diag(Fraction(1, 4), 0)
+        and e0_square != E0
+        and is_projector(E0) is False,
+    )
+    checks.check(
+        "theorem-2-instruments-disagree",
+        "Tr(rho P)=3/5 and Tr(rho E0)=3/10 disagree",
+        born(rho,P) == Fraction(3, 5)
+        and born(rho, E0) == Fraction(3, 10)
+        and born(rho,P) != born(rho, E0),
+    )
+
+    predicate_e0_is_projector = is_projector(E0)
+    checks.check(
+        "mutation-e0-is-projector-fails",
+        "the predicate E0 is a projector fails",
+        predicate_e0_is_projector is False,
+    )
+    predicate_traces_equal = born(rho,P) == born(rho, E0)
+    checks.check(
+        "mutation-traces-equal-fails",
+        "the predicate Tr(rho P)=Tr(rho E0) fails because 3/5 != 3/10",
+        predicate_traces_equal is False
+        and born(rho,P) == Fraction(3, 5)
+        and born(rho, E0) == Fraction(3, 10),
+    )
+
+    checks.check(
+        "binary-menus-resolve-identity",
+        "both displayed menus sum exactly to I",
+        matadd(P, I_minus_P) == identity and matadd(E0, I_minus_E0) == identity,
+    )
+    checks.check(
+        "complements-born-normalize",
+        "each menu's Born weights sum to one",
+        born(rho,P) + born(rho, I_minus_P) == 1
+        and born(rho, E0) + born(rho, I_minus_E0) == 1,
+    )
+
+    note_needles = (
+        "P^2=diag(1,0)=P",
+        "E_0^2=diag(1/4,0)",
+        "E_0` is not a projector",
+        "Tr(rho P)=3/5",
+        "Tr(rho E_0)=3/10",
+        "Neither sentence names `P` versus `cP`.",
+        "`{P,I-P}` and `{E_0,I-E_0}`",
+        "does not adopt either",
+        "does not force `r=1/2`",
+        "not replaced",
+    )
+    checks.check(
+        "note-theorem-surface",
+        "the note records both identities, non-adoption, no forced half-scale, and non-replacement",
+        all(needle in note for needle in note_needles),
+    )
+    checks.check(
+        "note-n5-theorem-4",
+        "N5 is attached to Theorem 4 and refuses L_phys adoption and a forced r=1/2",
+        "### N5 — resolution and rhetoric audit (Theorem 4)" in note
+        and "no adoption of `L_phys`, no forced `r=1/2`, no Lüders map" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "claim_type_reason:",
+                "trace_class: negative_route_pruning",
+                "source_of_blocker_text: handoff",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the displayed instruments are absent from the canonical axiom file",
+        all(
+            phrase not in axiom
+            for phrase in ("E_0=(1/2)P", "diag(1/2,0)", "L_phys", "cP")
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note
+        and "no later compiler can declare a scale" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the new note, the August 10 note, and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SCALED_EFFECT_IS_NOT_A_PROJECTOR_AXIOMS_PICK_NEITHER_INSTRUMENT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and PARENT_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "no-unmerged-pr-citation",
+        "the note cites no unmerged pull-request numbers",
+        "PR #" not in note
+        and "#6206" not in note
+        and "#6199" not in note
+        and "pvmselect" not in normalized_note
+        and "pvmluders" not in normalized_note,
+    )
+    checks.check(
+        "no-gleason",
+        "the note does not invoke Gleason",
+        "Gleason" not in note and "gleason" not in note,
+    )
+    checks.check(
+        "august-standing-not-replaced",
+        "August 9 and August 10 are left standing",
+        "August 9" in note and "August 10" in note and "not replaced" in note,
+    )
+    checks.check(
+        "theorem-3-axiom-quotes",
+        "the note quotes the distribution sentence and the lock sentence",
+        canonical_admissibility.replace("For each site, the p", "the p") in normalize(note)
+        or canonical_admissibility in normalize(note),
+    )
+
+    print("per_element: identity gates call born(rho,P) and is_projector(E0)")
+    print("per_site: one M_2(C) site; P versus (1/2)P only")
+    print("per_mode: the rank-one ray of P and the scale c=1/2")
+    print("per_block: instrument selection only; neither menu is adopted")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics claim")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

At one `M_2(C)` site, `E_0=(1/2)P` is not a projector (`E_0^2=diag(1/4,0)`). Against `rho=diag(3/5,2/5)`, `Tr(rho P)=3/5 ≠ Tr(rho E_0)=3/10`. Admissibility and Record name neither `P` nor `cP`. Both menus are displayed; neither is adopted. August 9/10 are not replaced. `r=1/2` is not forced. No Gleason.

## What this means for the TOE

Instrument scale is extra. Axioms pick neither projector nor scaled effect.

## What changed

- Note: `docs/SCALED_EFFECT_IS_NOT_A_PROJECTOR_AXIOMS_PICK_NEITHER_INSTRUMENT_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py`
- Cache: `logs/runner-cache/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.txt`

## Verification

```bash
python3 scripts/scaled_effect_is_not_a_projector_axioms_pick_neither_instrument_2026_08_13.py
# TOTAL: PASS=25 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
