### PR TITLE
[physics-loop] toe-lphys menuI: bounded_theorem / bounded-support

### DIFF
--- a/docs/MENU_IDENTITY_I2_IS_NOT_RECORD_I_EMPTY_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/MENU_IDENTITY_I2_IS_NOT_RECORD_I_EMPTY_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,328 @@
+---
+claim_id: menu_identity_i2_is_not_record_i_empty_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "One-site type-separation of two homonymous symbols named I. The menu identity I_2=diag(1,1) in M_2(C) has trace 2 and is the sum of every binary effect menu. The Record readout I is a scalar count of record collections with I(empty)=0. The objects are unequal as rationals and have different types. Identifying them is an extra dictionary, not a current-axiom or August 9 consequence. The note adopts no dictionary, does not claim Born is false, does not force r=1/2, and does not adopt L_phys."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py
+---
+
+# Menu Identity `I_2` Is Not Record `I(empty)=0`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site symbol/type separation between the operator identity
+used by binary menus and the Record scalar readout of the empty collection.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py`](../scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py)
+
+## Result Up Front
+
+Two different objects in the current surfaces are both written with the letter
+`I`.
+
+1. **Menu identity.** The operator identity `I_2=diag(1,1)` in `M_2(C)`
+   satisfies `Tr(I_2)=2`. A binary menu `{P, I_2-P}` of effects sums to
+   `I_2`.
+2. **Record readout.** The Record axiom supplies a scalar readout `I` of
+   finite collections of pairwise-disjoint records, with `I(empty)=0` in
+   `Z`.
+
+They are not the same object. `Tr(I_2)=2` is not `I(empty)=0`, even after
+both numbers are read as rationals. One object is a `2 times 2` matrix; the
+other is a scalar count. Quoting the two source sentences does not create a
+dictionary that identifies them. This note displays the mismatch and stops.
+
+The result is a type-separation theorem. It does not claim that the Born
+trace form is false. It does not force a weight `r=1/2`. It does not adopt a
+physical length `L_phys`. No canonical axiom is edited.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The rational inequality Tr(I_2)=2 != 0=I(empty) and the matrix-versus-scalar type split are proved on declared one-site objects, while any later dictionary, Born-weight identification, or physical-length adoption remains extra and is not taken."
+trace_class: negative_route_pruning
+target_claim_id: menu_identity_versus_record_readout_i
+target_blocker_text: "the menu identity I_2 is not the Record readout I(empty)=0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed rational mismatch and type split; no dictionary, Born negation, r=1/2 forcing, or L_phys adoption"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site, with local algebra `M_2(C)`.
+
+**Menu identity.** Write
+
+`I_2 = ((1, 0), (0, 1))` in `M_2(C)`.
+
+Its trace is the rational
+
+`Tr(I_2)=1+1=2`.
+
+For a rank-one projector `P` in `M_2(C)`, the complementary effect is
+`I_2-P`, and the binary menu `{P, I_2-P}` is a two-member family of effects
+summing to `I_2`. This is the same operator identity used by the parent
+binary/ternary scaled-projector theorem: menus are families of effects
+summing to `I_2`.
+
+**Record readout.** The current axiom memo states that only records are
+readable, that a readout value is determined by record content alone, and
+that for any finite collection of pairwise-disjoint records the scalar
+readout `I` is additive, with `I(empty)=0`. The empty collection is a
+collection of records. Its readout is the integer `0`, equivalently the
+rational `0`.
+
+These two objects share a letter and nothing else required by the quoted
+sources.
+
+## Theorem 1 — Unequal Even As Rationals
+
+`Tr(I_2)=2` and `I(empty)=0` are both elements of `Q`. They are unequal:
+
+`2 != 0`.
+
+The hostile predicate `Tr(I_2)=I(empty)` is therefore false. No further
+analytic continuation, dictionary, or units conversion is used. The identity
+gates that compare the two symbols call the explicit maps `tr_I2()` and
+`I_empty()` in the companion runner.
+
+## Theorem 2 — Different Types
+
+`I_2` is a `2 times 2` matrix. `I(empty)` is a scalar count.
+
+A matrix in `M_2(C)` is not an element of `Z`. A scalar count is not an
+operator that binary menus can sum to. Type disagreement is independent of
+the rational inequality in Theorem 1: even if someone renamed the symbols,
+one object still has shape `(2,2)` and the other has no matrix indices.
+
+## Theorem 3 — Quoted Sources Do Not Identify Them
+
+Quote Record from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar
+> readout `I` is additive, with `I(empty)=0`.
+
+Quote the August 9 parent
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md):
+
+> The three compressed rank-one projections are scaled rank-one qubit effects
+> summing to `I_2`.
+
+and
+
+> A menu is a finite family of nonzero members of `S` summing to `I`.
+
+The parent uses both `I` and `I_2` for the operator identity of a menu. The
+Record axiom uses `I` for a scalar readout of record collections. Juxtaposing
+those sentences does not identify the menu identity with Record `I`.
+Identifying the menu identity with Record `I` is extra.
+
+## Theorem 4 — Display The Mismatch; Adopt No Dictionary
+
+The mismatch is:
+
+| Symbol as written | Object | Value or shape |
+|---|---|---|
+| `I_2` | operator identity in `M_2(C)` | matrix `diag(1,1)`, `Tr=2` |
+| `I` in a menu sum | same operator identity (parent usage) | family of effects summing to `I_2` |
+| `I(empty)` | Record scalar readout of the empty collection | `0` in `Z` |
+
+This note displays that table. It does not adopt a dictionary
+
+`I_2 := I(empty)`, `I := Tr(I_2)`, or `I(empty) := 2`.
+
+It does not claim that the Born trace form is false. The parent theorem
+remains a conditional one-site implication from a supplied grading and
+eligible menus to a unique density-matrix trace form. Homonym collision of
+the letter `I` is not a counterexample to that implication.
+
+## Theorem 5 — Do Not Force `r=1/2`; Do Not Adopt `L_phys`
+
+Nothing in Theorems 1--4 selects a Koide or Born weight `r=1/2`. The binary
+menu `{P, I_2-P}` is an operator resolution; its existence does not force
+equal outcome grades, a unique mixing weight, or `r=1/2`.
+
+Nothing in Theorems 1--4 introduces or adopts a physical length `L_phys`.
+No continuum path length, valley length, or other dimensionful scale is
+identified with `Tr(I_2)`, with `I(empty)`, or with their difference.
+
+Those refusals are load-bearing. Closing the homonym does not license a
+weight-fixing step and does not license a length primitive.
+
+## Proof-Obligation Graph
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| compute `Tr(I_2)` exactly | Theorem 1 | `1+1=2` in `Q` |
+| read `I(empty)` from Record | Theorem 1 | quoted `0` in `Z`, hence `0` in `Q` |
+| reject `Tr(I_2)=I(empty)` | mutation | `2 != 0` |
+| exhibit matrix versus scalar types | Theorem 2 | `I_2` has shape `(2,2)`; `I(empty)` is a scalar |
+| quote both sources without adding a map | Theorem 3 | Record and August 9 sentences displayed |
+| refuse a dictionary and refuse Born negation | Theorem 4 | explicit non-adoption |
+| refuse `r=1/2` and refuse `L_phys` | Theorem 5 | explicit non-adoption |
+| edit a canonical axiom | out of scope | not done |
+
+## Independent Adversarial Checks
+
+The runner constructs `I_2` as an exact rational matrix, computes `tr_I2()`
+by summing the diagonal, and returns `I_empty()` as the exact rational `0`.
+Every identity-gate comparison calls those two maps. A rank-one projector
+`P` and its complement `I_2-P` are added in `M_2(Q)` and compared with
+`I_2`. The hostile predicate `tr_I2()==I_empty()` is required to fail.
+
+The runner also checks that the source note quotes both parents, states
+Theorems 1--5, refuses a dictionary, refuses a Born-false claim, refuses
+`r=1/2`, refuses `L_phys`, and does not mutate the canonical axiom memo.
+
+## Relation To The Current Axioms
+
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the
+one-site algebraic presentation `M_2(C)` and the Record scalar readout with
+`I(empty)=0`. It does not say that the operator identity of a menu is that
+readout. The August 9 parent supplies the menu-sum convention. Neither
+source is edited here.
+
+No hypothetical axiom wording is proposed. The sufficient next step, if a
+later note wants a single letter for both objects, is to adopt an explicit
+dictionary and justify it. This note does not take that step.
+
+## No-Go Discipline Gate
+
+The negative claim is only that the two homonymous symbols are not already
+the same object. The gate does not certify a Born no-go.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Rational identification | set `Tr(I_2)=I(empty)` in `Q` | Theorem 1: `2 != 0` | **ATTEMPTED** |
+| Type identification | treat the matrix `I_2` as the scalar count `I(empty)` | Theorem 2: shape `(2,2)` versus a scalar | **ATTEMPTED** |
+| Quotation dictionary | read Record and August 9 as already identifying the symbols | Theorem 3: the quoted sentences name different objects | **ATTEMPTED** |
+| Silent dictionary | adopt `I_2 := I` or `I := Tr(I_2)` to remove the clash | Theorem 4 refuses the dictionary | **ATTEMPTED** |
+| Born negation | treat the homonym as a counterexample to the parent trace form | Theorem 4 refuses the Born-false claim | **ATTEMPTED** |
+| Weight forcing | read a binary menu as forcing `r=1/2` | Theorem 5 refuses the forcing | **ATTEMPTED** |
+| Length adoption | read `2` or `0` as a physical length `L_phys` | Theorem 5 refuses the adoption | **ATTEMPTED** |
+
+None of these routes supports "Born is false" or "an axiom update is
+necessary."
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| rational inequality / type split | no: two rationals can differ while sharing a type | no: two types can differ while some traces coincide | independent |
+| source quotation / dictionary | no: quoting two sentences does not write a map | no: a later map would be extra structure, not a quotation | independent |
+| homonym display / Born form | no: unequal symbols do not refute a trace grade | no: a density-matrix grade does not identify `I_2` with `I(empty)` | independent |
+| homonym display / `r=1/2` | no: `2 != 0` does not select a weight | no: a weight does not identify the two `I` symbols | independent |
+| homonym display / `L_phys` | no: the mismatch introduces no length | no: a length would be a new object | independent |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `I_2` | explicit `2 times 2` identity matrix; not Record readout |
+| `I(empty)` | explicit Record scalar; not an operator |
+| `Tr` | ordinary matrix trace over `Q` |
+| binary menu `{P, I_2-P}` | exact operator resolution; grades unused |
+| "dictionary" | refused extra identification; not present in the axioms |
+| `r=1/2` | refused weight; not derived |
+| `L_phys` | refused length; not adopted |
+| observations or empirical frequencies | none |
+
+No continuity assumption, fitted value, or selected density matrix is hidden.
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md:82-84`](MINIMAL_AXIOMS_2026-06-29.md) | scalar readout `I` additive with `I(empty)=0` | exact current wording only; no menu-identity conclusion borrowed |
+| [`docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md:32-33`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md) | effects summing to `I_2` | menu-identity usage only |
+| [`docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md:77`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md) | a menu is a finite family of nonzero members of `S` summing to `I` | parent letter `I` for the same operator identity; not Record readout |
+
+No citation is used as authority for the rational inequality `2 != 0`; that
+is proved here and checked by the runner.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | diagonal entries of `I_2` and the empty-collection readout | no classification of every symbol named `I` in the repo |
+| per site | one `M_2(C)` site | no composite readout theorem |
+| per mode | the identity-versus-empty-readout pair only | no spectral-mode exhaustion |
+| per block | the two-symbol homonym only | no Born/Record/history closure |
+| lattice-wide | not executed | no lattice-wide dynamics or no-go |
+
+### N6 — live partial-closure paths
+
+1. A later note may adopt an explicit dictionary and justify it from
+   retained structure. That map is not present now.
+2. The parent frame-lift theorem remains a live conditional derivation of
+   the Born trace form on the scaled domain.
+3. Binary-menu grades, if derived, remain free of any `r=1/2` forcing from
+   this homonym.
+4. Physical scales, if derived, must be introduced as their own objects,
+   not by renaming `I_2` or `I(empty)` to `L_phys`.
+
+### N7 — hostile steelman
+
+> The letter `I` is used for the menu sum and for Record readout, so the
+> framework already treats them as one quantity. Then `Tr(I_2)` should equal
+> `I(empty)`, or else the Born form that normalizes menus to `I_2` would be
+> false.
+
+This steelman is rejected at the first step. Shared spelling is not an
+identification. The predicate `Tr(I_2)=I(empty)` fails, and the parent Born
+implication is not thereby refuted.
+
+### N8 — cross-cycle echo
+
+| Earlier surface | Later movement | Echo here |
+|---|---|---|
+| parent menus sum to the operator identity | August 9 writes both `I` and `I_2` for that operator | keep the operator identity typed as a matrix |
+| Record additivity | the axiom memo fixes `I(empty)=0` as a scalar count | keep the empty readout typed as a scalar |
+| letter collision | this note | display the mismatch; adopt no dictionary |
+
+**Gate disposition:** PASS for (i) `Tr(I_2)=2 != 0=I(empty)`, (ii) the
+matrix-versus-scalar type split, and (iii) the refusal to treat quotation as
+a dictionary. FAIL / DO NOT SHIP for "Born is false," "an axiom update is necessary,"
+"force `r=1/2`," or "adopt `L_phys`."
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current four axiom sentences | exact semantic baseline | supplied; no edit |
+| August 9 menu-sum convention | source of the operator identity `I_2` | explicit parent |
+| matrix trace over `Q` | Theorem 1 | definition-level mathematics |
+| matrix-versus-scalar typing | Theorem 2 | definition-level mathematics |
+| dictionary identifying the two `I` symbols | refused | not adopted |
+| Born-false claim | refused | not made |
+| weight `r=1/2` | refused | not forced |
+| physical length `L_phys` | refused | not adopted |
+| observed probabilities, frequencies, fits | none | not used |
+
+The exact advance is a symbol/type theorem. It does not move TOE percentages
+by itself because it derives no new physical interface. It makes the next
+update decision testable: keep the two objects distinct, or adopt an explicit
+justified dictionary; do not silently read `I_2` as `I(empty)`.
+
+## Review Record
+
+This source is stacked on the parent frame-lift theorem because that parent
+is the current menu-identity usage being separated from Record readout.
+Independent audit remains required before any effective status may change.
+No `review-loop` was invoked in producing or self-reviewing this artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12277,6 +12277,10 @@
   "memory_mu2_geometry_sweep_note_2026-04-11": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "menu_identity_i2_is_not_record_i_empty_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "8830c572e201",
+   "out_degree": 2
   },
   "mermin_wagner_bogoliubov_textbook_import_note_2026-05-18": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/menu_identity_i2_is_not_record_i_empty_2026_08_13.txt
+++ b/logs/runner-cache/menu_identity_i2_is_not_record_i_empty_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py
+runner_sha256: a0c48ddb7f45dfac69a2c565d8aca3642bd72e2792865238d323fd82dff9be29
+input_fingerprint_sha256: 0be7925bd0f293535572cdc7dbe703aa3e07271dad7c2b2e15c483a52ffedf92
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording and the parent menu-sum convention are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+identity_boundary: identity gates call tr_I2() and I_empty(); the hostile equality predicate must fail
+negative_scope: only the I_2 / I(empty) homonym is rejected; Born form, weights, and lengths remain unforced
+PASS: source-record Record supplies a scalar readout I with I(empty)=0
+PASS: source-parent-menu-identity the August 9 parent uses I_2 as the operator menus sum to
+PASS: i2-matrix-type I_2 is a 2x2 matrix over Q
+PASS: i-empty-scalar-type I(empty) is a scalar rational count
+PASS: type-separation the menu identity and the empty readout have different types
+PASS: tr-i2-value tr_I2() returns the exact rational 2
+PASS: i-empty-value I_empty() returns the exact rational 0
+PASS: identity-gate-rational-unequal Tr(I_2)=2 is not I(empty)=0 even as rationals
+PASS: mutation-predicate the hostile predicate Tr(I_2)=I(empty) fails
+PASS: binary-menu-resolution the binary menu {P, I_2-P} sums exactly to I_2
+PASS: theorem-surface the note states Theorems 1 through 5 on the declared objects
+PASS: no-dictionary-adoption the note displays the mismatch and refuses a dictionary
+PASS: no-born-false-claim the note does not claim Born is false
+PASS: no-r-half-force the note does not force r=1/2
+PASS: no-lphys-adoption the note does not adopt L_phys
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support and negative-route-pruning trace fields
+PASS: canonical-nonmutation the canonical axiom memo is not edited and still has only the Record scalar I(empty)=0
+PASS: no-unmerged-pr-citation the note does not cite unmerged PR labels
+PASS: no-go-gate all N1-N8 sections and the broad-claim rejection are source-visible
+per_element: I_2 diagonal entries, empty-collection readout, and one rank-one binary menu are checked
+per_site: the mismatch is a one-site statement in M_2(C); no composite carrier is asserted
+per_mode: only the identity-versus-empty-readout pair is tested
+per_block: the two-symbol homonym is the only negative block tested
+lattice_wide: checked and not executed — no lattice-wide dynamics or Born no-go is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py
+++ b/scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Exact checks that the menu identity I_2 is not Record I(empty)=0.
+
+Identity-gate comparisons call tr_I2() and I_empty(). The hostile predicate
+Tr(I_2)=I(empty) must fail because 2 != 0 in Q. No dictionary, Born negation,
+r=1/2 forcing, or L_phys adoption is accepted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "MENU_IDENTITY_I2_IS_NOT_RECORD_I_EMPTY_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PARENT_PATH = ROOT / "docs" / "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/MENU_IDENTITY_I2_IS_NOT_RECORD_I_EMPTY_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def I2() -> Matrix:
+    return ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(1)))
+
+
+def tr_I2() -> Fraction:
+    matrix = I2()
+    return matrix[0][0] + matrix[1][1]
+
+
+def I_empty() -> Fraction:
+    return Fraction(0)
+
+
+def matrix_add(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def matrix_sub(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (left[0][0] - right[0][0], left[0][1] - right[0][1]),
+        (left[1][0] - right[1][0], left[1][1] - right[1][1]),
+    )
+
+
+def identity_equal_predicate() -> bool:
+    """Hostile predicate Tr(I_2)=I(empty). Identity gates must call both maps."""
+    return tr_I2() == I_empty()
+
+
+@dataclass(frozen=True)
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> "Checks":
+        result = bool(condition)
+        if result:
+            self = Checks(self.passed + 1, self.failed)
+        else:
+            self = Checks(self.passed, self.failed + 1)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        return self
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+    normalized_parent = normalize(parent)
+
+    print("external_scientific_inputs: current axiom wording and the parent menu-sum convention are source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("identity_boundary: identity gates call tr_I2() and I_empty(); the hostile equality predicate must fail")
+    print("negative_scope: only the I_2 / I(empty) homonym is rejected; Born form, weights, and lengths remain unforced")
+
+    checks = checks.check(
+        "source-record",
+        "Record supplies a scalar readout I with I(empty)=0",
+        "scalar readout `I` is additive, with `I(empty)=0`" in normalized_axiom,
+    )
+    checks = checks.check(
+        "source-parent-menu-identity",
+        "the August 9 parent uses I_2 as the operator menus sum to",
+        all(
+            phrase in parent
+            for phrase in (
+                "scaled rank-one qubit effects summing to `I_2`",
+                "A menu is a finite family of nonzero members of `S` summing to `I`.",
+            )
+        ),
+    )
+
+    identity = I2()
+    checks = checks.check(
+        "i2-matrix-type",
+        "I_2 is a 2x2 matrix over Q",
+        len(identity) == 2
+        and all(len(row) == 2 for row in identity)
+        and all(isinstance(identity[i][j], Fraction) for i in range(2) for j in range(2)),
+    )
+    checks = checks.check(
+        "i-empty-scalar-type",
+        "I(empty) is a scalar rational count",
+        isinstance(I_empty(), Fraction) and not isinstance(I_empty(), tuple),
+    )
+    checks = checks.check(
+        "type-separation",
+        "the menu identity and the empty readout have different types",
+        type(identity) is not type(I_empty()),
+    )
+
+    checks = checks.check(
+        "tr-i2-value",
+        "tr_I2() returns the exact rational 2",
+        tr_I2() == Fraction(2),
+    )
+    checks = checks.check(
+        "i-empty-value",
+        "I_empty() returns the exact rational 0",
+        I_empty() == Fraction(0),
+    )
+    checks = checks.check(
+        "identity-gate-rational-unequal",
+        "Tr(I_2)=2 is not I(empty)=0 even as rationals",
+        tr_I2() != I_empty() and tr_I2() - I_empty() == Fraction(2),
+    )
+    checks = checks.check(
+        "mutation-predicate",
+        "the hostile predicate Tr(I_2)=I(empty) fails",
+        identity_equal_predicate() is False,
+    )
+
+    projector = (
+        (Fraction(1, 2), Fraction(1, 2)),
+        (Fraction(1, 2), Fraction(1, 2)),
+    )
+    complement = matrix_sub(I2(), projector)
+    menu_sum = matrix_add(projector, complement)
+    checks = checks.check(
+        "binary-menu-resolution",
+        "the binary menu {P, I_2-P} sums exactly to I_2",
+        menu_sum == I2() and projector[0][0] + projector[1][1] == Fraction(1),
+    )
+
+    theorem_needles = (
+        "Tr(I_2)=2` and `I(empty)=0` are both elements of `Q`",
+        "`I_2` is a `2 times 2` matrix. `I(empty)` is a scalar count.",
+        "Identifying the menu identity with Record `I` is extra.",
+        "It does not claim that the Born trace form is false.",
+        "Nothing in Theorems 1--4 selects a Koide or Born weight `r=1/2`.",
+        "Nothing in Theorems 1--4 introduces or adopts a physical length `L_phys`.",
+    )
+    checks = checks.check(
+        "theorem-surface",
+        "the note states Theorems 1 through 5 on the declared objects",
+        all(phrase in normalized_note for phrase in theorem_needles),
+    )
+    checks = checks.check(
+        "no-dictionary-adoption",
+        "the note displays the mismatch and refuses a dictionary",
+        "This note displays that table. It does not adopt a dictionary" in normalized_note
+        and "`I_2 := I(empty)`" in note,
+    )
+    checks = checks.check(
+        "no-born-false-claim",
+        "the note does not claim Born is false",
+        "does not claim that the Born trace form is false" in normalized_note
+        and "Born is false" in note,
+    )
+    checks = checks.check(
+        "no-r-half-force",
+        "the note does not force r=1/2",
+        "does not force a weight `r=1/2`" in normalized_note
+        and "force `r=1/2`" in note,
+    )
+    checks = checks.check(
+        "no-lphys-adoption",
+        "the note does not adopt L_phys",
+        "does not adopt a physical length `L_phys`" in normalized_note
+        and "adopt `L_phys`" in note,
+    )
+    checks = checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks = checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support and negative-route-pruning trace fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "claim_type_reason:",
+                "trace_class: negative_route_pruning",
+                "source_of_blocker_text: handoff",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks = checks.check(
+        "canonical-nonmutation",
+        "the canonical axiom memo is not edited and still has only the Record scalar I(empty)=0",
+        "scalar readout `I` is additive, with `I(empty)=0`." in normalized_axiom
+        and "I_2 := I(empty)" not in axiom
+        and "menu identity" not in axiom,
+    )
+    checks = checks.check(
+        "no-unmerged-pr-citation",
+        "the note does not cite unmerged PR labels",
+        all(
+            token not in note.lower()
+            for token in ("trvsi", "emptyvac", "#6215", "#6212", "unmerged pr")
+        ),
+    )
+    checks = checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note,
+    )
+
+    print("per_element: I_2 diagonal entries, empty-collection readout, and one rank-one binary menu are checked")
+    print("per_site: the mismatch is a one-site statement in M_2(C); no composite carrier is asserted")
+    print("per_mode: only the identity-versus-empty-readout pair is tested")
+    print("per_block: the two-symbol homonym is the only negative block tested")
+    print("lattice_wide: checked and not executed — no lattice-wide dynamics or Born no-go is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Menu identity `I_2=diag(1,1)` has `Tr(I_2)=2`. Record readout has `I(empty)=0`. They are unequal as rationals and have different types (matrix vs scalar). Identifying them is an extra dictionary. The note does not claim Born is false, does not force `r=1/2`, and does not adopt `L_phys`.

## What this means for the TOE

Two different “I”s. Shared spelling is not an identification.

## What changed

- Note: `docs/MENU_IDENTITY_I2_IS_NOT_RECORD_I_EMPTY_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py`
- Cache: `logs/runner-cache/menu_identity_i2_is_not_record_i_empty_2026_08_13.txt`

## Verification

```bash
python3 scripts/menu_identity_i2_is_not_record_i_empty_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
