### PR TITLE
[physics-loop] toe-lphys wgrade: bounded_theorem / bounded-support

### DIFF
--- a/docs/MENU_INDEPENDENT_GRADING_ON_SCALED_PROJECTORS_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/MENU_INDEPENDENT_GRADING_ON_SCALED_PROJECTORS_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,203 @@
+---
+claim_id: menu_independent_grading_on_scaled_projectors_is_extra_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "At one M_2(C) site, two exact trial grades on the scaled family {0, P_z, I} disagree at P_z. The current Admissibility and Record sentences name a nearest-neighbor distribution over possibilities and a lock-plus-additive-readout, not a menu-independent grade w on scaled projectors. The August 9 uniqueness theorem supplies a unique density matrix only after such a w is already the instrument. This note names that extra matching. It does not improve August 9, import Gleason as physics, say Born is false, force r=1/2, or adopt L_phys."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py
+---
+
+# A Menu-Independent Grading On Scaled Projectors Is Extra
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact one-site type comparison among two displayed trial grades,
+the current axiom sentences, and the August 9 uniqueness hypothesis.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py`](../scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py)
+
+## Result Up Front
+
+August 9 uniqueness is uniqueness *among* menu-independent, low-arity-normalized
+grades on the scaled-projector domain. This block names the extra matching,
+not a new Gleason theorem.
+
+Two exact trial grades already disagree on `{0,P_z,I}`. The current
+Admissibility and Record sentences do not name either grade. Selecting
+`w_ρ` as the instrument is therefore an extra matching, displayed here and
+not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: negative_route_pruning
+target_claim_id: menu_independent_grading_on_scaled_projectors_is_extra
+target_blocker_text: "name the extra matching that a menu-independent scaled-projector grade exists and is the instrument"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+conditional_surface_status: "exact disagreement of two displayed grades; extra matching named; no axiom edit"
+hypothetical_axiom_status: "no candidate wording is adopted"
+admitted_observation_status: null
+claim_type_reason: "The two grades, the axiom-text comparison, and the August 9 conditional uniqueness statement are exact finite objects. The matching that such a w exists and is the instrument remains extra."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work at one site with `H=C^2`. Write
+
+`P_z=diag(1,0)` and `I=diag(1,1)`.
+
+The trial domain is the scaled family
+
+`{0,P_z,I}={c P_z:0<=c<=1} union {c I:0<=c<=1}`.
+
+Two trial grades on that family are displayed, not adopted:
+
+- `w_ρ(c P_z)=c·3/5` and `w_ρ(c I)=c`, from `ρ=diag(3/5,2/5)`;
+- `w_*(c P_z)=c·1/2` and `w_*(c I)=c`, from `I/2`.
+
+Both send `0` to `0` and `I` to `1`. They are exact rational functions. They
+are not identified with a physical instrument, a selected density law, or an
+axiom sentence.
+
+The August 9 parent,
+[`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md),
+works on the larger scaled domain `S` of nonnegative multiples of rank-one
+projectors and of the identity. Its uniqueness statement is recalled only as
+already written there. This note does not extend, re-prove, or improve it.
+
+## Theorem 1 — Two Different Grades
+
+Evaluate the displayed grades at the unscaled projector:
+
+`w_ρ(P_z)=3/5 ≠ 1/2=w_*(P_z)`.
+
+The same split persists under scaling: for every `c in (0,1]`,
+
+`w_ρ(c P_z)=c·3/5 ≠ c·1/2=w_*(c P_z)`.
+
+The two functions agree on the identity ray, since both satisfy
+`w_ρ(c I)=c=w_*(c I)`. Agreement on `{0,I}` does not force agreement on
+`P_z`. Therefore a predicate `w_ρ=w_*` fails at `P_z`.
+
+This is only a witness that more than one exact grade exists on the trial
+family. It does not select a density matrix, force `r=1/2`, or say that Born
+weights are unavailable later.
+
+## Theorem 2 — The Axiom Sentences Do Not Name `w`
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is:
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record sentences used here are:
+
+> When present, a record locks exactly one admissible local possibility.
+
+and
+
+> For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+Admissibility names a nearest-neighbor-determined distribution over
+possibilities. Record names a lock of one possibility and an additive scalar
+readout of record collections. Neither sentence names a grade `w` on scaled
+projectors. In particular, neither sentence names `w_ρ`. A predicate
+“axioms name `w_ρ`” fails.
+
+This is a textual comparison with the linked axiom memo. It is not a theorem
+that no later derivation can produce a grade.
+
+## Theorem 3 — August 9 Uniqueness Is Conditional On The Extra Matching
+
+The August 9 parent states the exact claim:
+
+> There is a unique density matrix `rho in M_2(C)` such that
+> `w(E)=Tr(rho E)` for every `E in S`.
+
+The parent’s declared inputs are a menu-independent function `w` on the
+scaled-projector domain and normalization on every binary and ternary nonzero
+scaled-projector resolution of the identity. The uniqueness is therefore
+uniqueness *among such grades*: *if* a grade is menu-independent and
+normalized on binary and ternary scaled-projector menus, then it is
+`Tr(ρ E)` for a unique `ρ`.
+
+That uniqueness is conditional on the extra matching “such a `w` exists and
+is the instrument.” Display `w_ρ`; do not adopt it. Displaying `w_ρ` shows
+one Born-shaped grade that August 9 would recover *after* the matching is
+supplied. The matching is not written in the Admissibility or Record
+sentences of Theorem 2, and Theorem 1 shows that a different displayed grade
+`w_*` is available on the same trial family.
+
+## Theorem 4 — No Improvement, No Gleason-As-Physics, No Born Denial
+
+This note does not claim that the August 9 theorem is improved. The parent
+already records uniqueness among the grades it assumes. Naming the extra
+matching does not enlarge the mathematical domain, drop a hypothesis, or
+replace the parent’s named frame step.
+
+This note does not import Gleason as physics. No frame-function theorem is
+re-proved or treated as a physical registration of menus.
+
+This note does not say Born is false. Both displayed grades are Born-shaped
+on the trial family. The claim is only that the axioms do not already name
+one of them as the instrument.
+
+## Theorem 5 — No Forced Maximally Mixed Ray And No `L_phys`
+
+This note does not force `r=1/2`. The grade `w_*` is a displayed control,
+not a selected physical state. Nothing here installs a preferred Bloch
+radius, a preferred mixed state, or a preferred value of `w(P_z)`.
+
+This note does not adopt `L_phys`. No physical-length primitive, spacetime
+metric, or laboratory scale is introduced or selected.
+
+## Mutation Predicates
+
+The runner’s identity gates call `w_rho(Pz)` and `w_star(Pz)` and check
+
+`w_rho(Pz)=3/5` and `w_star(Pz)=1/2`.
+
+The equality predicate `w_ρ=w_*` is tested only at `P_z` and must fail.
+The naming predicate “axioms name `w_ρ`” is tested against the current axiom
+memo and must fail.
+
+## Claim Boundary
+
+| Claim | Status in this note |
+|---|---|
+| `w_ρ(P_z)=3/5 ≠ 1/2=w_*(P_z)` | proved on the displayed trial family |
+| Admissibility and Record name a grade `w` on scaled projectors | false as written; extra matching |
+| August 9 uniqueness among supplied menu-independent low-arity grades | recalled, not improved |
+| such a `w` exists and is the physical instrument | extra matching; displayed, not adopted |
+| Gleason is a physical law of the lattice | not claimed; not imported |
+| Born is false | not claimed |
+| `r=1/2` is forced | not claimed |
+| `L_phys` is adopted | not claimed |
+| no later compiler can supply a grade | not claimed |
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance | Open-bridge status |
+|---|---|---|---|
+| `M_2(C)` one-site possibility presentation | carrier context | current Qubit axiom | supplied algebraic presentation |
+| Admissibility distribution sentence | textual baseline | current axiom memo | does not name `w` |
+| Record lock and additive `I` | textual baseline | current axiom memo | does not name `w` |
+| August 9 uniqueness among menu-independent low-arity grades | parent mathematics | linked August 9 note | conditional on the extra matching |
+| displayed `w_ρ` and `w_*` | exact trial grades | this note | not adopted as instruments |
+| Gleason / frame theorem as physics | none | not imported | not applicable |
+| `L_phys`, forced `r=1/2` | none | not used | not applicable |
+
+Independent audit remains required before the repository may assign any
+effective claim status.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12277,6 +12277,10 @@
   "memory_mu2_geometry_sweep_note_2026-04-11": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "menu_independent_grading_on_scaled_projectors_is_extra_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "8830c572e201",
+   "out_degree": 2
   },
   "mermin_wagner_bogoliubov_textbook_import_note_2026-05-18": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.txt
+++ b/logs/runner-cache/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py
+runner_sha256: 0f724300f71aee8c82bcdc08adcbbcf3fde1ad6cd220e75d2a7c138c519b6af9
+input_fingerprint_sha256: a7ca4e25740069fb60326bf48705faea73f2dbc677a2a5cf7002e32b8481f7dd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording and the parent low-arity uniqueness theorem are source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; Gleason is not imported
+negative_scope: only the extra matching that a menu-independent scaled-projector grade exists and is the instrument is named; August 9 is not improved and Born is not denied
+PASS: pz-definition P_z is exactly diag(1, 0)
+PASS: identity-w-rho the identity gate w_rho(Pz) equals 3/5
+PASS: identity-w-star the identity gate w_star(Pz) equals 1/2
+PASS: mutation-grades-unequal the predicate w_ρ=w_* fails at P_z
+PASS: identity-ray-agreement both grades send c I to c and send 0 to 0
+PASS: scaled-projector-split the grades remain unequal on a proper multiple of P_z
+PASS: mutation-axioms-do-not-name-w-rho the predicate axioms-name-w_ρ fails on the current axiom memo
+PASS: source-admissibility the note quotes the nearest-neighbor distribution sentence
+PASS: source-record the note quotes the lock sentence and additive Record I
+PASS: source-parent-uniqueness the parent uniqueness statement is conditional on a supplied menu-independent grade
+PASS: extra-matching-surface the note names the extra matching and displays w_ρ without adopting it
+PASS: theorem-four-and-five-boundary the note refuses August 9 improvement, Gleason-as-physics, Born denial, forced r=1/2, and L_phys
+per_element: identity gates evaluate w_rho(Pz) and w_star(Pz); scaled and identity-ray controls use exact Fraction
+per_site: both trial grades and the axiom-text comparison are one-site statements
+per_mode: no spectral-mode exhaustion is claimed
+per_block: the extra matching that such a w exists and is the instrument is the only negative block tested
+lattice_wide: checked and not executed — no lattice-wide Born no-go is claimed
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py
+++ b/scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Exact checks that a menu-independent scaled-projector grade is extra.
+
+The runner compares two displayed trial grades at P_z, checks that the
+current axiom memo does not name w_ρ, and checks that the source note
+treats August 9 uniqueness as conditional on that extra matching. Exact
+Fraction arithmetic only. No Gleason import.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "MENU_INDEPENDENT_GRADING_ON_SCALED_PROJECTORS_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+PARENT_PATH = ROOT / "docs" / "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/MENU_INDEPENDENT_GRADING_ON_SCALED_PROJECTORS_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+Pz: Matrix = ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(0)))
+I2: Matrix = ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(1)))
+ZERO: Matrix = ((Fraction(0), Fraction(0)), (Fraction(0), Fraction(0)))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def scale(coefficient: Fraction, matrix: Matrix) -> Matrix:
+    return tuple(
+        tuple(coefficient * matrix[row][column] for column in range(2))
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def _entry_zero(matrix: Matrix, row: int, column: int) -> bool:
+    return matrix[row][column] == 0
+
+
+def _as_multiple(matrix: Matrix, basis: Matrix) -> Fraction | None:
+    coefficient: Fraction | None = None
+    for row in range(2):
+        for column in range(2):
+            basis_entry = basis[row][column]
+            matrix_entry = matrix[row][column]
+            if basis_entry == 0:
+                if matrix_entry != 0:
+                    return None
+                continue
+            candidate = matrix_entry / basis_entry
+            if coefficient is None:
+                coefficient = candidate
+            elif candidate != coefficient:
+                return None
+    return Fraction(0) if coefficient is None else coefficient
+
+
+def w_rho(effect: Matrix) -> Fraction:
+    """Displayed grade from ρ=diag(3/5, 2/5) on {0, P_z, I}."""
+    if effect == ZERO:
+        return Fraction(0)
+    identity_scale = _as_multiple(effect, I2)
+    if identity_scale is not None:
+        return identity_scale
+    projector_scale = _as_multiple(effect, Pz)
+    if projector_scale is not None:
+        return projector_scale * Fraction(3, 5)
+    raise ValueError("w_rho is defined only on scaled {0, P_z, I}")
+
+
+def w_star(effect: Matrix) -> Fraction:
+    """Displayed grade from I/2 on {0, P_z, I}."""
+    if effect == ZERO:
+        return Fraction(0)
+    identity_scale = _as_multiple(effect, I2)
+    if identity_scale is not None:
+        return identity_scale
+    projector_scale = _as_multiple(effect, Pz)
+    if projector_scale is not None:
+        return projector_scale * Fraction(1, 2)
+    raise ValueError("w_star is defined only on scaled {0, P_z, I}")
+
+
+def grades_equal_at_pz() -> bool:
+    return w_rho(Pz) == w_star(Pz)
+
+
+def axioms_name_w_rho(axiom_text: str) -> bool:
+    needles = (
+        "w_ρ",
+        "w_rho",
+        "menu-independent grading",
+        "scaled projector",
+        "scaled-projector",
+        "Tr(ρ",
+        "Tr(rho",
+    )
+    return any(needle in axiom_text for needle in needles)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    parent = PARENT_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording and the parent "
+        "low-arity uniqueness theorem are source-bound; no observational or "
+        "fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; Gleason is not imported"
+    )
+    print(
+        "negative_scope: only the extra matching that a menu-independent "
+        "scaled-projector grade exists and is the instrument is named; "
+        "August 9 is not improved and Born is not denied"
+    )
+
+    checks.check(
+        "pz-definition",
+        "P_z is exactly diag(1, 0)",
+        Pz == ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(0)))
+        and _entry_zero(Pz, 0, 1)
+        and _entry_zero(Pz, 1, 0)
+        and _entry_zero(Pz, 1, 1),
+    )
+    checks.check(
+        "identity-w-rho",
+        "the identity gate w_rho(Pz) equals 3/5",
+        w_rho(Pz) == Fraction(3, 5),
+    )
+    checks.check(
+        "identity-w-star",
+        "the identity gate w_star(Pz) equals 1/2",
+        w_star(Pz) == Fraction(1, 2),
+    )
+    checks.check(
+        "mutation-grades-unequal",
+        "the predicate w_ρ=w_* fails at P_z",
+        not grades_equal_at_pz() and w_rho(Pz) != w_star(Pz),
+    )
+    half = Fraction(1, 2)
+    checks.check(
+        "identity-ray-agreement",
+        "both grades send c I to c and send 0 to 0",
+        w_rho(I2) == 1
+        and w_star(I2) == 1
+        and w_rho(scale(half, I2)) == half
+        and w_star(scale(half, I2)) == half
+        and w_rho(ZERO) == 0
+        and w_star(ZERO) == 0,
+    )
+    checks.check(
+        "scaled-projector-split",
+        "the grades remain unequal on a proper multiple of P_z",
+        w_rho(scale(half, Pz)) == Fraction(3, 10)
+        and w_star(scale(half, Pz)) == Fraction(1, 4)
+        and w_rho(scale(half, Pz)) != w_star(scale(half, Pz)),
+    )
+    checks.check(
+        "mutation-axioms-do-not-name-w-rho",
+        "the predicate axioms-name-w_ρ fails on the current axiom memo",
+        not axioms_name_w_rho(axiom),
+    )
+    checks.check(
+        "source-admissibility",
+        "the note quotes the nearest-neighbor distribution sentence",
+        "the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions"
+        in normalized_axiom
+        and "the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions"
+        in normalized_note,
+    )
+    checks.check(
+        "source-record",
+        "the note quotes the lock sentence and additive Record I",
+        "a record locks exactly one admissible local possibility" in normalized_axiom
+        and "a record locks exactly one admissible local possibility" in normalized_note
+        and "scalar readout `I` is additive" in normalized_note
+        and "I(empty)=0" in normalized_axiom
+    )
+    checks.check(
+        "source-parent-uniqueness",
+        "the parent uniqueness statement is conditional on a supplied menu-independent grade",
+        all(
+            phrase in parent
+            for phrase in (
+                "menu-independent grading",
+                "Every two- or three-member menu is normalized",
+                "There is a unique density matrix",
+                "w(E)=Tr(rho E)",
+            )
+        ),
+    )
+    checks.check(
+        "extra-matching-surface",
+        "the note names the extra matching and displays w_ρ without adopting it",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "such a `w` exists and is the instrument",
+                "Display `w_ρ`; do not adopt it",
+                "Neither sentence names a grade `w` on scaled projectors",
+                "w_ρ(P_z)=3/5 ≠ 1/2=w_*(P_z)",
+            )
+        ),
+    )
+    checks.check(
+        "theorem-four-and-five-boundary",
+        "the note refuses August 9 improvement, Gleason-as-physics, Born denial, forced r=1/2, and L_phys",
+        all(
+            phrase in note
+            for phrase in (
+                "This note does not claim that the August 9 theorem is improved.",
+                "This note does not import Gleason as physics.",
+                "This note does not say Born is false.",
+                "This note does not force `r=1/2`.",
+                "This note does not adopt `L_phys`.",
+            )
+        ),
+    )
+
+    print("per_element: identity gates evaluate w_rho(Pz) and w_star(Pz); scaled and identity-ray controls use exact Fraction")
+    print("per_site: both trial grades and the axiom-text comparison are one-site statements")
+    print("per_mode: no spectral-mode exhaustion is claimed")
+    print("per_block: the extra matching that such a w exists and is the instrument is the only negative block tested")
+    print("lattice_wide: checked and not executed — no lattice-wide Born no-go is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two trial grades on `{0,P_z,I}` disagree: `w_ρ(P_z)=3/5 ≠ 1/2=w_*(P_z)`. Admissibility and Record do not name a menu-independent grade. August 9 uniqueness is conditional on that extra matching. Display `w_ρ`; do not adopt it. No Gleason-as-physics. No Born-false. No forced `r=1/2`. No `L_phys`.

## What this means for the TOE

The extra matching is “such a `w` exists and is the instrument.” August 9 then unique-ifies.

## What changed

- Note: `docs/MENU_INDEPENDENT_GRADING_ON_SCALED_PROJECTORS_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py`
- Cache: `logs/runner-cache/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.txt`

## Verification

```bash
python3 scripts/menu_independent_grading_on_scaled_projectors_is_extra_2026_08_13.py
# TOTAL: PASS=12 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
