### PR TITLE
[physics-loop] toe-lphys c2full: bounded_theorem / bounded-support

### DIFF
--- a/docs/QUBIT_FULL_VS_COMPOSITE_CARRIER_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/QUBIT_FULL_VS_COMPOSITE_CARRIER_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,212 @@
+---
+claim_id: qubit_full_vs_composite_carrier_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Integer dimension facts 9>4 and 8>2 are reconstructed here: there is no injective C-linear map M_3(C)→M_2(C), and C^8 is not the one-site Hilbert space C^2. Current Qubit sentence S and displayed counterfactual S' agree that the one-site algebra is M_2(C). The wall 'color/P-HY cannot exist unless we add an axiom' is a reading of S as 'nothing physical is larger than one-site A2', not a consequence of the dimension facts. S' is displayed and not adopted. A3 is not identified with QCD, C^8 is not identified with generations, and Y is not identified with U(1)_Y."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py
+---
+
+# Qubit “Full” Versus Composite Carrier (Hypothetical)
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact complex dimensions of `M_2(C)`, `M_3(C)`, and `C^8`,
+together with a displayed, not adopted, reading of the Qubit sentence.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py`](../scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py)
+
+## Result Up Front
+
+This is a hypothetical discriminating test, not an axiom edit.
+
+The current Qubit sentence names `M_2(C)` as the full one-site possibility
+algebra. The integer facts `9>4` and `8>2` then say that `M_3(C)` does not
+inject into that one-site algebra and that `C^8` is not the one-site Hilbert
+space. Those facts survive under both the current sentence and a displayed
+counterfactual that keeps the same one-site algebra while allowing a physical
+object to be a declared finite composite of sites or a declared larger
+carrier.
+
+What does not survive is a particular *reading* of the current sentence:
+that nothing physical may be larger than one-site `M_2(C)`. That reading,
+not the dimension comparison, is what turns color/`P-HY` into a “must add
+an axiom” wall. The counterfactual is displayed so the two readings can be
+told apart. It is not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: negative_route_pruning
+target_claim_id: qubit_full_vs_composite_carrier_hypothetical
+target_blocker_text: "separate the 9>4 and 8>2 dimension facts from a reading of Qubit that nothing physical is larger than one-site M_2(C)"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+conditional_surface_status: "exact integer dimensions and a displayed, not adopted, Qubit counterfactual; no axiom edit"
+hypothetical_axiom_status: "C2 counterfactual: M_2 is the local possibility algebra; physical carriers may be composites; not adopted"
+admitted_observation_status: null
+claim_type_reason: "The complex dimensions of M_2(C), M_3(C), C^8, and one-site C^2 are counted from standard bases. Injectivity failure is the finite-dimensional comparison. Agreement of S and S' on dim A2 is textual. Adoption of S' remains open."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write
+
+`A2 = M_2(C)`, `A3 = M_3(C)`, `H8 = C^8`.
+
+The standard matrix units `{E_{ij}: 1 ≤ i,j ≤ n}` are a basis of `M_n(C)`
+over `C`, so
+
+`dim_C A2 = 2·2 = 4`, `dim_C A3 = 3·3 = 9`.
+
+The standard basis of `C^n` has `n` vectors, so
+
+`dim_C H8 = 8`.
+
+The one-site Hilbert space for `A2` is `C^2`, with
+
+`dim_C C^2 = 2`.
+
+These four integers are counted here. They are not imported from another
+block.
+
+Current Qubit sentence **S**, quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+Counterfactual sentence **S′** (displayed, not adopted):
+
+> The local possibility algebra at a site is `M_2(C)`; a physical object
+> may be a declared finite composite of sites or a declared larger carrier.
+
+Both sentences name `A2` as the local one-site presentation. Neither
+sentence is rewritten in the axiom memo.
+
+## Theorem 1 — `9>4` And `8>2`
+
+Because `dim_C A3 = 9` and `dim_C A2 = 4`,
+
+`9 > 4`.
+
+A `C`-linear map `φ: A3 → A2` therefore cannot be injective: an injective
+linear map of finite-dimensional vector spaces exists only when the source
+dimension is at most the target dimension. Equivalently, any matrix of
+`φ` in the standard bases is a `4 × 9` matrix, hence has rank at most `4`
+and a kernel of dimension at least `5`.
+
+Because `dim_C H8 = 8` and the one-site Hilbert space has dimension `2`,
+
+`8 > 2`.
+
+So `C^8` is not the one-site Hilbert space of `A2`.
+
+The runner identity gates call `dim_m2()`, `dim_m3()`, and `dim_c8()`,
+which count the standard bases rather than storing the integers `4`, `9`,
+and `8` as bare constants.
+
+This theorem is only a dimension comparison. It does not name a physical
+color algebra, a generation space, or a hypercharge operator.
+
+## Theorem 2 — `S` And `S′` Agree On The One-Site Algebra
+
+Sentence `S` names `M_2(C)` as the algebraic presentation of the one-site
+possibility domain. Sentence `S′` names `M_2(C)` as the local possibility
+algebra at a site. Both therefore assign
+
+`dim_C A2 = 4`
+
+to the one-site algebra. A predicate “`S` and `S′` disagree about
+`dim A2`” fails.
+
+The integer facts of Theorem 1 are facts about `A2`, `A3`, and `C^8` as
+vector spaces. They do not depend on which of `S` or `S′` is read as the
+Qubit sentence. They survive under both.
+
+## Theorem 3 — The Wall Is A Reading Of `S`, Not Of The Dimensions
+
+Read `S` as “nothing physical is larger than one-site `A2`.” Under that
+reading, `A3` and `C^8` are extras *to the axiom*: any object whose
+carrier is nine-dimensional as an algebra or eight-dimensional as a
+Hilbert space is forbidden unless a new axiom names it.
+
+Read `S′`. The local algebra remains `A2`. The same objects are extras *to one site*.
+They may be declared finite composites of sites or declared larger carriers. The dimension facts of Theorem 1 still say they are not
+one-site `A2` and not one-site `C^2`. Those facts no longer say they are
+outside the axiom.
+
+The TOE wall “color/`P-HY` cannot exist unless we add an axiom” is a
+reading of `S`, not of the dimension facts. Display `S′`. Do not adopt
+it. This note does not rewrite the Qubit axiom.
+
+## Theorem 4 — No QCD, No Generations, No `U(1)_Y`, No Forced Ray
+
+This note does not identify `A3` with QCD. `M_3(C)` is a trial matrix
+algebra used only for the dimension comparison.
+
+This note does not identify `C^8` with generations, a taste cube, or a
+three-factor tensor. `C^8` is a trial Hilbert space used only for the
+comparison `8>2`.
+
+This note does not identify `Y` with `U(1)_Y`. No hypercharge operator is
+constructed.
+
+This note does not import `0.5934`. No numerical residue, fit, or
+prefactor from another lane is used.
+
+This note does not force `r=1/2`. No Bloch radius, mixed-state ray, or
+Born weight is selected.
+
+This note does not claim that a later multi-site compiler cannot realize
+a nine-dimensional algebra or an eight-dimensional carrier. It claims
+only that such a realization is extra to one site, and that whether it is
+extra to the axiom depends on the reading of the Qubit sentence.
+
+## Mutation Predicates
+
+The runner identity gates call `dim_m2()`, `dim_m3()`, and `dim_c8()`.
+
+The predicate “`dim M_3 ≤ dim M_2`” is tested as
+`dim_m3() ≤ dim_m2()` and must fail (`9 ≰ 4`).
+
+The predicate “`S` and `S′` disagree about `dim A2`” is tested by
+comparing the one-site dimension named by each sentence and must fail
+(both say `4`).
+
+## Claim Boundary
+
+| Claim | Status in this note |
+|---|---|
+| `dim_C M_2(C)=4`, `dim_C M_3(C)=9`, `dim_C C^8=8`, one-site `dim_C C^2=2` | proved by counting standard bases |
+| no injective `C`-linear map `A3 → A2` | proved from `9>4` |
+| `C^8` is not the one-site Hilbert space | proved from `8>2` |
+| `S` and `S′` agree that the one-site algebra is `A2` | textual; both name `M_2(C)` |
+| Theorem 1 survives under both `S` and `S′` | same vector-space comparison |
+| color/`P-HY` cannot exist unless an axiom is added | a reading of `S`, not a dimension theorem |
+| `S′` is the new Qubit axiom | not adopted |
+| `A3` is QCD | not claimed |
+| `C^8` is a generation space | not claimed |
+| `Y` is `U(1)_Y` | not claimed |
+| `0.5934` or `r=1/2` is used or forced | not claimed |
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance | Open-bridge status |
+|---|---|---|---|
+| current Qubit sentence `S` | exact semantic baseline | current axiom memo | supplied; not rewritten |
+| displayed sentence `S′` | C2 counterfactual | this note | displayed; not adopted |
+| `A2`, `A3`, `H8`, one-site `C^2` | dimension witnesses | constructed here | not identified with SM objects |
+| finite-dimensional injectivity | Theorem 1 | linear algebra | definition-level |
+| color/`P-HY` as physical content | none | not imported | wall is a reading of `S` |
+| QCD, generations, `U(1)_Y`, `0.5934`, `r=1/2` | none | not used | not applicable |
+
+Independent audit remains required before the repository may assign any
+effective claim status.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15505,6 +15505,10 @@
   "qubit_axiom_hardening_note_2026-05-20": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "qubit_full_vs_composite_carrier_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "qubit_k1_derivation_from_minimality_narrow_theorem_note_2026-05-22": {
    "deps_hash": "0b48e244e1f7",

--- a/logs/runner-cache/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py
+runner_sha256: c9d8b54c46d9e34f04b76272502cad16506a269439a68f95a9d5597479165219
+input_fingerprint_sha256: 7dbf70fccb86fb95516f9d02c02c8412510ebb148939d6a546c683d88f51f108
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; dimensions are counted from standard bases; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; unmerged color3/phycomp/ranksplit surfaces are not imported
+negative_scope: only the reading that nothing physical is larger than one-site A2 is separated from the 9>4 and 8>2 facts; S' is displayed and not adopted
+PASS: identity-dim-m2 the identity gate dim_m2() equals 4 by counting 2-by-2 matrix units
+PASS: identity-dim-m3 the identity gate dim_m3() equals 9 by counting 3-by-3 matrix units
+PASS: identity-dim-c8 the identity gate dim_c8() equals 8 by counting the standard basis of C^8
+PASS: one-site-hilbert the one-site Hilbert space of A2 is C^2 with dimension 2
+PASS: theorem1-no-injective 9>4 so no injective C-linear map A3→A2 exists
+PASS: theorem1-c8-not-one-site 8>2 so C^8 is not the one-site Hilbert space
+PASS: mutation-dim-m3-le-dim-m2 the predicate dim M_3 ≤ dim M_2 fails
+PASS: theorem2-agree-dim-a2 S and S' both name A2 and both assign dim_C A2 = 4
+PASS: mutation-s-sprime-disagree-dim-a2 the predicate that S and S' disagree about dim A2 fails
+PASS: source-qubit-sentence the current axiom memo and the note both carry sentence S
+PASS: displayed-not-adopted the note displays S' and refuses adoption and a Qubit rewrite
+PASS: theorem3-wall-is-reading the note locates the color/P-HY wall in a reading of S, not in the dimensions
+PASS: theorem4-boundary the note refuses QCD, generation, U(1)_Y, 0.5934, and r=1/2 identifications
+PASS: machine-status-contract the source uses the required C2 counterfactual and bounded-support fields
+PASS: no-unmerged-citation the note does not cite unmerged color3, phycomp, or ranksplit surfaces
+per_element: identity gates call dim_m2(), dim_m3(), and dim_c8(); injectivity is the dimension comparison
+per_site: A2 and C^2 are one-site objects; A3 and C^8 are extras to one site
+per_mode: no spectral-mode exhaustion is claimed
+per_block: the S-versus-S' reading of the Qubit sentence is the only negative block tested
+lattice_wide: checked and not executed — no lattice-wide compiler or QCD claim is made
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py
+++ b/scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Exact dimension checks for the Qubit full-versus-composite reading.
+
+The runner counts complex dimensions of M_2(C), M_3(C), C^8, and one-site
+C^2 from standard bases, checks that 9>4 and 8>2, and checks that current
+sentence S and displayed counterfactual S' agree on dim A2. No QCD, no
+0.5934, no forced r=1/2. S' is not adopted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "QUBIT_FULL_VS_COMPOSITE_CARRIER_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/QUBIT_FULL_VS_COMPOSITE_CARRIER_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+S = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+S_PRIME = (
+    "The local possibility algebra at a site is `M_2(C)`; a physical object "
+    "may be a declared finite composite of sites or a declared larger carrier."
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def standard_matrix_units(n: int) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    units = []
+    for row in range(n):
+        for column in range(n):
+            matrix = [[0] * n for _ in range(n)]
+            matrix[row][column] = 1
+            units.append(tuple(tuple(entry) for entry in matrix))
+    return tuple(units)
+
+
+def standard_basis(n: int) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(1 if index == axis else 0 for index in range(n)) for axis in range(n))
+
+
+def dim_mn(n: int) -> int:
+    units = standard_matrix_units(n)
+    if len(set(units)) != len(units):
+        raise ValueError("standard matrix units are not distinct")
+    return len(units)
+
+
+def dim_m2() -> int:
+    return dim_mn(2)
+
+
+def dim_m3() -> int:
+    return dim_mn(3)
+
+
+def dim_c8() -> int:
+    basis = standard_basis(8)
+    if len(set(basis)) != len(basis):
+        raise ValueError("standard basis of C^8 is not distinct")
+    return len(basis)
+
+
+def dim_one_site_hilbert() -> int:
+    basis = standard_basis(2)
+    if len(set(basis)) != len(basis):
+        raise ValueError("standard basis of C^2 is not distinct")
+    return len(basis)
+
+
+def exists_injective_c_linear(dim_src: int, dim_tgt: int) -> bool:
+    return dim_src <= dim_tgt
+
+
+def dim_a2_named_by(sentence: str) -> int:
+    if "M_2(C)" not in sentence and "M_2(C)" not in sentence.replace(" ", ""):
+        raise ValueError("sentence does not name A2")
+    if "M_2" not in sentence:
+        raise ValueError("sentence does not name A2")
+    return dim_m2()
+
+
+def predicate_dim_m3_le_dim_m2() -> bool:
+    return dim_m3() <= dim_m2()
+
+
+def predicate_s_and_sprime_disagree_dim_a2() -> bool:
+    return dim_a2_named_by(S) != dim_a2_named_by(S_PRIME)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "dimensions are counted from standard bases; no observational or "
+        "fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; unmerged color3/phycomp/ranksplit surfaces "
+        "are not imported"
+    )
+    print(
+        "negative_scope: only the reading that nothing physical is larger "
+        "than one-site A2 is separated from the 9>4 and 8>2 facts; S' is "
+        "displayed and not adopted"
+    )
+
+    d2 = dim_m2()
+    d3 = dim_m3()
+    d8 = dim_c8()
+    d_site = dim_one_site_hilbert()
+
+    checks.check(
+        "identity-dim-m2",
+        f"the identity gate dim_m2() equals {d2} by counting 2-by-2 matrix units",
+        d2 == 2 * 2 and d2 == len(standard_matrix_units(2)),
+    )
+    checks.check(
+        "identity-dim-m3",
+        f"the identity gate dim_m3() equals {d3} by counting 3-by-3 matrix units",
+        d3 == 3 * 3 and d3 == len(standard_matrix_units(3)),
+    )
+    checks.check(
+        "identity-dim-c8",
+        f"the identity gate dim_c8() equals {d8} by counting the standard basis of C^8",
+        d8 == 8 and d8 == len(standard_basis(8)),
+    )
+    checks.check(
+        "one-site-hilbert",
+        "the one-site Hilbert space of A2 is C^2 with dimension 2",
+        d_site == 2 and d_site == len(standard_basis(2)),
+    )
+    checks.check(
+        "theorem1-no-injective",
+        "9>4 so no injective C-linear map A3→A2 exists",
+        d3 > d2 and not exists_injective_c_linear(d3, d2),
+    )
+    checks.check(
+        "theorem1-c8-not-one-site",
+        "8>2 so C^8 is not the one-site Hilbert space",
+        d8 > d_site and not exists_injective_c_linear(d8, d_site),
+    )
+    checks.check(
+        "mutation-dim-m3-le-dim-m2",
+        "the predicate dim M_3 ≤ dim M_2 fails",
+        not predicate_dim_m3_le_dim_m2() and d3 > d2,
+    )
+    checks.check(
+        "theorem2-agree-dim-a2",
+        "S and S' both name A2 and both assign dim_C A2 = 4",
+        dim_a2_named_by(S) == d2 and dim_a2_named_by(S_PRIME) == d2,
+    )
+    checks.check(
+        "mutation-s-sprime-disagree-dim-a2",
+        "the predicate that S and S' disagree about dim A2 fails",
+        not predicate_s_and_sprime_disagree_dim_a2(),
+    )
+    checks.check(
+        "source-qubit-sentence",
+        "the current axiom memo and the note both carry sentence S",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays S' and refuses adoption and a Qubit rewrite",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                normalize(S_PRIME),
+                "displayed, not adopted",
+                "Display `S′`. Do not adopt it.",
+                "This note does not rewrite the Qubit axiom.",
+            )
+        )
+        and S_PRIME not in axiom
+        and "declared finite composite of sites" not in axiom,
+    )
+    checks.check(
+        "theorem3-wall-is-reading",
+        "the note locates the color/P-HY wall in a reading of S, not in the dimensions",
+        all(
+            phrase in note
+            for phrase in (
+                "extras *to the axiom*",
+                "extras *to one site*",
+                "The TOE wall “color/`P-HY` cannot exist unless we add an axiom” is a",
+                "reading of `S`, not of the dimension facts.",
+            )
+        ),
+    )
+    checks.check(
+        "theorem4-boundary",
+        "the note refuses QCD, generation, U(1)_Y, 0.5934, and r=1/2 identifications",
+        all(
+            phrase in note
+            for phrase in (
+                "This note does not identify `A3` with QCD.",
+                "This note does not identify `C^8` with generations",
+                "This note does not identify `Y` with `U(1)_Y`.",
+                "This note does not import `0.5934`.",
+                "This note does not force `r=1/2`.",
+            )
+        )
+        and "0.5934" not in axiom,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required C2 counterfactual and bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                'hypothetical_axiom_status: "C2 counterfactual: M_2 is the local possibility algebra; physical carriers may be composites; not adopted"',
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "no-unmerged-citation",
+        "the note does not cite unmerged color3, phycomp, or ranksplit surfaces",
+        all(
+            needle not in note.lower()
+            for needle in (
+                "color3",
+                "phycomp",
+                "ranksplit",
+                "unmerged pr",
+                "pull/6",
+            )
+        ),
+    )
+
+    print("per_element: identity gates call dim_m2(), dim_m3(), and dim_c8(); injectivity is the dimension comparison")
+    print("per_site: A2 and C^2 are one-site objects; A3 and C^8 are extras to one site")
+    print("per_mode: no spectral-mode exhaustion is claimed")
+    print("per_block: the S-versus-S' reading of the Qubit sentence is the only negative block tested")
+    print("lattice_wide: checked and not executed — no lattice-wide compiler or QCD claim is made")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Integer facts `9>4` and `8>2` are reconstructed from standard bases. Current Qubit sentence `S` and displayed counterfactual `S′` agree that the one-site algebra is `M_2(C)`. The wall “color/P-HY cannot exist unless we add an axiom” is a reading of `S`, not of the dimensions. `S′` is displayed, not adopted. No QCD, generations, `U(1)_Y`, `0.5934`, or `r=1/2`.

## What this means for the TOE

Composite carriers are extra to one site. Whether they are extra to the axiom depends on how Qubit is read.

## What changed

- Note: `docs/QUBIT_FULL_VS_COMPOSITE_CARRIER_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py`
- Cache: `logs/runner-cache/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.txt`

## Verification

```bash
python3 scripts/qubit_full_vs_composite_carrier_hypothetical_2026_08_13.py
# TOTAL: PASS=15 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Hypothetical C2 counterfactual, not adopted. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
