### PR TITLE
[physics-loop] toe-lphys c1siteJ: bounded_theorem / bounded-support

### DIFF
--- a/docs/SITE_INDEXED_J_RECOVERS_OCCUPANCY_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SITE_INDEXED_J_RECOVERS_OCCUPANCY_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,370 @@
+---
+claim_id: site_indexed_j_recovers_occupancy_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the two-site window W={x,y} with menu {A,B}, scalar Record I fails to split the unit-lock histories o10 and o01, while the displayed C1 site-indexed readout J does split them and retracts occupancy; the current Record sentences do not name J, C1 is not adopted, and the reconstructed I-table (0,1,1,2) still disagrees with the extra product table (0,0,0,1)."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py
+---
+
+# Site-Indexed J Recovers Occupancy (Hypothetical, Not Adopted)
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** two-site window, unit locks, displayed C1 readout versus current
+scalar `I`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py`](../scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py)
+
+Scientific parent on `origin/main`: the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+This is a hypothetical discriminating test. It is not an axiom edit.
+
+## Result Up Front
+
+Fix the two-site window `W={x,y}` and the finite menu `M={A,B}`. An occupancy
+is a map `o:W→{0,1}`. Current Record readout on unit locks is the scalar
+
+`I(o)=|o^{-1}(1)|`.
+
+The displayed C1 counterfactual readout (not adopted) is the site-indexed map
+
+`J:W → {0}∪M`,
+
+with `J(z)=0` if `o(z)=0` and `J(z)` equal to the locked menu entry if
+`o(z)=1`. Write `o_J(z)=0` if `J(z)=0` and `o_J(z)=1` otherwise.
+
+On the two unit-lock histories that lock `A` at exactly one site, scalar `I`
+and any site-blind one-site law `μ` are the same, so `(μ,I)` does not split
+them. The displayed `J` does. Occupancy is a definitional retract of `J`
+under C1 and remains extra on the current axiom sentences. The reconstructed
+`2×2` `I`-table is still `(0,1,1,2)` and the declared extra product table is
+still `(0,0,0,1)`. C1 dissolves the extra formation map `o`. It does not by
+itself dissolve a pairing through scalar `I`.
+
+The note displays `J`. It does not adopt C1. It does not force `r=1/2`. It
+does not adopt `L_phys`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "On W={x,y}, I(o10)=I(o01)=1 while J(o10)=(A,0) differs from J(o01)=(0,A), and o_J equals o on every {0,1}-occupancy. Current Record sentences do not name J. Adoption of C1, r=1/2, L_phys, and a pairing through I remain open."
+trace_class: negative_route_pruning
+target_claim_id: site_indexed_j_recovers_occupancy
+target_blocker_text: "replace scalar Record I by a site-indexed readout J that retracts occupancy"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed two-site unit-lock window and the displayed C1 map J; C1 is not adopted"
+hypothetical_axiom_status: "C1 counterfactual: Record readout is site-indexed J, not scalar I; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let
+
+`W={x,y}`, `M={A,B}`.
+
+An **occupancy** is a function `o:W→{0,1}`. The four occupancies are written
+
+`o00=(0,0)`, `o10=(1,0)`, `o01=(0,1)`, `o11=(1,1)`.
+
+A **history** on this window is an occupancy together with, at each occupied
+site, exactly one locked menu entry. The two discriminating unit-lock
+histories lock `A`:
+
+- `o10`: only `x` formed, lock `A`;
+- `o01`: only `y` formed, lock `A`.
+
+The empty history `o00` locks nothing. The double-lock history `o11` used
+below locks `A` at both sites. Record allows all four occupancies as finite
+collections of pairwise-disjoint unit locks.
+
+Current scalar readout on unit locks is
+
+`I(o)=|o^{-1}(1)|`,
+
+so `I(o00)=0`, `I(o10)=1`, `I(o01)=1`, `I(o11)=2`. This is additivity plus
+`I(empty)=0`: one unit lock has `I=1`, and two disjoint unit locks have
+`I=1+1=2`.
+
+A **site-blind** one-site law `μ` is the same probability law on `M` at both
+sites. It does not carry a site index.
+
+The displayed C1 readout is
+
+`J(z)=0` if `o(z)=0`, else the locked menu entry at `z`.
+
+The occupancy retract is
+
+`o_J(z)=0` if `J(z)=0`, else `1`.
+
+Write `I_J=|{z: J(z)≠0}|`.
+
+The reconstructed **I-table** on the four occupancies, in the order
+`(o00,o10,o01,o11)`, is
+
+`(I(o00),I(o10),I(o01),I(o11))=(0,1,1,2)`.
+
+The declared extra **product table** on the same order treats the two sites as
+unit atoms and multiplies their occupancies:
+
+`(0·0, 1·0, 0·1, 1·1)=(0,0,0,1)`.
+
+That product table is extra. It is not a Record readout.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether current scalar `I`, with a site-blind law,
+already splits the two unit-lock histories, and whether the displayed C1 map
+`J` recovers occupancy without being named by the current Record sentences.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| `I(o10)=I(o01)=1`; site-blind `μ` is the same; `(μ,I)` does not split | Theorem 1 | proved |
+| `J(o10)=(A,0)≠(0,A)=J(o01)` | Theorem 1 | proved |
+| `o_J=o` on every `{0,1}`-occupancy of `W` | Theorem 2 | proved |
+| `I_J=I`; I-table `(0,1,1,2)`; product table `(0,0,0,1)` | Theorem 3 | proved |
+| current Record sentences do not name `J`; do not adopt C1 | Theorem 4 | scoped residual |
+
+## Theorem 1 — Scalar `I` Does Not Split `o10` From `o01`; Displayed `J` Does
+
+Both discriminating histories are one unit lock, so
+
+`I(o10)=1=I(o01)`.
+
+Any site-blind law `μ` is the same object at `x` and at `y`. The pair
+`(μ,I)` is therefore the same on `o10` and on `o01`. The predicate
+“`I` splits `o10` from `o01`” fails.
+
+The locked content is `A` in both histories. Content-only readout of the
+locked possibility is therefore also the same. The site that carries the
+lock is not a value of scalar `I`.
+
+The displayed C1 map is
+
+`J(o10)=(A,0)`, `J(o01)=(0,A)`.
+
+These tuples are unequal. The predicate “`J(o10)=J(o01)`” fails. Identity
+gates for this theorem call `I_of` and `J_of`.
+
+## Theorem 2 — Occupancy Is A Retract Of `J` Under C1
+
+Let `J` be the displayed C1 readout of any `{0,1}`-occupancy of `W`, with
+any locks in `M` at occupied sites. Then `o_J(z)=0` exactly when `J(z)=0`,
+and `J(z)=0` exactly when `o(z)=0`. So `o_J=o`.
+
+Occupancy is therefore a definitional retract of `J`, not an extra map,
+**under the C1 counterfactual**. On the current axiom sentences the
+occupancy map remains extra: those sentences name a scalar additive `I`,
+not a site-indexed `J` from which `o` would be recovered.
+
+Identity gates for the retract call `o_from_J`.
+
+## Theorem 3 — `I_J` Equals Current `I`; The Product Table Stays Extra
+
+By definition `I_J=|{z: J(z)≠0}|`. Theorem 2 gives `J(z)≠0` exactly when
+`o(z)=1`, so `I_J=I` on every occupancy of `W`. The `2×2` I-table is
+therefore still
+
+`(0,1,1,2)`.
+
+The declared extra product table on the same four cells is still
+
+`(0,0,0,1)`.
+
+Those two tables disagree at three of the four cells, including the
+double-lock cell `2≠1`. A pairing through scalar `I` is still extra. C1
+dissolves the extra formation map `o`, because `o=o_J` once `J` is the
+readout. C1 does not by itself dissolve that pairing: replacing `I` by
+`I_J` leaves the product table untouched.
+
+This note does not import a force law, a Green kernel, or a coupling. The
+product table is reconstructed here as multiplication of the two unit
+occupancies.
+
+## Theorem 4 — Quote Current Record; Display `J`; Do Not Adopt C1
+
+The current Record sentences are:
+
+> Records form.
+>
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+>
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar
+> readout `I` is additive, with `I(empty)=0`.
+
+Those sentences name formation, a single lock per site, content-only
+readout, and additive scalar `I` with `I(empty)=0`. They do not name a
+site-indexed map `J:W→{0}∪M`.
+
+The Admissibility reading note already records that the one-site
+distribution is conditional on formation and does not supply the formation
+site, probability, or rate. Occupancy as a map `W→{0,1}` is that unsupplied
+site pattern.
+
+This note displays `J`. It does not adopt C1. It does not rewrite Record. It
+does not force `r=1/2`. It does not adopt `L_phys`.
+
+## Promotion Value Gate
+
+### V1 — current wording
+
+The load-bearing Record sentences are quoted in Theorem 4 from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). The named
+readout is scalar additive `I`. The displayed `J` is not in that text.
+
+### V2 — origin/main search
+
+A search of `origin/main` `docs/` for a site-indexed Record readout that
+retracts occupancy on a two-site window did not find a parent theorem to
+cite. Hits on the phrase “site-indexed” belong to other lanes. This note
+reconstructs the occupancy-bit arithmetic and the two `2×2` tables locally.
+No unmerged pull request is cited.
+
+### V3 — no literature substitution
+
+That occupancy is the indicator of a nonzero site-indexed label is a
+definitional retract, not a borrowed external theorem. The I-table is
+additivity plus `I(empty)=0`. The product table is declared extra
+multiplication of two unit occupancies.
+
+### V4 — exact witnesses
+
+`I(o10)=I(o01)=1`, `J(o10)=(A,0)≠(0,A)=J(o01)`, `o_J=o` on all four
+occupancies, `I_J=I`, I-table `(0,1,1,2)`, product table `(0,0,0,1)`.
+
+### V5 — not an axiom corollary
+
+A corollary of the current Record sentences would already name `J` or split
+`o10` from `o01` by scalar `I`. Theorem 1 and Theorem 4 show neither.
+
+## No-Go Discipline Gate
+
+The negative claims shipped here are narrow: scalar `I` does not split
+`o10` from `o01` on this window; the current Record sentences do not name
+`J`; a pairing through scalar `I` remains extra after C1 is displayed. The
+gate does not certify that no later derivation of a site-indexed readout
+exists, and it does not certify that gravity is impossible.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Scalar `I` as splitter | use `I(o)` to separate `o10` from `o01` | both have `I=1` | **ATTEMPTED** |
+| Site-blind law plus `I` | use `(μ,I)` as a joint readout | `μ` is the same and `I` is the same | **ATTEMPTED** |
+| Content-only lock label | use the locked menu entry `A` as a site address | both histories lock `A` | **ATTEMPTED** |
+| Formation sentence as occupancy map | read “Records form” as already supplying `o:W→{0,1}` | the sentence is occurrence, not a site-indexed table; named readout remains scalar `I` | **ATTEMPTED** |
+| Product table as Record readout | identify the I-table with occupancy multiplication | `(0,1,1,2)≠(0,0,0,1)` at three cells | **ATTEMPTED** |
+| Adopt C1 to dissolve the pairing | replace `I` by `I_J` and declare `π` selected | `I_J=I`, so the product table is unchanged and still extra | **ATTEMPTED** |
+| Force `r=1/2` or `L_phys` from `J` | treat menu labels in `J` as a Bloch radius or a physical length | `J` takes values in `{0}∪M`; no radius or length is named | **ATTEMPTED** |
+
+The broad statements “occupancy cannot be derived later” and “no pairing can
+exist later” are not shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| occupancy extra on current sentences / pairing through `I` extra | no: C1 retracts `o` and leaves the product table | no: a declared product on scalar `I` does not site-index the readout | independent |
+| occupancy extra / C1 not adopted | no: displaying `J` does not write it into the axiom memo | no: refusing adoption does not by itself prove `o` extra | distinct: one is a current-sentence fact, one is a governance refusal |
+| pairing extra / C1 not adopted | no | no | independent |
+
+The collapsed residual shipped with the theorems is: on the current
+sentences, `o` is extra and a pairing through `I` is extra. C1 is a
+displayed counterfactual, not a second independent physics wall.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| window `W={x,y}` | explicit finite window; not a lattice-wide claim |
+| menu `{A,B}` | explicit finite lock alphabet |
+| unit locks | explicit; `I` reconstructed from additivity and `I(empty)=0` |
+| site-blind `μ` | explicit same-law-at-both-sites hypothesis used only in Theorem 1 |
+| `J` | displayed C1 counterfactual; not attributed to the current axioms |
+| product table | declared extra multiplication; not attributed to Record |
+| “registered” / “canonical” | unused as load-bearing words |
+| `r=1/2`, `L_phys` | named only to refuse them |
+
+No hidden continuity, measure, dynamics, or force law is used.
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) Record block | formation sentence; content-only readout; additive `I` with `I(empty)=0`; no named `J` | exact current wording only |
+| same memo, Admissibility reading note (2) | distribution does not supply formation site, probability, or rate | used only to locate occupancy as that unsupplied site pattern |
+
+No other note is a scientific parent. Occupancy-formation no-gos in other
+lanes attack species-grain dictionaries, not this two-site retract.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | each site of `W` is assigned `0` or a menu lock in `J` | no claim about every possible menu alphabet |
+| per site | two named sites; unit locks | no composite-carrier theorem |
+| per mode | not a spectral claim | no mode exhaustion |
+| per block | only the `I` versus `J` readout block on this window | no Born, dynamics, or gravity closure |
+| lattice-wide | not executed | no lattice-wide frequency or formation-rate law |
+
+### N6 — live partial-closure paths
+
+C1 is a displayed counterfactual, not a required axiom edit. A later
+derivation that extracts site labels from the Lattice structure of a record
+collection, while keeping content-only readout, would be an extra theorem,
+not a silent rewrite of scalar `I`. A later supplier of the product table
+would still be extra after that derivation.
+
+The approved scale-reference, kinetic-isotropy, and realized-state
+primitives were checked against
+[`docs/audit/data/axiom_premise_nodes.json`](audit/data/axiom_premise_nodes.json).
+None supplies a site-indexed Record readout or a two-argument pairing, and
+none is counted as a wall.
+
+No unmerged pull request is cited as a closure path.
+
+### N7 — hostile steelman
+
+Lattice already distinguishes `x` from `y`. Record already says that a
+readout is determined by record content alone, and that a site carries at
+most one record. A hostile reading is that the pair (site, locked
+possibility) is already the physical record, so `J` is not counterfactual
+and occupancy is not extra.
+
+That reading names a different object than the *named* scalar `I`. Theorem
+1 is about `I`, not about an unspoken site-labeled ledger. Theorem 4 is
+about the sentences as written: they do not write `J`. If a later theorem
+constructs `J` from site labels plus content, that theorem is welcome and
+is not this note. The steelman does not restore a split of `o10` from `o01`
+by scalar `I`, and it does not write `J` into the current memo.
+
+### N8 — cross-cycle echo
+
+Formation-append notes record that “Records form” supplies occurrence and
+not a formation-site rule. That residual is similar in shape and is not
+retired into a site-indexed readout. This note does not re-open those
+species-grain no-gos and does not depend on them.
+
+The product-table residual is the same shape as a pairing through scalar
+`I`: additivity fills `(0,1,1,2)` and does not fill `(0,0,0,1)`. That
+disagreement is recomputed here.
+
+## Why The Broad Claim Is Rejected
+
+FAIL / DO NOT SHIP: “occupancy is underivable,” “C1 must be adopted,”
+“Newton is selected,” “no later compiler exists.”
+
+The shipped claim is only the displayed two-site arithmetic and the
+quotation of the current Record sentences.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16785,6 +16785,10 @@
   "single_step_locality_excludes_quadratic_generator_bounded_note_2026-07-02": {
    "deps_hash": "ccc79bcb9fe8",
    "out_degree": 2
+  },
+  "site_indexed_j_recovers_occupancy_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "site_license_tick_dichotomy_all_periods_bounded_theorem_note_2026-06-11": {
    "deps_hash": "71548c1b3e14",

--- a/logs/runner-cache/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py
+runner_sha256: dc98c1305dab65cbba193d58ca336cc87484a8880f1367eead8e924f315f4437
+input_fingerprint_sha256: 7f101eb9295f8665c58bff1518b376c65e3b014cf65c70b449962b4518464ef2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; occupancy bits and both 2x2 tables are reconstructed here
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: only scalar I as a splitter of o10/o01 and silent adoption of C1 or of a pairing through I are rejected
+PASS: source-records-form the axiom states that records form
+PASS: source-content-only the axiom makes readout content-only
+PASS: source-record-I the axiom supplies additive I with I(empty)=0
+PASS: source-formation-site-unsupplied the Admissibility reading note does not supply formation site
+PASS: source-does-not-name-J the axiom memo does not name the displayed site-indexed J
+PASS: theorem1-I-does-not-split I(o10)=I(o01)=1 and site-blind mu is the same
+PASS: theorem1-J-splits J(o10)=(A,0) differs from J(o01)=(0,A)
+PASS: theorem2-retract o_from_J recovers occupancy on every {0,1}-occupancy of W
+PASS: theorem3-I-J-equals-I I_J equals current I on the four occupancies
+PASS: theorem3-i-table the reconstructed I-table is (0,1,1,2)
+PASS: theorem3-pi-table the reconstructed product table is (0,0,0,1)
+PASS: mutation-I-splits the predicate that I splits o10 from o01 fails
+PASS: mutation-J-equal the predicate that J(o10)=J(o01) fails
+PASS: source-note-display the note displays J, refuses C1, and keeps the pairing extra
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the required C1 and bounded-support fields
+PASS: canonical-nonmutation the displayed C1 map is absent from the canonical axiom file
+PASS: no-go-gate all N1-N8 sections and the broad-claim rejection are source-visible
+per_element: each site of W is assigned 0 or a locked menu entry in J
+per_site: two named sites with unit locks; I(o10) and I(o01) are both 1
+per_mode: checked and not executed — no spectral or harmonic mode is used
+per_block: only the scalar-I versus site-indexed-J readout block is tested
+lattice_wide: checked and not executed — no lattice-wide formation rate is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py
+++ b/scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Exact checks: site-indexed J recovers occupancy under displayed C1.
+
+Window W={x,y}. Menu M={A,B}. Current readout I is scalar cardinality.
+Displayed C1 readout J is site-indexed. Identity gates call I_of(o10),
+J_of(o10), and o_from_J. The predicate that I splits o10 from o01 must
+fail. The predicate that J(o10)=J(o01) must fail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "SITE_INDEXED_J_RECOVERS_OCCUPANCY_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/SITE_INDEXED_J_RECOVERS_OCCUPANCY_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+WINDOW = ("x", "y")
+MENU = ("A", "B")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class History:
+    occupancy: tuple[int, int]
+    locks: tuple[object, object]
+
+    def occ_at(self, site: str) -> int:
+        return self.occupancy[WINDOW.index(site)]
+
+    def lock_at(self, site: str) -> object:
+        return self.locks[WINDOW.index(site)]
+
+
+def make_history(occ_x: int, occ_y: int, lock_x: object = 0, lock_y: object = 0) -> History:
+    if occ_x not in (0, 1) or occ_y not in (0, 1):
+        raise ValueError("occupancy bits must be 0 or 1")
+    if occ_x == 0 and lock_x != 0:
+        raise ValueError("unoccupied x cannot lock")
+    if occ_y == 0 and lock_y != 0:
+        raise ValueError("unoccupied y cannot lock")
+    if occ_x == 1 and lock_x not in MENU:
+        raise ValueError("occupied x must lock a menu entry")
+    if occ_y == 1 and lock_y not in MENU:
+        raise ValueError("occupied y must lock a menu entry")
+    return History((occ_x, occ_y), (lock_x, lock_y))
+
+
+o00 = make_history(0, 0)
+o10 = make_history(1, 0, lock_x="A")
+o01 = make_history(0, 1, lock_y="A")
+o11 = make_history(1, 1, lock_x="A", lock_y="A")
+
+
+def I_of(history: History) -> int:
+    return sum(history.occupancy)
+
+
+def J_of(history: History) -> tuple[object, object]:
+    values = []
+    for site in WINDOW:
+        if history.occ_at(site) == 0:
+            values.append(0)
+        else:
+            values.append(history.lock_at(site))
+    return (values[0], values[1])
+
+
+def o_from_J(site_indexed: tuple[object, object]) -> tuple[int, int]:
+    return tuple(0 if label == 0 else 1 for label in site_indexed)
+
+
+def I_from_J(site_indexed: tuple[object, object]) -> int:
+    return sum(1 for label in site_indexed if label != 0)
+
+
+def site_blind_mu() -> tuple[str, str]:
+    """Same one-site law token at both sites."""
+    return ("same-law-on-M", "same-law-on-M")
+
+
+def i_table() -> tuple[int, int, int, int]:
+    return (I_of(o00), I_of(o10), I_of(o01), I_of(o11))
+
+
+def pi_table() -> tuple[int, int, int, int]:
+    ox = (o00.occupancy[0], o10.occupancy[0], o01.occupancy[0], o11.occupancy[0])
+    oy = (o00.occupancy[1], o10.occupancy[1], o01.occupancy[1], o11.occupancy[1])
+    return (ox[0] * oy[0], ox[1] * oy[1], ox[2] * oy[2], ox[3] * oy[3])
+
+
+def i_splits_o10_from_o01() -> bool:
+    return I_of(o10) != I_of(o01)
+
+
+def j_of_o10_equals_j_of_o01() -> bool:
+    return J_of(o10) == J_of(o01)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "occupancy bits and both 2x2 tables are reconstructed here"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read "
+        "for claim-surface consistency"
+    )
+    print(
+        "negative_scope: only scalar I as a splitter of o10/o01 and silent "
+        "adoption of C1 or of a pairing through I are rejected"
+    )
+
+    checks.check(
+        "source-records-form",
+        "the axiom states that records form",
+        "Records form." in axiom,
+    )
+    checks.check(
+        "source-content-only",
+        "the axiom makes readout content-only",
+        "Only records are readable." in axiom
+        and "A readout value is determined by record content alone." in normalized_axiom,
+    )
+    checks.check(
+        "source-record-I",
+        "the axiom supplies additive I with I(empty)=0",
+        "I(empty)=0" in axiom,
+    )
+    checks.check(
+        "source-formation-site-unsupplied",
+        "the Admissibility reading note does not supply formation site",
+        "does not supply the formation site, probability, or rate" in normalized_axiom,
+    )
+    checks.check(
+        "source-does-not-name-J",
+        "the axiom memo does not name the displayed site-indexed J",
+        "J(z)" not in axiom and "site-indexed J" not in axiom,
+    )
+
+    identity_I = I_of(o10)
+    identity_J = J_of(o10)
+    identity_o = o_from_J(identity_J)
+
+    checks.check(
+        "theorem1-I-does-not-split",
+        "I(o10)=I(o01)=1 and site-blind mu is the same",
+        identity_I == 1
+        and I_of(o01) == 1
+        and site_blind_mu()[0] == site_blind_mu()[1],
+    )
+    checks.check(
+        "theorem1-J-splits",
+        "J(o10)=(A,0) differs from J(o01)=(0,A)",
+        identity_J == ("A", 0) and J_of(o01) == (0, "A") and identity_J != J_of(o01),
+    )
+    checks.check(
+        "theorem2-retract",
+        "o_from_J recovers occupancy on every {0,1}-occupancy of W",
+        identity_o == o10.occupancy
+        and o_from_J(J_of(o00)) == o00.occupancy
+        and o_from_J(J_of(o01)) == o01.occupancy
+        and o_from_J(J_of(o11)) == o11.occupancy,
+    )
+    checks.check(
+        "theorem3-I-J-equals-I",
+        "I_J equals current I on the four occupancies",
+        all(I_from_J(J_of(history)) == I_of(history) for history in (o00, o10, o01, o11))
+        and I_of(o00) == 0
+        and I_of(o11) == 2,
+    )
+    checks.check(
+        "theorem3-i-table",
+        "the reconstructed I-table is (0,1,1,2)",
+        i_table() == (0, 1, 1, 2),
+    )
+    checks.check(
+        "theorem3-pi-table",
+        "the reconstructed product table is (0,0,0,1)",
+        pi_table() == (0, 0, 0, 1) and i_table() != pi_table(),
+    )
+    checks.check(
+        "mutation-I-splits",
+        "the predicate that I splits o10 from o01 fails",
+        i_splits_o10_from_o01() is False,
+    )
+    checks.check(
+        "mutation-J-equal",
+        "the predicate that J(o10)=J(o01) fails",
+        j_of_o10_equals_j_of_o01() is False,
+    )
+    checks.check(
+        "source-note-display",
+        "the note displays J, refuses C1, and keeps the pairing extra",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "J(o10)=(A,0)",
+                "J(o01)=(0,A)",
+                "I(o10)=1=I(o01)",
+                "(0,1,1,2)",
+                "(0,0,0,1)",
+                "does not adopt C1",
+                "does not force `r=1/2`",
+                "does not adopt `L_phys`",
+                "does not by itself dissolve that pairing",
+            )
+        ),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required C1 and bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                'hypothetical_axiom_status: "C1 counterfactual: Record readout is site-indexed J, not scalar I; not adopted"',
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "claim_type_reason:",
+                "trace_class: negative_route_pruning",
+                "source_of_blocker_text: handoff",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the displayed C1 map is absent from the canonical axiom file",
+        all(
+            phrase not in axiom
+            for phrase in ("o10", "o_from_J", "L_phys", "C1 counterfactual")
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "no later compiler exists" in note,
+    )
+
+    print(
+        "per_element: each site of W is assigned 0 or a locked menu entry in J"
+    )
+    print(
+        "per_site: two named sites with unit locks; I(o10) and I(o01) are both 1"
+    )
+    print(
+        "per_mode: checked and not executed — no spectral or harmonic mode is used"
+    )
+    print(
+        "per_block: only the scalar-I versus site-indexed-J readout block is tested"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide formation rate is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On `W={x,y}`, scalar `I(o10)=I(o01)=1` does not split the unit-lock histories. Displayed C1 readout `J(o10)=(A,0) ≠ (0,A)=J(o01)` does, and occupancy is a retract of `J`. Current Record does not name `J`. I-table stays `(0,1,1,2)`; product table `(0,0,0,1)` is still extra. C1 is displayed, not adopted. No `r=1/2`. No `L_phys`. No Newton adoption.

## What this means for the TOE

C1 would dissolve extra occupancy `o`. It would not by itself dissolve a pairing through scalar `I`.

## What changed

- Note: `docs/SITE_INDEXED_J_RECOVERS_OCCUPANCY_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py`
- Cache: `logs/runner-cache/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.txt`

## Verification

```bash
python3 scripts/site_indexed_j_recovers_occupancy_hypothetical_2026_08_13.py
# TOTAL: PASS=18 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Hypothetical C1 counterfactual, not adopted. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
