### PR TITLE
[physics-loop] toe-lphys c3table: bounded_theorem / bounded-support

### DIFF
--- a/docs/DECLARED_TWO_SITE_L_TABLE_IS_EXTRA_NOT_FORCED_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/DECLARED_TWO_SITE_L_TABLE_IS_EXTRA_NOT_FORCED_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,179 @@
+---
+claim_id: declared_two_site_l_table_is_extra_not_forced_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a declared two-site window, two well-defined finite tables that jointly list (μ, o, K) disagree at μ and K. Current Admissibility names one fixed nearest-neighbor rule and leaves the distribution's form and values unspecified; it does not name either table. Granting that there is an L does not select the table. If a later owner adopted one displayed table as the referenced law, then μ, o, and K would be consequences of that one object, but that adoption is not made here. A friction-audit candidate C3 without a selected table is not cheaper than three extras. This note adopts no table, no L_phys, no r=1/2, and does not claim Born is derived."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py
+---
+
+# Declared Two-Site L-Table Is Extra, Not Forced
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite algebra on two displayed two-site tables, plus
+a textual non-selection reading of the current Admissibility wording.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py`](../scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py)
+**Parent on origin/main:** the current axiom memo only,
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+This is a hypothetical bounded theorem. It is not an `L_phys` adoption.
+It is not a fifth extra named “compiler.” No axiom is edited.
+
+## Result Up Front
+
+A friction-audit candidate can ask whether one executable table that
+jointly lists the site-conditional probability `μ`, the formation
+occupancy `o`, and a declared projector grade `K` would be cheaper than
+three separate extras. On a declared two-site window the answer is not
+automatic.
+
+Two finite tables `L0` and `L1` are displayed below. Both are
+well-defined. They disagree at `μ` and at `K` (`1/3 ≠ 3/5`). Current
+Admissibility names one fixed nearest-neighbor rule and does not specify
+the distribution's form or values. It does not name `L0` versus `L1`.
+Granting “there is an `L`” does not select the table.
+
+If a later owner adopted `L0` as the referenced law, then `μ`, `o`, and
+`K` would be consequences of that one object, and candidate C3 would be
+cheaper than three extras. That adoption is not made here. Candidate C3
+without a selected table is not cheaper than `H_extra`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two displayed finite tables are well-defined and disagree at exact Fraction entries; Admissibility is quoted as not selecting either table; no table is adopted and Born is not derived."
+trace_class: negative_route_pruning
+target_claim_id: declared_two_site_l_table_forced_by_admissibility
+target_blocker_text: "does current Admissibility force one executable two-site table jointly listing (μ, o, K), making candidate C3 cheaper than three extras?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed L0/L1 tables and the quoted non-selection of the current axiom memo; adoption of any table remains open and is not made here"
+hypothetical_axiom_status: "C3 counterfactual: Admissibility references one declared executable L-table; table not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let the window be `W={x,y}` and the finite menu be `{A,B}`. Write
+`P_z=diag(1,0)` for the rank-one projector
+
+```text
+P_z = ((1, 0), (0, 0)).
+```
+
+A **declared executable L-table** on this window is a finite triple
+`(μ, o, K)` with:
+
+- occupancy `o=(o_x, o_y)` in `{0,1}^2`, read as which sites of `W` are
+  formed (`1`) or unformed (`0`);
+- for each formed site, a probability `μ` on `{A,B}`: nonnegative
+  `Fraction` masses summing to `1`;
+- a finite grade `K(P_z)` in `[0,1]` assigned to the declared projector.
+
+The numerical match `K(P_z)=μ_x(A)` is a **declared identification** on
+each displayed table. It is not a derivation of Born.
+
+### Displayed table L0 (not adopted)
+
+- `o=(1,0)` — only site `x` formed
+- `μ_x(A)=1/3`, `μ_x(B)=2/3`
+- `K(P_z)=1/3`
+
+### Displayed table L1 (not adopted)
+
+- `o=(1,0)` — same occupancy
+- `μ_x(A)=3/5`, `μ_x(B)=2/5`
+- `K(P_z)=3/5`
+
+The runner identity gates are the accessors `L0_muA()` and `L1_muA()`.
+They return the declared `μ_x(A)` entries of `L0` and `L1`.
+
+## Theorem 1
+
+`L0` and `L1` are both well-defined finite tables: each occupancy is a
+`{0,1}` pair, each formed-site `μ` is a two-outcome probability, `P_z`
+is the declared projector, and each `K(P_z)` lies in `[0,1]`.
+
+They disagree at `μ` and at `K`:
+
+```text
+L0_muA() = 1/3
+L1_muA() = 3/5
+1/3 ≠ 3/5
+K_0(P_z) ≠ K_1(P_z)
+```
+
+The predicate `L0=L1` therefore fails.
+
+## Theorem 2
+
+Quote the current Admissibility wording. The axiom memo states that
+there is one fixed nearest-neighbor admissibility rule, covariant under
+lattice translations and proper cubic rotations, and that for each site
+the probability distribution over the possibilities is determined by,
+and varies with, the nearest-neighbor conditions. The same memo states
+that the distribution's extensional form and values are not specified
+by this memo, and that the remaining formation rules (the
+distribution's form and values, at which site, and at what rate) remain
+outside axiom content.
+
+That wording names one fixed nearest-neighbor rule. It does not name
+`L0` versus `L1`. Granting “there is an `L`” does not select the table.
+
+The predicate “axiom memo names `L0`” therefore fails.
+
+## Theorem 3
+
+*If* a later owner adopted `L0` as the referenced law, then `μ`, `o`,
+and `K` would be consequences of that one object. Candidate C3 would
+then be cheaper than three extras (`H_extra`).
+
+That adoption is not made here. Candidate C3 without a selected table
+is not cheaper than `H_extra`. The counterfactual cheapness is
+conditional on a later selected table; the current axiom memo does not
+perform that selection.
+
+## Theorem 4
+
+This note does not adopt `L0` or `L1`. It does not adopt `L_phys`. It
+does not force `r=1/2`. It does not claim Born is derived. The displayed
+`K(P_z)=μ_x(A)` match remains a declared identification on each table,
+not a physical readout theorem.
+
+## Scope And Non-Claims
+
+- The window, menu, occupancy pair, and both tables are declared
+  finite objects of this note. They are not lattice-wide laws.
+- No observational number is imported.
+- No unmerged pull request is cited. No other theorem note is a parent.
+- No axiom sentence is edited or proposed for edit.
+- No compiler extra is added to the primitive roster.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether current Admissibility already forces
+one executable two-site table jointly listing `(μ, o, K)`, so that
+friction-audit candidate C3 is cheaper than three extras without a
+later owner selecting the table.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| exhibit two well-defined finite tables | Theorem 1 | proved: `L0` and `L1` |
+| show they disagree at `μ` and `K` | Theorem 1 | proved: `1/3 ≠ 3/5` |
+| quote Admissibility as one fixed rule with form and values unspecified | Theorem 2 | quoted from the current axiom memo |
+| show the memo does not name `L0` versus `L1` | Theorem 2 | proved by absence |
+| record the counterfactual cheapness if `L0` were adopted | Theorem 3 | stated; adoption not made |
+| refuse table, `L_phys`, `r=1/2`, and Born-derivation claims | Theorem 4 | explicit non-adoption |
+
+The strongest missing lemma, if candidate C3 is to become cheaper than
+`H_extra`, is a later owner-selected referenced law that picks one
+executable table. That lemma is not supplied here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2964,6 +2964,10 @@
   },
   "declared_rg_map_uniform_chain_band_edge_fixed_point_nu_half_bounded_theorem_note_2026-06-12": {
    "deps_hash": "2d2872b7e917",
+   "out_degree": 1
+  },
+  "declared_two_site_l_table_is_extra_not_forced_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "decoherence_action_independence_note": {

--- a/logs/runner-cache/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.txt
@@ -1,0 +1,31 @@
+===== runner cache v1 =====
+runner: scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py
+runner_sha256: 315e07e6df9d945b7983c62cb686b061e687c5bee9ed8c231947953d8c03258c
+input_fingerprint_sha256: 16d0b501955b7dca5acf2c1b2181b0f1132fba20a4febe404db97ea5ce3f495e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: displayed L0 and L1 are not adopted; L_phys, r=1/2, and Born derivation are refused
+PASS: table-L0-well-defined L0 is a finite occupancy-probability-grade table on W={x,y}
+PASS: table-L1-well-defined L1 is a finite occupancy-probability-grade table on the same window
+PASS: projector-Pz P_z is the declared rank-one projector diag(1,0)
+PASS: identity-L0-muA identity gate L0_muA() returns the declared L0 menu mass at A
+PASS: identity-L1-muA identity gate L1_muA() returns the declared L1 menu mass at A
+PASS: tables-disagree L0 and L1 disagree at μ and K (1/3 ≠ 3/5)
+PASS: mutation-L0-equals-L1 predicate L0=L1 fails
+PASS: source-admissibility-one-rule Admissibility names one fixed nearest-neighbor rule
+PASS: source-form-values-unspecified the memo leaves the distribution form and values unspecified
+PASS: axiom-does-not-name-L0 predicate axiom memo names L0 fails
+PASS: granting-L-does-not-select the note records that granting there is an L does not select the table
+PASS: c3-not-cheaper-without-selection C3 without a selected table is not cheaper than H_extra
+PASS: machine-status-contract the source carries the required hypothetical and bounded-support fields
+PASS: theorem-four-non-adoption the note adopts neither table nor L_phys, does not force r=1/2, and does not claim Born is derived
+PASS: parents-axiom-memo-only AUDIT_INPUT_PATHS are the new note and the axiom memo
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py
+++ b/scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Exact checks: a declared two-site L-table is extra, not forced.
+
+Displayed tables L0 and L1 jointly list (μ, o, K) on W={x,y}. They are
+well-defined and disagree at μ and K. Current Admissibility does not name
+either table. No table is adopted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "DECLARED_TWO_SITE_L_TABLE_IS_EXTRA_NOT_FORCED_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/DECLARED_TWO_SITE_L_TABLE_IS_EXTRA_NOT_FORCED_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+WINDOW = ("x", "y")
+MENU = ("A", "B")
+P_Z = ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(0)))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def mat_mul(left: tuple, right: tuple) -> tuple:
+    return tuple(
+        tuple(
+            left[row][0] * right[0][col] + left[row][1] * right[1][col]
+            for col in range(2)
+        )
+        for row in range(2)
+    )
+
+
+def mat_adj(matrix: tuple) -> tuple:
+    return tuple(tuple(matrix[col][row] for col in range(2)) for row in range(2))
+
+
+def mat_trace(matrix: tuple) -> Fraction:
+    return matrix[0][0] + matrix[1][1]
+
+
+@dataclass(frozen=True)
+class LTable:
+    name: str
+    occupancy: tuple[int, int]
+    mu_x_A: Fraction
+    mu_x_B: Fraction
+    k_pz: Fraction
+
+    def well_defined(self) -> bool:
+        o_ok = self.occupancy == (1, 0) and set(self.occupancy) <= {0, 1}
+        mu_ok = (
+            self.mu_x_A >= 0
+            and self.mu_x_B >= 0
+            and self.mu_x_A + self.mu_x_B == 1
+        )
+        k_ok = Fraction(0) <= self.k_pz <= Fraction(1)
+        return o_ok and mu_ok and k_ok
+
+
+L0 = LTable(
+    name="L0",
+    occupancy=(1, 0),
+    mu_x_A=Fraction(1, 3),
+    mu_x_B=Fraction(2, 3),
+    k_pz=Fraction(1, 3),
+)
+L1 = LTable(
+    name="L1",
+    occupancy=(1, 0),
+    mu_x_A=Fraction(3, 5),
+    mu_x_B=Fraction(2, 5),
+    k_pz=Fraction(3, 5),
+)
+
+
+def L0_muA() -> Fraction:
+    return L0.mu_x_A
+
+
+def L1_muA() -> Fraction:
+    return L1.mu_x_A
+
+
+def predicate_L0_equals_L1() -> bool:
+    return (
+        L0.occupancy == L1.occupancy
+        and L0_muA() == L1_muA()
+        and L0.mu_x_B == L1.mu_x_B
+        and L0.k_pz == L1.k_pz
+    )
+
+
+def predicate_axiom_memo_names_L0(axiom: str) -> bool:
+    return "L0" in axiom
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: displayed L0 and L1 are not adopted; L_phys, r=1/2, and Born derivation are refused")
+
+    checks.check(
+        "table-L0-well-defined",
+        "L0 is a finite occupancy-probability-grade table on W={x,y}",
+        L0.well_defined() and WINDOW == ("x", "y") and MENU == ("A", "B"),
+    )
+    checks.check(
+        "table-L1-well-defined",
+        "L1 is a finite occupancy-probability-grade table on the same window",
+        L1.well_defined() and L1.occupancy == L0.occupancy,
+    )
+    checks.check(
+        "projector-Pz",
+        "P_z is the declared rank-one projector diag(1,0)",
+        P_Z == ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(0)))
+        and mat_mul(P_Z, P_Z) == P_Z
+        and mat_adj(P_Z) == P_Z
+        and mat_trace(P_Z) == 1,
+    )
+    checks.check(
+        "identity-L0-muA",
+        "identity gate L0_muA() returns the declared L0 menu mass at A",
+        L0_muA() == L0.mu_x_A and L0.k_pz == L0_muA(),
+    )
+    checks.check(
+        "identity-L1-muA",
+        "identity gate L1_muA() returns the declared L1 menu mass at A",
+        L1_muA() == L1.mu_x_A and L1.k_pz == L1_muA(),
+    )
+    checks.check(
+        "tables-disagree",
+        "L0 and L1 disagree at μ and K (1/3 ≠ 3/5)",
+        L0_muA() != L1_muA() and L0.k_pz != L1.k_pz,
+    )
+    checks.check(
+        "mutation-L0-equals-L1",
+        "predicate L0=L1 fails",
+        predicate_L0_equals_L1() is False,
+    )
+    checks.check(
+        "source-admissibility-one-rule",
+        "Admissibility names one fixed nearest-neighbor rule",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    checks.check(
+        "source-form-values-unspecified",
+        "the memo leaves the distribution form and values unspecified",
+        "the distribution's extensional form and values are not specified by this memo"
+        in normalized_axiom
+        and "the remaining formation rules (the distribution's form and"
+        in normalized_axiom,
+    )
+    checks.check(
+        "axiom-does-not-name-L0",
+        "predicate axiom memo names L0 fails",
+        predicate_axiom_memo_names_L0(axiom) is False and "L1" not in axiom,
+    )
+    checks.check(
+        "granting-L-does-not-select",
+        "the note records that granting there is an L does not select the table",
+        "Granting “there is an `L`” does not select the table." in normalized_note
+        or 'Granting "there is an `L`" does not select the table.' in normalized_note,
+    )
+    checks.check(
+        "c3-not-cheaper-without-selection",
+        "C3 without a selected table is not cheaper than H_extra",
+        "Candidate C3 without a selected table is not cheaper than `H_extra`."
+        in normalized_note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source carries the required hypothetical and bounded-support fields",
+        'hypothetical_axiom_status: "C3 counterfactual: Admissibility references one declared executable L-table; table not adopted"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "theorem-four-non-adoption",
+        "the note adopts neither table nor L_phys, does not force r=1/2, and does not claim Born is derived",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "This note does not adopt `L0` or `L1`.",
+                "It does not adopt `L_phys`.",
+                "It does not force `r=1/2`.",
+                "It does not claim Born is derived.",
+            )
+        )
+        and "0.5934" not in note
+        and "github.com" not in note,
+    )
+    checks.check(
+        "parents-axiom-memo-only",
+        "AUDIT_INPUT_PATHS are the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/DECLARED_TWO_SITE_L_TABLE_IS_EXTRA_NOT_FORCED_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two well-defined finite tables `L0` and `L1` jointly list `(μ, o, K)` on `W={x,y}` and disagree at `μ` and `K` (`1/3 ≠ 3/5`). Current Admissibility names one fixed nearest-neighbor rule and leaves form and values unspecified; it does not name either table. Granting that there is an `L` does not select the table. If a later owner adopted `L0`, C3 would be cheaper than three extras; that adoption is not made here. No `L_phys`, no `r=1/2`, Born is not derived.

## What this means for the TOE

A declared two-site L-table is extra, not forced. C3 without a selected table is not cheaper than `H_extra`.

## What changed

- Note: `docs/DECLARED_TWO_SITE_L_TABLE_IS_EXTRA_NOT_FORCED_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py`
- Cache: `logs/runner-cache/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.txt`

## Verification

```bash
python3 scripts/declared_two_site_l_table_is_extra_not_forced_hypothetical_2026_08_13.py
# TOTAL: PASS=15 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Hypothetical C3 counterfactual, not adopted. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.