### PR TITLE
[physics-loop] toe-lphys c9edge: bounded_theorem / bounded-support

### DIFF
--- a/docs/NAMING_NN_EDGES_WOULD_TYPE_A_LINK_FIELD_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/NAMING_NN_EDGES_WOULD_TYPE_A_LINK_FIELD_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,193 @@
+---
+claim_id: naming_nn_edges_would_type_a_link_field_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the unit cube, |V|=8 sites and |E|=12 nearest-neighbor edges. Current Lattice names sites of Z^3 with nearest-neighbor adjacency, so a map θ:E→{0,1} is an extra object. The displayed, unadopted counterfactual sentence S' names those edges as a set E; then θ has the same type as a site occupancy o:V→{0,1}. The integer 8≠12 survives. S' does not name a holonomy, a group, a Bianchi identity, L_phys, or gauge values. Formation occupancy, Newton B, and Born K are not dissolved. S' is displayed only; it is not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py
+---
+
+# Naming Nearest-Neighbor Edges Would Type a Link Field (Hypothetical)
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** finite unit-cube counting and type comparison under the current
+Lattice sentence versus one displayed, unadopted retype of that sentence.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py`](../scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py)
+**Parents on origin/main:** the current axiom memo only,
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+**Friction-audit role:** addendum candidate C9. Hypothetical Lattice retype.
+Not a holonomy law. Not `L_phys`.
+
+## Result Up Front
+
+On the unit cube the runner counts eight sites and twelve nearest-neighbor
+edges. Those integers are unequal, so there is no bijection between sites and
+edges. That inequality is not a missing connection axiom. It is a counting
+fact about the 0-skeleton and the 1-skeleton of one cube.
+
+The current Lattice sentence names physical sites as the points of `Z^3`
+together with nearest-neighbor *adjacency*. Adjacency is a relation on the
+named site set. It does not promote the related pairs to a named domain. A
+map `θ:E→{0,1}` is therefore extra relative to the current sentence: its
+domain is not an axiom-named set.
+
+Display, and do not adopt, the counterfactual sentence `S'`:
+
+> Physical sites are points of `Z^3`; nearest-neighbor *edges* are named
+> objects (the adjacency relation is promoted to a set `E`).
+
+Under `S'`, `θ` has the same type as a site occupancy `o:V→{0,1}`: both are
+`{0,1}`-fields on a named set. The integer `8≠12` survives. The reading “a
+connection cannot exist unless we add an axiom” is a reading of the current
+sentence `S`, not of `8≠12`.
+
+`S'` still does not name a holonomy, a group, or a Bianchi identity. Gauge
+*values* remain extra. Only the *domain* of `θ` becomes axiom-typed. This
+note does not adopt `S'` and does not adopt `L_phys`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Unit-cube cardinalities and the S versus S' typing of θ are proved on declared finite objects; S' is displayed and not adopted; holonomy, group, Bianchi, L_phys, and gauge values remain untyped."
+trace_class: axiom_challenge_counterfactual
+target_claim_id: naming_nn_edges_would_type_a_link_field
+target_blocker_text: "decide whether a {0,1}-assignment on nearest-neighbor edges is extra or a field on a named 1-skeleton"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for |V|=8, |E|=12, and the type comparison under displayed S'; S' is not adopted"
+hypothetical_axiom_status: "C9 counterfactual: Lattice names sites and NN edges; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Work on the unit cube in `Z^3`.
+
+`V = {0,1}^3`
+
+so `|V| = 8`. An edge is an unordered pair of sites that differ in exactly one
+coordinate. There are twelve such pairs:
+
+- four edges parallel to each of the three lattice axes.
+
+Write `E` for that set, so `|E| = 12`. The identity gates are `vertex_count()`
+and `edge_count()` in the primary runner; both values are counted from the
+listed sets, not inserted as free constants.
+
+A site occupancy is a map
+
+`o : V → {0,1}`.
+
+A link field is a map
+
+`θ : E → {0,1}`.
+
+Current Lattice sentence `S`, quoted from the axiom memo:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with
+> nearest-neighbor adjacency, standard translations, and proper cubic
+> rotations about each site.
+
+Counterfactual sentence `S'` (displayed, not adopted):
+
+> Physical sites are points of `Z^3`; nearest-neighbor *edges* are named
+> objects (the adjacency relation is promoted to a set `E`).
+
+Both sentences name the same site set. On the unit cube both therefore give
+`|V| = 8`. They disagree only about whether `E` is a named domain.
+
+## Theorem 1 — Eight Sites Are Not Twelve Edges
+
+The runner enumerates `V` and `E` and checks
+
+`vertex_count() = 8`, `edge_count() = 12`, `8 ≠ 12`.
+
+There is no bijection `V ↔ E`. The mutation predicate `|V| = |E|` fails. The
+mutation predicate “`S` and `S'` disagree about `|V|`” also fails: both
+sentences keep eight sites on this cube.
+
+## Theorem 2 — Under `S` The Link Map Is Extra; Under `S'` It Is Typed
+
+Under `S`, the named carrier is the site set. Nearest-neighbor adjacency is a
+relation on that set. The pair set `E` is not a named domain, so a map
+`θ:E→{0,1}` is extra: it requires a domain the current sentence does not
+name.
+
+Under `S'`, `E` is named. Then `θ` has the same type as occupancy `o:V→{0,1}`:
+each is a `{0,1}`-field on a named set. The fields are still not the same
+object, because their domains have different cardinalities. The integer
+`8 ≠ 12` survives, and so do the unequal pattern counts `2^8 = 256` and
+`2^12 = 4096`.
+
+The TOE-wall reading “a connection cannot exist unless we add an axiom” is
+therefore a reading of `S`, not a reading of the counting inequality. This
+note records that reading. It does not adopt `S'`.
+
+## Theorem 3 — `S'` Types The Domain, Not Gauge Values
+
+`S'` names sites and nearest-neighbor edges. It does not name:
+
+- a holonomy around a face or larger loop,
+- a structure group or a connection-value group,
+- a Bianchi identity,
+- or `L_phys`.
+
+Gauge *values* remain extra. Only the *domain* of `θ` becomes axiom-typed
+under the counterfactual. Display `S'`. Do not adopt it. Do not adopt
+`L_phys`.
+
+## Theorem 4 — Formation, Newton, And Born Stay Undissolved
+
+C9 does not dissolve formation occupancy `o`. Formation remains a
+`{0,1}`-field on sites: Record still locks a possibility at a site, and
+`o` is still indexed by `V`. Naming edges does not move formation onto `E`.
+
+C9 does not dissolve Newton `B` or Born `K`. Those remain outside this
+retype.
+
+What C9 would change is only the type of a `{0,1}`-assignment on
+nearest-neighbor edges. Constructions that presently treat a link-valued map
+or a star-plaquette assignment as an extra object would, under displayed
+`S'`, become fields on a named 1-skeleton. That is a domain retype, not a
+holonomy law and not a value law.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** On the unit cube, count `|V|` and `|E|`, compare the type of
+`θ` under current `S` with its type under displayed `S'`, and record that
+`S'` is not adopted.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| count unit-cube sites | identity gate | `vertex_count()` returns 8 |
+| count unit-cube NN edges | identity gate | `edge_count()` returns 12 |
+| reject `|V| = |E|` | mutation | fails; `8 ≠ 12` |
+| reject “`S` and `S'` disagree about `|V|`” | mutation | fails; both have 8 sites |
+| type `θ` under `S` | extra-object test | domain `E` is unnamed |
+| type `θ` under `S'` | counterfactual type | `{0,1}`-field on named `E` |
+| keep holonomy, group, Bianchi extra | negative scope | `S'` does not name them |
+| keep formation, Newton `B`, Born `K` | negative scope | not dissolved |
+| adopt `S'` or `L_phys` | axiom edit | not performed |
+
+## What This Note Does Not Claim
+
+- It does not edit the Lattice axiom or any other axiom.
+- It does not adopt a connection axiom, `S'`, or `L_phys`.
+- It does not compute a holonomy, impose a structure group, or prove a
+  Bianchi identity.
+- It does not identify `θ` with a physical gauge field or with Wilson
+  plaquettes.
+- It does not dissolve formation occupancy, Newton `B`, or Born `K`.
+- It does not claim four-dimensional `SU(3)`.
+- It does not cite unmerged companion constructions as parents.
+
+Independent audit remains required. No canonical axiom edit is proposed.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12605,6 +12605,10 @@
   "naive_lattice_fermion_two_power_d_species_count_narrow_theorem_note_2026-05-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "naming_nn_edges_would_type_a_link_field_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "native_carrier_registration_kernel_rate_vs_unit_variance_point_theorem_note_2026-07-02": {
    "deps_hash": "f0528fe9a3de",

--- a/logs/runner-cache/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py
+runner_sha256: bede99ba1741b5754e5927a136d0fd583430033094c3ed994bb0d8966bee931d
+input_fingerprint_sha256: d80ec2f8bb129981a0fa66012a253ca14f99c701731dd82d860daba1e42a0eb8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: S' is displayed and not adopted; holonomy, group, Bianchi, L_phys, and gauge values remain extra
+PASS: source-lattice the current Lattice sentence names sites of Z^3 with nearest-neighbor adjacency
+PASS: identity-vertex-count vertex_count() enumerates eight unit-cube sites
+PASS: identity-edge-count edge_count() enumerates twelve nearest-neighbor edges
+PASS: theorem-1-unequal-cardinalities eight sites are not twelve edges
+PASS: mutation-V-equals-E the predicate |V|=|E| fails
+PASS: occupancy-type site occupancy is a {0,1}-field on the eight named sites
+PASS: link-field-type a link assignment is a {0,1}-field on the twelve edges
+PASS: theorem-2-current-S-extra under current S the edge set is unnamed, so θ is extra
+PASS: theorem-2-counterfactual-typed under displayed S' both occupancy and θ are {0,1}-fields on named sets
+PASS: theorem-2-pattern-counts-survive the unequal domain sizes keep 2^|V| distinct from 2^|E|
+PASS: mutation-S-S-prime-site-count the predicate that S and S' disagree about |V| fails; both have eight sites
+PASS: displayed-S-prime the note displays the unadopted counterfactual sentence S'
+PASS: theorem-3-no-gauge-values S' does not name a holonomy, a group, or a Bianchi identity
+PASS: theorem-4-undissolved-walls C9 does not dissolve formation occupancy, Newton B, or Born K
+PASS: machine-status-contract the note carries the required C9 counterfactual and bounded-support fields
+PASS: canonical-nonmutation the canonical axiom memo does not name S', θ on E, or a connection axiom
+PASS: no-adoption-imports the note refuses to adopt S' or L_phys and does not import 0.5934
+per_element: eight unit-cube sites and twelve Hamming-1 edges are enumerated
+per_block: current-S extra typing versus displayed-S' named-domain typing is the only retype tested
+lattice_wide: checked and not executed — the cube is a finite window; no holonomy, L_phys, or axiom edit is claimed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py
+++ b/scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Exact unit-cube checks for the C9 Lattice-edge-naming counterfactual.
+
+The runner enumerates the unit-cube sites and nearest-neighbor edges, compares
+the type of a {0,1}-map on those edges under the current Lattice sentence and
+under displayed S', and checks that S' is not adopted. Counts are taken from
+the enumerated sets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "NAMING_NN_EDGES_WOULD_TYPE_A_LINK_FIELD_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/NAMING_NN_EDGES_WOULD_TYPE_A_LINK_FIELD_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Site = tuple[int, int, int]
+Edge = frozenset[Site]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def unit_cube_sites() -> tuple[Site, ...]:
+    return tuple((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+
+
+def hamming(left: Site, right: Site) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def unit_cube_edges() -> tuple[Edge, ...]:
+    sites = unit_cube_sites()
+    edges = []
+    for index, left in enumerate(sites):
+        for right in sites[index + 1 :]:
+            if hamming(left, right) == 1:
+                edges.append(frozenset((left, right)))
+    return tuple(edges)
+
+
+def vertex_count() -> int:
+    return len(unit_cube_sites())
+
+
+def edge_count() -> int:
+    return len(unit_cube_edges())
+
+
+def binary_field(domain: tuple[object, ...]) -> dict[object, int]:
+    return {element: 0 for element in domain}
+
+
+def is_binary_field_on(field: dict[object, int], domain: tuple[object, ...]) -> bool:
+    return set(field) == set(domain) and set(field.values()) <= {0, 1}
+
+
+@dataclass(frozen=True)
+class SentenceTyping:
+    """Named domains under a Lattice sentence; sites are always named."""
+
+    names_edges: bool
+
+    def names_sites(self) -> bool:
+        return True
+
+    def site_count(self) -> int:
+        return vertex_count()
+
+    def types_occupancy(self) -> bool:
+        return self.names_sites()
+
+    def types_link_field(self) -> bool:
+        return self.names_edges
+
+
+CURRENT_S = SentenceTyping(names_edges=False)
+COUNTERFACTUAL_S_PRIME = SentenceTyping(names_edges=True)
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+    print(
+        "negative_scope: S' is displayed and not adopted; holonomy, group, "
+        "Bianchi, L_phys, and gauge values remain extra"
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    checks.check(
+        "source-lattice",
+        "the current Lattice sentence names sites of Z^3 with nearest-neighbor adjacency",
+        lattice_sentence in normalized_axiom,
+    )
+
+    sites = unit_cube_sites()
+    edges = unit_cube_edges()
+    n_sites = vertex_count()
+    n_edges = edge_count()
+
+    checks.check(
+        "identity-vertex-count",
+        "vertex_count() enumerates eight unit-cube sites",
+        n_sites == 8 and n_sites == len(sites) and len(set(sites)) == n_sites,
+    )
+    checks.check(
+        "identity-edge-count",
+        "edge_count() enumerates twelve nearest-neighbor edges",
+        n_edges == 12 and n_edges == len(edges) and len(set(edges)) == n_edges,
+    )
+    checks.check(
+        "theorem-1-unequal-cardinalities",
+        "eight sites are not twelve edges",
+        n_sites != n_edges,
+    )
+    mutation_equal_cardinalities = n_sites == n_edges
+    checks.check(
+        "mutation-V-equals-E",
+        "the predicate |V|=|E| fails",
+        mutation_equal_cardinalities is False,
+    )
+
+    occupancy = binary_field(sites)
+    theta = binary_field(edges)
+    checks.check(
+        "occupancy-type",
+        "site occupancy is a {0,1}-field on the eight named sites",
+        is_binary_field_on(occupancy, sites) and len(occupancy) == n_sites,
+    )
+    checks.check(
+        "link-field-type",
+        "a link assignment is a {0,1}-field on the twelve edges",
+        is_binary_field_on(theta, edges) and len(theta) == n_edges,
+    )
+    checks.check(
+        "theorem-2-current-S-extra",
+        "under current S the edge set is unnamed, so θ is extra",
+        CURRENT_S.types_occupancy()
+        and not CURRENT_S.types_link_field()
+        and CURRENT_S.names_sites()
+        and not CURRENT_S.names_edges,
+    )
+    checks.check(
+        "theorem-2-counterfactual-typed",
+        "under displayed S' both occupancy and θ are {0,1}-fields on named sets",
+        COUNTERFACTUAL_S_PRIME.types_occupancy()
+        and COUNTERFACTUAL_S_PRIME.types_link_field()
+        and is_binary_field_on(occupancy, sites)
+        and is_binary_field_on(theta, edges)
+        and n_sites != n_edges,
+    )
+    occupancy_patterns = 1 << n_sites
+    link_patterns = 1 << n_edges
+    checks.check(
+        "theorem-2-pattern-counts-survive",
+        "the unequal domain sizes keep 2^|V| distinct from 2^|E|",
+        occupancy_patterns != link_patterns
+        and occupancy_patterns == 256
+        and link_patterns == 4096,
+    )
+
+    site_count_S = CURRENT_S.site_count()
+    site_count_S_prime = COUNTERFACTUAL_S_PRIME.site_count()
+    mutation_site_disagreement = site_count_S != site_count_S_prime
+    checks.check(
+        "mutation-S-S-prime-site-count",
+        "the predicate that S and S' disagree about |V| fails; both have eight sites",
+        mutation_site_disagreement is False
+        and site_count_S == 8
+        and site_count_S_prime == 8,
+    )
+
+    s_prime_needles = (
+        "nearest-neighbor *edges* are named objects",
+        "the adjacency relation is promoted to a set `E`",
+    )
+    checks.check(
+        "displayed-S-prime",
+        "the note displays the unadopted counterfactual sentence S'",
+        all(needle in normalized_note for needle in s_prime_needles)
+        and "not adopted" in normalized_note,
+    )
+    checks.check(
+        "theorem-3-no-gauge-values",
+        "S' does not name a holonomy, a group, or a Bianchi identity",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "does not name a holonomy",
+                "a structure group or a connection-value group",
+                "a Bianchi identity",
+                "Gauge *values* remain extra",
+            )
+        ),
+    )
+    checks.check(
+        "theorem-4-undissolved-walls",
+        "C9 does not dissolve formation occupancy, Newton B, or Born K",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "does not dissolve formation occupancy",
+                "does not dissolve Newton `B` or Born `K`",
+                "fields on a named 1-skeleton",
+            )
+        ),
+    )
+    checks.check(
+        "machine-status-contract",
+        "the note carries the required C9 counterfactual and bounded-support fields",
+        'hypothetical_axiom_status: "C9 counterfactual: Lattice names sites and NN edges; not adopted"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the canonical axiom memo does not name S', θ on E, or a connection axiom",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "promoted to a set",
+                "named 1-skeleton",
+                "connection axiom",
+            )
+        ),
+    )
+    checks.check(
+        "no-adoption-imports",
+        "the note refuses to adopt S' or L_phys and does not import 0.5934",
+        "Do not adopt it" in note
+        and "Do not adopt" in note
+        and "L_phys" in note
+        and "0.5934" not in note,
+    )
+
+    print(
+        "per_element: eight unit-cube sites and twelve Hamming-1 edges are enumerated"
+    )
+    print(
+        "per_block: current-S extra typing versus displayed-S' named-domain typing "
+        "is the only retype tested"
+    )
+    print(
+        "lattice_wide: checked and not executed — the cube is a finite window; "
+        "no holonomy, L_phys, or axiom edit is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the unit cube, `|V|=8` and `|E|=12`. Current Lattice names sites of `Z^3` with nearest-neighbor adjacency, so a map `θ:E→{0,1}` is extra. Displayed, unadopted `S'` names those edges as a set `E`; then `θ` has the same type as site occupancy `o:V→{0,1}`. The integer `8≠12` survives. `S'` does not name a holonomy, a group, a Bianchi identity, or `L_phys`. Gauge values remain extra.

## What this means for the TOE

The wall “a connection cannot exist unless we add an axiom” is a reading of current Lattice, not of `8≠12`. C9 would retype a link assignment as a field on a named 1-skeleton. Formation `o`, Newton `B`, and Born `K` are not dissolved.

## What changed

- Note: `docs/NAMING_NN_EDGES_WOULD_TYPE_A_LINK_FIELD_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py`
- Cache: `logs/runner-cache/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.txt`

## Verification

```bash
python3 scripts/naming_nn_edges_would_type_a_link_field_hypothetical_2026_08_13.py
# TOTAL: PASS=17 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Hypothetical C9 counterfactual, not adopted. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.