### PR TITLE
[physics-loop] toe-lphys c8prodI: bounded_theorem / bounded-support

### DIFF
--- a/docs/MULTIPLICATIVE_I_WOULD_MAKE_PRODUCT_TABLE_NATIVE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/MULTIPLICATIVE_I_WOULD_MAKE_PRODUCT_TABLE_NATIVE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,197 @@
+---
+claim_id: multiplicative_i_would_make_product_table_native_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "A one-argument multiplicative retype I_× of Record readout, with I_×(empty)=1 and I_×(n units)=q^n, has a different identity from current additive I and never equals a two-cardinality product n m. The 2×2 product table T_π therefore stays two-argument. The C8 slogan that replacing + by × on I would make T_π native fails. I_× is displayed and is not adopted. No axiom is edited."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py
+---
+
+# Multiplicative I Would Make The Product Table Native — Hypothetical Failure
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** one-argument Record readout on finite unit-lock collections;
+displayed counterfactual `I_×` versus current additive `I`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py`](../scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Current Record supplies a one-argument additive scalar `I` with
+`I(empty)=0`. On two named unit locks the filled I-table is `(0,1,1,2)`.
+The two-argument product table on the same four pairs is `T_π=(0,0,0,1)`.
+
+The C8 counterfactual replaces that additive sentence by a one-argument
+multiplicative readout `I_×` with empty-product identity `I_×(empty)=1` and
+`I_×(n units)=q^n` for a declared rational `q`. That retype has a different
+identity (`0≠1`) and, at two units with `q=1`, a different value (`2≠1`).
+Neither one-argument map on a single collection equals a product of two
+cardinalities. So “replace `+` by `×` on `I`” does not make `T_π` native.
+The pairing remains two-argument. `I_×` is displayed only. It is not
+adopted. The current Record sentence is not edited.
+
+A different cut — site-indexed `J` rather than scalar `I` — is a different
+counterfactual. It is not this note’s object and is not adopted here.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The empty-identity mismatch, the two-unit q=1 mismatch, the reconstructed 2×2 tables, and the incompatibility of I_×(empty)=1 with additivity are exact finite identities. Adoption of I_×, a two-argument pairing primitive, Newton’s law, G_N, and 1/r remain closed."
+trace_class: negative_route_pruning
+target_claim_id: newton_product_pairing_from_record_readout
+target_blocker_text: "one-argument Record readout, additive or multiplicative, does not supply the two-argument product table T_π"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed I / I_× / T_π tables on empty-or-unit pairs; no physical pairing is selected"
+hypothetical_axiom_status: "C8 counterfactual: Record readout is multiplicative I_× with I_×(empty)=1; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `s` and `t` be two named unit atoms, treated as disjoint unit locks.
+The four pairs of collections are
+
+`(∅,∅)`, `(∅,{t})`, `({s},∅)`, `({s},{t})`.
+
+Write `I_+` for the current one-argument readout: cardinality of a finite
+unit-lock collection. Record additivity and `I(empty)=0` give
+
+`I_+(∅)=0`, `I_+({t})=1`, `I_+({s})=1`, `I_+({s}⊔{t})=I_+({s})+I_+({t})=2`.
+
+The I-table on those four pairs, read as the one-argument union when the
+two sides are disjoint, is therefore
+
+`T_+ = (0, 1, 1, 2)`.
+
+The declared two-argument product table (extra, not axiom content) is
+
+`T_π(∅,∅)=0`, `T_π(∅,{t})=0`, `T_π({s},∅)=0`, `T_π({s},{t})=1`,
+
+i.e. `T_π=(0,0,0,1)`. Equivalently `T_π(S,T)=I_+(S) I_+(T)`, which is
+already a pairing of two values, not a retype of one readout.
+
+The C8 counterfactual is still one-argument. For a declared rational `q`
+and an integer lock count `n≥0`,
+
+`I_×(empty)=1`, `I_×(n units)=q^n`.
+
+This is the empty-product convention together with a constant per-unit
+factor `q`. For `q=1` one has `I_×(n)=1` for every `n`, so `I_×` is
+blind to cardinality. The one-argument `I_×`-table on
+`∅,{t},{s},{s}⊔{t}` is then `(1,1,1,1)`. The induced pairing
+`I_×(S) I_×(T)` on the four pairs is likewise `(1,1,1,1)`.
+
+A two-argument primitive `Π(S,T)` with `Π(empty,T)=0`, `Π(S,empty)=0`,
+`Π(unit,unit)=1`, and bi-additivity would make `T_π` axiom content. That
+is a pairing axiom, not a one-argument retype of `I`. It is not the C8
+object, and it is not adopted.
+
+Identity gates in the runner call `I_plus(n)` and `I_times(n,q)`.
+
+## Reconstructed Tables
+
+One-argument values on the four named collections:
+
+| collection | `I_+` | `I_×` at `q=1` |
+|---|---|---|
+| `∅` | `0` | `1` |
+| `{t}` | `1` | `1` |
+| `{s}` | `1` | `1` |
+| `{s}⊔{t}` | `2` | `1` |
+
+Two-argument tables on `(∅,∅)`, `(∅,{t})`, `({s},∅)`, `({s},{t})`:
+
+| table | values |
+|---|---|
+| union readout `T_+` | `(0, 1, 1, 2)` |
+| product `T_π` | `(0, 0, 0, 1)` |
+| pairing `I_×(S) I_×(T)` at `q=1` | `(1, 1, 1, 1)` |
+
+`T_+` disagrees with `T_π` at three of four cells, including the
+`(unit,unit)` cell `2≠1`. The `I_×` pairing disagrees with `T_π` at
+every cell.
+
+## Theorem 1 — Different identities
+
+`I_+(empty)=I_plus(0)=0` and `I_×(empty)=I_times(0,q)=q^0=1` for every
+declared `q`. In particular `I_+(empty)≠I_×(empty)`. The additive
+identity and the empty-product identity are different numbers. The
+predicate `I_+(empty)=I_×(empty)` fails.
+
+## Theorem 2 — Two units, and no one-argument product
+
+`I_+(2 units)=I_plus(2)=2`. `I_×(2 units)=I_times(2,q)=q^2`. For the
+unit-factor choice `q=1`, `I_×(2)=1≠2`. The predicate
+`I_+(2)=I_×(2)` at `q=1` fails.
+
+Neither map, evaluated on a *single* collection, equals a product of two
+cardinalities. For lock counts `n=2` and `m=3` one has `n m=6`, while
+
+`I_plus(2)=2`, `I_plus(3)=3`, `I_plus(5)=5`,
+`I_times(2,1)=1`, `I_times(3,1)=1`, `I_times(5,1)=1`.
+
+None equals `6`. For `q=1`, `I_×` is constantly `1` and cannot see
+`n` or `m`. For any other declared `q`, `I_×` is an exponential of one
+integer, still one-argument.
+
+## Theorem 3 — C8 fails to make `T_π` native
+
+A one-argument retype of `I` therefore cannot make `T_π` native.
+`T_π` is a function of an ordered pair of collections. C8 as “replace
+`+` by `×` on `I`” fails to dissolve the two-argument Newton-B residual.
+The pairing remains two-argument.
+
+Displaying `I_+(S) I_+(T)` recovers `T_π` only by introducing that
+pairing. That is not a retype of the one-argument readout. Displaying
+`Π` as a primitive pairing is adopting the product table as axiom
+content. Neither move is made here. `I_×` is not adopted. Site-indexed
+`J` is a different cut and is not this counterfactual.
+
+## Theorem 4 — Additivity forces `I(empty)=0`
+
+The current Record axiom states that only records are readable, that a
+readout value is determined by record content alone, and that for any
+finite collection of pairwise-disjoint records, scalar readout `I` is
+additive, with `I(empty)=0`.
+
+Additivity on the empty collection against itself forces the identity:
+`empty ⊔ empty = empty`, so `I(empty)=I(empty)+I(empty)`, hence
+`I(empty)=0`. The counterfactual `I_×(empty)=1` is incompatible with
+that additive sentence, because `1=1+1` is false. The axiom is not
+edited. The incompatibility is the reason C8 is a counterfactual rather
+than a rewrite.
+
+## Mutation Predicates
+
+The following predicates are required to fail, and the identity gates
+must call `I_plus(n)` and `I_times(n,q)`:
+
+1. `I_plus(0)=I_times(0,1)` fails because `0≠1`.
+2. `I_plus(2)=I_times(2,1)` fails because `2≠1`.
+
+## What This Note Does Not Do
+
+- It does not adopt `I_×`.
+- It does not adopt a pairing primitive `Π` or the table `T_π`.
+- It does not install `G_N` or `1/r`.
+- It does not claim Newton’s law.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not treat site-indexed `J` as a parent or as adopted content.
+
+## Quoted Current Record Wording
+
+From [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12569,6 +12569,10 @@
   "multifactor_connes_lott_purchases_not_derives_koide_multiplicity_narrow_obstruction_note_2026-06-04": {
    "deps_hash": "ecc26c550a95",
    "out_degree": 10
+  },
+  "multiplicative_i_would_make_product_table_native_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "multipole_tidal_response_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py
+runner_sha256: 53cf6724518e444e445586e4d33bc40b53eae8a3a7d9b0b34da4e9b3044e4732
+input_fingerprint_sha256: c1c056cd0d89db2ca80ecdf36356d34630b6f90fe941b493ff77c8ba09012adf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS: docs/MULTIPLICATIVE_I_WOULD_MAKE_PRODUCT_TABLE_NATIVE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md, docs/MINIMAL_AXIOMS_2026-06-29.md
+external_scientific_inputs: current Record additive wording is source-bound; no observational or fitted inputs are used
+I_× adoption: displayed only; not installed as axiom content
+PASS: theorem-1-identities I_+(empty)=0 and I_×(empty)=1, so the identities differ
+PASS: mutation-empty-identities the predicate I_+(empty)=I_×(empty) fails (0≠1)
+PASS: theorem-2-two-units I_+(2)=2 and I_×(2,q=1)=1
+PASS: mutation-two-units-q1 the predicate I_+(2)=I_×(2) for q=1 fails (2≠1)
+PASS: theorem-2-no-one-arg-product neither I_+ nor I_× on a single collection equals n m for n=2, m=3
+PASS: i-table-from-additivity union I-table on (empty,empty),(empty,unit),(unit,empty),(unit,unit) is (0,1,1,2)
+PASS: product-table T_π on the four pairs is (0,0,0,1)
+PASS: tables-disagree T_+ disagrees with T_π at the (unit,unit) cell 2≠1
+PASS: i-times-pairing-not-pi the q=1 pairing I_×(S) I_×(T) is (1,1,1,1), not T_π
+PASS: multiplicativity I_×(n+m,q)=I_×(n,q) I_×(m,q) and I_+(n+m)=I_+(n)+I_+(m)
+PASS: additivity-forces-empty-zero I_+(empty)=I_+(empty)+I_+(empty) holds and I_×(empty)=I_×(empty)+I_×(empty) fails
+PASS: source-record-additivity the current axiom memo names additive I with I(empty)=0
+PASS: axiom-does-not-name-i-times the current axiom memo does not name I_× or a product table T_π
+PASS: machine-status-contract the note carries the required C8 counterfactual and bounded-support status lines
+PASS: non-adoption-surface the note displays the C8 failure and refuses I_×, G_N, and 1/r
+per_element: empty and two-unit identity gates call I_plus(n) and I_times(n,q); the four-pair tables are reconstructed from those gates
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py
+++ b/scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Exact checks for the C8 one-argument multiplicative-I counterfactual.
+
+I_plus is current additive cardinality. I_times is the displayed
+multiplicative retype. Neither is a two-argument product table.
+I_times is not adopted.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "MULTIPLICATIVE_I_WOULD_MAKE_PRODUCT_TABLE_NATIVE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/MULTIPLICATIVE_I_WOULD_MAKE_PRODUCT_TABLE_NATIVE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def I_plus(n: int) -> Fraction:
+    """Current additive cardinality readout: I_+(n units) = n, I_+(empty) = 0."""
+    if n < 0:
+        raise ValueError("unit-lock count must be nonnegative")
+    return Fraction(n)
+
+
+def I_times(n: int, q: Fraction) -> Fraction:
+    """Counterfactual multiplicative readout: I_×(empty)=1, I_×(n units)=q^n."""
+    if n < 0:
+        raise ValueError("unit-lock count must be nonnegative")
+    return Fraction(q) ** n
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def i_union_table() -> tuple[Fraction, Fraction, Fraction, Fraction]:
+    empty = I_plus(0)
+    unit_t = I_plus(1)
+    unit_s = I_plus(1)
+    both = I_plus(1) + I_plus(1)
+    return (empty, unit_t, unit_s, both)
+
+
+def pi_table() -> tuple[Fraction, Fraction, Fraction, Fraction]:
+    pairs = ((0, 0), (0, 1), (1, 0), (1, 1))
+    return tuple(I_plus(n) * I_plus(m) for n, m in pairs)
+
+
+def i_times_pairing_table(q: Fraction) -> tuple[Fraction, Fraction, Fraction, Fraction]:
+    pairs = ((0, 0), (0, 1), (1, 0), (1, 1))
+    return tuple(I_times(n, q) * I_times(m, q) for n, m in pairs)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS: " + ", ".join(AUDIT_INPUT_PATHS))
+    print(
+        "external_scientific_inputs: current Record additive wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print("I_× adoption: displayed only; not installed as axiom content")
+
+    q_one = Fraction(1)
+    n_empty = 0
+    n_two = 2
+
+    checks.check(
+        "theorem-1-identities",
+        "I_+(empty)=0 and I_×(empty)=1, so the identities differ",
+        I_plus(n_empty) == 0 and I_times(n_empty, q_one) == 1,
+    )
+    checks.check(
+        "mutation-empty-identities",
+        "the predicate I_+(empty)=I_×(empty) fails (0≠1)",
+        I_plus(n_empty) != I_times(n_empty, q_one),
+    )
+    checks.check(
+        "theorem-2-two-units",
+        "I_+(2)=2 and I_×(2,q=1)=1",
+        I_plus(n_two) == 2 and I_times(n_two, q_one) == 1,
+    )
+    checks.check(
+        "mutation-two-units-q1",
+        "the predicate I_+(2)=I_×(2) for q=1 fails (2≠1)",
+        I_plus(n_two) != I_times(n_two, q_one),
+    )
+
+    product_two_three = I_plus(2) * I_plus(3)
+    one_arg_candidates = (
+        I_plus(2),
+        I_plus(3),
+        I_plus(5),
+        I_times(2, q_one),
+        I_times(3, q_one),
+        I_times(5, q_one),
+    )
+    checks.check(
+        "theorem-2-no-one-arg-product",
+        "neither I_+ nor I_× on a single collection equals n m for n=2, m=3",
+        product_two_three == 6 and all(value != product_two_three for value in one_arg_candidates),
+    )
+
+    reconstructed = i_union_table()
+    t_pi = pi_table()
+    t_times = i_times_pairing_table(q_one)
+    checks.check(
+        "i-table-from-additivity",
+        "union I-table on (empty,empty),(empty,unit),(unit,empty),(unit,unit) is (0,1,1,2)",
+        reconstructed == (Fraction(0), Fraction(1), Fraction(1), Fraction(2)),
+    )
+    checks.check(
+        "product-table",
+        "T_π on the four pairs is (0,0,0,1)",
+        t_pi == (Fraction(0), Fraction(0), Fraction(0), Fraction(1)),
+    )
+    checks.check(
+        "tables-disagree",
+        "T_+ disagrees with T_π at the (unit,unit) cell 2≠1",
+        reconstructed != t_pi and reconstructed[3] != t_pi[3],
+    )
+    checks.check(
+        "i-times-pairing-not-pi",
+        "the q=1 pairing I_×(S) I_×(T) is (1,1,1,1), not T_π",
+        t_times == (Fraction(1), Fraction(1), Fraction(1), Fraction(1)) and t_times != t_pi,
+    )
+
+    q_other = Fraction(2)
+    checks.check(
+        "multiplicativity",
+        "I_×(n+m,q)=I_×(n,q) I_×(m,q) and I_+(n+m)=I_+(n)+I_+(m)",
+        I_times(2, q_other) == I_times(1, q_other) * I_times(1, q_other)
+        and I_plus(2) == I_plus(1) + I_plus(1)
+        and I_times(0, q_other) == 1,
+    )
+    checks.check(
+        "additivity-forces-empty-zero",
+        "I_+(empty)=I_+(empty)+I_+(empty) holds and I_×(empty)=I_×(empty)+I_×(empty) fails",
+        I_plus(0) == I_plus(0) + I_plus(0) and I_times(0, q_one) != I_times(0, q_one) + I_times(0, q_one),
+    )
+
+    record_sentence = "`I` is additive, with `I(empty)=0`."
+    checks.check(
+        "source-record-additivity",
+        "the current axiom memo names additive I with I(empty)=0",
+        record_sentence in axiom,
+    )
+    checks.check(
+        "axiom-does-not-name-i-times",
+        "the current axiom memo does not name I_× or a product table T_π",
+        "I_×" not in axiom and "T_π" not in axiom and "I_times" not in axiom,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the note carries the required C8 counterfactual and bounded-support status lines",
+        'hypothetical_axiom_status: "C8 counterfactual: Record readout is multiplicative I_× with I_×(empty)=1; not adopted"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "non-adoption-surface",
+        "the note displays the C8 failure and refuses I_×, G_N, and 1/r",
+        all(
+            phrase in note
+            for phrase in (
+                "I_×` is displayed only. It is not",
+                "fails to dissolve the two-argument Newton-B residual",
+                "It does not adopt `I_×`",
+                "It does not install `G_N` or `1/r`",
+                "The current Record sentence is not edited",
+            )
+        ),
+    )
+
+    print(
+        "per_element: empty and two-unit identity gates call I_plus(n) and I_times(n,q); "
+        "the four-pair tables are reconstructed from those gates"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

A one-argument multiplicative retype `I_×` with `I_×(empty)=1` and `I_×(n)=q^n` has a different identity from additive `I` (`0≠1`) and, at two units with `q=1`, a different value (`2≠1`). Neither one-argument map equals a two-cardinality product `n m`. The 2×2 product table `T_π=(0,0,0,1)` stays two-argument. Replacing `+` by `×` on `I` does not make `T_π` native. `I_×` is displayed, not adopted. No `G_N`, no `1/r`.

## What this means for the TOE

C8 as a one-argument Record retype fails to dissolve Newton `B`. The pairing remains two-argument. Site-indexed `J` is a different cut.

## What changed

- Note: `docs/MULTIPLICATIVE_I_WOULD_MAKE_PRODUCT_TABLE_NATIVE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py`
- Cache: `logs/runner-cache/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.txt`

## Verification

```bash
python3 scripts/multiplicative_i_would_make_product_table_native_hypothetical_2026_08_13.py
# TOTAL: PASS=15 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Hypothetical C8 counterfactual, not adopted. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.