### PR TITLE
[physics-loop] toe-lphys c5os0: bounded_theorem / bounded-support

### DIFF
--- a/docs/OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,254 @@
+---
+claim_id: os0_is_a_primitive_cut_not_lattice_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The Euclidean OS0 quadratic Q_E=(k4^{2}+k^{2})/4 is independent of the linear Wick parameter a. Speed-preservation on Q_E selects a^{2}=1; the displayed unadopted lopsided cut Q_lopsided=(4 k4^{2}+k^{2})/4 selects a^{2}=1/4. Current Lattice names Z^{3}, nearest-neighbor adjacency, and proper cubic rotations, and does not name a Euclidean tick or c_t. The kinetic-isotropy primitive supplies c_t=c_s rather than deriving it. The clock extra therefore lives in that primitive cut, not in Lattice. Q_lopsided is displayed only; OS0 is not dropped; a=1 is not installed."
+upstream_dependencies:
+  - minimal_axioms
+  - kinetic_isotropy_primitive
+runner: scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py
+---
+
+# OS0 Euclidean Isotropy Is a Primitive Cut, Not Lattice Content
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact Fraction algebra on two displayed Euclidean quadratic
+cuts and a textual location reading of current Lattice versus the
+kinetic-isotropy primitive.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py`](../scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py)
+**Parents on origin/main:**
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+and the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+This is a hypothetical bounded theorem about *where* Euclidean isotropy
+lives. It is not a Wick `a=1` install. It is not an `a`-family listing.
+No axiom is edited. No primitive is edited.
+
+## Result Up Front
+
+A friction-audit candidate can ask whether the OS0 equality `c_t=c_s`
+already sits inside Lattice, because Lattice already forces equal spatial
+spacings. The Euclidean quadratic and the current wording say no.
+
+Reconstruct the OS0 Euclidean form
+
+```text
+Q_E = (k4^{2} + k^{2})/4
+```
+
+with both quadratic coefficients `1/4`. Reconstruct the displayed,
+unadopted lopsided cut
+
+```text
+Q_lopsided = (4 k4^{2} + k^{2})/4
+```
+
+with temporal coefficient `1` and spatial coefficient `1/4`. If the
+Euclidean form is written `(c_t^{2} k4^{2} + c_s^{2} k^{2})/4`, the
+lopsided display is the speed ratio `c_t=2 c_s`. Neither Euclidean
+polynomial names the linear Wick parameter `a`.
+
+Linear Wick is the substitution `k4 = i a ω` with `a ∈ Q\{0}`. The
+identity gates are
+
+```text
+omega_coeff_E(a) = −a^{2}/4
+omega_coeff_lop(a) = −a^{2}
+```
+
+Speed-preservation (declared extra matching, not an axiom) equates the
+absolute temporal coefficient to the spatial coefficient. For `Q_E`
+that is `a^{2}=1`. For `Q_lopsided` the spatial coefficient is still
+`1/4` while `|omega_coeff_lop|=a^{2}`, so `a^{2}=1/4` and `a=±1/2`.
+Different Euclidean cuts select different Wick `|a|`.
+
+Current Lattice names `Z^3`, nearest-neighbor adjacency, and proper
+cubic rotations. It does not name a Euclidean tick or `c_t`. The
+kinetic-isotropy primitive supplies `c_t=c_s` rather than deriving it.
+The clock wall therefore lives in the *primitive cut*, not in Lattice.
+`Q_lopsided` is displayed; it is not adopted. OS0 is not dropped.
+`a=1` is not installed.
+
+Candidate C5 does not dissolve formation occupancy `o`, Newton pairing
+`B`, or a color algebra `M_3`. It says only that the clock extra is
+attached to OS0, not to the four axioms.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Q_E and Q_lopsided are reconstructed as a-free Euclidean quadratics; speed-preservation selects a^{2}=1 on Q_E and a^{2}=1/4 on Q_lopsided; Lattice is quoted as not naming a Euclidean tick or c_t; OS0 remains the primitive cut and is not moved into Lattice or dropped."
+trace_class: axiom_challenge_counterfactual
+target_claim_id: os0_euclidean_isotropy_is_lattice_content
+target_blocker_text: "does current Lattice already contain OS0 Euclidean isotropy c_t=c_s, so that the clock extra is not a primitive cut?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed Q_E/Q_lopsided algebra and the quoted Lattice versus kinetic-isotropy location; a=1 is not installed and Q_lopsided is not adopted"
+hypothetical_axiom_status: "C5: OS0 Euclidean isotropy is a primitive cut; not moved into Lattice; not dropped"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `k4` be the Euclidean temporal momentum and `k` a spatial momentum
+magnitude. Work throughout with exact `Fraction` coefficients.
+
+The **OS0 Euclidean quadratic** is
+
+```text
+Q_E(k4, k) = (k4^{2} + k^{2})/4.
+```
+
+Both quadratic coefficients equal `1/4`. This is the kinetic-form
+statement `c_t=c_s`. The monomials are `k4^{2}` and `k^{2}` only. There
+is no symbol `a` in `Q_E`.
+
+The **displayed lopsided Euclidean quadratic** (not adopted) is
+
+```text
+Q_lopsided(k4, k) = (4 k4^{2} + k^{2})/4.
+```
+
+The temporal coefficient is `1` and the spatial coefficient is `1/4`.
+Equivalently, if `Q=(c_t^{2} k4^{2} + c_s^{2} k^{2})/4` with `c_s=1`,
+this is `c_t=2 c_s`. There is no symbol `a` in `Q_lopsided`.
+
+**Linear Wick** is the substitution `k4 = i a ω` with `a ∈ Q\{0}`. Then
+`k4^{2} = −a^{2} ω^{2}`, so
+
+```text
+Q_E  ↦  (−a^{2} ω^{2} + k^{2})/4
+Q_lopsided  ↦  −a^{2} ω^{2} + k^{2}/4.
+```
+
+The identity gates of the runner are the ω² coefficients
+
+```text
+omega_coeff_E(a) = −a^{2}/4
+omega_coeff_lop(a) = −a^{2}.
+```
+
+**Speed-preservation** is the extra matching `|omega_coeff| =` spatial
+coefficient. It is not an axiom sentence and is not installed here.
+
+## Theorem 1 — Euclidean forms do not name `a`
+
+`Q_E` is independent of `a`. Reconstructing the Euclidean polynomial
+uses only `k4` and `k`. There is no `a` in `Q_E`.
+
+`Q_lopsided` is also independent of `a`. Reconstructing that displayed
+polynomial likewise uses only `k4` and `k`.
+
+The predicate “`Q_E` names `a`” therefore fails.
+
+The Wick parameter appears only after the linear substitution
+`k4 = i a ω`. That substitution is not part of the Euclidean cut.
+
+## Theorem 2 — Different Euclidean cuts select different Wick `|a|`
+
+Speed-preservation for `Q_E` is `|omega_coeff_E(a)| = 1/4`, hence
+`a^{2}/4 = 1/4`, hence `a^{2}=1`.
+
+Speed-preservation for `Q_lopsided` is not the same condition. The
+spatial coefficient remains `1/4` while `|omega_coeff_lop(a)|=a^{2}`,
+so `a^{2}=1/4` and `a=±1/2`.
+
+Explicit gates:
+
+```text
+omega_coeff_E(1)     = −1/4
+omega_coeff_E(1/2)   = −1/16
+omega_coeff_lop(1)   = −1
+omega_coeff_lop(1/2) = −1/4
+```
+
+Thus `|omega_coeff_E(1)|` matches the OS0 spatial coefficient, while
+`|omega_coeff_lop(1/2)|` matches the lopsided spatial coefficient and
+`|omega_coeff_lop(1)|` does not.
+
+The predicate “speed-preservation selects the same `a` for `Q_E` and
+`Q_lopsided`” therefore fails (`1` versus `1/2`).
+
+Different Euclidean cuts select different Wick `|a|`. Installing
+`a=1` would silently assume the OS0 cut. That install is not made.
+
+## Theorem 3 — The clock wall is the primitive cut, not Lattice
+
+Quote Lattice. The current axiom memo states:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+That sentence names `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. It does not name a Euclidean tick, a temporal momentum `k4`,
+or a kinetic-form ratio `c_t`. Equal spatial spacings are not a
+Euclidean clock.
+
+Quote the kinetic-isotropy primitive. That source states that the
+framework takes one structural graining fact, the matter kinetic
+normalization `c_t = c_s`, equivalently the Osterwalder-Schrader OS0
+kinetic normalization, and that within this declaration `c_t = c_s` is
+supplied rather than derived. The four-axiom baseline is not used there
+as a derivation of that equality.
+
+The clock wall therefore lives in the *primitive cut*, not in Lattice.
+Display `Q_lopsided`; do not adopt it. Do not drop OS0. Do not install
+`a=1`.
+
+## Theorem 4 — C5 does not dissolve the other extras
+
+Candidate C5 does not dissolve formation occupancy `o`, Newton pairing
+`B`, or a color algebra `M_3`. Those remain separate extras. C5 says
+only that the clock extra is attached to OS0, not to the four axioms.
+
+This note does not force `r=1/2`. It does not adopt `L_phys`. It does
+not adopt `Q_lopsided`. It does not drop OS0. It does not install
+`a=1`. It does not claim Lorentz closure.
+
+## Mutation Predicates
+
+The following predicates are required to fail, and the identity gates
+must call `omega_coeff_E(a)` and `omega_coeff_lop(a)`:
+
+1. “`Q_E` names `a`” fails, because the Euclidean monomials are `k4^{2}`
+   and `k^{2}` only.
+2. “Speed-preservation selects the same `a` for `Q_E` and
+   `Q_lopsided`” fails, because the selected values are `a^{2}=1` versus
+   `a^{2}=1/4`.
+
+## What This Note Does Not Do
+
+- It does not move OS0 Euclidean isotropy into Lattice.
+- It does not drop OS0 or the kinetic-isotropy primitive.
+- It does not install `a=1` or any other Wick parameter.
+- It does not adopt `Q_lopsided`.
+- It does not adopt `L_phys`.
+- It does not force `r=1/2`.
+- It does not dissolve formation `o`, Newton `B`, or color `M_3`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not list an `a`-family as a new primitive.
+
+## Quoted Current Wording
+
+From `docs/MINIMAL_AXIOMS_2026-06-29.md`, Lattice:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+From `docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`:
+
+> Within this declaration, `c_t = c_s` is supplied rather than derived.
+
+and
+
+> It does not add or amend an axiom. The minimal framework baseline is the four
+> named axioms in `MINIMAL_AXIOMS_2026-06-29.md`: Lattice, Qubit,
+> Admissibility, and Record.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13413,6 +13413,10 @@
   "ordered_lattice_quasi_persistent_relaunch_note": {
    "deps_hash": "599444f3c8b2",
    "out_degree": 1
+  },
+  "os0_is_a_primitive_cut_not_lattice_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "0d988fd1ac07",
+   "out_degree": 2
   },
   "osterwalder_schrader_from_framework_narrow_theorem_note_2026-05-27": {
    "deps_hash": "37b34cf3d5e2",

--- a/logs/runner-cache/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py
+runner_sha256: 207e1f62a0df26124a1352cc3013e04218cd86642a55157d3933b3c4d80f594d
+input_fingerprint_sha256: 8e96996683261ba9255068acc272c85b93a8275ce57d55e9c50a13402b703fa9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS: docs/OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md, docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md, docs/MINIMAL_AXIOMS_2026-06-29.md
+external_scientific_inputs: current Lattice wording and the kinetic-isotropy primitive are source-bound; no observational or fitted inputs are used
+Q_lopsided adoption: displayed only; a=1 is not installed; OS0 is not dropped
+PASS: q-e-coefficients Q_E has quadratic coefficients 1/4 and 1/4
+PASS: q-lopsided-coefficients Q_lopsided has temporal coefficient 1 and spatial coefficient 1/4
+PASS: mutation-q-e-names-a predicate Q_E names a fails
+PASS: identity-omega-coeff-E identity gate omega_coeff_E(a) equals -a^2/4
+PASS: identity-omega-coeff-lop identity gate omega_coeff_lop(a) equals -a^2
+PASS: reconstructed-omega-values omega_coeff_E(1)=-1/4, omega_coeff_E(1/2)=-1/16, omega_coeff_lop(1)=-1, omega_coeff_lop(1/2)=-1/4
+PASS: speed-preservation-Q-E speed-preservation on Q_E is a^2=1
+PASS: speed-preservation-Q-lopsided speed-preservation on Q_lopsided is a^2=1/4, a=±1/2
+PASS: mutation-same-wick-a predicate speed-preservation selects the same a for Q_E and Q_lopsided fails (1 vs 1/2)
+PASS: source-lattice Lattice names Z^3, nearest-neighbor adjacency, and proper cubic rotations
+PASS: source-lattice-no-clock Lattice does not name a Euclidean tick, c_t, OS0, or Wick a
+PASS: source-kinetic-isotropy the kinetic-isotropy primitive supplies c_t = c_s rather than deriving it
+PASS: machine-status-contract the note carries the required C5 primitive-cut and bounded-support status lines
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: theorem-surface the note locates the clock wall in the primitive cut and refuses a=1, Q_lopsided, L_phys, and r=1/2
+PASS: parents-and-paths AUDIT_INPUT_PATHS are the new note, kinetic isotropy, and the axiom memo
+per_element: identity gates call omega_coeff_E(a) and omega_coeff_lop(a) at a=1/2, 1, and 2; Euclidean polynomials are reconstructed without a
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py
+++ b/scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Exact checks: OS0 Euclidean isotropy is a primitive cut, not Lattice.
+
+Q_E and the displayed Q_lopsided are a-free Euclidean quadratics.
+Speed-preservation selects a^2=1 on Q_E and a^2=1/4 on Q_lopsided.
+Identity gates call omega_coeff_E(a) and omega_coeff_lop(a).
+OS0 is not moved into Lattice and is not dropped. a=1 is not installed.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+KINETIC_PATH = ROOT / "docs" / "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+I_SQUARED = Fraction(-1)
+
+
+def Q_E_coefficients() -> dict[tuple[str, str], Fraction]:
+    """Euclidean OS0 quadratic: both coefficients 1/4. No Wick symbol a."""
+    return {
+        ("k4", "k4"): Fraction(1, 4),
+        ("k", "k"): Fraction(1, 4),
+    }
+
+
+def Q_lopsided_coefficients() -> dict[tuple[str, str], Fraction]:
+    """Displayed lopsided cut: temporal coeff 1, spatial coeff 1/4. No a."""
+    return {
+        ("k4", "k4"): Fraction(1),
+        ("k", "k"): Fraction(1, 4),
+    }
+
+
+def Q_E(k4: Fraction, k: Fraction) -> Fraction:
+    coeffs = Q_E_coefficients()
+    return coeffs[("k4", "k4")] * k4 * k4 + coeffs[("k", "k")] * k * k
+
+
+def Q_lopsided(k4: Fraction, k: Fraction) -> Fraction:
+    coeffs = Q_lopsided_coefficients()
+    return coeffs[("k4", "k4")] * k4 * k4 + coeffs[("k", "k")] * k * k
+
+
+def polynomial_names_a(coefficients: dict[tuple[str, str], Fraction]) -> bool:
+    return any(symbol == "a" for monomial in coefficients for symbol in monomial)
+
+
+def q_e_names_a() -> bool:
+    return polynomial_names_a(Q_E_coefficients())
+
+
+def q_lopsided_names_a() -> bool:
+    return polynomial_names_a(Q_lopsided_coefficients())
+
+
+def wick_k4_squared(a: Fraction, omega: Fraction) -> Fraction:
+    """k4 = i a ω, so k4² = i² a² ω² = −a² ω²."""
+    return I_SQUARED * a * a * omega * omega
+
+
+def omega_coeff_E(a: Fraction) -> Fraction:
+    return (wick_k4_squared(a, Fraction(1)) + Fraction(0)) / 4
+
+
+def omega_coeff_lop(a: Fraction) -> Fraction:
+    return (4 * wick_k4_squared(a, Fraction(1)) + Fraction(0)) / 4
+
+
+def spatial_coeff_E() -> Fraction:
+    return Q_E(Fraction(0), Fraction(1))
+
+
+def spatial_coeff_lop() -> Fraction:
+    return Q_lopsided(Fraction(0), Fraction(1))
+
+
+def speed_preserving_a_squared_E() -> Fraction:
+    """|omega_coeff_E(a)| = a²/4 equals spatial 1/4 iff a² = 1."""
+    return spatial_coeff_E() / Fraction(1, 4)
+
+
+def speed_preserving_a_squared_lop() -> Fraction:
+    """|omega_coeff_lop(a)| = a² equals spatial 1/4 iff a² = 1/4."""
+    return spatial_coeff_lop()
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    kinetic = KINETIC_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS: " + ", ".join(AUDIT_INPUT_PATHS))
+    print(
+        "external_scientific_inputs: current Lattice wording and the "
+        "kinetic-isotropy primitive are source-bound; no observational "
+        "or fitted inputs are used"
+    )
+    print("Q_lopsided adoption: displayed only; a=1 is not installed; OS0 is not dropped")
+
+    a_half = Fraction(1, 2)
+    a_one = Fraction(1)
+    a_two = Fraction(2)
+
+    checks.check(
+        "q-e-coefficients",
+        "Q_E has quadratic coefficients 1/4 and 1/4",
+        Q_E_coefficients() == {("k4", "k4"): Fraction(1, 4), ("k", "k"): Fraction(1, 4)}
+        and Q_E(Fraction(2), Fraction(2)) == Fraction(2),
+    )
+    checks.check(
+        "q-lopsided-coefficients",
+        "Q_lopsided has temporal coefficient 1 and spatial coefficient 1/4",
+        Q_lopsided_coefficients()
+        == {("k4", "k4"): Fraction(1), ("k", "k"): Fraction(1, 4)}
+        and Q_lopsided(Fraction(1), Fraction(2)) == Fraction(2),
+    )
+    checks.check(
+        "mutation-q-e-names-a",
+        "predicate Q_E names a fails",
+        q_e_names_a() is False and q_lopsided_names_a() is False,
+    )
+    checks.check(
+        "identity-omega-coeff-E",
+        "identity gate omega_coeff_E(a) equals -a^2/4",
+        omega_coeff_E(a_half) == -a_half * a_half / 4
+        and omega_coeff_E(a_one) == -a_one * a_one / 4
+        and omega_coeff_E(a_two) == -a_two * a_two / 4,
+    )
+    checks.check(
+        "identity-omega-coeff-lop",
+        "identity gate omega_coeff_lop(a) equals -a^2",
+        omega_coeff_lop(a_half) == -a_half * a_half
+        and omega_coeff_lop(a_one) == -a_one * a_one
+        and omega_coeff_lop(a_two) == -a_two * a_two,
+    )
+    checks.check(
+        "reconstructed-omega-values",
+        "omega_coeff_E(1)=-1/4, omega_coeff_E(1/2)=-1/16, omega_coeff_lop(1)=-1, omega_coeff_lop(1/2)=-1/4",
+        omega_coeff_E(a_one) == Fraction(-1, 4)
+        and omega_coeff_E(a_half) == Fraction(-1, 16)
+        and omega_coeff_lop(a_one) == Fraction(-1)
+        and omega_coeff_lop(a_half) == Fraction(-1, 4),
+    )
+    checks.check(
+        "speed-preservation-Q-E",
+        "speed-preservation on Q_E is a^2=1",
+        abs(omega_coeff_E(a_one)) == spatial_coeff_E()
+        and spatial_coeff_E() == Fraction(1, 4)
+        and speed_preserving_a_squared_E() == Fraction(1)
+        and abs(omega_coeff_E(a_half)) != spatial_coeff_E(),
+    )
+    checks.check(
+        "speed-preservation-Q-lopsided",
+        "speed-preservation on Q_lopsided is a^2=1/4, a=±1/2",
+        abs(omega_coeff_lop(a_half)) == spatial_coeff_lop()
+        and spatial_coeff_lop() == Fraction(1, 4)
+        and speed_preserving_a_squared_lop() == Fraction(1, 4)
+        and abs(omega_coeff_lop(a_one)) != spatial_coeff_lop(),
+    )
+    checks.check(
+        "mutation-same-wick-a",
+        "predicate speed-preservation selects the same a for Q_E and Q_lopsided fails (1 vs 1/2)",
+        speed_preserving_a_squared_E() != speed_preserving_a_squared_lop()
+        and speed_preserving_a_squared_E() == Fraction(1)
+        and speed_preserving_a_squared_lop() == Fraction(1, 4),
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    checks.check(
+        "source-lattice",
+        "Lattice names Z^3, nearest-neighbor adjacency, and proper cubic rotations",
+        lattice_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-lattice-no-clock",
+        "Lattice does not name a Euclidean tick, c_t, OS0, or Wick a",
+        "c_t" not in axiom
+        and "OS0" not in axiom
+        and "Euclidean tick" not in axiom
+        and "k4" not in axiom,
+    )
+    checks.check(
+        "source-kinetic-isotropy",
+        "the kinetic-isotropy primitive supplies c_t = c_s rather than deriving it",
+        "c_t = c_s" in kinetic
+        and "is supplied rather than derived" in kinetic
+        and "It does not add or amend an axiom." in kinetic,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the note carries the required C5 primitive-cut and bounded-support status lines",
+        'hypothetical_axiom_status: "C5: OS0 Euclidean isotropy is a primitive cut; not moved into Lattice; not dropped"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "theorem-surface",
+        "the note locates the clock wall in the primitive cut and refuses a=1, Q_lopsided, L_phys, and r=1/2",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "The clock wall therefore lives in the *primitive cut*, not in Lattice.",
+                "Display `Q_lopsided`; do not adopt it.",
+                "Do not drop OS0.",
+                "Do not install `a=1`.",
+                "does not dissolve formation occupancy `o`",
+                "Newton pairing",
+                "color algebra `M_3`",
+                "does not force `r=1/2`",
+                "does not adopt `L_phys`",
+            )
+        )
+        and "github.com" not in note,
+    )
+    checks.check(
+        "parents-and-paths",
+        "AUDIT_INPUT_PATHS are the new note, kinetic isotropy, and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and KINETIC_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    print(
+        "per_element: identity gates call omega_coeff_E(a) and omega_coeff_lop(a) "
+        "at a=1/2, 1, and 2; Euclidean polynomials are reconstructed without a"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`Q_E=(k4²+k²)/4` and displayed `Q_lopsided=(4 k4²+k²)/4` are a-free Euclidean quadratics. Speed-preservation selects `a²=1` on `Q_E` and `a²=1/4` on `Q_lopsided`. Current Lattice names `Z^3`, nearest-neighbor adjacency, and proper cubic rotations; it does not name a Euclidean tick or `c_t`. The kinetic-isotropy primitive supplies `c_t=c_s` rather than deriving it. The clock extra lives in that primitive cut, not in Lattice. `Q_lopsided` is displayed only. OS0 is not dropped. `a=1` is not installed.

## What this means for the TOE

OS0 Euclidean isotropy is a primitive cut, not Lattice content. C5 does not dissolve formation `o`, Newton `B`, or color `M_3`.

## What changed

- Note: `docs/OS0_IS_A_PRIMITIVE_CUT_NOT_LATTICE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md`
- Runner: `scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py`
- Cache: `logs/runner-cache/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.txt`

## Verification

```bash
python3 scripts/os0_is_a_primitive_cut_not_lattice_hypothetical_2026_08_13.py
# TOTAL: PASS=16 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Hypothetical C5 counterfactual, not adopted. Independent audit required. No axiom or primitive edit.

Campaign: `toe-lphys-20260812`.