### PR TITLE
[physics-loop] toe-lphys c1perm: bounded_theorem / bounded-support

### DIFF
--- a/docs/PERMANENCE_NOT_VISIBLE_IN_SCALAR_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/PERMANENCE_NOT_VISIBLE_IN_SCALAR_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,253 @@
+---
+claim_id: permanence_not_visible_in_scalar_i_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a two-site window with two snapshots and occupancy already one unit lock, the named scalar readout I and the site-blind lock bag assign the same sequence to a legal stay and to an illegal site-to-site move, while the reconstructed site-indexed lock field J splits them. The Record permanence clause is therefore not a property of the named scalar readout on this window. The note displays a C1 retype to J as the cheapest change that makes permanence checkable from the named readout; it does not adopt that retype, does not reopen formation, and does not install a pairing, a clock, r=1/2, or L_phys."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py
+---
+
+# Record Permanence Is Not Visible In Scalar I
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact two-site, two-snapshot integer occupancy arithmetic on a
+displayed stay versus an illegal move. Hypothetical test of the Record
+permanence clause against the named scalar readout. Not a formation-rate
+claim and not an addition-order-of-legal-growth claim.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py`](../scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py)
+
+Parent on `origin/main`: the axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The current Record axiom says records are permanent. The named readout is
+still scalar `I`. On a two-site window whose occupancy is already one unit
+lock, a legal stay and an illegal site-to-site move have the same `I`
+sequence and the same site-blind lock bag. The reconstructed site-indexed
+lock field `J` splits them. Permanence is therefore not a property of the
+named scalar readout on this window.
+
+Displayed counterfactual C1: the named Record readout is the site-indexed
+lock field `J`, not scalar `I`. A C1 retype is the cheapest change that
+makes permanence checkable from the named readout on this window. This note
+does not adopt that retype.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer I-sequence, bag, and J-sequence identities on one declared two-site two-snapshot window; C1 retype, axiom adoption, formation, pairing, clock, r=1/2, and L_phys remain unadopted."
+trace_class: negative_route_pruning
+target_claim_id: null
+target_blocker_text: "is Record permanence visible in the named scalar readout I on a two-site stay-versus-move window"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed stay and illegal-move sequences; no axiom edit"
+hypothetical_axiom_status: "C1 follow-on: Record permanence is not visible in scalar I; J splits stay vs illegal move; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Quoted Record Wording
+
+From [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+>
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar
+> readout `I` is additive, with `I(empty)=0`.
+
+The permanence sentence is the constraint under test. The named readout
+remains scalar `I`. This note does not rewrite those sentences.
+
+## Exact Objects
+
+Window `W={x,y}` in site order `(x,y)`. Lock menu `{A,B}`. Two snapshots
+`t=0,1`. Occupancy is already one unit lock at `t=0`.
+
+Reconstructed C1 lock field, displayed and not adopted:
+
+```text
+J : W → {0} ∪ {A,B}
+J(z) = 0 if site z is unformed, else the locked menu entry at z.
+I(J) = |{z in W : J(z) ≠ 0}|
+bag(J) = { J(z) : z in W and J(z) ≠ 0 }
+```
+
+`0` is absence, not a menu element. Occupancy is the retract
+`o_J(z)=0` if `J(z)=0` else `1`. No pairing is placed on `J`. No clock map
+is imported. Snapshots are an unordered pair of labels `{0,1}` used only to
+compare two configurations; they are not a time metric.
+
+Two histories, each already carrying one unit lock at `t=0`:
+
+| History | Role | `J_0` | `J_1` |
+|---|---|---|---|
+| `S` | legal stay | `(A,0)` | `(A,0)` |
+| `M` | illegal move | `(A,0)` | `(0,A)` |
+
+Permanence on this window means: if `J_0(z)≠0`, then `J_1(z)=J_0(z)`. The
+stay keeps the lock `A` at `x`. The move empties `x` and places `A` at `y`.
+Record says records are permanent, so `M` is forbidden as a history.
+
+## Theorem 1
+
+The `I`-sequence and the site-blind bag do not split stay from illegal move.
+
+```text
+I_seq(S) = (I(J_0), I(J_1)) = (1,1)
+I_seq(M) = (1,1)
+bag_seq(S) = ({A},{A})
+bag_seq(M) = ({A},{A})
+```
+
+Both snapshots of both histories have occupancy one and lock content `{A}`.
+Scalar `I` and the site-blind bag are therefore identical on `S` and `M`.
+
+## Theorem 2
+
+The `J`-sequence splits them.
+
+```text
+J_seq(S) = ((A,0),(A,0))
+J_seq(M) = ((A,0),(0,A))
+J_seq(S) ≠ J_seq(M)
+```
+
+Identity gates call `I_seq(S)`, `I_seq(M)`, `J_seq(S)`, and `J_seq(M)`.
+
+## Theorem 3
+
+Quote current Record: “records are permanent.” That constraint is not a
+property of the named scalar readout. On this window the cheapest change
+that makes permanence checkable from the named readout is a C1 retype to
+`J`. The note displays that retype and does not adopt it. The current
+file still names additive scalar `I` with `I(empty)=0`.
+
+## Theorem 4
+
+This is not a formation rate and not an addition-order-of-legal-growth
+exercise. There is no growth from empty: occupancy stays `1` on every
+snapshot of `S` and of `M`. The comparison is stay versus illegal move of
+an already-formed unit lock. Formation is not reopened. No site-picking
+rule and no occurrence rate are selected.
+
+## Theorem 5
+
+Display only. Do not adopt C1. Do not force `r=1/2`. Do not adopt
+`L_phys`. Do not put a pairing on `J`. Do not import a clock.
+
+## Mutation Predicates
+
+The predicate “`I_seq(S)` differs from `I_seq(M)`” fails.
+
+The predicate “`J_seq(S)=J_seq(M)`” fails.
+
+## What This Note Does Not Claim
+
+- It does not edit the axiom memo.
+- It does not adopt a Record rewrite, a C1 retype, `L_phys`, or `r=1/2`.
+- It does not place a pairing on `J`.
+- It does not import a clock, a formation rate, or a site-picking rule.
+- It does not treat an unmerged pull request as a parent.
+
+## Runner
+
+[`scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py`](../scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py)
+recomputes `I_seq` and `J_seq` from the two displayed histories with exact
+integers, guards the quoted permanence sentence, and checks the mutation
+predicates. No runner cache is written.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to stay versus illegal move on two
+snapshots. The gate does not certify a Record rewrite.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| I-seq as a permanence check | compare `I_seq(S)` with `I_seq(M)` | Theorem 1: both `(1,1)` | **ATTEMPTED** |
+| Site-blind bag as a permanence check | compare bags | Theorem 1: both `({A},{A})` | **ATTEMPTED** |
+| J-seq as a permanence check | compare `J_seq` | Theorem 2: `((A,0),(A,0))` vs `((A,0),(0,A))` | **ATTEMPTED** |
+| Current Record as a named-readout permanence test | quote “records are permanent” | Theorem 3: constraint is not a property of scalar `I` | **ATTEMPTED** |
+| Rate, clock, pairing, `r=1/2`, `L_phys` | enlarge the display | Theorem 4–5: refused | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| I-seq / J-seq | no: `I` identifies stay with move | no: `J` splits them and still yields the same `I` | independent |
+| permanence type / formation rate | no: stay vs move is not a rate | no: a rate would still need a typed stack | independent |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| window `W={x,y}` | stipulated finite object |
+| occupancy already 1 | stipulated; not growth from empty |
+| permanence | quoted Record sentence |
+| clock, rate, pairing, `r=1/2`, `L_phys` | not used |
+| observations | none |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | records are permanent; content-only additive `I` | exact current wording; no J-process borrowed |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | two snapshots; unit lock `I=1` | no classification of every history |
+| per site | illegal move empties `x` and occupies `y` | no lattice-wide permanence dynamics |
+| per mode | I-seq and bag are stay/move-blind; J-seq is not | no spectral claim |
+| per block | permanence visibility in named readout only | no rate, clock, `L_phys`, or pairing |
+| lattice-wide | not executed | two-site window only |
+
+The runner emits substantive `per_element`, `per_site`, `per_mode`,
+`per_block`, and `lattice_wide` lines.
+
+### N6 — live partial-closure paths
+
+1. Keep current Record: permanence as an existence constraint, scalar `I`.
+2. Owner wording could name `J` later; permanence would then be checkable.
+3. A later derivation could produce a site-indexed stack from Record dynamics.
+
+None of those paths is taken here.
+
+### N7 — hostile steelman
+
+> Permanence already forbids `M`, so comparing `S` with an illegal history
+> is not a readout test. Scalar `I` only needs to read legal records.
+
+The steelman names a real constraint — `M` is forbidden — and then
+overclaims that the named readout therefore sees permanence. Theorem 1
+shows the named readout cannot tell `S` from `M`. A constraint that is
+invisible to the named readout is not a property of that readout.
+
+### N8 — cross-cycle echo
+
+This is a C1 follow-on permanence test, not `c1hist` (no growth from
+empty), not a second formation exercise, and not pairing-on-`J`.
+
+**Gate disposition:** PASS for (i) I-seqs agree, (ii) J-seqs differ, and
+(iii) permanence is not a property of scalar `I`. FAIL / DO NOT SHIP for
+"adopt C1," "install a clock," "select a formation rate," "force `r=1/2`,"
+"adopt `L_phys`," or "put a pairing on `J`."
+
+## Review Record
+
+Independent audit remains required before any effective status may
+change. No `review-loop` was invoked in producing this artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13561,6 +13561,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "permanence_not_visible_in_scalar_i_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py
+runner_sha256: c159ddfb5b5761e06d7c540be83c4b6dd6116244a34d025b93b19a15c6a7233e
+input_fingerprint_sha256: f05d16f46ec97cc3b14d451a53467ad361c3fd81fed6798ae80914a6680190d2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; no observational or fitted inputs
+package_local_integrity_reads: proposed source note plus axiom memo
+input_sha256: docs/PERMANENCE_NOT_VISIBLE_IN_SCALAR_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md=3b68743937db52530cf9a3d1ad42d717a29df38f50261c832e5c7e1c3fd6cc7c, docs/MINIMAL_AXIOMS_2026-06-29.md=53175250f0458168330160ad6a39c8ec708316f338efd69c49e8eb09e3267b39
+PASS: source-permanence axiom memo contains records are permanent
+PASS: source-named-I axiom memo names additive scalar readout I
+PASS: source-one-lock axiom memo locks exactly one admissible local possibility
+PASS: menu-absence absence 0 is not a menu element
+PASS: identity-I-S I_seq(S) is (1, 1)
+PASS: identity-I-M I_seq(M) is (1, 1)
+PASS: identity-J-S J_seq(S) is ((A, 0), (A, 0))
+PASS: identity-J-M J_seq(M) is ((A, 0), (0, A))
+PASS: identity-call-sites runner source calls I_seq(S), I_seq(M), J_seq(S), J_seq(M)
+PASS: theorem-1-I I-seq and bag do not split stay from illegal move
+PASS: theorem-2-J J-seq of S differs from J-seq of M
+PASS: theorem-4-occupancy occupancy stays 1; no growth from empty
+PASS: permanence-S-legal stay S respects permanence
+PASS: permanence-M-illegal move M is forbidden by permanence
+PASS: mutation-I-seq predicate I_seq(S) differs from I_seq(M) fails
+PASS: mutation-J-seq predicate J_seq(S)=J_seq(M) fails
+PASS: note-hypothetical-status note carries the required hypothetical_axiom_status
+PASS: note-surface-status note carries actual_current_surface_status bounded-support
+PASS: note-permanence-quote note quotes records are permanent
+PASS: note-display-only note does not adopt C1, r=1/2, L_phys, or a pairing on J
+PASS: note-not-formation note refuses formation-rate and addition-order growth readings
+PASS: parents-axiom-only AUDIT_INPUT_PATHS are the new note and the axiom memo
+per_element: two snapshots, unit lock I=1 on stay and illegal move
+per_site: window {x,y}; illegal move empties x and occupies y
+per_mode: I-seq and bag are stay/move-blind; J-seq is not
+per_block: permanence visibility in named readout only; no rate or clock
+lattice_wide: checked and not executed — two-site window only
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py
+++ b/scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Exact stay-versus-move checks: permanence is not visible in scalar I.
+
+Reconstructs the displayed C1 lock field J on a two-site window and compares
+a legal stay to an illegal site-to-site move. All load-bearing values are
+exact integers computed from the two histories. The note is not adopted as
+an axiom edit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PERMANENCE_NOT_VISIBLE_IN_SCALAR_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/PERMANENCE_NOT_VISIBLE_IN_SCALAR_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+# Site order (x, y). 0 is absence, not a menu element.
+ABSENT = 0
+A = "A"
+B = "B"
+MENU = frozenset({A, B})
+SITES = ("x", "y")
+
+# Histories are sequences of site-indexed lock snapshots.
+# Occupancy is already one unit lock at t=0.
+S = ((A, ABSENT), (A, ABSENT))
+M = ((A, ABSENT), (ABSENT, A))
+
+
+def file_sha256(rel_path: str) -> str:
+    data = (ROOT / rel_path).read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def J_of(snapshot: tuple[object, object]) -> tuple[object, object]:
+    """Site-indexed lock field on one snapshot: 0 if unformed, else the lock."""
+    if len(snapshot) != 2:
+        raise ValueError("window is exactly two sites")
+    reconstructed = []
+    for lock in snapshot:
+        if lock == ABSENT:
+            reconstructed.append(ABSENT)
+        elif lock in MENU:
+            reconstructed.append(lock)
+        else:
+            raise ValueError("lock is neither absence nor a menu entry")
+    return (reconstructed[0], reconstructed[1])
+
+
+def I_of(snapshot: tuple[object, object]) -> int:
+    """Named scalar readout: count of formed sites."""
+    return sum(1 for lock in J_of(snapshot) if lock != ABSENT)
+
+
+def bag_of(snapshot: tuple[object, object]) -> frozenset:
+    """Site-blind lock bag on one snapshot."""
+    return frozenset(lock for lock in J_of(snapshot) if lock != ABSENT)
+
+
+def I_seq(history: tuple[tuple[object, object], ...]) -> tuple[int, ...]:
+    return tuple(I_of(snapshot) for snapshot in history)
+
+
+def J_seq(history: tuple[tuple[object, object], ...]) -> tuple[tuple[object, object], ...]:
+    return tuple(J_of(snapshot) for snapshot in history)
+
+
+def bag_seq(history: tuple[tuple[object, object], ...]) -> tuple[frozenset, ...]:
+    return tuple(bag_of(snapshot) for snapshot in history)
+
+
+def occupancy_seq(history: tuple[tuple[object, object], ...]) -> tuple[int, ...]:
+    return I_seq(history)
+
+
+def respects_permanence(history: tuple[tuple[object, object], ...]) -> bool:
+    """If a site is locked at t=0, the same lock remains at t=1."""
+    first, second = J_seq(history)
+    for prior, later in zip(first, second):
+        if prior != ABSENT and later != prior:
+            return False
+    return True
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_norm = normalize(note).replace("> ", "")
+    axiom_norm = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current axiom wording only; no observational or fitted inputs")
+    print("package_local_integrity_reads: proposed source note plus axiom memo")
+    print(
+        "input_sha256: "
+        + ", ".join(f"{path}={file_sha256(path)}" for path in AUDIT_INPUT_PATHS)
+    )
+
+    checks.check(
+        "source-permanence",
+        "axiom memo contains records are permanent",
+        "records are permanent" in axiom_norm,
+    )
+    checks.check(
+        "source-named-I",
+        "axiom memo names additive scalar readout I",
+        "scalar readout `I` is additive, with `I(empty)=0`" in axiom_norm
+        or "scalar readout I is additive, with I(empty)=0" in axiom_norm.replace("`", ""),
+    )
+    checks.check(
+        "source-one-lock",
+        "axiom memo locks exactly one admissible local possibility",
+        "locks exactly one admissible local possibility" in axiom_norm,
+    )
+    checks.check(
+        "menu-absence",
+        "absence 0 is not a menu element",
+        ABSENT not in MENU and A in MENU and B in MENU,
+    )
+
+    # Identity gates: must call I_seq(S), I_seq(M), J_seq(S), J_seq(M).
+    i_s = I_seq(S)
+    i_m = I_seq(M)
+    j_s = J_seq(S)
+    j_m = J_seq(M)
+    bags = bag_seq(S)
+    bagm = bag_seq(M)
+
+    checks.check("identity-I-S", "I_seq(S) is (1, 1)", i_s == (1, 1))
+    checks.check("identity-I-M", "I_seq(M) is (1, 1)", i_m == (1, 1))
+    checks.check(
+        "identity-J-S",
+        "J_seq(S) is ((A, 0), (A, 0))",
+        j_s == ((A, ABSENT), (A, ABSENT)),
+    )
+    checks.check(
+        "identity-J-M",
+        "J_seq(M) is ((A, 0), (0, A))",
+        j_m == ((A, ABSENT), (ABSENT, A)),
+    )
+    checks.check(
+        "identity-call-sites",
+        "runner source calls I_seq(S), I_seq(M), J_seq(S), J_seq(M)",
+        "I_seq(S)" in source
+        and "I_seq(M)" in source
+        and "J_seq(S)" in source
+        and "J_seq(M)" in source,
+    )
+
+    checks.check(
+        "theorem-1-I",
+        "I-seq and bag do not split stay from illegal move",
+        i_s == i_m == (1, 1) and bags == bagm == (frozenset({A}), frozenset({A})),
+    )
+    checks.check(
+        "theorem-2-J",
+        "J-seq of S differs from J-seq of M",
+        j_s != j_m,
+    )
+    checks.check(
+        "theorem-4-occupancy",
+        "occupancy stays 1; no growth from empty",
+        occupancy_seq(S) == (1, 1) and occupancy_seq(M) == (1, 1),
+    )
+    checks.check(
+        "permanence-S-legal",
+        "stay S respects permanence",
+        respects_permanence(S) is True,
+    )
+    checks.check(
+        "permanence-M-illegal",
+        "move M is forbidden by permanence",
+        respects_permanence(M) is False,
+    )
+
+    predicate_I_differs = I_seq(S) != I_seq(M)
+    predicate_J_equal = J_seq(S) == J_seq(M)
+    checks.check(
+        "mutation-I-seq",
+        "predicate I_seq(S) differs from I_seq(M) fails",
+        predicate_I_differs is False,
+    )
+    checks.check(
+        "mutation-J-seq",
+        "predicate J_seq(S)=J_seq(M) fails",
+        predicate_J_equal is False,
+    )
+
+    required_status = (
+        'hypothetical_axiom_status: "C1 follow-on: Record permanence is not '
+        'visible in scalar I; J splits stay vs illegal move; not adopted"'
+    )
+    checks.check(
+        "note-hypothetical-status",
+        "note carries the required hypothetical_axiom_status",
+        required_status in note,
+    )
+    checks.check(
+        "note-surface-status",
+        "note carries actual_current_surface_status bounded-support",
+        "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "note-permanence-quote",
+        "note quotes records are permanent",
+        "records are permanent" in note_norm,
+    )
+    checks.check(
+        "note-display-only",
+        "note does not adopt C1, r=1/2, L_phys, or a pairing on J",
+        "Do not adopt C1" in note_norm
+        and "Do not force `r=1/2`" in note_norm
+        and "Do not adopt `L_phys`" in note_norm
+        and "Do not put a pairing on `J`" in note_norm,
+    )
+    checks.check(
+        "note-not-formation",
+        "note refuses formation-rate and addition-order growth readings",
+        "not a formation rate" in note_norm
+        and "occupancy stays `1`" in note_norm,
+    )
+    checks.check(
+        "parents-axiom-only",
+        "AUDIT_INPUT_PATHS are the new note and the axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+    )
+
+    print("per_element: two snapshots, unit lock I=1 on stay and illegal move")
+    print("per_site: window {x,y}; illegal move empties x and occupies y")
+    print("per_mode: I-seq and bag are stay/move-blind; J-seq is not")
+    print("per_block: permanence visibility in named readout only; no rate or clock")
+    print("lattice_wide: checked and not executed — two-site window only")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On W={x,y}, I-seq and the site-blind bag are (1,1) and ({A},{A}) on both a legal stay and an illegal site-to-site move. J-seq splits them. Record permanence is not a property of scalar I. Hypothetical C1 follow-on; not adopted. Occupancy I=1 is a unit-count convention.

## What this means for the TOE

Permanence is checkable from a site-indexed lock field, not from the named scalar readout. Not a formation rate. Not c1hist (no growth).

## Verification

```bash
python3 scripts/permanence_not_visible_in_scalar_i_hypothetical_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.
