### PR TITLE
[physics-loop] toe-lphys c1read: bounded_theorem / bounded-support

### DIFF
--- a/docs/ONLY_RECORDS_READABLE_NOT_REPAIRED_BY_J_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/ONLY_RECORDS_READABLE_NOT_REPAIRED_BY_J_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,276 @@
+---
+claim_id: only_records_readable_not_repaired_by_j_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the two-site C1 display of Record, I(empty)=0 and J(empty)=(0,0) are defined readouts of the empty collection. The strict reading that a readout exists only if at least one record is present therefore fails for both current I and displayed J. C1 copies the empty identity as the zero field and does not repair the leftover Record clause 'Only records are readable.' The note does not adopt a Record rewrite, a pairing on J, L_phys, or a fifth axiom."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py
+---
+
+# Only Records Are Readable Is Not Repaired By J
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** honesty test of the leftover Record clause “Only records are
+readable” against current scalar `I` and the displayed C1 field `J`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py`](../scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py)
+
+## Result Up Front
+
+The current Record axiom names a defined empty readout and, in the same
+paragraph, the clause “Only records are readable.”
+
+C1 copies `I(empty)=0` as the displayed zero field `J ≡ 0`. That copy keeps
+the empty history readable. It does not implement the strict predicate that a
+readout exists only when at least one record is present.
+
+So the leftover clause is still on the table after C1. Owner wording must
+read it as “only record-configurations (including empty) have a readout,” or
+drop it. This note displays that residual. It does not adopt C1 and does not
+rewrite Record.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "On a declared two-site window the empty and unit C1 fields are explicit, I and J of the empty configuration are defined, and occupancy of the empty configuration is the zero pair. No axiom is edited or adopted."
+trace_class: negative_route_pruning
+target_claim_id: record_only_records_readable_clause
+target_blocker_text: "read 'Only records are readable' against defined I(empty)=0 and displayed J(empty)=(0,0)"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the declared window, menu, empty field, and unit field; no Record rewrite and no C1 adoption"
+hypothetical_axiom_status: "C1 follow-on: only-records-readable is not repaired by J; empty still has a readout; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Parents on `origin/main` are the axiom memo only.
+
+Record currently says:
+
+> Only records are readable. A readout value is determined by record content
+> alone. For any finite collection of pairwise-disjoint records, scalar readout
+> `I` is additive, with `I(empty)=0`.
+
+C1 is the displayed copy of that empty identity as a site field, not a
+pairing on `J` and not a fifth axiom. Reconstruct the arithmetic on a
+two-site window.
+
+Let the window be
+
+`W = {x, y}`
+
+and the menu
+
+`M = {A, B}`.
+
+A C1 field is a map
+
+`J : W → {0} ∪ M`,
+
+written in site order `(J(x), J(y))`. The blank token `0` is the no-lock
+value. It is not a menu label.
+
+Occupancy is the derived `{0,1}`-valued field
+
+`o_J(z) = 0` if `J(z) = 0`, else `1`.
+
+Scalar `I` used here is the unit-count of occupied sites,
+
+`I(J) = o_J(x) + o_J(y)`.
+
+The value `I = 1` on a single lock is that counting convention. Record
+additivity plus `I(empty)=0` fixes the empty identity and finite disjoint
+sums; it does not by itself force the unit to be `1`.
+
+Two configurations:
+
+| configuration | `J` | `I` | `o_J` | locks |
+|---|---|---|---|---|
+| empty `e` | `(0, 0)` | `0` | `(0, 0)` | none |
+| unit `u` | `(A, 0)` | `1` | `(1, 0)` | one lock, label `A` at `x` |
+
+Write `R_strict` for the predicate: a readout exists only if at least one
+record is present. Under `R_strict`, `e` has no readout.
+
+Current `I` and displayed `J` both assign `e` a defined value. That is the
+honesty gap.
+
+## Theorem 1 — Current `I(e) = 0` is a defined readout
+
+The axiom sentence supplies `I(empty)=0` as a value, not as a hole. On the
+declared window the empty field is `e`, so
+
+`I_of(e) = 0`.
+
+The predicate “`I(e)` is undefined” fails. The identity gate is `I_of(e)`.
+
+`R_strict` would have left `I(e)` undefined. The current surface does not.
+
+## Theorem 2 — Displayed `J(e) = (0, 0)` is a defined field
+
+C1 copies the empty identity by displaying the zero field. The empty history
+is a value of `J : W → {0} ∪ M`:
+
+`J_of(e) = (0, 0)`.
+
+The predicate “`J(e)` is undefined” fails. The identity gate is `J_of(e)`.
+
+C1 therefore does not make the empty history unreadable. It makes absence
+the zero section of the same field that carries a lock at `u`:
+
+`J_of(u) = (A, 0)`, `I_of(u) = 1`.
+
+Those unit values are the counting convention on one occupied site, not a
+new additive theorem.
+
+## Theorem 3 — Both `I` and `J` read absence; C1 does not repair the clause
+
+The empty configuration contains no lock:
+
+`o_from_J(e) = (0, 0)`.
+
+The predicate “`e` has a lock” fails.
+
+Record still says “Only records are readable.” Read strictly, that is
+`R_strict`: no record, no readout. Both current `I` and displayed `J` read
+the empty collection. C1 does not repair the clause.
+
+Owner wording has two honest options:
+
+1. read the sentence as “only record-configurations (including empty) have a
+   readout,” so the empty configuration is a readable configuration whose
+   content is empty; or
+2. drop the sentence.
+
+This note picks neither as an axiom edit.
+
+## Theorem 4 — Not c1zero and not c1addI
+
+The present statement is not c1zero: the menu is `{A, B}` and the blank
+token is not being tested as a menu label. The present statement is not
+c1addI: it does not prove additivity of `I` on disjoint unions.
+
+What remains is the leftover readability clause. Display it. Do not adopt
+C1. Do not adopt a Record rewrite.
+
+## Theorem 5 — No forced extras
+
+Do not force `r = 1/2`. Do not adopt `L_phys`. Do not put a pairing on `J`.
+The displayed field is a sitewise lock map, not an inner-product object.
+
+## Mutation
+
+The following predicates must fail on the declared objects:
+
+- “`I(e)` is undefined”
+- “`J(e)` is undefined”
+- “`e` has a lock”
+
+Identity gates call `I_of(e)`, `J_of(e)`, `o_from_J(e)`, `I_of(u)`, and
+`J_of(u)`.
+
+## Does Not
+
+- Does not edit `docs/MINIMAL_AXIOMS_2026-06-29.md`.
+- Does not adopt C1, a fifth axiom, a pairing on `J`, `L_phys`, or `r = 1/2`.
+- Does not claim Record additivity forces the unit-count `I(u) = 1`.
+- Does not prove additivity of `I` and does not treat `0` as a menu token.
+- Does not cite unmerged pull requests.
+- Does not set audit status.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to “C1 makes the empty history
+unreadable” and “current `I(e)` is undefined.” The gate does not certify
+a Record rewrite.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Current `I(e)` as a hole | evaluate `I_of(e)` | Theorem 1: defined `0` | **ATTEMPTED** |
+| Displayed `J(e)` as a hole | evaluate `J_of(e)` | Theorem 2: defined `(0,0)` | **ATTEMPTED** |
+| Empty occupancy as a lock | evaluate `o_from_J(e)` | Theorem 3: `(0,0)`, no lock | **ATTEMPTED** |
+| Treat as c1zero / c1addI | menu-zero or additivity | Theorem 4: leftover clause only | **ATTEMPTED** |
+| Adopt C1, pairing on `J`, `r=1/2`, `L_phys` | enlarge the display | Theorem 5: refused | **ATTEMPTED** |
+
+### N2 — wall independence
+
+A defined empty `I` does not force a defined empty `J`. A defined empty
+`J` does not repair the leftover clause. Occupancy zero is independent
+of the wording fork.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| window `W={x,y}`, menu `{A,B}` | stipulated finite objects |
+| unit-count `I(u)=1` | convention; not forced by additivity |
+| `R_strict` | contrast predicate; not adopted |
+| C1 adoption, pairing on `J` | not used |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | “Only records are readable.” and `I(empty)=0` | quoted; C1 copies the empty identity |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | empty and unit fields | no classification of every `J` |
+| per site | both sites of `W` | no lattice-wide type theorem |
+| per mode | defined empty readout versus `R_strict` | no pairing on `J` |
+| per block | leftover clause versus C1 copy | no additivity proof |
+| lattice-wide | not executed | only `W={x,y}` |
+
+The runner emits `per_element` and `per_site` lines.
+
+### N6 — live partial-closure paths
+
+1. Read the leftover clause as “only record-configurations (including
+   empty) have a readout.”
+2. Drop the leftover clause.
+3. Do not treat C1 as a repair of either option.
+
+### N7 — hostile steelman
+
+> Displayed `J≡0` is the empty history, so only records (and the empty
+> record-configuration) are readable; C1 already repairs the clause.
+
+The steelman is owner wording option 1. It is not a type theorem of
+`J`. The current sentence still reads as `R_strict` unless rewritten.
+
+### N8 — cross-cycle echo
+
+This is a C1 follow-on, not C6 or C7. It is not c1zero and not c1addI.
+It reconstructs C1 `J` arithmetic and stops.
+
+**Gate disposition:** PASS for (i) `I(e)=0` defined, (ii) `J(e)=(0,0)`
+defined, and (iii) `e` has no lock. FAIL / DO NOT SHIP for “adopt C1,”
+“put a pairing on `J`,” “force `r=1/2`,” or “adopt `L_phys`.”
+
+## Dependencies
+
+- [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+## No-Promotion Statement
+
+This note does not promote, demote, or set the audit status of any
+dependency. The independent audit lane is the only status authority.
+
+## Review Record
+
+Independent audit remains required before any effective status may
+change. No `review-loop` was invoked in producing this artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13369,6 +13369,10 @@
   "one_time_dimension_dt1_reduces_to_emergent_dynamics_gate_open_gate_note_2026-06-17": {
    "deps_hash": "6b456ae72212",
    "out_degree": 3
+  },
+  "only_records_readable_not_repaired_by_j_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "onsite_charge_conserving_endpoint_symmetric_common_hamiltonian_strict_qca_dichotomy_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py
+runner_sha256: 68f01a3c8ba8667eee4dc747790be4975ef382c40ecc3c61c5020024f0afbf47
+input_fingerprint_sha256: 372ecc0dc1a8fd1c86d309e0d04f05ab59a11d169eb1f036f70c02907d789ed1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: C1 is displayed only; no Record rewrite, pairing on J, L_phys, or r=1/2 is adopted
+PASS: identity-gate-calls identity gates call I_of(e), J_of(e), o_from_J(e), I_of(u), and J_of(u)
+PASS: empty-I-defined predicate I(e) is undefined fails because I_of(e) equals 0
+PASS: empty-J-defined predicate J(e) is undefined fails because J_of(e) equals (0, 0)
+PASS: empty-has-no-lock predicate e has a lock fails because o_from_J(e) equals (0, 0)
+PASS: unit-I-convention I_of(u) equals the unit-count convention 1
+PASS: unit-J-field J_of(u) is the one-lock field (A, 0)
+PASS: strict-readout-contrast R_strict leaves e without a readout while current I still reads 0
+PASS: c1-type both displayed fields are values of J:W to {0} union M and 0 is not a menu label
+PASS: source-record-clause the axiom memo still carries the leftover clause and the empty identity
+PASS: note-leftover-display the note displays the leftover clause and the including-empty owner reading
+PASS: machine-status-contract the source uses the required C1 follow-on hypothetical status and bounded-support surface
+PASS: no-adoption the note refuses a Record rewrite, pairing on J, L_phys, and r=1/2
+PASS: unit-count-is-convention the note does not claim Record additivity forces I(u)=1
+PASS: canonical-nonmutation the canonical axiom file is not rewritten with C1 field notation
+per_element: empty and unit C1 fields are the only configurations evaluated
+per_site: occupancy is the sitewise blank-versus-lock bit; no lattice-wide dynamics is claimed
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py
+++ b/scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Honesty checks: C1 J does not repair 'Only records are readable'.
+
+Reconstructs the two-site C1 field, evaluates I and J on the empty and unit
+configurations, and confirms that the empty history remains a defined readout.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ONLY_RECORDS_READABLE_NOT_REPAIRED_BY_J_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/ONLY_RECORDS_READABLE_NOT_REPAIRED_BY_J_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BLANK = 0
+A = "A"
+B = "B"
+WINDOW = ("x", "y")
+MENU = frozenset({A, B})
+CODOMAIN = frozenset({BLANK}) | MENU
+
+UNDEFINED = object()
+
+
+@dataclass(frozen=True)
+class Config:
+    name: str
+    field: tuple[Any, ...]
+
+
+def J_of(config: Config) -> tuple[Any, ...]:
+    if len(config.field) != len(WINDOW):
+        raise ValueError("J must be indexed by the declared window")
+    if any(value not in CODOMAIN for value in config.field):
+        raise ValueError("J must land in {0} union M")
+    return config.field
+
+
+def o_from_J(config: Config) -> tuple[int, ...]:
+    return tuple(0 if value == BLANK else 1 for value in J_of(config))
+
+
+def I_of(config: Config) -> int:
+    return sum(o_from_J(config))
+
+
+def has_lock(config: Config) -> bool:
+    return I_of(config) != 0
+
+
+def is_undefined(value: object) -> bool:
+    return value is UNDEFINED
+
+
+def r_strict_readout(config: Config) -> object:
+    if not has_lock(config):
+        return UNDEFINED
+    return I_of(config)
+
+
+def identity_gates(e: Config, u: Config) -> dict[str, object]:
+    return {
+        "I_of(e)": I_of(e),
+        "J_of(e)": J_of(e),
+        "o_from_J(e)": o_from_J(e),
+        "I_of(u)": I_of(u),
+        "J_of(u)": J_of(u),
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Record wording is source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: C1 is displayed only; no Record rewrite, pairing on J, L_phys, or r=1/2 is adopted")
+
+    e = Config("e", (BLANK, BLANK))
+    u = Config("u", (A, BLANK))
+    gates = identity_gates(e, u)
+    gate_source = inspect.getsource(identity_gates)
+
+    checks.check(
+        "identity-gate-calls",
+        "identity gates call I_of(e), J_of(e), o_from_J(e), I_of(u), and J_of(u)",
+        all(
+            needle in gate_source
+            for needle in ("I_of(e)", "J_of(e)", "o_from_J(e)", "I_of(u)", "J_of(u)")
+        ),
+    )
+    checks.check(
+        "empty-I-defined",
+        "predicate I(e) is undefined fails because I_of(e) equals 0",
+        not is_undefined(gates["I_of(e)"]) and gates["I_of(e)"] == 0,
+    )
+    checks.check(
+        "empty-J-defined",
+        "predicate J(e) is undefined fails because J_of(e) equals (0, 0)",
+        not is_undefined(gates["J_of(e)"]) and gates["J_of(e)"] == (0, 0),
+    )
+    checks.check(
+        "empty-has-no-lock",
+        "predicate e has a lock fails because o_from_J(e) equals (0, 0)",
+        not has_lock(e) and gates["o_from_J(e)"] == (0, 0),
+    )
+    checks.check(
+        "unit-I-convention",
+        "I_of(u) equals the unit-count convention 1",
+        gates["I_of(u)"] == 1,
+    )
+    checks.check(
+        "unit-J-field",
+        "J_of(u) is the one-lock field (A, 0)",
+        gates["J_of(u)"] == (A, 0),
+    )
+    checks.check(
+        "strict-readout-contrast",
+        "R_strict leaves e without a readout while current I still reads 0",
+        is_undefined(r_strict_readout(e))
+        and r_strict_readout(u) == 1
+        and I_of(e) == 0,
+    )
+    checks.check(
+        "c1-type",
+        "both displayed fields are values of J:W to {0} union M and 0 is not a menu label",
+        BLANK not in MENU
+        and set(J_of(e)) <= CODOMAIN
+        and set(J_of(u)) <= CODOMAIN,
+    )
+    checks.check(
+        "source-record-clause",
+        "the axiom memo still carries the leftover clause and the empty identity",
+        "Only records are readable." in axiom
+        and "I(empty)=0" in axiom.replace(" ", ""),
+    )
+    checks.check(
+        "note-leftover-display",
+        "the note displays the leftover clause and the including-empty owner reading",
+        "Only records are readable" in note
+        and "only record-configurations (including empty) have a readout" in note
+        and "not c1zero" in note
+        and "not c1addI" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required C1 follow-on hypothetical status and bounded-support surface",
+        'hypothetical_axiom_status: "C1 follow-on: only-records-readable is not repaired by J; empty still has a readout; not adopted"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "no-adoption",
+        "the note refuses a Record rewrite, pairing on J, L_phys, and r=1/2",
+        "Does not adopt C1" in note
+        and "Do not put a pairing on `J`" in note
+        and "Do not adopt `L_phys`" in note
+        and "Do not force `r = 1/2`" in note
+        and "cheapest change" not in note,
+    )
+    checks.check(
+        "unit-count-is-convention",
+        "the note does not claim Record additivity forces I(u)=1",
+        "does not by itself force the unit to be `1`" in note
+        and "Does not claim Record additivity forces the unit-count" in note,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the canonical axiom file is not rewritten with C1 field notation",
+        all(phrase not in axiom for phrase in ("J_of", "o_from_J", "R_strict", "C1 follow-on")),
+    )
+
+    print("per_element: empty and unit C1 fields are the only configurations evaluated")
+    print("per_site: occupancy is the sitewise blank-versus-lock bit; no lattice-wide dynamics is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

C1 copies I(empty)=0 as J≡0. Both I(e)=0 and J(e)=(0,0) are defined readouts of the empty collection. The leftover Record clause “Only records are readable” is not repaired. Owner wording must read it as including-empty or drop it. Hypothetical; not adopted.

## What this means for the TOE

Displayed J does not implement R_strict. The empty history stays readable after a C1 retype.

## Verification

```bash
python3 scripts/only_records_readable_not_repaired_by_j_hypothetical_2026_08_13.py
# TOTAL: PASS=14 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.