### PR TITLE
[physics-loop] toe-lphys c1one: bounded_theorem / bounded-support

### DIFF
--- a/docs/UNIQUENESS_PER_SITE_IS_J_TYPE_NOT_A_THEOREM_OF_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/UNIQUENESS_PER_SITE_IS_J_TYPE_NOT_A_THEOREM_OF_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,313 @@
+---
+claim_id: uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a two-site window, a legal unit lock is a value of the displayed C1 map J:W→{0}∪M, while a double mark at one site is not; current scalar I is not even defined on that double mark, so one-lock-per-site uniqueness is the type of J rather than a theorem of I. The C1 type is displayed and not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py
+---
+
+# Uniqueness Per Site Is J's Type, Not A Theorem Of I
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact two-site typing of a displayed site-indexed lock map
+against current scalar Record readout. Hypothetical only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py`](../scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py)
+
+Parents on `origin/main`: the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Current Record says a record "locks exactly one admissible local possibility"
+and "A site never carries more than one record." Those sentences name a
+codomain constraint. They are not an equation in the scalar readout `I`.
+
+On the displayed two-site window the honest C1 type is a map
+
+`J : W → {0} ∪ M`.
+
+A legal unit lock is a value of that type. A double mark at one site is a
+map into finite subsets of `M`, so it is not a value of `J`. Current `I` is
+defined on legal occupancies and unit locks; the double mark is outside that
+domain. Extending occupancy-count to the double mark still returns `1`, the
+same integer carried by the legal unit lock. Therefore `I` does not forbid
+the double mark.
+
+This note reconstructs that type gap. It does not adopt C1, does not enlarge
+`J` to power-set valued maps, does not edit an axiom, and does not put a
+pairing on `J`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "L is exhibited as a value of J:W→{0}∪M and D is exhibited as not a value; I(L)=1 is the unit-count convention on the legal lock; occupancy-count of D is 1; uniqueness-per-site is therefore typed as J's codomain, not an I-equation. C1 is not adopted."
+trace_class: negative_route_pruning
+target_claim_id: uniqueness_per_site_from_scalar_I
+target_blocker_text: "derive 'a site never carries more than one record' as a theorem of scalar I"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the displayed two-site window, honest menu, legal unit lock, and counterfactual double mark; C1 not adopted"
+hypothetical_axiom_status: "C1 follow-on: at most one lock per site is J's type, not a property of I; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let
+
+`W = {x, y}`
+
+be a two-site window and
+
+`M = {A, B}`
+
+an honest finite menu with `0 ∉ M`. The honest C1 type, displayed and not
+adopted, is
+
+`J : W → {0} ∪ M`.
+
+The token `0` is absence, not a menu element. Occupancy of a C1 value is the
+retract
+
+`o_J(z) = 0` if `J(z) = 0`, else `1`.
+
+**Legal unit lock `L`.** The map `J_L = (A, 0)`, meaning `J_L(x) = A` and
+`J_L(y) = 0`, with occupancy `o_L = (1, 0)`. Scalar readout on this legal
+unit lock is the unit-count convention
+
+`I(L) = 1`.
+
+Record additivity with `I(empty) = 0` does not force that unit. The integer
+`1` is a choice of scale for one occupied site, not a derived theorem of
+additivity.
+
+**Counterfactual double mark `D` at the single site `x`.** A map
+
+`J* : W →` finite subsets of `M`
+
+with
+
+`J*(x) = {A, B}`, `J*(y) = ∅`.
+
+The value `J*(x)` is a two-element set. It is not an element of `{0} ∪ M`.
+So `D` is not a value of `J : W → {0} ∪ M`.
+
+Occupancy-count of a mark-map is the number of sites whose mark is nonempty.
+That count is defined on `D` without making `D` a legal occupancy:
+
+`occ_count(D) = 1`.
+
+Current scalar `I` is not defined on `D`. There is therefore no `I`-equation
+that can fail on `D`.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether "a site never carries more than one record"
+is a theorem of current scalar `I` on the displayed window, or only a typing
+constraint of the displayed C1 map.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| exhibit `L` as a value of `J : W → {0} ∪ M` | type witness | proved; identity gate `J_of(L)` |
+| exhibit `D` as not a value of that type | type rejector | proved; identity gate `is_J_value(D)` is false |
+| evaluate `I` on the legal unit lock | current readout | `I(L) = 1` by unit-count convention; identity gate `I_of(L)` |
+| show `I` has no equation on `D` | domain gap | `D` is not a legal occupancy |
+| evaluate occupancy-count on `D` | naive extension | `occ_count(D) = 1`; identity gate `occ_count(D)` |
+| quote current Record uniqueness sentences | source pin | axiom memo; those sentences name `J`'s type |
+| keep the gap distinct from a zero-token menu | sibling type | not the `0 ∈ M` confusion |
+| adopt C1 or enlarge `J` to power-set maps | non-goal | not done |
+
+## Theorem 1 — `L` Is A Value Of `J`; `D` Is Not
+
+The pair `(A, 0)` has both coordinates in `{0, A, B} = {0} ∪ M`. Hence `L`
+is a value of `J : W → {0} ∪ M`.
+
+The pair `({A, B}, ∅)` has first coordinate a two-element subset of `M`.
+That subset is not an element of `{0} ∪ M`. Hence `D` is not a value of
+`J`.
+
+The identity gates are `J_of(L) = (A, 0)` and `is_J_value(D) = false`.
+
+This is a type statement. It does not say `D` is physically realized. It
+says the honest C1 codomain already excludes two labels at one site.
+
+## Theorem 2 — Scalar `I` Does Not Forbid `D`
+
+Current scalar `I` is defined on legal occupancies and unit locks. On `L`
+the unit-count convention gives `I(L) = 1`. The identity gate is `I_of(L)`.
+
+`D` is not in that domain: it is not an occupancy `W → {0, 1}` and not a
+value of `J`. There is no current `I`-equation that can be evaluated on `D`,
+so there is no `I`-equation that fails on `D`. Scalar `I` therefore does not
+forbid the double mark.
+
+If occupancy-count is extended to mark-maps by counting sites with a
+nonempty mark, then `occ_count(D) = 1`, the same integer as `I(L)`. The
+identity gate is `occ_count(D)`. A one-site double mark and a one-site legal
+lock are not separated by that count.
+
+Record additivity is not used and is not claimed to force `I(L) = 1`.
+
+## Theorem 3 — The Record Uniqueness Sentences Are The Type Of `J`
+
+The current Record axiom reads:
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+The two uniqueness sentences constrain what a lock is allowed to be at a
+site: exactly one admissible local possibility, and never more than one
+record. Those sentences are the type of J (codomain `{0}∪M`), not a theorem of I. On the displayed C1 type they say that each site
+value lies in `{0} ∪ M`, not in the set of two-element subsets of `M`.
+
+Theorem 2 shows why they cannot be a theorem of `I` on this window: `I`
+does not take `D` as an argument, and the naive occupancy-count extension
+agrees on `L` and `D`.
+
+This note does not drop those sentences from the axiom file. It displays
+their type. Under displayed C1 they are already encoded by the codomain of
+`J`. They are not an extra scalar constraint.
+
+## Theorem 4 — This Is Not A Zero-Token Menu Gap
+
+A different type error is to put the absence token into the menu,
+`0 ∈ M`, so that the same symbol is both unformed and a lock label. That
+is not the object here. The honest menu is `{A, B}` with `0 ∉ M`. The
+rejector is two distinct lock labels `{A, B}` at the single site `x`, not a
+zero token.
+
+The type gap displayed here is
+
+`{A, B} ∉ {0} ∪ M`,
+
+not
+
+`0 ∈ M`.
+
+C1 is not adopted. The map `J` is not enlarged to power-set valued maps.
+Doing so would type `D` and would erase the uniqueness sentences as
+codomain constraints.
+
+## Theorem 5 — No Pairing, No Half-Rate, No Physical Carrier
+
+This note does not force a formation rate `r = 1/2`. It does not adopt a
+physical lattice carrier `L_phys`. It does not put a pairing, product
+table, or two-argument readout on `J`. Those objects are extra relative to
+both current `I` and displayed `J`.
+
+Displayed C1 is a retype of site-indexed lock content. It is not a
+dynamics axiom, not a Born compiler, and not a Newton pairing.
+
+## Consequence For The Axiom Surface
+
+The current canonical wording is
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). Record
+already states one-lock-per-site uniqueness in English. The displayed C1
+map makes that statement a typing fact about `J`. Current `I` does not.
+
+No axiom text is edited. No Record rewrite is adopted. The hypothetical
+status is only that uniqueness-per-site, if one writes C1, is already `J`'s
+type and is not a property one should expect scalar `I` to prove.
+
+## No-Go Discipline Gate
+
+The negative claim is restricted to: uniqueness-per-site is not a theorem
+of current scalar `I` on the displayed window, because `D` is outside `I`'s
+domain and occupancy-count does not split `D` from `L`. The gate does not
+certify that C1 must be adopted or that uniqueness cannot be derived from
+some other later object.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Evaluate `I` on `D` | treat `D` as a legal occupancy | `D` is not in the domain of current `I` | **ATTEMPTED** |
+| Extend `I` by occupancy-count | `occ_count(D)` | equals `1`, same as `I(L)` | **ATTEMPTED** |
+| Record additivity | use `I(S ∪ T) = I(S) + I(T)` on disjoint collections | additivity never sees two labels at one site; it also does not force the unit `I = 1` | **ATTEMPTED** |
+| `I(empty) = 0` | empty-collection normalization | does not constrain a nonempty double mark | **ATTEMPTED** |
+| Site-blind bag of labels | `{A, B}` versus `{A}` | a bag can split contents, but that is not scalar `I` | **ATTEMPTED** |
+| Enlarge `J` to power-set maps | type `D` as legal | would erase uniqueness as a codomain fact; not adopted | **ATTEMPTED** |
+| Zero-token menu `0 ∈ M` | confuse absence with a lock label | a different type gap; not this rejector | **ATTEMPTED** |
+| Axiom edit | add an `I`-equation forbidding `D` | not required to display the type; not done | **ATTEMPTED** |
+
+The first four routes concern scalar `I`. They do not forbid `D`. The last
+four use other objects or an edit. None is shipped as an axiom change.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `I`-domain gap / occupancy-count equality | no: undefined is not the integer `1` | no: equal counts do not decide domain | independent |
+| uniqueness as `J`-type / uniqueness as `I`-theorem | no: typing `L` does not create an `I`-equation on `D` | no: an `I`-equation would not be the C1 codomain | independent |
+| double mark / zero-token menu | no: `{A, B}` is not the token `0` | no: `0 ∈ M` is not two labels at one site | independent |
+
+### N3 — residual after the displayed type
+
+After Theorems 1–3 the residual is not "how to make `I` reject `D`." The
+residual is whether a later retained construction should adopt C1, keep
+uniqueness as English axiom text, or derive uniqueness from some other
+named object. That residual is open.
+
+### N4 — what would close the residual
+
+A close would be either (i) an adopted C1-type Record rewrite, which this
+note does not perform, or (ii) a retained derivation of uniqueness from
+objects already on the axiom surface other than the English uniqueness
+sentences themselves. Scalar `I` is not that derivation.
+
+### N5 — scoped negatives
+
+- `D` is not a value of `J : W → {0} ∪ M`.
+- `I` is not defined on `D`.
+- `occ_count(D) = 1 = I(L)` under the unit-count convention.
+- Therefore uniqueness-per-site is not a theorem of `I` on this window.
+- These negatives do not say gravity is impossible, do not say formation is
+  impossible, and do not say a later object cannot enforce uniqueness.
+
+### N6 — axiom update is not required
+
+Displaying the type gap does not require an axiom update. The current
+Record sentences already state uniqueness in English. This note does not
+claim an axiom update is necessary, sufficient, or cheapest.
+
+### N7 — non-claims
+
+This note does not adopt C1. It does not enlarge `J` to power-set valued
+maps. It does not force `r = 1/2`. It does not adopt `L_phys`. It does not
+put a pairing on `J`. It does not claim Record additivity forces `I = 1`.
+It does not install a vacuum possibility. It does not pick the menu
+`{A, B}` as physical.
+
+### N8 — FAIL / DO NOT SHIP
+
+Do not ship any of the following as retained content of this note:
+
+- "scalar `I` forbids a double mark";
+- "Record additivity forces `I(L) = 1`";
+- "C1 is adopted";
+- "enlarge `J` to maps into subsets of `M`";
+- "this is the zero-token menu gap";
+- "an axiom update is necessary";
+- any pairing, `r = 1/2`, or `L_phys` adoption.
+
+## Identity And Mutation Gates
+
+The runner must call `J_of(L)`, `is_J_value(D)`, `I_of(L)`, and
+`occ_count(D)`.
+
+- The predicate "`D` is a value of `J : W → {0} ∪ M`" must fail.
+- The predicate "`I(L) ≠ 1`" must fail.
+- The predicate "`occ_count(D) ≠ 1`" must fail.
+
+Mutating `J_of` off `(A, 0)`, mutating `is_J_value(D)` to true, mutating
+`I_of(L)` off `1`, or mutating `occ_count(D)` off `1` fails the runner.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18445,6 +18445,10 @@
   "unified_program_note": {
    "deps_hash": "dd9fd64aa659",
    "out_degree": 22
+  },
+  "uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unit_conversion_is_the_accepted_non_bounding_ruler_reconciliation_note_2026-06-08": {
    "deps_hash": "d292eab310f2",

--- a/logs/runner-cache/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py
+runner_sha256: 54b4a252dad4ef2a07b23e514283f03fa2f94475d7d9911296958d9458e71ffb
+input_fingerprint_sha256: 6b319a6dda247f0dc3a5d7ac36d77deb320d689c9278f8915274ccdd1721dade
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: uniqueness-per-site is not an I-equation on the displayed window; C1 is not adopted
+PASS: source-record-lock-one the axiom memo states that a record locks exactly one admissible local possibility
+PASS: source-record-one-per-site the axiom memo states that a site never carries more than one record
+PASS: honest-menu-excludes-zero honest M={A,B} has 0 notin M, so the rejector is not a zero token
+PASS: identity-J-of-L J_of(L) is the legal unit lock (A, 0)
+PASS: mutation-D-not-J-value predicate 'D is a value of J:W→{0}∪M' fails
+PASS: mutation-I-of-L-is-one predicate 'I(L)≠1' fails by the unit-count convention
+PASS: mutation-occ-count-D-is-one predicate 'occ_count(D)≠1' fails
+PASS: I-domain-excludes-D current scalar I is not defined on the double mark, so no I-equation fails on D
+PASS: double-mark-contents D marks {A,B} at x and empty at y, and {A,B} is not in {0}∪M
+PASS: note-type-not-I-theorem the note states uniqueness is J's type, not a theorem of I, and does not adopt C1
+PASS: note-not-c1zero the note displays the type gap and separates it from a zero-token menu
+PASS: note-non-claims the note refuses r=1/2, L_phys, pairing on J, and additivity-forced I=1
+PASS: machine-status-contract the source uses the required hypothetical and bounded-support status strings
+PASS: canonical-nonmutation the axiom memo is not rewritten with C1 maps or double-mark notation
+PASS: no-go-gate N1-N8 and the do-not-ship list are source-visible
+per_element: legal unit lock L and double mark D are the only displayed histories
+per_site: both objects occupy only x; y is unformed / unmarked
+per_mode: occupancy-count and C1 typing are the only compared readouts
+lattice_wide: checked and not executed — the window is two named sites
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py
+++ b/scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Exact checks: uniqueness-per-site is J's type, not a theorem of I.
+
+Displayed C1 type J:W→{0}∪M. Legal unit lock L is a value. Double mark D
+is not. Scalar I is defined on L only; occupancy-count of D is 1.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "UNIQUENESS_PER_SITE_IS_J_TYPE_NOT_A_THEOREM_OF_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/UNIQUENESS_PER_SITE_IS_J_TYPE_NOT_A_THEOREM_OF_I_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+W = ("x", "y")
+M = frozenset({"A", "B"})
+J_CODOMAIN = frozenset({0}) | M
+UNIT_I = 1  # convention; Record additivity does not force the unit
+
+# Legal unit lock L: J=(A,0), o=(1,0), I=1.
+L = {
+    "name": "L",
+    "J": {"x": "A", "y": 0},
+    "o": {"x": 1, "y": 0},
+}
+
+# Counterfactual double mark D: J*(x)={A,B}, J*(y)=∅.
+D = {
+    "name": "D",
+    "marks": {"x": frozenset({"A", "B"}), "y": frozenset()},
+}
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def J_of(history: dict) -> tuple:
+    """Displayed C1 value as the ordered pair (J(x), J(y))."""
+    return (history["J"]["x"], history["J"]["y"])
+
+
+def _site_values(obj: dict) -> tuple:
+    if "J" in obj:
+        return tuple(obj["J"][site] for site in W)
+    if "marks" in obj:
+        return tuple(obj["marks"][site] for site in W)
+    raise TypeError("object supplies neither a C1 map nor a mark-map")
+
+
+def is_J_value(obj: dict) -> bool:
+    """True iff obj is a value of J:W→{0}∪M."""
+    try:
+        return all(value in J_CODOMAIN for value in _site_values(obj))
+    except TypeError:
+        return False
+
+
+def is_legal_occupancy(history: dict) -> bool:
+    if "o" not in history or "J" not in history:
+        return False
+    occupancy = history["o"]
+    lock = history["J"]
+    if any(occupancy[site] not in (0, 1) for site in W):
+        return False
+    if not is_J_value(history):
+        return False
+    for site in W:
+        formed = occupancy[site] == 1
+        locked = lock[site] != 0
+        if formed != locked:
+            return False
+    return True
+
+
+def I_of(history: dict) -> int:
+    """Scalar I on legal occupancies / unit locks. Unit-count convention."""
+    if not is_legal_occupancy(history):
+        raise TypeError("current scalar I is not defined on this object")
+    occupied = sum(1 for site in W if history["o"][site] == 1)
+    return occupied * UNIT_I
+
+
+def occ_count(mark_map: dict) -> int:
+    """Number of sites with a nonempty mark. Defined on D without typing D as J."""
+    return sum(1 for site in W if mark_map["marks"][site])
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+
+    print("external_scientific_inputs: current axiom wording only; no observational or fitted inputs")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: uniqueness-per-site is not an I-equation on the displayed window; C1 is not adopted")
+
+    checks.check(
+        "source-record-lock-one",
+        "the axiom memo states that a record locks exactly one admissible local possibility",
+        "locks exactly one admissible local possibility" in normalized_axiom,
+    )
+    checks.check(
+        "source-record-one-per-site",
+        "the axiom memo states that a site never carries more than one record",
+        "A site never carries more than one record" in normalized_axiom,
+    )
+    checks.check(
+        "honest-menu-excludes-zero",
+        "honest M={A,B} has 0 notin M, so the rejector is not a zero token",
+        0 not in M and J_CODOMAIN == frozenset({0, "A", "B"}),
+    )
+
+    # Identity gates required by the spec.
+    j_L = J_of(L)
+    d_is_j = is_J_value(D)
+    i_L = I_of(L)
+    c_D = occ_count(D)
+
+    checks.check(
+        "identity-J-of-L",
+        "J_of(L) is the legal unit lock (A, 0)",
+        j_L == ("A", 0) and is_J_value(L),
+    )
+    checks.check(
+        "mutation-D-not-J-value",
+        "predicate 'D is a value of J:W→{0}∪M' fails",
+        d_is_j is False,
+    )
+    checks.check(
+        "mutation-I-of-L-is-one",
+        "predicate 'I(L)≠1' fails by the unit-count convention",
+        i_L == 1,
+    )
+    checks.check(
+        "mutation-occ-count-D-is-one",
+        "predicate 'occ_count(D)≠1' fails",
+        c_D == 1,
+    )
+
+    i_undefined_on_D = False
+    try:
+        I_of(D)
+    except TypeError:
+        i_undefined_on_D = True
+    checks.check(
+        "I-domain-excludes-D",
+        "current scalar I is not defined on the double mark, so no I-equation fails on D",
+        i_undefined_on_D,
+    )
+    checks.check(
+        "double-mark-contents",
+        "D marks {A,B} at x and empty at y, and {A,B} is not in {0}∪M",
+        D["marks"]["x"] == frozenset({"A", "B"})
+        and D["marks"]["y"] == frozenset()
+        and frozenset({"A", "B"}) not in J_CODOMAIN,
+    )
+    checks.check(
+        "note-type-not-I-theorem",
+        "the note states uniqueness is J's type, not a theorem of I, and does not adopt C1",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "not a theorem of I",
+                "Those sentences are the type of J",
+                "C1 is not adopted",
+                "not enlarged to power-set valued maps",
+            )
+        ),
+    )
+    checks.check(
+        "note-not-c1zero",
+        "the note displays the type gap and separates it from a zero-token menu",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "This Is Not A Zero-Token Menu Gap",
+                "{A, B} ∉ {0} ∪ M",
+                "not a zero token",
+            )
+        ),
+    )
+    checks.check(
+        "note-non-claims",
+        "the note refuses r=1/2, L_phys, pairing on J, and additivity-forced I=1",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "does not force a formation rate `r = 1/2`",
+                "does not adopt a physical lattice carrier `L_phys`",
+                "does not put a pairing",
+                "does not claim Record additivity forces `I = 1`",
+            )
+        )
+        and "cheapest change" not in normalized_note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required hypothetical and bounded-support status strings",
+        all(
+            phrase in note
+            for phrase in (
+                'hypothetical_axiom_status: "C1 follow-on: at most one lock per site is J\'s type, not a property of I; not adopted"',
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo is not rewritten with C1 maps or double-mark notation",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "J : W → {0} ∪ M",
+                "J*(x) = {A, B}",
+                "double mark",
+            )
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "N1-N8 and the do-not-ship list are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note,
+    )
+
+    print("per_element: legal unit lock L and double mark D are the only displayed histories")
+    print("per_site: both objects occupy only x; y is unformed / unmarked")
+    print("per_mode: occupancy-count and C1 typing are the only compared readouts")
+    print("lattice_wide: checked and not executed — the window is two named sites")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On W={x,y} with honest M={A,B}, legal unit lock L=(A,0) is a value of J:W→{0}∪M. Double mark D with J*(x)={A,B} is not. Scalar I is defined on L only (I(L)=1 by unit-count convention). Occupancy-count of D is still 1, so I does not forbid D. Uniqueness-per-site is J's type, not a theorem of I. Hypothetical; not adopted.

## What this means for the TOE

If Record is later retyped to J, “a site never carries more than one record” is already the codomain. Do not expect scalar I to prove it.

## Verification

```bash
python3 scripts/uniqueness_per_site_is_j_type_not_a_theorem_of_i_hypothetical_2026_08_13.py
# TOTAL: PASS=15 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.