### PR TITLE
[physics-loop] toe-lphys c1lockperm: bounded_theorem / bounded-support

### DIFF
--- a/docs/LOCK_LABEL_PERMANENCE_NOT_VISIBLE_IN_I_OR_O_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/LOCK_LABEL_PERMANENCE_NOT_VISIBLE_IN_I_OR_O_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,261 @@
+---
+claim_id: lock_label_permanence_not_visible_in_i_or_o_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a two-site window with a two-entry menu and two snapshots, a legal stay and an illegal same-site lock-label flip share the unit-count I-sequence and the site-occupancy o-sequence. The site-blind bag and the site-indexed field J split them. Record permanence together with one lock per record forbids the relock. The split is displayed and is not adopted as a Record rewrite."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py
+---
+
+# Lock-Label Permanence Is Not Visible in I or o
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** two-snapshot visibility of a same-site lock-label flip on a
+two-site window, under current Record wording and a displayed site-indexed
+field `J`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py`](../scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py)
+
+Parent on `origin/main`: the axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Occupancy stays one unit lock at a fixed site. A legal stay keeps the same
+lock label. An illegal relock flips the label at that same site. The named
+scalar readout sequence and the weak occupancy sequence are identical on
+both histories. The site-blind bag of lock labels and the site-indexed field
+`J` split them. The current Record sentences “records are permanent” and
+“locks exactly one” together forbid the relock. This note displays that
+visibility split. It does not adopt a Record rewrite, a formation rate, a
+pairing on `J`, `L_phys`, or a forced value `r=1/2`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer identities on a declared two-site, two-snapshot window; no axiom edit and no adopted readout retype."
+trace_class: negative_route_pruning
+target_claim_id: lock_label_permanence_visibility_in_named_readout
+target_blocker_text: "named scalar I and weak occupancy o do not witness same-site lock-label permanence"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the declared window and the displayed J arithmetic; not adopted"
+hypothetical_axiom_status: "C1 follow-on: lock-label permanence not visible in I or o; J and bag split relock; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Window `W={x,y}` with the listed order `(x,y)`. Finite menu `M={A,B}`.
+Two snapshots `t=0,1`. Occupancy is already one unit lock at `x` and stays
+there.
+
+Reconstructed site-indexed field, displayed and not adopted:
+
+```text
+J : W → {0} ∪ M
+J(z) = 0                 if the site is empty
+J(z) = locked menu entry if the site carries the unit lock
+```
+
+A snapshot is written as the ordered pair `(J(x), J(y))`. A history is a pair
+of snapshots.
+
+Derived maps, computed from `J` rather than supplied independently:
+
+```text
+o(z) = 0 if J(z)=0 else 1
+I(J) = |{z in W : J(z) ≠ 0}|
+bag(J) = {J(z) : J(z) ≠ 0}
+```
+
+The integer `I=1` on a single occupied site is a **unit-count convention**.
+Record additivity with `I(empty)=0` is compatible with any fixed positive
+unit per disjoint lock; the axioms do not force that unit to be `1`.
+
+Sequences are the two-snapshot tuples
+
+```text
+I_seq(H)   = (I(H_0), I(H_1))
+o_seq(H)   = (o(H_0), o(H_1))
+bag_seq(H) = (bag(H_0), bag(H_1))
+J_seq(H)   = (H_0, H_1)
+```
+
+Two histories on this window:
+
+```text
+legal stay S:     J_0 = (A, 0),  J_1 = (A, 0)
+illegal relock R: J_0 = (A, 0),  J_1 = (B, 0)
+```
+
+A reconstructed site-move history is used only as a contrast, not as the
+illegal object of this note:
+
+```text
+site-move Move:   J_0 = (A, 0),  J_1 = (0, A)
+```
+
+Identity gates call `I_seq`, `o_seq`, `bag_seq`, and `J_seq` on `S` and `R`.
+
+## Theorem 1 — I-seq and o-seq do not split stay from relock
+
+**Statement.** `I_seq(S)=I_seq(R)=(1,1)` and
+`o_seq(S)=o_seq(R)=((1,0),(1,0))`. Weak occupancy is not enough for
+lock-label permanence.
+
+**Proof.** Each snapshot of `S` and of `R` has `J(x)∈M` and `J(y)=0`. The
+occupancy pair is therefore `(1,0)` at both times, and the unit-count
+convention gives `I=1` at both times. The two sequences agree, so neither
+`I_seq` nor `o_seq` can tell stay from relock. ∎
+
+The predicates “`I_seq(S)` differs from `I_seq(R)`” and
+“`o_seq(S)` differs from `o_seq(R)`” therefore fail.
+
+## Theorem 2 — Bag and J split stay from relock
+
+**Statement.** `bag_seq(S)=({A},{A})` and `bag_seq(R)=({A},{B})`.
+`J_seq(S)=((A,0),(A,0))` and `J_seq(R)=((A,0),(B,0))`. Those two pairs
+differ.
+
+**Proof.** The site-blind bag of a snapshot is the set of nonzero lock
+labels. Stay keeps `{A}` at both times. Relock replaces `{A}` by `{B}` at
+`t=1`. The site-indexed field keeps the site and changes the label, so the
+`J` sequences differ in the second snapshot. ∎
+
+The predicate “`J_seq(S)=J_seq(R)`” therefore fails.
+
+## Theorem 3 — Record forbids relock; visibility is split across maps
+
+Quote the current Record wording:
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+Together those sentences forbid relock. At `t=0` the record at `x` locks
+`A`. Permanence keeps that record. Replacing `A` by `B` at the same site
+removes the earlier lock and violates permanence. Adding `B` beside `A` at
+the same site would make the site carry more than one record and would
+violate “locks exactly one.”
+
+A reconstructed site-move `Move` with the same lock `A` has
+
+```text
+I_seq(Move)   = (1,1)                 = I_seq(S)
+bag_seq(Move) = ({A},{A})             = bag_seq(S)
+o_seq(Move)   = ((1,0),(0,1))        ≠ o_seq(S)
+J_seq(Move)   = ((A,0),(0,A))        ≠ J_seq(S)
+```
+
+so a site-move is invisible in `I` and in the bag. The label-flip `R` is
+invisible in `I` and in `o`, and is visible in the bag. Strong `J` sees
+both illegalities. Weak `o` sees only the move. The bag sees only the
+relock.
+
+## Theorem 4 — Not a site-move test and not a formation rate
+
+The illegal history of this note does not change site. Occupancy stays one
+unit lock at `x` on both `S` and `R`. There is no growth from empty, no
+second formation event, and no formation-rate target. Formation is not
+reopened. The objects are displayed. They are not adopted.
+
+## Theorem 5 — Display only
+
+Do not adopt a Record rewrite. Do not force `r=1/2`. Do not adopt
+`L_phys`. Do not put a pairing on `J`. The `2×2` product table on
+occupancies remains extra; this note never introduces a two-argument
+pairing through `I` or through `J`.
+
+## Non-claims
+
+- The axioms are not edited.
+- Unit-count `I=1` is not derived from Record additivity.
+- The note does not select a physical clock, a formation law, or a
+  Newton pairing.
+- Visibility on this finite window is not an exhaustion of every possible
+  record-identity semantics outside the displayed `J` representation.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to “`I`-seq or `o`-seq witnesses
+lock-label permanence” and “this is a restatement of the site-move test.”
+The gate does not certify a Record rewrite.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Scalar `I`-seq as the split | evaluate `I_seq` on `S` and `R` | Theorem 1: both `(1,1)` | **ATTEMPTED** |
+| Weak occupancy `o`-seq | evaluate `o_seq` on `S` and `R` | Theorem 1: both `((1,0),(1,0))` | **ATTEMPTED** |
+| Site-blind bag | evaluate `bag_seq` | Theorem 2: `({A},{A})` vs `({A},{B})` | **ATTEMPTED** |
+| Site-indexed `J` | evaluate `J_seq` | Theorem 2: stay ≠ relock | **ATTEMPTED** |
+| Treat as site-move / formation | occupy a new site or grow from empty | Theorem 4: occupancy stays at `x` | **ATTEMPTED** |
+| Adopt C1, pairing on `J`, `r=1/2`, `L_phys` | enlarge the display | Theorem 5: refused | **ATTEMPTED** |
+
+### N2 — wall independence
+
+Equal `I`-seq does not give equal bags. Equal `o`-seq does not give equal
+`J`. A site-move is a different invisibility pattern.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| window `W={x,y}`, menu `{A,B}`, two snapshots | stipulated finite objects |
+| unit-count `I=1` | convention; not forced by additivity |
+| reconstructed site-move `Move` | contrast only |
+| C1 adoption, pairing on `J` | not used |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | “records are permanent” and “locks exactly one” | quoted; jointly forbid relock |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | stay `S` and relock `R` | no classification of every history |
+| per site | occupancy stays at `x` | no lattice-wide permanence theorem |
+| per mode | `I`/`o` versus bag/`J` | no pairing on `J` |
+| per block | label-flip versus site-move | no formation rate |
+| lattice-wide | not executed | only `W={x,y}` |
+
+### N6 — live partial-closure paths
+
+1. Keep permanence as English on the current axiom file.
+2. If C1 is later adopted, lock-label permanence is a `J`-seq (and bag)
+   fact, not an `I` or `o` fact.
+3. A pairing on `J` remains extra either way.
+
+### N7 — hostile steelman
+
+> Permanence is already occupancy permanence, so a same-site relock is
+> another record and `o` should not have to see it.
+
+The steelman rewrites “records are permanent.” On the current sentence
+plus “locks exactly one,” the same-site label flip is illegal and still
+invisible in `I` and `o`.
+
+### N8 — cross-cycle echo
+
+This is a C1 follow-on, not C6 or C7. It is not c1perm: the site does
+not change. Formation is not reopened.
+
+**Gate disposition:** PASS for (i) `I_seq` and `o_seq` agree on `S` and
+`R`, and (ii) bag and `J` split them. FAIL / DO NOT SHIP for “adopt C1,”
+“put a pairing on `J`,” “force `r=1/2`,” or “adopt `L_phys`.”
+
+## Review Record
+
+Independent audit remains required before any effective status may
+change. No `review-loop` was invoked in producing this artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12117,6 +12117,10 @@
   "localized_source_response_sweep_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "lock_label_permanence_not_visible_in_i_or_o_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "lock_point_menu_record_and_likelihood_lemma_cycle911_bounded_theorem_note_2026-07-28": {
    "deps_hash": "9250d476c7ae",

--- a/logs/runner-cache/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py
+runner_sha256: 475faa28a1c1c8be5e78109bffa5650622dc7caf02f5cfef1f2919d8b6f9b634
+input_fingerprint_sha256: ef5c292fbb4f4cae3f71d47359f36ceafffdae3f7117ee6aa367bb9803fef6b8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording only; J arithmetic is reconstructed in this runner
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+PASS: source-permanence Record states that records are permanent
+PASS: source-locks-exactly-one Record states that a record locks exactly one admissible local possibility
+PASS: source-additivity Record names additive scalar I with I(empty)=0
+PASS: note-hypothetical-status note carries the required hypothetical axiom status
+PASS: note-surface-status note is bounded-support and not adopted
+identity_gate I_seq(S)=(1, 1)
+identity_gate I_seq(R)=(1, 1)
+identity_gate o_seq(S)=((1, 0), (1, 0))
+identity_gate o_seq(R)=((1, 0), (1, 0))
+identity_gate bag_seq(S)=(['A'], ['A'])
+identity_gate bag_seq(R)=(['A'], ['B'])
+identity_gate J_seq(S)=(('A', 0), ('A', 0))
+identity_gate J_seq(R)=(('A', 0), ('B', 0))
+PASS: identity-gate-calls runner source calls I_seq, o_seq, bag_seq, J_seq on S and R
+PASS: occupancy-stays-at-x both histories keep one unit lock at x
+PASS: I-seq-both I-seq of stay and relock is (1,1) by unit count
+PASS: mutation-I-seq-differs predicate I_seq(S) differs from I_seq(R) fails
+PASS: mutation-o-seq-differs predicate o_seq(S) differs from o_seq(R) fails
+PASS: bag-stay site-blind bag of stay is ({A},{A})
+PASS: bag-relock site-blind bag of relock is ({A},{B})
+PASS: bag-splits bag_seq splits stay from relock
+PASS: J-seq-values J-seq is ((A,0),(A,0)) on stay and ((A,0),(B,0)) on relock
+PASS: mutation-J-seq-equal predicate J_seq(S)=J_seq(R) fails
+PASS: site-move-contrast reconstructed site-move shares I and bag with stay, not o or J
+PASS: visibility-split J sees move and relock; o sees only the move; bag sees only the relock
+PASS: unit-count-convention I=1 is a unit convention; additivity also holds for unit 2
+PASS: not-formation occupancy count stays 1; this is not a formation-rate history
+PASS: not-site-change relock keeps the occupied site; it is not a site move
+PASS: note-forbids-relock-quotes note quotes permanence and locks-exactly-one as jointly forbidding relock
+PASS: display-only note does not force r=1/2, adopt L_phys, or put a pairing on J
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py
+++ b/scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Exact integer checks: lock-label permanence is not visible in I or o.
+
+A legal stay and an illegal same-site relock share I-seq and o-seq.
+The site-blind bag and site-indexed J split them. Values are computed
+from the displayed J field. Unit-count I=1 is a convention.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "LOCK_LABEL_PERMANENCE_NOT_VISIBLE_IN_I_OR_O_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/LOCK_LABEL_PERMANENCE_NOT_VISIBLE_IN_I_OR_O_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+EMPTY = 0
+A = "A"
+B = "B"
+
+# Histories are pairs of J snapshots (J(x), J(y)).
+S = ((A, EMPTY), (A, EMPTY))
+R = ((A, EMPTY), (B, EMPTY))
+MOVE = ((A, EMPTY), (EMPTY, A))
+
+
+def occupancy(snapshot: tuple) -> tuple[int, int]:
+    return tuple(0 if value == EMPTY else 1 for value in snapshot)
+
+
+def I_of(snapshot: tuple) -> int:
+    """Unit-count convention: each occupied site contributes 1."""
+    return sum(occupancy(snapshot))
+
+
+def bag_of(snapshot: tuple) -> frozenset:
+    return frozenset(value for value in snapshot if value != EMPTY)
+
+
+def I_seq(history: tuple) -> tuple:
+    return tuple(I_of(snapshot) for snapshot in history)
+
+
+def o_seq(history: tuple) -> tuple:
+    return tuple(occupancy(snapshot) for snapshot in history)
+
+
+def bag_seq(history: tuple) -> tuple:
+    return tuple(bag_of(snapshot) for snapshot in history)
+
+
+def J_seq(history: tuple) -> tuple:
+    return tuple(history)
+
+
+def i_seq_differs(left: tuple, right: tuple) -> bool:
+    return I_seq(left) != I_seq(right)
+
+
+def o_seq_differs(left: tuple, right: tuple) -> bool:
+    return o_seq(left) != o_seq(right)
+
+
+def j_seq_equal(left: tuple, right: tuple) -> bool:
+    return J_seq(left) == J_seq(right)
+
+
+def I_scaled(snapshot: tuple, unit: int) -> int:
+    return unit * I_of(snapshot)
+
+
+def additive_on_sites(unit: int) -> bool:
+    lock_x = (A, EMPTY)
+    lock_y = (EMPTY, B)
+    both = (A, B)
+    empty = (EMPTY, EMPTY)
+    return (
+        I_scaled(empty, unit) == 0
+        and I_scaled(lock_x, unit) + I_scaled(lock_y, unit)
+        == I_scaled(both, unit) + I_scaled(empty, unit)
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_source = Path(__file__).read_text(encoding="utf-8")
+    norm_note = normalize(note)
+    norm_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording only; "
+        "J arithmetic is reconstructed in this runner"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read "
+        "for claim-surface consistency"
+    )
+
+    checks.check(
+        "source-permanence",
+        "Record states that records are permanent",
+        "records are permanent" in norm_axiom,
+    )
+    checks.check(
+        "source-locks-exactly-one",
+        "Record states that a record locks exactly one admissible local possibility",
+        "locks exactly one admissible local possibility" in norm_axiom,
+    )
+    checks.check(
+        "source-additivity",
+        "Record names additive scalar I with I(empty)=0",
+        "scalar readout `I` is additive, with `I(empty)=0`" in axiom
+        or "I(empty)=0" in axiom,
+    )
+    checks.check(
+        "note-hypothetical-status",
+        "note carries the required hypothetical axiom status",
+        'hypothetical_axiom_status: "C1 follow-on: lock-label permanence not visible in I or o; J and bag split relock; not adopted"'
+        in note,
+    )
+    checks.check(
+        "note-surface-status",
+        "note is bounded-support and not adopted",
+        "actual_current_surface_status: bounded-support" in note
+        and "not adopted" in note,
+    )
+
+    # Identity gates: must call I_seq, o_seq, bag_seq, J_seq on S and R.
+    i_s = I_seq(S)
+    i_r = I_seq(R)
+    o_s = o_seq(S)
+    o_r = o_seq(R)
+    bag_s = bag_seq(S)
+    bag_r = bag_seq(R)
+    j_s = J_seq(S)
+    j_r = J_seq(R)
+
+    print(f"identity_gate I_seq(S)={i_s}")
+    print(f"identity_gate I_seq(R)={i_r}")
+    print(f"identity_gate o_seq(S)={o_s}")
+    print(f"identity_gate o_seq(R)={o_r}")
+    print(f"identity_gate bag_seq(S)={tuple(sorted(item) for item in bag_s)}")
+    print(f"identity_gate bag_seq(R)={tuple(sorted(item) for item in bag_r)}")
+    print(f"identity_gate J_seq(S)={j_s}")
+    print(f"identity_gate J_seq(R)={j_r}")
+
+    checks.check(
+        "identity-gate-calls",
+        "runner source calls I_seq, o_seq, bag_seq, J_seq on S and R",
+        all(
+            f"{name}(S)" in runner_source and f"{name}(R)" in runner_source
+            for name in ("I_seq", "o_seq", "bag_seq", "J_seq")
+        ),
+    )
+    checks.check(
+        "occupancy-stays-at-x",
+        "both histories keep one unit lock at x",
+        o_s == ((1, 0), (1, 0)) and o_r == ((1, 0), (1, 0)),
+    )
+    checks.check(
+        "I-seq-both",
+        "I-seq of stay and relock is (1,1) by unit count",
+        i_s == (1, 1) and i_r == (1, 1),
+    )
+    checks.check(
+        "mutation-I-seq-differs",
+        "predicate I_seq(S) differs from I_seq(R) fails",
+        i_seq_differs(S, R) is False,
+    )
+    checks.check(
+        "mutation-o-seq-differs",
+        "predicate o_seq(S) differs from o_seq(R) fails",
+        o_seq_differs(S, R) is False,
+    )
+    checks.check(
+        "bag-stay",
+        "site-blind bag of stay is ({A},{A})",
+        bag_s == (frozenset({A}), frozenset({A})),
+    )
+    checks.check(
+        "bag-relock",
+        "site-blind bag of relock is ({A},{B})",
+        bag_r == (frozenset({A}), frozenset({B})),
+    )
+    checks.check(
+        "bag-splits",
+        "bag_seq splits stay from relock",
+        bag_s != bag_r,
+    )
+    checks.check(
+        "J-seq-values",
+        "J-seq is ((A,0),(A,0)) on stay and ((A,0),(B,0)) on relock",
+        j_s == ((A, EMPTY), (A, EMPTY)) and j_r == ((A, EMPTY), (B, EMPTY)),
+    )
+    checks.check(
+        "mutation-J-seq-equal",
+        "predicate J_seq(S)=J_seq(R) fails",
+        j_seq_equal(S, R) is False,
+    )
+
+    i_move = I_seq(MOVE)
+    o_move = o_seq(MOVE)
+    bag_move = bag_seq(MOVE)
+    j_move = J_seq(MOVE)
+    checks.check(
+        "site-move-contrast",
+        "reconstructed site-move shares I and bag with stay, not o or J",
+        i_move == i_s
+        and bag_move == bag_s
+        and o_move != o_s
+        and j_move != j_s
+        and o_move == ((1, 0), (0, 1))
+        and j_move == ((A, EMPTY), (EMPTY, A)),
+    )
+    checks.check(
+        "visibility-split",
+        "J sees move and relock; o sees only the move; bag sees only the relock",
+        j_move != j_s
+        and j_r != j_s
+        and o_move != o_s
+        and o_r == o_s
+        and bag_move == bag_s
+        and bag_r != bag_s,
+    )
+    checks.check(
+        "unit-count-convention",
+        "I=1 is a unit convention; additivity also holds for unit 2",
+        I_of((A, EMPTY)) == 1
+        and additive_on_sites(1)
+        and additive_on_sites(2)
+        and I_scaled((A, EMPTY), 2) == 2,
+    )
+    checks.check(
+        "not-formation",
+        "occupancy count stays 1; this is not a formation-rate history",
+        i_s == (1, 1) and i_r == (1, 1) and I_of(S[0]) == I_of(S[1]),
+    )
+    checks.check(
+        "not-site-change",
+        "relock keeps the occupied site; it is not a site move",
+        occupancy(R[0]) == occupancy(R[1]) == (1, 0)
+        and occupancy(MOVE[0]) != occupancy(MOVE[1]),
+    )
+    checks.check(
+        "note-forbids-relock-quotes",
+        "note quotes permanence and locks-exactly-one as jointly forbidding relock",
+        "records are permanent" in norm_note
+        and "locks exactly one" in norm_note
+        and "forbid relock" in norm_note,
+    )
+    checks.check(
+        "display-only",
+        "note does not force r=1/2, adopt L_phys, or put a pairing on J",
+        "Do not force `r=1/2`" in note
+        and "Do not adopt" in note
+        and "`L_phys`" in note
+        and "Do not put a pairing on `J`" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Legal stay S and illegal same-site relock R share I-seq=(1,1) and o-seq=((1,0),(1,0)). Site-blind bag and site-indexed J split them. Record permanence plus “locks exactly one” forbids the relock. Not c1perm (site stays). Hypothetical; not adopted.

## What this means for the TOE

Lock-label permanence is a J/bag fact, not an I or o fact. Weak occupancy sees site-moves, not relocks.

## Verification

```bash
python3 scripts/lock_label_permanence_not_visible_in_i_or_o_hypothetical_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.