### PR TITLE
[physics-loop] toe-lphys rfreq: bounded_theorem / bounded-support

### DIFF
--- a/docs/RECORD_FREQUENCY_IS_HISTORY_NOT_AXIOM_RHALF_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/RECORD_FREQUENCY_IS_HISTORY_NOT_AXIOM_RHALF_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,195 @@
+---
+claim_id: record_frequency_is_history_not_axiom_rhalf_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a one-site toy menu of two lock labels, empirical frequency is a function of a nonempty finite history of admissible locks. Live Record does not name a frequency, does not assign a readout to a blank site, and does not select r=1/2. Equal-block Koide (1,1) is a supplied weighting plus a selector, not a theorem of live Record. The note neither adopts r=1/2 nor bans it."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py
+---
+
+# Record Frequency Is History, Not An Axiom `r=1/2`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite-word frequency on a one-site two-lock toy menu
+under the current Record wording.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py`](../scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py)
+**Parent on origin/main:** the axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Live Record does not select a lock frequency. A realized frequency is a
+property of a nonempty finite history of locks. The value `r=1/2` may
+occur as one such history (it is not banned science). It is not axiom
+content, and it is not the unique frequency of admissible lock sequences.
+
+Three exact statements locate the boundary.
+
+1. Two length-4 histories of admissible locks have different `A`
+   frequencies, `3/4` and `1/2`. The axiom text names neither.
+2. The empty history has no frequency. A map that returns `1/2` on the
+   blank is not a Record readout.
+3. Equal-block Koide `(1,1) -> r=1/2` is a supplied weighting plus a
+   selector. It is not a theorem of live Record. Koide `Q` is not derived
+   here.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Fraction counts on a declared two-letter toy menu, with live Record quoted verbatim; no axiom retype, no frequency adoption, and no Koide Q derivation."
+trace_class: negative_route_pruning
+target_claim_id: record_frequency_selection
+target_blocker_text: "do the current axioms select a lock frequency, in particular r=1/2?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the declared toy histories and the displayed equal-block selector; no physical flavor, quark, or Koide-Q claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+This is current Record, not a retype. No hypothetical axiom wording is
+offered.
+
+## Exact Objects
+
+Fix one site and a toy menu of two lock labels `{A,B}`. Each letter is one
+admissible local possibility that a forming record may lock. A history `H`
+is a finite word in `{A,B}`. Write `|H|` for its length and `n_A` for the
+number of letters equal to `A`.
+
+When `|H| >= 1`, the empirical frequency is the exact rational
+
+`f(H,A) = n_A / |H|`
+
+as a `Fraction`. The empty history has no frequency: blank cannot be read,
+and `f(empty, ·)` is undefined. In particular this note does not set
+`f(empty)=1/2`.
+
+The construction is a counting interface on already-formed locks. It does
+not supply a formation rate, a probability law over words, or a preferred
+letter.
+
+## Live Record
+
+The current Record axiom is the `Record / Fixed Reality` section of
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). The three
+readout sentences, quoted verbatim, are:
+
+Only records are readable. A readout value is determined by record content alone. A site with no record cannot be read.
+
+The same memo states that finite additivity, a named scalar collection
+functional `I`, and an assigned value `I(empty)=0` are not Record axiom
+content. Named `I` is not axiom content. A site with no record cannot be
+read; the axiom does not assign a scalar to absence.
+
+Record therefore licenses reading the content of formed locks and forbids
+reading a blank site. It does not name a frequency of lock labels.
+
+## Theorem 1 — Two Admissible Histories Carry Distinct Frequencies
+
+Let
+
+`H1 = AAAB` and `H2 = AABB`.
+
+Both are length-4 words in `{A,B}`, hence finite sequences of admissible
+locks on the toy menu. Exact counts give
+
+`f(H1,A) = 3/4` and `f(H2,A) = 1/2`.
+
+Both values are realized frequencies of admissible lock sequences. The
+axiom text does not name either frequency. In particular it does not
+select `1/2`, and it does not forbid `3/4`.
+
+The claim of this note is not that every history has `r=1/2`, and not
+that `r=1/2` is impossible. The claim is that the axioms do not select a
+frequency.
+
+## Theorem 2 — Empty History Has No Frequency
+
+`f(empty, ·)` is undefined. There is no letter count to form a
+`Fraction`, and live Record supplies no substitute scalar: a site with no
+record cannot be read.
+
+A function that returns `1/2` on the empty history is not a Record
+readout. It assigns a value where there is no record content. The same
+objection applies to writing `I(empty)=0` and then converting that `0`
+into a frequency: `I(empty)=0` is not axiom content, and a blank cannot
+be read.
+
+## Theorem 3 — Equal-Block `(1,1)` Is A Supplied Selector
+
+The equal-block Koide weighting `(1,1) -> r=1/2` is a supplied weighting
+plus a selector, not a theorem of live Record.
+
+Display the two histories again:
+
+`H1 = AAAB` has `f(H1,A)=3/4`.
+
+`H2 = AABB` has `f(H2,A)=1/2`.
+
+If one supplies block weights `(1,1)` and selects the normalized first
+weight
+
+`1 / (1+1) = 1/2`,
+
+one has chosen `r=1/2` by that selector. The same selector is compatible
+with `H2` and incompatible with `H1`. Live Record names neither the
+weights nor the selector. The two displayed histories remain admissible
+lock sequences.
+
+This note does not derive Koide `Q`. It does not identify `{A,B}` with
+quark flavors, lepton isotypes, or any physical generation carrier. It
+does not say quarks forbid the investigation. The value `r=1/2` may be
+recorded frequently under a later supplied law; that possibility is not
+banned, and it is not made the whole program.
+
+## Mutation Predicates
+
+The following hostile predicates fail on the objects above.
+
+1. “Every length-4 history has `f(A)=1/2`.” Counterexample: `H1 = AAAB`
+   has `f(H1,A)=3/4`. Among the sixteen words of length 4, the possible
+   `A` frequencies are `0, 1/4, 1/2, 3/4, 1`.
+2. “`f(empty)=1/2` is axiom content.” False: `f(empty, ·)` is undefined,
+   and the live Record readout sentences assign no value to a site with
+   no record.
+
+## Claim Boundary
+
+| Item | Status |
+|---|---|
+| live Record readout sentences | quoted; not edited |
+| named `I` and `I(empty)=0` | not axiom content |
+| `f(H,A)` for `|H|>=1` | exact count on a nonempty word |
+| `f(empty, ·)` | undefined |
+| `r=1/2` as one realized frequency | permitted (`H2`); not adopted |
+| universal `r=1/2` | rejected (`H1`) |
+| equal-block `(1,1)` | supplied weighting plus selector |
+| Koide `Q` | not derived |
+| quark/flavor identification | not used |
+| axiom edit or retype | none |
+
+No canonical axiom is edited here.
+
+## Imports And Open
+
+**Imported.** The current four-axiom memo, used only for the Record
+readout sentences and the explicit statement that named `I` and
+`I(empty)=0` are not Record content.
+
+**Derived here.** Exact frequencies of `H1` and `H2`; undefined empty
+frequency; failure of the two mutation predicates; the typing of
+equal-block `(1,1)` as a supplied selector.
+
+**Open.** Any physical identification of the toy labels with a flavor
+carrier; any formation law that would make one frequency typical; any
+Koide `Q` derivation; any claim that a later retained law cannot prefer
+`r=1/2`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15769,6 +15769,10 @@
   "record_formation_to_kraus_isometry_bridge_2026-06-06": {
    "deps_hash": "3b37788c6bc3",
    "out_degree": 3
+  },
+  "record_frequency_is_history_not_axiom_rhalf_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "record_function_finite_sector_algebra_2026-06-05": {
    "deps_hash": "9efb4237fec5",

--- a/logs/runner-cache/record_frequency_is_history_not_axiom_rhalf_2026_08_13.txt
+++ b/logs/runner-cache/record_frequency_is_history_not_axiom_rhalf_2026_08_13.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py
+runner_sha256: c31f46a82e8458e515dadde1c18089d9519a791e81a246933e78ae6514b3d608
+input_fingerprint_sha256: 87d23e0153e90bc68ecd537927e4e563674ba505e5d8b2df00c89c9e1c5355e5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current Record wording from the axiom memo only; no observational, fitted, or Koide-Q inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency against the live axiom memo
+PASS: source-record-readout the three live Record readout sentences occur verbatim
+PASS: source-named-I-not-content named I and I(empty)=0 are stated not to be Record axiom content
+PASS: theorem1-histories H1=AAAB and H2=AABB are length-4 words in the two-lock menu
+PASS: theorem1-frequencies computed f(H1,A)=3/4 and f(H2,A)=1/2
+PASS: theorem1-axiom-silent-on-frequencies the axiom memo names neither displayed history nor either frequency
+PASS: theorem2-empty-undefined f(empty, ·) is undefined
+PASS: theorem2-half-on-blank-is-not-readout returning 1/2 on the empty history is not a Record readout
+PASS: theorem3-supplied-selector equal-block (1,1) supplies r=1/2 by normalization, not by Record
+PASS: theorem3-histories-displayed the note displays both histories and types (1,1) as a supplied selector
+PASS: theorem3-no-koide-q the note does not derive Koide Q and does not say quarks forbid the investigation
+PASS: mutation-universal-half not every length-4 history has f(A)=1/2; H1 is the witness
+PASS: mutation-empty-half-axiom f(empty)=1/2 is not axiom content
+PASS: note-quotes-live-record the note quotes the three readout sentences verbatim
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract current-surface status is bounded-support and is not a retype
+PASS: no-adoption the note neither adopts nor universally forces r=1/2
+PASS: canonical-nonmutation the axiom memo is not edited and does not contain the toy frequency algebra
+PASS: parent-is-axiom-memo-only declared audit inputs are exactly the new note and the axiom memo
+per_element: sixteen length-4 words and the two displayed histories are counted with exact Fraction
+per_site: the toy menu is one site with two lock labels; no composite carrier is asserted
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py
+++ b/scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Exact checks: record frequency is history, not an axiom r=1/2.
+
+Frequencies are computed as Fraction counts on declared finite words.
+The runner does not adopt r=1/2, does not assign a frequency to the empty
+history, and does not derive Koide Q.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "RECORD_FREQUENCY_IS_HISTORY_NOT_AXIOM_RHALF_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/RECORD_FREQUENCY_IS_HISTORY_NOT_AXIOM_RHALF_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+MENU = frozenset({"A", "B"})
+H1 = "AAAB"
+H2 = "AABB"
+EMPTY = ""
+
+READOUT_SENTENCES = (
+    "Only records are readable.",
+    "A readout value is determined by record content alone.",
+    "A site with no record cannot be read.",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def frequency(history: str, label: str) -> Fraction | None:
+    if any(letter not in MENU for letter in history):
+        raise ValueError("history uses a letter outside the toy menu")
+    if label not in MENU:
+        raise ValueError("label is outside the toy menu")
+    if len(history) == 0:
+        return None
+    return Fraction(history.count(label), len(history))
+
+
+def supplied_equal_block_r(weights: tuple[int, int]) -> Fraction:
+    total = weights[0] + weights[1]
+    if total == 0:
+        raise ValueError("equal-block weights must have positive sum")
+    return Fraction(weights[0], total)
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_norm = normalize(note)
+    axiom_norm = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current Record wording from the axiom "
+        "memo only; no observational, fitted, or Koide-Q inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency against the live axiom memo"
+    )
+
+    checks.check(
+        "source-record-readout",
+        "the three live Record readout sentences occur verbatim",
+        all(sentence in axiom_norm for sentence in READOUT_SENTENCES),
+    )
+    checks.check(
+        "source-named-I-not-content",
+        "named I and I(empty)=0 are stated not to be Record axiom content",
+        (
+            "a named scalar collection functional `I`" in axiom
+            and "`I(empty)=0` are not Record axiom content" in axiom_norm
+        ),
+    )
+
+    f_h1 = frequency(H1, "A")
+    f_h2 = frequency(H2, "A")
+    checks.check(
+        "theorem1-histories",
+        "H1=AAAB and H2=AABB are length-4 words in the two-lock menu",
+        len(H1) == 4
+        and len(H2) == 4
+        and set(H1) <= MENU
+        and set(H2) <= MENU
+        and H1 != H2,
+    )
+    checks.check(
+        "theorem1-frequencies",
+        "computed f(H1,A)=3/4 and f(H2,A)=1/2",
+        f_h1 == Fraction(3, 4) and f_h2 == Fraction(1, 2),
+    )
+    checks.check(
+        "theorem1-axiom-silent-on-frequencies",
+        "the axiom memo names neither displayed history nor either frequency",
+        all(
+            needle not in axiom
+            for needle in ("AAAB", "AABB", "f(H1", "f(H2", "3/4")
+        ),
+    )
+
+    empty_freq = frequency(EMPTY, "A")
+    checks.check(
+        "theorem2-empty-undefined",
+        "f(empty, ·) is undefined",
+        empty_freq is None,
+    )
+    checks.check(
+        "theorem2-half-on-blank-is-not-readout",
+        "returning 1/2 on the empty history is not a Record readout",
+        empty_freq != Fraction(1, 2)
+        and "A site with no record cannot be read." in axiom_norm
+        and "I(empty)=0" in axiom_norm
+        and "are not Record axiom content" in axiom_norm,
+    )
+
+    selector = supplied_equal_block_r((1, 1))
+    checks.check(
+        "theorem3-supplied-selector",
+        "equal-block (1,1) supplies r=1/2 by normalization, not by Record",
+        selector == Fraction(1, 2) and f_h1 != selector and f_h2 == selector,
+    )
+    checks.check(
+        "theorem3-histories-displayed",
+        "the note displays both histories and types (1,1) as a supplied selector",
+        "H1 = AAAB" in note
+        and "H2 = AABB" in note
+        and "supplied weighting plus a selector" in note_norm
+        and "not a theorem of live Record" in note_norm,
+    )
+    checks.check(
+        "theorem3-no-koide-q",
+        "the note does not derive Koide Q and does not say quarks forbid the investigation",
+        "does not derive Koide `Q`" in note_norm
+        and "does not say quarks forbid the investigation" in note_norm,
+    )
+
+    length4 = ["".join(word) for word in product("AB", repeat=4)]
+    half_on_all_length4 = all(
+        frequency(word, "A") == Fraction(1, 2) for word in length4
+    )
+    length4_values = {frequency(word, "A") for word in length4}
+    checks.check(
+        "mutation-universal-half",
+        "not every length-4 history has f(A)=1/2; H1 is the witness",
+        half_on_all_length4 is False
+        and frequency(H1, "A") == Fraction(3, 4)
+        and H1 in length4
+        and length4_values
+        == {
+            Fraction(0),
+            Fraction(1, 4),
+            Fraction(1, 2),
+            Fraction(3, 4),
+            Fraction(1),
+        },
+    )
+    checks.check(
+        "mutation-empty-half-axiom",
+        "f(empty)=1/2 is not axiom content",
+        empty_freq is None
+        and "f(empty)=1/2 is axiom content" not in axiom_norm
+        and "A site with no record cannot be read." in axiom_norm,
+    )
+
+    checks.check(
+        "note-quotes-live-record",
+        "the note quotes the three readout sentences verbatim",
+        all(sentence in note_norm for sentence in READOUT_SENTENCES),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "current-surface status is bounded-support and is not a retype",
+        "actual_current_surface_status: bounded-support" in note
+        and "This is current Record, not a retype." in note
+        and "hypothetical_axiom_status" not in note,
+    )
+    checks.check(
+        "no-adoption",
+        "the note neither adopts nor universally forces r=1/2",
+        "axioms do not select a frequency" in note_norm
+        and "not adopted" in note_norm
+        and "universal `r=1/2`" in note
+        and "rejected" in note_norm,
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo is not edited and does not contain the toy frequency algebra",
+        "f(H,A)" not in axiom and "H1 = AAAB" not in axiom,
+    )
+    checks.check(
+        "parent-is-axiom-memo-only",
+        "declared audit inputs are exactly the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/RECORD_FREQUENCY_IS_HISTORY_NOT_AXIOM_RHALF_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    print(
+        "per_element: sixteen length-4 words and the two displayed histories "
+        "are counted with exact Fraction"
+    )
+    print(
+        "per_site: the toy menu is one site with two lock labels; no "
+        "composite carrier is asserted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On a one-site toy menu `{A,B}`, `f(AAAB,A)=3/4` and `f(AABB,A)=1/2`. Live Record names neither frequency. Empty history has no frequency; `f(empty)=1/2` is not a Record readout. Equal-block `(1,1)→r=1/2` is a supplied selector. `r=1/2` is allowed, not axiom-forced. No Koide Q derivation.

## What this means for the TOE

Lock frequency is history, not axiom content. Do not put `r=1/2` into axiom text, and do not make proving only `r=1/2` the whole program.

## Verification

```bash
python3 scripts/record_frequency_is_history_not_axiom_rhalf_2026_08_13.py
# TOTAL: PASS=18 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.