### PR TITLE
[physics-loop] toe-lphys blankocc: bounded_theorem / bounded-support

### DIFF
--- a/docs/BLANK_SITE_UNREAD_OCCUPANCY_IS_NOT_SITE_READOUT_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/BLANK_SITE_UNREAD_OCCUPANCY_IS_NOT_SITE_READOUT_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,142 @@
+---
+claim_id: blank_site_unread_occupancy_is_not_site_readout_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a two-site window, a site readout is defined only where a record is present. Occupancy of a blank site is a total extra field, not Record content, and the old formation count I(W) is a lemma of a supplied set, not a live axiom readout. The note does not adopt J, restore I, or pick a formation rate."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py
+---
+
+# Blank Unread: Window Occupancy Is Not a Site Readout
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** two-site window consequence of the landed Record wording.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py`](../scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py)
+**Parent:** axiom memo only
+([`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)).
+
+## Result Up Front
+
+Live Record says:
+
+> A site with no record cannot be read.
+
+On a two-site window with one blank site, a site readout is therefore a
+partial map: defined at the occupied site and undefined at the blank site.
+The occupancy field that returns `0` at the blank site is defined there. So
+occupancy is extra bookkeeping, not a site readout and not Record content.
+
+The old formation count `I(W)` is the cardinality of the set of occupied
+sites in a supplied window. That integer is a lemma of the supplied set. Live
+Record does not name `I`. This note does not restore `I`, does not adopt
+`J`, and does not pick a formation rate.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact two-configuration algebra on a declared window: site-readout domain, occupancy totality, and supplied-set count. No axiom edit, no J, no restored I, no formation rate."
+trace_class: negative_route_pruning
+target_claim_id: null
+target_blocker_text: "whether blank-site occupancy or the old I(W) count can be read as live Record site readout"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the declared two-site window and the two lock configurations; formation law and any later occupancy field remain extra if wanted as a total field on W"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let the window be
+
+`W = {x, y}`.
+
+A configuration of locks is a partial assignment of record values to sites of
+`W`. The two configurations used here are
+
+`σ_occ = {x ↦ A}`
+
+with `y` blank, and
+
+`σ_full = {x ↦ A, y ↦ B}`.
+
+A **site readout** of a configuration is the partial map that returns the
+locked value only at sites that carry a record. Live Record:
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+So a site readout of `σ_occ` is defined at `x` (value `A`) and undefined at
+`y`.
+
+Define occupancy by
+
+`o(z) = 1` if `z` carries a record, else `0`.
+
+Then `o` is a total function on `W`. On `σ_occ` one has `o(y) = 0`.
+
+The old formation count of a supplied window is the cardinality
+
+`I(W) := |{z ∈ W : formed}|`.
+
+That symbol is historical. It is not named by live Record.
+
+## Theorem 1
+
+Quote the blank-unread sentence: “A site with no record cannot be read.”
+
+On `σ_occ`, the domain of a site readout is `{x}`, not `W`. The value at `x`
+is `A`. The map is undefined at `y`.
+
+## Theorem 2
+
+The occupancy function `o` is defined at `y` on `σ_occ`, with value `0`.
+A site readout of `σ_occ` is not defined at `y`. Therefore `o` is not a site
+readout in the sense of the landed sentence. Occupancy of a blank site is
+extra bookkeeping, not Record content.
+
+## Theorem 3
+
+The old count `I(W) = |{z ∈ W : formed}|` equals `1` on `σ_occ` and `2` on
+`σ_full`. Each number is the cardinality of a set of sites. Live Record does
+not name `I`. Display the count as a lemma of a supplied set, not as axiom
+readout.
+
+## Theorem 4
+
+This note does not adopt `J`, does not restore `I`, and does not pick a
+formation rate. Formation occupancy remains extra if one wants a total field
+on `W`.
+
+## Mutation Predicates
+
+The following predicates fail:
+
+1. “site readout of `σ_occ` is defined at `y`”
+2. “live memo contains `I(empty)=0`” as governing Record content
+
+The live Record section of
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+is the text from `### Record / Fixed Reality` through `## Qualification`.
+That section contains the blank-unread sentence and does not contain
+`I(empty)=0`. The rest of the memo may mention `I(empty)=0` only as removed
+or as “not Record axiom content.”
+
+## What This Does Not Claim
+
+- No axiom is edited.
+- Named `I` is not restored as axiom content.
+- `J` is not adopted.
+- No formation site, probability, or rate is selected.
+- Occupancy is not promoted to Record content.
+- The result is a consequence check on the landed wording, not a pairing
+  construction and not a further axiom wave.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1381,6 +1381,10 @@
   "bksf_holonomy_compression_cycle728_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2bdda41c6188",
    "out_degree": 3
+  },
+  "blank_site_unread_occupancy_is_not_site_readout_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "block_gaussian_schur_marginalization_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.txt
+++ b/logs/runner-cache/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.txt
@@ -1,0 +1,37 @@
+===== runner cache v1 =====
+runner: scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py
+runner_sha256: 6f77160a968bb297c0ec7c1b5307c2cdf97cfa01e7f318f18671ce6186ba0c57
+input_fingerprint_sha256: d87f8ed22cd2eedb376b00b83262e573547ebad7d499c0f48916b764910fd6b8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+PASS: source-blank-unread live Record quotes the blank-unread sentence
+PASS: source-only-records live Record says only records are readable
+PASS: source-content-alone live Record determines readout value by record content alone
+PASS: mutation-live-memo-I-empty predicate live memo contains I(empty)=0 fails on governing Record
+PASS: source-I-excluded memo states named I and I(empty)=0 are not Record axiom content
+PASS: t1-domain-occ site readout domain of sigma_occ is {x}
+PASS: t1-domain-not-W site readout domain of sigma_occ is not W
+PASS: t1-value-x site readout of sigma_occ at x is A
+PASS: mutation-readout-defined-at-y predicate site readout of sigma_occ is defined at y fails
+PASS: t2-occupancy-at-y occupancy is defined at blank y on sigma_occ with value 0
+PASS: t2-occupancy-total occupancy is a total function on W for sigma_occ
+PASS: t2-o-not-site-readout occupancy domain W is not the site-readout domain {x}
+PASS: t3-count-occ supplied-set formation count on sigma_occ is 1
+PASS: t3-count-full supplied-set formation count on sigma_full is 2
+PASS: t3-count-is-cardinality formation count equals cardinality of occupied sites in W
+PASS: t3-full-readout-domain site readout of sigma_full is defined on all of W
+PASS: t4-no-J note does not adopt J
+PASS: t4-no-restore-I note does not restore I
+PASS: t4-no-formation-rate note does not pick a formation rate
+PASS: note-quotes-blank-unread note quotes the live blank-unread sentence
+PASS: note-status note machine status is bounded-support
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the declared note and axiom memo
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py
+++ b/scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Exact checks: blank-site occupancy is not a site readout.
+
+Window algebra on two lock configurations. Live Record is quoted from the
+governing Record section of the axiom memo. Occupancy and the old formation
+count are computed from the supplied sets; they are not axiom readout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "BLANK_SITE_UNREAD_OCCUPANCY_IS_NOT_SITE_READOUT_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/BLANK_SITE_UNREAD_OCCUPANCY_IS_NOT_SITE_READOUT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BLANK_UNREAD = "A site with no record cannot be read."
+ONLY_RECORDS = "Only records are readable."
+CONTENT_ALONE = "A readout value is determined by record content alone."
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def governing_record_section(note: str) -> str:
+    """Live Record axiom only; exclude historical discussion."""
+    try:
+        section = note.split("### Record / Fixed Reality", 1)[1]
+        section = section.split("## Qualification", 1)[0]
+    except IndexError:
+        return ""
+    return normalize(section)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def site_readout(sigma: dict[str, str], site: str) -> str | None:
+    return sigma[site] if site in sigma else None
+
+
+def site_readout_domain(sigma: dict[str, str], window: frozenset[str]) -> frozenset[str]:
+    return frozenset(site for site in window if site in sigma)
+
+
+def occupancy(sigma: dict[str, str], site: str) -> int:
+    return 1 if site in sigma else 0
+
+
+def supplied_formation_count(sigma: dict[str, str], window: frozenset[str]) -> int:
+    return sum(1 for site in window if site in sigma)
+
+
+def site_readout_of_sigma_occ_defined_at_y(sigma_occ: dict[str, str]) -> bool:
+    return "y" in sigma_occ and site_readout(sigma_occ, "y") is not None
+
+
+def live_memo_contains_I_empty_as_governing_content(record_section: str) -> bool:
+    return "I(empty)=0" in record_section
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    record_section = governing_record_section(axiom)
+    normalized_note = normalize(note)
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+
+    window = frozenset({"x", "y"})
+    sigma_occ: dict[str, str] = {"x": "A"}
+    sigma_full: dict[str, str] = {"x": "A", "y": "B"}
+
+    occ_domain = site_readout_domain(sigma_occ, window)
+    full_domain = site_readout_domain(sigma_full, window)
+    occ_count = supplied_formation_count(sigma_occ, window)
+    full_count = supplied_formation_count(sigma_full, window)
+    occ_occupancy = {site: occupancy(sigma_occ, site) for site in window}
+
+    checks.check(
+        "source-blank-unread",
+        "live Record quotes the blank-unread sentence",
+        BLANK_UNREAD in record_section,
+    )
+    checks.check(
+        "source-only-records",
+        "live Record says only records are readable",
+        ONLY_RECORDS in record_section,
+    )
+    checks.check(
+        "source-content-alone",
+        "live Record determines readout value by record content alone",
+        CONTENT_ALONE in record_section,
+    )
+    checks.check(
+        "mutation-live-memo-I-empty",
+        "predicate live memo contains I(empty)=0 fails on governing Record",
+        live_memo_contains_I_empty_as_governing_content(record_section) is False,
+    )
+    checks.check(
+        "source-I-excluded",
+        "memo states named I and I(empty)=0 are not Record axiom content",
+        "named scalar collection functional `I`" in axiom
+        and "I(empty)=0` are not Record axiom content" in axiom,
+    )
+    checks.check(
+        "t1-domain-occ",
+        "site readout domain of sigma_occ is {x}",
+        occ_domain == frozenset({"x"}),
+    )
+    checks.check(
+        "t1-domain-not-W",
+        "site readout domain of sigma_occ is not W",
+        occ_domain != window,
+    )
+    checks.check(
+        "t1-value-x",
+        "site readout of sigma_occ at x is A",
+        site_readout(sigma_occ, "x") == "A",
+    )
+    checks.check(
+        "mutation-readout-defined-at-y",
+        "predicate site readout of sigma_occ is defined at y fails",
+        site_readout_of_sigma_occ_defined_at_y(sigma_occ) is False
+        and site_readout(sigma_occ, "y") is None,
+    )
+    checks.check(
+        "t2-occupancy-at-y",
+        "occupancy is defined at blank y on sigma_occ with value 0",
+        occ_occupancy["y"] == 0 and "y" in occ_occupancy,
+    )
+    checks.check(
+        "t2-occupancy-total",
+        "occupancy is a total function on W for sigma_occ",
+        occ_occupancy == {"x": 1, "y": 0} and set(occ_occupancy) == set(window),
+    )
+    checks.check(
+        "t2-o-not-site-readout",
+        "occupancy domain W is not the site-readout domain {x}",
+        set(occ_occupancy) == set(window) and occ_domain == frozenset({"x"}),
+    )
+    checks.check(
+        "t3-count-occ",
+        "supplied-set formation count on sigma_occ is 1",
+        occ_count == 1,
+    )
+    checks.check(
+        "t3-count-full",
+        "supplied-set formation count on sigma_full is 2",
+        full_count == 2,
+    )
+    checks.check(
+        "t3-count-is-cardinality",
+        "formation count equals cardinality of occupied sites in W",
+        occ_count == len(occ_domain) and full_count == len(full_domain),
+    )
+    checks.check(
+        "t3-full-readout-domain",
+        "site readout of sigma_full is defined on all of W",
+        full_domain == window and site_readout(sigma_full, "y") == "B",
+    )
+    checks.check(
+        "t4-no-J",
+        "note does not adopt J",
+        "does not adopt `J`" in normalized_note or "does not adopt J" in note,
+    )
+    checks.check(
+        "t4-no-restore-I",
+        "note does not restore I",
+        "does not restore `I`" in normalized_note or "does not restore I" in note,
+    )
+    checks.check(
+        "t4-no-formation-rate",
+        "note does not pick a formation rate",
+        "does not pick a formation rate" in normalized_note,
+    )
+    checks.check(
+        "note-quotes-blank-unread",
+        "note quotes the live blank-unread sentence",
+        BLANK_UNREAD in note,
+    )
+    checks.check(
+        "note-status",
+        "note machine status is bounded-support",
+        "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the declared note and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/BLANK_SITE_UNREAD_OCCUPANCY_IS_NOT_SITE_READOUT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Live Record says a site with no record cannot be read. On `W={x,y}` with `σ_occ={x↦A}`, a site readout is defined only at `x`. Occupancy `o(y)=0` is a total extra field, not Record content. Old `I(W)` is a supplied-set count, not a live axiom readout. Does not adopt `J`, restore `I`, or pick a formation rate.

## What this means for the TOE

Blank-site occupancy is extra bookkeeping after the landed Record cut. Window counts are lemmas of a supplied set.

## Verification

```bash
python3 scripts/blank_site_unread_occupancy_is_not_site_readout_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.