### PR TITLE
[physics-loop] toe-lphys c2declare: bounded_theorem / bounded-support

### DIFF
--- a/docs/DECLARED_M3_CARRIER_IS_EXTRA_NOT_COMPOSITE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/DECLARED_M3_CARRIER_IS_EXTRA_NOT_COMPOSITE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,295 @@
+---
+claim_id: declared_m3_carrier_is_extra_not_composite_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "After the tensor/sum class of M_2 fails to host unital M_3, declaring M_3(C) as a one-object carrier is an extra object (a second carrier type), not a composite construction from Lattice+Qubit+S'. Sentence S names only one-site M_2(C). Displayed S' plus class C still excludes unital M_3 because 3 never divides 2^k and simplicity forces a unital map through one power-of-two summand. Displayed S'' names M_3 by declaration and is not adopted. C2 as a reading of 'full' removes a wall slogan, not the extra object. No QCD. No fifth axiom."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py
+---
+
+# Declared `M_3` Carrier Is Extra, Not Composite
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact leftover type after the `M_2` tensor/sum class fails to
+host unital `M_3(C)`: a declared larger carrier is an extra object, not
+a construction.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py`](../scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+This is a hypothetical leftover-type test, not an axiom edit.
+
+Live Qubit names one-site `M_2(C)`. After finite tensor and finite direct
+sum of that algebra fail to host unital `M_3`, the honest leftover type
+is “declare a larger carrier.” That leftover is an extra object — a
+second carrier type — not a composite construction from Lattice, Qubit,
+and a displayed composite reading.
+
+The C2 move that “full is a reading” removes a *wall slogan*. It does
+not supply the extra object. Color remains extra unless some later
+construction that is not in the tensor/sum class, and is not a silent
+declaration, is actually given.
+
+Display the leftover sentences. Do not adopt them. Do not adopt a fifth axiom.
+Do not call the leftover QCD.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Dimensions of M_2(C) and M_3(C) are counted from standard matrix units. Unital exclusion from the tensor/sum class is the integer obstruction 3 never divides 2^k plus simplicity of M_3. S'' is displayed declaration, not a theorem of Lattice+Qubit+S'. Adoption of S', S'', a fifth axiom, and any QCD identification remain open and are refused here."
+trace_class: negative_route_pruning
+target_claim_id: declared_m3_carrier_is_extra_not_composite
+target_blocker_text: "after tensor/sum fail, is declaring M_3 as a carrier a composite construction or an extra object"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for dimensions, class-C unital exclusion, and leftover type; other constructions remain unclaimed"
+hypothetical_axiom_status: "C2 leftover: declaring M_3 as a carrier is an extra object; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Current Qubit sentence **S**, quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+Let **S′** be the displayed, not adopted, C2 reading:
+
+> The local algebra is `M_2`; a physical object may be a declared finite
+> composite in the tensor/sum class `C` of `M_2`.
+
+Let **S′′** be a second displayed, not adopted, sentence:
+
+> There is also a declared one-object algebra `M_3(C)`.
+
+Write `A2 = M_2(C)` and `A3 = M_3(C)`. The standard matrix units
+`{E_{ij}: 1 ≤ i,j ≤ n}` are a basis of `M_n(C)` over `C`, so
+
+`dim_C A2 = 2·2 = 4`, `dim_C A3 = 3·3 = 9`.
+
+Let `C` be the smallest class of finite-dimensional unital C*-algebras
+such that `M_2(C) ∈ C` and `C` is closed under finite tensor product and
+finite direct sum. Every object of `C` is *-isomorphic to
+
+`M_{2^{k_1}} ⊕ ⋯ ⊕ M_{2^{k_r}}`
+
+for some `r ≥ 1` and `k_i ≥ 1`. Tensor of matrix algebras multiplies
+sizes that are powers of two; direct sum concatenates those sizes.
+
+A unital C-linear *-homomorphism `M_k(C) → M_m(C)` exists if and only if
+`k` divides `m`. The algebra `A3` is simple: its only two-sided ideals
+are `0` and itself. A unital *-hom `φ : A3 → ⊕_i M_{2^{k_i}}` composed
+with the coordinate projections is therefore either zero or a unital
+*-hom into that summand. Unitality forbids the all-zero case, so some
+coordinate is a unital *-hom `A3 → M_{2^{k}}`. That exists if and only
+if `3 | 2^{k}`.
+
+These objects are reconstructed here. They are not imported from a QCD
+package. Neither `S′` nor `S′′` is written into the axiom memo.
+
+## Theorem 1 — `dim M_2=4`, `dim M_3=9`, `9>4`; `S` does not name `M_3`
+
+Counting the standard matrix units gives `dim_C A2 = 4` and
+`dim_C A3 = 9`. Therefore
+
+`9 > 4`.
+
+Sentence `S` names the algebraic presentation `M_2(C)`. It does not name
+`M_3` and it does not name `M_3(C)`. The live axiom memo likewise does
+not name `M_3(C)`.
+
+This theorem is only a dimension comparison plus a textual non-naming.
+It does not identify `A3` with a physical color algebra.
+
+## Theorem 2 — `S′` plus class `C` still does not contain unital `M_3`
+
+Grant `S′` only as a displayed reading. The allowed composites are then
+the objects of `C`.
+
+For every `k ≥ 1`, `2^{k}` is a power of two, so its only prime factor
+is `2`. In particular
+
+`3 ∤ 2^{k}`.
+
+Hence there is no unital *-hom `A3 → M_{2^{k}}`. By simplicity of `A3`,
+there is also no unital *-hom `A3 → ⊕_i M_{2^{k_i}}` for any finite list
+of exponents. Explicit witnesses in `C` used by the runner are
+
+`M_2`, `M_2 ⊗ M_2 ≅ M_4`, `M_2 ⊕ M_2`, `M_4 ⊕ M_2`.
+
+Each has only power-of-two matrix-summand sizes, and `3` divides none of
+those sizes. So class `C` contains no unital copy of `M_3`.
+Sentence `S′` therefore does not supply `M_3`.
+
+The check is exact integer remainder, not a float tolerance.
+
+## Theorem 3 — `S′′` names `M_3` by declaration; that is extra
+
+Sentence `S′′` names `M_3(C)` by declaration:
+
+> There is also a declared one-object algebra `M_3(C)`.
+
+That is an extra object — a second carrier type — not a theorem of
+Lattice + Qubit + `S′`. Theorems 1 and 2 show that `S` does not name
+`M_3` and that `S′` plus `C` does not construct it. The only remaining
+move in this leftover is to put `M_3` in by hand.
+
+Display `S′′`. Do not adopt it. Do not call it QCD. Do not adopt a fifth axiom.
+
+## Theorem 4 — C2 as a reading removes a wall slogan, not the extra object
+
+Read current `S` as “nothing physical is larger than one-site `A2`.”
+That reading is a *wall slogan*: color cannot exist unless an axiom is
+added.
+
+Read `S` as naming only the one-site algebra, so that “full” is a
+reading rather than a ban on every larger physical object. That move
+removes the wall slogan. It does not produce `M_3`. Theorem 2 still
+says unital `M_3` is not in class `C`. Theorem 3 still says a declared
+one-object `M_3` is extra.
+
+Color remains extra unless some other construction — not in `C`, and
+not a silent declaration — is supplied later. This note does not
+supply that construction. This note does not rewrite the Qubit axiom.
+
+## Mutation Predicates
+
+The runner identity gates call `dim_m2()` and `dim_m3()`, which count
+standard matrix units.
+
+The predicate “the axiom memo names `M_3(C)`” is tested against the
+live memo text and must fail.
+
+The predicate “`9 ≤ 4`” is tested as `dim_m3() ≤ dim_m2()` and must
+fail.
+
+## Claim Boundary
+
+| Claim | Status in this note |
+|---|---|
+| `dim_C M_2(C)=4`, `dim_C M_3(C)=9`, `9>4` | proved by counting standard bases |
+| `S` does not name `M_3` | textual; quoted Qubit sentence and live memo |
+| `3 ∤ 2^{k}` for every finite `k` | prime factorization of a power of two |
+| no unital `M_3` in class `C` | simplicity plus the divisibility obstruction |
+| `S′` supplies `M_3` | false; Theorem 2 |
+| `S′′` is a theorem of Lattice+Qubit+`S′` | false; it is a declaration |
+| declared `M_3` is an extra object / second carrier type | Theorem 3 |
+| C2 as a reading removes the extra object | false; it removes a wall slogan only |
+| `S′` or `S′′` is the new Qubit axiom | not adopted |
+| a fifth axiom is adopted | not adopted |
+| `A3` is QCD | not claimed |
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance | Open-bridge status |
+|---|---|---|---|
+| current Qubit sentence `S` | exact semantic baseline | current axiom memo | supplied; not rewritten |
+| displayed sentence `S′` | C2 composite reading | this note | displayed; not adopted |
+| displayed sentence `S′′` | declared one-object `M_3` | this note | displayed; not adopted |
+| class `C` | finite tensor/sum closure of `M_2` | reconstructed here | comparison class only |
+| `A2`, `A3` | dimension and unital-hom witnesses | constructed here | not identified with SM objects |
+| color as physical content | none | not imported | remains extra |
+| QCD | none | not used | not applicable |
+
+Independent audit remains required before the repository may assign any
+effective claim status.
+
+## No-Go Discipline Gate
+
+The negative claim is only: declaring `M_3` as a carrier after tensor/sum
+fail is an extra object, not a composite in `C`. The gate does not
+certify that every later construction of a nine-dimensional algebra is
+impossible.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Live sentence `S` names `M_3` | quote Qubit | Theorem 1: `S` names `M_2(C)` only | **ATTEMPTED** |
+| Dimension coincidence | set `9 ≤ 4` | mutation: `9 > 4` | **ATTEMPTED** |
+| Unital `M_3` in class `C` | require `3 | 2^{k}` or a simple factor | Theorems 2: never | **ATTEMPTED** |
+| `S′` as a construction of `M_3` | composites in `C` supply color | Theorem 2: `S′` does not supply `M_3` | **ATTEMPTED** |
+| `S′′` as a theorem | declaration equals derivation | Theorem 3: extra object | **ATTEMPTED** |
+| C2 reading as removing the extra | wall slogan = extra object | Theorem 4: slogan only | **ATTEMPTED** |
+| Adopt `S′` or `S′′` | rewrite Qubit | refused | **CLOSED HERE** |
+| Adopt a fifth axiom / call it QCD | name color or QCD | refused | **CLOSED HERE** |
+| Other constructions not in `C` | later non-class, non-declaration route | not claimed | **LIVE / OUT OF SCOPE** |
+
+The broad statement “the axioms cannot derive color by any route” is
+not shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `9>4` / `3 ∤ 2^{k}` | no: dimension does not decide matrix-size divisibility | no: non-divisibility does not compute `3^2` | independent identities |
+| `S` non-naming / class-`C` exclusion | no: text does not prove unital homs | no: class `C` is not the live sentence | independent leftovers |
+| class-`C` exclusion / declared `S′′` | no: exclusion does not write `S′′` | no: a declaration is not a hom | extra vs construction |
+| wall-slogan removal / extra object | no: Theorem 4 separates them | no: extra remains after the slogan drops | independent readings |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `A2`, `A3`, class `C` | reconstructed finite matrix objects |
+| unital C-linear *-hom | standard finite-factor criterion `k | m` |
+| simplicity of `A3` | standard; forces factoring through one summand |
+| `S′`, `S′′` | explicit hypothetical readings; not adopted |
+| color / QCD | comparison language only; not identified |
+| observations or fitted constants | none |
+| float approximations | none; integer remainder only |
+
+### N4 — hostile counter-reading
+
+A reader might say: “C2 already allowed composites, so writing `M_3`
+is just naming the composite we wanted.” Class `C` is exactly those
+composites. Unital `M_3` is not among them. Writing `M_3` is a new
+carrier type, not a name for an object already in `C`.
+
+### N5 — exhaustion claim refused
+
+Only the tensor/sum class and the silent-declaration leftover are
+typed here. Other constructions are not exhausted.
+
+### N6 — axiom-edit refusal
+
+No axiom sentence is edited. The Qubit one-site `M_2(C)` wording remains
+the live parent.
+
+### N7 — adoption refusal
+
+`hypothetical_axiom_status` records the leftover and marks it
+**not adopted**. Neither `S′` nor `S′′` is adopted. No fifth axiom is
+proposed.
+
+### N8 — FAIL / DO NOT SHIP
+
+Do not ship any of the following as consequences of this note:
+
+- “an axiom update is necessary”
+- “declared `M_3` is a composite in `C`”
+- “`A3` is QCD”
+- “`S′` or `S′′` is now axiom content”
+
+## Live Parent Quote
+
+The only parent on the current public axiom memo is the Qubit
+one-site sentence, quoted for non-mutation:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+That sentence names a local algebra. It does not name `M_3`, the class
+`C` as axiom content, a declared one-object `M_3(C)`, a color primitive,
+or QCD.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2961,6 +2961,10 @@
   "de_sitter_curvature_gap_not_fierz_pauli_mass_diagnostic_bounded_theorem_note_2026-06-08": {
    "deps_hash": "0b315d22e768",
    "out_degree": 2
+  },
+  "declared_m3_carrier_is_extra_not_composite_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "declared_rg_map_uniform_chain_band_edge_fixed_point_nu_half_bounded_theorem_note_2026-06-12": {
    "deps_hash": "2d2872b7e917",

--- a/logs/runner-cache/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py
+runner_sha256: 927dd8fdbd295ca86180292cfcc59f7372ac2fc17e9c69122c700ad34acfe160
+input_fingerprint_sha256: 2cf42ab665e6606cb164ae0483f026361c236cecfca69eaf4bb224c985c10104
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; dimensions are counted from standard bases; class-C exclusion is exact integer remainder; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note and live axiom memo only
+negative_scope: declared M_3 is typed as extra, not as a composite in C; S' and S'' are displayed and not adopted
+PASS: identity-dim-m2 dim_m2() counts the four standard 2-by-2 matrix units
+PASS: identity-dim-m3 dim_m3() counts the nine standard 3-by-3 matrix units
+PASS: theorem1-nine-gt-four 9>4 so dim M_3 exceeds dim M_2
+PASS: theorem1-s-does-not-name-m3 sentence S names M_2(C) and does not name M_3
+PASS: theorem2-three-never-divides 3 does not divide 2^k for each k in 1..8
+PASS: theorem2-no-unital-into-power-of-two no unital *-hom M_3 -> M_{2^k} for k=1..8
+PASS: theorem2-simple-factor-witnesses unital M_3 is absent from the four class-C witnesses by simple factoring
+PASS: theorem2-sprime-does-not-supply-m3 S' plus class C does not supply M_3
+PASS: mutation-memo-names-m3 the predicate that the axiom memo names M_3(C) fails
+PASS: mutation-nine-le-four the predicate 9≤4 fails
+PASS: theorem3-sdoubleprime-is-declaration S'' names M_3 by declaration and is displayed as extra, not adopted
+PASS: theorem4-wall-slogan-not-extra C2 as a reading removes a wall slogan, not the extra object
+PASS: machine-status-contract the source uses the required leftover status and bounded-support fields
+PASS: live-qubit-nonmutation live axiom memo still states one-site M_2(C); leftover sentences are not adopted
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: no-qcd-no-fifth-axiom note refuses QCD identification and a fifth axiom; runner loads no QCD module
+per_element: identity gates call dim_m2() and dim_m3(); 3 ∤ 2^k is integer remainder
+per_site: A2 is the one-site algebra named by S; A3 is a comparison algebra only
+per_block: leftover type after class C is the only negative block tested
+lattice_wide: checked and not executed — no lattice-wide color or QCD claim
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py
+++ b/scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Exact leftover-type checks: declared M_3 is extra, not a composite.
+
+Counts dim M_2 and dim M_3 from standard matrix units, reconstructs that
+class C (finite tensor/sum of M_2) has no unital M_3 because 3 never
+divides 2^k and simplicity factors a unital map through one summand,
+and checks that displayed S'' is a declaration, not a theorem of
+Lattice+Qubit+S'. S' and S'' are not adopted. No QCD. No fifth axiom.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "DECLARED_M3_CARRIER_IS_EXTRA_NOT_COMPOSITE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/DECLARED_M3_CARRIER_IS_EXTRA_NOT_COMPOSITE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+S = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+S_PRIME = (
+    "The local algebra is `M_2`; a physical object may be a declared finite "
+    "composite in the tensor/sum class `C` of `M_2`."
+)
+S_DOUBLE_PRIME = "There is also a declared one-object algebra `M_3(C)`."
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def standard_matrix_units(n: int) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    units = []
+    for row in range(n):
+        for column in range(n):
+            matrix = [[0] * n for _ in range(n)]
+            matrix[row][column] = 1
+            units.append(tuple(tuple(entry) for entry in matrix))
+    return tuple(units)
+
+
+def dim_mn(n: int) -> int:
+    units = standard_matrix_units(n)
+    if len(set(units)) != len(units):
+        raise ValueError("standard matrix units are not distinct")
+    return len(units)
+
+
+def dim_m2() -> int:
+    return dim_mn(2)
+
+
+def dim_m3() -> int:
+    return dim_mn(3)
+
+
+def power_of_two(k: int) -> int:
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    return 2**k
+
+
+def three_divides_power_of_two(k: int) -> bool:
+    return power_of_two(k) % 3 == 0
+
+
+def unital_hom_exists(source_size: int, target_size: int) -> bool:
+    return target_size % source_size == 0
+
+
+def class_c_witness_summand_sizes() -> tuple[tuple[int, ...], ...]:
+    # M_2, M_2⊗M_2 ≅ M_4, M_2⊕M_2, M_4⊕M_2
+    return ((2,), (4,), (2, 2), (4, 2))
+
+
+def hosts_unital_m3(summand_sizes: tuple[int, ...]) -> bool:
+    # Simplicity: a unital *-hom into a finite sum factors through one summand.
+    return any(unital_hom_exists(3, size) for size in summand_sizes)
+
+
+def predicate_memo_names_m3(axiom_text: str) -> bool:
+    return "M_3(C)" in axiom_text
+
+
+def predicate_nine_le_four() -> bool:
+    return dim_m3() <= dim_m2()
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "dimensions are counted from standard bases; class-C exclusion is "
+        "exact integer remainder; no observational or fitted inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note and live "
+        "axiom memo only"
+    )
+    print(
+        "negative_scope: declared M_3 is typed as extra, not as a composite "
+        "in C; S' and S'' are displayed and not adopted"
+    )
+
+    d2 = dim_m2()
+    d3 = dim_m3()
+
+    checks.check(
+        "identity-dim-m2",
+        "dim_m2() counts the four standard 2-by-2 matrix units",
+        d2 == 2 * 2 and d2 == len(standard_matrix_units(2)),
+    )
+    checks.check(
+        "identity-dim-m3",
+        "dim_m3() counts the nine standard 3-by-3 matrix units",
+        d3 == 3 * 3 and d3 == len(standard_matrix_units(3)),
+    )
+    checks.check(
+        "theorem1-nine-gt-four",
+        "9>4 so dim M_3 exceeds dim M_2",
+        d3 > d2,
+    )
+    checks.check(
+        "theorem1-s-does-not-name-m3",
+        "sentence S names M_2(C) and does not name M_3",
+        "M_2(C)" in S and "M_3" not in S and S in axiom and S in note,
+    )
+    remainders = tuple(power_of_two(k) % 3 for k in range(1, 9))
+    checks.check(
+        "theorem2-three-never-divides",
+        "3 does not divide 2^k for each k in 1..8",
+        remainders == (2, 1, 2, 1, 2, 1, 2, 1)
+        and all(not three_divides_power_of_two(k) for k in range(1, 9)),
+    )
+    checks.check(
+        "theorem2-no-unital-into-power-of-two",
+        "no unital *-hom M_3 -> M_{2^k} for k=1..8",
+        all(not unital_hom_exists(3, power_of_two(k)) for k in range(1, 9)),
+    )
+    witnesses = class_c_witness_summand_sizes()
+    checks.check(
+        "theorem2-simple-factor-witnesses",
+        "unital M_3 is absent from the four class-C witnesses by simple factoring",
+        witnesses == ((2,), (4,), (2, 2), (4, 2))
+        and all(not hosts_unital_m3(sizes) for sizes in witnesses),
+    )
+    checks.check(
+        "theorem2-sprime-does-not-supply-m3",
+        "S' plus class C does not supply M_3",
+        normalize(S_PRIME) in normalized_note
+        and "Sentence `S′` therefore does not supply `M_3`." in note
+        and "So class `C` contains no unital copy of `M_3`." in note,
+    )
+    checks.check(
+        "mutation-memo-names-m3",
+        "the predicate that the axiom memo names M_3(C) fails",
+        not predicate_memo_names_m3(axiom),
+    )
+    checks.check(
+        "mutation-nine-le-four",
+        "the predicate 9≤4 fails",
+        not predicate_nine_le_four() and d3 > d2,
+    )
+    checks.check(
+        "theorem3-sdoubleprime-is-declaration",
+        "S'' names M_3 by declaration and is displayed as extra, not adopted",
+        S_DOUBLE_PRIME in note
+        and all(
+            phrase in note
+            for phrase in (
+                "That is an extra object — a second carrier type — not a theorem of",
+                "Lattice + Qubit + `S′`.",
+                "Display `S′′`. Do not adopt it. Do not call it QCD.",
+            )
+        )
+        and S_DOUBLE_PRIME not in axiom
+        and S_PRIME not in axiom,
+    )
+    checks.check(
+        "theorem4-wall-slogan-not-extra",
+        "C2 as a reading removes a wall slogan, not the extra object",
+        all(
+            phrase in note
+            for phrase in (
+                "removes a *wall slogan*",
+                "It does not produce `M_3`.",
+                "Color remains extra unless some other construction",
+                "not in `C`, and",
+                "not a silent declaration",
+            )
+        ),
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required leftover status and bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                'hypothetical_axiom_status: "C2 leftover: declaring M_3 as a carrier is an extra object; not adopted"',
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "live-qubit-nonmutation",
+        "live axiom memo still states one-site M_2(C); leftover sentences are not adopted",
+        S in axiom
+        and "Do not adopt a fifth axiom." in note
+        and "Do not adopt them." in note
+        and "Neither `S′` nor `S′′` is written into the axiom memo." in note
+        and "declared one-object algebra" not in axiom,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/DECLARED_M3_CARRIER_IS_EXTRA_NOT_COMPOSITE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and (
+            "AUDIT_INPUT_PATHS = (\n"
+            '    "docs/DECLARED_M3_CARRIER_IS_EXTRA_NOT_COMPOSITE_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",\n'
+            '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+            ")"
+        )
+        in self_source,
+    )
+    qcd_module_load = "from " + "qcd"
+    checks.check(
+        "no-qcd-no-fifth-axiom",
+        "note refuses QCD identification and a fifth axiom; runner loads no QCD module",
+        all(
+            phrase in note
+            for phrase in (
+                "Do not call it QCD.",
+                "Do not adopt a fifth axiom.",
+                "`A3` is QCD",
+                "not adopted",
+            )
+        )
+        and qcd_module_load not in self_source.lower()
+        and qcd_module_load not in note.lower()
+        and "**Type:** bounded_theorem" in note,
+    )
+
+    print("per_element: identity gates call dim_m2() and dim_m3(); 3 ∤ 2^k is integer remainder")
+    print("per_site: A2 is the one-site algebra named by S; A3 is a comparison algebra only")
+    print("per_block: leftover type after class C is the only negative block tested")
+    print("lattice_wide: checked and not executed — no lattice-wide color or QCD claim")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Live `S` names one-site `M_2(C)` and does not name `M_3`. Displayed `S'` plus class `C` still excludes unital `M_3`. Displayed `S''` names `M_3` by declaration: extra object, not a composite construction. C2 as a reading of “full” removes a wall slogan, not the extra. Not adopted. No fifth axiom. No QCD.

## What this means for the TOE

After tensor/sum fail, the honest leftover is declaration. That is H_extra, not a theorem of Lattice+Qubit+`S'`.

## Verification

```bash
python3 scripts/declared_m3_carrier_is_extra_not_composite_hypothetical_2026_08_13.py
# TOTAL: PASS=16 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.