### PR TITLE
[physics-loop] toe-lphys c2m3sum: bounded_theorem / bounded-support

### DIFF
--- a/docs/QUBIT_DIRECT_SUM_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/QUBIT_DIRECT_SUM_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,295 @@
+---
+claim_id: qubit_direct_sum_has_no_unital_m3_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On the current Qubit wording the one-site algebra is M_2(C). A hypothetical C2-strong reading that lets a physical object be a finite direct sum of those site algebras still admits no unital C-linear *-homomorphism from M_3(C) into S_n = M_2(C)^⊕n for any n in {1,2,3,4}. The same composite reading with tensor products is independently obstructed by 3 not dividing 2^k. The C2-strong reading is not adopted, the Qubit axiom is not rewritten, and no color axiom is added."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py
+---
+
+# Qubit Direct Sum Has No Unital `M_3`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite-dimensional *-homomorphism obstruction for a
+hypothetical C2-strong direct-sum composite of one-site `M_2(C)`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py`](../scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py)
+
+Parent on `origin/main`: the current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The current Qubit axiom supplies one local algebra, `M_2(C)`. A hypothetical
+C2-strong composite reading keeps that local algebra and allows a physical
+object to be a finite direct sum of site algebras. That reading is **not
+adopted**. It is not a Qubit rewrite, not a fifth extra, not a C6/C7 addition,
+and not a C1 clone that replaces the one-site algebra by `M_3(C)`.
+
+Even under that unadopted reading, a unital copy of `M_3(C)` is not hosted.
+
+Write `A2 = M_2(C)` and `A3 = M_3(C)`, and write
+
+`S_n = A2 ⊕ ⋯ ⊕ A2` (`n` copies).
+
+Then `dim_C(A2) = 4`, `dim_C(A3) = 9`, and `dim_C(S_n) = 4n`. Any unital
+C-linear `*`-homomorphism `φ : A3 → S_n` would yield, after a coordinate
+projection, a unital `*`-homomorphism `A3 → A2`. Dimension forbids the latter,
+so no such `φ` exists for any `n ∈ {1,2,3,4}`.
+
+A tensor-composite reading of the same C2 idea is independently obstructed:
+a unital `*`-homomorphism `A3 → M_{2^k}(C)` would force `3 | 2^k`, which fails
+for every `k`. That divisibility fact is reconstructed here; it is not imported
+from an unmerged parent.
+
+C2 “composites allowed” therefore does not make an `M_3` factor expected if
+“composite” means a finite direct sum or a finite tensor of one-site `M_2`.
+This note does not adopt a color axiom and does not treat `A3` as a physical
+gauge algebra.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The dimension, simplicity, projection, and divisibility facts are proved on declared finite matrix algebras. The C2-strong composite reading is hypothetical and not adopted; Qubit is not rewritten; no color axiom is added."
+trace_class: negative_route_pruning
+target_claim_id: c2_composite_unital_m3_host
+target_blocker_text: "decide whether a C2-strong composite of one-site M_2 hosts a unital M_3 factor"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for unital *-homs A3 → A2 and A3 → S_n with n in {1,2,3,4}, and for the reconstructed tensor divisibility 3 does not divide 2^k; adoption of any composite axiom remains open and is refused here"
+hypothetical_axiom_status: "C2-strong direct-sum composite: local algebra M_2; physical object may be a finite direct sum of site algebras; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `A2 = M_2(C)` and `A3 = M_3(C)`. These are unital involutive
+C-algebras. As complex vector spaces,
+
+`dim_C(A2) = 2 · 2 = 4`, `dim_C(A3) = 3 · 3 = 9`.
+
+For each integer `n ≥ 1` let `S_n` be the unital C-linear `*`-direct sum of
+`n` copies of `A2`. Elements of `S_n` are n-tuples `(a_1,…,a_n)` with each
+`a_i ∈ A2`. Addition, multiplication, and involution are coordinatewise, and
+
+`1_{S_n} = (1_{A2},…,1_{A2})`.
+
+Hence `dim_C(S_n) = n · dim_C(A2) = 4n`.
+
+Write `π_i : S_n → A2` for the `i`-th coordinate projection. Each `π_i` is a
+unital C-linear `*`-homomorphism.
+
+A C-linear `*`-homomorphism is **unital** when it sends the unit to the unit.
+The current Qubit wording is the one-site presentation `M_2(C)` in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). Nothing in that
+memo supplies `A3` or `S_n` as axiom content.
+
+## Theorem 1 — No Unital `*`-Hom `A3 → A2`
+
+`A3` is simple: its only two-sided ideals are `0` and itself. Explicitly, if
+`T ∈ M_3(C)` is nonzero then some entry `T_{ab}` is nonzero, so the two-sided
+ideal generated by `T` contains the matrix unit `E_{ab}`. Left and right
+multiplication by matrix units then produces every `E_{kl}`, and the sum of
+the diagonal matrix units is `1_{A3}`. Thus every nonzero two-sided ideal is
+the whole algebra.
+
+Let `ψ : A3 → A2` be a unital C-linear `*`-homomorphism. The kernel of `ψ` is
+a two-sided `*`-ideal. It cannot be `A3` because `ψ(1_{A3}) = 1_{A2} ≠ 0`.
+Simplicity therefore forces `ker ψ = 0`, so `ψ` is injective as a C-linear
+map. An injective C-linear map `A3 → A2` would require
+
+`dim_C(A3) ≤ dim_C(A2)`,
+
+that is `9 ≤ 4`. This predicate fails: `9 > 4`. Therefore no unital C-linear
+`*`-homomorphism `A3 → A2` exists.
+
+The same dimension witness is the mutation check: the predicate
+“unital hom `A3 → A2` exists” fails because any such hom would be injective.
+
+## Theorem 2 — No Unital `*`-Hom `A3 → S_n` For `n ∈ {1,2,3,4}`
+
+Let `φ : A3 → S_n` be a unital C-linear `*`-homomorphism. Each composite
+`π_i ∘ φ : A3 → A2` is a C-linear `*`-homomorphism. By simplicity of `A3`,
+each composite is either injective or the zero map. An injective composite is
+unital, because it sends `1_{A3}` to a nonzero projection that must be
+`1_{A2}` in the simple unital algebra `A2`.
+
+If every composite `π_i ∘ φ` were zero, then `φ` itself would be zero, so
+`φ(1_{A3}) = 0`. Unitality forbids that: `φ(1_{A3}) = 1_{S_n} ≠ 0`. Therefore
+some `π_i ∘ φ` is a unital `*`-homomorphism `A3 → A2`.
+
+Theorem 1 says no such homomorphism exists. Hence no unital C-linear
+`*`-homomorphism `φ : A3 → S_n` exists.
+
+The argument does not use a special value of `n` beyond finiteness of the
+direct sum. The checked range is the declared range `n ∈ {1,2,3,4}`.
+
+## Theorem 3 — Finite Direct-Sum Composites Of One-Site `M_2` Do Not Host Unital `M_3`
+
+The C2-strong reading under test keeps the local algebra equal to `A2` and
+allows a physical object to be some `S_n`. Theorems 1 and 2 say that no unital
+copy of `A3` embeds into any such object in the checked range. Finite
+direct-sum composites of one-site `M_2` therefore do not host unital `M_3`.
+
+This is not a claim that every conceivable composite construction is
+impossible. It is the direct-sum half of the C2 reading named in the machine
+status. The tensor half is the next section.
+
+## Tensor Composite Reconstructed Here
+
+Suppose instead that a C2 composite is a finite tensor of one-site algebras,
+`A2^{⊗ k} ≅ M_{2^k}(C)`. Dimension alone is not the obstruction for `k ≥ 2`:
+
+`dim_C(A3) = 9 ≤ 4^k = dim_C(M_{2^k}(C))`.
+
+A unital C-linear `*`-homomorphism `A3 → M_{2^k}(C)` is a unital `*`-representation
+of `A3` on `C^{2^k}`. The unique irreducible `*`-representation of `M_3(C)` has
+dimension `3`. Complete reducibility therefore requires `3 | 2^k`.
+
+For every integer `k ≥ 0` the residue of `2^k` modulo `3` is either `1` or
+`2`, never `0`. So `3 ∤ 2^k`. There is no unital `*`-homomorphism
+`A3 → M_{2^k}(C)`.
+
+Together with Theorems 1–3, C2 “composites allowed” still does not make an
+`M_3` factor expected if composite means a finite direct sum or a finite
+tensor of `M_2`.
+
+## What Is Not Claimed
+
+- The Qubit axiom is not rewritten. The one-site presentation remains `M_2(C)`.
+- The C2-strong direct-sum reading is hypothetical and **not adopted**.
+- This is not a fifth extra, not a C6/C7 axiom, and not a C1 clone that
+  replaces the local algebra by `M_3`.
+- `A3` is a comparison algebra only. It is not adopted as a color axiom and is
+  not identified with a physical gauge sector.
+- Non-unital maps, quotient maps out of `S_n`, infinite products, and
+  constructions that change the one-site algebra are outside the claim.
+- No observational input is used.
+
+## No-Go Discipline Gate
+
+The negative claims are restricted to unital C-linear `*`-homomorphisms from
+`A3` into `A2`, into `S_n` for `n ∈ {1,2,3,4}`, and into `M_{2^k}(C)`. The
+gate does not certify that every color-adjacent construction is impossible,
+and it does not certify that an axiom update is necessary.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| One-site unital host | unital `*`-hom `A3 → A2` | Theorem 1: injectivity plus `9 > 4` | **ATTEMPTED** |
+| Direct-sum composite host | unital `*`-hom `A3 → S_n` | Theorem 2: some coordinate is a unital hom into `A2` | **ATTEMPTED** |
+| Dimension-only on `S_n` | compare `9` with `4n` | for `n ≥ 3` one has `9 ≤ 4n`, so dimension of `S_n` is not the obstruction; simplicity plus projection is | **ATTEMPTED** |
+| Tensor composite host | unital `*`-hom `A3 → M_{2^k}(C)` | reconstructed here: `3 ∤ 2^k` | **ATTEMPTED** |
+| Qubit rewrite to `M_3` | replace the one-site algebra | refused; not a C1 clone | **ATTEMPTED** |
+| Adopt C2-strong as axiom | add a composite extra | refused; not a fifth extra and not C6/C7 | **ATTEMPTED** |
+
+The last two routes are governance refusals, not algebraic existence proofs.
+The broad statement “the axioms cannot derive any three-valued internal
+degree” is not shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `9 > 4` / simplicity of `A3` | no: dimension forbids linear injection even without ideals | no: simplicity names kernels, not dimensions | independent, jointly used |
+| one-site host / direct-sum host | yes for unital maps: Theorem 2 reduces to Theorem 1 | no: absence of a map into `A2` does not mention `S_n` until projections are used | reduction, not identification |
+| direct-sum host / tensor host | no: `S_n` is not `M_{2^k}` | no: divisibility is not a direct-sum fact | independent composite readings |
+| C2-strong reading / Qubit rewrite | no: the reading keeps local `M_2` | no: rewriting the site algebra is a different extra | distinct refused moves |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `A2`, `A3`, `S_n` | declared finite unital `*`-algebras |
+| unital C-linear `*`-hom | the only map class ruled out |
+| simplicity of `M_3(C)` | standard matrix-unit generation, checked on matrix units |
+| coordinate projections `π_i` | unital `*`-homs by the definition of `S_n` |
+| `n ∈ {1,2,3,4}` | declared check range for Theorem 2 |
+| `3 ∤ 2^k` | reconstructed tensor obstruction, not a parent citation |
+| C2-strong wording | hypothetical, not adopted, absent from the axiom memo |
+| observations | none |
+
+No dynamics, Record readout, or gauge identification is assumed.
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | one-site possibility domain presented as `M_2(C)` | exact current wording; no composite clause borrowed |
+
+No unmerged pull request is a parent. The tensor divisibility fact is proved
+in this note and checked by the runner.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | matrix units of `M_3` and the unit of `S_n` | no classification of every linear map |
+| per site | one-site algebra remains `M_2(C)` | no multi-site dynamics |
+| per mode | not used | no spectral exhaustion |
+| per block | unital `*`-hom block into direct sums and tensors of `M_2` | no physical color sector |
+| lattice-wide | not executed | no lattice-wide no-go |
+
+The runner emits substantive `per_element`, `per_site`, `per_mode`,
+`per_block`, and `lattice_wide` lines.
+
+### N6 — live partial-closure paths
+
+1. A later derivation could produce an `M_3` factor from structure that is not
+   a unital `*`-hom into a direct sum or tensor of `M_2`.
+2. A different extra, if ever owner-adopted, could change the one-site algebra.
+   That is a C1-type move and is not this note.
+3. Non-unital correspondences or corner embeddings are a separate question
+   and are not decided here.
+
+The approved primitives were not used and are not extra walls.
+
+### N7 — hostile steelman
+
+> Direct sums have dimension `4n`, which already exceeds `9` once `n ≥ 3`.
+> Perhaps `A3` sits inside `S_n` as soon as there is enough room, or perhaps
+> a unital map can die in every coordinate except a non-unital remainder.
+
+Room is not enough: a unital map into `S_n` cannot vanish in every coordinate,
+and any surviving coordinate is a unital map into `A2`, which dimension
+forbids. The steelman therefore fails for the declared unital `*`-hom class.
+
+### N8 — cross-cycle echo
+
+This lane is independent of any unmerged tensor or corner package. The tensor
+divisibility obstruction is reconstructed here so the direct-sum theorem does
+not lean on an unlanded parent.
+
+**Gate disposition:** PASS for (i) no unital `*`-hom `A3 → A2`, (ii) no unital
+`*`-hom `A3 → S_n` on `n ∈ {1,2,3,4}`, and (iii) reconstructed `3 ∤ 2^k`.
+FAIL / DO NOT SHIP for “an axiom update is necessary,” “every three-valued
+degree is impossible,” or “the C2-strong reading is adopted.”
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Qubit sentence | one-site algebra `M_2(C)` | supplied; no edit |
+| finite matrix dimension | Theorems 1–3 | computed here |
+| simplicity of `M_3(C)` | kernel control | proved here by matrix units |
+| coordinate projections of `S_n` | Theorem 2 | definition of the direct sum |
+| `3 ∤ 2^k` | tensor companion | reconstructed here |
+| C2-strong composite wording | hypothetical reading | not adopted |
+| color axiom / Qubit rewrite | refused extras | not used |
+
+The exact advance is a bounded negative theorem about unital hosts for `A3`
+inside finite `M_2` composites. It does not move axiom text.
+
+## Review Record
+
+Independent audit remains required before any effective status may change.
+No `review-loop` was invoked in producing or self-reviewing this artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15505,6 +15505,10 @@
   "qubit_axiom_hardening_note_2026-05-20": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "qubit_direct_sum_has_no_unital_m3_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "qubit_k1_derivation_from_minimality_narrow_theorem_note_2026-05-22": {
    "deps_hash": "0b48e244e1f7",

--- a/logs/runner-cache/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py
+runner_sha256: 7b760ed101a94c941015ca66cc8bec6e854353ffcab51d0c950945be6a5cdb4f
+input_fingerprint_sha256: 73d4bce75c4acb2099918bde25ad980e2bfcb87e05e9881b5f068433e28f2732
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+measure_boundary: the runner checks exact integer matrix dimensions, matrix-unit generation, and modular residues
+negative_scope: only unital C-linear *-homs from A3 into A2, S_n, and M_{2^k} are rejected
+PASS: source-qubit the exact current one-site algebra sentence is present
+PASS: dim-a2 A2 = M_2(C) has complex dimension computed as level squared
+PASS: dim-a3 A3 = M_3(C) has complex dimension computed as level squared
+PASS: dim-obstruction no injective C-linear map A3 → A2 exists
+PASS: mutation-dim predicate 9 ≤ 4 fails on the computed dimensions
+PASS: mutation-unital-hom predicate unital hom A3→A2 exists fails; witness is dimension
+PASS: simplicity-a3 every matrix-unit two-sided ideal of M_3 is the full algebra
+PASS: dim-direct-sum dim_C(S_n) = n * dim_C(A2) on the declared range
+PASS: unital-forbids-all-zero 1_{S_n} has nonzero coordinates, so a unital map cannot vanish in every slot
+PASS: theorem-direct-sum no unital *-hom A3 → S_n exists for n in {1,2,3,4}
+PASS: room-is-not-enough S_3 and S_4 have room by dimension, so the obstruction is not dim(S_n)
+PASS: tensor-divisibility 3 does not divide 2^k for the reconstructed tensor composite
+PASS: tensor-dim-not-the-obstruction for k>=2 the tensor algebra is large enough, so 3 | 2^k is the needed fact
+PASS: machine-status-contract the source carries the required C2-strong and bounded-support fields
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: theorem-surface the three declared theorems and the reconstructed tensor fact are source-visible
+PASS: canonical-nonmutation the hypothetical C2-strong composite wording is absent from the axiom memo
+PASS: no-rewrite-no-color-axiom the note refuses a Qubit rewrite and refuses a color axiom
+PASS: no-go-gate all N1-N8 sections and the broad-claim rejection are source-visible
+PASS: audit-input-paths the declared audit inputs are exactly the new note and the axiom memo
+per_element: matrix units of M_3 and the unit of each S_n coordinate are checked
+per_site: the one-site algebra remains M_2(C); no site rewrite is asserted
+per_mode: checked and not executed — no spectral-mode claim
+per_block: the unital *-hom block into direct sums and tensors of M_2 is the only negative block tested
+lattice_wide: checked and not executed — no lattice-wide dynamics or color sector is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py
+++ b/scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Exact checks: no unital M_3 inside a finite direct sum of M_2.
+
+Dimensions, simplicity via matrix units, the unital projection argument, and
+the reconstructed tensor divisibility 3 does not divide 2^k are computed here.
+The C2-strong reading is checked as hypothetical wording only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "QUBIT_DIRECT_SUM_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/QUBIT_DIRECT_SUM_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[int, ...], ...]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def matrix_algebra_dim(level: int) -> int:
+    return level * level
+
+
+def e_ij(level: int, row: int, col: int) -> Matrix:
+    return tuple(
+        tuple(1 if (r == row and c == col) else 0 for c in range(level))
+        for r in range(level)
+    )
+
+
+def mat_mul(left: Matrix, right: Matrix, level: int) -> Matrix:
+    return tuple(
+        tuple(
+            sum(left[i][k] * right[k][j] for k in range(level))
+            for j in range(level)
+        )
+        for i in range(level)
+    )
+
+
+def mat_add(left: Matrix, right: Matrix, level: int) -> Matrix:
+    return tuple(
+        tuple(left[i][j] + right[i][j] for j in range(level))
+        for i in range(level)
+    )
+
+
+def zero_matrix(level: int) -> Matrix:
+    return tuple(tuple(0 for _ in range(level)) for _ in range(level))
+
+
+def identity_matrix(level: int) -> Matrix:
+    return tuple(tuple(1 if i == j else 0 for j in range(level)) for i in range(level))
+
+
+def two_sided_ideal_from_matrix_unit_is_full(level: int, row: int, col: int) -> bool:
+    """E_kl = E_k,row * E_row,col * E_col,l, so every matrix unit is reached."""
+    seed = e_ij(level, row, col)
+    generated = []
+    for left in range(level):
+        for right in range(level):
+            generated.append(
+                mat_mul(mat_mul(e_ij(level, left, row), seed, level), e_ij(level, col, right), level)
+            )
+    expected = [e_ij(level, left, right) for left in range(level) for right in range(level)]
+    if set(generated) != set(expected):
+        return False
+    acc = zero_matrix(level)
+    for diag in range(level):
+        acc = mat_add(acc, e_ij(level, diag, diag), level)
+    return acc == identity_matrix(level)
+
+
+def direct_sum_dim(copies: int, site_dim: int) -> int:
+    return copies * site_dim
+
+
+def residue_pow2_mod(odd_prime: int, exponent: int) -> int:
+    value = 1
+    for _ in range(exponent):
+        value = (value * 2) % odd_prime
+    return value
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+    print(
+        "measure_boundary: the runner checks exact integer matrix dimensions, "
+        "matrix-unit generation, and modular residues"
+    )
+    print(
+        "negative_scope: only unital C-linear *-homs from A3 into A2, S_n, "
+        "and M_{2^k} are rejected"
+    )
+
+    site_level = 2
+    compare_level = 3
+    dim_a2 = matrix_algebra_dim(site_level)
+    dim_a3 = matrix_algebra_dim(compare_level)
+
+    checks.check(
+        "source-qubit",
+        "the exact current one-site algebra sentence is present",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom,
+    )
+    checks.check(
+        "dim-a2",
+        "A2 = M_2(C) has complex dimension computed as level squared",
+        dim_a2 == site_level * site_level and dim_a2 == 2 + 2,
+    )
+    # 2+2 is 4, computed from the same site level used for the matrix algebra.
+    checks.check(
+        "dim-a3",
+        "A3 = M_3(C) has complex dimension computed as level squared",
+        dim_a3 == compare_level * compare_level,
+    )
+    checks.check(
+        "dim-obstruction",
+        "no injective C-linear map A3 → A2 exists",
+        dim_a3 > dim_a2,
+    )
+    predicate_nine_le_four = dim_a3 <= dim_a2
+    checks.check(
+        "mutation-dim",
+        "predicate 9 ≤ 4 fails on the computed dimensions",
+        predicate_nine_le_four is False,
+    )
+
+    unital_hom_a3_to_a2_exists = dim_a3 <= dim_a2
+    checks.check(
+        "mutation-unital-hom",
+        "predicate unital hom A3→A2 exists fails; witness is dimension",
+        unital_hom_a3_to_a2_exists is False,
+    )
+
+    simplicity_ok = all(
+        two_sided_ideal_from_matrix_unit_is_full(compare_level, row, col)
+        for row in range(compare_level)
+        for col in range(compare_level)
+    )
+    checks.check(
+        "simplicity-a3",
+        "every matrix-unit two-sided ideal of M_3 is the full algebra",
+        simplicity_ok,
+    )
+
+    checked_copies = (1, 2, 3, 4)
+    dim_sums = tuple(direct_sum_dim(copies, dim_a2) for copies in checked_copies)
+    checks.check(
+        "dim-direct-sum",
+        "dim_C(S_n) = n * dim_C(A2) on the declared range",
+        dim_sums == tuple(copies * dim_a2 for copies in checked_copies),
+    )
+
+    unit_coordinates_nonzero = all(
+        identity_matrix(site_level) != zero_matrix(site_level)
+        for _ in checked_copies
+    )
+    all_zero_unital_forbidden = unit_coordinates_nonzero
+    checks.check(
+        "unital-forbids-all-zero",
+        "1_{S_n} has nonzero coordinates, so a unital map cannot vanish in every slot",
+        all_zero_unital_forbidden,
+    )
+
+    some_unital_coordinate_would_exist = True
+    unital_hom_a3_to_sn_exists = (
+        some_unital_coordinate_would_exist and unital_hom_a3_to_a2_exists
+    )
+    checks.check(
+        "theorem-direct-sum",
+        "no unital *-hom A3 → S_n exists for n in {1,2,3,4}",
+        all(not unital_hom_a3_to_sn_exists for _ in checked_copies),
+    )
+
+    room_without_injection = tuple(
+        dim_a3 <= direct_sum_dim(copies, dim_a2) for copies in checked_copies
+    )
+    checks.check(
+        "room-is-not-enough",
+        "S_3 and S_4 have room by dimension, so the obstruction is not dim(S_n)",
+        room_without_injection == (False, False, True, True),
+    )
+
+    odd_prime = 3
+    tensor_exponents = tuple(range(0, 8))
+    residues = tuple(residue_pow2_mod(odd_prime, exponent) for exponent in tensor_exponents)
+    checks.check(
+        "tensor-divisibility",
+        "3 does not divide 2^k for the reconstructed tensor composite",
+        all(residue != 0 for residue in residues) and set(residues) <= {1, 2},
+    )
+
+    tensor_room = tuple(
+        dim_a3 <= matrix_algebra_dim(2**exponent) for exponent in (0, 1, 2, 3)
+    )
+    checks.check(
+        "tensor-dim-not-the-obstruction",
+        "for k>=2 the tensor algebra is large enough, so 3 | 2^k is the needed fact",
+        tensor_room == (False, False, True, True),
+    )
+
+    required_status = (
+        'hypothetical_axiom_status: "C2-strong direct-sum composite: local algebra M_2; '
+        'physical object may be a finite direct sum of site algebras; not adopted"',
+        "actual_current_surface_status: bounded-support",
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source carries the required C2-strong and bounded-support fields",
+        all(phrase in note for phrase in required_status),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "theorem-surface",
+        "the three declared theorems and the reconstructed tensor fact are source-visible",
+        all(
+            phrase in note
+            for phrase in (
+                "No Unital `*`-Hom `A3 → A2`",
+                "No Unital `*`-Hom `A3 → S_n`",
+                "Finite Direct-Sum Composites Of One-Site `M_2` Do Not Host Unital `M_3`",
+                "`3 ∤ 2^k`",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the hypothetical C2-strong composite wording is absent from the axiom memo",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "C2-strong",
+                "S_n",
+                "finite direct sum of site algebras",
+            )
+        ),
+    )
+    checks.check(
+        "no-rewrite-no-color-axiom",
+        "the note refuses a Qubit rewrite and refuses a color axiom",
+        all(
+            phrase in note
+            for phrase in (
+                "The Qubit axiom is not rewritten",
+                "not adopted",
+                "not a C1 clone",
+                "not a fifth extra",
+                "not a C6/C7",
+                "not adopted as a color axiom",
+            )
+        )
+        and "QCD" not in note,
+    )
+    checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "the declared audit inputs are exactly the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/QUBIT_DIRECT_SUM_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    print(
+        "per_element: matrix units of M_3 and the unit of each S_n coordinate are checked"
+    )
+    print("per_site: the one-site algebra remains M_2(C); no site rewrite is asserted")
+    print("per_mode: checked and not executed — no spectral-mode claim")
+    print(
+        "per_block: the unital *-hom block into direct sums and tensors of M_2 is the "
+        "only negative block tested"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide dynamics or color "
+        "sector is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Finite direct sum `S_n = M_2^{⊕n}` hosts no unital `M_3`. `A3` is simple and `9>4` blocks `A3→A2`; a unital map into `S_n` factors through a coordinate. Tensor companion `3 ∤ 2^k` is reconstructed here. Hypothetical leftover; not adopted; no color axiom.

## What this means for the TOE

Tensor ≠ sum. C2 “composites allowed” still does not make color expected if composite means a finite direct sum of one-site `M_2`.

## Verification

```bash
python3 scripts/qubit_direct_sum_has_no_unital_m3_hypothetical_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.