### PR TITLE
[physics-loop] toe-lphys c2m3class: bounded_theorem / bounded-support

### DIFF
--- a/docs/M2_TENSOR_SUM_CLASS_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/M2_TENSOR_SUM_CLASS_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,244 @@
+---
+claim_id: m2_tensor_sum_class_has_no_unital_m3_hypothetical_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The smallest class C of finite-dimensional unital C*-algebras containing M_2(C) and closed under finite tensor product and finite direct sum consists exactly of finite direct sums of matrix algebras of power-of-two size. Unital M_3(C) does not embed into any object of C, because a unital *-hom from the simple algebra M_3 factors through a unital *-hom into one summand M_{2^k}, which exists if and only if 3 divides 2^k. The result is a hypothetical C2-strong composite-class test. It does not adopt that class as a Qubit rewrite, does not declare a larger carrier, and does not identify M_3 with QCD."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py
+---
+
+# The `M_2` Tensor/Sum Class Has No Unital `M_3`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite-dimensional unital `C*`-algebra arithmetic for the
+class generated from one-site `M_2(C)` by finite tensor product and finite
+direct sum.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py`](../scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py)
+
+## Result Up Front
+
+Current Qubit names one local possibility algebra: `M_2(C)`. A leftover C2
+reading says that a physical object may still be a finite composite built from
+that local algebra by tensor and direct sum. Let `C` be exactly that generated
+class. Every object of `C` is `*-isomorphic` to a finite direct sum of matrix
+algebras whose sizes are powers of two. Unital `M_3` does not sit in any such
+object.
+
+Color, read here as a unital copy of `M_3`, is therefore not an expected
+construction on this class. The remaining C2 escape is a *declared* larger
+carrier — a different type — not a Lattice+Qubit composite in `C`. That
+declaration is displayed and not adopted. QCD is not imported. No axiom is
+edited.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The class form and the unital-division obstruction are proved on declared finite-dimensional C*-algebras generated from M_2 by finite tensor and finite direct sum. Adoption of that composite class as a Qubit rewrite, and any declared larger carrier, remain open and are not taken."
+trace_class: negative_route_pruning
+target_claim_id: c2_m2_tensor_sum_class_hosts_unital_m3
+target_blocker_text: "maybe some mix of tensor and direct sum of M_2 hosts unital M_3"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the generated tensor/sum class C; a declared larger carrier remains a different type and is not adopted"
+hypothetical_axiom_status: "C2-strong: composites are the class generated from M_2 by finite tensor and finite direct sum; not adopted"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+Independent audit remains required before any effective status may change. No
+canonical axiom edit.
+
+## Exact Objects
+
+The current Qubit sentence, quoted from
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), is:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+Write `A2 = M_2(C)` and `A3 = M_3(C)`. Complex dimensions are
+`dim_C(A2) = 2^2 = 4` and `dim_C(A3) = 3^2 = 9`.
+
+Let `C` be the smallest class of finite-dimensional unital `C*`-algebras such
+that `M_2(C) ∈ C` and `C` is closed under finite tensor product and finite
+direct sum.
+
+Tensor of matrix algebras multiplies sizes:
+`M_a ⊗ M_b ≅ M_{ab}`. Direct sum concatenates summands:
+`M_a ⊕ M_b` is the indicated two-summand algebra. Starting from `M_2` and
+closing under those operations, every object of `C` is `*-isomorphic` to
+
+```text
+M_{2^{k_1}} ⊕ ⋯ ⊕ M_{2^{k_r}}
+```
+
+for some `r ≥ 1` and integers `k_i ≥ 1`. No odd prime appears as a matrix
+size.
+
+A unital `C`-linear `*-homomorphism` `M_k → M_m` exists if and only if `k`
+divides `m`: the standard module `C^m` becomes a unital left `M_k`-module, so
+it is a multiple of `C^k`.
+
+`A3` is simple: its only closed two-sided ideals are `0` and itself. A unital
+`*-hom` `φ : M_3 → ⊕_i M_{2^{k_i}}` therefore cannot have nontrivial kernel.
+Composing with a coordinate projection `π_i` yields a `*-hom`
+`π_i ∘ φ : M_3 → M_{2^{k_i}}`. Unitality of `φ` sends the unit to the unit
+`(1,…,1)` of the sum, so some (in fact each) component is a unital `*-hom`
+`M_3 → M_{2^{k}}`. That map exists if and only if `3 | 2^{k}`, which is false
+for every integer `k ≥ 1`.
+
+The displayed C2-strong sentence `S'` (not adopted) is: local algebra is
+`M_2`; a physical object may be any member of the generated class `C`.
+
+The remaining displayed leftover `S''` (not adopted) is: there is also a
+declared one-object algebra `M_3(C)` of a different type, not required to lie
+in `C`.
+
+## Theorem 1 — four witnesses in `C`
+
+The following four objects lie in `C` and have only power-of-two matrix
+summand sizes.
+
+| Witness | Construction | Summand sizes | `dim_C` |
+|---|---|---|---|
+| `M_2` | generator | `2` | `4` |
+| `M_2 ⊗ M_2 ≅ M_4` | finite tensor | `4` | `16` |
+| `M_2 ⊕ M_2` | finite direct sum | `2, 2` | `8` |
+| `M_4 ⊕ M_2` | tensor then sum | `4, 2` | `20` |
+
+The concatenated summand-size list is `{2, 4, 2, 4, 2}`. Each entry is a
+positive power of two.
+
+## Theorem 2 — no unital `M_3` into the four witnesses
+
+`3` divides none of `{2, 4, 2, 4, 2}`. Therefore there is no unital `*-hom`
+`M_3 → M_2`, none `M_3 → M_4`, and, by the simplicity factoring of the
+previous section, none into `M_2 ⊕ M_2` or `M_4 ⊕ M_2`.
+
+Separately, `M_2 ⊕ M_2` is not `*-isomorphic` to `M_3`: the complex dimensions
+are `8` and `9`.
+
+## Theorem 3 — the obstruction is the whole class
+
+The same division obstruction holds for every object of `C`. Any
+`X ∈ C` is `*-isomorphic` to `⊕_i M_{2^{k_i}}` with each `k_i ≥ 1`. A unital
+`*-hom` `M_3 → X` would yield a unital `*-hom` `M_3 → M_{2^{k}}` for some `k`,
+hence `3 | 2^{k}`. No such `k` exists.
+
+Unital `M_3` is not an expected construction on this class. The leftover C2
+escape after tensor and sum is therefore a declared larger carrier (`S''`),
+not a Lattice+Qubit composite in `C`. `S'` and `S''` are displayed only.
+Neither is adopted. Neither is a Qubit rewrite. `A3` is not identified with
+QCD.
+
+## No-Go Discipline
+
+### N1 — materially distinct routes
+
+| Route | Status here |
+|---|---|
+| one-site unital `M_3 → M_2` | closed: `3 ∤ 2` |
+| finite tensor of `M_2` | closed: sizes `2^n`, and `3 ∤ 2^n` |
+| finite direct sum of `M_2` | closed: simplicity factors through a summand |
+| mixed finite tensor and finite direct sum (the class `C`) | closed by Theorems 1–3 |
+| declared larger carrier `S''` | a different type; displayed; not adopted |
+
+### N2 — wall independence and collapse
+
+The tensor obstruction (`3 ∤ 2^k`) and the sum obstruction (simplicity plus
+unital factoring) are independent elementary facts. Their join is not a new
+mechanism: it is the inductive closure of those two operations. Collapsing
+them into a slogan “composites can be anything” would hide that `C` is a
+specific class.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `C` | explicit generated class; not present in the current axioms |
+| `S'` | displayed C2-strong reading; not adopted |
+| `S''` | displayed leftover declaration of a larger carrier; not adopted |
+| unital `*-hom` | the only embedding type tested |
+| non-unital maps, corners, essential ideals | not claimed to be absent; not the C2 composite reading under test |
+| QCD, `SU(3)`, running couplings | not used |
+| observations or fitted constants | none |
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | one-site possibility domain `M_2(C)` | exact current Qubit wording only; no composite class is borrowed from the memo |
+
+No unmerged parent is cited. The class form and the division facts are proved
+here.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | four explicit witnesses and the concatenated size list `{2,4,2,4,2}` | no classification of every C*-algebra |
+| per site | local algebra remains `M_2` | no multi-site dynamics |
+| per mode | every finite tensor/sum word in `C` | no claim about objects outside `C` |
+| per block | unital `M_3` into `C` | no QCD identification |
+| lattice-wide | not executed | no lattice-wide color construction |
+
+### N6 — live partial-closure paths
+
+1. A later construction could place unital `M_3` in an object *not* in `C`.
+2. A declared larger carrier (`S''`) could be proposed as an extra object.
+   That is a different type, not a theorem of Lattice+Qubit+`S'`.
+3. A non-unital or corner embedding is a different mathematical question and
+   is not the unital composite reading tested here.
+
+None of those paths is taken here. An owner-approved extra object would still
+be an extra object.
+
+### N7 — hostile steelman
+
+> Perhaps no single tensor power and no single direct sum of `M_2` hosts
+> unital `M_3`, but some mixed word in tensor and direct sum does. The
+> generated class might be larger than the obvious power-of-two sums, or
+> simplicity might fail to force a unital map into one summand.
+
+The class form answers the first half: every mixed word reduces to
+`⊕_i M_{2^{k_i}}`. Simplicity plus unitality answers the second half. The
+steelman is the claim under test, and it fails on `C`.
+
+### N8 — cross-cycle echo
+
+Earlier C2 readings that treat “full” as local-only, and that allow
+composites, still have to name the composite *type*. Tensor alone and sum
+alone are two types. Their generated mix is a third named type, and it is
+still power-of-two matrix sums. Cross-cycle movement does not turn `S''` into
+a theorem.
+
+**Gate disposition:** PASS for (i) the four witnesses lie in `C` with only
+power-of-two summand sizes, (ii) `3` divides none of those sizes, and
+(iii) the same obstruction holds for every object of `C`. FAIL / DO NOT SHIP
+for “an axiom update is necessary,” “QCD is derived,” “every larger algebra is
+impossible,” or “the leftover declaration `S''` is adopted.”
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Qubit sentence | local algebra `M_2(C)` | supplied; no edit |
+| generated class `C` | hypothetical C2-strong composite type | displayed; not adopted |
+| unital division criterion | Theorem 2 and Theorem 3 | definition-level matrix algebra |
+| simplicity of `M_3` | factoring through a summand | standard `C*`-algebra fact used here |
+| declared larger carrier `S''` | leftover type after `C` | displayed; not adopted |
+| QCD / color gauge physics | none | not imported |
+| Qubit rewrite | none | not adopted |
+
+## Review Record
+
+Parents on `origin/main` are the axiom memo only. Independent audit remains
+required. No `review-loop` was invoked in producing or self-reviewing this
+artifact.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12189,6 +12189,10 @@
   "m2_tensor_d4_dimension_256_bounded_note_2026-05-26": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "m2_tensor_sum_class_has_no_unital_m3_hypothetical_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "m_dm_nsites_v_integer_16_factorization_enumeration_narrow_theorem_note_2026-05-28": {
    "deps_hash": "cce9e6a23a29",

--- a/logs/runner-cache/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.txt
+++ b/logs/runner-cache/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py
+runner_sha256: 9985bbfbfc2de57bdf81a3b1c5787bbfa86361bf315aedeecd5128698a504b08
+input_fingerprint_sha256: b946e2874d68b8a9c6e539ba28d7171878bec194200f3a18c94893ebbd51bac6
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: unital M_3 into the generated tensor/sum class is rejected; a declared larger carrier remains a different type
+PASS: source-qubit the current Qubit sentence names M_2(C) as the one-site algebra
+PASS: identity-dims dim_C(M_2)=4 and dim_C(M_3)=9
+PASS: theorem1-tensor-witness M_2⊗M_2 has size 4 and exponents (2,)
+PASS: theorem1-sum-witnesses M_2⊕M_2 dim=8; M_4⊕M_2 dim=20
+PASS: theorem1-power-of-two-summands concatenated summand sizes (2, 4, 2, 2, 4, 2) are powers of two
+PASS: theorem2-listed-sizes 3 divides none of listed sizes (2, 4, 2, 4, 2)
+PASS: theorem2-no-unital-m3 no unital M_3 into any of the four witnesses
+PASS: theorem3-universal-division 3 divides none of 2^k for k=1..8; remainders=(2, 1, 2, 1, 2, 1, 2, 1)
+PASS: theorem3-class-form every generated witness is a sum of M_{2^{k}} with k>=1
+PASS: mutation-three-divides-power-of-two predicate '3 divides 2^k for some k=1..8' fails
+PASS: mutation-sum-not-m3 predicate 'M_2⊕M_2 ≅ M_3' fails (8!=9)
+PASS: machine-status-contract the note carries the required C2-strong and bounded-support fields
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: non-adoption-surface the leftover declaration is displayed and QCD is refused
+PASS: no-go-gate all N1-N8 sections and the broad-claim rejection are source-visible
+PASS: declared-inputs AUDIT_INPUT_PATHS names the new note and the axiom memo, both present
+PASS: canonical-nonmutation the generated class notation is absent from the canonical axiom file
+per_element: four witnesses and the listed summand sizes {2,4,2,4,2}
+per_site: local algebra remains M_2; no multi-site dynamics claimed
+per_mode: k=1..8 powers of two checked against division by 3
+per_block: unital M_3 into the generated tensor/sum class only
+lattice_wide: checked and not executed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py
+++ b/scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Exact checks: the M_2 tensor/sum class hosts no unital M_3.
+
+The runner computes matrix dimensions, tensor sizes, and integer remainders.
+It does not adopt the generated class as a Qubit rewrite and does not import
+QCD.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/M2_TENSOR_SUM_CLASS_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/M2_TENSOR_SUM_CLASS_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def dim_matrix(size: int) -> int:
+    return size * size
+
+
+def dim_m2() -> int:
+    return dim_matrix(2)
+
+
+def dim_m3() -> int:
+    return dim_matrix(3)
+
+
+def tensor_matrix_size(left: int, right: int) -> int:
+    return left * right
+
+
+def direct_sum_dim(sizes: tuple[int, ...]) -> int:
+    return sum(dim_matrix(size) for size in sizes)
+
+
+def is_power_of_two(value: int) -> bool:
+    return value >= 2 and value.bit_count() == 1
+
+
+def divides(divisor: int, dividend: int) -> bool:
+    return dividend % divisor == 0
+
+
+def unital_matrix_hom_exists(source_size: int, target_size: int) -> bool:
+    return divides(source_size, target_size)
+
+
+def unital_m3_into_summands(sizes: tuple[int, ...]) -> bool:
+    return any(unital_matrix_hom_exists(3, size) for size in sizes)
+
+
+def three_divides_some_power_of_two(k_max: int) -> bool:
+    return any(divides(3, 2**k) for k in range(1, k_max + 1))
+
+
+def m2_oplus_m2_isomorphic_to_m3() -> bool:
+    return direct_sum_dim((2, 2)) == dim_m3()
+
+
+def tensor_exponents(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(a + b for a in left for b in right)
+
+
+def sum_exponents(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[int, ...]:
+    return left + right
+
+
+def sizes_from_exponents(exponents: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(2**k for k in exponents)
+
+
+@dataclass(frozen=True)
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> "Checks":
+        result = bool(condition)
+        if result:
+            object.__setattr__(self, "passed", self.passed + 1)
+        else:
+            object.__setattr__(self, "failed", self.failed + 1)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        return self
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+    print(
+        "negative_scope: unital M_3 into the generated tensor/sum class is "
+        "rejected; a declared larger carrier remains a different type"
+    )
+
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-qubit",
+        "the current Qubit sentence names M_2(C) as the one-site algebra",
+        qubit_sentence in axiom,
+    )
+
+    d2 = dim_m2()
+    d3 = dim_m3()
+    checks.check(
+        "identity-dims",
+        f"dim_C(M_2)={d2} and dim_C(M_3)={d3}",
+        d2 == 4 and d3 == 9,
+    )
+
+    gen = (1,)
+    tensor_two = tensor_exponents(gen, gen)
+    sum_two = sum_exponents(gen, gen)
+    mixed = sum_exponents(tensor_two, gen)
+    witnesses = (
+        ("M_2", gen),
+        ("M_2⊗M_2", tensor_two),
+        ("M_2⊕M_2", sum_two),
+        ("M_4⊕M_2", mixed),
+    )
+    witness_sizes = tuple(sizes_from_exponents(exponents) for _, exponents in witnesses)
+    concatenated = tuple(size for sizes in witness_sizes for size in sizes)
+
+    checks.check(
+        "theorem1-tensor-witness",
+        f"M_2⊗M_2 has size {tensor_matrix_size(2, 2)} and exponents {tensor_two}",
+        tensor_two == (2,) and tensor_matrix_size(2, 2) == 4 and witness_sizes[1] == (4,),
+    )
+    checks.check(
+        "theorem1-sum-witnesses",
+        f"M_2⊕M_2 dim={direct_sum_dim(witness_sizes[2])}; "
+        f"M_4⊕M_2 dim={direct_sum_dim(witness_sizes[3])}",
+        witness_sizes[2] == (2, 2)
+        and witness_sizes[3] == (4, 2)
+        and direct_sum_dim(witness_sizes[2]) == 8
+        and direct_sum_dim(witness_sizes[3]) == 20,
+    )
+    checks.check(
+        "theorem1-power-of-two-summands",
+        f"concatenated summand sizes {concatenated} are powers of two",
+        concatenated == (2, 4, 2, 2, 4, 2)
+        and all(is_power_of_two(size) for size in concatenated),
+    )
+
+    listed = witness_sizes[0] + witness_sizes[1] + (witness_sizes[2][0],) + witness_sizes[3]
+    checks.check(
+        "theorem2-listed-sizes",
+        f"3 divides none of listed sizes {listed}",
+        listed == (2, 4, 2, 4, 2) and all(not divides(3, size) for size in listed),
+    )
+    checks.check(
+        "theorem2-no-unital-m3",
+        "no unital M_3 into any of the four witnesses",
+        all(not unital_m3_into_summands(sizes) for sizes in witness_sizes),
+    )
+
+    k_max = 8
+    remainders = tuple((2**k) % 3 for k in range(1, k_max + 1))
+    checks.check(
+        "theorem3-universal-division",
+        f"3 divides none of 2^k for k=1..{k_max}; remainders={remainders}",
+        all(rem != 0 for rem in remainders) and not three_divides_some_power_of_two(k_max),
+    )
+    checks.check(
+        "theorem3-class-form",
+        "every generated witness is a sum of M_{2^{k}} with k>=1",
+        all(min(exponents) >= 1 for _, exponents in witnesses)
+        and all(all(is_power_of_two(size) for size in sizes) for sizes in witness_sizes),
+    )
+
+    checks.check(
+        "mutation-three-divides-power-of-two",
+        "predicate '3 divides 2^k for some k=1..8' fails",
+        three_divides_some_power_of_two(8) is False,
+    )
+    sum_dim = direct_sum_dim((2, 2))
+    checks.check(
+        "mutation-sum-not-m3",
+        f"predicate 'M_2⊕M_2 ≅ M_3' fails ({sum_dim}!={d3})",
+        m2_oplus_m2_isomorphic_to_m3() is False and sum_dim != d3,
+    )
+
+    required_status = (
+        'hypothetical_axiom_status: "C2-strong: composites are the class '
+        'generated from M_2 by finite tensor and finite direct sum; not adopted"',
+        "actual_current_surface_status: bounded-support",
+    )
+    checks.check(
+        "machine-status-contract",
+        "the note carries the required C2-strong and bounded-support fields",
+        all(phrase in note for phrase in required_status),
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "non-adoption-surface",
+        "the leftover declaration is displayed and QCD is refused",
+        all(
+            phrase in normalize(note)
+            for phrase in (
+                "declared larger carrier",
+                "not adopted",
+                "QCD is not imported",
+                "Unital `M_3` is not an expected construction on this class",
+            )
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "all N1-N8 sections and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note,
+    )
+    checks.check(
+        "declared-inputs",
+        "AUDIT_INPUT_PATHS names the new note and the axiom memo, both present",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/M2_TENSOR_SUM_CLASS_HAS_NO_UNITAL_M3_HYPOTHETICAL_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the generated class notation is absent from the canonical axiom file",
+        all(phrase not in axiom for phrase in ("S''", "generated class `C`", "M_{2^{k_1}}")),
+    )
+
+    print("per_element: four witnesses and the listed summand sizes {2,4,2,4,2}")
+    print("per_site: local algebra remains M_2; no multi-site dynamics claimed")
+    print("per_mode: k=1..8 powers of two checked against division by 3")
+    print("per_block: unital M_3 into the generated tensor/sum class only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The class `C` generated from `M_2` by finite tensor and finite direct sum consists of sums of `M_{2^k}`. Unital `M_3` never embeds: `3` never divides `2^k`. Mix of `⊕` and `⊗` is still that class. Leftover is a declared larger carrier, not adopted. No QCD.

## What this means for the TOE

“Maybe some mix of sum and tensor works” is closed. Remaining C2 escape is a declared different type, not a Lattice+Qubit composite in `C`.

## Verification

```bash
python3 scripts/m2_tensor_sum_class_has_no_unital_m3_hypothetical_2026_08_13.py
# TOTAL: PASS=17 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.