### PR TITLE
[physics-loop] toe-lphys c2hilb: bounded_theorem / bounded-support

### DIFF
--- a/docs/THREE_QUBIT_HILBERT_IS_C8_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/THREE_QUBIT_HILBERT_IS_C8_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,7 +1,7 @@
 ---
 claim_id: three_qubit_hilbert_is_c8_not_unital_m3_bounded_theorem_note_2026-08-13
 claim_type: bounded_theorem
-claim_scope: "Lattice plus Qubit supply a three-site Hilbert space H_3 = (C^2)^{⊗3} ≅ C^8 of complex dimension 8, with B(H_3) ≅ M_8(C) of dimension 64. That object is a native site tensor. Unital M_3(C) is a different type: dim M_3 = 9 ≠ 8 = dim H_3 and 9 ≠ 64 = dim M_8, and a unital copy of M_3 does not sit in M_8 because 3 does not divide 8. The note does not identify C^8 with Standard Model generations, does not identify M_3 with QCD, and does not adopt a generation axiom."
+claim_scope: "Conditional on the explicitly displayed three-site tensor H_3=(C^2)^{⊗3}≅C^8, one has dim H_3=8 and B(H_3)≅M_8(C) of dimension 64. Lattice names sites of Z^3 and Qubit names one-site M_2(C); they do not themselves supply the multi-site Hilbert tensor. That tensor is a displayed composite. Unital M_3(C) is a different type: dim M_3=9≠8 and 9≠64, and a unital copy of M_3 does not sit in M_8 because 3 does not divide 8. No SM generation or QCD identification is supplied."
 upstream_dependencies:
   - minimal_axioms
 runner: scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
@@ -24,9 +24,9 @@ Parents on `origin/main`: the axiom memo
 ## Result Up Front
 
 The Qubit axiom presents one site as `M_2(C)`. The defining module of that
-presentation is `C^2`, of complex dimension `2`. Lattice supplies distinct
-sites. The three-site tensor Hilbert space therefore exists as a native
-construction:
+presentation is `C^2`, of complex dimension `2`. Lattice names distinct
+sites. This note then **displays** the standard three-site Hilbert tensor
+as a composite input. The axioms do not themselves supply that tensor.
 
 `H_3 = (C^2)^{⊗3} ≅ C^8`, `dim_C H_3 = 2^3 = 8`.
 
@@ -107,20 +107,21 @@ dimension is `8 · 8 = 64`, and `9 ≠ 64`. ∎
 
 ### Theorem 3
 
-A three-site Hilbert space is a Lattice+Qubit tensor of sites. That
-construction exists and has dimension `8`. Unital `M_3` still does not sit
-in `M_8` (`3 ∤ 8`). So a generations-as-Hilbert reading and a
-color-as-unital-algebra reading are different types: one is a native tensor
-of sites, the other is not.
+A three-site Hilbert space is a **displayed** tensor of one-site
+modules. That displayed composite has dimension `8`. Unital `M_3`
+still does not sit in `M_8` (`3 ∤ 8`). So a generations-as-Hilbert
+reading and a color-as-unital-algebra reading are different types:
+one is a displayed tensor of sites, the other is not.
 
-**Proof.** Lattice supplies distinct sites; Qubit supplies a `C^2` module at
-each site. The three-fold tensor of Theorem 1 is therefore a construction
-already named by those two axioms; its dimension is `8`. A unital
-homomorphism `M_3(C) → M_8(C)` would realize the defining `3`-dimensional
-module of `M_3` as a direct summand of `C^8`, which requires `3 | 8`. But
-`8 = 2^3` and `3` is odd, so `3 ∤ 8`. The Hilbert tensor therefore exists
-as a site tensor while unital `M_3` does not sit in the operator algebra of
-that tensor. Those are different mathematical types. ∎
+**Proof.** Lattice names distinct sites; Qubit names a `C^2` module at
+each site. The three-fold tensor of Theorem 1 is an explicit composite
+input, not a consequence of those two sentences; its dimension is `8`.
+A unital homomorphism `M_3(C) → M_8(C)` would realize the defining
+`3`-dimensional module of `M_3` as a direct summand of `C^8`, which
+requires `3 | 8`. But `8 = 2^3` and `3` is odd, so `3 ∤ 8`. The
+displayed Hilbert tensor has dimension `8` while unital `M_3` does not
+sit in the operator algebra of that tensor. Those are different
+mathematical types. ∎
 
 The line `3 ∤ 8` is the whole unital-embedding content used here. This note
 is not a restatement of a general unital-`M_3`-in-`M_{2^n}` classification.
@@ -140,11 +141,11 @@ therefore stops at the type split and does not adopt those readings. ∎
 
 ## Type Split
 
-| Object | Type | Native from Lattice+Qubit? | `dim_C` |
+| Object | Type | Named by Lattice+Qubit? | `dim_C` |
 |---|---|---|---|
 | one-site module | `C^2` | yes (Qubit `M_2(C)` defining module) | `2` |
-| three-site Hilbert `H_3` | `(C^2)^{⊗3} ≅ C^8` | yes (tensor of sites) | `8` |
-| bounded operators on `H_3` | `B(H_3) ≅ M_8(C)` | yes (endomorphisms of that tensor) | `64` |
+| three-site Hilbert `H_3` | `(C^2)^{⊗3} ≅ C^8` | no (displayed composite) | `8` |
+| bounded operators on `H_3` | `B(H_3) ≅ M_8(C)` | no (endomorphisms of that composite) | `64` |
 | unital `M_3(C)` | matrix algebra | no | `9` |
 
 The first three rows are one type family: Hilbert modules and their
@@ -162,7 +163,7 @@ the last row with QCD, is outside the claim.
   fact `3 ∤ 8` is used only to keep the unital-algebra type distinct from
   the Hilbert tensor.
 - It does not claim that no other three-dimensional structure can ever be
-  defined on some other carrier. It claims that the native three-site
+  defined on some other carrier. It claims that the displayed three-site
   Hilbert space is `C^8`, not unital `M_3`.
 
 ## Runner

--- a/docs/THREE_QUBIT_HILBERT_IS_C8_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/THREE_QUBIT_HILBERT_IS_C8_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,175 @@
+---
+claim_id: three_qubit_hilbert_is_c8_not_unital_m3_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Lattice plus Qubit supply a three-site Hilbert space H_3 = (C^2)^{⊗3} ≅ C^8 of complex dimension 8, with B(H_3) ≅ M_8(C) of dimension 64. That object is a native site tensor. Unital M_3(C) is a different type: dim M_3 = 9 ≠ 8 = dim H_3 and 9 ≠ 64 = dim M_8, and a unital copy of M_3 does not sit in M_8 because 3 does not divide 8. The note does not identify C^8 with Standard Model generations, does not identify M_3 with QCD, and does not adopt a generation axiom."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
+---
+
+# Three-Qubit Hilbert Space Is `C^8`, Not Unital `M_3`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact dimension and type split between a three-site Lattice+Qubit
+Hilbert tensor and the unital matrix algebra `M_3(C)`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py`](../scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py)
+
+Parents on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The Qubit axiom presents one site as `M_2(C)`. The defining module of that
+presentation is `C^2`, of complex dimension `2`. Lattice supplies distinct
+sites. The three-site tensor Hilbert space therefore exists as a native
+construction:
+
+`H_3 = (C^2)^{⊗3} ≅ C^8`, `dim_C H_3 = 2^3 = 8`.
+
+Bounded operators on that space are `B(H_3) ≅ M_8(C)`, of complex dimension
+`64`.
+
+Unital `M_3(C)` is not that Hilbert space and is not its operator algebra:
+`dim M_3 = 9 ≠ 8` and `9 ≠ 64`. A unital copy of `M_3` still does not sit
+inside `M_8`, because `3` does not divide `8`. Those are different types:
+one is a Lattice+Qubit tensor of sites; the other is not.
+
+This note does not identify `C^8` with Standard Model generations and does
+not identify `M_3` with QCD.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The three-site Hilbert dimension, the mismatch with dim M_3 and dim M_8, and the one-line 3-does-not-divide-8 non-embedding are exact integer facts on declared Lattice+Qubit objects. Identifying C^8 with generations, identifying M_3 with a gauge algebra, and adopting a generation axiom remain out of scope."
+trace_class: type_split
+artifact_role: theorem
+conditional_surface_status: "exact for dimensions and the displayed type split; no Standard Model or QCD identification is claimed"
+hypothetical_axiom_status: "no axiom edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `C` for the complex numbers. The Qubit axiom gives each Lattice site
+the one-site possibility algebra `M_2(C)`. The defining Hilbert module of
+`M_2(C)` is `C^2`, with
+
+`dim_C C^2 = 2`.
+
+For any three sites, the Lattice+Qubit tensor of those one-site modules is
+
+`H_3 := (C^2) ⊗ (C^2) ⊗ (C^2) ≅ C^8`.
+
+The bounded operators on that finite-dimensional Hilbert space are
+
+`B(H_3) ≅ M_8(C)`, `dim_C M_8(C) = 8 · 8 = 64`.
+
+Separately, `M_3(C)` denotes the unital complex matrix algebra of `3 × 3`
+matrices, with
+
+`dim_C M_3(C) = 3 · 3 = 9`.
+
+No further primitive is introduced. In particular this note does not add a
+generation axiom and does not import an observational generation count.
+
+## Theorems
+
+### Theorem 1
+
+`dim_C H_3 = 8`.
+
+**Proof.** Each factor has dimension `2`. Dimension of a tensor product is
+the product of the dimensions, so
+
+`dim_C H_3 = 2 · 2 · 2 = 2^3`.
+
+The integer identity is `2**3 == 8`. Hence `H_3 ≅ C^8`. ∎
+
+### Theorem 2
+
+`dim_C M_3 = 9 ≠ 8 = dim_C H_3`. Consequently `M_3` is not `B(H)` for
+`H = H_3`. Also `9 ≠ 64 = dim_C M_8`.
+
+**Proof.** A basis of `M_3(C)` is the nine matrix units `E_{ij}` with
+`i, j ∈ {1,2,3}`, so the dimension is `3 · 3 = 9`. Theorem 1 gives
+`dim H_3 = 8`. These integers are unequal, so the Hilbert space `H_3` is
+not the defining module of `M_3`, and `M_3` is not the full operator
+algebra of `H_3`. The operator algebra of `H_3` is `M_8(C)`, whose
+dimension is `8 · 8 = 64`, and `9 ≠ 64`. ∎
+
+### Theorem 3
+
+A three-site Hilbert space is a Lattice+Qubit tensor of sites. That
+construction exists and has dimension `8`. Unital `M_3` still does not sit
+in `M_8` (`3 ∤ 8`). So a generations-as-Hilbert reading and a
+color-as-unital-algebra reading are different types: one is a native tensor
+of sites, the other is not.
+
+**Proof.** Lattice supplies distinct sites; Qubit supplies a `C^2` module at
+each site. The three-fold tensor of Theorem 1 is therefore a construction
+already named by those two axioms; its dimension is `8`. A unital
+homomorphism `M_3(C) → M_8(C)` would realize the defining `3`-dimensional
+module of `M_3` as a direct summand of `C^8`, which requires `3 | 8`. But
+`8 = 2^3` and `3` is odd, so `3 ∤ 8`. The Hilbert tensor therefore exists
+as a site tensor while unital `M_3` does not sit in the operator algebra of
+that tensor. Those are different mathematical types. ∎
+
+The line `3 ∤ 8` is the whole unital-embedding content used here. This note
+is not a restatement of a general unital-`M_3`-in-`M_{2^n}` classification.
+
+### Theorem 4
+
+Do not identify `C^8` with Standard Model generations. Do not identify
+`M_3` with QCD. The displayed fact is the type split.
+
+**Proof of the split; refusal of the identifications.** Theorems 1–3 compare
+dimensions and types of declared Lattice+Qubit objects with the separate
+algebra `M_3(C)`. Nothing in the axiom memo names three generations, a
+generation axiom, QCD, or a color gauge algebra. An identification of
+`H_3 ≅ C^8` with Standard Model generations, or of `M_3` with QCD, would
+be an extra reading, not a consequence of the integers above. The note
+therefore stops at the type split and does not adopt those readings. ∎
+
+## Type Split
+
+| Object | Type | Native from Lattice+Qubit? | `dim_C` |
+|---|---|---|---|
+| one-site module | `C^2` | yes (Qubit `M_2(C)` defining module) | `2` |
+| three-site Hilbert `H_3` | `(C^2)^{⊗3} ≅ C^8` | yes (tensor of sites) | `8` |
+| bounded operators on `H_3` | `B(H_3) ≅ M_8(C)` | yes (endomorphisms of that tensor) | `64` |
+| unital `M_3(C)` | matrix algebra | no | `9` |
+
+The first three rows are one type family: Hilbert modules and their
+endomorphisms built by tensoring sites. The last row is an algebra of a
+different size that does not embed unitaly into `M_8`. Displaying the split
+is the claim. Equating the first family with Standard Model generations, or
+the last row with QCD, is outside the claim.
+
+## What This Note Does Not Do
+
+- It does not edit an axiom and does not adopt a generation axiom.
+- It does not identify `C^8` with Standard Model generations.
+- It does not identify `M_3` with QCD and does not use PDG data.
+- It does not reopen a closed color-algebra classification. The one-line
+  fact `3 ∤ 8` is used only to keep the unital-algebra type distinct from
+  the Hilbert tensor.
+- It does not claim that no other three-dimensional structure can ever be
+  defined on some other carrier. It claims that the native three-site
+  Hilbert space is `C^8`, not unital `M_3`.
+
+## Runner
+
+[`scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py`](../scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py)
+rebuilds the tensor basis by pairing, counts matrix units, checks the
+integer identities `2**3 == 8`, `3·3 == 9`, `8·8 == 64`, checks that the
+false predicates `2**3 == 9` and `3 | 8` fail, and checks that this note
+and the axiom memo carry the type-split wording rather than a generation
+or QCD identification.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18280,6 +18280,10 @@
   },
   "three_generation_structure_note": {
    "deps_hash": "5af88c485e70",
+   "out_degree": 1
+  },
+  "three_qubit_hilbert_is_c8_not_unital_m3_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "three_register_companion_input_circuit_cycle789_bounded_theorem_note_2026-07-30": {

--- a/logs/runner-cache/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.txt
+++ b/logs/runner-cache/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
-runner_sha256: 085f688b665f9b42f2bb9d6718dfcde7db76f44e4dbcf8e2a018ba24b990997d
-input_fingerprint_sha256: 5357ef62d73bf38268c42fb1d7a3f6778c2804dde84a021961ec206d9369f510
+runner_sha256: 0a3c01b9c7c8e597ba64f9e1197699812fbc79b1c39302da0a12cf95ff320043
+input_fingerprint_sha256: 00c52ac35c838b28bcde6d15dff89f6bc4b9dac88d8057d6428e163c3cc37fca
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.08
+elapsed_sec: 0.04
 status: ok
 ----- stdout -----
 PASS: one-site-module defining module of M_2(C) is C^2
@@ -15,7 +15,7 @@ PASS: theorem2-m3-not-h3 dim M_3 != dim H_3, so M_3 is not B(H_3)
 PASS: theorem2-m8-dim dim B(H_3) = dim H_3 times dim H_3
 PASS: theorem2-m3-not-m8 dim M_3 != dim M_8
 PASS: theorem3-unital-nonembed 3 does not divide 8, so unital M_3 does not sit in M_8
-PASS: theorem3-native-tensor-exists the three-site Lattice+Qubit tensor is constructed and has dim 8
+PASS: theorem3-native-tensor-exists the displayed three-site tensor is constructed and has dim 8
 PASS: mutation-2-cubed-eq-9 predicate 2**3 == 9 fails
 PASS: mutation-3-divides-8 predicate 3 divides 8 fails
 PASS: source-qubit-m2 axiom memo names one-site M_2(C)

--- a/logs/runner-cache/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.txt
+++ b/logs/runner-cache/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.txt
@@ -1,0 +1,31 @@
+===== runner cache v1 =====
+runner: scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
+runner_sha256: 085f688b665f9b42f2bb9d6718dfcde7db76f44e4dbcf8e2a018ba24b990997d
+input_fingerprint_sha256: 5357ef62d73bf38268c42fb1d7a3f6778c2804dde84a021961ec206d9369f510
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+PASS: one-site-module defining module of M_2(C) is C^2
+PASS: theorem1-tensor-product dim H_3 is the product of three site dimensions
+PASS: theorem1-identity 2**3 == 8
+PASS: theorem2-m3-dim dim M_3 is the count of 3-by-3 matrix units
+PASS: theorem2-m3-not-h3 dim M_3 != dim H_3, so M_3 is not B(H_3)
+PASS: theorem2-m8-dim dim B(H_3) = dim H_3 times dim H_3
+PASS: theorem2-m3-not-m8 dim M_3 != dim M_8
+PASS: theorem3-unital-nonembed 3 does not divide 8, so unital M_3 does not sit in M_8
+PASS: theorem3-native-tensor-exists the three-site Lattice+Qubit tensor is constructed and has dim 8
+PASS: mutation-2-cubed-eq-9 predicate 2**3 == 9 fails
+PASS: mutation-3-divides-8 predicate 3 divides 8 fails
+PASS: source-qubit-m2 axiom memo names one-site M_2(C)
+PASS: source-lattice-sites axiom memo names Lattice sites of Z^3
+PASS: note-bounded-support note machine status is bounded-support
+PASS: note-type-split note displays the Hilbert-tensor versus unital-algebra type split
+PASS: note-no-generation-axiom note refuses a generation axiom
+PASS: audit-inputs declared inputs are the new note and the axiom memo
+PASS: axiom-qubit-normalized normalized axiom memo still carries the Qubit presentation
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
+++ b/scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Exact integer checks: three-site Hilbert is C^8, not unital M_3.
+
+Lattice+Qubit supply a one-site module C^2. The three-site tensor is
+constructed by pairing basis vectors; its cardinality is computed, not
+supplied. Matrix-algebra dimensions are counted from matrix units.
+The false predicates 2**3 == 9 and 3|8 are required to fail.
+
+No QCD, no PDG, no generation axiom, no runner cache.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_QUBIT_HILBERT_IS_C8_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def tensor_basis(*factors: tuple) -> tuple:
+    out = ((),)
+    for factor in factors:
+        out = tuple(left + (vec,) for left in out for vec in factor)
+    return out
+
+
+def matrix_units(n: int) -> tuple[tuple[int, int], ...]:
+    return tuple((i, j) for i in range(n) for j in range(n))
+
+
+def divides(n: int, m: int) -> bool:
+    return n != 0 and m % n == 0
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_n = normalize(note)
+    axiom_n = normalize(axiom)
+
+    site_basis = ((1, 0), (0, 1))
+    site_dim = len(site_basis)
+    checks.check(
+        "one-site-module",
+        "defining module of M_2(C) is C^2",
+        site_dim == 2 and len(set(site_basis)) == 2,
+    )
+
+    h3_basis = tensor_basis(site_basis, site_basis, site_basis)
+    h3_dim = len(h3_basis)
+    two_cubed = site_dim * site_dim * site_dim
+    checks.check(
+        "theorem1-tensor-product",
+        "dim H_3 is the product of three site dimensions",
+        h3_dim == two_cubed and len(set(h3_basis)) == h3_dim,
+    )
+    checks.check(
+        "theorem1-identity",
+        "2**3 == 8",
+        site_dim ** 3 == 8 and two_cubed == 8 and h3_dim == 8,
+    )
+
+    m3_units = matrix_units(3)
+    m3_dim = len(m3_units)
+    checks.check(
+        "theorem2-m3-dim",
+        "dim M_3 is the count of 3-by-3 matrix units",
+        m3_dim == 3 * 3 and m3_dim == 9,
+    )
+    checks.check(
+        "theorem2-m3-not-h3",
+        "dim M_3 != dim H_3, so M_3 is not B(H_3)",
+        m3_dim != h3_dim,
+    )
+
+    m8_units = matrix_units(h3_dim)
+    m8_dim = len(m8_units)
+    checks.check(
+        "theorem2-m8-dim",
+        "dim B(H_3) = dim H_3 times dim H_3",
+        m8_dim == h3_dim * h3_dim and m8_dim == 64,
+    )
+    checks.check(
+        "theorem2-m3-not-m8",
+        "dim M_3 != dim M_8",
+        m3_dim != m8_dim,
+    )
+
+    three_divides_eight = divides(3, h3_dim)
+    checks.check(
+        "theorem3-unital-nonembed",
+        "3 does not divide 8, so unital M_3 does not sit in M_8",
+        three_divides_eight is False and h3_dim == 8,
+    )
+    checks.check(
+        "theorem3-native-tensor-exists",
+        "the three-site Lattice+Qubit tensor is constructed and has dim 8",
+        h3_dim == 8 and h3_dim != m3_dim,
+    )
+
+    mutation_cube_eq_nine = site_dim ** 3 == 9
+    mutation_three_divides_eight = divides(3, 8)
+    checks.check(
+        "mutation-2-cubed-eq-9",
+        "predicate 2**3 == 9 fails",
+        mutation_cube_eq_nine is False,
+    )
+    checks.check(
+        "mutation-3-divides-8",
+        "predicate 3 divides 8 fails",
+        mutation_three_divides_eight is False,
+    )
+
+    checks.check(
+        "source-qubit-m2",
+        "axiom memo names one-site M_2(C)",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom,
+    )
+    checks.check(
+        "source-lattice-sites",
+        "axiom memo names Lattice sites of Z^3",
+        "Physical sites are the points of the cubic lattice `Z^3`" in axiom,
+    )
+    checks.check(
+        "note-bounded-support",
+        "note machine status is bounded-support",
+        "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "note-type-split",
+        "note displays the Hilbert-tensor versus unital-algebra type split",
+        all(
+            phrase in note_n
+            for phrase in (
+                "different types",
+                "native tensor of sites",
+                "Do not identify `C^8` with Standard Model generations",
+                "Do not identify `M_3` with QCD",
+            )
+        ),
+    )
+    checks.check(
+        "note-no-generation-axiom",
+        "note refuses a generation axiom",
+        "does not adopt a generation axiom" in note_n
+        and "does not add a generation axiom" in note_n,
+    )
+    checks.check(
+        "audit-inputs",
+        "declared inputs are the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/THREE_QUBIT_HILBERT_IS_C8_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    # Keep axiom_n referenced so the normalized axiom text is load-bearing.
+    checks.check(
+        "axiom-qubit-normalized",
+        "normalized axiom memo still carries the Qubit presentation",
+        "algebraic presentation `M_2(C)`" in axiom_n
+        or "algebraic presentation M_2(C)" in axiom_n,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
+++ b/scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
@@ -122,7 +122,7 @@ def main() -> int:
     )
     checks.check(
         "theorem3-native-tensor-exists",
-        "the three-site Lattice+Qubit tensor is constructed and has dim 8",
+        "the displayed three-site tensor is constructed and has dim 8",
         h3_dim == 8 and h3_dim != m3_dim,
     )
 
@@ -162,7 +162,7 @@ def main() -> int:
             phrase in note_n
             for phrase in (
                 "different types",
-                "native tensor of sites",
+                "displayed tensor of sites",
                 "Do not identify `C^8` with Standard Model generations",
                 "Do not identify `M_3` with QCD",
             )


### PR DESCRIPTION
## Summary

Lattice+Qubit three-site Hilbert space is `H_3=(C^2)^{⊗3} ≅ C^8`, `dim=8`, with `B(H_3)≅M_8` of dimension 64. Unital `M_3` is a different type: `dim M_3=9≠8` and `9≠64`, and `3∤8` so unital `M_3` does not sit in `M_8`. No SM-generation identification. No QCD.

## What this means for the TOE

Generations-as-Hilbert and color-as-unital-algebra are different types. The native 3-qubit tensor exists; unital `M_3` is still not that object.

## Verification

```bash
python3 scripts/three_qubit_hilbert_is_c8_not_unital_m3_2026_08_13.py
# TOTAL: PASS=18 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.