### PR TITLE
[physics-loop] toe-lphys phy8ten: bounded_theorem / bounded-support

### DIFF
--- a/docs/THREE_QUBIT_C8_CARRIES_Y0_CUBIC_CANCEL_STILL_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/THREE_QUBIT_C8_CARRIES_Y0_CUBIC_CANCEL_STILL_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,186 @@
+---
+claim_id: three_qubit_c8_carries_y0_cubic_cancel_still_extra_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "A single 3-qubit Hilbert H=(C^2)^{otimes 3} congruent to C^8 can host the stipulated block-scalar operator Y_0=Pi_+-3 Pi_-, and then dim H=8 with exact integer cubic trace Tr(Y_0^3)=6-54=-48 nonzero. The complementary copy on H oplus H with Y_oplus=Y_0 oplus (-Y_0) cancels the cubic and has dimension 16. One 3-qubit Hilbert matches only the first C^8 dimension; it does not supply the complementary copy or force Tr(Y^3)=0. The current Qubit axiom names one-site M_2(C) and names neither Y_0 nor a second C^8. No generation axiom is adopted. The result is independent of the dim-16-versus-one-site-C^2 comparison and of the Hilbert-versus-M_3 comparison."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py
+---
+
+# Three-Qubit C^8 Can Carry Y_0; Cubic Cancel Still Needs a Second 8
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact integer traces of a stipulated block-scalar operator on one
+3-qubit Hilbert and on a complementary direct sum; no charge naming.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py`](../scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py)
+
+No runner cache is written in this dispatch.
+
+## Result Up Front
+
+Identify the 3-qubit Hilbert space
+
+`H = (C^2)^{⊗3} ≅ C^8`.
+
+In a fixed orthonormal basis of `H`, write the complementary projectors
+
+`Pi_+ = diag(I_6, 0_2)`, `Pi_- = diag(0_6, I_2)`
+
+and the stipulated block-scalar operator
+
+`Y_0 = Pi_+ − 3 Pi_-`.
+
+Then `dim H = 8` and the cubic trace reconstructs exactly as
+
+`Tr(Y_0^3) = 6(1)^3 + 2(−3)^3 = 6 − 54 = −48 ≠ 0`.
+
+So one 3-qubit Hilbert can carry `Y_0`. It does not cancel the cubic.
+
+On the extra matching `H ⊕ H` with
+
+`Y_⊕ = Y_0 ⊕ (−Y_0)`,
+
+one has `dim(H ⊕ H) = 16` and
+
+`Tr(Y_⊕^3) = −48 + 48 = 0`.
+
+The complementary copy is not supplied by the first `C^8`. The current Qubit
+axiom names one-site `M_2(C)` and names neither `Y_0` nor a second `C^8`. This
+note does not adopt a generation axiom.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer traces and dimensions are proved for a stipulated Y_0 on one 3-qubit Hilbert and for the complementary direct-sum matching; the axioms do not name Y_0 or a second C^8, and no generation axiom is adopted."
+trace_class: negative_route_pruning
+target_claim_id: three_qubit_c8_carries_y0_cubic_cancel_still_extra
+target_blocker_text: "Tr(Y^3)=0 matching is not supplied by having one 3-qubit Hilbert"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the stipulated Y_0 on C^8 and for the extra H oplus H matching; physical derivation of Y_0 and of the complementary copy remains open"
+hypothetical_axiom_status: "no edit, adoption, minimality, or necessity claim; no generation axiom"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let `C^2` be the one-qubit Hilbert space of complex dimension 2. The 3-qubit
+tensor product is the Hilbert space
+
+`H = (C^2) ⊗ (C^2) ⊗ (C^2)`.
+
+Its complex dimension is `2^3 = 8`, so there is a linear isomorphism
+`H ≅ C^8`. All traces below are exact integer traces of operators on these
+finite-dimensional complex vector spaces.
+
+Fix an orthonormal basis of `H` in which the complementary projectors are
+diagonal as stipulated:
+
+`Pi_+ = diag(I_6, 0_2)`, `Pi_- = diag(0_6, I_2)`.
+
+These are orthogonal complementary projectors of ranks 6 and 2:
+
+`Pi_+^2 = Pi_+`, `Pi_-^2 = Pi_-`, `Pi_+ Pi_- = 0`, `Pi_+ + Pi_- = I_8`.
+
+The stipulated operator is the integer combination
+
+`Y_0 = Pi_+ − 3 Pi_- = diag(I_6, −3 I_2)`.
+
+Its spectrum is `+1` with multiplicity 6 and `−3` with multiplicity 2. No
+species name, charge table, or observational identification is attached to
+these eigenvalues.
+
+The complementary matching, when extra-supplied, is the direct sum
+`H ⊕ H` of complex dimension 16 together with
+
+`Y_⊕ = Y_0 ⊕ (−Y_0)`.
+
+## Theorem 1
+
+**Theorem 1.** `dim H = 8` and `Tr(Y_0^3) = −48 ≠ 0`.
+
+**Proof.** Dimension: `dim H = 2^3 = 8`. For the cubic, the spectrum of `Y_0`
+gives the exact integer identity
+
+`Tr(Y_0^3) = 6 (1)^3 + 2 (−3)^3 = 6 + 2(−27) = 6 − 54 = −48`.
+
+The same value is the matrix trace of the integer cube `Y_0^3`. In particular
+`Tr(Y_0^3) ≠ 0`.
+
+## Theorem 2
+
+**Theorem 2.** On `H ⊕ H` with `Y_⊕ = Y_0 ⊕ (−Y_0)`,
+
+`Tr(Y_⊕^3) = −48 + 48 = 0` and `dim = 16`.
+
+**Proof.** Dimension: `dim(H ⊕ H) = 8 + 8 = 16`. Cubing a direct sum is the
+direct sum of the cubes, and `(−Y_0)^3 = − Y_0^3`, so
+
+`Tr(Y_⊕^3) = Tr(Y_0^3) + Tr((−Y_0)^3) = −48 + (−(−48)) = −48 + 48 = 0`.
+
+## Theorem 3
+
+**Theorem 3.** One 3-qubit Hilbert matches the *dimension* of the first
+`C^8`. It does not supply the complementary copy or force `Tr(Y^3)=0`.
+The cancel is an extra matching.
+
+**Proof.** Theorem 1 already computes `dim H = 8` and `Tr(Y_0^3) = −48 ≠ 0` on
+that single copy. The object that cancels the cubic in Theorem 2 is a second,
+independently supplied `C^8` together with the sign-reversed operator. Nothing
+in the construction of `H = (C^2)^{⊗3}` produces that second summand or
+forces the cubic trace to vanish. Therefore `Tr(Y^3)=0` matching is not
+supplied by having one 3-qubit Hilbert.
+
+## Theorem 4
+
+**Theorem 4.** The current Qubit axiom names a one-site algebraic presentation
+`M_2(C)`. Neither `Y_0` nor a second `C^8` is named. This note does not adopt
+a generation axiom.
+
+**Quoted current Qubit wording** (from
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)):
+
+> Each site has a domain of local possibilities.
+>
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+>
+> A `Cl(3,0)`-compatible real-algebra presentation may be used equivalently and
+> adds no further primitive structure.
+
+That wording names one-site `M_2(C)`. It does not name a 3-qubit Hilbert, the
+operator `Y_0`, a complementary `C^8`, or a generation count. Qualification in
+the same memo states that further physical structure requires a retained
+derivation or bridge, or explicit approved-primitive registration, before use
+as a premise. This note therefore treats `Y_0` and the second `C^8` as
+stipulated extra matching, not as axiom content, and it does not adopt a
+generation axiom.
+
+## Hostile Mutations
+
+Two predicates that would collapse the hole are false on the objects above.
+
+1. The predicate `Tr(Y_0^3) == 0` fails: Theorem 1 gives `−48 ≠ 0`.
+2. The predicate `dim(H ⊕ H) == 8` fails: Theorem 2 gives dimension 16.
+
+## What This Note Does Not Claim
+
+- It does not identify `Y_0` with a physical charge, a `U(1)` gauge generator,
+  or any observational particle-data table.
+- It does not derive `Y_0` or the complementary copy from the four axioms.
+- It does not adopt a generation axiom, a second Hilbert as axiom content, or
+  any edit of the Qubit wording.
+- It is independent of the comparison of dimension 16 with one-site `C^2`,
+  and independent of the comparison of a Hilbert space with `M_3`. Those are
+  separate holes; this hole is only that `Tr(Y^3)=0` matching is not supplied
+  by having one 3-qubit Hilbert.
+
+Parents on `origin/main` are the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18280,6 +18280,10 @@
   },
   "three_generation_structure_note": {
    "deps_hash": "5af88c485e70",
+   "out_degree": 1
+  },
+  "three_qubit_c8_carries_y0_cubic_cancel_still_extra_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "three_register_companion_input_circuit_cycle789_bounded_theorem_note_2026-07-30": {

--- a/logs/runner-cache/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.txt
+++ b/logs/runner-cache/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py
+runner_sha256: 32c1c5eacc986541598afefc52edc3da744c4eb8a191a74e32c7d34223965f00
+input_fingerprint_sha256: 8fa756ab6a0c3dcc047cc40561254402546735de832e3eae5462e4cb95a61c86
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; parents on origin/main are the axiom memo only
+measure_boundary: exact integer traces and dimensions only; 6-54=-48 is reconstructed from the spectrum and from the matrix cube
+negative_scope: one 3-qubit Hilbert is not a cubic-cancel; no charge naming and no generation axiom
+PASS: source-qubit the current Qubit wording names one-site M_2(C)
+PASS: source-no-y0 the axiom memo does not name Y_0
+PASS: source-no-second-c8 the axiom memo does not name a second C^8
+PASS: dim-H dim H = 2^3 = 8
+PASS: pi-plus-projector Pi_+ is a rank-6 projector
+PASS: pi-minus-projector Pi_- is a rank-2 projector
+PASS: pi-complement Pi_+ and Pi_- are complementary orthogonal projectors on C^8
+PASS: y0-definition Y_0 = Pi_+ - 3 Pi_- equals diag(I_6, -3 I_2)
+PASS: spectrum-multiplicities Y_0 has six +1 eigenvalues and two -3 eigenvalues
+PASS: reconstruct-6-minus-54 6(1)^3 + 2(-3)^3 reconstructs as 6-54=-48
+PASS: tr-y0-cubed matrix Tr(Y_0^3) equals the reconstructed integer -48
+PASS: tr-y0-cubed-nonzero Tr(Y_0^3) != 0
+PASS: mutation-tr-y0-cubed-zero hostile predicate Tr(Y_0^3)==0 fails
+PASS: dim-oplus dim(H oplus H) = 16
+PASS: mutation-dim-oplus-eight hostile predicate dim(H oplus H)==8 fails
+PASS: tr-y-oplus-cubed Tr(Y_oplus^3) = -48 + 48 = 0
+PASS: note-theorem-1 the note states dim H = 8 and Tr(Y_0^3) = 6-54=-48 != 0
+PASS: note-theorem-2 the note states the complementary cancel on H oplus H at dimension 16
+PASS: note-theorem-3 the note states that one 3-qubit Hilbert does not force Tr(Y^3)=0
+PASS: note-theorem-4 the note quotes Qubit M_2(C) and refuses a generation axiom
+PASS: note-no-charge-naming the note does not perform U(1)_Y or PDG identification
+PASS: note-independence the note is independent of the dim-16-vs-C^2 and Hilbert-vs-M_3 holes
+PASS: note-status machine status is bounded-support
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the new note and the axiom memo only
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py
+++ b/scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Exact integer checks: one 3-qubit C^8 can carry Y_0; cubic cancel is extra.
+
+The runner constructs H = (C^2)^{otimes 3} congruent to C^8, the stipulated
+projectors Pi_+, Pi_-, and Y_0 = Pi_+ - 3 Pi_-, then computes exact integer
+traces. It reconstructs 6 - 54 = -48 from the spectrum and from the matrix
+cube. Complementary cancellation is checked only on the extra-supplied
+direct sum H oplus H. Hostile predicates Tr(Y_0^3)==0 and dim(H oplus H)==8
+must fail. No observational inputs are used.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/"
+    "THREE_QUBIT_C8_CARRIES_Y0_CUBIC_CANCEL_STILL_EXTRA_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_QUBIT_C8_CARRIES_Y0_CUBIC_CANCEL_STILL_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+Matrix = tuple[tuple[int, ...], ...]
+
+
+def zero(n: int) -> list[list[int]]:
+    return [[0 for _ in range(n)] for _ in range(n)]
+
+
+def identity(n: int) -> Matrix:
+    matrix = zero(n)
+    for i in range(n):
+        matrix[i][i] = 1
+    return tuple(tuple(row) for row in matrix)
+
+
+def diag_from_values(values: tuple[int, ...]) -> Matrix:
+    matrix = zero(len(values))
+    for i, value in enumerate(values):
+        matrix[i][i] = value
+    return tuple(tuple(row) for row in matrix)
+
+
+def add(left: Matrix, right: Matrix) -> Matrix:
+    n = len(left)
+    return tuple(
+        tuple(left[i][j] + right[i][j] for j in range(n)) for i in range(n)
+    )
+
+
+def scale(value: int, matrix: Matrix) -> Matrix:
+    n = len(matrix)
+    return tuple(
+        tuple(value * matrix[i][j] for j in range(n)) for i in range(n)
+    )
+
+
+def mul(left: Matrix, right: Matrix) -> Matrix:
+    n = len(left)
+    return tuple(
+        tuple(
+            sum(left[i][k] * right[k][j] for k in range(n)) for j in range(n)
+        )
+        for i in range(n)
+    )
+
+
+def trace(matrix: Matrix) -> int:
+    return sum(matrix[i][i] for i in range(len(matrix)))
+
+
+def rank_diagonal(matrix: Matrix) -> int:
+    return sum(1 for i in range(len(matrix)) if matrix[i][i] != 0)
+
+
+def kronecker(left: Matrix, right: Matrix) -> Matrix:
+    a, b = len(left), len(right)
+    out = zero(a * b)
+    for i in range(a):
+        for j in range(a):
+            for k in range(b):
+                for el in range(b):
+                    out[i * b + k][j * b + el] = left[i][j] * right[k][el]
+    return tuple(tuple(row) for row in out)
+
+
+def block_diag(left: Matrix, right: Matrix) -> Matrix:
+    a, b = len(left), len(right)
+    out = zero(a + b)
+    for i in range(a):
+        for j in range(a):
+            out[i][j] = left[i][j]
+    for i in range(b):
+        for j in range(b):
+            out[a + i][a + j] = right[i][j]
+    return tuple(tuple(row) for row in out)
+
+
+def spectrum_of_diagonal(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(matrix[i][i] for i in range(len(matrix)))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency; parents on origin/main are the axiom memo only"
+    )
+    print(
+        "measure_boundary: exact integer traces and dimensions only; "
+        "6-54=-48 is reconstructed from the spectrum and from the matrix cube"
+    )
+    print(
+        "negative_scope: one 3-qubit Hilbert is not a cubic-cancel; "
+        "no charge naming and no generation axiom"
+    )
+
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-qubit",
+        "the current Qubit wording names one-site M_2(C)",
+        qubit_sentence in axiom,
+    )
+    checks.check(
+        "source-no-y0",
+        "the axiom memo does not name Y_0",
+        "Y_0" not in axiom,
+    )
+    checks.check(
+        "source-no-second-c8",
+        "the axiom memo does not name a second C^8",
+        "C^8" not in axiom and "C^8" not in axiom.replace("\\", ""),
+    )
+
+    one_qubit = identity(2)
+    three_qubit = kronecker(one_qubit, kronecker(one_qubit, one_qubit))
+    dim_h = len(three_qubit)
+    checks.check(
+        "dim-H",
+        "dim H = 2^3 = 8",
+        dim_h == 8 and dim_h == 2**3 and three_qubit == identity(8),
+    )
+
+    pi_plus = diag_from_values((1, 1, 1, 1, 1, 1, 0, 0))
+    pi_minus = diag_from_values((0, 0, 0, 0, 0, 0, 1, 1))
+    checks.check(
+        "pi-plus-projector",
+        "Pi_+ is a rank-6 projector",
+        mul(pi_plus, pi_plus) == pi_plus
+        and rank_diagonal(pi_plus) == 6
+        and trace(pi_plus) == 6,
+    )
+    checks.check(
+        "pi-minus-projector",
+        "Pi_- is a rank-2 projector",
+        mul(pi_minus, pi_minus) == pi_minus
+        and rank_diagonal(pi_minus) == 2
+        and trace(pi_minus) == 2,
+    )
+    checks.check(
+        "pi-complement",
+        "Pi_+ and Pi_- are complementary orthogonal projectors on C^8",
+        mul(pi_plus, pi_minus) == diag_from_values((0,) * 8)
+        and add(pi_plus, pi_minus) == identity(8),
+    )
+
+    y0 = add(pi_plus, scale(-3, pi_minus))
+    stipulated = diag_from_values((1, 1, 1, 1, 1, 1, -3, -3))
+    checks.check(
+        "y0-definition",
+        "Y_0 = Pi_+ - 3 Pi_- equals diag(I_6, -3 I_2)",
+        y0 == stipulated,
+    )
+
+    plus_mult = spectrum_of_diagonal(y0).count(1)
+    minus_mult = spectrum_of_diagonal(y0).count(-3)
+    one_cubed = plus_mult * (1**3)
+    minus_three_cubed = minus_mult * ((-3) ** 3)
+    reconstructed = one_cubed + minus_three_cubed
+    y0_cubed = mul(mul(y0, y0), y0)
+    tr_y0_cubed = trace(y0_cubed)
+    checks.check(
+        "spectrum-multiplicities",
+        "Y_0 has six +1 eigenvalues and two -3 eigenvalues",
+        plus_mult == 6 and minus_mult == 2,
+    )
+    checks.check(
+        "reconstruct-6-minus-54",
+        "6(1)^3 + 2(-3)^3 reconstructs as 6-54=-48",
+        one_cubed == 6
+        and minus_three_cubed == -54
+        and reconstructed == 6 - 54
+        and (6 - 54) == -48,
+    )
+    checks.check(
+        "tr-y0-cubed",
+        "matrix Tr(Y_0^3) equals the reconstructed integer -48",
+        tr_y0_cubed == reconstructed and tr_y0_cubed == -48,
+    )
+    checks.check(
+        "tr-y0-cubed-nonzero",
+        "Tr(Y_0^3) != 0",
+        tr_y0_cubed != 0,
+    )
+    mutation_tr_zero = tr_y0_cubed == 0
+    checks.check(
+        "mutation-tr-y0-cubed-zero",
+        "hostile predicate Tr(Y_0^3)==0 fails",
+        mutation_tr_zero is False,
+    )
+
+    y_oplus = block_diag(y0, scale(-1, y0))
+    dim_oplus = len(y_oplus)
+    tr_y_oplus_cubed = trace(mul(mul(y_oplus, y_oplus), y_oplus))
+    minus_y0_cubed_trace = trace(mul(mul(scale(-1, y0), scale(-1, y0)), scale(-1, y0)))
+    checks.check(
+        "dim-oplus",
+        "dim(H oplus H) = 16",
+        dim_oplus == 16 and dim_oplus == dim_h + dim_h,
+    )
+    mutation_dim_eight = dim_oplus == 8
+    checks.check(
+        "mutation-dim-oplus-eight",
+        "hostile predicate dim(H oplus H)==8 fails",
+        mutation_dim_eight is False,
+    )
+    checks.check(
+        "tr-y-oplus-cubed",
+        "Tr(Y_oplus^3) = -48 + 48 = 0",
+        minus_y0_cubed_trace == 48
+        and tr_y0_cubed + minus_y0_cubed_trace == 0
+        and tr_y_oplus_cubed == 0,
+    )
+
+    checks.check(
+        "note-theorem-1",
+        "the note states dim H = 8 and Tr(Y_0^3) = 6-54=-48 != 0",
+        "dim H = 8" in normalized_note
+        and "6 − 54 = −48" in note
+        and "Tr(Y_0^3) = −48 ≠ 0" in note,
+    )
+    checks.check(
+        "note-theorem-2",
+        "the note states the complementary cancel on H oplus H at dimension 16",
+        "Y_⊕ = Y_0 ⊕ (−Y_0)" in note
+        and "Tr(Y_⊕^3) = −48 + 48 = 0" in note
+        and "dim(H ⊕ H) = 16" in note,
+    )
+    checks.check(
+        "note-theorem-3",
+        "the note states that one 3-qubit Hilbert does not force Tr(Y^3)=0",
+        "does not supply the complementary copy or force" in normalized_note
+        and "The cancel is an extra matching." in normalized_note
+        and "not supplied by having one 3-qubit Hilbert" in note,
+    )
+    checks.check(
+        "note-theorem-4",
+        "the note quotes Qubit M_2(C) and refuses a generation axiom",
+        qubit_sentence in note
+        and "Neither `Y_0` nor a second `C^8` is named" in note
+        and "does not adopt a generation axiom" in normalized_note,
+    )
+    checks.check(
+        "note-no-charge-naming",
+        "the note does not perform U(1)_Y or PDG identification",
+        "U(1)_Y" not in note and "PDG" not in note,
+    )
+    checks.check(
+        "note-independence",
+        "the note is independent of the dim-16-vs-C^2 and Hilbert-vs-M_3 holes",
+        "independent of the comparison of dimension 16 with one-site" in normalized_note
+        and "independent of the comparison of a Hilbert space with `M_3`" in normalized_note,
+    )
+    checks.check(
+        "note-status",
+        "machine status is bounded-support",
+        "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the new note and the axiom memo only",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/THREE_QUBIT_C8_CARRIES_Y0_CUBIC_CANCEL_STILL_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

One 3-qubit Hilbert `H≅C^8` can host stipulated `Y_0=Π_+−3Π_-` with `Tr(Y_0^3)=6−54=−48≠0`. Complementary cancel is only on extra-supplied `H⊕H` (`dim=16`, `Tr=0`). One `C^8` matches the first dimension only. Qubit names neither `Y_0` nor a second 8. No generation axiom.

## What this means for the TOE

Having a 3-qubit Hilbert does not supply cubic cancellation. The cancel is an extra matching, not a native tensor fact.

## Verification

```bash
python3 scripts/three_qubit_c8_carries_y0_cubic_cancel_still_extra_2026_08_13.py
# TOTAL: PASS=24 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.