### PR TITLE
[physics-loop] toe-lphys clockrec: bounded_theorem / bounded-support

### DIFF
--- a/docs/LOCK_HISTORY_LENGTH_IS_NOT_WICK_CLOCK_A_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/LOCK_HISTORY_LENGTH_IS_NOT_WICK_CLOCK_A_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,292 @@
+---
+claim_id: lock_history_length_is_not_wick_clock_a_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "Live Record plus a finite lock-history length n does not name the Wick clock parameter a_w. Two lawful histories with n=2 and n=4 share no readout of blank sites. The OS0 form Q_E=(k4^2+k^2)/4 continued by k4=i a_w omega has omega_coeff(a_w)=-a_w^2/4; omega_coeff(1)=-1/4 and omega_coeff(2)=-1 are distinct and equal neither n nor 1/n. Kinetic isotropy is c_t=c_s, not a function of |H|. Independent of the Q_E/Q_lopsided |a| split and of a_sr versus a_w. The note does not install a_w=1 and does not adopt L_phys."
+upstream_dependencies:
+  - minimal_axioms
+  - kinetic_isotropy_primitive_note_2026-06-09
+runner: scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py
+---
+
+# A Lock-History Length Is Not The Wick Clock Parameter `a`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact finite lock-history lengths versus the linear Wick
+continuation `k4 = i a_w omega` of the Euclidean OS0 form.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py`](../scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py)
+**Parents on origin/main:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md).
+
+## Result Up Front
+
+Live Record, with no named `I` and with blank sites unread, plus a history
+of `n` locks, does not name the Wick clock parameter `a_w`.
+
+1. Two lawful lock words have lengths `n=2` and `n=4`. Blank unread
+   forbids assigning a readout to empty sites in order to manufacture a
+   clock.
+2. After `k4 = i a_w omega` in the OS0 form `Q_E = (k4^2 + k^2)/4`, one
+   has `omega_coeff(a_w) = -a_w^2/4`. Then `omega_coeff(1) = -1/4` and
+   `omega_coeff(2) = -1` are different, and neither equals `n` or `1/n`
+   for those two lengths.
+3. Kinetic isotropy names `c_t = c_s`, not a function of `|H|`. Record
+   names no Wick parameter. The clock map `a_w` remains extra.
+
+This note does not install `a_w = 1` and does not adopt `L_phys`. It is
+independent of the Euclidean-versus-lopsided cut that can select different
+`|a|`, and independent of the type split `a_sr ≠ a_w`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Fraction algebra on declared lock words and the OS0 quadratic; live Record quoted; a_w=1 and L_phys not adopted."
+trace_class: negative_route_pruning
+target_claim_id: wick_clock_map_a
+target_blocker_text: "live Record plus a history of n locks does not name Wick a"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed words and omega_coeff identities; a declared clock map remains extra"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+This is current Record, not a retype. No axiom or primitive is edited.
+
+## Exact Objects
+
+A **history** `H` is a finite word of locks. Write `|H| = n` for its
+length. The lengths used here are
+
+```text
+n ∈ {0, 1, 2, 3, 4}.
+```
+
+The empty word has `n = 0`. The two displayed nonempty words are
+
+```text
+H2 = AB,     |H2| = 2,
+H4 = ABCD,   |H4| = 4.
+```
+
+Each letter is one admissible local possibility locked by a forming
+record. Both words are lawful lock histories. Length is a cardinality of
+already-formed locks. It is not a site readout of a blank.
+
+The **linear Wick map** is a nonzero rational `a_w ∈ Q \ {0}` together
+with
+
+```text
+k4 = i a_w omega.
+```
+
+The **Euclidean OS0 form** is the `a_w`-free quadratic
+
+```text
+Q_E(k4, k) = (k4^2 + k^2)/4.
+```
+
+Because `i^2 = -1`, the continuation is
+
+```text
+Q_E(i a_w omega, k) = (-a_w^2 omega^2 + k^2)/4,
+```
+
+and the **Lorentzian `omega^2` coefficient** is the exact rational
+
+```text
+omega_coeff(a_w) = -a_w^2 / 4.
+```
+
+The map `n ↦ a_w` is not named by Record and is not named by
+`c_t = c_s`.
+
+## Live Record
+
+The current Record axiom is the `Record / Fixed Reality` section of
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). Quoted
+verbatim:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility. A
+site never carries more than one record; records are permanent.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+
+The same memo states that finite additivity, a named scalar collection
+functional `I`, and an assigned value `I(empty)=0` are not Record axiom
+content. Named `I` is not axiom content. A site with no record cannot be
+read; the axiom does not assign a scalar to absence.
+
+The live Record section, from `### Record / Fixed Reality` through
+`## Qualification`, does not contain `I(empty)=0`.
+
+## Kinetic Isotropy
+
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+supplies the Euclidean kinetic-form equality
+
+```text
+c_t = c_s,
+```
+
+the Osterwalder-Schrader OS0 kinetic normalization. It states that the
+framework's time remains emergent and derived, and that the primitive
+does not add or amend an axiom. It does not write `k4 = i a_w omega`,
+does not name `omega_coeff`, and does not name a function of `|H|`.
+
+## Theorem 1 — Two Lawful Histories; Blank Unread
+
+`H2 = AB` and `H4 = ABCD` are finite words of locks. Both are lawful:
+each letter is one locked admissible possibility, and Record licenses
+reading formed lock content.
+
+Their lengths are different:
+
+```text
+|H2| = 2,    |H4| = 4.
+```
+
+Quote blank-unread: a site with no record cannot be read. Do not assign
+a readout to empty sites to manufacture a clock. The empty history has
+no lock content, so it has no readout. Padding either word with unread
+sites, or assigning a scalar to absence, is not a Record clock. In particular one must not write `I(empty)=0` and then convert
+that assigned absence into a tick count or a Wick parameter.
+
+Length `|H|` is therefore only the number of letters already present.
+It is not a manufactured window clock that reads blanks.
+
+## Theorem 2 — Distinct `omega_coeff`; Neither Is `n` Or `1/n`
+
+The polynomial `Q_E = (k4^2 + k^2)/4` is written in the Euclidean
+momenta alone. Substituting `k4 = i a_w omega` gives
+
+```text
+(i a_w omega)^2 / 4 + k^2/4 = (i^2 a_w^2 omega^2)/4 + k^2/4
+                            = (-a_w^2 omega^2)/4 + k^2/4.
+```
+
+So `omega_coeff(a_w) = -a_w^2/4`. Exact rationals:
+
+```text
+omega_coeff(1) = -1/4,
+omega_coeff(2) = -1.
+```
+
+These two values are different: `-1/4 ≠ -1`. For the displayed lengths,
+
+```text
+n ∈ {2, 4},    1/n ∈ {1/2, 1/4}.
+```
+
+Neither coefficient equals either length or either reciprocal:
+
+```text
+-1/4 ∉ {2, 4, 1/2, 1/4},
+-1   ∉ {2, 4, 1/2, 1/4}.
+```
+
+The same `omega_coeff` pair is obtained for every history: the
+continuation does not see `|H|`. The same pair of lengths is obtained
+for every `a_w`: the word length does not see the Wick parameter.
+
+The sample `a_w = 1` is one nonzero rational among others. It is
+displayed so that `-1/4` can be compared with `-1`. It is not installed
+as a law.
+
+## Theorem 3 — OS0 Is `c_t = c_s`; `a_w` Remains Extra
+
+OS0 names `c_t = c_s`, the equality of the Euclidean `k4^2` and spatial
+`k^2` coefficients, both `1/4` in `Q_E`. That equality is not a function
+of `|H|`. Changing a lock-word length leaves `Q_E` unchanged.
+
+Record names formation, one-site locking, permanence, content-only
+readout, and unreadability of a blank site. It names no Wick parameter
+and no map `n ↦ a_w`.
+
+Therefore a live lock history plus OS0 leaves the clock map `a_w` extra.
+This note does not install `a_w = 1` and does not adopt `L_phys` as a
+stand-in for `a_w` or as a clock built from unread sites.
+
+## Mutation Predicates
+
+The following hostile predicates fail on the objects above.
+
+1. “`omega_coeff(a_w)` equals `|H|` for all `a_w`, `H`.” Counterexample:
+   `omega_coeff(1) = -1/4` and `|H2| = 2` are unequal, and
+   `omega_coeff(2) = -1` is unequal to both `2` and `4`.
+2. “The live memo contains `I(empty)=0`.” False of the live Record
+   section (`### Record / Fixed Reality` through `## Qualification`).
+   Named `I` and `I(empty)=0` are not Record axiom content.
+
+## Independence
+
+This note does not rerun two neighboring cuts.
+
+- Euclidean `Q_E` versus a lopsided kinetic form can select different
+  `|a|`. That is a different residual. The algebra here keeps `Q_E`
+  fixed and varies only the lock-word length against `a_w`.
+- Scale-reference `a_sr` is not the Wick parameter `a_w`. That is a
+  different type split. The algebra here never uses `a_sr`.
+
+## Claim Boundary
+
+| Item | Status |
+|---|---|
+| live Record readout sentences | quoted; not edited |
+| named `I` and `I(empty)=0` | not axiom content |
+| `|H2|=2`, `|H4|=4` | exact word lengths |
+| blank unread | quoted; no clock from empty sites |
+| `omega_coeff(1)=-1/4`, `omega_coeff(2)=-1` | derived from `Q_E` |
+| `n ↦ a_w` | not named |
+| `a_w = 1` | displayed sample; not installed |
+| `L_phys` | not adopted |
+| `Q_E` versus lopsided `|a|` | independent; not claimed |
+| `a_sr ≠ a_w` | independent; not claimed |
+| axiom or primitive edit | none |
+
+## What This Does Not Claim
+
+- No axiom or primitive is edited.
+- `a_w = 1` is not installed.
+- `L_phys` is not adopted as a clock or as `a_w`.
+- Lorentzian closure, boost generators, and OS reconstruction are not
+  claimed.
+- Nonlinear clock maps are out of scope.
+- A later declared continuation rule remains a live formal escape. It is
+  not derived here.
+
+## Imports And Open
+
+**Imported.** The current four-axiom memo, used for the live Record
+sentences and the statement that named `I` and `I(empty)=0` are not
+Record content. The kinetic-isotropy primitive, used for `c_t = c_s`
+and the Euclidean OS0 form.
+
+**Derived here.** Lawful lengths `2` and `4`; blank unread as a bar on
+manufacturing a clock from empty sites; `omega_coeff(a_w) = -a_w^2/4`
+with the displayed pair `-1/4 ≠ -1`; failure of both mutation
+predicates.
+
+**Open.** Any separately declared linear or nonlinear clock map; any
+identification of `|H|` with a physical length `L_phys`; Lorentzian
+closure.
+
+## Primary Runner
+
+[`scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py`](../scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py)
+recomputes `|H|` and `omega_coeff(a_w)` in exact `Fraction` arithmetic,
+re-reads the two source notes, and checks the two mutation predicates.
+No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15602,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12117,6 +12117,10 @@
   "localized_source_response_sweep_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "lock_history_length_is_not_wick_clock_a_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "0d988fd1ac07",
+   "out_degree": 2
   },
   "lock_point_menu_record_and_likelihood_lemma_cycle911_bounded_theorem_note_2026-07-28": {
    "deps_hash": "9250d476c7ae",

--- a/logs/runner-cache/lock_history_length_is_not_wick_clock_a_2026_08_13.txt
+++ b/logs/runner-cache/lock_history_length_is_not_wick_clock_a_2026_08_13.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py
+runner_sha256: 9178e4dc259c1acd29f3cc4c539a8a57625beb5fd333ba110702cd9027d737d4
+input_fingerprint_sha256: 7de0fda8c3db5ad9cffbaaedf164fe57938a7548a8d90f6fedef109590a1541a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/LOCK_HISTORY_LENGTH_IS_NOT_WICK_CLOCK_A_BOUNDED_THEOREM_NOTE_2026-08-13.md
+  docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: axiom memo and kinetic-isotropy primitive; no observational or fitted inputs
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency; no runner cache is written
+negative_scope: lock-history length as a selector of a_w is rejected; a declared continuation remains extra
+PASS: audit-input-paths declared audit inputs are the new note, kinetic isotropy, and axiom memo
+PASS: source-record-readout the three live Record readout sentences occur verbatim
+PASS: source-records-form-lock-permanence live Record names formation, locking, and permanence
+PASS: source-named-I-not-content named I and I(empty)=0 are stated not to be Record axiom content
+PASS: source-kinetic-os0 the primitive supplies Euclidean c_t = c_s / OS0, not a_w
+PASS: theorem-1-histories H2=AB and H4=ABCD are lawful lock words with n=2 and n=4
+PASS: theorem-1-blank-unread blank unread: empty history has no lock content and is not a clock readout
+PASS: theorem-2-omega-coeff derived omega_coeff(1)=-1/4 and omega_coeff(2)=-1
+PASS: theorem-2-distinct omega_coeff(1) and omega_coeff(2) are different
+PASS: theorem-2-neither-n-nor-reciprocal neither coefficient equals n or 1/n for n=2 and n=4
+PASS: theorem-2-q-e-independent Q_E has no a_w argument and is unchanged across Wick samples
+PASS: theorem-3-os0-not-function-of-H OS0 is c_t=c_s, not a function of |H|
+PASS: theorem-3-record-names-no-wick live Record names no Wick parameter; a_w remains extra
+PASS: theorem-3-no-a1-no-lphys the note does not install a_w=1 and does not adopt L_phys
+PASS: mutation-omega-equals-length-fails predicate omega_coeff(a_w) equals |H| for all a_w,H fails
+PASS: mutation-live-I-empty-fails predicate live memo contains I(empty)=0 fails
+PASS: note-quotes-live-record the note quotes the live Record sentences and that named I is not content
+PASS: note-parents-and-witnesses the note links both parents and records the displayed algebra
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: forbidden-rhetoric-absent the note avoids axiom-adoption, promotion, and executor-name rhetoric
+PASS: identity-gates-present identity gates history_length and omega_coeff are the called maps
+per_element: a_w in {1, 2} tested against lock words of length 2 and 4
+per_site: a history is a word of already-formed locks; blanks are unread
+per_mode: quadratic OS0 TT form only; no spectral-mode exhaustion
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py
+++ b/scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Exact checks: a lock-history length is not the Wick clock parameter a.
+
+Histories are finite lock words. omega_coeff is derived by substituting
+k4 = i a_w omega into Q_E = (k4^2 + k^2)/4 using exact Fraction
+arithmetic. The runner does not install a_w = 1 and does not adopt
+L_phys. No cache is written.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/LOCK_HISTORY_LENGTH_IS_NOT_WICK_CLOCK_A_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+PRIMITIVE_REL = "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/LOCK_HISTORY_LENGTH_IS_NOT_WICK_CLOCK_A_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+PRIMITIVE_PATH = ROOT / PRIMITIVE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+LOCK_ALPHABET = frozenset("ABCD")
+H0 = ""
+H2 = "AB"
+H4 = "ABCD"
+ALLOWED_LENGTHS = frozenset({0, 1, 2, 3, 4})
+A_SAMPLES = (Fraction(1), Fraction(2))
+
+READOUT_SENTENCES = (
+    "Only records are readable.",
+    "A readout value is determined by record content alone.",
+    "A site with no record cannot be read.",
+)
+WICK_PHRASES = (
+    "k4 = i a_w omega",
+    "k_4 = i a_w",
+    "omega_coeff",
+    "a_w",
+    "Wick clock",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def live_record_section(axiom: str) -> str:
+    start = axiom.index("### Record / Fixed Reality")
+    end = axiom.index("## Qualification")
+    return axiom[start:end]
+
+
+def history_length(history: str) -> int:
+    """Cardinality of a finite lock word. Independent of a_w."""
+    if any(letter not in LOCK_ALPHABET for letter in history):
+        raise ValueError("history uses a letter outside the lock alphabet")
+    n = len(history)
+    if n not in ALLOWED_LENGTHS:
+        raise ValueError("history length is outside the declared set")
+    return n
+
+
+def q_e(k4_sq: Fraction, k_sq: Fraction) -> Fraction:
+    """Euclidean OS0 form Q_E = (k4^2 + k^2)/4. No Wick parameter."""
+    return (k4_sq + k_sq) / Fraction(4)
+
+
+def wick_k4_squared(a_w: Fraction, omega: Fraction) -> Fraction:
+    """k4 = i a_w omega implies k4^2 = -a_w^2 omega^2."""
+    return -(a_w * a_w) * (omega * omega)
+
+
+def omega_coeff(a_w: Fraction) -> Fraction:
+    """Coefficient of omega^2 after substituting k4 = i a_w omega into Q_E."""
+    return q_e(wick_k4_squared(a_w, Fraction(1)), Fraction(0))
+
+
+def omega_coeff_equals_length_for_all(
+    a_values: tuple[Fraction, ...], histories: tuple[str, ...]
+) -> bool:
+    """Hostile predicate: omega_coeff(a_w) equals |H| for all a_w, H."""
+    return all(
+        omega_coeff(a_w) == Fraction(history_length(history))
+        for a_w in a_values
+        for history in histories
+    )
+
+
+def live_memo_contains_i_empty(axiom: str) -> bool:
+    """Hostile predicate: live Record section contains I(empty)=0."""
+    return "I(empty)=0" in live_record_section(axiom)
+
+
+def n_or_reciprocal(n: int) -> set[Fraction]:
+    if n == 0:
+        raise ValueError("1/n is undefined for the empty history")
+    return {Fraction(n), Fraction(1, n)}
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    primitive = PRIMITIVE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_n = normalize(note)
+    primitive_n = normalize(primitive)
+    axiom_n = normalize(axiom)
+    live = live_record_section(axiom)
+    live_n = normalize(live)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: axiom memo and kinetic-isotropy "
+        "primitive; no observational or fitted inputs"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read "
+        "for claim-surface consistency; no runner cache is written"
+    )
+    print(
+        "negative_scope: lock-history length as a selector of a_w is "
+        "rejected; a declared continuation remains extra"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared audit inputs are the new note, kinetic isotropy, and axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, PRIMITIVE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "source-record-readout",
+        "the three live Record readout sentences occur verbatim",
+        all(sentence in live_n for sentence in READOUT_SENTENCES),
+    )
+    checks.check(
+        "source-records-form-lock-permanence",
+        "live Record names formation, locking, and permanence",
+        "Records form." in live
+        and "a record locks exactly one admissible local possibility" in live_n
+        and "records are permanent" in live_n,
+    )
+    checks.check(
+        "source-named-I-not-content",
+        "named I and I(empty)=0 are stated not to be Record axiom content",
+        "a named scalar collection functional `I`" in axiom
+        and "`I(empty)=0` are not Record axiom content" in axiom_n,
+    )
+    checks.check(
+        "source-kinetic-os0",
+        "the primitive supplies Euclidean c_t = c_s / OS0, not a_w",
+        "c_t = c_s" in primitive
+        and "Osterwalder-Schrader OS0 kinetic" in primitive_n
+        and all(phrase not in primitive for phrase in WICK_PHRASES),
+    )
+
+    n2 = history_length(H2)
+    n4 = history_length(H4)
+    n0 = history_length(H0)
+    checks.check(
+        "theorem-1-histories",
+        "H2=AB and H4=ABCD are lawful lock words with n=2 and n=4",
+        n2 == 2
+        and n4 == 4
+        and n0 == 0
+        and set(H2) <= LOCK_ALPHABET
+        and set(H4) <= LOCK_ALPHABET
+        and H2 != H4
+        and {n0, n2, n4} <= ALLOWED_LENGTHS,
+    )
+    checks.check(
+        "theorem-1-blank-unread",
+        "blank unread: empty history has no lock content and is not a clock readout",
+        n0 == 0
+        and "A site with no record cannot be read." in live_n
+        and "Do not assign a readout to empty sites" in note_n,
+    )
+
+    coeff_one = omega_coeff(Fraction(1))
+    coeff_two = omega_coeff(Fraction(2))
+    length_values = n_or_reciprocal(n2) | n_or_reciprocal(n4)
+    checks.check(
+        "theorem-2-omega-coeff",
+        "derived omega_coeff(1)=-1/4 and omega_coeff(2)=-1",
+        coeff_one == Fraction(-1, 4) and coeff_two == Fraction(-1),
+    )
+    checks.check(
+        "theorem-2-distinct",
+        "omega_coeff(1) and omega_coeff(2) are different",
+        coeff_one != coeff_two,
+    )
+    checks.check(
+        "theorem-2-neither-n-nor-reciprocal",
+        "neither coefficient equals n or 1/n for n=2 and n=4",
+        coeff_one not in length_values and coeff_two not in length_values,
+    )
+    checks.check(
+        "theorem-2-q-e-independent",
+        "Q_E has no a_w argument and is unchanged across Wick samples",
+        q_e(Fraction(4), Fraction(9)) == Fraction(13, 4)
+        and q_e.__code__.co_argcount == 2
+        and omega_coeff(Fraction(1)) == q_e(wick_k4_squared(Fraction(1), Fraction(1)), Fraction(0)),
+    )
+    checks.check(
+        "theorem-3-os0-not-function-of-H",
+        "OS0 is c_t=c_s, not a function of |H|",
+        "c_t = c_s" in primitive
+        and q_e(Fraction(1), Fraction(1)) == Fraction(1, 2)
+        and history_length(H2) != history_length(H4)
+        and "not a function of `|H|`" in note,
+    )
+    checks.check(
+        "theorem-3-record-names-no-wick",
+        "live Record names no Wick parameter; a_w remains extra",
+        all(phrase not in live for phrase in WICK_PHRASES)
+        and "clock map `a_w` remains extra" in note,
+    )
+    checks.check(
+        "theorem-3-no-a1-no-lphys",
+        "the note does not install a_w=1 and does not adopt L_phys",
+        "does not install `a_w = 1`" in note
+        and "does not adopt `L_phys`" in note
+        and "L_phys" not in live
+        and "L_phys" not in primitive,
+    )
+
+    displayed = (H2, H4)
+    checks.check(
+        "mutation-omega-equals-length-fails",
+        "predicate omega_coeff(a_w) equals |H| for all a_w,H fails",
+        omega_coeff_equals_length_for_all(A_SAMPLES, displayed) is False
+        and coeff_one != Fraction(n2)
+        and coeff_two != Fraction(n4),
+    )
+    checks.check(
+        "mutation-live-I-empty-fails",
+        "predicate live memo contains I(empty)=0 fails",
+        live_memo_contains_i_empty(axiom) is False
+        and "I(empty)=0" not in live
+        and "A site with no record cannot be read." in live_n,
+    )
+
+    checks.check(
+        "note-quotes-live-record",
+        "the note quotes the live Record sentences and that named I is not content",
+        all(sentence in note_n for sentence in READOUT_SENTENCES)
+        and "Named `I` is not axiom content" in note,
+    )
+    checks.check(
+        "note-parents-and-witnesses",
+        "the note links both parents and records the displayed algebra",
+        "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md" in note
+        and "H2 = AB" in note
+        and "H4 = ABCD" in note
+        and "omega_coeff(1) = -1/4" in note
+        and "omega_coeff(2) = -1" in note
+        and "omega_coeff(a_w) = -a_w^2 / 4" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        "actual_current_surface_status: bounded-support" in note
+        and "target_claim_type: bounded_theorem" in note
+        and "trace_class: negative_route_pruning" in note
+        and "This is current Record, not a retype." in note,
+    )
+
+    forbidden = ("new axiom", "we adopt", "promoted", "Codex")
+    retained_hits = [
+        line
+        for line in note.splitlines()
+        if "retained" in line
+        and "audit_required_before_effective_retained" not in line
+        and "bare_retained_allowed" not in line
+    ]
+    checks.check(
+        "forbidden-rhetoric-absent",
+        "the note avoids axiom-adoption, promotion, and executor-name rhetoric",
+        all(phrase not in note for phrase in forbidden) and retained_hits == [],
+    )
+    checks.check(
+        "identity-gates-present",
+        "identity gates history_length and omega_coeff are the called maps",
+        history_length.__doc__ is not None
+        and "Independent of a_w" in (history_length.__doc__ or "")
+        and omega_coeff(Fraction(2)) == Fraction(-1)
+        and "def omega_coeff(" in Path(__file__).read_text(encoding="utf-8"),
+    )
+
+    print(
+        "per_element: a_w in {1, 2} tested against lock words of length 2 and 4"
+    )
+    print(
+        "per_site: a history is a word of already-formed locks; blanks are unread"
+    )
+    print(
+        "per_mode: quadratic OS0 TT form only; no spectral-mode exhaustion"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Live Record plus lock-history lengths `n=2` and `n=4` do not name Wick `a_w`. Blank unread forbids manufacturing a clock from empty sites. `omega_coeff(1)=−1/4` and `omega_coeff(2)=−1` are distinct and equal neither `n` nor `1/n`. OS0 is `c_t=c_s`, not a function of `|H|`. No `a=1`. No `L_phys`.

## What this means for the TOE

A history of locks is not a clock parameter. The Wick map `a_w` remains extra after live Record and OS0.

## Verification

```bash
python3 scripts/lock_history_length_is_not_wick_clock_a_2026_08_13.py
# TOTAL: PASS=22 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.