### PR TITLE
[physics-loop] toe-lphys bornk2: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_KERNELS_ONE_MENU_K_IS_NOT_LOCK_CONTENT_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_KERNELS_ONE_MENU_K_IS_NOT_LOCK_CONTENT_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,130 @@
+---
+claim_id: two_kernels_one_menu_k_is_not_lock_content_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On one binary menu and one density, the trace kernel and the half-threshold step kernel disagree at the formed lock of content A. Live Record names the lock label A from record content alone, not a kernel number. Neither kernel is named by live Record. A Born number requires a supplied kernel. Both kernels are displayed; neither is adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py
+---
+
+# Two Kernels On One Menu: K Is Not Lock Content
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** one binary menu, one density, two displayed kernels, one formed lock.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py`](../scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py)
+**Parent:** axiom memo only
+([`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)).
+
+## Result Up Front
+
+The same formed lock and the same menu do not pick a kernel. Live Record:
+
+> A readout value is determined by record content alone.
+
+That readout is the lock label `A`, not `3/5` and not `1`. Named `I` is not
+axiom content; this note does not write `I(A)=1` as an axiom step. The lock is
+`A`.
+
+Two exact kernels on the same pair `ρ`, `P_A` disagree. A Born number
+therefore requires a supplied kernel. Both kernels are displayed. Neither is
+adopted.
+
+This block is independent of the occupancy-menu-kernel triple (drop `o`,
+menu, or kernel one at a time) and of the C1 occupancy-retract ledger. The
+hole here is two kernels on one already-formed lock.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Fraction algebra on one menu and one density: two kernels disagree at the lock of content A, and live Record names the label A rather than either kernel value. No axiom edit, no named I, no adopted Born kernel."
+trace_class: negative_route_pruning
+target_claim_id: null
+target_blocker_text: "whether a formed lock of content A on a displayed menu already is a Born number"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the declared menu, density, two kernels, and formed lock of content A; no kernel is selected as physical law"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+The menu is `{A, B}` with projectors
+
+`P_A = diag(1, 0)`, `P_B = I − P_A`.
+
+The density is
+
+`ρ = diag(3/5, 2/5)`.
+
+The trace kernel is
+
+`K_tr(ρ, P) = Tr(ρ P)`.
+
+So `K_tr(ρ, P_A) = 3/5` and `K_tr(ρ, P_B) = 2/5`.
+
+The step kernel is
+
+`K_step(ρ, P) = 1` if `Tr(ρ P) ≥ 1/2`, else `0`.
+
+So `K_step(ρ, P_A) = 1` and `K_step(ρ, P_B) = 0`.
+
+A formed lock of content `A` is the Record datum. The readout is determined
+by record content alone. That value is the label `A`.
+
+## Theorem 1
+
+`K_tr(ρ, P_A) = 3/5 ≠ 1 = K_step(ρ, P_A)`.
+
+Same menu, same `ρ`, same lock label `A`. The two kernels disagree at the
+formed lock. Kernel equality is false.
+
+## Theorem 2
+
+Neither kernel is named by live Record. `I` is not axiom content, so this
+note does not write `I(A)=1` as an axiom step. The lock is `A`.
+
+The governing Record section of
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+says that records form, lock one admissible possibility, are unique and
+permanent, are the only readable objects, and that a readout value is
+determined by record content alone. It does not name `Tr(ρ P)`, `K_tr`, or
+`K_step`.
+
+## Theorem 3
+
+A Born number requires a supplied kernel. Display both kernels. Do not adopt
+either. Do not adopt Born. Do not import Gleason.
+
+## Mutation Predicates
+
+The following predicates fail:
+
+1. `K_tr(ρ, P_A) == K_step(ρ, P_A)`
+2. “live memo names `Tr(ρ P)`” as governing Record content
+
+The live Record section of
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+is the text from `### Record / Fixed Reality` through `## Qualification`.
+That section contains the content-alone sentence and does not contain
+`Tr(ρ P)`.
+
+## What This Does Not Claim
+
+- No axiom is edited.
+- Named `I` is not restored as axiom content.
+- Neither `K_tr` nor `K_step` is adopted as physical law.
+- Born is not adopted and is not claimed false.
+- Gleason is not imported.
+- Occupancy, a second menu, and a C1 retract of `J` are out of scope.
+- The result is a type split between lock content and a supplied kernel, not
+  a uniqueness theorem among kernels.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18393,6 +18393,10 @@
   "two_field_retarded_probe_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "two_kernels_one_menu_k_is_not_lock_content_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_seam_forest_gauge_polyakov_holonomy_preservation_bounded_theorem_note_2026-07-12": {
    "deps_hash": "5fc9a31251f2",

--- a/logs/runner-cache/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.txt
+++ b/logs/runner-cache/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py
+runner_sha256: 575e9a6868097c47fdeb00926cecc8cdf6398f88b042f386984e481bfb3117b0
+input_fingerprint_sha256: 7c9d18cefd2aa5c443c08e47b487a6acd3819d1b93d46f1ab1aaedc5d072b2cc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+arithmetic: exact Fraction matrix pairing; two kernels on one menu
+PASS: source-content-alone live Record determines readout value by record content alone
+PASS: source-locks-one live Record locks exactly one admissible local possibility
+PASS: source-I-excluded memo states named I and I(empty)=0 are not Record axiom content
+PASS: mutation-live-memo-tr predicate live memo names Tr(ρP) fails on governing Record
+PASS: menu-resolution P_A and P_B sum exactly to the identity
+PASS: density-trace-one rho is a diagonal trace-one positive matrix
+PASS: identity-K-tr-A K_tr(rho, P_A) computes the exact value 3/5
+PASS: identity-K-tr-B K_tr(rho, P_B) computes the exact value 2/5
+PASS: identity-K-step-A K_step(rho, P_A) computes the exact value 1
+PASS: identity-K-step-B K_step(rho, P_B) computes the exact value 0
+PASS: mutation-kernel-equality predicate K_tr(rho, P_A) == K_step(rho, P_A) fails
+PASS: t1-disagreement same menu, same rho, same lock label A, kernels 3/5 and 1 disagree
+PASS: t2-lock-is-label the formed lock is the label A, not 3/5 and not 1
+PASS: t2-no-I-A-axiom-step note does not write I(A)=1 as an axiom step
+PASS: t3-display-both note displays both kernels and adopts neither
+PASS: note-theorems note states Theorems 1-3 and the two failed predicates
+PASS: note-quotes-content-alone note quotes the live content-alone sentence
+PASS: hygiene-forbidden-phrases the source does not adopt Born, restore I, or import Gleason
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+PASS: note-status note machine status is bounded-support
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the declared note and axiom memo
+per_element: one binary menu, one density, two exact kernels, one lock label
+per_site: one formed lock of content A; no composite carrier is asserted
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py
+++ b/scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Exact checks: two kernels on one menu; K is not lock content.
+
+Same menu, same density, same formed lock of content A. The trace kernel and
+the half-threshold step kernel disagree. Live Record names the lock label A
+from content alone, not a kernel number.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_KERNELS_ONE_MENU_K_IS_NOT_LOCK_CONTENT_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_KERNELS_ONE_MENU_K_IS_NOT_LOCK_CONTENT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CONTENT_ALONE = "A readout value is determined by record content alone."
+LOCKS_ONE = "a record locks exactly one admissible local possibility"
+
+
+Matrix = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def governing_record_section(note: str) -> str:
+    """Live Record axiom only; exclude historical discussion."""
+    try:
+        section = note.split("### Record / Fixed Reality", 1)[1]
+        section = section.split("## Qualification", 1)[0]
+    except IndexError:
+        return ""
+    return normalize(section)
+
+
+def mat_add(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][column] + right[row][column] for column in range(2))
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def mat_sub(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][column] - right[row][column] for column in range(2))
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(
+            left[row][0] * right[0][column] + left[row][1] * right[1][column]
+            for column in range(2)
+        )
+        for row in range(2)
+    )  # type: ignore[return-value]
+
+
+def tr(matrix: Matrix) -> Fraction:
+    return matrix[0][0] + matrix[1][1]
+
+
+def K_tr(rho: Matrix, projector: Matrix) -> Fraction:
+    return tr(mat_mul(rho, projector))
+
+
+def K_step(rho: Matrix, projector: Matrix) -> Fraction:
+    return Fraction(1) if K_tr(rho, projector) >= Fraction(1, 2) else Fraction(0)
+
+
+def kernels_agree_at_P_A(rho: Matrix, P_A: Matrix) -> bool:
+    return K_tr(rho, P_A) == K_step(rho, P_A)
+
+
+def live_memo_names_tr_rho_p(record_section: str) -> bool:
+    compact = record_section.replace(" ", "")
+    needles = (
+        "Tr(ρP)",
+        "Tr(ρ P)",
+        "Tr(\\rho P)",
+        "Tr(rhoP)",
+        "Tr(rho P)",
+    )
+    return any(needle.replace(" ", "") in compact for needle in needles)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    record_section = governing_record_section(axiom)
+    normalized_note = normalize(note)
+
+    print(
+        "external_scientific_inputs: current axiom wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print(
+        "package_local_integrity_reads: the proposed source note is read for "
+        "claim-surface consistency"
+    )
+    print(
+        "arithmetic: exact Fraction matrix pairing; two kernels on one menu"
+    )
+
+    identity: Matrix = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(1)),
+    )
+    P_A: Matrix = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(0)),
+    )
+    P_B = mat_sub(identity, P_A)
+    rho: Matrix = (
+        (Fraction(3, 5), Fraction(0)),
+        (Fraction(0), Fraction(2, 5)),
+    )
+    lock_label = "A"
+
+    k_tr_a = K_tr(rho, P_A)
+    k_tr_b = K_tr(rho, P_B)
+    k_step_a = K_step(rho, P_A)
+    k_step_b = K_step(rho, P_B)
+
+    checks.check(
+        "source-content-alone",
+        "live Record determines readout value by record content alone",
+        CONTENT_ALONE in record_section,
+    )
+    checks.check(
+        "source-locks-one",
+        "live Record locks exactly one admissible local possibility",
+        LOCKS_ONE in record_section,
+    )
+    checks.check(
+        "source-I-excluded",
+        "memo states named I and I(empty)=0 are not Record axiom content",
+        "named scalar collection functional `I`" in axiom
+        and "I(empty)=0` are not Record axiom content" in axiom,
+    )
+    checks.check(
+        "mutation-live-memo-tr",
+        "predicate live memo names Tr(ρP) fails on governing Record",
+        live_memo_names_tr_rho_p(record_section) is False,
+    )
+    checks.check(
+        "menu-resolution",
+        "P_A and P_B sum exactly to the identity",
+        mat_add(P_A, P_B) == identity,
+    )
+    checks.check(
+        "density-trace-one",
+        "rho is a diagonal trace-one positive matrix",
+        tr(rho) == Fraction(1)
+        and rho[0][0] == Fraction(3, 5)
+        and rho[1][1] == Fraction(2, 5)
+        and rho[0][1] == 0
+        and rho[1][0] == 0,
+    )
+    checks.check(
+        "identity-K-tr-A",
+        "K_tr(rho, P_A) computes the exact value 3/5",
+        k_tr_a == Fraction(3, 5),
+    )
+    checks.check(
+        "identity-K-tr-B",
+        "K_tr(rho, P_B) computes the exact value 2/5",
+        k_tr_b == Fraction(2, 5),
+    )
+    checks.check(
+        "identity-K-step-A",
+        "K_step(rho, P_A) computes the exact value 1",
+        k_step_a == Fraction(1),
+    )
+    checks.check(
+        "identity-K-step-B",
+        "K_step(rho, P_B) computes the exact value 0",
+        k_step_b == Fraction(0),
+    )
+    checks.check(
+        "mutation-kernel-equality",
+        "predicate K_tr(rho, P_A) == K_step(rho, P_A) fails",
+        kernels_agree_at_P_A(rho, P_A) is False
+        and k_tr_a != k_step_a,
+    )
+    checks.check(
+        "t1-disagreement",
+        "same menu, same rho, same lock label A, kernels 3/5 and 1 disagree",
+        k_tr_a == Fraction(3, 5)
+        and k_step_a == Fraction(1)
+        and k_tr_a != k_step_a
+        and lock_label == "A",
+    )
+    checks.check(
+        "t2-lock-is-label",
+        "the formed lock is the label A, not 3/5 and not 1",
+        lock_label == "A"
+        and lock_label != str(k_tr_a)
+        and lock_label != str(k_step_a),
+    )
+    checks.check(
+        "t2-no-I-A-axiom-step",
+        "note does not write I(A)=1 as an axiom step",
+        "does not write `I(A)=1` as an axiom step" in normalized_note,
+    )
+    checks.check(
+        "t3-display-both",
+        "note displays both kernels and adopts neither",
+        "Display both kernels" in note
+        and "Do not adopt" in note
+        and "Do not adopt Born" in note,
+    )
+    checks.check(
+        "note-theorems",
+        "note states Theorems 1-3 and the two failed predicates",
+        all(
+            phrase in note
+            for phrase in (
+                "## Theorem 1",
+                "## Theorem 2",
+                "## Theorem 3",
+                "`K_tr(ρ, P_A) == K_step(ρ, P_A)`",
+                "live memo names `Tr(ρ P)`",
+            )
+        ),
+    )
+    checks.check(
+        "note-quotes-content-alone",
+        "note quotes the live content-alone sentence",
+        CONTENT_ALONE in note,
+    )
+    checks.check(
+        "hygiene-forbidden-phrases",
+        "the source does not adopt Born, restore I, or import Gleason",
+        "we adopt" not in note
+        and "Born axiom" not in note
+        and "GLEASON_ON_QUBIT_LATTICE" not in note
+        and "I(A)=1` as an axiom step" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "note-status",
+        "note machine status is bounded-support",
+        "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the declared note and axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_KERNELS_ONE_MENU_K_IS_NOT_LOCK_CONTENT_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+
+    print(
+        "per_element: one binary menu, one density, two exact kernels, one lock label"
+    )
+    print(
+        "per_site: one formed lock of content A; no composite carrier is asserted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same menu `{A,B}`, same `ρ=diag(3/5,2/5)`, same lock label `A`: `K_tr=3/5 ≠ 1=K_step`. Live Record names the lock label from content alone, not a kernel number. Neither kernel is named. Both displayed; neither adopted. No Gleason. No restored `I`.

## What this means for the TOE

A formed lock is not a Born number. A kernel is extra supplied structure, not Record content.

## Verification

```bash
python3 scripts/two_kernels_one_menu_k_is_not_lock_content_2026_08_13.py
# TOTAL: PASS=21 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.