### PR TITLE
[physics-loop] toe-lphys pair2arg: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_OCCUPIED_PAIRINGS_LIVE_RECORD_NAMES_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_OCCUPIED_PAIRINGS_LIVE_RECORD_NAMES_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,238 @@
+---
+claim_id: two_occupied_pairings_live_record_names_neither_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On two disjoint occupied unit locks, a supplied product pairing B_π fills the four occupied-pair cells by (0,0,0,1) and a supplied count-add pairing B_+ fills the same cells by (0,1,1,2). They disagree at the occupied-occupied cell 1≠2. Live Record names only records readable, content-alone readout, and blank unreadability. It does not name a two-argument map and does not name B_+ as axiom content. Both tables are extras. Neither π nor a J-field pairing is adopted. Named additive I is not restored."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py
+---
+
+# Two Occupied Pairings; Live Record Names Neither
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact four-cell comparison of two supplied pairings on occupied
+unit-lock collections against the live Record wording.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py`](../scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Take two disjoint occupied unit locks `s` and `t`. The four pairs of occupied
+collections are
+
+```text
+(∅,∅), (∅,{t}), ({s},∅), ({s},{t}).
+```
+
+A *supplied* product pairing `B_π` fills those cells by `(0, 0, 0, 1)`. A
+*supplied* count-add pairing `B_+` fills the same cells by `(0, 1, 1, 2)`.
+At the occupied-occupied cell,
+
+```text
+B_π({s},{t}) = 1 ≠ 2 = B_+({s},{t}).
+```
+
+Live Record names neither table. The live axiom text says that only records
+are readable, that a readout value is determined by record content alone, and
+that a site with no record cannot be read. It does not name a two-argument
+map. It does not name `B_+` as axiom content. Named additive `I` is not
+axiom content.
+
+Both tables are extras. They are displayed. This note does not adopt `π`.
+It does not pair on a `J` field. It does not restore `I` as an axiom. It
+does not install `G_N` or `1/r`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two supplied four-cell tables are exact Fractions; their occupied-occupied disagreement is 1≠2; live Record is quoted and names neither a two-argument map nor B_+; both tables remain extras."
+trace_class: negative_route_pruning
+target_claim_id: two_occupied_pairings_live_record_names_neither
+target_blocker_text: "even a supplied count-pairing and a product-pairing are both extra; live Record names neither"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the four occupied-pair cells; no pairing axiom, J-field pairing, or named I is adopted"
+hypothetical_axiom_status: "no pairing axiom is adopted, recommended, or edited; named I is not restored"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Quoted Live Record
+
+The live Record axiom, from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), is used only
+for its readable-content wording:
+
+```text
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+```
+
+That wording names no two-argument map of occupied collections. It names no
+count-add pairing `B_+`. It names no product pairing `B_π`. A blank site is
+unread; it is not assigned a scalar pairing value.
+
+The same memo states that finite additivity, a named scalar collection
+functional `I`, and an assigned value `I(empty)=0` are not Record axiom
+content. The live Record body therefore does not contain `I(empty)=0`. The
+predicate “live memo contains `I(empty)=0`” fails.
+
+## Exact Objects
+
+Let `s` and `t` be two occupied unit locks, treated as disjoint. The four
+*occupied collections* they generate are `∅`, `{t}`, `{s}`, and `{s} ∪ {t}`.
+The four *pairs of occupied collections* are the ordered pairs
+
+```text
+(∅, ∅), (∅, {t}), ({s}, ∅), ({s}, {t}).
+```
+
+The **product pairing** `B_π` is a supplied extra two-argument table on
+those four pairs, *not* axiom content:
+
+```text
+B_π(∅, ∅) = 0,
+B_π(∅, {t}) = 0,
+B_π({s}, ∅) = 0,
+B_π({s}, {t}) = 1.
+```
+
+Equivalently, on these unit locks, `B_π(S, T) = |S| |T|`. Displayed as a
+2×2 with rows `{∅, {s}}` and columns `{∅, {t}}`:
+
+```text
+        ∅     {t}
+∅       0      0
+{s}     0      1
+```
+
+The **count-add pairing** `B_+` is a supplied extra two-argument table on
+the same four pairs, *not* axiom content. It is count-add on occupied sets:
+
+```text
+B_+(∅, ∅) = 0,
+B_+(∅, {t}) = 1,
+B_+({s}, ∅) = 1,
+B_+({s}, {t}) = 2.
+```
+
+Equivalently, `B_+(S, T) = |S| + |T|`. Displayed on the same 2×2:
+
+```text
+        ∅     {t}
+∅       0      1
+{s}     1      2
+```
+
+All displayed scalars are exact rationals (`Fraction` in the runner). Identity
+gates call `B_pi(S, T)` and `B_plus(S, T)`.
+
+Neither table is a pairing on a `J` field. The arguments are occupied
+collections of unit locks, not a site-indexed field.
+
+## Theorem 1 — The occupied-occupied cells disagree
+
+**Statement.** `B_π({s},{t}) = 1 ≠ 2 = B_+({s},{t})`.
+
+**Proof.** The supplied product table assigns the occupied-occupied cell
+`B_π({s},{t}) = 1`. The supplied count-add table assigns the same cell
+`B_+({s},{t}) = 2`. Those are different rationals. Cellwise:
+
+| cell | `B_π` | `B_+` | equal? |
+|---|---:|---:|---|
+| `(∅, ∅)` | `0` | `0` | yes |
+| `(∅, {t})` | `0` | `1` | no |
+| `({s}, ∅)` | `0` | `1` | no |
+| `({s}, {t})` | `1` | `2` | no |
+
+Three of four cells disagree. In particular the occupied-occupied cell is
+`1 ≠ 2`. The predicate `B_π == B_+` is therefore false.
+
+## Theorem 2 — Live Record names neither map
+
+**Statement.** Quote live Record. It does not name a two-argument map and
+does not name `B_+` as axiom content.
+
+**Proof.** The quoted live Record sentences are:
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+Those sentences mention records, readability, content-alone determination,
+and unreadability of a blank site. They do not introduce a symbol for a map
+
+```text
+(occupied collection, occupied collection) ↦ scalar
+```
+
+and they do not assign values to the four ordered pairs. In particular they
+do not name `B_+` and they do not name `B_π`. The memo's Record body does
+not contain `I(empty)=0`, and it states that a named scalar collection
+functional `I` is not Record axiom content. So `B_+` is not a live-axiom
+rewrite of `I`, and it is not axiom content.
+
+## Theorem 3 — Both tables are extras
+
+**Statement.** Both tables are extras. Display them. Do not adopt `π`. Do
+not pair on a `J` field.
+
+**Proof.** Theorem 1 displays both four-cell tables and their disagreement.
+Theorem 2 shows that live Record names neither table. A table that is not
+named by the live axiom, and is not a retained derivation, is extra. The
+product table `B_π` is therefore extra. The count-add table `B_+` is
+therefore extra. Displaying them does not adopt them.
+
+This note does not adopt `π`. It does not promote `B_π` or `B_+` to axiom
+content. It does not pair on a `J` field: the displayed arguments are
+occupied collections of unit locks, not values of a site-indexed field `J`.
+Named additive `I` is not restored.
+
+## Mutation
+
+Two predicates must fail.
+
+1. The predicate `B_π == B_+` must fail. By Theorem 1 it fails at
+   `({s},{t})`, where the values are `1` and `2`. The runner evaluates that
+   predicate by calling `B_pi` and `B_plus`.
+2. The predicate “live memo contains `I(empty)=0`” must fail. By the quoted
+   live Record body, that string is absent from the live Record section.
+
+Identity gates call `B_pi(S, T)` and `B_plus(S, T)` rather than substituting
+a hardcoded four-tuple in place of the pairing constructors.
+
+## Non-Claims
+
+This note does not:
+
+- adopt, recommend, or edit a pairing axiom;
+- adopt `π` or the product table `B_π`;
+- adopt the count-add table `B_+`;
+- pair on a `J` field;
+- restore named additive `I` as axiom content;
+- claim Newton, a force law, or a gravitational coupling;
+- install `G_N` or `1/r`;
+- identify occupied-lock counts with physical masses;
+- depend on an empty/unit I-table versus `T_π` comparison;
+- depend on a multiplicative retype of `I`.
+
+Both supplied pairings remain extras.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py
+```
+
+Expected closeout includes `TOTAL: PASS>=12 FAIL=0`, identity gates that call
+`B_pi` and `B_plus`, a failing equality predicate `B_π == B_+`, and a failing
+predicate that the live memo contains `I(empty)=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18393,6 +18393,10 @@
   "two_field_retarded_probe_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "two_occupied_pairings_live_record_names_neither_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_seam_forest_gauge_polyakov_holonomy_preservation_bounded_theorem_note_2026-07-12": {
    "deps_hash": "5fc9a31251f2",

--- a/logs/runner-cache/two_occupied_pairings_live_record_names_neither_2026_08_13.txt
+++ b/logs/runner-cache/two_occupied_pairings_live_record_names_neither_2026_08_13.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py
+runner_sha256: 31ea4a734cbb0662722ef2323cf03ad6c91dc45e92058320c12d8dbd31eb1686
+input_fingerprint_sha256: 34a8fdd58d3febd9ef0dc14105456febf912fdb5060db77179ecd258c40102d9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: live Record wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+negative_scope: both pairings are extras; no pairing axiom, J-field pairing, G_N, or 1/r is installed
+PASS: audit-input-paths-literal AUDIT_INPUT_PATHS is the string-literal tuple of the new note and the axiom memo
+PASS: source-live-record the live Record body names readable records, content-alone readout, and blank unreadability
+PASS: source-i-not-axiom the axiom memo states that named I and I(empty)=0 are not Record axiom content
+PASS: note-quotes-live-record the note quotes the three live Record readout sentences
+PASS: identity-pi-table B_pi reconstructs the Fraction four-tuple (0, 0, 0, 1)
+PASS: identity-plus-table B_plus reconstructs the Fraction four-tuple (0, 1, 1, 2)
+PASS: identity-gate-calls identity gates call B_pi(S, T) and B_plus(S, T)
+PASS: theorem1-occupied-occupied B_π({s},{t})=1 ≠ 2=B_+({s},{t})
+PASS: theorem1-disagreement-count the two supplied tables disagree at three of four cells
+PASS: theorem2-no-two-argument-map live Record does not name a two-argument map and the note says so
+PASS: theorem2-b-plus-not-axiom live Record does not name B_+ as axiom content
+PASS: theorem3-both-extras the note declares both tables extras and displays them
+PASS: theorem3-do-not-adopt-pi the note does not adopt π and does not pair on a J field
+PASS: mutation-tables-equal-fails the predicate B_π == B_+ is false
+PASS: mutation-live-memo-i-empty-fails the predicate live memo contains I(empty)=0 is false
+PASS: fraction-types every B_π and B_+ cell is an exact Fraction
+PASS: nonclaims-surface the note refuses G_N, 1/r, J-field pairing, and restoring I
+PASS: independence-surface the note does not depend on the I-table versus T_π cut or a multiplicative I retype
+PASS: claim-type-contract the author hint uses the exact bounded-theorem enum
+per_element: four occupied-pair cells on two disjoint unit locks are checked
+per_site: no lattice site composite is asserted
+per_mode: no spectral-mode exhaustion is claimed
+per_block: the two extra pairing tables are the only comparison tested
+lattice_wide: checked and not executed — no G_N or 1/r installation is claimed
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py
+++ b/scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Exact checks: two occupied pairings; live Record names neither.
+
+Identity gates call B_pi(S, T) and B_plus(S, T). The predicate B_π == B_+
+fails at the occupied-occupied cell. The predicate that the live Record
+memo contains I(empty)=0 also fails. All displayed scalars are Fraction.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "TWO_OCCUPIED_PAIRINGS_LIVE_RECORD_NAMES_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_OCCUPIED_PAIRINGS_LIVE_RECORD_NAMES_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+EMPTY: frozenset[str] = frozenset()
+S: frozenset[str] = frozenset({"s"})
+T: frozenset[str] = frozenset({"t"})
+PAIR_CELLS: tuple[tuple[frozenset[str], frozenset[str]], ...] = (
+    (EMPTY, EMPTY),
+    (EMPTY, T),
+    (S, EMPTY),
+    (S, T),
+)
+OCCUPIED_OCCUPIED = (S, T)
+
+LIVE_RECORD_SENTENCES = (
+    "Only records are readable.",
+    "A readout value is determined by record content alone.",
+    "A site with no record cannot be read.",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def B_pi(left: frozenset[str], right: frozenset[str]) -> Fraction:
+    """Supplied product-pairing on occupied collections: |S| |T|."""
+    return Fraction(len(left)) * Fraction(len(right))
+
+
+def B_plus(left: frozenset[str], right: frozenset[str]) -> Fraction:
+    """Supplied count-add pairing on occupied collections: |S| + |T|."""
+    return Fraction(len(left)) + Fraction(len(right))
+
+
+def pi_table() -> dict[tuple[frozenset[str], frozenset[str]], Fraction]:
+    return {cell: B_pi(*cell) for cell in PAIR_CELLS}
+
+
+def plus_table() -> dict[tuple[frozenset[str], frozenset[str]], Fraction]:
+    return {cell: B_plus(*cell) for cell in PAIR_CELLS}
+
+
+def identity_pi_table() -> bool:
+    table = pi_table()
+    expected = {
+        (EMPTY, EMPTY): Fraction(0),
+        (EMPTY, T): Fraction(0),
+        (S, EMPTY): Fraction(0),
+        (S, T): Fraction(1),
+    }
+    return table == expected and all(isinstance(table[cell], Fraction) for cell in PAIR_CELLS)
+
+
+def identity_plus_table() -> bool:
+    table = plus_table()
+    expected = {
+        (EMPTY, EMPTY): Fraction(0),
+        (EMPTY, T): Fraction(1),
+        (S, EMPTY): Fraction(1),
+        (S, T): Fraction(2),
+    }
+    return table == expected and all(isinstance(table[cell], Fraction) for cell in PAIR_CELLS)
+
+
+def tables_equal() -> bool:
+    """Predicate B_π == B_+. Must fail."""
+    return all(B_pi(*cell) == B_plus(*cell) for cell in PAIR_CELLS)
+
+
+def disagreeing_cells() -> tuple[tuple[frozenset[str], frozenset[str]], ...]:
+    return tuple(cell for cell in PAIR_CELLS if B_pi(*cell) != B_plus(*cell))
+
+
+def live_record_section(axiom: str) -> str:
+    start = axiom.index("### Record / Fixed Reality")
+    end = axiom.index("## Qualification")
+    return axiom[start:end]
+
+
+def live_memo_contains_i_empty_zero(axiom: str) -> bool:
+    """Predicate 'live memo contains I(empty)=0'. Must fail."""
+    return "I(empty)=0" in live_record_section(axiom)
+
+
+def audit_input_paths_literal() -> bool:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if node.targets[0].id != "AUDIT_INPUT_PATHS":
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return False
+        values = []
+        for element in node.value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                return False
+            values.append(element.value)
+        return tuple(values) == AUDIT_INPUT_PATHS
+    return False
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    normalized_axiom = normalize(axiom)
+    live_record = live_record_section(axiom)
+    normalized_live_record = normalize(live_record)
+
+    print(
+        "external_scientific_inputs: live Record wording is source-bound; "
+        "no observational or fitted inputs are used"
+    )
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("negative_scope: both pairings are extras; no pairing axiom, J-field pairing, G_N, or 1/r is installed")
+
+    checks.check(
+        "audit-input-paths-literal",
+        "AUDIT_INPUT_PATHS is the string-literal tuple of the new note and the axiom memo",
+        audit_input_paths_literal()
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_OCCUPIED_PAIRINGS_LIVE_RECORD_NAMES_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    checks.check(
+        "source-live-record",
+        "the live Record body names readable records, content-alone readout, and blank unreadability",
+        all(sentence in normalized_live_record for sentence in LIVE_RECORD_SENTENCES),
+    )
+    checks.check(
+        "source-i-not-axiom",
+        "the axiom memo states that named I and I(empty)=0 are not Record axiom content",
+        "are not Record axiom content" in normalized_axiom
+        and "named scalar collection functional `I`" in axiom,
+    )
+    checks.check(
+        "note-quotes-live-record",
+        "the note quotes the three live Record readout sentences",
+        all(sentence in normalized_note for sentence in LIVE_RECORD_SENTENCES),
+    )
+    checks.check(
+        "identity-pi-table",
+        "B_pi reconstructs the Fraction four-tuple (0, 0, 0, 1)",
+        identity_pi_table(),
+    )
+    checks.check(
+        "identity-plus-table",
+        "B_plus reconstructs the Fraction four-tuple (0, 1, 1, 2)",
+        identity_plus_table(),
+    )
+    identity_sources = (
+        inspect.getsource(identity_pi_table)
+        + inspect.getsource(identity_plus_table)
+        + inspect.getsource(tables_equal)
+        + inspect.getsource(pi_table)
+        + inspect.getsource(plus_table)
+    )
+    checks.check(
+        "identity-gate-calls",
+        "identity gates call B_pi(S, T) and B_plus(S, T)",
+        "B_pi(" in identity_sources and "B_plus(" in identity_sources,
+    )
+    checks.check(
+        "theorem1-occupied-occupied",
+        "B_π({s},{t})=1 ≠ 2=B_+({s},{t})",
+        B_pi(S, T) == Fraction(1)
+        and B_plus(S, T) == Fraction(2)
+        and B_pi(S, T) != B_plus(S, T),
+    )
+    checks.check(
+        "theorem1-disagreement-count",
+        "the two supplied tables disagree at three of four cells",
+        len(disagreeing_cells()) == 3 and OCCUPIED_OCCUPIED in disagreeing_cells(),
+    )
+    checks.check(
+        "theorem2-no-two-argument-map",
+        "live Record does not name a two-argument map and the note says so",
+        "two-argument map" not in live_record
+        and "does not name a two-argument map" in normalized_note,
+    )
+    checks.check(
+        "theorem2-b-plus-not-axiom",
+        "live Record does not name B_+ as axiom content",
+        "B_+" not in live_record
+        and "does not name `B_+` as axiom content" in note,
+    )
+    checks.check(
+        "theorem3-both-extras",
+        "the note declares both tables extras and displays them",
+        "Both tables are extras" in note
+        and "B_π({s},{t}) = 1" in note
+        and "B_+({s},{t}) = 2" in note,
+    )
+    checks.check(
+        "theorem3-do-not-adopt-pi",
+        "the note does not adopt π and does not pair on a J field",
+        "does not adopt `π`" in normalized_note
+        and "does not pair on a `J` field" in normalized_note,
+    )
+    checks.check(
+        "mutation-tables-equal-fails",
+        "the predicate B_π == B_+ is false",
+        tables_equal() is False,
+    )
+    checks.check(
+        "mutation-live-memo-i-empty-fails",
+        "the predicate live memo contains I(empty)=0 is false",
+        live_memo_contains_i_empty_zero(axiom) is False,
+    )
+    checks.check(
+        "fraction-types",
+        "every B_π and B_+ cell is an exact Fraction",
+        all(isinstance(value, Fraction) for value in pi_table().values())
+        and all(isinstance(value, Fraction) for value in plus_table().values()),
+    )
+    checks.check(
+        "nonclaims-surface",
+        "the note refuses G_N, 1/r, J-field pairing, and restoring I",
+        "does not install `G_N` or `1/r`" in normalized_note
+        and "pair on a `J` field" in normalized_note
+        and "Named additive `I` is not restored" in note,
+    )
+    checks.check(
+        "independence-surface",
+        "the note does not depend on the I-table versus T_π cut or a multiplicative I retype",
+        "does not" in normalized_note
+        and "empty/unit I-table versus `T_π`" in note
+        and "multiplicative retype of `I`" in note,
+    )
+    checks.check(
+        "claim-type-contract",
+        "the author hint uses the exact bounded-theorem enum",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+
+    print("per_element: four occupied-pair cells on two disjoint unit locks are checked")
+    print("per_site: no lattice site composite is asserted")
+    print("per_mode: no spectral-mode exhaustion is claimed")
+    print("per_block: the two extra pairing tables are the only comparison tested")
+    print("lattice_wide: checked and not executed — no G_N or 1/r installation is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On two occupied unit locks, supplied `B_π` is `(0,0,0,1)` and supplied `B_+` is `(0,1,1,2)`. Occupied-occupied cell: `1≠2`. Live Record names neither two-argument map. Both tables are extras. No `π` adoption. No pairing-on-`J`. No restored `I`. No `G_N`.

## What this means for the TOE

Even after named `I` is gone, a product pairing and a count pairing are still extras. Live Record does not pick a two-argument table.

## Verification

```bash
python3 scripts/two_occupied_pairings_live_record_names_neither_2026_08_13.py
# TOTAL: PASS=19 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.