### PR TITLE
[physics-loop] toe-lphys formtwo: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_OCCUPANCY_COUNTS_ONE_MU_LIVE_RECORD_PICKS_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_OCCUPANCY_COUNTS_ONE_MU_LIVE_RECORD_PICKS_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,175 @@
+---
+claim_id: two_occupancy_counts_one_mu_live_record_picks_neither_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On a four-site window the same site content law μ is compatible with two record configurations that differ in occupancy. The empirical counts r=N_formed/|W| are then 1/4 and 1/2. Live Record (blank unread; no named I) supplies a site readout only where a record is present, so neither displayed rate is Record content and neither is adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py
+---
+
+# Two Occupancy Counts At One μ; Live Record Picks Neither Rate
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact four-site occupancy versus content-law split under the
+live Record wording (blank unread; named `I` not axiom content).
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py`](../scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py)
+
+## Result Up Front
+
+A nearest-neighbor content law can be the same at every site of a finite
+window while the number of formed records on that window is not. The two
+displayed occupancy rates therefore disagree. Live Record does not turn
+either rate into a readout, and this note adopts neither.
+
+Three exact statements locate the split.
+
+1. **Content law is not occupancy.** The same `μ` is compatible with one
+   lock and with two locks on a four-site window. The empirical ratios
+   `r(σ1)=1/4` and `r(σ2)=1/2` are then unequal.
+2. **Blank occupancy is not a site readout.** Live Record makes a site
+   with no record unreadable. Reconstructing that fact: the site readout
+   of `σ1` is defined only at `w`. A ratio `N_formed/|W|` puts unread
+   blank sites in the denominator and is not Record content.
+3. **Live Record does not name `r`.** Both rates are displayed. Neither
+   is adopted. Named `I` and `I(empty)=0` are not restored.
+
+No canonical axiom is edited. No formation-site rule, minimum occupancy,
+or rate-law class is selected.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The four-site occupancy split, blank-unread readout domain, and non-adoption of either displayed rate are proved on declared finite objects. A physical formation-rate law remains extra."
+trace_class: negative_route_pruning
+target_claim_id: record_formation_rate
+target_blocker_text: "live Record (blank unread, no named I) still does not pick a formation rate"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed two-configuration witness; a derived rate law remains open"
+hypothetical_axiom_status: "none; no edit, adoption, minimality, or necessity claim"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Let the window be
+
+`W={w,x,y,z}`, `|W|=4`.
+
+At every site of `W` the same content law on two admissible local
+possibilities is
+
+`μ(A)=3/5`, `μ(B)=2/5`.
+
+This is a sitewise possibility distribution of the kind the live
+Admissibility wording supplies: it concerns which possibility a forming
+record locks. It is the same function at every site of the window. It is
+not an occupancy count.
+
+A state is a configuration of records. Write `blank` for a site with no
+record. The two configurations are
+
+- `σ1`: lock `A` at `w`; `x,y,z` blank
+- `σ2`: lock `A` at `w` and at `x`; `y,z` blank
+
+Let `N_formed(σ)` be the number of sites in `W` that carry a record.
+The empirical occupancy ratio on the window is the extra assignment
+
+`r(σ)=N_formed(σ)/|W|`.
+
+Direct count gives `N_formed(σ1)=1` and `N_formed(σ2)=2`, hence
+
+`r(σ1)=1/4`, `r(σ2)=1/2`.
+
+Live Record, quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+```text
+Records form.
+
+When present, a record locks exactly one admissible local possibility. A
+site never carries more than one record; records are permanent.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+```
+
+The same memo states that a named scalar functional `I`, finite
+additivity, and `I(empty)=0` are not Record axiom content. The 2026-08-13
+revision removed those clauses; they are not restored here.
+
+## Theorem 1 — Same μ, Two Occupancy Counts
+
+Every formed lock in `σ1` and in `σ2` is the possibility `A`. That
+possibility is in the support of `μ` because `μ(A)=3/5≠0`. Blank sites
+do not contradict `μ`: the content law is not an occupancy law, and
+Admissibility does not supply the formation site or rate.
+
+Both configurations are therefore compatible with the same `μ`. They are
+not the same occupancy:
+
+`N_formed(σ1)=1 ≠ 2=N_formed(σ2)`,
+
+so the empirical ratios disagree:
+
+`r(σ1)=1/4 ≠ 1/2=r(σ2)`.
+
+The predicate `r(σ1)==r(σ2)` fails. Content law and occupancy are
+different objects.
+
+## Theorem 2 — Occupancy Of A Blank Site Is Not A Site Readout
+
+Live Record: only records are readable; a readout value is determined by
+record content alone; a site with no record cannot be read.
+
+In `σ1` the only site that carries a record is `w`, and that record locks
+`A`. The site readout of `σ1` is therefore defined only at `w`. The
+sites `x,y,z` are blank. Assigning them occupancy `0` and reading that
+`0` would be a readout of absence. The live wording does not assign a
+scalar to absence.
+
+The ratio `r(σ)=N_formed(σ)/|W|` uses `|W|` as denominator. On `σ1`
+that denominator is one formed site plus three unread blanks. The blanks
+are not Record content, so `r` is not a Record readout.
+
+The same holds for `σ2`: the site readout is defined only at `{w,x}`;
+`y` and `z` remain unread; `r(σ2)=1/2` still divides by `|W|`.
+
+## Theorem 3 — Live Record Does Not Name r
+
+Record names occurrence, one lock per site, permanence, content-only
+readout, and unreadability of a blank site. It does not name a window
+ratio, a formation-rate law, or a choice between `1/4` and `1/2`.
+
+Both rates are displayed:
+
+| configuration | formed sites | `N_formed` | `r=N_formed/|W|` |
+|---|---|---|---|
+| `σ1` | `{w}` | `1` | `1/4` |
+| `σ2` | `{w,x}` | `2` | `1/2` |
+
+Neither rate is adopted. The note does not install a rate law, does not
+prefer the smaller occupancy, does not prefer the larger occupancy, and
+does not restore `I` or `I(empty)=0`.
+
+## Boundary
+
+- The witness is one four-site window and one pair of configurations.
+  It does not classify all occupancy patterns or all content laws.
+- Compatibility with `μ` is support compatibility of formed locks. It is
+  not a derivation of `μ` from occupancy, or of occupancy from `μ`.
+- A later retained construction could still supply a formation-site rule
+  or a rate law. This note does not close that route and does not take
+  it.
+- Independent questions about a distinguished formation site or a
+  selected rate-law class are out of scope.
+- No axiom, primitive, ledger, or audit surface is edited.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18393,6 +18393,10 @@
   "two_field_retarded_probe_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "two_occupancy_counts_one_mu_live_record_picks_neither_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_seam_forest_gauge_polyakov_holonomy_preservation_bounded_theorem_note_2026-07-12": {
    "deps_hash": "5fc9a31251f2",

--- a/logs/runner-cache/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.txt
+++ b/logs/runner-cache/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py
+runner_sha256: 7f010b00d60aab14fe124ab698c2a925da9aa63f842ef5155a49e44fc53947e7
+input_fingerprint_sha256: 3fbd5df22a9351e5b42c46aa54d371619e75a79ecaddc05b3a4e2cc0d90b22c4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: live axiom wording only; no observational or fitted inputs
+package_local_integrity_reads: the source note is read for claim-surface consistency
+negative_scope: neither displayed window ratio is adopted; I is not restored
+PASS: window-cardinality the declared window has four sites
+PASS: content-law μ assigns 3/5 and 2/5 and is a probability on {A,B}
+PASS: same-mu both configurations are compatible with that one content law
+PASS: occupancy-split formed counts are 1 and 2 on the same window
+PASS: empirical-rates computed window ratios are exactly 1/4 and 1/2
+PASS: theorem-1-rates-differ same μ does not force equal occupancy ratios
+PASS: theorem-2-sigma1-readout site readout of σ1 is defined only at w
+PASS: theorem-2-sigma2-readout site readout of σ2 is defined only at w and x
+PASS: theorem-2-blank-not-readout blank occupancy is not a site readout: unread sites have no content
+PASS: theorem-2-rate-uses-blanks each ratio puts unread blanks in the denominator
+PASS: mutation-equal-rates predicate r(σ1)==r(σ2) fails
+PASS: mutation-i-empty predicate live memo contains I(empty)=0 fails
+PASS: source-blank-unread live Record states that a site with no record cannot be read
+PASS: source-content-only live Record names content-only readout and does not name I
+PASS: source-i-not-content the memo states that I(empty)=0 is not Record axiom content
+PASS: source-rate-downstream the memo keeps formation rate outside axiom supply
+PASS: note-displays-both-rates the note displays 1/4 and 1/2 and adopts neither
+PASS: note-does-not-restore-i the note quotes live blank-unread Record and does not restore I
+PASS: machine-status-contract the source uses the controlled bounded-support fields
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the new note and the axiom memo
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py
+++ b/scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Exact checks: two occupancy counts at one μ; live Record picks neither rate.
+
+The runner builds a four-site window, one shared content law μ, and two
+record configurations. It counts formed locks, computes the empirical
+window ratios in Fraction arithmetic, and checks the live Record block
+for blank-unread wording without restoring I. It adopts no rate law.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_OCCUPANCY_COUNTS_ONE_MU_LIVE_RECORD_PICKS_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_OCCUPANCY_COUNTS_ONE_MU_LIVE_RECORD_PICKS_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+WINDOW = ("w", "x", "y", "z")
+A = "A"
+B = "B"
+BLANK = None
+MU = {A: Fraction(3, 5), B: Fraction(2, 5)}
+
+SIGMA1 = {"w": A, "x": BLANK, "y": BLANK, "z": BLANK}
+SIGMA2 = {"w": A, "x": A, "y": BLANK, "z": BLANK}
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def formed_sites(sigma: dict[str, str | None]) -> tuple[str, ...]:
+    return tuple(site for site in WINDOW if sigma[site] is not BLANK)
+
+
+def n_formed(sigma: dict[str, str | None]) -> int:
+    return len(formed_sites(sigma))
+
+
+def empirical_rate(sigma: dict[str, str | None]) -> Fraction:
+    return Fraction(n_formed(sigma), len(WINDOW))
+
+
+def locked_contents(sigma: dict[str, str | None]) -> tuple[str, ...]:
+    return tuple(sigma[site] for site in formed_sites(sigma))
+
+
+def compatible_with_mu(sigma: dict[str, str | None]) -> bool:
+    return all(MU[content] > 0 for content in locked_contents(sigma))
+
+
+def record_axiom_block(axiom_text: str) -> str:
+    start = axiom_text.index("### Record / Fixed Reality")
+    end = axiom_text.index("## Qualification")
+    return axiom_text[start:end]
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    live_record = record_axiom_block(axiom)
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    live_record_flat = normalize(live_record)
+
+    print("external_scientific_inputs: live axiom wording only; no observational or fitted inputs")
+    print("package_local_integrity_reads: the source note is read for claim-surface consistency")
+    print("negative_scope: neither displayed window ratio is adopted; I is not restored")
+
+    rate1 = empirical_rate(SIGMA1)
+    rate2 = empirical_rate(SIGMA2)
+    readout1 = formed_sites(SIGMA1)
+    readout2 = formed_sites(SIGMA2)
+    blanks1 = tuple(site for site in WINDOW if site not in readout1)
+    blanks2 = tuple(site for site in WINDOW if site not in readout2)
+
+    checks.check(
+        "window-cardinality",
+        "the declared window has four sites",
+        WINDOW == ("w", "x", "y", "z") and len(WINDOW) == 4,
+    )
+    checks.check(
+        "content-law",
+        "μ assigns 3/5 and 2/5 and is a probability on {A,B}",
+        MU[A] == Fraction(3, 5)
+        and MU[B] == Fraction(2, 5)
+        and MU[A] + MU[B] == 1
+        and set(MU) == {A, B},
+    )
+    checks.check(
+        "same-mu",
+        "both configurations are compatible with that one content law",
+        compatible_with_mu(SIGMA1)
+        and compatible_with_mu(SIGMA2)
+        and locked_contents(SIGMA1) == (A,)
+        and locked_contents(SIGMA2) == (A, A),
+    )
+    checks.check(
+        "occupancy-split",
+        "formed counts are 1 and 2 on the same window",
+        n_formed(SIGMA1) == 1 and n_formed(SIGMA2) == 2,
+    )
+    checks.check(
+        "empirical-rates",
+        "computed window ratios are exactly 1/4 and 1/2",
+        rate1 == Fraction(1, 4) and rate2 == Fraction(1, 2),
+    )
+    checks.check(
+        "theorem-1-rates-differ",
+        "same μ does not force equal occupancy ratios",
+        rate1 != rate2 and n_formed(SIGMA1) != n_formed(SIGMA2),
+    )
+    checks.check(
+        "theorem-2-sigma1-readout",
+        "site readout of σ1 is defined only at w",
+        readout1 == ("w",) and blanks1 == ("x", "y", "z"),
+    )
+    checks.check(
+        "theorem-2-sigma2-readout",
+        "site readout of σ2 is defined only at w and x",
+        readout2 == ("w", "x") and blanks2 == ("y", "z"),
+    )
+    checks.check(
+        "theorem-2-blank-not-readout",
+        "blank occupancy is not a site readout: unread sites have no content",
+        all(SIGMA1[site] is BLANK for site in blanks1)
+        and all(SIGMA2[site] is BLANK for site in blanks2)
+        and BLANK not in MU,
+    )
+    checks.check(
+        "theorem-2-rate-uses-blanks",
+        "each ratio puts unread blanks in the denominator",
+        n_formed(SIGMA1) + len(blanks1) == len(WINDOW)
+        and n_formed(SIGMA2) + len(blanks2) == len(WINDOW)
+        and rate1 == Fraction(n_formed(SIGMA1), len(WINDOW))
+        and rate2 == Fraction(n_formed(SIGMA2), len(WINDOW))
+        and len(blanks1) > 0
+        and len(blanks2) > 0,
+    )
+    checks.check(
+        "mutation-equal-rates",
+        "predicate r(σ1)==r(σ2) fails",
+        (rate1 == rate2) is False,
+    )
+    checks.check(
+        "mutation-i-empty",
+        "predicate live memo contains I(empty)=0 fails",
+        "I(empty)=0" not in live_record and "I(empty)=0" not in live_record_flat,
+    )
+    checks.check(
+        "source-blank-unread",
+        "live Record states that a site with no record cannot be read",
+        "A site with no record cannot be read." in live_record,
+    )
+    checks.check(
+        "source-content-only",
+        "live Record names content-only readout and does not name I",
+        "A readout value is determined by record content alone." in live_record_flat
+        and "Only records are readable." in live_record
+        and "Records form." in live_record
+        and "`I`" not in live_record,
+    )
+    checks.check(
+        "source-i-not-content",
+        "the memo states that I(empty)=0 is not Record axiom content",
+        "assigned value `I(empty)=0` are not Record axiom content" in axiom_flat,
+    )
+    checks.check(
+        "source-rate-downstream",
+        "the memo keeps formation rate outside axiom supply",
+        "it does not supply the formation site, probability, or rate" in axiom_flat
+        and "at what rate" in axiom_flat,
+    )
+    checks.check(
+        "note-displays-both-rates",
+        "the note displays 1/4 and 1/2 and adopts neither",
+        "`r(σ1)=1/4`" in note
+        and "`r(σ2)=1/2`" in note
+        and "Neither rate is adopted" in note
+        and "does not install a rate law" in note,
+    )
+    checks.check(
+        "note-does-not-restore-i",
+        "the note quotes live blank-unread Record and does not restore I",
+        "A site with no record cannot be read." in note
+        and "they are not restored here" in note
+        and "does not restore `I` or `I(empty)=0`" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the controlled bounded-support fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "claim_type_reason:",
+                "trace_class: negative_route_pruning",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the new note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_OCCUPANCY_COUNTS_ONE_MU_LIVE_RECORD_PICKS_NEITHER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and Path(__file__).name in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same `μ(A)=3/5`, `μ(B)=2/5` on a 4-site window is compatible with `σ1` (`r=1/4`) and `σ2` (`r=1/2`). Live Record (blank unread, no named `I`) supplies a site readout only where a record is present. A rate `N/|W|` uses blanks in the denominator and is not Record content. Neither rate adopted.

## What this means for the TOE

Content law is not occupancy. Live Record still does not pick a formation rate.

## Verification

```bash
python3 scripts/two_occupancy_counts_one_mu_live_record_picks_neither_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.