### PR TITLE
[physics-loop] toe-lphys coloradj: bounded_theorem / bounded-support

### DIFF
--- a/docs/SU3_ADJOINT_EIGHT_IN_M8_IS_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/SU3_ADJOINT_EIGHT_IN_M8_IS_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,337 @@
+---
+claim_id: su3_adjoint_eight_in_m8_is_not_unital_m3_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The eight Gell-Mann matrices are an R-basis of su(3), dim_R = 8 ≠ 9 = dim_C M_3(C). Commutators close on the standard real structure constants. The adjoint representation ad(λ_a)_{bc} = 2 f_abc is an injective Lie homomorphism su(3) → M_8(R) ⊂ M_8(C) = End(C^8). That leftover does not install a unital *-hom M_3(C) → M_8(C), because 3 does not divide 8. Qubit names M_2(C), not su(3). The leftover is not adopted as QCD or as a unital M_3 summand, and Y_0 / hypercharge are not identified."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py
+---
+
+# su(3) Adjoint Eight In `M_8` Is Not Unital `M_3`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact type split between the real Lie algebra `su(3)` (adjoint-8
+inside `End(C^8)`) and the unital `*`-algebra `M_3(C)`. No QCD. No Qubit
+rewrite.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py`](../scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py)
+
+Parents on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Lattice plus Qubit supply a three-site Hilbert space
+
+`H = (C^2)^{⊗3} ≅ C^8`, `B(H) ≅ M_8(C)`, `dim_C M_8(C) = 64`.
+
+That Hilbert space is a native site tensor. Separately, the eight Gell-Mann
+matrices `{λ_a}_{a=1..8}` are traceless Hermitian and `R`-linearly
+independent, so `dim_R su(3) = 8`. The unit algebra `M_3(C)` has
+`dim_C M_3(C) = 9`. The integers `8 ≠ 9`: the color Lie algebra is not the
+unit algebra `M_3`.
+
+Commutators close on the standard real structure constants:
+
+`[λ_a, λ_b] = 2i ∑_c f_abc λ_c`.
+
+The adjoint matrices `ad(λ_a)_{bc} = 2 f_abc` are eight linearly independent
+real `8 × 8` matrices, so
+
+`ad : su(3) → M_8(R) ⊂ M_8(C) = End(C^8)`
+
+is an injective Lie homomorphism. Thus `su(3)` sits in `End(C^8)`.
+
+That leftover is still not a unital `M_3` factor of the three-qubit algebra:
+there is no unital `*`-homomorphism `M_3(C) → M_8(C)`, because `3 ∤ 8`.
+Do not identify `C^8` with `M_3`. Do not identify `ad(su(3))` with a unital
+`M_3` summand.
+
+Qubit names `M_2(C)`, not `su(3)`. Lattice+Qubit supply `C^8` as a Hilbert
+space. They do not name Gell-Mann matrices or QCD. This note does not adopt
+a color axiom and does not identify `Y_0` or hypercharge.
+
+This hole is independent of the three-site Hilbert-versus-unital-`M_3` type
+split (`H ≅ C^8` is not unital `M_3`) and of the two-block `Y_0` carrier.
+The present hole is type: color-as-Lie-8 versus color-as-`M_3`-9.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Gell-Mann independence, structure-constant closure, injective adjoint into M_8, and the 3-does-not-divide-8 unital obstruction are proved on declared finite matrix objects. Adoption of a color axiom, QCD identification, and a unital M_3 summand remain refused."
+trace_class: type_split
+target_claim_id: color_as_adjoint_8_is_not_unital_m3
+target_blocker_text: "does su(3) sitting in End(C^8) install unital M_3 as a three-qubit color algebra"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for adjoint-8 versus unital M_3 on End(C^8); other color leftovers remain unclaimed"
+hypothetical_axiom_status: "color-as-adjoint-8 leftover: su(3) closes in M_8; not adopted as QCD or as unital M_3"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `C` for the complex numbers. The Qubit axiom gives each Lattice site
+the one-site possibility algebra `M_2(C)`. The defining module is `C^2`.
+The three-site tensor is
+
+`H := (C^2)^{⊗3} ≅ C^8`, `B(H) ≅ M_8(C)`, `dim_C M_8(C) = 8 · 8 = 64`.
+
+Let `{λ_a}_{a=1..8}` be the standard Gell-Mann matrices (traceless Hermitian
+`3 × 3`). They are `C`-linearly independent as well, but the Lie algebra they
+span is the **real** span of `{i λ_a}` (equivalently the real span of the
+`λ_a` inside the traceless Hermitian matrices). Thus `dim_R su(3) = 8`.
+
+Separately, `M_3(C)` is the unital complex `*`-algebra of `3 × 3` matrices,
+with matrix-unit basis of cardinality `9`, so `dim_C M_3(C) = 9`.
+
+The standard totally antisymmetric real structure constants of `su(3)` are
+determined by the independent values
+
+`f_123 = 1`,
+`f_147 = f_246 = f_257 = f_345 = 1/2`,
+`f_156 = f_367 = -1/2`,
+`f_458 = f_678 = √3 / 2`,
+
+and the sign of the permutation on each triple. The Lie bracket in the
+Gell-Mann basis is
+
+`[λ_a, λ_b] = 2i ∑_{c=1}^8 f_abc λ_c`.
+
+The adjoint representation used here is the real `8 × 8` family
+
+`ad(λ_a)_{bc} = 2 f_{abc}`,
+
+with `b, c` running through `{1,...,8}`. These matrices lie in
+`M_8(R) ⊂ M_8(C) = End(C^8)`.
+
+No axiom is edited. The Gell-Mann matrices and `ad` are displayed test
+objects, not a proposed Qubit rewrite and not a registered primitive.
+
+## Theorems
+
+### Theorem 1 — eight, not nine
+
+The eight Gell-Mann matrices are linearly independent over `R` and each has
+trace `0`. The real span therefore has dimension `8`, not `9`.
+
+**Proof.** Each `λ_a` is Hermitian by inspection and `Tr λ_a = 0` (the
+diagonal matrices `λ_3` and `λ_8` are `diag(1,-1,0)` and
+`(1/√3) diag(1,1,-2)`). The trace form is
+
+`Tr(λ_a λ_b) = 2 δ_{ab}`.
+
+If `∑_a r_a λ_a = 0` with real coefficients, pairing against `λ_b` gives
+`2 r_b = 0`. Hence the eight matrices are `R`-independent, so
+`dim_R su(3) = 8`. The unit algebra `M_3(C)` has dimension `9`. These are
+different integers. ∎
+
+### Theorem 2 — commutators close
+
+`[λ_a, λ_b] = 2i ∑_c f_abc λ_c` with the standard real `f_abc`.
+
+A generating set used by the companion runner:
+
+- I-spin: `[λ_1, λ_2] = 2i λ_3`.
+- V-spin: `[λ_4, λ_5] = 2i (½ λ_3 + (√3/2) λ_8)`.
+- U-spin: `[λ_6, λ_7] = 2i (-½ λ_3 + (√3/2) λ_8)`.
+- The identity `f_147 = 1/2`: `[λ_1, λ_4] = i λ_7`.
+
+The V-spin and U-spin brackets mix `λ_3` with `λ_8`. They are **not** equal
+to `2i λ_3`. The structure-constant formula is the claim; the I-spin copy
+is the only one of those three su(2) triples whose third generator is
+exactly `λ_3`.
+
+**Proof.** Direct matrix multiplication on the four pairs, using only
+integer/`Fraction` entries except the exact `√3` coefficients of `λ_8` and
+of `f_458`, `f_678`. The same `f_abc` reproduce every pair through the
+stated formula. ∎
+
+### Theorem 3 — adjoint eight sits in `End(C^8)`
+
+The matrices `ad(λ_a)_{bc} = 2 f_{abc}` are eight linearly independent real
+`8 × 8` matrices. Therefore
+
+`ad : su(3) → M_8(R) ⊂ M_8(C)`
+
+is an injective Lie homomorphism, and `su(3)` sits in `End(C^8)`.
+
+**Proof.** The entries `2 f_abc` are real. The Frobenius pairing
+
+`∑_{b,c} ad(λ_a)_{bc} ad(λ_d)_{bc} = 4 ∑_{b,c} f_abc f_dbc = 12 δ_{ad}`
+
+is nondegenerate, so the eight matrices are `R`-independent and `ad` has
+trivial kernel. Internal consistency of the index convention
+`ad(λ_a)_{bc} = 2 f_{abc}` is the homomorphism identity on the I-spin
+generators,
+
+`[ad(λ_1), ad(λ_2)] = -2 ad(λ_3)`.
+
+The minus sign is the matrix-index counterpart of `f_{abc} = -f_{acb}`;
+it is the real adjoint of `[λ_1, λ_2] = 2i λ_3` in this convention. ∎
+
+### Theorem 4 — still no unital `M_3` in `M_8`
+
+There is still no unital `*`-homomorphism `M_3(C) → M_8(C)`, because
+`3 ∤ 8`. Adjoint-8 is not a unital `M_3` factor of the three-qubit algebra.
+
+**Proof.** A unital `C`-linear `*`-hom `M_k(C) → M_m(C)` exists if and only
+if `k` divides `m`: the standard module `C^m` must be a multiple of `C^k`.
+Here `k = 3` and `m = 8 = 2^3`, so `3 ∤ 8`. An injective Lie embedding of
+`su(3)` into `M_8` is a different type from a unital algebra embedding of
+`M_3`. The extra complex dimension `9 - 8 = 1` is exactly the unit line
+that `su(3)` does not contain. ∎
+
+### Theorem 5 — Qubit does not name this leftover
+
+Qubit names `M_2(C)`, not `su(3)`. Lattice+Qubit supply `C^8` as a Hilbert
+space. They do not name Gell-Mann matrices or QCD. This note does not adopt
+a color axiom and does not identify `Y_0` or hypercharge.
+
+**Proof of the split; refusal of the identifications.** Theorems 1–4 compare
+a displayed Lie algebra and its adjoint representation with the separate
+unital algebra `M_3(C)` and with the native three-site Hilbert space. The
+live axiom memo names one-site `M_2(C)` and does not name `su(3)`, Gell-Mann
+matrices, QCD, `Y_0`, or hypercharge. Displaying the leftover does not adopt
+it. ∎
+
+## Type Split
+
+| Object | Type | Native from Lattice+Qubit? | Dimension |
+|---|---|---|---|
+| one-site module | `C^2` | yes (Qubit defining module) | `dim_C = 2` |
+| three-site Hilbert `H` | `(C^2)^{⊗3} ≅ C^8` | yes (tensor of sites) | `dim_C = 8` |
+| bounded operators on `H` | `B(H) ≅ M_8(C)` | yes (endomorphisms) | `dim_C = 64` |
+| `su(3)` | real Lie algebra | no; displayed leftover | `dim_R = 8` |
+| `ad(su(3))` | eight matrices in `M_8(R)` | no; injective Lie image | `dim_R = 8` |
+| unital `M_3(C)` | unital `*`-algebra | no | `dim_C = 9` |
+
+The first three rows are the Lattice+Qubit Hilbert type. The next two rows
+are a Lie-algebra leftover that happens to act on an 8-dimensional space.
+The last row is a 9-dimensional unital algebra that does not embed unitaly
+into `M_8`. Equating the leftover with QCD, or with a unital `M_3` summand,
+is outside the claim.
+
+## Mutations
+
+Three hostile predicates must fail.
+
+1. “`dim su(3) == 9`.” False: Theorem 1 reconstructs `dim_R su(3) = 8`.
+2. “`3` divides `8`.” False: `8 = 2^3` and `3` is odd.
+3. “The eight matrices `ad(λ_a)` are linearly dependent.” False: Theorem 3,
+   the pairing is `12 δ_{ad}`.
+
+## What This Note Does Not Do
+
+- It does not edit an axiom and does not rewrite Qubit.
+- It does not adopt a color axiom.
+- It does not identify `C^8` with `M_3`.
+- It does not identify `ad(su(3))` with a unital `M_3` summand.
+- It does not identify the leftover with QCD, and it does not identify
+  `Y_0` or hypercharge.
+- It does not rest on, and does not reopen, the separate hole that the
+  three-site Hilbert space `C^8` is not itself unital `M_3`, nor the
+  two-block `Y_0` carrier hole.
+- It does not claim that every other color construction is impossible.
+
+## No-Go Discipline Gate
+
+The negative claim is only: adjoint-8 sits in `End(C^8)` and is still not
+unital `M_3`. The gate does not certify that color is underivable by every
+route.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Gell-Mann span equals `M_3` | compare `dim_R su(3)` to `dim_C M_3` | Theorem 1: `8 ≠ 9` | **ATTEMPTED** |
+| Commutator closure | check `[λ_a,λ_b]=2i ∑ f_abc λ_c` on a generating set | Theorem 2 | **ATTEMPTED** |
+| Adjoint injection into `M_8` | `ad(λ_a)_{bc}=2 f_abc` independent | Theorem 3: injective Lie hom | **ATTEMPTED** |
+| Unital `*`-hom `M_3 → M_8` | require `3 \| 8` | Theorem 4: `3 ∤ 8` | **ATTEMPTED** |
+| Identify `ad(su(3))` with a unital `M_3` summand | equate Lie image with unit algebra | refused; different types | **CLOSED HERE** |
+| Identify `C^8` with `M_3` | equate Hilbert space with unit algebra | refused | **CLOSED HERE** |
+| Adopt a color axiom / name QCD | fifth primitive or QCD import | refused; leftover not adopted | **CLOSED HERE** |
+| Identify `Y_0` or hypercharge | extra reading | refused | **CLOSED HERE** |
+| Other color leftovers | non-unital pads, declared carriers | not claimed | **LIVE / OUT OF SCOPE** |
+
+The broad statement “the axioms cannot derive color by any route” is not
+shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `dim su(3)=8` / `3 ∤ 8` | no: a Lie dimension does not decide unital divisibility | no: non-divisibility does not compute the Gell-Mann span | independent identities |
+| adjoint injection / unital `M_3` obstruction | no: a Lie hom can exist when no unital `*`-hom exists | no: absence of a unital map does not produce `ad` | independent holes |
+| leftover display / axiom adoption | no: Theorem 5 refuses adoption | no: the live memo does not name Gell-Mann matrices | leftover remains hypothetical |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `H`, `M_8`, `M_3`, `{λ_a}`, `f_abc`, `ad` | reconstructed finite matrix objects |
+| unital `C`-linear `*`-hom | standard finite-factor criterion `k \| m` |
+| color-as-adjoint-8 leftover | explicit hypothetical reading; not adopted |
+| QCD / `Y_0` / hypercharge | comparison language only; not identified |
+| observations or fitted constants | none |
+| float approximations | none required; `√3` kept as an exact `Q(√3)` coefficient |
+
+### N4 — hostile counter-reading
+
+A reader might say: “`su(3)` injects into `M_8`, and `C^8` is the
+three-qubit space, so color is already a three-qubit algebra.” An injective
+Lie homomorphism is not a unital `*`-homomorphism of `M_3`. The missing
+complex dimension is the unit. `3 ∤ 8` still forbids a unital copy of
+`M_3` inside `B(H)`.
+
+### N5 — exhaustion claim refused
+
+Only the adjoint-8-versus-unital-`M_3` route is closed. Other color
+constructions are not exhausted.
+
+### N6 — axiom-edit refusal
+
+No axiom sentence is edited. The Qubit one-site `M_2(C)` wording remains
+the live parent.
+
+### N7 — adoption refusal
+
+`hypothetical_axiom_status` records the leftover and marks it **not
+adopted** as QCD or as unital `M_3`. No fifth axiom named color is
+proposed.
+
+### N8 — FAIL / DO NOT SHIP
+
+Do not ship any of the following as consequences of this note:
+
+- “an axiom update is necessary”
+- “color is derived from three qubits”
+- “`ad(su(3))` is a unital `M_3` summand”
+- “the leftover is now axiom content”
+- “`Y_0` is hypercharge”
+
+## Live Parent Quote
+
+The only parent on the current public axiom memo is the Qubit one-site
+sentence, quoted for non-mutation:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+That sentence names a local algebra. It does not name `su(3)`, Gell-Mann
+matrices, a color primitive, QCD, `Y_0`, or hypercharge.
+
+## Runner
+
+[`scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py`](../scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py)
+reconstructs the Gell-Mann matrices and the standard `f_abc` over
+`Q(√3)`, checks Theorems 1–5, requires the three hostile predicates to
+fail, and checks that this note and the axiom memo carry the leftover
+wording rather than a QCD or unital-`M_3` identification.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17616,6 +17616,10 @@
   },
   "su3_adjoint_casimir_theorem_note_2026-05-02": {
    "deps_hash": "5e93d700a831",
+   "out_degree": 1
+  },
+  "su3_adjoint_eight_in_m8_is_not_unital_m3_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "su3_anomaly_forced_3bar_completion_theorem_note_2026-05-02": {

--- a/logs/runner-cache/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.txt
+++ b/logs/runner-cache/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py
+runner_sha256: 342b00207f68915ef786930849365b83be69d6cd183fc73448dd11e87f8b0d36
+input_fingerprint_sha256: 21cab54e7905523b60387e060c43e311b33fb28a291fb26de7f5d3ed234037ac
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.18
+status: ok
+----- stdout -----
+external_scientific_inputs: none; Gell-Mann data reconstructed over Q(sqrt(3))
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: exact Fraction / Q(sqrt(3)); no QCD import
+negative_scope: adjoint-8 is not unital M_3; leftover not adopted
+PASS: theorem1-count there are eight Gell-Mann matrices
+PASS: theorem1-traceless each Gell-Mann matrix has trace 0
+PASS: theorem1-hermitian each Gell-Mann matrix is Hermitian
+PASS: theorem1-trace-form Tr(λ_a λ_b) = 2 δ_ab, so the eight are R-independent
+PASS: theorem1-eight-not-nine dim_R su(3) = 8 is not dim_C M_3 = 9
+PASS: theorem2-i-spin [λ_1, λ_2] = 2i λ_3
+PASS: theorem2-v-spin [λ_4, λ_5] = 2i (1/2 λ_3 + √3/2 λ_8)
+PASS: theorem2-u-spin [λ_6, λ_7] = 2i (-1/2 λ_3 + √3/2 λ_8)
+PASS: theorem2-f147 f_147 = 1/2, so [λ_1, λ_4] = i λ_7
+PASS: theorem2-closure-formula [λ_a, λ_b] = 2i ∑_c f_abc λ_c on a generating set
+PASS: theorem3-shape ad(λ_a) are eight 8x8 real matrices
+PASS: theorem3-independent Frobenius pairing of ad(λ_a) is 12 δ_ad, so they are independent
+PASS: theorem3-homomorphism [ad(λ_1), ad(λ_2)] = -2 ad(λ_3) in the convention ad_{bc}=2 f_abc
+PASS: theorem3-sits-in-m8 three-site H ≅ C^8 and ad(su(3)) ⊂ M_8(R) ⊂ End(C^8)
+PASS: theorem4-three-not-divide-eight 3 does not divide 8
+PASS: theorem4-no-unital-hom no unital *-hom M_3(C) -> M_8(C)
+PASS: mutation-dim-su3-eq-9 predicate dim su(3) == 9 fails
+PASS: mutation-3-divides-8 predicate 3 divides 8 fails
+PASS: mutation-ad-dependent predicate ad(λ_a) linearly dependent fails
+PASS: machine-status-contract note carries the required leftover status and bounded-support surface
+PASS: theorem5-qubit-names-m2 live axiom memo names one-site M_2(C), not su(3)
+PASS: theorem5-refusals note refuses QCD, a color axiom, C^8=M_3, Y_0, and hypercharge
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-type-and-gate bounded theorem type and N1-N8 gate are source-visible; no QCD module load
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py
+++ b/scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""Exact checks: su(3) adjoint-8 sits in M_8 and is not unital M_3.
+
+Gell-Mann matrices and f_abc are reconstructed over Q(sqrt(3)).
+The leftover is displayed and not adopted as QCD or as unital M_3.
+No QCD import, no Qubit rewrite, no runner cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "SU3_ADJOINT_EIGHT_IN_M8_IS_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/SU3_ADJOINT_EIGHT_IN_M8_IS_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+@dataclass(frozen=True)
+class Q3:
+    """a + b*sqrt(3) with a, b rational."""
+
+    rat: Fraction
+    s3: Fraction = Fraction(0)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rat", Fraction(self.rat))
+        object.__setattr__(self, "s3", Fraction(self.s3))
+
+    def __add__(self, other: Q3) -> Q3:
+        return Q3(self.rat + other.rat, self.s3 + other.s3)
+
+    def __sub__(self, other: Q3) -> Q3:
+        return Q3(self.rat - other.rat, self.s3 - other.s3)
+
+    def __neg__(self) -> Q3:
+        return Q3(-self.rat, -self.s3)
+
+    def __mul__(self, other: Q3) -> Q3:
+        return Q3(
+            self.rat * other.rat + 3 * self.s3 * other.s3,
+            self.rat * other.s3 + self.s3 * other.rat,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Q3):
+            return NotImplemented
+        return self.rat == other.rat and self.s3 == other.s3
+
+    def is_zero(self) -> bool:
+        return self.rat == 0 and self.s3 == 0
+
+
+@dataclass(frozen=True)
+class Cpx:
+    re: Q3
+    im: Q3 = Q3(0)
+
+    def __add__(self, other: Cpx) -> Cpx:
+        return Cpx(self.re + other.re, self.im + other.im)
+
+    def __sub__(self, other: Cpx) -> Cpx:
+        return Cpx(self.re - other.re, self.im - other.im)
+
+    def __neg__(self) -> Cpx:
+        return Cpx(-self.re, -self.im)
+
+    def __mul__(self, other: Cpx) -> Cpx:
+        return Cpx(
+            self.re * other.re - self.im * other.im,
+            self.re * other.im + self.im * other.re,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Cpx):
+            return NotImplemented
+        return self.re == other.re and self.im == other.im
+
+    def is_zero(self) -> bool:
+        return self.re.is_zero() and self.im.is_zero()
+
+    def conjugate(self) -> Cpx:
+        return Cpx(self.re, -self.im)
+
+
+ZERO = Cpx(Q3(0))
+ONE = Cpx(Q3(1))
+I_UNIT = Cpx(Q3(0), Q3(1))
+TWO_I = Cpx(Q3(0), Q3(2))
+
+Matrix = tuple[tuple[Cpx, ...], ...]
+Real8 = tuple[tuple[Q3, ...], ...]
+
+
+def zmat(n: int) -> list[list[Cpx]]:
+    return [[ZERO for _ in range(n)] for _ in range(n)]
+
+
+def freeze(data: list[list[Cpx]]) -> Matrix:
+    return tuple(tuple(row) for row in data)
+
+
+def madd(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[r][c] + right[r][c] for c in range(len(left)))
+        for r in range(len(left))
+    )
+
+
+def mscale(scalar: Cpx, matrix: Matrix) -> Matrix:
+    return tuple(
+        tuple(scalar * matrix[r][c] for c in range(len(matrix)))
+        for r in range(len(matrix))
+    )
+
+
+def mmul(left: Matrix, right: Matrix) -> Matrix:
+    size = len(left)
+    return tuple(
+        tuple(
+            sum((left[r][k] * right[k][c] for k in range(size)), ZERO)
+            for c in range(size)
+        )
+        for r in range(size)
+    )
+
+
+def comm(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left_val - right_val for left_val, right_val in zip(left_row, right_row))
+        for left_row, right_row in zip(mmul(left, right), mmul(right, left))
+    )
+
+
+def mtrace(matrix: Matrix) -> Cpx:
+    return sum((matrix[i][i] for i in range(len(matrix))), ZERO)
+
+
+def madjoint(matrix: Matrix) -> Matrix:
+    size = len(matrix)
+    return tuple(tuple(matrix[c][r].conjugate() for c in range(size)) for r in range(size))
+
+
+def matrices_equal(left: Matrix, right: Matrix) -> bool:
+    return all(
+        left[r][c] == right[r][c]
+        for r in range(len(left))
+        for c in range(len(left))
+    )
+
+
+def gell_mann() -> tuple[Matrix, ...]:
+    """Standard Gell-Mann matrices; λ_8 uses the exact coefficient 1/sqrt(3)."""
+    inv_sqrt3 = Q3(0, Fraction(1, 3))  # sqrt(3)/3 = 1/sqrt(3)
+
+    l1 = freeze(
+        [
+            [ZERO, ONE, ZERO],
+            [ONE, ZERO, ZERO],
+            [ZERO, ZERO, ZERO],
+        ]
+    )
+    l2 = freeze(
+        [
+            [ZERO, -I_UNIT, ZERO],
+            [I_UNIT, ZERO, ZERO],
+            [ZERO, ZERO, ZERO],
+        ]
+    )
+    l3 = freeze(
+        [
+            [ONE, ZERO, ZERO],
+            [ZERO, -ONE, ZERO],
+            [ZERO, ZERO, ZERO],
+        ]
+    )
+    l4 = freeze(
+        [
+            [ZERO, ZERO, ONE],
+            [ZERO, ZERO, ZERO],
+            [ONE, ZERO, ZERO],
+        ]
+    )
+    l5 = freeze(
+        [
+            [ZERO, ZERO, -I_UNIT],
+            [ZERO, ZERO, ZERO],
+            [I_UNIT, ZERO, ZERO],
+        ]
+    )
+    l6 = freeze(
+        [
+            [ZERO, ZERO, ZERO],
+            [ZERO, ZERO, ONE],
+            [ZERO, ONE, ZERO],
+        ]
+    )
+    l7 = freeze(
+        [
+            [ZERO, ZERO, ZERO],
+            [ZERO, ZERO, -I_UNIT],
+            [ZERO, I_UNIT, ZERO],
+        ]
+    )
+    diag8 = Cpx(inv_sqrt3)
+    l8 = freeze(
+        [
+            [diag8, ZERO, ZERO],
+            [ZERO, diag8, ZERO],
+            [ZERO, ZERO, Cpx(Q3(0, Fraction(-2, 3)))],
+        ]
+    )
+    return (l1, l2, l3, l4, l5, l6, l7, l8)
+
+
+def perm_sign(triple: tuple[int, int, int]) -> int | None:
+    a, b, c = triple
+    if len({a, b, c}) < 3:
+        return None
+    inversions = int(a > b) + int(a > c) + int(b > c)
+    return 1 if inversions % 2 == 0 else -1
+
+
+def structure_constants() -> tuple[tuple[tuple[Q3, ...], ...], ...]:
+    """f_abc with 0-based indices, totally antisymmetric, values in Q(sqrt(3))."""
+    independent = {
+        (0, 1, 2): Q3(1),
+        (0, 3, 6): Q3(Fraction(1, 2)),
+        (0, 4, 5): Q3(Fraction(-1, 2)),
+        (1, 3, 5): Q3(Fraction(1, 2)),
+        (1, 4, 6): Q3(Fraction(1, 2)),
+        (2, 3, 4): Q3(Fraction(1, 2)),
+        (2, 5, 6): Q3(Fraction(-1, 2)),
+        (3, 4, 7): Q3(0, Fraction(1, 2)),
+        (5, 6, 7): Q3(0, Fraction(1, 2)),
+    }
+    data = [[[Q3(0) for _ in range(8)] for _ in range(8)] for _ in range(8)]
+    for (a0, b0, c0), value in independent.items():
+        base = (a0, b0, c0)
+        base_sign = perm_sign(base)
+        assert base_sign is not None
+        for a in range(8):
+            for b in range(8):
+                for c in range(8):
+                    if {a, b, c} != {a0, b0, c0}:
+                        continue
+                    sign = perm_sign((a, b, c))
+                    if sign is None:
+                        continue
+                    data[a][b][c] = value if sign == base_sign else -value
+    return tuple(tuple(tuple(row) for row in plane) for plane in data)
+
+
+def adjoint_matrices(f: tuple[tuple[tuple[Q3, ...], ...], ...]) -> tuple[Real8, ...]:
+    """ad(λ_a)_{bc} = 2 f_abc, eight real 8x8 matrices."""
+    out: list[Real8] = []
+    for a in range(8):
+        out.append(
+            tuple(tuple(Q3(2) * f[a][b][c] for c in range(8)) for b in range(8))
+        )
+    return tuple(out)
+
+
+def real_mul(left: Real8, right: Real8) -> Real8:
+    return tuple(
+        tuple(
+            sum((left[r][k] * right[k][c] for k in range(8)), Q3(0))
+            for c in range(8)
+        )
+        for r in range(8)
+    )
+
+
+def real_comm(left: Real8, right: Real8) -> Real8:
+    product = real_mul(left, right)
+    opposite = real_mul(right, left)
+    return tuple(
+        tuple(product[r][c] - opposite[r][c] for c in range(8)) for r in range(8)
+    )
+
+
+def real_scale(scalar: Q3, matrix: Real8) -> Real8:
+    return tuple(tuple(scalar * matrix[r][c] for c in range(8)) for r in range(8))
+
+
+def real_equal(left: Real8, right: Real8) -> bool:
+    return all(left[r][c] == right[r][c] for r in range(8) for c in range(8))
+
+
+def frobenius(left: Real8, right: Real8) -> Q3:
+    return sum((left[r][c] * right[r][c] for r in range(8) for c in range(8)), Q3(0))
+
+
+def tensor_basis(*factors: tuple) -> tuple:
+    out: tuple = ((),)
+    for factor in factors:
+        out = tuple(left + (vec,) for left in out for vec in factor)
+    return out
+
+
+def matrix_units(n: int) -> tuple[tuple[int, int], ...]:
+    return tuple((i, j) for i in range(n) for j in range(n))
+
+
+def divides(n: int, m: int) -> bool:
+    return n != 0 and m % n == 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; Gell-Mann data reconstructed over Q(sqrt(3))")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: exact Fraction / Q(sqrt(3)); no QCD import")
+    print("negative_scope: adjoint-8 is not unital M_3; leftover not adopted")
+
+    lambdas = gell_mann()
+    f_abc = structure_constants()
+    ads = adjoint_matrices(f_abc)
+
+    checks.check(
+        "theorem1-count",
+        "there are eight Gell-Mann matrices",
+        len(lambdas) == 8,
+    )
+    checks.check(
+        "theorem1-traceless",
+        "each Gell-Mann matrix has trace 0",
+        all(mtrace(matrix).is_zero() for matrix in lambdas),
+    )
+    checks.check(
+        "theorem1-hermitian",
+        "each Gell-Mann matrix is Hermitian",
+        all(matrices_equal(matrix, madjoint(matrix)) for matrix in lambdas),
+    )
+    gram_ok = True
+    for a, left in enumerate(lambdas):
+        for b, right in enumerate(lambdas):
+            value = mtrace(mmul(left, right))
+            target = Cpx(Q3(2 if a == b else 0))
+            if value != target:
+                gram_ok = False
+    checks.check(
+        "theorem1-trace-form",
+        "Tr(λ_a λ_b) = 2 δ_ab, so the eight are R-independent",
+        gram_ok,
+    )
+    dim_su3 = 8
+    dim_m3 = 3 * 3
+    checks.check(
+        "theorem1-eight-not-nine",
+        "dim_R su(3) = 8 is not dim_C M_3 = 9",
+        dim_su3 == 8 and dim_m3 == 9 and dim_su3 != dim_m3,
+    )
+
+    two_i_l3 = mscale(TWO_I, lambdas[2])
+    checks.check(
+        "theorem2-i-spin",
+        "[λ_1, λ_2] = 2i λ_3",
+        matrices_equal(comm(lambdas[0], lambdas[1]), two_i_l3),
+    )
+    half = Cpx(Q3(Fraction(1, 2)))
+    sqrt3_over_2 = Cpx(Q3(0, Fraction(1, 2)))
+    v_spin_target = mscale(
+        TWO_I,
+        madd(mscale(half, lambdas[2]), mscale(sqrt3_over_2, lambdas[7])),
+    )
+    checks.check(
+        "theorem2-v-spin",
+        "[λ_4, λ_5] = 2i (1/2 λ_3 + √3/2 λ_8)",
+        matrices_equal(comm(lambdas[3], lambdas[4]), v_spin_target),
+    )
+    u_spin_target = mscale(
+        TWO_I,
+        madd(mscale(-half, lambdas[2]), mscale(sqrt3_over_2, lambdas[7])),
+    )
+    checks.check(
+        "theorem2-u-spin",
+        "[λ_6, λ_7] = 2i (-1/2 λ_3 + √3/2 λ_8)",
+        matrices_equal(comm(lambdas[5], lambdas[6]), u_spin_target),
+    )
+    checks.check(
+        "theorem2-f147",
+        "f_147 = 1/2, so [λ_1, λ_4] = i λ_7",
+        f_abc[0][3][6] == Q3(Fraction(1, 2))
+        and matrices_equal(comm(lambdas[0], lambdas[3]), mscale(I_UNIT, lambdas[6])),
+    )
+    closure_ok = True
+    sample_pairs = ((0, 1), (3, 4), (5, 6), (0, 3), (3, 7), (5, 7))
+    for a, b in sample_pairs:
+        target = tuple(
+            tuple(ZERO for _ in range(3)) for _ in range(3)
+        )
+        acc = target
+        for c in range(8):
+            coeff = Cpx(Q3(0), Q3(2)) * Cpx(f_abc[a][b][c])
+            acc = madd(acc, mscale(coeff, lambdas[c]))
+        if not matrices_equal(comm(lambdas[a], lambdas[b]), acc):
+            closure_ok = False
+    checks.check(
+        "theorem2-closure-formula",
+        "[λ_a, λ_b] = 2i ∑_c f_abc λ_c on a generating set",
+        closure_ok,
+    )
+
+    checks.check(
+        "theorem3-shape",
+        "ad(λ_a) are eight 8x8 real matrices",
+        len(ads) == 8 and all(len(mat) == 8 and len(mat[0]) == 8 for mat in ads),
+    )
+    pairing_ok = True
+    for a in range(8):
+        for d in range(8):
+            value = frobenius(ads[a], ads[d])
+            target = Q3(12 if a == d else 0)
+            if value != target:
+                pairing_ok = False
+    checks.check(
+        "theorem3-independent",
+        "Frobenius pairing of ad(λ_a) is 12 δ_ad, so they are independent",
+        pairing_ok,
+    )
+    checks.check(
+        "theorem3-homomorphism",
+        "[ad(λ_1), ad(λ_2)] = -2 ad(λ_3) in the convention ad_{bc}=2 f_abc",
+        real_equal(real_comm(ads[0], ads[1]), real_scale(Q3(-2), ads[2])),
+    )
+    site_basis = ((1, 0), (0, 1))
+    h_basis = tensor_basis(site_basis, site_basis, site_basis)
+    h_dim = len(h_basis)
+    m8_dim = len(matrix_units(h_dim))
+    checks.check(
+        "theorem3-sits-in-m8",
+        "three-site H ≅ C^8 and ad(su(3)) ⊂ M_8(R) ⊂ End(C^8)",
+        h_dim == 8 and m8_dim == 64 and len(ads) == 8,
+    )
+
+    checks.check(
+        "theorem4-three-not-divide-eight",
+        "3 does not divide 8",
+        divides(3, 8) is False,
+    )
+    checks.check(
+        "theorem4-no-unital-hom",
+        "no unital *-hom M_3(C) -> M_8(C)",
+        divides(3, h_dim) is False and dim_m3 != 8 and dim_m3 != 64,
+    )
+
+    mutation_dim_nine = dim_su3 == 9
+    mutation_divides = divides(3, 8)
+    mutation_dependent = pairing_ok is False
+    checks.check(
+        "mutation-dim-su3-eq-9",
+        "predicate dim su(3) == 9 fails",
+        mutation_dim_nine is False,
+    )
+    checks.check(
+        "mutation-3-divides-8",
+        "predicate 3 divides 8 fails",
+        mutation_divides is False,
+    )
+    checks.check(
+        "mutation-ad-dependent",
+        "predicate ad(λ_a) linearly dependent fails",
+        mutation_dependent is False,
+    )
+
+    required_status = (
+        'hypothetical_axiom_status: "color-as-adjoint-8 leftover: su(3) closes in M_8; not adopted as QCD or as unital M_3"',
+        "actual_current_surface_status: bounded-support",
+    )
+    checks.check(
+        "machine-status-contract",
+        "note carries the required leftover status and bounded-support surface",
+        all(phrase in note for phrase in required_status),
+    )
+    checks.check(
+        "theorem5-qubit-names-m2",
+        "live axiom memo names one-site M_2(C), not su(3)",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "Qubit names `M_2(C)`, not `su(3)`" in note,
+    )
+    checks.check(
+        "theorem5-refusals",
+        "note refuses QCD, a color axiom, C^8=M_3, Y_0, and hypercharge",
+        all(
+            phrase in note
+            for phrase in (
+                "does not adopt a color axiom",
+                "does not identify `Y_0` or hypercharge",
+                "Do not identify `C^8` with `M_3`",
+                "Do not identify `ad(su(3))` with a unital",
+                "They do not name Gell-Mann matrices or QCD",
+            )
+        ),
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SU3_ADJOINT_EIGHT_IN_M8_IS_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and (
+            "AUDIT_INPUT_PATHS = (\n"
+            '    "docs/SU3_ADJOINT_EIGHT_IN_M8_IS_NOT_UNITAL_M3_BOUNDED_THEOREM_NOTE_2026-08-13.md",\n'
+            '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+            ")"
+        )
+        in self_source
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    qcd_module_load = "from " + "qcd"
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and N1-N8 gate are source-visible; no QCD module load",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note
+        and qcd_module_load not in self_source.lower()
+        and qcd_module_load not in note.lower(),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`su(3)` is 8-dimensional. `M_3(C)` is 9-dimensional. The adjoint representation injects `su(3)` into `End(C^8) ≅ M_8`. There is still no unital `*`-hom `M_3 → M_8` because `3 ∤ 8`. Color-as-Lie-8 is not color-as-unital-`M_3`.

## What this means for the TOE

Lattice+Qubit supply a three-site Hilbert `C^8`. They do not name Gell-Mann matrices or QCD. Hosting the adjoint Lie algebra is a different type from hosting a unital `M_3` factor.

## Verification

```bash
python3 scripts/su3_adjoint_eight_in_m8_is_not_unital_m3_2026_08_13.py
# TOTAL: PASS=24 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`. Exercise live route 3 of `color-unital-m3-20260813`.