### PR TITLE
[physics-loop] toe-lphys colorp: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_SITE_SWAP_CORNER_HOSTS_M3_WITH_UNIT_P_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_SITE_SWAP_CORNER_HOSTS_M3_WITH_UNIT_P_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,357 @@
+---
+claim_id: two_site_swap_corner_hosts_m3_with_unit_p_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "The two-site swap F on T_2 ≅ M_4(C) is Hermitian of square I_4 and trace 2. The projector p=(I_4+F)/2 has rank 3 and is not I_4. The corner C=p M_4 p is a unital *-algebra with unit p, complex dimension 9, and is *-isomorphic to M_3(C) via the matrix units of an orthonormal basis of im(p), with ψ(I_3)=p. The inclusion C ↪ M_4 is not unital. The result does not install SU(3), does not name QCD, does not rewrite Qubit, and does not select color."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py
+---
+
+# Two-Site SWAP Corner Hosts `M_3` With Unit `p`
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact two-site tensor algebra `T_2 = M_2(C) ⊗ M_2(C) ≅ M_4(C)`
+and the rank-3 corner of the displayed two-site swap projector.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py`](../scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py)
+
+Parents on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The Qubit axiom supplies one site with possibility algebra `M_2(C)`. The
+two-site tensor leftover is `T_2 = M_2(C) ⊗ M_2(C) ≅ M_4(C)`. In the product
+basis `|00>`, `|01>`, `|10>`, `|11>` the swap operator `F` is the displayed
+permutation matrix below. Its `+1` spectral projection `p = (I_4 + F)/2` is
+an orthogonal rank-3 projector, not `I_4`. The corner
+
+`C = p T_2 p = p M_4(C) p`
+
+is a unital `*`-algebra with unit `p`, not `I_4`. It is `*`-isomorphic to
+`M_3(C)` by the matrix units of an orthonormal basis of `im(p)`, and
+`ψ(I_3) = p`.
+
+This is a corner host. It is not a unital `M_3` factor of `T_2`, not an
+installation of `SU(3)`, not a naming of QCD, not a Qubit rewrite to `M_3`,
+and not a selection of color.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The swap projector and its rank-3 corner are proved by exact integer/Fraction matrix identities; a *-isomorphism onto M_3(C) with unit p is exhibited on an orthonormal basis of im(p). Unital factorhood in T_2, SU(3), QCD, Qubit rewrite, and color-axiom adoption remain outside the claim."
+trace_class: type_split
+target_claim_id: two_site_swap_corner_hosts_m3_with_unit_p
+target_blocker_text: "does a two-site SWAP projector host an M_3 with unit p rather than I_4?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed two-site swap on T_2 ≅ M_4(C); other embeddings, other projectors, and unital M_3 factors of T_2 remain separate"
+hypothetical_axiom_status: "color-as-corner leftover: p M_4 p ≅ M_3 with unit p; not adopted as QCD"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+The current Qubit axiom names the full one-site possibility domain with
+algebraic presentation `M_2(C)`. Write
+
+`T_2 = M_2(C) ⊗ M_2(C) ≅ M_4(C)`
+
+for the two-site tensor leftover. Identify `T_2` with `4 × 4` matrices in the
+product basis `|00>`, `|01>`, `|10>`, `|11>`. The two-site swap is the
+permutation matrix
+
+```
+F = [[1, 0, 0, 0],
+     [0, 0, 1, 0],
+     [0, 1, 0, 0],
+     [0, 0, 0, 1]]
+```
+
+Define `p = (I_4 + F)/2`. Explicitly
+
+```
+p = [[1,   0,   0, 0],
+     [0, 1/2, 1/2, 0],
+     [0, 1/2, 1/2, 0],
+     [0,   0,   0, 1]]
+```
+
+The corner is `C = p M_4(C) p`. Write `{E_{ij}}_{1 ≤ i,j ≤ 3}` for the
+standard matrix units of `M_3(C)`, and write `I_3` (resp. `I_4`) for the
+unit of `M_3(C)` (resp. `M_4(C)`). An orthonormal basis of `im(p)` is
+
+`|e_1> = |00>`, `|e_2> = (|01> + |10>)/√2`, `|e_3> = |11>`.
+
+The displayed `*`-isomorphism is `ψ : M_3(C) → C`, `ψ(E_{ij}) = |e_i><e_j>`.
+
+No axiom is edited. The matrices `F` and `p` are displayed mathematical test
+objects, not a proposed Qubit rewrite and not a registered primitive.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** Decide whether the two-site swap projector hosts a copy of
+`M_3(C)` whose unit is `p`, and whether that copy is a unital factor of
+`T_2`.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| `F` Hermitian, `F^2 = I_4`, `Tr(F) = 2` | Theorem 1 | proved; runner checks |
+| eigenvalues of `F` are `+1` (mult. 3) and `−1` (mult. 1) | Theorem 1 | proved as ranks of `p` and `I_4 − p` |
+| `p` orthogonal projection, rank 3, `p ≠ I_4` | Theorem 2 | proved; runner checks the displayed matrix |
+| `C = p M_4 p` unital `*`-algebra with unit `p`, `dim_C C = 9` | Theorem 3 | proved |
+| `ψ : M_3(C) → C` a `*`-isomorphism with `ψ(I_3) = p` | Theorem 3 | exhibited on the ON basis of `im(p)` |
+| inclusion `C ↪ M_4` unital | Theorem 4 | fails; `p ≠ I_4` |
+| install `SU(3)`, name QCD, rewrite Qubit, select color | out of scope | not claimed |
+
+## Theorem 1 — The two-site swap
+
+`F` is Hermitian, `F^2 = I_4`, and `Tr(F) = 2`. The eigenvalues of `F` are
+`+1` with multiplicity 3 (symmetric subspace) and `−1` with multiplicity 1
+(antisymmetric subspace).
+
+Proof. `F` is real symmetric, so `F* = F`. Direct multiplication of the
+displayed matrix gives `F^2 = I_4`. The diagonal of `F` is `(1,0,0,1)`, so
+the trace is `2`. The identity `F^2 = I_4` forces the minimal polynomial to
+divide `x^2 − 1`, hence the only possible eigenvalues are `±1`. The `+1`
+spectral projection is `p = (I_4 + F)/2` and the `−1` spectral projection is
+`I_4 − p = (I_4 − F)/2`. Theorem 2 computes `rank(p) = 3` and
+`rank(I_4 − p) = 1`, which are the geometric multiplicities.
+
+## Theorem 2 — The swap projector
+
+`p = (I_4 + F)/2` is an orthogonal projection: `p* = p = p^2`. It has
+`rank(p) = 3` and `p ≠ I_4`. The displayed matrix in Exact Objects is this
+`p`.
+
+Proof. Hermiticity of `F` gives hermiticity of `p`. Then
+
+`p^2 = (I_4 + 2F + F^2)/4 = (I_4 + 2F + I_4)/4 = (I_4 + F)/2 = p`.
+
+The complementary projection `I_4 − p` is nonzero because `F ≠ I_4` (the
+`(2,3)` entry of `F` is `1`). Hence `p ≠ I_4`. Exact rational row rank of
+the displayed matrix is `3`. Equivalently, `im(p)` is spanned by the three
+independent vectors `|00>`, `|01> + |10>`, `|11>`.
+
+## Theorem 3 — The corner is `M_3` with unit `p`
+
+The corner `C = p T_2 p = p M_4(C) p` is a unital `*`-algebra with unit `p`.
+Its complex dimension is `rank(p)^2 = 9 = dim_C M_3(C)`.
+
+The map `ψ : M_3(C) → C` defined on matrix units by
+`ψ(E_{ij}) = |e_i><e_j|` is a `*`-isomorphism, and `ψ(I_3) = p`.
+
+Proof. For any `X, Y ∈ M_4(C)`,
+
+`(p X p)(p Y p) = p X p Y p ∈ C`, `(p X p)* = p X* p ∈ C`,
+
+so `C` is a `*`-subalgebra of `M_4(C)`. The element `p = p I_4 p` lies in
+`C`, and `p (p X p) = p X p = (p X p) p`, so `p` is the unit of `C`.
+
+A rank-`k` orthogonal projection in `M_n(C)` has corner `p M_n p ≅ M_k(C)`
+of dimension `k^2`. Here `k = 3`, so `dim_C C = 9`. The runner also computes
+this dimension as the exact rational rank of the sixteen compressed matrix
+units `{p E^{(4)}_{ab} p}_{1 ≤ a,b ≤ 4}`.
+
+On the orthonormal basis `|e_1>`, `|e_2>`, `|e_3>` of `im(p)`, the operators
+`|e_i><e_j|` satisfy the matrix-unit table
+
+`|e_i><e_j| |e_k><e_l| = δ_{jk} |e_i><e_l|`, `(|e_i><e_j|)* = |e_j><e_i|`,
+
+and each equals `p |e_i><e_j| p` because `p |e_i> = |e_i>`. Linear
+independence of the nine units is the matrix-unit theorem. Therefore `ψ` is
+a `*`-isomorphism onto `C`. The unit is
+
+`ψ(I_3) = |e_1><e_1| + |e_2><e_2| + |e_3><e_3|`.
+
+The first and third summands are the coordinate projectors onto `|00>` and
+`|11>`. The middle summand is the Fraction matrix
+
+```
+|e_2><e_2| = [[0,   0,   0, 0],
+              [0, 1/2, 1/2, 0],
+              [0, 1/2, 1/2, 0],
+              [0,   0,   0, 0]]
+```
+
+and the sum is the displayed `p`.
+
+The same corner is available over `Q` without storing `√2`. The integer
+spanning set `|w_1> = |00>`, `|w_2> = |01> + |10>`, `|w_3> = |11>` has Gram
+matrix `G = diag(1, 2, 1)`. If `W` is the `4 × 3` matrix with those columns,
+the map `φ(X) = W G^{-1} X W*` is a unital algebra isomorphism `M_3(C) → C`
+given by integer and Fraction matrices, and `φ(I_3) = p`. The ON map `ψ` is
+the `*`-isomorphism; it is `φ` transported along the diagonal rescaling that
+sends `|w_2>` to `|e_2>`. The integer ket-bras `|w_i><w_j|` obey the matrix-
+unit table with structure constants `<w_j|w_k>` and are closed under adjoint.
+The runner checks `φ` as an algebra map, checks that table, and checks
+`ψ(I_3) = p` by summing the three ON rank-1 projectors.
+
+## Theorem 4 — The inclusion into `M_4` is not unital
+
+The inclusion `C ↪ M_4(C)` is **not** unital: `p ≠ I_4`. So this is not a
+unital `M_3` factor of `T_2`. It is a corner host whose unit is `p`.
+
+The unit of `T_2` remains `I_2 ⊗ I_2 = I_4`. A unital algebra homomorphism
+`M_3(C) → T_2` would have to send `I_3` to `I_4`. The displayed `ψ` sends
+`I_3` to `p`, so it cannot be such a factor embedding. The obstruction to a
+unital `M_3` factor of a finite qubit tensor is a separate hole; this note
+does not adopt it and does not depend on it.
+
+## Theorem 5 — Qubit is unchanged; color is not selected
+
+Qubit still names one-site `M_2(C)`. This construction uses the two-site
+tensor leftover and a displayed swap. It does not install `SU(3)`, does not
+name QCD, does not flip Qubit to `M_3`, and does not select color.
+
+The four axioms do not name a three-dimensional internal algebra. Hosting
+`M_3(C)` as a corner of `T_2` with unit `p` is a type fact about a displayed
+projector. It is not an axiom update and it is not adopted as QCD.
+
+## Mutation
+
+The predicate `p == I_4` must fail.
+The predicate `rank(p) == 4` must fail.
+The predicate `dim_C(C) == 9` must hold.
+
+All three are runner-checked by constructing `p` from `F` and computing exact
+rational ranks.
+
+## No-Go Discipline Gate
+
+The positive claim is only that the displayed swap projector hosts a corner
+`p M_4 p ≅ M_3(C)` with unit `p`. The gate does not certify that color is
+derived, that a unital `M_3` factor of `T_2` exists, or that Qubit should be
+rewritten.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Displayed two-site swap `F` and `p = (I_4+F)/2` | compute involution, trace, rank, corner unit | Theorems 1–3: `p` rank 3, `C ≅ M_3` with unit `p` | **ATTEMPTED** |
+| Opposite swap projector `(I_4−F)/2` | same tests on the antisymmetric line | rank 1; hosts `M_1`, not `M_3` | **ATTEMPTED** |
+| Treat `C ↪ M_4` as a unital factor | require `ψ(I_3) = I_4` | fails; Theorem 4 | **ATTEMPTED** |
+| Top-left pad `diag(X,0)` as the color algebra of `T_2` | unitality of that pad | independent hole; not used as a parent here | live |
+| Install `SU(3)` from `M_3` matrix units | Lie algebra of traceless anti-Hermitians | not constructed and not adopted | live |
+| Owner-approved primitive or retained derivation selecting color | governance, not this projector | not supplied by the current axioms or approved primitives | live |
+
+The first three routes concern the displayed swap corner. The last three
+remain possible or independent. Accordingly, the broad statement “color is
+selected by the two-site swap” is not shipped.
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `p ≠ I_4` / `rank(p) ≠ 4` | almost: a proper projection already has rank `< 4` once ranks are computed | almost: rank `3 ≠ 4` already implies `p ≠ I_4` | two readings of the same projection |
+| corner `≅ M_3` / unital factor in `T_2` | no: a corner iso does not make `p = I_4` | no: failing unitality does not compute `dim C = 9` | independent type split |
+| corner host / SU(3) installation | no: matrix units are not a Lie bracket selection | no: an `su(3)` basis would not change `p` | independent |
+| corner host / QCD naming | no | no | independent; QCD is never used |
+| corner host / Qubit rewrite | no: the current one-site wording is untouched | no: a rewrite would be a different object | independent |
+
+The load-bearing positive wall is the rank-3 corner with unit `p`. Unital
+factorhood, `SU(3)`, and QCD are not additional walls of this claim.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| `T_2 = M_2 ⊗ M_2 ≅ M_4(C)` | standard finite-dimensional identification; dimension 16 is runner-checked |
+| displayed swap `F` | explicit test matrix, not attributed to the axioms |
+| `p = (I_4+F)/2` | spectral projection of that matrix |
+| ON basis of `im(p)` | explicit; middle vector uses `√2` only as a label; runner identities are Fraction/integer |
+| `*` | conjugate transpose on finite matrices |
+| rank | exact rational row rank |
+| “corner host” | unital `*`-algebra `p M_4 p` with unit `p` |
+| “color algebra” | leftover name only; not a derived or selected object |
+| `SU(3)`, QCD | named only to refuse installation and naming |
+| observations or fitted constants | none |
+
+No continuum limit, gauge connection, representation theory of `SU(3)`, or
+empirical color quantum number is used.
+
+### N4 — source residual matching
+
+| Source | Exact residual used | Match and limit |
+|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | one-site possibility domain `M_2(C)`; further structure requires a retained derivation, bridge, or approved primitive | wording only; no composite or color conclusion is borrowed |
+
+The swap identities, the projector, the corner dimension, and the
+`*`-isomorphism are proved here and checked by the runner. No other
+scientific parent is used.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | swap `F`, projector `p`, matrix units of `im(p)`, units `I_3` and `I_4` | no classification of every projector in `M_4` |
+| per site | two-site tensor `T_2` only | no lattice-wide color field |
+| per mode | the displayed swap and its `+1` corner | no spectral exhaustion of other involutions |
+| per block | corner host with unit `p` | no QCD, no `SU(3)`, no axiom edit, no color selection |
+| lattice-wide | not executed | no lattice-wide existence or no-go |
+
+### N6 — live partial-closure paths
+
+1. A unital embedding of `M_3(C)` into some other algebra is a separate
+   question; for finite qubit tensors it is independently obstructed, but
+   that obstruction is not adopted here.
+2. A different involution or a different two-site operator could host a
+   different corner; this note tests only the displayed swap.
+3. A derived internal algebra could appear from Record/Admissibility
+   structure rather than from a displayed swap.
+4. An owner-approved primitive could register a three-dimensional internal
+   algebra; none of the current approved primitives does so.
+5. A Qubit rewrite that changes the one-site algebra is a governance act,
+   not a consequence of this corner, and is not adopted.
+
+Scale reference, kinetic isotropy, and realized state were checked in the
+premise registry. None supplies a color algebra, and none is counted as an
+extra wall.
+
+### N7 — concrete-mechanism steelman
+
+The strongest steelman of the corner is: treat `p M_4 p ≅ M_3` as “the color
+block” of a two-site composite because it is unital for itself and has the
+right dimension. That still fails as a selection of color, because the
+two-site unit remains `I_4`, Qubit remains `M_2(C)`, and no axiom names the
+swap as a color projector. Calling the corner “color” is a leftover name,
+not an adopted axiom, and it is not adopted as QCD.
+
+### N8 — cross-cycle echo
+
+Historical color-selection and unital-factor notes reject other cheap
+identifications, including the non-unital pad of `M_3` into `M_4`. This note
+does not reuse those conclusions and does not take them as parents. It
+recomputes only the displayed swap corner on `T_2` and refuses to import
+QCD.
+
+## FAIL / DO NOT SHIP
+
+Do not ship any of the following from this note:
+
+- “color is selected by the two-site swap”
+- “the axioms derive QCD or `SU(3)`”
+- “`M_3(C)` is a unital factor of `T_2`”
+- “Qubit should be rewritten to `M_3`”
+- “an axiom update is necessary”
+- “this constructs the Standard Model color algebra”
+
+The shipped claim is only: the displayed two-site swap projector hosts a
+corner `p M_4 p ≅ M_3(C)` whose unit is `p`, not `I_4`.
+
+## Provenance
+
+Parent on `origin/main`: the axiom memo only. The runner binds
+
+`AUDIT_INPUT_PATHS = (this note, docs/MINIMAL_AXIOMS_2026-06-29.md)`
+
+as a string-literal tuple. No citation-manifest edit and no runner-cache
+write are part of this surface.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18405,6 +18405,10 @@
   "two_site_qubit_tensor_carrier_bridge_narrow_theorem_note_2026-06-06": {
    "deps_hash": "4fb4f7ea0100",
    "out_degree": 4
+  },
+  "two_site_swap_corner_hosts_m3_with_unit_p_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "u0_plaquette_quartic_derivation_narrow_theorem_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.txt
+++ b/logs/runner-cache/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py
+runner_sha256: 90ff174345672a1063272db19aef3314ff6b872968a525f320d5353eb3c0c491
+input_fingerprint_sha256: be2b435d249523a0357cf3723c37ce6d9a2adefc2751aed7108019477811c2ea
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+measure_boundary: exact integer/Fraction matrix algebra only
+negative_scope: only the displayed swap corner is identified; SU(3), QCD, a Qubit rewrite, and a color axiom are not installed
+PASS: source-qubit the axiom memo names the full one-site possibility domain M_2(C)
+PASS: dim-two-site T_2 = M_2 ⊗ M_2 has complex dimension 16, matching M_4
+PASS: thm1-hermitian the two-site swap F is Hermitian
+PASS: thm1-involution F squared equals I_4
+PASS: thm1-trace Tr(F) equals 2
+PASS: thm1-spectrum the +1 space of F has rank 3 and the -1 space has rank 1
+PASS: thm2-projection p = (I_4 + F)/2 is an orthogonal projection
+PASS: thm2-explicit p equals the displayed rank-3 swap projector
+PASS: thm2-not-identity p is not I_4
+PASS: thm2-image-basis p fixes |00>, |01>+|10>, |11> and kills |01>-|10>
+PASS: thm3-unit p is the unit of the corner p M_4 p
+PASS: thm3-dim dim_C(C) equals rank(p)^2 equals 9
+PASS: thm3-iso-unit the Fraction *-iso and the ON projector sum both send I_3 to p
+PASS: thm3-iso-hom phi is a Q-linear algebra map, and the ON units of im(p) multiply as matrix units
+PASS: thm3-iso-injective phi has trivial kernel on the nine matrix units
+PASS: thm3-on-table integer spanning vectors of im(p) are orthogonal with middle norm squared 2
+PASS: thm4-inclusion-not-unital the inclusion C into M_4 is not unital
+PASS: thm5-qubit-untouched Qubit still names one-site M_2(C) and is not rewritten to M_3
+PASS: mutation-unital predicate p == I_4 fails
+PASS: mutation-rank predicate rank(p) == 4 fails
+PASS: mutation-dim predicate dim_C(C) == 9 holds
+PASS: machine-status-contract the source uses the required bounded-support and color-as-corner leftover status lines
+PASS: note-negative-scope the note refuses SU(3) installation, QCD naming, Qubit rewrite, and color selection
+PASS: canonical-nonmutation the axiom memo does not contain the swap projector or a color-algebra rewrite
+PASS: no-go-gate N1-N8 and the broad-claim rejection are source-visible
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the declared note-plus-axiom tuple
+per_element: F, p, I_3, I_4, and the matrix units of im(p) are evaluated
+per_site: the statement is the two-site tensor T_2 ≅ M_4; no lattice-wide carrier is asserted
+per_mode: the displayed two-site swap and its +1 corner are the tested maps
+per_block: only the corner host with unit p is identified; unital factorhood and color selection are refused
+lattice_wide: checked and not executed
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py
+++ b/scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Exact checks: two-site SWAP corner hosts M_3 with unit p.
+
+Finite integer/Fraction matrix identities only. No QCD, no axiom edit, no
+cache write, no network.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "TWO_SITE_SWAP_CORNER_HOSTS_M3_WITH_UNIT_P_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_SITE_SWAP_CORNER_HOSTS_M3_WITH_UNIT_P_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, ...], ...]
+Vector = tuple[Fraction, ...]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def zero(n: int) -> Matrix:
+    return tuple(tuple(Fraction(0) for _ in range(n)) for _ in range(n))
+
+
+def eye(n: int) -> Matrix:
+    return tuple(tuple(Fraction(int(row == col)) for col in range(n)) for row in range(n))
+
+
+def e_unit(n: int, row: int, col: int) -> Matrix:
+    data = [[Fraction(0) for _ in range(n)] for _ in range(n)]
+    data[row][col] = Fraction(1)
+    return tuple(tuple(item) for item in data)
+
+
+def add(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][col] + right[row][col] for col in range(len(left)))
+        for row in range(len(left))
+    )
+
+
+def sub(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][col] - right[row][col] for col in range(len(left)))
+        for row in range(len(left))
+    )
+
+
+def scale(scalar: Fraction, matrix: Matrix) -> Matrix:
+    return tuple(tuple(scalar * matrix[row][col] for col in range(len(matrix))) for row in range(len(matrix)))
+
+
+def mul(left: Matrix, right: Matrix) -> Matrix:
+    size = len(left)
+    return tuple(
+        tuple(
+            sum((left[row][mid] * right[mid][col] for mid in range(size)), Fraction(0))
+            for col in range(size)
+        )
+        for row in range(size)
+    )
+
+
+def adj(matrix: Matrix) -> Matrix:
+    size = len(matrix)
+    return tuple(tuple(matrix[col][row] for col in range(size)) for row in range(size))
+
+
+def transpose(matrix: tuple[tuple[Fraction, ...], ...]) -> tuple[tuple[Fraction, ...], ...]:
+    return tuple(tuple(matrix[row][col] for row in range(len(matrix))) for col in range(len(matrix[0])))
+
+
+def trace(matrix: Matrix) -> Fraction:
+    return sum((matrix[i][i] for i in range(len(matrix))), Fraction(0))
+
+
+def ketbra(left: Vector, right: Vector) -> Matrix:
+    return tuple(tuple(left[row] * right[col] for col in range(len(right))) for row in range(len(left)))
+
+
+def matvec(matrix: Matrix, vector: Vector) -> Vector:
+    return tuple(
+        sum((matrix[row][col] * vector[col] for col in range(len(vector))), Fraction(0))
+        for row in range(len(matrix))
+    )
+
+
+def inner(left: Vector, right: Vector) -> Fraction:
+    return sum((left[i] * right[i] for i in range(len(left))), Fraction(0))
+
+
+def mul_rect(left: tuple[tuple[Fraction, ...], ...], right: tuple[tuple[Fraction, ...], ...]) -> tuple[tuple[Fraction, ...], ...]:
+    rows = len(left)
+    mid = len(left[0])
+    cols = len(right[0])
+    return tuple(
+        tuple(
+            sum((left[row][k] * right[k][col] for k in range(mid)), Fraction(0))
+            for col in range(cols)
+        )
+        for row in range(rows)
+    )
+
+
+def rank(matrix: Matrix) -> int:
+    """Exact row rank over Q by Gaussian elimination."""
+    rows = [list(row) for row in matrix]
+    height = len(rows)
+    width = len(rows[0]) if rows else 0
+    lead = 0
+    computed = 0
+    for r in range(height):
+        if lead >= width:
+            return computed
+        i = r
+        while rows[i][lead] == 0:
+            i += 1
+            if i == height:
+                i = r
+                lead += 1
+                if lead == width:
+                    return computed
+        rows[i], rows[r] = rows[r], rows[i]
+        pivot = rows[r][lead]
+        rows[r] = [value / pivot for value in rows[r]]
+        for i in range(height):
+            if i == r:
+                continue
+            factor = rows[i][lead]
+            rows[i] = [rows[i][c] - factor * rows[r][c] for c in range(width)]
+        computed += 1
+        lead += 1
+    return computed
+
+
+def flatten(matrix: Matrix) -> tuple[Fraction, ...]:
+    return tuple(value for row in matrix for value in row)
+
+
+def stack_rows(matrices: list[Matrix]) -> Matrix:
+    return tuple(flatten(matrix) for matrix in matrices)
+
+
+def dim_mn(n: int) -> int:
+    return n * n
+
+
+def swap_matrix() -> Matrix:
+    """Permutation matrix of |ab> <-> |ba> on the product basis |00>,|01>,|10>,|11>."""
+    data = [[Fraction(0) for _ in range(4)] for _ in range(4)]
+    for a in (0, 1):
+        for b in (0, 1):
+            source = 2 * a + b
+            target = 2 * b + a
+            data[target][source] = Fraction(1)
+    return tuple(tuple(item) for item in data)
+
+
+def phi(matrix3: Matrix, wide: tuple[tuple[Fraction, ...], ...], gram_inv: Matrix) -> Matrix:
+    """Fraction *-iso M_3 → p M_4 p given by φ(X) = W G^{-1} X W*."""
+    return mul_rect(wide, mul_rect(gram_inv, mul_rect(matrix3, transpose(wide))))
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+
+    print("external_scientific_inputs: current axiom wording is source-bound; no observational or fitted inputs are used")
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("measure_boundary: exact integer/Fraction matrix algebra only")
+    print("negative_scope: only the displayed swap corner is identified; SU(3), QCD, a Qubit rewrite, and a color axiom are not installed")
+
+    identity3 = eye(3)
+    identity4 = eye(4)
+    swap = swap_matrix()
+    projector = scale(Fraction(1, 2), add(identity4, swap))
+    opposite = sub(identity4, projector)
+
+    displayed_projector = (
+        (Fraction(1), Fraction(0), Fraction(0), Fraction(0)),
+        (Fraction(0), Fraction(1, 2), Fraction(1, 2), Fraction(0)),
+        (Fraction(0), Fraction(1, 2), Fraction(1, 2), Fraction(0)),
+        (Fraction(0), Fraction(0), Fraction(0), Fraction(1)),
+    )
+
+    w1: Vector = (Fraction(1), Fraction(0), Fraction(0), Fraction(0))
+    w2: Vector = (Fraction(0), Fraction(1), Fraction(1), Fraction(0))
+    w3: Vector = (Fraction(0), Fraction(0), Fraction(0), Fraction(1))
+    wide = tuple(zip(w1, w2, w3))
+    gram_inv = (
+        (Fraction(1), Fraction(0), Fraction(0)),
+        (Fraction(0), Fraction(1, 2), Fraction(0)),
+        (Fraction(0), Fraction(0), Fraction(1)),
+    )
+
+    on_sum = add(add(ketbra(w1, w1), scale(Fraction(1, 2), ketbra(w2, w2))), ketbra(w3, w3))
+    compressed_units = [mul(mul(projector, e_unit(4, row, col)), projector) for row in range(4) for col in range(4)]
+    corner_dim = rank(stack_rows(compressed_units))
+
+    phi_id = phi(identity3, wide, gram_inv)
+    e12 = e_unit(3, 0, 1)
+    e21 = e_unit(3, 1, 0)
+    e11 = e_unit(3, 0, 0)
+    e22 = e_unit(3, 1, 1)
+    sample = add(scale(Fraction(2), e12), scale(Fraction(-3), identity3))
+
+    checks.check(
+        "source-qubit",
+        "the axiom memo names the full one-site possibility domain M_2(C)",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in axiom,
+    )
+    checks.check(
+        "dim-two-site",
+        "T_2 = M_2 ⊗ M_2 has complex dimension 16, matching M_4",
+        dim_mn(2) * dim_mn(2) == 16 and dim_mn(4) == 16,
+    )
+    checks.check(
+        "thm1-hermitian",
+        "the two-site swap F is Hermitian",
+        adj(swap) == swap,
+    )
+    checks.check(
+        "thm1-involution",
+        "F squared equals I_4",
+        mul(swap, swap) == identity4,
+    )
+    checks.check(
+        "thm1-trace",
+        "Tr(F) equals 2",
+        trace(swap) == Fraction(2),
+    )
+    checks.check(
+        "thm1-spectrum",
+        "the +1 space of F has rank 3 and the -1 space has rank 1",
+        rank(projector) == 3 and rank(opposite) == 1 and add(projector, opposite) == identity4,
+    )
+    checks.check(
+        "thm2-projection",
+        "p = (I_4 + F)/2 is an orthogonal projection",
+        mul(projector, projector) == projector and adj(projector) == projector,
+    )
+    checks.check(
+        "thm2-explicit",
+        "p equals the displayed rank-3 swap projector",
+        projector == displayed_projector,
+    )
+    checks.check(
+        "thm2-not-identity",
+        "p is not I_4",
+        projector != identity4,
+    )
+    checks.check(
+        "thm2-image-basis",
+        "p fixes |00>, |01>+|10>, |11> and kills |01>-|10>",
+        matvec(projector, w1) == w1
+        and matvec(projector, w2) == w2
+        and matvec(projector, w3) == w3
+        and matvec(projector, (Fraction(0), Fraction(1), Fraction(-1), Fraction(0)))
+        == (Fraction(0), Fraction(0), Fraction(0), Fraction(0)),
+    )
+    checks.check(
+        "thm3-unit",
+        "p is the unit of the corner p M_4 p",
+        all(mul(mul(projector, matrix), projector) == matrix for matrix in compressed_units)
+        and mul(mul(projector, identity4), projector) == projector,
+    )
+    checks.check(
+        "thm3-dim",
+        "dim_C(C) equals rank(p)^2 equals 9",
+        corner_dim == 9 and rank(projector) ** 2 == 9 and dim_mn(3) == 9,
+    )
+    checks.check(
+        "thm3-iso-unit",
+        "the Fraction *-iso and the ON projector sum both send I_3 to p",
+        phi_id == projector and on_sum == projector,
+    )
+    basis = (w1, w2, w3)
+    unnorm_units = [[ketbra(basis[i], basis[j]) for j in range(3)] for i in range(3)]
+    checks.check(
+        "thm3-iso-hom",
+        "phi is a Q-linear algebra map, and the ON units of im(p) multiply as matrix units",
+        phi(sample, wide, gram_inv) == add(scale(Fraction(2), phi(e12, wide, gram_inv)), scale(Fraction(-3), phi_id))
+        and phi(mul(e12, e21), wide, gram_inv) == mul(phi(e12, wide, gram_inv), phi(e21, wide, gram_inv))
+        and mul(phi(e12, wide, gram_inv), phi(e21, wide, gram_inv)) == phi(e11, wide, gram_inv)
+        and all(
+            mul(unnorm_units[i][j], unnorm_units[k][l])
+            == scale(inner(basis[j], basis[k]), unnorm_units[i][l])
+            for i in range(3)
+            for j in range(3)
+            for k in range(3)
+            for l in range(3)
+        )
+        and all(adj(unnorm_units[i][j]) == unnorm_units[j][i] for i in range(3) for j in range(3)),
+    )
+    checks.check(
+        "thm3-iso-injective",
+        "phi has trivial kernel on the nine matrix units",
+        all(phi(e_unit(3, row, col), wide, gram_inv) != zero(4) for row in range(3) for col in range(3)),
+    )
+    checks.check(
+        "thm3-on-table",
+        "integer spanning vectors of im(p) are orthogonal with middle norm squared 2",
+        inner(w1, w2) == 0
+        and inner(w1, w3) == 0
+        and inner(w2, w3) == 0
+        and inner(w1, w1) == 1
+        and inner(w2, w2) == 2
+        and inner(w3, w3) == 1
+        and phi(e22, wide, gram_inv) == scale(Fraction(1, 2), ketbra(w2, w2)),
+    )
+    checks.check(
+        "thm4-inclusion-not-unital",
+        "the inclusion C into M_4 is not unital",
+        projector != identity4 and phi_id != identity4,
+    )
+    checks.check(
+        "thm5-qubit-untouched",
+        "Qubit still names one-site M_2(C) and is not rewritten to M_3",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in axiom
+        and "rewritten to `M_3`" not in axiom,
+    )
+    unital_predicate = projector == identity4
+    rank_predicate = rank(projector) == 4
+    dim_predicate = corner_dim == 9
+    checks.check(
+        "mutation-unital",
+        "predicate p == I_4 fails",
+        unital_predicate is False,
+    )
+    checks.check(
+        "mutation-rank",
+        "predicate rank(p) == 4 fails",
+        rank_predicate is False,
+    )
+    checks.check(
+        "mutation-dim",
+        "predicate dim_C(C) == 9 holds",
+        dim_predicate is True,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required bounded-support and color-as-corner leftover status lines",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                'hypothetical_axiom_status: "color-as-corner leftover: p M_4 p ≅ M_3 with unit p; not adopted as QCD"',
+                "**Type:** bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "note-negative-scope",
+        "the note refuses SU(3) installation, QCD naming, Qubit rewrite, and color selection",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "does not install `SU(3)`",
+                "does not name QCD",
+                "does not flip Qubit to `M_3`",
+                "does not select color",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo does not contain the swap projector or a color-algebra rewrite",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "swap projector",
+                "p M_4 p",
+                "color algebra",
+                "SU(3)",
+                "QCD",
+            )
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "N1-N8 and the broad-claim rejection are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "color is selected by the two-site swap" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the declared note-plus-axiom tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_SITE_SWAP_CORNER_HOSTS_M3_WITH_UNIT_P_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    print("per_element: F, p, I_3, I_4, and the matrix units of im(p) are evaluated")
+    print("per_site: the statement is the two-site tensor T_2 ≅ M_4; no lattice-wide carrier is asserted")
+    print("per_mode: the displayed two-site swap and its +1 corner are the tested maps")
+    print("per_block: only the corner host with unit p is identified; unital factorhood and color selection are refused")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two-site swap `F` on `T_2 ≅ M_4` has `p=(I_4+F)/2` of rank 3, `p≠I_4`. The corner `p M_4 p` is a unital `*`-algebra with unit `p`, `dim=9`, `*-isomorphic` to `M_3` via `ψ(I_3)=p`. The inclusion into `M_4` is not unital. No SU(3), no QCD, no Qubit rewrite.

## What this means for the TOE

Color-as-corner is a leftover host whose unit is `p`, not a unital `M_3` factor of the two-site tensor. Independent of #6251 (pad not unital).

## Verification

```bash
python3 scripts/two_site_swap_corner_hosts_m3_with_unit_p_2026_08_13.py
# TOTAL: PASS=26 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.