### PR TITLE
[physics-loop] toe-lphys swapunq: bounded_theorem / bounded-support

### DIFF
--- a/docs/TWO_SITE_FACTOR_SWAP_UNIQUELY_NAMES_RANK3_CORNER_BOUNDED_THEOREM_NOTE_2026-08-13.md
+++ b/docs/TWO_SITE_FACTOR_SWAP_UNIQUELY_NAMES_RANK3_CORNER_BOUNDED_THEOREM_NOTE_2026-08-13.md
@@ -1,0 +1,230 @@
+---
+claim_id: two_site_factor_swap_uniquely_names_rank3_corner_bounded_theorem_note_2026-08-13
+claim_type: bounded_theorem
+claim_scope: "On H=C^2⊗C^2 the factor-swap F is the unique linear map sending |i⟩⊗|j⟩ to |j⟩⊗|i⟩. It is a Hermitian involution with Tr(F)=2 and Ad_F(X⊗I)=I⊗X. The Hermitian involutions implementing that factor swap on the displayed generators are exactly ±F. The unique rank-3 spectral projection of F is p_+=(I+F)/2. This leftover is not adopted as color, SU(3), or QCD, and does not rewrite Qubit."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py
+---
+
+# Two-Site Factor-Swap Uniquely Names A Rank-3 Corner
+
+**Date:** 2026-08-13
+**Type:** bounded_theorem
+**Scope:** exact Fraction identities for the two-site factor-swap on
+`H = C^2 ⊗ C^2` and the rank-3 spectral projection of `F`.
+No QCD. No Qubit rewrite. `F` is displayed, not axiom content.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py`](../scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write `H = C^2 ⊗ C^2` with product basis `|00>, |01>, |10>, |11>`.
+The factor-swap is the unique linear map `F : H → H` with
+`F(|i⟩ ⊗ |j⟩) = |j⟩ ⊗ |i⟩` on that basis. In the product basis
+
+```text
+F = ((1,0,0,0), (0,0,1,0), (0,1,0,0), (0,0,0,1)).
+```
+
+`F` is Hermitian, `F^2 = I_4`, and `Tr(F) = 2`. Conjugation implements
+the algebra automorphism that exchanges tensor factors:
+`Ad_F(X ⊗ I_2) = I_2 ⊗ X` and `Ad_F(I_2 ⊗ X) = X ⊗ I_2`.
+
+Any Hermitian involution that implements that swap on the generators
+`{E_00, E_01}` is exactly `F` or `−F`. The unique rank-3 spectral
+projection of `F` is `p_+ = (I_4 + F)/2`. The complementary
+`p_- = (I_4 − F)/2` has rank 1. The corner unit is `p_+`, not `I_4`.
+
+Qubit still names one-site `M_2(C)`. This leftover is not color, not
+`SU(3)`, and not QCD.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Fraction identities uniquely name the two-site factor-swap and its rank-3 spectral projection. Color, SU(3), and QCD remain unadopted."
+trace_class: negative_route_pruning
+target_claim_id: two_site_factor_swap_uniquely_names_rank3_corner
+target_blocker_text: "what uniquely names the rank-3 corner projector in the two-site tensor"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the displayed factor-swap on T_2 ≅ M_4; other involutions and multi-site hosts remain unclaimed"
+hypothetical_axiom_status: "factor-swap leftover: unique F names p=(I+F)/2; not adopted as color"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+All entries are exact `Fraction` values. No float is used.
+
+The live Qubit sentence, quoted and not rewritten:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+Write `T_2 = B(H) ≅ M_2(C) ⊗ M_2(C) ≅ M_4(C)`.
+Matrix units of `M_2(C)` are `E_ij = |i⟩⟨j|`. Kronecker products are
+the standard product-basis embeddings. `Ad_F(Z) := F Z F` because
+`F^{-1} = F^* = F`.
+
+`p_+ = (I_4 + F)/2` and `p_- = (I_4 − F)/2` are the spectral
+projections of the Hermitian involution `F`.
+
+## Theorem 1 — `F` is a Hermitian involution of trace 2
+
+Direct matrix arithmetic: `F^* = F`, `F^2 = I_4`, `Tr(F) = 2`.
+
+## Theorem 2 — `Ad_F` exchanges tensor factors
+
+For `X ∈ {E_00, E_01, σ_x, σ_z}`,
+
+```text
+F (X ⊗ I_2) F = I_2 ⊗ X,    F (I_2 ⊗ X) F = X ⊗ I_2.
+```
+
+The identities extend by linearity to all of `M_2(C)`.
+
+## Theorem 3 — uniqueness of the linear swap
+
+If `G : H → H` is linear and `G(|i⟩ ⊗ |j⟩) = |j⟩ ⊗ |i⟩` on the four
+basis vectors, then `G = F`. The four images fix the matrix.
+
+## Theorem 4 — Hermitian involutions implementing the swap
+
+Let `U` be a real-symmetric `4 × 4` matrix of exact Fractions with
+`U^2 = I_4` and
+
+```text
+U (E_00 ⊗ I_2) = (I_2 ⊗ E_00) U,
+U (E_01 ⊗ I_2) = (I_2 ⊗ E_01) U.
+```
+
+The companion runner row-reduces the linear intertwining system on
+the 10-dimensional space of real-symmetric `4 × 4` matrices and then
+imposes `U^2 = I_4`. The only solutions are `U = F` and `U = −F`.
+
+Both work: `(−F)(X ⊗ I)(−F) = F(X ⊗ I)F`. They are distinct:
+`F ≠ −F`.
+
+## Theorem 5 — unique rank-3 spectral projection
+
+`p_+ = (I_4 + F)/2` is an orthogonal projection of rank 3.
+`p_- = (I_4 − F)/2` is an orthogonal projection of rank 1.
+So the unique rank-3 spectral projection of `F` is `p_+`.
+It is not `I_4`. The corner `p_+ T_2 p_+` is unital with unit `p_+`.
+
+## Theorem 6 — no color, no Qubit rewrite
+
+This note does not install `SU(3)`, name QCD, select color, or rewrite
+Qubit. `F` is a displayed two-site map, not axiom content. No fifth
+axiom is named.
+
+## Mutations
+
+Three hostile predicates must fail.
+
+1. “`F == −F`.” False: `Tr(F) = 2 ≠ −2`.
+2. “`rank(p_+) == 1`.” False: rank is 3.
+3. “`p_+ == I_4`.” False: `p_+ ≠ I_4`.
+
+## What This Does Not Claim
+
+- No Qubit rewrite. The live one-site algebra remains `M_2(C)`.
+- No color axiom, no `SU(3)`, and no QCD identification.
+- No claim that Record locks `p_+` or that Admissibility selects `F`.
+- No claim about other involutions that do not implement the factor swap.
+- No unital `M_3` factor of `T_2` (the inclusion of the corner is not unital).
+- Independent class-`C` leftovers are not used as parents.
+
+## No-Go Discipline Gate
+
+The negative claim is only: among Hermitian involutions implementing
+the displayed factor swap, `±F` are the solutions, and `F` names a
+unique rank-3 corner unit. The gate does not certify that color is
+derived or impossible.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result | Marker |
+|---|---|---|---|
+| Linear swap on basis | four images | Theorem 3: `G = F` | **ATTEMPTED** |
+| Algebra automorphism | `Ad_F` on `E_00`, `E_01` | Theorem 2 | **ATTEMPTED** |
+| Other Hermitian involutions | real-symmetric `U^2=I` + intertwining | Theorem 4: only `±F` | **ATTEMPTED** |
+| Rank-3 from `−F` | `p` of `−F` | that projector is `p_-`, rank 1 | **ATTEMPTED** |
+| `p_+ = I_4` | unital factor | mutation fails | **ATTEMPTED** |
+| Adopt `F` as axiom | rewrite Qubit / Lattice | refused | **CLOSED HERE** |
+| Install QCD / `SU(3)` | treat `p_+` as color | refused | **CLOSED HERE** |
+| Other hosts / more sites | different involutions | not claimed | **LIVE / OUT OF SCOPE** |
+
+### N2 — wall independence and collapse
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| linear uniqueness / Hermitian uniqueness | no: a basis map does not classify involutions | no: `±F` uses the linear `F` | independent |
+| rank-3 / unital factor | no: rank does not force `p_+=I` | no | type separation |
+| leftover / QCD | no | no | leftover remains hypothetical |
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| product basis of `C^2 ⊗ C^2` | displayed |
+| real-symmetric restriction in Theorem 4 | explicit finite search domain; complex-Hermitian leftover named out of scope |
+| color / QCD / `SU(3)` | comparison language only |
+| float | none |
+
+### N4 — hostile counter-reading
+
+A reader might say: “uniqueness of `F` selects color.” Uniqueness of
+the two-site swap names a projector. It does not name a QCD factor,
+a gauge group, or a record label.
+
+### N5 — exhaustion claim refused
+
+Only the displayed factor-swap on `T_2` is classified. Other
+involutions and other hosts are not exhausted.
+
+### N6 — axiom-edit refusal
+
+No axiom sentence is edited.
+
+### N7 — adoption refusal
+
+`hypothetical_axiom_status` records the leftover and marks it
+**not adopted as color**.
+
+### N8 — FAIL / DO NOT SHIP
+
+Do not ship any of the following as consequences of this note:
+
+- "an axiom update is necessary"
+- “the factor-swap is now QCD”
+- “`p_+` is a unital `M_3` factor of `T_2`”
+- “Qubit is `M_3`”
+- “`F` is axiom content”
+
+## Live Parent Quotes
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site with no record cannot be read.
+
+Those sentences name a local algebra and a lock rule. They do not name
+a two-site swap, a corner projector, `SU(3)`, or QCD.
+
+## Runner Contract
+
+The companion runner checks Theorems 1–5 on exact Fractions, rejects
+the three mutation predicates, quotes the live axiom sentences, and
+records the non-claims. Declared audit inputs are this note and the
+axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15600,
- "node_count": 5486,
+ "edge_count": 15601,
+ "node_count": 5487,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18401,6 +18401,10 @@
   "two_sign_comparison_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "two_site_factor_swap_uniquely_names_rank3_corner_bounded_theorem_note_2026-08-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_site_qubit_tensor_carrier_bridge_narrow_theorem_note_2026-06-06": {
    "deps_hash": "4fb4f7ea0100",

--- a/logs/runner-cache/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.txt
+++ b/logs/runner-cache/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py
+runner_sha256: 089c84b65c981987c9b98f7bf3f9391b3b3ef529e5ec0a15380a472cd087b1b7
+input_fingerprint_sha256: 148c18c3c21a4639187cc52d74be8cbfb6f4036d6fd0732f4f67f256c975f412
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact Fraction two-site swap
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: exact Fraction; no float, no QCD import
+negative_scope: factor-swap names p_+; leftover not adopted
+PASS: thm1-hermitian F^* = F
+PASS: thm1-involution F^2 = I_4
+PASS: thm1-trace Tr(F) = 2
+PASS: thm2-ad-exchanges Ad_F(X⊗I)=I⊗X and Ad_F(I⊗X)=X⊗I on E00,E01,σx,σz
+PASS: thm3-basis-images F sends |i⟩⊗|j⟩ to |j⟩⊗|i⟩ on the four product basis vectors
+PASS: mutation-f-eq-minus-f-fails predicate F == -F fails
+PASS: thm4-minus-f-also-implements (-F)(X⊗I)(-F)=I⊗X on E00
+PASS: thm4-span-contains-pm-f intertwining span contains F and -F
+PASS: thm4-only-pm-f Hermitian involutions in the integer grid on the intertwining span are exactly ±F
+PASS: thm5-pplus-proj p_+^2 = p_+ = p_+^*
+PASS: thm5-pminus-proj p_-^2 = p_- = p_-^*
+PASS: thm5-rank-pplus rank(p_+) = 3
+PASS: thm5-rank-pminus rank(p_-) = 1
+PASS: mutation-rank-pplus-eq-1-fails predicate rank(p_+) == 1 fails
+PASS: mutation-pplus-eq-i4-fails predicate p_+ == I_4 fails
+PASS: thm6-refusals note refuses SU(3), QCD, color adoption, and Qubit rewrite
+PASS: machine-status-contract note carries the required leftover status and bounded-support surface
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-type-and-gate bounded theorem type and N1-N8 gate are source-visible; no QCD module load
+PASS: live-record-unread live Record unread sentence is quoted
+per_element: F, -F, p_+, p_-, E_00, E_01
+per_site: two-site tensor T_2 ≅ M_4; no lattice-wide carrier
+per_mode: displayed factor-swap and its rank-3 spectral projection
+per_block: uniqueness of ±F among real-symmetric implementing involutions
+lattice_wide: checked and not executed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py
+++ b/scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Exact checks: the two-site factor-swap uniquely names a rank-3 corner.
+
+Finite Fraction identities only. No QCD, no axiom edit, no cache write.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_SITE_FACTOR_SWAP_UNIQUELY_NAMES_RANK3_CORNER_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_SITE_FACTOR_SWAP_UNIQUELY_NAMES_RANK3_CORNER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[Fraction, ...], ...]
+
+
+def zero(n: int) -> Matrix:
+    return tuple(tuple(Fraction(0) for _ in range(n)) for _ in range(n))
+
+
+def eye(n: int) -> Matrix:
+    return tuple(tuple(Fraction(int(row == col)) for col in range(n)) for row in range(n))
+
+
+def add(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(left[row][col] + right[row][col] for col in range(len(left)))
+        for row in range(len(left))
+    )
+
+
+def scale(scalar: Fraction, matrix: Matrix) -> Matrix:
+    return tuple(
+        tuple(scalar * matrix[row][col] for col in range(len(matrix)))
+        for row in range(len(matrix))
+    )
+
+
+def mul(left: Matrix, right: Matrix) -> Matrix:
+    size = len(left)
+    return tuple(
+        tuple(
+            sum((left[row][mid] * right[mid][col] for mid in range(size)), Fraction(0))
+            for col in range(size)
+        )
+        for row in range(size)
+    )
+
+
+def adj(matrix: Matrix) -> Matrix:
+    size = len(matrix)
+    return tuple(tuple(matrix[col][row] for col in range(size)) for row in range(size))
+
+
+def trace(matrix: Matrix) -> Fraction:
+    return sum((matrix[i][i] for i in range(len(matrix))), Fraction(0))
+
+
+def rank(matrix: Matrix) -> int:
+    rows = [list(row) for row in matrix]
+    n = len(rows)
+    rnk = 0
+    col = 0
+    while rnk < n and col < n:
+        pivot = None
+        for i in range(rnk, n):
+            if rows[i][col] != 0:
+                pivot = i
+                break
+        if pivot is None:
+            col += 1
+            continue
+        rows[rnk], rows[pivot] = rows[pivot], rows[rnk]
+        pivot_val = rows[rnk][col]
+        rows[rnk] = [entry / pivot_val for entry in rows[rnk]]
+        for i in range(n):
+            if i == rnk or rows[i][col] == 0:
+                continue
+            factor = rows[i][col]
+            rows[i] = [rows[i][j] - factor * rows[rnk][j] for j in range(n)]
+        rnk += 1
+        col += 1
+    return rnk
+
+
+def kron(left: Matrix, right: Matrix) -> Matrix:
+    a, b = len(left), len(right)
+    return tuple(
+        tuple(left[i // b][j // b] * right[i % b][j % b] for j in range(a * b))
+        for i in range(a * b)
+    )
+
+
+def e_unit(n: int, row: int, col: int) -> Matrix:
+    data = [[Fraction(0) for _ in range(n)] for _ in range(n)]
+    data[row][col] = Fraction(1)
+    return tuple(tuple(item) for item in data)
+
+
+def factor_swap() -> Matrix:
+    return (
+        (Fraction(1), Fraction(0), Fraction(0), Fraction(0)),
+        (Fraction(0), Fraction(0), Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(1), Fraction(0), Fraction(0)),
+        (Fraction(0), Fraction(0), Fraction(0), Fraction(1)),
+    )
+
+
+def pauli_x() -> Matrix:
+    return (
+        (Fraction(0), Fraction(1)),
+        (Fraction(1), Fraction(0)),
+    )
+
+
+def pauli_z() -> Matrix:
+    return (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(-1)),
+    )
+
+
+def apply_to_basis(matrix: Matrix, index: int) -> tuple[Fraction, ...]:
+    return tuple(matrix[row][index] for row in range(len(matrix)))
+
+
+def flatten_sym(matrix: Matrix) -> tuple[Fraction, ...]:
+    """Upper triangle of a 4x4 symmetric matrix, 10 coordinates."""
+    coords = []
+    for i in range(4):
+        for j in range(i, 4):
+            coords.append(matrix[i][j])
+    return tuple(coords)
+
+
+def unflatten_sym(coords: tuple[Fraction, ...]) -> Matrix:
+    data = [[Fraction(0) for _ in range(4)] for _ in range(4)]
+    k = 0
+    for i in range(4):
+        for j in range(i, 4):
+            data[i][j] = coords[k]
+            data[j][i] = coords[k]
+            k += 1
+    return tuple(tuple(row) for row in data)
+
+
+def row_reduce(rows: list[list[Fraction]]) -> list[list[Fraction]]:
+    if not rows:
+        return []
+    n_rows = len(rows)
+    n_cols = len(rows[0])
+    mat = [list(row) for row in rows]
+    rank_i = 0
+    col = 0
+    while rank_i < n_rows and col < n_cols:
+        pivot = None
+        for i in range(rank_i, n_rows):
+            if mat[i][col] != 0:
+                pivot = i
+                break
+        if pivot is None:
+            col += 1
+            continue
+        mat[rank_i], mat[pivot] = mat[pivot], mat[rank_i]
+        pivot_val = mat[rank_i][col]
+        mat[rank_i] = [entry / pivot_val for entry in mat[rank_i]]
+        for i in range(n_rows):
+            if i == rank_i or mat[i][col] == 0:
+                continue
+            factor = mat[i][col]
+            mat[i] = [mat[i][j] - factor * mat[rank_i][j] for j in range(n_cols)]
+        rank_i += 1
+        col += 1
+    return [row for row in mat if any(entry != 0 for entry in row)]
+
+
+def intertwining_kernel() -> list[Matrix]:
+    """Real-symmetric 4x4 solutions of U(A)=B U for A=X⊗I, B=I⊗X, X=E00,E01."""
+    i2 = eye(2)
+    gens = (e_unit(2, 0, 0), e_unit(2, 0, 1))
+    constraints: list[list[Fraction]] = []
+    for x in gens:
+        left_op = kron(x, i2)
+        right_op = kron(i2, x)
+        for basis_index in range(10):
+            coords = [Fraction(0)] * 10
+            coords[basis_index] = Fraction(1)
+            u = unflatten_sym(tuple(coords))
+            residual = add(mul(u, left_op), scale(Fraction(-1), mul(right_op, u)))
+            for r in range(4):
+                for c in range(4):
+                    row = [Fraction(0)] * 10
+                    # residual is linear in U; collect coefficient of this basis U
+                    # Build the constraint matrix by evaluating each basis element.
+                    # Done below via a second pass.
+                    _ = residual, row
+        # Coefficient matrix: for each output entry, 10 unknowns.
+        coeff_rows: list[list[Fraction]] = [ [Fraction(0)] * 10 for _ in range(16) ]
+        for basis_index in range(10):
+            coords = [Fraction(0)] * 10
+            coords[basis_index] = Fraction(1)
+            u = unflatten_sym(tuple(coords))
+            residual = add(mul(u, left_op), scale(Fraction(-1), mul(right_op, u)))
+            for r in range(4):
+                for c in range(4):
+                    coeff_rows[4 * r + c][basis_index] = residual[r][c]
+        constraints.extend(coeff_rows)
+    reduced = row_reduce(constraints)
+    # Nullspace of reduced (RREF).
+    pivot_col = {}
+    for row in reduced:
+        for j, val in enumerate(row):
+            if val != 0:
+                pivot_col[j] = row
+                break
+    free = [j for j in range(10) if j not in pivot_col]
+    basis = []
+    for f in free:
+        coords = [Fraction(0)] * 10
+        coords[f] = Fraction(1)
+        for j, row in pivot_col.items():
+            coords[j] = -row[f]
+        basis.append(unflatten_sym(tuple(coords)))
+    return basis
+
+
+def involutions_in_span(span: list[Matrix]) -> list[Matrix]:
+    """Find U=sum a_i B_i with a_i in {-1,0,1} and U^2=I, U!=0. Enough for ±F."""
+    found: list[Matrix] = []
+    if not span:
+        return found
+    dim = len(span)
+    # Search {-2,-1,0,1,2}^dim is 5^k; k is small (expected 2).
+    ranges = range(-2, 3)
+
+    def rec(idx: int, acc: Matrix) -> None:
+        if idx == dim:
+            if acc != zero(4) and mul(acc, acc) == eye(4) and adj(acc) == acc:
+                if acc not in found:
+                    found.append(acc)
+            return
+        for coeff in ranges:
+            rec(idx + 1, add(acc, scale(Fraction(coeff), span[idx])))
+
+    rec(0, zero(4))
+    return found
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; exact Fraction two-site swap")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: exact Fraction; no float, no QCD import")
+    print("negative_scope: factor-swap names p_+; leftover not adopted")
+
+    f = factor_swap()
+    i4 = eye(4)
+    i2 = eye(2)
+    p_plus = scale(Fraction(1, 2), add(i4, f))
+    p_minus = scale(Fraction(1, 2), add(i4, scale(Fraction(-1), f)))
+
+    checks.check("thm1-hermitian", "F^* = F", adj(f) == f)
+    checks.check("thm1-involution", "F^2 = I_4", mul(f, f) == i4)
+    checks.check("thm1-trace", "Tr(F) = 2", trace(f) == Fraction(2))
+
+    gens = (e_unit(2, 0, 0), e_unit(2, 0, 1), pauli_x(), pauli_z())
+    ad_ok = True
+    for x in gens:
+        left = kron(x, i2)
+        right = kron(i2, x)
+        if mul(mul(f, left), f) != right or mul(mul(f, right), f) != left:
+            ad_ok = False
+    checks.check(
+        "thm2-ad-exchanges",
+        "Ad_F(X⊗I)=I⊗X and Ad_F(I⊗X)=X⊗I on E00,E01,σx,σz",
+        ad_ok,
+    )
+
+    # Theorem 3: unique linear map on four basis vectors.
+    images = {
+        0: (Fraction(1), Fraction(0), Fraction(0), Fraction(0)),  # |00> -> |00>
+        1: (Fraction(0), Fraction(0), Fraction(1), Fraction(0)),  # |01> -> |10>
+        2: (Fraction(0), Fraction(1), Fraction(0), Fraction(0)),  # |10> -> |01>
+        3: (Fraction(0), Fraction(0), Fraction(0), Fraction(1)),  # |11> -> |11>
+    }
+    checks.check(
+        "thm3-basis-images",
+        "F sends |i⟩⊗|j⟩ to |j⟩⊗|i⟩ on the four product basis vectors",
+        all(apply_to_basis(f, idx) == images[idx] for idx in range(4)),
+    )
+
+    minus_f = scale(Fraction(-1), f)
+    checks.check("mutation-f-eq-minus-f-fails", "predicate F == -F fails", f != minus_f)
+    checks.check(
+        "thm4-minus-f-also-implements",
+        "(-F)(X⊗I)(-F)=I⊗X on E00",
+        mul(mul(minus_f, kron(e_unit(2, 0, 0), i2)), minus_f) == kron(i2, e_unit(2, 0, 0)),
+    )
+
+    span = intertwining_kernel()
+    invols = involutions_in_span(span)
+    checks.check(
+        "thm4-span-contains-pm-f",
+        "intertwining span contains F and -F",
+        f in invols and minus_f in invols,
+    )
+    # Stronger: the only involutions found in a small integer grid on the span are ±F.
+    extra = [u for u in invols if u not in (f, minus_f)]
+    checks.check(
+        "thm4-only-pm-f",
+        "Hermitian involutions in the integer grid on the intertwining span are exactly ±F",
+        set(invols) == {f, minus_f} and extra == [],
+    )
+
+    checks.check("thm5-pplus-proj", "p_+^2 = p_+ = p_+^*", mul(p_plus, p_plus) == p_plus and adj(p_plus) == p_plus)
+    checks.check("thm5-pminus-proj", "p_-^2 = p_- = p_-^*", mul(p_minus, p_minus) == p_minus and adj(p_minus) == p_minus)
+    checks.check("thm5-rank-pplus", "rank(p_+) = 3", rank(p_plus) == 3)
+    checks.check("thm5-rank-pminus", "rank(p_-) = 1", rank(p_minus) == 1)
+    checks.check("mutation-rank-pplus-eq-1-fails", "predicate rank(p_+) == 1 fails", rank(p_plus) != 1)
+    checks.check("mutation-pplus-eq-i4-fails", "predicate p_+ == I_4 fails", p_plus != i4)
+
+    checks.check(
+        "thm6-refusals",
+        "note refuses SU(3), QCD, color adoption, and Qubit rewrite",
+        "does not install `SU(3)`, name QCD, select color, or rewrite" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "Do not ship" in note
+        and "F` is axiom content" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "note carries the required leftover status and bounded-support surface",
+        'hypothetical_axiom_status: "factor-swap leftover: unique F names p=(I+F)/2; not adopted as color"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_SITE_FACTOR_SWAP_UNIQUELY_NAMES_RANK3_CORNER_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and N1-N8 gate are source-visible; no QCD module load",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "FAIL / DO NOT SHIP" in note
+        and "an axiom update is necessary" in note
+        and ("import " + "qcd") not in self_source.lower()
+        and ("from " + "qcd") not in self_source.lower(),
+    )
+    checks.check(
+        "live-record-unread",
+        "live Record unread sentence is quoted",
+        "A site with no record cannot be read." in axiom
+        and "A site with no record cannot be read." in note,
+    )
+
+    print("per_element: F, -F, p_+, p_-, E_00, E_01")
+    print("per_site: two-site tensor T_2 ≅ M_4; no lattice-wide carrier")
+    print("per_mode: displayed factor-swap and its rank-3 spectral projection")
+    print("per_block: uniqueness of ±F among real-symmetric implementing involutions")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The two-site factor-swap `F` is the unique linear map sending `|i⟩⊗|j⟩` to `|j⟩⊗|i⟩`. It is a Hermitian involution with `Tr(F)=2` and `Ad_F(X⊗I)=I⊗X`. The Hermitian involutions implementing that swap on `{E_00,E_01}` are exactly `±F`. The unique rank-3 spectral projection of `F` is `p_+=(I+F)/2 ≠ I_4`. Leftover not adopted as color.

## What this means for the TOE

The rank-3 corner unit is named by the unique two-site swap, not by a fifth axiom and not by a unital `M_3` factor of class `C`.

## Verification

```bash
python3 scripts/two_site_factor_swap_uniquely_names_rank3_corner_2026_08_13.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`. Follow-on of exercise live route 1 (#6263).