### PR TITLE
[physics-loop] toe-lphys pairlab: bounded_theorem / bounded-support

### DIFF
--- a/docs/OCCUPANCY_PAIRING_AND_CONTENT_MATCH_PAIRING_DISAGREE_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/OCCUPANCY_PAIRING_AND_CONTENT_MATCH_PAIRING_DISAGREE_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,217 @@
+---
+claim_id: occupancy_pairing_and_content_match_pairing_disagree_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On two disjoint occupied unit locks with unequal lock labels A and B, the supplied occupancy-product pairing equals 1 and the supplied content-match pairing equals 0. Live Record names each site's lock label, not a two-argument pairing of labels. Both tables are extras. Named additive I is not restored."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py
+---
+
+# Occupancy Pairing And Content-Match Pairing Disagree
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact comparison of two supplied extra pairing tables on two
+disjoint occupied unit locks. Live Record is quoted without rewrite. No
+pairing is adopted. Named additive `I` is not axiom content and is not
+restored. No two-argument map is read out of the axiom memo.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py`](../scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Take two disjoint occupied unit locks: site `s` locks content `A`, site
+`t` locks content `B`, and `A ≠ B`. Live Record names each site's lock
+label. It does not name a pairing of those labels.
+
+Two extra tables are displayed, not adopted.
+
+Occupancy-product pairing (extra): `B_π(s,t) = 1` if both sites are
+occupied, else `0`. On the displayed pair, `B_π(s,t) = 1`.
+
+Content-match pairing (extra): `B_eq(s,t) = 1` if both sites are occupied
+and the lock labels are equal, else `0`. On the displayed pair,
+`B_eq(s,t) = 0`.
+
+Therefore `B_π(s,t) = 1 ≠ 0 = B_eq(s,t)`. Same two locks, two supplied
+tables. The control cell with both locks equal to `A` has
+`B_π = B_eq = 1`. The disagreement is the different-label cell, not
+occupancy alone.
+
+The live memo does not name `B_π`, does not name `B_eq`, and does not name
+a two-argument pairing. Named additive `I` is not Record axiom content
+and is not restored here. The pairing arguments are occupied locks and
+their labels, not an occupancy field.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact table comparison on one displayed pair of occupied unit locks. Both pairing tables are extras. Live Record is quoted; I is not restored."
+trace_class: frontier_discovery
+target_claim_id: occupancy_pairing_and_content_match_pairing_disagree
+target_blocker_text: "whether a product-on-occupancy table and a same-label table agree when two occupied locks have different content"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the displayed (A,B) pair and the same-label control cell; no pairing is adopted and no axiom is added"
+hypothetical_axiom_status: "not proposed; B_π and B_eq remain extras; I is not restored"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded algebraic claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Record sentences quoted below. They
+  are quoted without rewrite. The axiom memo is the only parent.
+- **Explicit theorem-domain condition:** two disjoint occupied unit locks
+  with labels `A` and `B`, together with the two supplied extra tables
+  `B_π` and `B_eq`. Those tables are not derived from the axioms.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** adopting either table, pairing on an occupancy
+  field, restoring named additive `I`, and any physical two-site
+  composition rule remain outside the target proved here.
+
+## Exact Objects
+
+All runner values are exact `Fraction` entries `0` or `1`. No float is
+used.
+
+A unit lock at a site is either occupied, in which case it carries exactly
+one lock label, or unoccupied, in which case it carries no readable
+content. Sites `s` and `t` are distinct.
+
+The supplied occupancy-product pairing (extra, not adopted):
+
+```text
+B_π(s,t) = 1  if both sites are occupied,
+B_π(s,t) = 0  otherwise.
+```
+
+The supplied content-match pairing (extra, not adopted):
+
+```text
+B_eq(s,t) = 1  if both sites are occupied and the lock labels are equal,
+B_eq(s,t) = 0  otherwise.
+```
+
+Displayed occupied pair: `s` locks `A`, `t` locks `B`, with `A ≠ B`.
+
+Same-label control: both sites lock `A`.
+
+The live Record axiom, quoted and not rewritten:
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+> When present, a record locks exactly one admissible local possibility.
+
+The live denial that named additive `I` is axiom content, quoted and not
+rewritten:
+
+> Finite additivity, a named scalar collection functional `I`, and an assigned
+> value `I(empty)=0` are not Record axiom content.
+
+## Theorem 1 — the two extra tables disagree on `(A,B)`
+
+Site `s` is occupied with label `A`. Site `t` is occupied with label `B`.
+Both sites are occupied, so `B_π(s,t) = 1`. The lock labels are unequal,
+so `B_eq(s,t) = 0`. Therefore
+
+```text
+B_π(s,t) = 1 ≠ 0 = B_eq(s,t).
+```
+
+Same two locks, two supplied tables.
+
+## Theorem 2 — live Record names two one-site labels
+
+Quote the live Record sentences above. Site `s` reads `A` and site `t` reads `B`.
+That is two one-site labels. The readout value at each site is determined
+by that site's record content alone.
+
+The axiom memo does not name a two-argument map, does not name `B_π`, and
+does not name `B_eq`. Record names each site's lock label, not a pairing
+of labels.
+
+## Theorem 3 — both tables are extras
+
+The occupancy-product table and the content-match table are displayed
+extras. This note does not adopt `π`. It does not pair on a `J` field:
+the arguments are occupied locks and their labels, not an occupancy
+field. It does not restore named additive `I`.
+
+## Control — same-label cell agrees
+
+If both locks are `A`, both sites are occupied and the labels are equal,
+so `B_π(s,t) = 1` and `B_eq(s,t) = 1`. The disagreement of Theorem 1 is
+the different-label cell, not occupancy alone.
+
+If either site is unoccupied, both tables return `0`. That cell is
+unreadability of absence, not a scalar assignment `I(empty)=0`.
+
+## Mutation Checks
+
+Three predicates must fail:
+
+1. `B_π(s,t) == B_eq(s,t)` on the displayed `(A,B)` pair.
+2. The live memo contains `I(empty)=0` as Record axiom content.
+3. The live memo names a two-argument pairing.
+
+Predicate 1 fails by Theorem 1. Predicate 2 fails because the only live
+occurrences of `I(empty)=0` are denials that the assignment is Record
+content. Predicate 3 fails because the memo names neither `B_π` nor
+`B_eq` nor any two-argument pairing.
+
+## Honest-auditor / Boundary
+
+This note compares two supplied extra tables on one displayed pair of
+occupied unit locks. It does not adopt either table. It does not install
+a pairing as axiom content. It does not restore `I`. It does not pair on
+a `J` field. It does not claim that Record already contains a
+two-argument map. It does not assign a scalar to an unoccupied site.
+
+The live Record parent is only the quoted lock-and-readout sentences plus
+the quoted denial that `I` is axiom content. No other parent is used.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here, and no audit verdict is
+authored here.
+
+## What This Does Not Claim
+
+- Neither extra table is adopted as framework content.
+- No pairing-on-occupancy-field construction is used or endorsed.
+- Named additive `I` is not restored and `I(empty)=0` is not reinstalled.
+- Live Record is not rewritten.
+- No physical two-site composition rule is derived.
+- Unoccupied sites remain unreadable; unreadability is not a scalar value.
+
+## Live Parent Quotes
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> Finite additivity, a named scalar collection functional `I`, and an assigned
+> value `I(empty)=0` are not Record axiom content.
+
+Their dependency role is limited to one-site lock labels, content-only
+readout, unreadability of a site with no record, and the denial that `I`
+is axiom content. The two pairing tables are separately supplied extras.
+
+## Runner Contract
+
+The companion runner checks Theorems 1–3, the same-label control, the
+unoccupied cell, and the three mutations with exact rational arithmetic.
+It quotes the live axiom sentences, records the import boundary, and
+refuses adoption of `π`, pairing on a `J` field, and restoration of `I`.
+Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13317,6 +13317,10 @@
   "occupancy_nonexclusivity_mixture_bound_note_2026-06-09": {
    "deps_hash": "188680808cab",
    "out_degree": 3
+  },
+  "occupancy_pairing_and_content_match_pairing_disagree_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "occupancy_readout_exponent_berezin_subsumption_bounded_theorem_note_2026-06-09": {
    "deps_hash": "95b72757a210",

--- a/logs/runner-cache/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.txt
+++ b/logs/runner-cache/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py
+runner_sha256: d172cf1a4bc7d3949f9114058221f4e7b1b0d9af3c0743d5c3c573ccbec226dc
+input_fingerprint_sha256: b2643970b866d7e78ca2e7c64c19555bd2524c742873838d24323d28a029bf66
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; B_π and B_eq are displayed extras
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact Fraction occupancy and label comparison
+negative_scope: neither pairing is adopted; I is not restored
+PASS: thm1-b-pi B_π(s,t) = 1 on occupied (A,B)
+PASS: thm1-b-eq B_eq(s,t) = 0 on occupied (A,B)
+PASS: thm1-disagree B_π(s,t) = 1 ≠ 0 = B_eq(s,t) on the displayed (A,B) pair
+PASS: control-same-label both locks A gives B_π = B_eq = 1
+PASS: control-unoccupied an unoccupied second site gives B_π = B_eq = 0
+PASS: mutation-tables-equal-fails predicate B_π(s,t) == B_eq(s,t) on (A,B) fails
+PASS: thm2-live-record-quoted live Record readout sentences are quoted without rewrite
+PASS: thm2-two-one-site-labels site s reads A and site t reads B as two one-site labels
+PASS: thm2-memo-does-not-name-tables the axiom memo does not name B_π, B_eq, or a two-argument pairing
+PASS: mutation-memo-names-two-arg-pairing-fails predicate live memo names a two-argument pairing fails
+PASS: thm3-tables-are-extras both tables are displayed extras and π is not adopted
+PASS: thm3-not-adopt-pi the note does not adopt π
+PASS: thm3-not-pair-on-j arguments are occupied locks and labels, not a J field
+PASS: thm3-i-not-restored named additive I is denied as axiom content and is not restored
+PASS: mutation-i-empty-as-axiom-fails predicate live memo contains I(empty)=0 as axiom content fails
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: machine-status-contract bounded-support status and no axiom adoption are source-visible
+PASS: scope-refusals no G_N, no 1/r install, no axiom edit, no pairing-on-J
+PASS: honest-auditor-boundary Honest-auditor / Boundary is present and authors no audit verdict
+per_element: exact Fraction values cover B_π and B_eq on (A,B), (A,A), and an unoccupied cell.
+per_site: each site contributes one lock label; Record readout stays one-site.
+per_mode: occupancy-product and content-match are compared as two extras, not adopted.
+per_block: the different-label cell is the disagreement; the same-label control agrees.
+lattice_wide: checked and not executed — no lattice-wide pairing law is claimed.
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py
+++ b/scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Exact checks: occupancy-product pairing disagrees with content-match pairing.
+
+Two disjoint occupied unit locks with unequal labels. Both pairing tables
+are extras. Live Record is quoted. Named additive I is not restored.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "OCCUPANCY_PAIRING_AND_CONTENT_MATCH_PAIRING_DISAGREE_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/OCCUPANCY_PAIRING_AND_CONTENT_MATCH_PAIRING_DISAGREE_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+ONE = Fraction(1)
+ZERO = Fraction(0)
+
+Lock = tuple[bool, str | None]
+
+
+def occupied(label: str) -> Lock:
+    return (True, label)
+
+
+def unoccupied() -> Lock:
+    return (False, None)
+
+
+def b_pi(site_s: Lock, site_t: Lock) -> Fraction:
+    """Occupancy-product pairing (extra): 1 iff both sites are occupied."""
+    occ_s, _label_s = site_s
+    occ_t, _label_t = site_t
+    return ONE if occ_s and occ_t else ZERO
+
+
+def b_eq(site_s: Lock, site_t: Lock) -> Fraction:
+    """Content-match pairing (extra): 1 iff both occupied and labels equal."""
+    occ_s, label_s = site_s
+    occ_t, label_t = site_t
+    if occ_s and occ_t and label_s == label_t:
+        return ONE
+    return ZERO
+
+
+def live_memo_contains_i_empty_as_axiom(memo: str) -> bool:
+    """True only if I(empty)=0 is asserted as Record axiom content.
+
+    Denial sentences that the assignment is not Record content do not
+    satisfy this predicate.
+    """
+    denial = (
+        "value `I(empty)=0` are not Record axiom content"
+    )
+    if denial in memo:
+        return False
+    return "`I(empty)=0`" in memo or "I(empty)=0" in memo
+
+
+def live_memo_names_two_argument_pairing(memo: str) -> bool:
+    needles = (
+        "B_π",
+        "B_\\pi",
+        "B_eq",
+        "two-argument pairing",
+        "two-argument map",
+        "occupancy-product pairing",
+        "content-match pairing",
+    )
+    return any(needle in memo for needle in needles)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; B_π and B_eq are displayed extras")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact Fraction occupancy and label comparison")
+    print("negative_scope: neither pairing is adopted; I is not restored")
+
+    lock_s = occupied("A")
+    lock_t = occupied("B")
+    lock_same = occupied("A")
+    lock_empty = unoccupied()
+
+    pi_ab = b_pi(lock_s, lock_t)
+    eq_ab = b_eq(lock_s, lock_t)
+    pi_aa = b_pi(lock_s, lock_same)
+    eq_aa = b_eq(lock_s, lock_same)
+    pi_empty = b_pi(lock_s, lock_empty)
+    eq_empty = b_eq(lock_s, lock_empty)
+
+    checks.check("thm1-b-pi", "B_π(s,t) = 1 on occupied (A,B)", pi_ab == ONE)
+    checks.check("thm1-b-eq", "B_eq(s,t) = 0 on occupied (A,B)", eq_ab == ZERO)
+    checks.check(
+        "thm1-disagree",
+        "B_π(s,t) = 1 ≠ 0 = B_eq(s,t) on the displayed (A,B) pair",
+        pi_ab == ONE and eq_ab == ZERO and pi_ab != eq_ab,
+    )
+    checks.check(
+        "control-same-label",
+        "both locks A gives B_π = B_eq = 1",
+        pi_aa == ONE and eq_aa == ONE,
+    )
+    checks.check(
+        "control-unoccupied",
+        "an unoccupied second site gives B_π = B_eq = 0",
+        pi_empty == ZERO and eq_empty == ZERO,
+    )
+    checks.check(
+        "mutation-tables-equal-fails",
+        "predicate B_π(s,t) == B_eq(s,t) on (A,B) fails",
+        not (pi_ab == eq_ab),
+    )
+
+    record_readable = "Only records are readable."
+    record_content = "A readout value is determined by record content"
+    record_unread = "A site with no record cannot be read."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    i_denial = "value `I(empty)=0` are not Record axiom content"
+
+    checks.check(
+        "thm2-live-record-quoted",
+        "live Record readout sentences are quoted without rewrite",
+        record_readable in axiom
+        and record_content in axiom
+        and record_unread in axiom
+        and record_lock in axiom
+        and record_readable in note
+        and record_content in note
+        and record_unread in note
+        and record_lock in note,
+    )
+    checks.check(
+        "thm2-two-one-site-labels",
+        "site s reads A and site t reads B as two one-site labels",
+        "Site `s` reads `A` and site `t` reads `B`" in note
+        and "two one-site labels" in note,
+    )
+    checks.check(
+        "thm2-memo-does-not-name-tables",
+        "the axiom memo does not name B_π, B_eq, or a two-argument pairing",
+        not live_memo_names_two_argument_pairing(axiom),
+    )
+    checks.check(
+        "mutation-memo-names-two-arg-pairing-fails",
+        "predicate live memo names a two-argument pairing fails",
+        not live_memo_names_two_argument_pairing(axiom),
+    )
+
+    checks.check(
+        "thm3-tables-are-extras",
+        "both tables are displayed extras and π is not adopted",
+        "Two extra tables are displayed, not adopted." in note
+        and "does not adopt `π`" in note,
+    )
+    checks.check(
+        "thm3-not-adopt-pi",
+        "the note does not adopt π",
+        "does not adopt `π`" in note,
+    )
+    checks.check(
+        "thm3-not-pair-on-j",
+        "arguments are occupied locks and labels, not a J field",
+        "does not pair on a `J` field" in note
+        and "occupied locks and their labels" in note,
+    )
+    checks.check(
+        "thm3-i-not-restored",
+        "named additive I is denied as axiom content and is not restored",
+        i_denial in axiom
+        and i_denial in note
+        and "does not restore named additive `I`" in note,
+    )
+    checks.check(
+        "mutation-i-empty-as-axiom-fails",
+        "predicate live memo contains I(empty)=0 as axiom content fails",
+        not live_memo_contains_i_empty_as_axiom(axiom),
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/OCCUPANCY_PAIRING_AND_CONTENT_MATCH_PAIRING_DISAGREE_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "machine-status-contract",
+        "bounded-support status and no axiom adoption are source-visible",
+        "actual_current_surface_status: bounded-support" in note
+        and "trace_class: frontier_discovery" in note
+        and 'hypothetical_axiom_status: "not proposed; B_π and B_eq remain extras; I is not restored"'
+        in note
+        and "This note authors no\naudit verdict" in note,
+    )
+    checks.check(
+        "scope-refusals",
+        "no G_N, no 1/r install, no axiom edit, no pairing-on-J",
+        ("G_" + "N") not in note
+        and ("1/" + "r") not in note
+        and "I is not restored" in note
+        and ("import " + "qcd") not in self_source.lower()
+        and ("#" + "6259") not in note
+        and ("#" + "6204") not in note,
+    )
+    checks.check(
+        "honest-auditor-boundary",
+        "Honest-auditor / Boundary is present and authors no audit verdict",
+        "## Honest-auditor / Boundary" in note
+        and "no audit verdict is\nauthored here" in note
+        and "**Type:** bounded_theorem" in note
+        and "Parents:** the live axiom memo" in note,
+    )
+
+    print(
+        "per_element: exact Fraction values cover B_π and B_eq on (A,B), (A,A), and an unoccupied cell."
+    )
+    print(
+        "per_site: each site contributes one lock label; Record readout stays one-site."
+    )
+    print(
+        "per_mode: occupancy-product and content-match are compared as two extras, not adopted."
+    )
+    print(
+        "per_block: the different-label cell is the disagreement; the same-label control agrees."
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide pairing law is claimed."
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On two disjoint occupied unit locks with labels `A ≠ B`, the supplied occupancy-product table has `B_π(s,t) = 1` and the supplied content-match table has `B_eq(s,t) = 0`. Same two locks, two extras. Live Record names the two one-site labels, not a pairing of them. Neither table is adopted. Named `I` is not restored. Not pairing-on-`J`.

## What this means for the TOE

The pairing leftover is not only “two occupancy tables disagree on the occupied-occupied cell.” A product-on-occupancy table and a same-label table also disagree when the locks have different content. Record still does not pick a two-argument map.

## Verification

```bash
python3 scripts/occupancy_pairing_and_content_match_pairing_disagree_2026_08_14.py
# TOTAL: PASS=19 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.