### PR TITLE
[physics-loop] toe-lphys pairblank: bounded_theorem / bounded-support

### DIFF
--- a/docs/EMPTY_EMPTY_PAIRING_CELL_IS_NOT_A_BLANK_READOUT_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/EMPTY_EMPTY_PAIRING_CELL_IS_NOT_A_BLANK_READOUT_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,258 @@
+---
+claim_id: empty_empty_pairing_cell_is_not_a_blank_readout_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "Two reconstructed occupancy pairings agree at the empty-empty cell, B_π(∅,∅)=B_+(∅,∅)=0 as Fractions. Live Record says a site with no record cannot be read. That agreed 0 is a supplied table entry, not a site readout of a blank and not I(empty). Agreement is not selection of either pairing."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py
+---
+
+# Empty-Empty Pairing Cell Is Not A Blank Readout
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact Fraction identities for two reconstructed occupancy
+pairings at the empty-empty cell, plus the live Record unreadability of a
+blank site. No pairing is adopted. Named additive `I` is not restored. No
+`J`-field pairing, vacuum energy, or Newton constant is asserted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py`](../scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `∅` be the empty occupied-lock collection: no formed records. Occupancy
+of a lock collection `A` is the exact count `|A|`, written as a `Fraction`.
+Two occupancy pairings are reconstructed locally from those counts:
+
+```text
+B_π(A,B) = |A| · |B|,
+B_+(A,B) = |A| + |B|.
+```
+
+The empty-empty cell is then
+
+```text
+B_π(∅,∅) = 0 · 0 = 0,
+B_+(∅,∅) = 0 + 0 = 0.
+```
+
+The two tables agree at that one cell. Identity gates — the pairing maps
+evaluated on the identity lock collection `∅` — return those zeros. Agreement
+at one cell is not selection of either table.
+
+Live Record, quoted and not rewritten:
+
+> Only records are readable. A readout value is determined by record
+> content alone. A site with no record cannot be read.
+
+An empty site has no record, so it cannot be read. It has no defined
+readout value. The pairing cell `0` is a supplied table entry, not a site
+readout of any blank, and it is not `I(empty)`. Named additive `I` is not
+axiom content. The live Record axiom text does not contain `I(empty)=0`.
+
+The agreed empty-empty cell remains extra bookkeeping. This note displays
+it. It does not adopt `π`, restore `I`, pair on a `J` field, or treat the
+cell as a vacuum energy or a Newton constant.
+
+On two occupied unit locks `s` and `t`, the same reconstructions give
+`B_π({s},{t}) = 1` and `B_+({s},{t}) = 2`. The tables disagree elsewhere.
+That occupied-occupied disagreement is a control, not this note's
+load-bearing cut. The load-bearing cut is that the agreed empty-empty `0`
+is still not a blank-site readout.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact occupancy counts give Fraction zeros at the empty-empty cell of two reconstructed pairings. Live Record unreadability of a blank site shows that cell is extra table data, not a site readout and not I(empty)."
+trace_class: negative_route_pruning
+target_claim_id: empty_empty_pairing_cell_is_not_a_blank_readout
+target_blocker_text: "whether the agreed empty-empty pairing cell 0 is a blank-site readout or I(empty)"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for the two reconstructed occupancy pairings and the live Record unreadability sentence; no pairing, I, J-field, vacuum energy, or Newton constant is adopted"
+hypothetical_axiom_status: "none; I is not restored and no axiom is edited"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded pairing-versus-readout claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Record axiom, quoted below without
+  rewrite. As the registered `minimal_axioms` premise, it is not a
+  bounded-status source.
+- **Explicit theorem-domain condition:** the empty occupied-lock collection
+  `∅`, occupancy counts as `Fraction` cardinalities, the product pairing
+  `B_π(A,B)=|A|·|B|`, and the count-add pairing `B_+(A,B)=|A|+|B|` are
+  reconstructed locally as supplied table data. They are not derived as
+  physical pairings.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selection of either pairing, any restoration of
+  named additive `I`, any `J`-field pairing, and any identification of the
+  empty-empty cell with vacuum energy or a Newton constant remain outside
+  the target proved here.
+
+## Live Record Quote
+
+From [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), Record
+/ Fixed Reality, quoted in full and not rewritten:
+
+> Records form.
+>
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+>
+> Only records are readable. A readout value is determined by record
+> content alone. A site with no record cannot be read.
+
+The same memo states that finite additivity, a named scalar collection
+functional `I`, and an assigned value `I(empty)=0` are not Record axiom
+content. That denial is not an assertion of `I(empty)=0`. The Record axiom
+text itself does not contain `I(empty)=0`.
+
+## Exact Objects
+
+All runner coefficients are exact `Fraction` values. No float is used.
+
+An occupied-lock collection is a finite set of formed records. The empty
+collection `∅` has occupancy `|∅| = 0`. A unit lock `{s}` has occupancy
+`1`. Occupancy is a count of formed records; it is not a site readout.
+
+The two pairings are maps from pairs of lock collections to `Fraction`:
+
+```text
+B_π(A,B) := |A| · |B|,
+B_+(A,B) := |A| + |B|.
+```
+
+Identity gates are those maps evaluated at `(∅,∅)`.
+
+A blank site is a lattice site that carries no record. Live Record supplies
+no readout value on a blank site. A pairing-table cell is not a readout.
+
+## Exact Target And Proof Obligations
+
+The exact target is to display the agreed empty-empty cell of the two
+reconstructed pairings as extra table data, and to show that live Record
+does not make that cell a blank-site readout or `I(empty)`.
+
+| Obligation | Disposition |
+|---|---|
+| `B_π(∅,∅) = 0 = B_+(∅,∅)` as `Fraction` | proved here in Theorem 1 |
+| identity gates return those zeros; agreement is not selection | proved here in Theorem 1 |
+| a blank site has no defined readout; the cell is not `I(empty)` | proved here in Theorem 2 |
+| the agreed cell remains extra; `π`, `I`, `J`, vacuum energy, and a Newton constant are not adopted | proved here in Theorem 3 |
+| occupied-occupied control `1 ≠ 2` | displayed as a control, not the load-bearing cut |
+
+There is no missing lemma for this bounded target. Selecting a pairing,
+restoring `I`, or installing a physical constant would be a separate claim
+with separate support.
+
+## Theorem 1 — The empty-empty cells agree at `Fraction` zero
+
+By the reconstructed definitions,
+
+```text
+B_π(∅,∅) = |∅| · |∅| = 0 · 0 = 0,
+B_+(∅,∅) = |∅| + |∅| = 0 + 0 = 0,
+```
+
+with each `0` the exact `Fraction` `0`. Therefore
+`B_π(∅,∅) = 0 = B_+(∅,∅)`. The identity gates return those zeros.
+
+Agreement at `(∅,∅)` does not select a pairing. The same definitions on
+occupied unit locks give two different values, so the tables are not the
+same map. Sharing one cell is not a selection rule.
+
+## Theorem 2 — The cell is not a blank readout and is not `I(empty)`
+
+Quote live Record: only records are readable; a readout value is determined
+by record content alone; a site with no record cannot be read.
+
+A blank site has no record. Therefore it has no defined readout value. The
+empty-empty pairing cell is a supplied table entry computed from occupancy
+counts of empty lock collections. A table entry is not a site readout of a
+blank. In particular the cell is not `I(empty)`: named additive `I` is not
+axiom content, and the live Record axiom text does not contain `I(empty)=0`.
+
+## Theorem 3 — The agreed cell is still extra
+
+The empty-empty cell is displayed above as bookkeeping shared by two
+reconstructed tables. This note does not adopt `π`. It does not restore
+`I`. It does not pair on a `J` field. It does not treat the cell as a
+vacuum energy or a Newton constant. The cell remains extra.
+
+## Control — Occupied-occupied cells disagree
+
+Let `s` and `t` be two occupied unit locks. Then
+
+```text
+B_π({s},{t}) = 1 · 1 = 1,
+B_+({s},{t}) = 1 + 1 = 2.
+```
+
+The tables disagree on that occupied-occupied cell. The runner still knows
+the tables disagree elsewhere. That disagreement is not this note's
+load-bearing cut. The load-bearing cut is Theorem 2: the agreed
+empty-empty `0` is not a blank-site readout.
+
+## Mutation Checks
+
+Three predicates must fail:
+
+1. “live memo contains `I(empty)=0`” — fail: the Record axiom text does not
+   contain that identity; the memo mentions the string only to deny that it
+   is axiom content.
+2. “empty-empty cell is a site readout of a blank” — fail: a blank site has
+   no defined readout value; the pairing cell is a supplied table entry, not
+   that readout.
+3. `B_π(∅,∅) != B_+(∅,∅)` — fail: the cells agree at `Fraction` zero.
+
+## Honest-Auditor Read
+
+The arithmetic is two occupancy counts and the live Record unreadability
+sentence. Each identity is a `Fraction` evaluation, not a fitted scalar.
+The empty-empty agreement can be deleted without changing Record: a blank
+site remains unreadable whether or not a pairing table writes `0` at
+`(∅,∅)`. The occupied-occupied control `1 ≠ 2` is kept visible so the
+shared zero cannot be misread as a uniqueness proof for either table. The
+independent audit lane sets status.
+
+## Boundary
+
+- The pairings are reconstructed table data, not derived physical laws.
+- Agreement at one cell is not selection of `π` or of `+`.
+- Named additive `I` is not restored as axiom content.
+- No pairing on a `J` field is defined.
+- The empty-empty cell is not a vacuum energy and is not a Newton
+  constant. No `G_N` and no `1/r` law is installed.
+- Occupancy of a lock collection is not a site readout.
+- The occupied-occupied disagreement is a control, not the load-bearing
+  cut of this note.
+- Independent class-`C` leftovers are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## What This Does Not Claim
+
+- It does not adopt either pairing as a physical bilinear.
+- It does not identify occupancy with Record readout.
+- It does not assign the empty-empty cell a gravitational, vacuum, or
+  cosmological meaning.
+- It does not edit an axiom.
+
+## Runner Contract
+
+The companion runner reconstructs `B_π` and `B_+` from occupancy counts,
+checks Theorems 1–3 with exact `Fraction` arithmetic, checks the
+occupied-occupied control, and checks that the three mutation predicates
+fail. Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4353,6 +4353,10 @@
   "emergent_product_law_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "empty_empty_pairing_cell_is_not_a_blank_readout_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "empty_state_bootstrap_all_open_availability_orbit_dichotomy_degree_nine_chirality_wall_bounded_theorem_note_2026-07-04": {
    "deps_hash": "d8a3bd39934d",

--- a/logs/runner-cache/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.txt
+++ b/logs/runner-cache/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py
+runner_sha256: 2ef75f1166716a4b10c425d7087c4b137462bacebedf88aa655e5d067c601192
+input_fingerprint_sha256: 5536b9592cd2f416673122876d2a4626e2f18af46eeb61dcd7e3d375bed40e45
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; reconstructed occupancy pairings only
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: exact Fraction occupancy counts; no floating-point inputs
+claim_boundary: agreed empty-empty cell is table data, not a blank readout
+PASS: thm1-empty-pi-zero B_π(∅,∅) is the exact Fraction 0
+PASS: thm1-empty-plus-zero B_+(∅,∅) is the exact Fraction 0
+PASS: thm1-empty-cells-agree B_π(∅,∅) = B_+(∅,∅) as Fractions
+PASS: thm1-identity-gates-return-zeros identity gates return those zeros
+PASS: thm1-agreement-is-not-selection shared empty-empty cell does not select a pairing
+PASS: control-occupied-pi B_π({s},{t}) = 1
+PASS: control-occupied-plus B_+({s},{t}) = 2
+PASS: control-disagreement-not-load-bearing-cut occupied-occupied 1≠2 is a control, not this note's cut
+PASS: thm2-live-record-quote live Record unreadability sentences are quoted without rewrite
+PASS: thm2-blank-has-no-defined-readout a blank site has no defined readout value
+PASS: thm2-pairing-cell-is-table-entry-not-readout the pairing cell is a supplied table entry, not a blank readout
+PASS: thm2-cell-is-not-i-empty the pairing cell is not I(empty)
+PASS: thm3-cell-is-still-extra the agreed empty-empty cell remains extra bookkeeping
+PASS: mutation-live-memo-contains-i-empty-zero-fails predicate “live memo contains I(empty)=0” fails
+PASS: mutation-empty-empty-is-blank-readout-fails predicate “empty-empty cell is a site readout of a blank” fails
+PASS: mutation-empty-cells-disagree-fails predicate B_π(∅,∅) != B_+(∅,∅) fails
+PASS: machine-status-contract bounded status and leftover-cut trace are source-visible
+PASS: scope-exclusions no G_N, no 1/r install, no axiom edit, I is not restored
+PASS: parents-axiom-only declared parents are the live axiom memo only
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+per_element: empty-empty and occupied-occupied cells of both pairings.
+per_site: a blank site has no defined readout; occupancy is not a readout.
+per_mode: product and count-add tables are both evaluated, neither adopted.
+per_block: identity gates, mutation predicates, and Record unreadability.
+lattice_wide: checked and not executed — no lattice-wide pairing is claimed.
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py
+++ b/scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Exact checks: empty-empty pairing cell is not a blank readout.
+
+Two occupancy pairings are reconstructed from lock-collection counts.
+The empty-empty cells agree at Fraction 0. That cell is table data, not
+a site readout of a blank and not I(empty). No pairing is adopted and I
+is not restored.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "EMPTY_EMPTY_PAIRING_CELL_IS_NOT_A_BLANK_READOUT_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/EMPTY_EMPTY_PAIRING_CELL_IS_NOT_A_BLANK_READOUT_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+LockCollection = frozenset[str]
+EMPTY: LockCollection = frozenset()
+
+
+def occupancy(locks: LockCollection) -> Fraction:
+    """Count of formed records in a lock collection, as an exact Fraction."""
+    return Fraction(len(locks))
+
+
+def b_pi(left: LockCollection, right: LockCollection) -> Fraction:
+    """Product occupancy pairing, reconstructed locally."""
+    return occupancy(left) * occupancy(right)
+
+
+def b_plus(left: LockCollection, right: LockCollection) -> Fraction:
+    """Count-add occupancy pairing, reconstructed locally."""
+    return occupancy(left) + occupancy(right)
+
+
+def identity_gate_pi() -> Fraction:
+    """Product pairing evaluated at the identity lock collection."""
+    return b_pi(EMPTY, EMPTY)
+
+
+def identity_gate_plus() -> Fraction:
+    """Count-add pairing evaluated at the identity lock collection."""
+    return b_plus(EMPTY, EMPTY)
+
+
+def record_axiom_section(axiom_text: str) -> str:
+    """Return the live Record axiom body, not later commentary."""
+    marker = "### Record / Fixed Reality"
+    start = axiom_text.index(marker)
+    rest = axiom_text[start + len(marker) :]
+    next_heading = rest.find("\n### ")
+    if next_heading < 0:
+        next_heading = rest.find("\n## ")
+    if next_heading < 0:
+        return axiom_text[start:]
+    return axiom_text[start : start + len(marker) + next_heading]
+
+
+def live_memo_contains_i_empty_zero(axiom_text: str) -> bool:
+    """True only if the Record axiom text asserts I(empty)=0."""
+    compact = record_axiom_section(axiom_text).replace(" ", "")
+    return "I(empty)=0" in compact
+
+
+def blank_site_readout() -> Fraction | None:
+    """A blank site has no record, so it has no defined readout value."""
+    record_content = None
+    if record_content is None:
+        return None
+    raise AssertionError("blank-site branch must return before any readout")
+
+
+def empty_empty_cell_is_site_readout_of_a_blank() -> bool:
+    """Pairing cell is a supplied table entry, not a blank-site readout."""
+    readout = blank_site_readout()
+    if readout is None:
+        return False
+    pairing_cell = b_pi(EMPTY, EMPTY)
+    return pairing_cell == readout
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; reconstructed occupancy pairings only")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: exact Fraction occupancy counts; no floating-point inputs")
+    print("claim_boundary: agreed empty-empty cell is table data, not a blank readout")
+
+    empty_pi = b_pi(EMPTY, EMPTY)
+    empty_plus = b_plus(EMPTY, EMPTY)
+    unit_s: LockCollection = frozenset({"s"})
+    unit_t: LockCollection = frozenset({"t"})
+    occupied_pi = b_pi(unit_s, unit_t)
+    occupied_plus = b_plus(unit_s, unit_t)
+    gate_pi = identity_gate_pi()
+    gate_plus = identity_gate_plus()
+    blank_value = blank_site_readout()
+
+    checks.check(
+        "thm1-empty-pi-zero",
+        "B_π(∅,∅) is the exact Fraction 0",
+        empty_pi == Fraction(0) and isinstance(empty_pi, Fraction),
+    )
+    checks.check(
+        "thm1-empty-plus-zero",
+        "B_+(∅,∅) is the exact Fraction 0",
+        empty_plus == Fraction(0) and isinstance(empty_plus, Fraction),
+    )
+    checks.check(
+        "thm1-empty-cells-agree",
+        "B_π(∅,∅) = B_+(∅,∅) as Fractions",
+        empty_pi == empty_plus,
+    )
+    checks.check(
+        "thm1-identity-gates-return-zeros",
+        "identity gates return those zeros",
+        gate_pi == Fraction(0)
+        and gate_plus == Fraction(0)
+        and gate_pi == empty_pi
+        and gate_plus == empty_plus,
+    )
+    checks.check(
+        "thm1-agreement-is-not-selection",
+        "shared empty-empty cell does not select a pairing",
+        empty_pi == empty_plus and occupied_pi != occupied_plus,
+    )
+    checks.check(
+        "control-occupied-pi",
+        "B_π({s},{t}) = 1",
+        occupied_pi == Fraction(1),
+    )
+    checks.check(
+        "control-occupied-plus",
+        "B_+({s},{t}) = 2",
+        occupied_plus == Fraction(2),
+    )
+    checks.check(
+        "control-disagreement-not-load-bearing-cut",
+        "occupied-occupied 1≠2 is a control, not this note's cut",
+        occupied_pi != occupied_plus
+        and "not this note's" in note
+        and "load-bearing cut" in note,
+    )
+    checks.check(
+        "thm2-live-record-quote",
+        "live Record unreadability sentences are quoted without rewrite",
+        "Only records are readable." in axiom
+        and "A readout value is determined by record" in axiom
+        and "A site with no record cannot be read." in axiom
+        and "Only records are readable." in note
+        and "A readout value is determined by record" in note
+        and "A site with no record cannot be read." in note,
+    )
+    checks.check(
+        "thm2-blank-has-no-defined-readout",
+        "a blank site has no defined readout value",
+        blank_value is None,
+    )
+    checks.check(
+        "thm2-pairing-cell-is-table-entry-not-readout",
+        "the pairing cell is a supplied table entry, not a blank readout",
+        not empty_empty_cell_is_site_readout_of_a_blank()
+        and empty_pi == Fraction(0)
+        and blank_value is None,
+    )
+    checks.check(
+        "thm2-cell-is-not-i-empty",
+        "the pairing cell is not I(empty)",
+        "it is not `I(empty)`" in note
+        and "Named additive `I` is not" in note
+        and "I(empty)=0` are not Record axiom content" in axiom,
+    )
+    checks.check(
+        "thm3-cell-is-still-extra",
+        "the agreed empty-empty cell remains extra bookkeeping",
+        "remains extra" in note
+        and "does not adopt `π`" in note
+        and "does not restore" in note
+        and "`J` field" in note
+        and "vacuum energy" in note
+        and "Newton constant" in note,
+    )
+    checks.check(
+        "mutation-live-memo-contains-i-empty-zero-fails",
+        "predicate “live memo contains I(empty)=0” fails",
+        live_memo_contains_i_empty_zero(axiom) is False,
+    )
+    checks.check(
+        "mutation-empty-empty-is-blank-readout-fails",
+        "predicate “empty-empty cell is a site readout of a blank” fails",
+        empty_empty_cell_is_site_readout_of_a_blank() is False,
+    )
+    checks.check(
+        "mutation-empty-cells-disagree-fails",
+        "predicate B_π(∅,∅) != B_+(∅,∅) fails",
+        (empty_pi != empty_plus) is False,
+    )
+    checks.check(
+        "machine-status-contract",
+        "bounded status and leftover-cut trace are source-visible",
+        "actual_current_surface_status: bounded-support" in note
+        and "trace_class: negative_route_pruning" in note
+        and "target_claim_id: empty_empty_pairing_cell_is_not_a_blank_readout"
+        in note,
+    )
+    checks.check(
+        "scope-exclusions",
+        "no G_N, no 1/r install, no axiom edit, I is not restored",
+        "No `G_N`" in note
+        and "no `1/r`" in note
+        and "I is not restored" in note
+        and "no axiom is edited" in note
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    checks.check(
+        "parents-axiom-only",
+        "declared parents are the live axiom memo only",
+        "Parents:** the live axiom memo" in note
+        and "upstream_dependencies:\n  - minimal_axioms\n" in note
+        and "### N8" not in note
+        and "FAIL / DO NOT SHIP" not in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/EMPTY_EMPTY_PAIRING_CELL_IS_NOT_A_BLANK_READOUT_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    print("per_element: empty-empty and occupied-occupied cells of both pairings.")
+    print("per_site: a blank site has no defined readout; occupancy is not a readout.")
+    print("per_mode: product and count-add tables are both evaluated, neither adopted.")
+    print("per_block: identity gates, mutation predicates, and Record unreadability.")
+    print("lattice_wide: checked and not executed — no lattice-wide pairing is claimed.")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two reconstructed occupancy pairings agree at the empty-empty cell: `B_π(∅,∅) = B_+(∅,∅) = 0`. That agreed `0` is extra table data. Live Record says a site with no record cannot be read. The cell is not a blank-site readout and not `I(empty)`. Occupied-occupied `1 ≠ 2` is a control, not the load-bearing cut.

## What this means for the TOE

After named `I` is gone, the one pairing cell two occupancy tables agree on is still not Record. Agreement is not selection. Blank unreadability is not a scalar assignment `I(empty)=0`.

## Verification

```bash
python3 scripts/empty_empty_pairing_cell_is_not_a_blank_readout_2026_08_14.py
# TOTAL: PASS=20 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`.