### PR TITLE
[physics-loop] toe-lphys adjfork: bounded_theorem / bounded-support

### DIFF
--- a/docs/TRIVIAL_VS_PAULI_ADJOINT_CUBE_ACTION_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TRIVIAL_VS_PAULI_ADJOINT_CUBE_ACTION_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,210 @@
+---
+claim_id: trivial_vs_pauli_adjoint_cube_action_is_extra_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On one-site M_2(C) over Q(i), the identity map φ0 and the displayed Pauli-adjoint cycle φAd both send the body-diagonal cube 3-fold to automorphisms of M_2, but φ0(σx)=σx ≠ σy=φAd(σx). Live Lattice names proper cubic rotations of Z^3 sites; live Qubit names the one-site algebra M_2(C). Neither sentence names φ0, φAd, Ad_U, or an intertwiner. Both maps are extras. φAd is displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py
+---
+
+# Trivial Versus Pauli-Adjoint Cube Action Is Extra
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact `Q(i)` identities for two displayed maps of one body-diagonal
+cube 3-fold onto one-site `M_2(C)`. No pairing table, no 3-menu, no unital
+`M_3` factor in `C`, no Qubit rewrite, and no adopted intertwiner.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py`](../scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Work in one-site `M_2(C)` with the Pauli matrices over `Q(i)` written below.
+The body-diagonal cube 3-fold is the order-3 rotation of the unit cube about
+the space diagonal. Two maps of that 3-fold onto `M_2` are displayed.
+
+- Trivial action `φ0`: the identity on `M_2`. So `φ0(σx)=σx`, `φ0(σy)=σy`,
+  `φ0(σz)=σz`. Physical cubic rotations still move sites of `Z^3`; they do
+  not act on the one-site algebra. This is a lawful reading of Lattice+Qubit
+  with no intertwiner.
+- Pauli-adjoint action `φAd`: the unique unital `*`-linear map with
+  `φAd(σx)=σy`, `φAd(σy)=σz`, `φAd(σz)=σx`. The matrix
+  `U=(I-i(σx+σy+σz))/2` is an exhibit of this map by `Ad_U(X)=U X U*`. The
+  matrix `U` is not axiom content.
+
+Theorem 1 is the disagreement: `φ0(σx)=σx ≠ σy=φAd(σx)`. Same cube 3-fold,
+two maps. The control that both maps have order dividing three does not
+identify them.
+
+Live Lattice names proper cubic rotations of the sites of `Z^3`. Live Qubit
+names the one-site algebra `M_2(C)`. Those sentences do not name `φ0`,
+`φAd`, `Ad_U`, or an intertwiner. Both maps are extras. This note displays
+them. It does not adopt `φAd`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Q(i) identities exhibit two maps of one cube 3-fold onto M_2 that disagree on σx. Live Lattice and Qubit sentences are quoted and do not name either map. Neither map is adopted as axiom content."
+trace_class: negative_route_pruning
+target_claim_id: trivial_vs_pauli_adjoint_cube_action_is_extra
+target_blocker_text: "whether a Lattice cubic rotation of Z^3 is the same map as a Pauli-axis adjoint action on M_2"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded algebra; no intertwiner is adopted"
+conditional_surface_status: "exact for the two displayed maps on one-site M_2(C); no physical selector of φAd is claimed"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+From [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), Lattice:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+From the same memo, Qubit:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+The Qualification sentence of the same memo is quoted only as a parent
+boundary, not as a derived lemma:
+
+> These axioms state only their named primitive content. Further physical
+> structure requires a retained derivation or bridge, or explicit approved-
+> primitive registration, before use as a premise.
+
+## Exact Objects
+
+Entries live in the Gaussian field `Q(i)` with `i^2 = -1`. The companion
+runner implements this as pairs `(a, b)` meaning `a + b i` with
+`a, b ∈ Q`.
+
+```text
+σx = ((0, 1), (1, 0))
+σy = ((0, -i), (i, 0))
+σz = ((1, 0), (0, -1))
+I  = ((1, 0), (0, 1))
+```
+
+The set `{I, σx, σy, σz}` is a `Q(i)`-basis of `M_2`. A unital linear map
+on `M_2` is therefore uniquely determined by the images of `σx`, `σy`, and
+`σz`.
+
+- `φ0` is the identity map of `M_2`.
+- `φAd` is the unique unital `*`-linear map with
+  `φAd(σx)=σy`, `φAd(σy)=σz`, `φAd(σz)=σx`.
+- The exhibit `U = (I - i(σx + σy + σz))/2` is a displayed matrix in
+  `M_2(Q(i))`. Write `Ad_U(X) = U X U*`.
+
+Physical rotations of `Z^3` remain site permutations. They are not rewritten
+as algebra maps.
+
+## Theorem 1 — the two maps disagree on `σx`
+
+`φ0(σx) = σx` and `φAd(σx) = σy`. The matrices `σx` and `σy` differ in
+every off-diagonal entry (`1` versus `-i` in position `(1,2)`). Therefore
+
+```text
+φ0(σx) = σx ≠ σy = φAd(σx).
+```
+
+The same cube 3-fold therefore admits two distinct maps into the automorphism
+picture of `M_2`. The identification of those maps is not an identity.
+
+## Theorem 2 — live Lattice and Qubit do not name either map
+
+The Lattice sentence quoted above names the sites of `Z^3` and the proper
+cubic rotations about each site. It names a geometric action on the lattice.
+It does not name `φ0`, `φAd`, `Ad_U`, or an intertwiner from site rotations
+into `Aut(M_2)`.
+
+The Qubit sentence quoted above names the one-site algebraic presentation
+`M_2(C)`. It does not name a preferred action of the cube 3-fold on that
+algebra, and it does not rewrite the presentation as `M_3`.
+
+The live memo therefore supplies site rotations and the one-site algebra as
+separate primitive sentences. It does not supply a map that identifies them.
+
+## Theorem 3 — both maps are extras
+
+An extra, in this note, is a map or identification that is not named by the
+quoted Lattice or Qubit sentences and is not a registered approved primitive.
+Both `φ0` (as an algebra action of the cube 3-fold) and `φAd` are extras.
+
+`φ0` is a lawful reading of the two axioms with no intertwiner: Lattice
+rotations move sites; Qubit still presents each site as `M_2(C)`; the algebra
+is not required to transform. Displaying `φ0` does not add a primitive.
+
+`φAd` is a displayed unital `*`-linear cycle of the Pauli axes. It is a
+standard mathematical automorphism of `M_2`. Displaying it does not make it
+axiom content. This note does not adopt `φAd`. The exhibit `U` is a lift of
+`φAd`, not a Lattice object and not a Qubit rewrite.
+
+## Control — order three is not the disagreement
+
+Direct composition on the Pauli basis gives
+
+```text
+φAd(σx) = σy,   φAd(σy) = σz,   φAd(σz) = σx,
+```
+
+so `φAd³` is the identity on that basis, hence `φAd³ = id` on `M_2`. Also
+`φAd(σx) = σy ≠ σx`, so `φAd ≠ id`. The identity map satisfies `φ0³ = id`.
+
+Both maps therefore have order dividing three. The disagreement is the image
+of `σx`, not the order.
+
+The exhibit matches the cycle: `U*U = I` and `Ad_U(σx)=σy`,
+`Ad_U(σy)=σz`, `Ad_U(σz)=σx`. That calculation identifies `Ad_U` with the
+already-displayed map `φAd`. It does not promote `U` into the axiom memo.
+
+## Mutations
+
+1. Predicate `φ0(σx) == φAd(σx)` must fail.
+2. Predicate “live memo names `Ad_U` or Pauli-adjoint” must fail.
+3. Predicate “live memo contains Lattice-named” must fail.
+
+## Honest-auditor / Boundary
+
+The algebra is elementary: four `2 × 2` matrices over `Q(i)`, two maps, and
+one displayed unitary exhibit. The runner reconstructs `φAd` from the three
+Pauli images, reconstructs `Ad_U` from the displayed formula for `U`, and
+checks the three mutation predicates against the live axiom memo rather than
+against a working-tree paraphrase.
+
+Boundary, stated positively. The theorem classifies two displayed maps of one
+cube 3-fold onto one-site `M_2`. It does not classify every automorphism of
+`M_2`, every cubic rotation, or every possible intertwiner. It does not select
+a physical algebra action. It does not rewrite Qubit. It does not introduce a
+pairing table, a 3-menu, or a unital `M_3` host. `G_N` and QCD are unused.
+
+The independent audit lane sets status. This note records
+`actual_current_surface_status: bounded-support` as the machine surface of
+the present packet and authors no audit verdict.
+
+## What This Does Not Claim
+
+- Neither displayed map is adopted as axiom content.
+- Qubit remains `M_2(C)`. It is not flipped to `M_3`.
+- No pairing table of lattice rotations with Pauli axes is asserted.
+- No 3-menu and no unital `M_3(C)` factor inside `C` is asserted.
+- No color, QCD, or `G_N` identification is supplied.
+- `U` is an exhibit of `φAd`, not a Lattice object.
+
+## Runner Contract
+
+The companion runner checks the Pauli matrices and the two maps over `Q(i)`,
+checks `φAd³ = id` with `φAd ≠ id`, checks the `Ad_U` exhibit, rejects the
+three mutation predicates, and verifies that the live axiom memo quotes used
+above are present while `Ad_U`, Pauli-adjoint, and Lattice-named are absent
+from that memo. Declared audit inputs are this note and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18357,6 +18357,10 @@
   "triple_stack_collapse_scaling_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "trivial_vs_pauli_adjoint_cube_action_is_extra_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "truncated_fock_component_naming_note_2026-07-28": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.txt
+++ b/logs/runner-cache/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py
+runner_sha256: eeb826b73f23d27cb3f4243f6e31ae05b22167edbfb8e0436e46e370fd979bb6
+input_fingerprint_sha256: 11bfddfea2e21251ec9ae5d8317627b27d45da28dd68683157dd5d1e1efc2746
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none; displayed φ0, φAd, and U are theorem objects
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact Q(i); no fitted, QCD, or G_N input
+negative_scope: the two displayed maps disagree on σx; neither is axiom-named
+PASS: field-i-square i^2 = -1
+PASS: pauli-x-formula σx = ((0,1),(1,0))
+PASS: pauli-y-formula σy = ((0,-i),(i,0))
+PASS: pauli-z-formula σz = ((1,0),(0,-1))
+PASS: pauli-x-square σx^2 = I
+PASS: pauli-y-square σy^2 = I
+PASS: pauli-z-square σz^2 = I
+PASS: pauli-basis-rank-4 {I,σx,σy,σz} has Q(i)-rank 4
+PASS: star-x σx* = σx
+PASS: star-y σy* = σy
+PASS: star-z σz* = σz
+PASS: phi0-x φ0(σx) = σx
+PASS: phi0-y φ0(σy) = σy
+PASS: phi0-z φ0(σz) = σz
+PASS: phi0-unital φ0(I) = I
+PASS: phiad-x φAd(σx) = σy
+PASS: phiad-y φAd(σy) = σz
+PASS: phiad-z φAd(σz) = σx
+PASS: phiad-unital φAd(I) = I
+PASS: phiad-star-x φAd(σx)* = φAd(σx*)
+PASS: thm1-disagreement φ0(σx) = σx ≠ σy = φAd(σx)
+PASS: mutation-images-equal-fails predicate φ0(σx) == φAd(σx) fails
+PASS: control-phiad-order-three φAd³ = id on {I,σx,σy,σz}
+PASS: control-phiad-not-id φAd ≠ id
+PASS: control-phi0-order-three φ0³ = id
+PASS: control-twice-not-id φAd² ≠ id (disagreement is the image, not the order)
+PASS: exhibit-u-unitary U* U = I
+PASS: exhibit-ad-x Ad_U(σx) = σy
+PASS: exhibit-ad-y Ad_U(σy) = σz
+PASS: exhibit-ad-z Ad_U(σz) = σx
+PASS: exhibit-matches-phiad Ad_U agrees with φAd on the Pauli basis
+PASS: thm2-live-lattice-quote live Lattice names proper cubic rotations about each site
+PASS: thm2-live-qubit-quote live Qubit names one-site M_2(C)
+PASS: thm2-note-quotes-parents note quotes the live Lattice and Qubit sentences
+PASS: mutation-memo-names-adu-or-pauli-adjoint-fails predicate live memo names Ad_U or Pauli-adjoint fails
+PASS: mutation-memo-lattice-named-fails predicate live memo contains Lattice-named fails
+PASS: thm3-both-extras-displayed note displays both maps as extras and does not adopt φAd
+PASS: boundary-no-qubit-flip note does not flip Qubit to M_3
+PASS: boundary-no-unmerged-pr note reconstructs locally and does not cite #6268
+PASS: machine-status-contract note carries bounded-support status and no axiom adoption
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+TOTAL: PASS=41 FAIL=0
+
+----- stderr -----
+

--- a/scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py
+++ b/scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Exact Q(i) checks: trivial vs Pauli-adjoint cube action is extra.
+
+One-site M_2. Two displayed maps of the body-diagonal cube 3-fold.
+No QCD, no G_N, no axiom edit, no cache write, no network.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TRIVIAL_VS_PAULI_ADJOINT_CUBE_ACTION_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TRIVIAL_VS_PAULI_ADJOINT_CUBE_ACTION_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+class Qi:
+    """a + b i with i^2 = -1 and a, b in Q."""
+
+    __slots__ = ("a", "b")
+
+    def __init__(self, a: Fraction | int, b: Fraction | int = 0) -> None:
+        self.a = Fraction(a)
+        self.b = Fraction(b)
+
+    def __add__(self, other: Qi) -> Qi:
+        return Qi(self.a + other.a, self.b + other.b)
+
+    def __sub__(self, other: Qi) -> Qi:
+        return Qi(self.a - other.a, self.b - other.b)
+
+    def __mul__(self, other: Qi) -> Qi:
+        return Qi(
+            self.a * other.a - self.b * other.b,
+            self.a * other.b + self.b * other.a,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Qi):
+            return NotImplemented
+        return self.a == other.a and self.b == other.b
+
+    def __neg__(self) -> Qi:
+        return Qi(-self.a, -self.b)
+
+    def conj(self) -> Qi:
+        return Qi(self.a, -self.b)
+
+    def is_zero(self) -> bool:
+        return self.a == 0 and self.b == 0
+
+
+I_UNIT = Qi(1, 0)
+ZERO = Qi(0, 0)
+IMAG = Qi(0, 1)
+
+Matrix = tuple[tuple[Qi, Qi], tuple[Qi, Qi]]
+
+
+def mat_add(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def mat_sub(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (left[0][0] - right[0][0], left[0][1] - right[0][1]),
+        (left[1][0] - right[1][0], left[1][1] - right[1][1]),
+    )
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def mat_scale(coeff: Qi, matrix: Matrix) -> Matrix:
+    return (
+        (coeff * matrix[0][0], coeff * matrix[0][1]),
+        (coeff * matrix[1][0], coeff * matrix[1][1]),
+    )
+
+
+def mat_adj(matrix: Matrix) -> Matrix:
+    return (
+        (matrix[0][0].conj(), matrix[1][0].conj()),
+        (matrix[0][1].conj(), matrix[1][1].conj()),
+    )
+
+
+def flatten(matrix: Matrix) -> tuple[Qi, ...]:
+    return (matrix[0][0], matrix[0][1], matrix[1][0], matrix[1][1])
+
+
+def span_rank(matrices: tuple[Matrix, ...]) -> int:
+    """Exact row rank over Q(i)."""
+    rows = [list(flatten(matrix)) for matrix in matrices]
+    rank = 0
+    col = 0
+    n_rows = len(rows)
+    n_cols = 4
+    while rank < n_rows and col < n_cols:
+        pivot = None
+        for i in range(rank, n_rows):
+            if not rows[i][col].is_zero():
+                pivot = i
+                break
+        if pivot is None:
+            col += 1
+            continue
+        rows[rank], rows[pivot] = rows[pivot], rows[rank]
+        pivot_entry = rows[rank][col]
+        # Inverse of a+bi is (a-bi)/(a^2+b^2).
+        denom = pivot_entry.a * pivot_entry.a + pivot_entry.b * pivot_entry.b
+        pivot_inv = Qi(pivot_entry.a / denom, -pivot_entry.b / denom)
+        rows[rank] = [entry * pivot_inv for entry in rows[rank]]
+        for i in range(n_rows):
+            if i == rank or rows[i][col].is_zero():
+                continue
+            factor = rows[i][col]
+            rows[i] = [rows[i][j] - factor * rows[rank][j] for j in range(n_cols)]
+        rank += 1
+        col += 1
+    return rank
+
+
+def identity2() -> Matrix:
+    return ((I_UNIT, ZERO), (ZERO, I_UNIT))
+
+
+def sigma_x() -> Matrix:
+    return ((ZERO, I_UNIT), (I_UNIT, ZERO))
+
+
+def sigma_y() -> Matrix:
+    return ((ZERO, Qi(0, -1)), (IMAG, ZERO))
+
+
+def sigma_z() -> Matrix:
+    return ((I_UNIT, ZERO), (ZERO, Qi(-1, 0)))
+
+
+def phi0(matrix: Matrix) -> Matrix:
+    return matrix
+
+
+def phi_ad(matrix: Matrix) -> Matrix:
+    """Unique unital linear extension of σx↦σy, σy↦σz, σz↦σx."""
+    # M_2 basis expansion: X = a I + b σx + c σy + d σz,
+    # a = Tr(X)/2, b = Tr(X σx)/2, and cyclic.
+    sx, sy, sz, unit = sigma_x(), sigma_y(), sigma_z(), identity2()
+    half = Qi(Fraction(1, 2), 0)
+    coeff_i = half * (matrix[0][0] + matrix[1][1])
+    xs = mat_mul(matrix, sx)
+    ys = mat_mul(matrix, sy)
+    zs = mat_mul(matrix, sz)
+    coeff_x = half * (xs[0][0] + xs[1][1])
+    coeff_y = half * (ys[0][0] + ys[1][1])
+    coeff_z = half * (zs[0][0] + zs[1][1])
+    return mat_add(
+        mat_add(mat_scale(coeff_i, unit), mat_scale(coeff_x, sy)),
+        mat_add(mat_scale(coeff_y, sz), mat_scale(coeff_z, sx)),
+    )
+
+
+def displayed_u() -> Matrix:
+    sx, sy, sz, unit = sigma_x(), sigma_y(), sigma_z(), identity2()
+    summed = mat_add(mat_add(sx, sy), sz)
+    minus_i_sum = mat_scale(Qi(0, -1), summed)
+    return mat_scale(Qi(Fraction(1, 2), 0), mat_add(unit, minus_i_sum))
+
+
+def ad_u(matrix: Matrix) -> Matrix:
+    unitary = displayed_u()
+    return mat_mul(unitary, mat_mul(matrix, mat_adj(unitary)))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; displayed φ0, φAd, and U are theorem objects")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact Q(i); no fitted, QCD, or G_N input")
+    print("negative_scope: the two displayed maps disagree on σx; neither is axiom-named")
+
+    checks.check("field-i-square", "i^2 = -1", IMAG * IMAG == Qi(-1, 0))
+
+    sx, sy, sz, unit = sigma_x(), sigma_y(), sigma_z(), identity2()
+    checks.check("pauli-x-formula", "σx = ((0,1),(1,0))", sx == ((ZERO, I_UNIT), (I_UNIT, ZERO)))
+    checks.check(
+        "pauli-y-formula",
+        "σy = ((0,-i),(i,0))",
+        sy == ((ZERO, Qi(0, -1)), (IMAG, ZERO)),
+    )
+    checks.check(
+        "pauli-z-formula",
+        "σz = ((1,0),(0,-1))",
+        sz == ((I_UNIT, ZERO), (ZERO, Qi(-1, 0))),
+    )
+    checks.check("pauli-x-square", "σx^2 = I", mat_mul(sx, sx) == unit)
+    checks.check("pauli-y-square", "σy^2 = I", mat_mul(sy, sy) == unit)
+    checks.check("pauli-z-square", "σz^2 = I", mat_mul(sz, sz) == unit)
+    checks.check(
+        "pauli-basis-rank-4",
+        "{I,σx,σy,σz} has Q(i)-rank 4",
+        span_rank((unit, sx, sy, sz)) == 4,
+    )
+    checks.check("star-x", "σx* = σx", mat_adj(sx) == sx)
+    checks.check("star-y", "σy* = σy", mat_adj(sy) == sy)
+    checks.check("star-z", "σz* = σz", mat_adj(sz) == sz)
+
+    checks.check("phi0-x", "φ0(σx) = σx", phi0(sx) == sx)
+    checks.check("phi0-y", "φ0(σy) = σy", phi0(sy) == sy)
+    checks.check("phi0-z", "φ0(σz) = σz", phi0(sz) == sz)
+    checks.check("phi0-unital", "φ0(I) = I", phi0(unit) == unit)
+
+    checks.check("phiad-x", "φAd(σx) = σy", phi_ad(sx) == sy)
+    checks.check("phiad-y", "φAd(σy) = σz", phi_ad(sy) == sz)
+    checks.check("phiad-z", "φAd(σz) = σx", phi_ad(sz) == sx)
+    checks.check("phiad-unital", "φAd(I) = I", phi_ad(unit) == unit)
+    checks.check("phiad-star-x", "φAd(σx)* = φAd(σx*)", mat_adj(phi_ad(sx)) == phi_ad(mat_adj(sx)))
+
+    checks.check(
+        "thm1-disagreement",
+        "φ0(σx) = σx ≠ σy = φAd(σx)",
+        phi0(sx) == sx and phi_ad(sx) == sy and sx != sy,
+    )
+    checks.check(
+        "mutation-images-equal-fails",
+        "predicate φ0(σx) == φAd(σx) fails",
+        phi0(sx) != phi_ad(sx),
+    )
+
+    composed_once = phi_ad
+    composed_twice = lambda m: phi_ad(phi_ad(m))
+    composed_thrice = lambda m: phi_ad(phi_ad(phi_ad(m)))
+    checks.check(
+        "control-phiad-order-three",
+        "φAd³ = id on {I,σx,σy,σz}",
+        all(composed_thrice(m) == m for m in (unit, sx, sy, sz)),
+    )
+    checks.check("control-phiad-not-id", "φAd ≠ id", composed_once(sx) != sx)
+    checks.check(
+        "control-phi0-order-three",
+        "φ0³ = id",
+        all(phi0(phi0(phi0(m))) == m for m in (unit, sx, sy, sz)),
+    )
+    checks.check(
+        "control-twice-not-id",
+        "φAd² ≠ id (disagreement is the image, not the order)",
+        composed_twice(sx) != sx,
+    )
+
+    unitary = displayed_u()
+    checks.check("exhibit-u-unitary", "U* U = I", mat_mul(mat_adj(unitary), unitary) == unit)
+    checks.check("exhibit-ad-x", "Ad_U(σx) = σy", ad_u(sx) == sy)
+    checks.check("exhibit-ad-y", "Ad_U(σy) = σz", ad_u(sy) == sz)
+    checks.check("exhibit-ad-z", "Ad_U(σz) = σx", ad_u(sz) == sx)
+    checks.check(
+        "exhibit-matches-phiad",
+        "Ad_U agrees with φAd on the Pauli basis",
+        all(ad_u(m) == phi_ad(m) for m in (unit, sx, sy, sz)),
+    )
+
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    qubit_quote = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "thm2-live-lattice-quote",
+        "live Lattice names proper cubic rotations about each site",
+        lattice_quote in axiom
+        and "proper cubic rotations about each site" in axiom,
+    )
+    checks.check(
+        "thm2-live-qubit-quote",
+        "live Qubit names one-site M_2(C)",
+        qubit_quote in axiom,
+    )
+    checks.check(
+        "thm2-note-quotes-parents",
+        "note quotes the live Lattice and Qubit sentences",
+        lattice_quote in note and qubit_quote in note,
+    )
+    checks.check(
+        "mutation-memo-names-adu-or-pauli-adjoint-fails",
+        "predicate live memo names Ad_U or Pauli-adjoint fails",
+        "Ad_U" not in axiom
+        and "Pauli-adjoint" not in axiom
+        and "pauli-adjoint" not in axiom.lower()
+        and "φAd" not in axiom,
+    )
+    checks.check(
+        "mutation-memo-lattice-named-fails",
+        "predicate live memo contains Lattice-named fails",
+        "Lattice-named" not in axiom,
+    )
+    checks.check(
+        "thm3-both-extras-displayed",
+        "note displays both maps as extras and does not adopt φAd",
+        "Both maps are extras" in note
+        and "It does not adopt `φAd`" in note
+        and "lawful reading of Lattice+Qubit" in note,
+    )
+    checks.check(
+        "boundary-no-qubit-flip",
+        "note does not flip Qubit to M_3",
+        "Qubit remains `M_2(C)`" in note
+        and "not flipped to `M_3`" in note
+        and "Do not flip Qubit" not in axiom,
+    )
+    checks.check(
+        "boundary-no-unmerged-pr",
+        "note reconstructs locally and does not cite #6268",
+        "#6268" not in note and "PR #" not in note,
+    )
+    note_flat = " ".join(note.split())
+    checks.check(
+        "machine-status-contract",
+        "note carries bounded-support status and no axiom adoption",
+        "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "This note authors no audit verdict" in note_flat,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TRIVIAL_VS_PAULI_ADJOINT_CUBE_ACTION_IS_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On one-site `M_2(C)` over `Q(i)`, the identity map `φ0` and the displayed Pauli-adjoint cycle `φAd` both send the body-diagonal cube 3-fold to automorphisms of `M_2`, but `φ0(σx)=σx ≠ σy=φAd(σx)`. Live Lattice names proper cubic rotations of `Z^3` sites; live Qubit names the one-site algebra `M_2(C)`. Neither sentence names `φ0`, `φAd`, `Ad_U`, or an intertwiner. Both maps are extras. `φAd` is displayed, not adopted. The matrix `U=(I-i(σx+σy+σz))/2` is an exhibit of `Ad_U`, not axiom content.

## What this means for the TOE

This names the smuggled identification “Lattice cubic rotation = Pauli-axis `Ad_U` on `M_2`” as extra. It does not select a physical algebra action. Qubit stays `M_2(C)`. No QCD. No pairing table. No 3-menu.

## Verification

```bash
python3 scripts/trivial_vs_pauli_adjoint_cube_action_is_extra_2026_08_14.py
# TOTAL: PASS=41 FAIL=0
```

Honest status: `bounded_theorem` / `bounded-support`. Independent audit required. No axiom edit.

Campaign: `toe-lphys-20260812`. Investment bar: named smuggled extra (trivial vs Pauli-adjoint fork).