### PR TITLE
[physics-loop] toe-lphys cubeframe: bounded_theorem / bounded-support

### DIFF
--- a/docs/FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,258 @@
+---
+claim_id: faithful_cube_action_on_m2_is_unique_up_to_conjugacy_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "Conditional on requiring a faithful unital *-action of the concrete proper cubic group G (|G|=24) on one-site M_2(C), those actions form one conjugacy class. The trivial action φ0 is not faithful. The displayed standard Bloch action α is faithful. A displayed conjugate β = α_Sω ∘ α ∘ α_Sω^{-1} is faithful, distinct from α on Rx, and conjugate to α. Live Lattice and Qubit do not require a faithful action and do not privilege a frame. α is displayed, not adopted. No SWAP-corner Aut, QCD, or Qubit rewrite is supplied."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
+---
+
+# Faithful Cube Actions On `M_2` Form One Conjugacy Class
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact integer/`Q(i)` identities for the concrete proper cubic
+group `G` and two displayed unital `*`-actions on one-site `M_2(C)`.
+Uniqueness is **conditional on requiring a faithful** action. No pairing
+table, no 3-menu, no unital `M_3`, no SWAP-corner Aut-selection, no Qubit
+rewrite, and no adopted intertwiner.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py`](../scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write `G` for the concrete proper cubic rotation group: the `3 × 3`
+signed-permutation matrices of determinant `+1`. Then `|G| = 24`. The
+standard generators used below are the right-handed `90°` turns
+
+```text
+Rx = ((1,0,0),(0,0,-1),(0,1,0))
+Ry = ((0,0,1),(0,1,0),(-1,0,0))
+Rz = ((0,-1,0),(1,0,0),(0,0,1))
+```
+
+so `Rx` sends `y → z` and `z → −y`. Live Lattice names those site
+rotations. Live Qubit names one-site `M_2(C)`. Neither sentence requires
+an action of `G` on the algebra.
+
+Two displayed actions and one excluded action:
+
+- Trivial `φ0`: every `R ∈ G` acts as `id` on `M_2`. Not faithful.
+- Standard Bloch action `α`: the unique unital `*`-linear family with
+  `α_R(σ_j) = Σ_i R_{ij} σ_i`. Faithful. Explicitly
+  `α_Rx(σx)=σx`, `α_Rx(σy)=σz`, `α_Rx(σz)=−σy`.
+- Conjugate `β_R = α_{Sω} ∘ α_R ∘ α_{Sω}^{-1}` for the displayed
+  `120°` cycle `Sω = ((0,0,1),(1,0,0),(0,1,0)) ∈ G`. Faithful, conjugate
+  to `α`, and `β_{Rx} ≠ α_{Rx}`.
+
+Finite subgroups of `SO(3)` of order `24` are octahedral and form one
+conjugacy class. Identifying `Aut(M_2) ≅ SO(3)` by the Bloch action,
+every faithful unital `*`-action of `G` on `M_2` is therefore conjugate
+to `α`. That is **one conjugacy class**. The leftover inside the class
+is a Bloch frame. This note does not pick a representative and does not
+adopt `α`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact count |G|=24, exact Q(i) Pauli identities, and an explicit conjugator show faithful cube actions on M_2 form one conjugacy class conditional on requiring a faithful action. No action is adopted."
+trace_class: frontier_discovery
+target_claim_id: faithful_cube_action_on_m2_is_unique_up_to_conjugacy
+target_blocker_text: "whether a faithful cube action on M_2 is unique up to conjugacy"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded algebra; no action is adopted"
+conditional_surface_status: "exact for the concrete G and the displayed actions on one-site M_2(C); whether any action is required remains extra"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+From [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), Lattice:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+From the same memo, Qubit:
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> A `Cl(3,0)`-compatible real-algebra presentation may be used equivalently and
+> adds no further primitive structure.
+
+> No possibility is privileged. Possibilities are distinguished by the supplied
+> algebraic structure alone.
+
+The Qualification sentence of the same memo is quoted only as a parent
+boundary, not as a derived lemma:
+
+> These axioms state only their named primitive content. Further physical
+> structure requires a retained derivation or bridge, or explicit approved-
+> primitive registration, before use as a premise.
+
+## Exact Objects
+
+Entries live in the Gaussian field `Q(i)` with `i^2 = -1`. The companion
+runner implements this as pairs `(a, b)` meaning `a + b i` with
+`a, b ∈ Q`.
+
+```text
+σx = ((0, 1), (1, 0))
+σy = ((0, -i), (i, 0))
+σz = ((1, 0), (0, -1))
+I  = ((1, 0), (0, 1))
+```
+
+The set `{I, σx, σy, σz}` is a `Q(i)`-basis of `M_2`. A unital linear map
+on `M_2` is uniquely determined by the images of `σx`, `σy`, and `σz`.
+
+A proper cubic matrix is a `3 × 3` monomial signed-permutation matrix
+with exactly one nonzero `±1` in each row and column and determinant
+`+1`. There are `3! × 2^3 = 48` signed permutation matrices and exactly
+half have determinant `+1`, so `|G| = 24`. The three generators `Rx`,
+`Ry`, `Rz` displayed above lie in `G`.
+
+The standard action is
+
+```text
+α_R(σ_j) = Σ_i R_{ij} σ_i
+```
+
+extended unital-linearly. Equivalently, the Bloch vector transforms as
+`n ↦ R n`. This is a group homomorphism because matrix multiplication
+matches composition of the induced maps.
+
+The displayed conjugator is
+
+```text
+Sω = ((0, 0, 1), (1, 0, 0), (0, 1, 0))
+```
+
+which cycles `x → y → z → x` and has determinant `+1`, hence lies in `G`.
+
+## Theorem 1 — `|G| = 24` and the generators lie in `G`
+
+Enumerate the `48` signed permutation matrices and keep determinant `+1`.
+The count is `24`. Each of `Rx`, `Ry`, `Rz`, `Sω` is a signed permutation
+of determinant `+1`.
+
+## Theorem 2 — `φ0` is not faithful; `α` is faithful
+
+`φ0` sends every element of `G` to `id`, so `ker(φ0) = G` and `φ0` is
+not injective.
+
+`Rx ≠ I_3`. The standard action satisfies `α_Rx(σy) = σz ≠ σy`, so
+`α_Rx ≠ id`. Therefore `α` is not the trivial hom. Because `α_R` is the
+Bloch action of the concrete matrix `R`, `α_R = id` if and only if
+`R = I_3`. Hence `α` is injective: `is_faithful(α)` holds.
+
+## Theorem 3 — faithful actions form one conjugacy class
+
+Identify `Aut(M_2)` with `SO(3)` by the Bloch action: every unital
+`*`-automorphism is inner, and inner automorphisms act as orientation-preserving
+rotations of the Bloch ball. Under that identification, a faithful unital
+`*`-action of `G` on `M_2` is an injective hom `G → SO(3)`.
+
+Finite subgroups of `SO(3)` are cyclic, dihedral, tetrahedral, octahedral,
+or icosahedral. The only order-`24` groups in that list are octahedral
+(`≅ S_4`). Those subgroups form one conjugacy class in `SO(3)`. Therefore
+every injective hom `G → Aut(M_2)` is conjugate to the standard inclusion,
+which is exactly `α`. That is one conjugacy class.
+
+Constructively: for a faithful action `ρ`, the image `ρ(Rx)` is a `90°`
+Bloch rotation about a unique axis `n_x`, and cyclic for `Ry`, `Rz`. The
+cube relations force `(n_x, n_y, n_z)` to be a right-handed orthonormal
+frame. There is a unique `S ∈ SO(3)` with `S ê_i = n_i`. Then
+`ρ(R) = α_S ∘ α_R ∘ α_S^{-1}` on the generators, hence on `G`.
+
+Qubit says no possibility is privileged and the `Cl(3,0)` parenthetical
+adds no further primitive structure. Those sentences forbid reading the
+standard frame as axiom content. They do not create a second conjugacy
+class.
+
+## Theorem 4 — a displayed distinct conjugate
+
+Let `β_R = α_{Sω} ∘ α_R ∘ α_{Sω}^{-1}`. Because `α` is a hom this is
+`α_{Sω R Sω^{-1}}`. In particular `β` is faithful and
+`conjugator_exhibits_beta` holds by construction.
+
+The axis of `α_{Rx}` is `ê_x`. The axis of `β_{Rx}` is `Sω ê_x = ê_y`.
+Explicitly `α_{Rx}(σy) = σz` while `β_{Rx}(σy) ≠ σz`. So `β_{Rx} ≠ α_{Rx}`.
+The two faithful actions are distinct representatives of the same class.
+
+## Theorem 5 — live Lattice and Qubit do not require the action
+
+The Lattice sentence names proper cubic rotations of the sites of `Z^3`.
+The Qubit sentence names the one-site algebra `M_2(C)`. The `Cl(3,0)`
+sentence says that presentation adds no further primitive structure.
+“No possibility is privileged” forbids selecting a Bloch frame from the
+algebra alone.
+
+Those sentences do not require a faithful action of `G` on `M_2`. The
+uniqueness in Theorems 3–4 is **conditional on requiring a faithful**
+unital `*`-action. This note displays the class. It does not adopt `α`.
+It does not call `α` a Lattice name.
+
+## Theorem 6 — this is not an Aut of a SWAP corner
+
+The theorem lives on one-site `M_2`. It does not name `p = (I+F)/2`,
+does not name `Aut(p M_4 p)`, and does not select a color rotation.
+Qubit remains `M_2(C)`.
+
+## Mutations
+
+1. Predicate “`φ0` is injective” must fail.
+2. Predicate “`α_Rx == id`” must fail.
+3. Predicate “`β_Rx == α_Rx`” must fail.
+4. Predicate “no conjugator: `α_{Sω} ∘ α_R ∘ α_{Sω}^{-1} != β_R`” must fail.
+5. Predicate “live memo names the standard action as axiom content” must fail.
+6. Predicate “note claims a Lattice name for the action” must fail.
+
+Identity gates call `proper_cubic_count()`, `is_faithful(phi)`,
+`alpha_rx_on_sigmay()`, and `conjugator_exhibits_beta()`.
+
+## Honest-auditor / Boundary
+
+The algebra is finite: `24` integer matrices and four `2 × 2` matrices
+over `Q(i)`. The runner enumerates `G`, reconstructs `α` from the Bloch
+formula, reconstructs `β` from `Sω`, and checks the mutation predicates
+against the live axiom memo rather than a working-tree paraphrase.
+
+Boundary, stated positively. The theorem classifies faithful unital
+`*`-actions of this concrete `G` on one-site `M_2` up to conjugacy. It
+does not classify unfaithful actions beyond excluding `φ0`. It does not
+select a physical algebra action. It does not rewrite Qubit. It does not
+introduce a pairing table, a 3-menu, or a unital `M_3` host. It does not
+pick an automorphism of a two-site corner. QCD is unused.
+
+The independent audit lane sets status. This note records
+`actual_current_surface_status: bounded-support` as the machine surface of
+the present packet and authors no audit verdict.
+
+## What This Does Not Claim
+
+- No displayed action is adopted as axiom content.
+- Qubit remains `M_2(C)`. It is not flipped to `M_3`.
+- The `Cl(3,0)` parenthetical is not used as a frame.
+- No pairing table of lattice rotations with Pauli axes is asserted.
+- No SWAP-corner Aut element is selected.
+- No color or QCD identification is supplied.
+- Whether any faithful action is required remains extra.
+
+## Runner Contract
+
+The companion runner counts `|G|`, checks `Rx,Ry,Rz,Sω ∈ G`, checks
+`φ0` is not faithful, checks `α` is faithful via `α_Rx(σy)=σz`, checks
+`β` is the displayed conjugate and disagrees with `α` on `Rx`, rejects
+the mutation predicates, and verifies the live axiom quotes used above
+are present while a Lattice name for the action is absent from that memo.
+Declared audit inputs are this note and the axiom memo.

--- a/docs/FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,7 +1,7 @@
 ---
 claim_id: faithful_cube_action_on_m2_is_unique_up_to_conjugacy_bounded_theorem_note_2026-08-14
 claim_type: bounded_theorem
-claim_scope: "Conditional on requiring a faithful unital *-action of the concrete proper cubic group G (|G|=24) on one-site M_2(C), those actions form one conjugacy class. The trivial action φ0 is not faithful. The displayed standard Bloch action α is faithful. A displayed conjugate β = α_Sω ∘ α ∘ α_Sω^{-1} is faithful, distinct from α on Rx, and conjugate to α. Live Lattice and Qubit do not require a faithful action and do not privilege a frame. α is displayed, not adopted. No SWAP-corner Aut, QCD, or Qubit rewrite is supplied."
+claim_scope: "Conditional on requiring a faithful unital *-action of the concrete proper cubic group G (|G|=24) on one-site M_2(C), those actions form one conjugacy class. G is isomorphic to S_4 via its action on the four space diagonals. A faithful image is therefore S_4, not C_24 or D_12 (G has eight order-3 elements). The only 3-dimensional real irrep of S_4 that lands in Aut(M_2)≅SO(3) is the standard 3, not 3⊗sgn. The runner conjugates α by every element of G. Live Lattice and Qubit do not require a faithful action and do not privilege a frame. α is displayed, not adopted."
 upstream_dependencies:
   - minimal_axioms
 runner: scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
@@ -48,12 +48,18 @@ Two displayed actions and one excluded action:
   `120°` cycle `Sω = ((0,0,1),(1,0,0),(0,1,0)) ∈ G`. Faithful, conjugate
   to `α`, and `β_{Rx} ≠ α_{Rx}`.
 
-Finite subgroups of `SO(3)` of order `24` are octahedral and form one
-conjugacy class. Identifying `Aut(M_2) ≅ SO(3)` by the Bloch action,
-every faithful unital `*`-action of `G` on `M_2` is therefore conjugate
-to `α`. That is **one conjugacy class**. The leftover inside the class
-is a Bloch frame. This note does not pick a representative and does not
-adopt `α`.
+`G` is isomorphic to `S_4` by permuting the four space diagonals.
+A faithful unital `*`-action is an injective hom `G → Aut(M_2) ≅ SO(3)`,
+so its image is isomorphic to `S_4`. Cyclic `C_{24}` and dihedral
+`D_{12}` are order-`24` subgroups of `SO(3)` and are **not** isomorphic
+to `S_4` (`G` has eight order-3 elements; those groups have two).
+The only 3-dimensional real irrep of `S_4` that lands in `SO(3)` is
+the standard `3`; `3 ⊗ sgn` sends some cube rotations to determinant
+`-1`. Therefore every faithful action is equivalent to the standard
+inclusion `α`, and the leftover inside the class is a Bloch frame.
+This note does not pick a representative and does not adopt `α`.
+The runner conjugates `α` by every element of `G`, not by one
+displayed `Sω`.
 
 ## Machine Status And Trace
 
@@ -155,29 +161,57 @@ not injective.
 Bloch action of the concrete matrix `R`, `α_R = id` if and only if
 `R = I_3`. Hence `α` is injective: `is_faithful(α)` holds.
 
-## Theorem 3 — faithful actions form one conjugacy class
+## Theorem 3 — `G ≅ S_4`; faithful images cannot be cyclic or dihedral
 
-Identify `Aut(M_2)` with `SO(3)` by the Bloch action: every unital
-`*`-automorphism is inner, and inner automorphisms act as orientation-preserving
-rotations of the Bloch ball. Under that identification, a faithful unital
-`*`-action of `G` on `M_2` is an injective hom `G → SO(3)`.
+The four space diagonals of the unit cube are the lines through
 
-Finite subgroups of `SO(3)` are cyclic, dihedral, tetrahedral, octahedral,
-or icosahedral. The only order-`24` groups in that list are octahedral
-(`≅ S_4`). Those subgroups form one conjugacy class in `SO(3)`. Therefore
-every injective hom `G → Aut(M_2)` is conjugate to the standard inclusion,
-which is exactly `α`. That is one conjugacy class.
+```text
+(1,1,1),   (1,1,−1),   (1,−1,1),   (1,−1,−1).
+```
 
-Constructively: for a faithful action `ρ`, the image `ρ(Rx)` is a `90°`
-Bloch rotation about a unique axis `n_x`, and cyclic for `Ry`, `Rz`. The
-cube relations force `(n_x, n_y, n_z)` to be a right-handed orthonormal
-frame. There is a unique `S ∈ SO(3)` with `S ê_i = n_i`. Then
-`ρ(R) = α_S ∘ α_R ∘ α_S^{-1}` on the generators, hence on `G`.
+Each `R ∈ G` permutes these four lines (a vertex and its opposite
+label the same line). The resulting map `G → S_4` is a group
+isomorphism: the runner lists 24 distinct permutations.
+
+Consequently a faithful hom `G → Aut(M_2)` has image isomorphic to
+`S_4`. That already excludes the order-`24` subgroups `C_{24}` and
+`D_{12}` of `SO(3)`. Independently, `G` has exactly eight elements
+of order 3 (the 3-cycles of `S_4`). Cyclic and dihedral groups of
+order 24 have two. A census that treats octahedral groups as the
+sole order-24 finite subgroups of `SO(3)` is false, and is not used.
+
+## Theorem 3b — only the standard `3` lands in `SO(3)`
+
+`S_4` has two 3-dimensional real irreps, `3` and `3 ⊗ sgn`. Inner
+automorphisms of `M_2` act as orientation-preserving Bloch rotations,
+so `Aut(M_2) ≅ SO(3)` and every image matrix has determinant `+1`.
+
+The standard inclusion `α` is the irrep `3`. For `3 ⊗ sgn`, an odd
+permutation of the diagonals would flip the determinant. The runner
+checks that `R_z` induces a 4-cycle on the diagonals (odd), while
+`det(R_z) = +1`. Therefore `3 ⊗ sgn` does not land in `SO(3)`.
+The only remaining 3-dimensional irrep is `3`, which is `α`.
+
+Constructively, the same uniqueness is the right-handed frame of
+`90°` axes: `ρ(R_x)`, `ρ(R_y)`, `ρ(R_z)` determine a unique
+`S ∈ SO(3)` with `ρ = Ad_S ∘ α ∘ Ad_S^{-1}`.
 
 Qubit says no possibility is privileged and the `Cl(3,0)` parenthetical
 adds no further primitive structure. Those sentences forbid reading the
 standard frame as axiom content. They do not create a second conjugacy
 class.
+
+## Theorem 3c — every `G`-conjugate of `α` is faithful and conjugate
+
+For every `S ∈ G` the conjugate action
+
+```text
+β^S_R = α_S ∘ α_R ∘ α_S^{-1} = α_{S R S^{-1}}
+```
+
+is faithful, and the conjugator is `α_S`. That is the full discrete
+orbit of frames named by `G` itself. Combined with Theorem 3b, every
+faithful unital `*`-action lies in this one conjugacy class.
 
 ## Theorem 4 — a displayed distinct conjugate
 
@@ -223,9 +257,10 @@ Identity gates call `proper_cubic_count()`, `is_faithful(phi)`,
 ## Honest-auditor / Boundary
 
 The algebra is finite: `24` integer matrices and four `2 × 2` matrices
-over `Q(i)`. The runner enumerates `G`, reconstructs `α` from the Bloch
-formula, reconstructs `β` from `Sω`, and checks the mutation predicates
-against the live axiom memo rather than a working-tree paraphrase.
+over `Q(i)`. The runner enumerates `G`, proves `G ≅ S_4` on the four
+space diagonals, counts eight order-3 elements, checks that `3 ⊗ sgn`
+cannot land in `SO(3)`, and conjugates `α` by every element of `G`.
+It does not import a census of all order-24 subgroups of `SO(3)`.
 
 Boundary, stated positively. The theorem classifies faithful unital
 `*`-actions of this concrete `G` on one-site `M_2` up to conjugacy. It

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4596,6 +4596,10 @@
   },
   "factorization_object_api_support_note_2026-07-28": {
    "deps_hash": "759285fc1e81",
+   "out_degree": 1
+  },
+  "faithful_cube_action_on_m2_is_unique_up_to_conjugacy_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "family_companion_compare_note": {

--- a/logs/runner-cache/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.txt
+++ b/logs/runner-cache/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
-runner_sha256: 15d857ca1a62a5fbaf319f2f16a3bcd319fd0c1dc084e694e518016b87748552
-input_fingerprint_sha256: 1fcba796642bde01d78697317da0f2c649da1830415eb65b71e45d06c2aee2a3
+runner_sha256: a970ed055059ce313dee77b22fb91d323702815668ca438875409c72245f3f69
+input_fingerprint_sha256: ebb7a9ca97ba27e054284dab9f9822444372ad874e571341053acf7c3914c06b
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.44
+elapsed_sec: 1.12
 status: ok
 ----- stdout -----
 external_scientific_inputs: none; G, α, φ0, Sω, β are theorem data
@@ -35,6 +35,11 @@ PASS: thm4-beta-faithful is_faithful(β) holds
 PASS: thm4-axes axis(α_Rx)=ê_x and axis(β_Rx)=Sω ê_x=ê_y
 PASS: thm3-rx-ry-is-sw Rx Ry = Sω, so the cube 120° relation holds on the nose
 PASS: thm3-frame-of-alpha α axes are the standard right-handed frame
+PASS: thm3-g-iso-s4 G ≅ S_4 via the four space diagonals
+PASS: thm3-eight-order-3 G has eight order-3 elements, so it is not C_24 or D_12
+PASS: thm3b-rz-odd-det-plus Rz is an odd permutation of the diagonals with det=+1, so 3⊗sgn misses SO(3)
+PASS: thm3c-all-g-conjugates every G-conjugate of α is faithful and conjugate by α_S
+PASS: thm3-no-false-census note does not claim octahedral groups are the only order-24 subgroups of SO(3)
 PASS: mutation-memo-names-action-fails predicate live memo names the standard action as axiom content must fail
 PASS: mutation-lattice-named-fails predicate note claims Lattice-named action must fail
 PASS: thm5-quoted-lattice-qubit note quotes live Lattice and Qubit, including the Cl(3,0) non-structure sentence
@@ -48,7 +53,7 @@ per_site: checked exactly — α and β are unital *-actions on one-site M_2(C) 
 per_mode: checked exactly — φ0 is unfaithful; α and β are faithful and conjugate
 per_block: checked exactly — uniqueness is one conjugacy class, conditional on faithfulness
 lattice_wide: checked and not executed — no action is adopted and none is required by the axioms
-TOTAL: PASS=32 FAIL=0
+TOTAL: PASS=37 FAIL=0
 
 ----- stderr -----
 

--- a/logs/runner-cache/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.txt
+++ b/logs/runner-cache/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
+runner_sha256: 15d857ca1a62a5fbaf319f2f16a3bcd319fd0c1dc084e694e518016b87748552
+input_fingerprint_sha256: 1fcba796642bde01d78697317da0f2c649da1830415eb65b71e45d06c2aee2a3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.44
+status: ok
+----- stdout -----
+external_scientific_inputs: none; G, α, φ0, Sω, β are theorem data
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact Q(i) and integer 3x3 matrices; no adopted action
+negative_scope: φ0 is unfaithful; uniqueness is conditional on a faithful action
+PASS: identity-proper-cubic-count |G|=24 via proper_cubic_count()
+PASS: thm1-signed-perm-pool 48 signed permutation matrices before the det=+1 cut
+PASS: thm1-generators-in-G Rx, Ry, Rz, Sω lie in G
+PASS: thm1-group-closed G is closed under multiplication and transpose-inverse
+PASS: qi-i-square i^2 = -1
+PASS: pauli-involutions σx^2 = σy^2 = σz^2 = I
+PASS: pauli-hermitian each Pauli is Hermitian
+PASS: pauli-rh-triad σx σy = i σz
+PASS: identity-alpha-rx-sigmay α_Rx(σy) = σz via alpha_rx_on_sigmay()
+PASS: thm2-alpha-rx-images α_Rx(σx)=σx, α_Rx(σz)=-σy
+PASS: thm2-alpha-hom α_R ∘ α_S = α_{RS} on all of G
+PASS: identity-alpha-faithful is_faithful(α) holds
+PASS: identity-phi0-unfaithful is_faithful(φ0) fails
+PASS: mutation-phi0-injective-fails predicate φ0 is injective must fail
+PASS: mutation-alpha-rx-id-fails predicate α_Rx == id must fail
+PASS: thm4-sw-order-3 Sω^3 = I and det(Sω)=+1
+PASS: identity-conjugator conjugator_exhibits_beta() holds
+PASS: thm4-beta-rx-formula β_Rx = α_{Sω Rx Sω^{-1}} equals the conjugated action
+PASS: mutation-beta-eq-alpha-fails predicate β_Rx == α_Rx must fail
+PASS: mutation-no-conjugator-fails predicate no conjugator must fail
+PASS: thm4-beta-faithful is_faithful(β) holds
+PASS: thm4-axes axis(α_Rx)=ê_x and axis(β_Rx)=Sω ê_x=ê_y
+PASS: thm3-rx-ry-is-sw Rx Ry = Sω, so the cube 120° relation holds on the nose
+PASS: thm3-frame-of-alpha α axes are the standard right-handed frame
+PASS: mutation-memo-names-action-fails predicate live memo names the standard action as axiom content must fail
+PASS: mutation-lattice-named-fails predicate note claims Lattice-named action must fail
+PASS: thm5-quoted-lattice-qubit note quotes live Lattice and Qubit, including the Cl(3,0) non-structure sentence
+PASS: thm5-not-required note states the axioms do not require a faithful action and do not adopt α
+PASS: boundary-forbidden-phrases note omits the forbidden close-the-route and adoption phrases
+PASS: machine-status-contract note carries bounded-support status and no hypothetical axiom adoption
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: thm6-not-qcd-color QCD appears only as a negation / unused boundary
+per_element: checked exactly — each of the 24 proper cubic matrices is a det=+1 signed permutation
+per_site: checked exactly — α and β are unital *-actions on one-site M_2(C) over Q(i)
+per_mode: checked exactly — φ0 is unfaithful; α and β are faithful and conjugate
+per_block: checked exactly — uniqueness is one conjugacy class, conditional on faithfulness
+lattice_wide: checked and not executed — no action is adopted and none is required by the axioms
+TOTAL: PASS=32 FAIL=0
+
+----- stderr -----
+

--- a/scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
+++ b/scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
@@ -316,6 +316,77 @@ def apply_intmat(matrix: IntMat, vector: tuple[int, int, int]) -> tuple[int, int
     )
 
 
+DIAGONALS: tuple[tuple[int, int, int], ...] = (
+    (1, 1, 1),
+    (1, 1, -1),
+    (1, -1, 1),
+    (1, -1, -1),
+)
+
+
+def canon_diag(vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    for entry in vector:
+        if entry != 0:
+            return vector if entry > 0 else (-vector[0], -vector[1], -vector[2])
+    return vector
+
+
+def diagonal_perm(rotation: IntMat) -> tuple[int, int, int, int]:
+    images = []
+    for diag in DIAGONALS:
+        mapped = canon_diag(apply_intmat(rotation, diag))
+        images.append(DIAGONALS.index(mapped))
+    return (images[0], images[1], images[2], images[3])
+
+
+def perm_sign(perm: tuple[int, int, int, int]) -> int:
+    inversions = 0
+    for i in range(4):
+        for j in range(i + 1, 4):
+            if perm[i] > perm[j]:
+                inversions += 1
+    return 1 if inversions % 2 == 0 else -1
+
+
+def element_order(matrix: IntMat) -> int:
+    acc = identity3()
+    for order in range(1, 25):
+        acc = mat3_mul(acc, matrix)
+        if acc == identity3():
+            return order
+    return 0
+
+
+def g_iso_s4_via_diagonals() -> bool:
+    perms = [diagonal_perm(rotation) for rotation in proper_cubic_group()]
+    return len(set(perms)) == 24 and all(sorted(perm) == [0, 1, 2, 3] for perm in perms)
+
+
+def order3_count() -> int:
+    return sum(1 for rotation in proper_cubic_group() if element_order(rotation) == 3)
+
+
+def all_g_conjugates_faithful() -> bool:
+    for conjugator in proper_cubic_group():
+        inverse = mat3_transpose(conjugator)
+
+        def conjugate_action(
+            rotation: IntMat, conjugator: IntMat = conjugator, inverse: IntMat = inverse
+        ) -> Auto:
+            return alpha_on(mat3_mul(conjugator, mat3_mul(rotation, inverse)))
+
+        if not is_faithful(conjugate_action):
+            return False
+        for rotation in proper_cubic_group():
+            conjugated = compose_auto(
+                alpha_on(conjugator),
+                compose_auto(alpha_on(rotation), alpha_on(inverse)),
+            )
+            if conjugated != conjugate_action(rotation):
+                return False
+    return True
+
+
 class Checks:
     def __init__(self) -> None:
         self.passed = 0
@@ -487,6 +558,36 @@ def main() -> int:
         plus_one_axis(RX) == (1, 0, 0)
         and plus_one_axis(RY) == (0, 1, 0)
         and plus_one_axis(RZ) == (0, 0, 1),
+    )
+    checks.check(
+        "thm3-g-iso-s4",
+        "G ≅ S_4 via the four space diagonals",
+        g_iso_s4_via_diagonals(),
+    )
+    checks.check(
+        "thm3-eight-order-3",
+        "G has eight order-3 elements, so it is not C_24 or D_12",
+        order3_count() == 8,
+    )
+    rz_perm = diagonal_perm(RZ)
+    checks.check(
+        "thm3b-rz-odd-det-plus",
+        "Rz is an odd permutation of the diagonals with det=+1, so 3⊗sgn misses SO(3)",
+        perm_sign(rz_perm) == -1
+        and det3(RZ) == 1
+        and len(set(rz_perm)) == 4,
+    )
+    checks.check(
+        "thm3c-all-g-conjugates",
+        "every G-conjugate of α is faithful and conjugate by α_S",
+        all_g_conjugates_faithful(),
+    )
+    checks.check(
+        "thm3-no-false-census",
+        "note does not claim octahedral groups are the only order-24 subgroups of SO(3)",
+        "The only order-`24` groups" not in note
+        and "dihedral" in note
+        and "isomorphic to `S_4`" in note,
     )
 
     memo_names_standard_action = (

--- a/scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
+++ b/scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Exact Q(i) / integer checks: faithful cube actions on M_2 form one class.
+
+Concrete proper cubic G (|G|=24) acting by unital *-maps on one-site
+M_2(C). No axiom edit, no cache write, no adopted action.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+class Qi:
+    """a + b i with a, b in Q and i^2 = -1."""
+
+    __slots__ = ("re", "im")
+
+    def __init__(self, re: Fraction | int, im: Fraction | int = 0) -> None:
+        self.re = Fraction(re)
+        self.im = Fraction(im)
+
+    def __add__(self, other: Qi) -> Qi:
+        return Qi(self.re + other.re, self.im + other.im)
+
+    def __sub__(self, other: Qi) -> Qi:
+        return Qi(self.re - other.re, self.im - other.im)
+
+    def __mul__(self, other: Qi) -> Qi:
+        return Qi(
+            self.re * other.re - self.im * other.im,
+            self.re * other.im + self.im * other.re,
+        )
+
+    def __neg__(self) -> Qi:
+        return Qi(-self.re, -self.im)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Qi):
+            return NotImplemented
+        return self.re == other.re and self.im == other.im
+
+    def __hash__(self) -> int:
+        return hash((self.re, self.im))
+
+    def conj(self) -> Qi:
+        return Qi(self.re, -self.im)
+
+    def is_zero(self) -> bool:
+        return self.re == 0 and self.im == 0
+
+
+ZERO = Qi(0)
+ONE = Qi(1)
+I_UNIT = Qi(0, 1)
+NEG_I = Qi(0, -1)
+HALF = Qi(Fraction(1, 2))
+
+Mat2 = tuple[tuple[Qi, Qi], tuple[Qi, Qi]]
+Auto = tuple[Mat2, Mat2, Mat2]
+IntMat = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+
+def mat2_add(left: Mat2, right: Mat2) -> Mat2:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def mat2_mul(left: Mat2, right: Mat2) -> Mat2:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def mat2_scale(coeff: Qi, matrix: Mat2) -> Mat2:
+    return (
+        (coeff * matrix[0][0], coeff * matrix[0][1]),
+        (coeff * matrix[1][0], coeff * matrix[1][1]),
+    )
+
+
+def mat2_neg(matrix: Mat2) -> Mat2:
+    return (
+        (-matrix[0][0], -matrix[0][1]),
+        (-matrix[1][0], -matrix[1][1]),
+    )
+
+
+def mat2_adj(matrix: Mat2) -> Mat2:
+    return (
+        (matrix[0][0].conj(), matrix[1][0].conj()),
+        (matrix[0][1].conj(), matrix[1][1].conj()),
+    )
+
+
+def mat2_trace(matrix: Mat2) -> Qi:
+    return matrix[0][0] + matrix[1][1]
+
+
+def identity2() -> Mat2:
+    return ((ONE, ZERO), (ZERO, ONE))
+
+
+def zero2() -> Mat2:
+    return ((ZERO, ZERO), (ZERO, ZERO))
+
+
+SX: Mat2 = ((ZERO, ONE), (ONE, ZERO))
+SY: Mat2 = ((ZERO, NEG_I), (I_UNIT, ZERO))
+SZ: Mat2 = ((ONE, ZERO), (ZERO, -ONE))
+PAULIS: tuple[Mat2, Mat2, Mat2] = (SX, SY, SZ)
+
+
+def pauli_coeff(matrix: Mat2, pauli: Mat2) -> Qi:
+    return mat2_trace(mat2_mul(matrix, pauli)) * HALF
+
+
+def apply_auto(auto: Auto, matrix: Mat2) -> Mat2:
+    scalar = mat2_trace(matrix) * HALF
+    out = mat2_scale(scalar, identity2())
+    for index, pauli in enumerate(PAULIS):
+        out = mat2_add(out, mat2_scale(pauli_coeff(matrix, pauli), auto[index]))
+    return out
+
+
+def compose_auto(left: Auto, right: Auto) -> Auto:
+    return (
+        apply_auto(left, right[0]),
+        apply_auto(left, right[1]),
+        apply_auto(left, right[2]),
+    )
+
+
+def identity_auto() -> Auto:
+    return (SX, SY, SZ)
+
+
+def det3(matrix: IntMat) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat3_mul(left: IntMat, right: IntMat) -> IntMat:
+    return tuple(
+        tuple(
+            left[row][0] * right[0][col]
+            + left[row][1] * right[1][col]
+            + left[row][2] * right[2][col]
+            for col in range(3)
+        )
+        for row in range(3)
+    )
+
+
+def mat3_transpose(matrix: IntMat) -> IntMat:
+    return tuple(tuple(matrix[col][row] for col in range(3)) for row in range(3))
+
+
+def identity3() -> IntMat:
+    return ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def is_signed_permutation(matrix: IntMat) -> bool:
+    for row in matrix:
+        nonzero = [entry for entry in row if entry != 0]
+        if len(nonzero) != 1 or nonzero[0] not in (-1, 1):
+            return False
+    for col in range(3):
+        nonzero = [matrix[row][col] for row in range(3) if matrix[row][col] != 0]
+        if len(nonzero) != 1 or nonzero[0] not in (-1, 1):
+            return False
+    return True
+
+
+def all_signed_permutation_matrices() -> list[IntMat]:
+    out: list[IntMat] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = []
+            for row in range(3):
+                entries = [0, 0, 0]
+                entries[perm[row]] = signs[row]
+                rows.append(tuple(entries))
+            out.append(tuple(rows))
+    return out
+
+
+def proper_cubic_group() -> list[IntMat]:
+    return [matrix for matrix in all_signed_permutation_matrices() if det3(matrix) == 1]
+
+
+def proper_cubic_count() -> int:
+    return len(proper_cubic_group())
+
+
+RX: IntMat = ((1, 0, 0), (0, 0, -1), (0, 1, 0))
+RY: IntMat = ((0, 0, 1), (0, 1, 0), (-1, 0, 0))
+RZ: IntMat = ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+SW: IntMat = ((0, 0, 1), (1, 0, 0), (0, 1, 0))
+
+
+def alpha_on(rotation: IntMat) -> Auto:
+    images: list[Mat2] = []
+    for col in range(3):
+        acc = zero2()
+        for row in range(3):
+            coeff = rotation[row][col]
+            if coeff == 1:
+                acc = mat2_add(acc, PAULIS[row])
+            elif coeff == -1:
+                acc = mat2_add(acc, mat2_neg(PAULIS[row]))
+        images.append(acc)
+    return (images[0], images[1], images[2])
+
+
+def phi0_on(_rotation: IntMat) -> Auto:
+    return identity_auto()
+
+
+def is_faithful(phi) -> bool:
+    group = proper_cubic_group()
+    identity_hits = [rotation for rotation in group if phi(rotation) == identity_auto()]
+    images = [phi(rotation) for rotation in group]
+    return len(identity_hits) == 1 and len(set(images)) == len(group)
+
+
+def alpha_rx_on_sigmay() -> Mat2:
+    return alpha_on(RX)[1]
+
+
+def conjugator_exhibits_beta() -> bool:
+    sw_inv = mat3_transpose(SW)
+    for rotation in proper_cubic_group():
+        conjugated = compose_auto(
+            alpha_on(SW),
+            compose_auto(alpha_on(rotation), alpha_on(sw_inv)),
+        )
+        beta_image = alpha_on(mat3_mul(SW, mat3_mul(rotation, sw_inv)))
+        if conjugated != beta_image:
+            return False
+    return True
+
+
+def plus_one_axis(rotation: IntMat) -> tuple[int, int, int]:
+    shifted = tuple(
+        tuple(rotation[row][col] - (1 if row == col else 0) for col in range(3))
+        for row in range(3)
+    )
+    rows = [list(row) for row in shifted]
+    candidates = (
+        (
+            rows[1][1] * rows[2][2] - rows[1][2] * rows[2][1],
+            rows[1][2] * rows[2][0] - rows[1][0] * rows[2][2],
+            rows[1][0] * rows[2][1] - rows[1][1] * rows[2][0],
+        ),
+        (
+            rows[2][1] * rows[0][2] - rows[2][2] * rows[0][1],
+            rows[2][2] * rows[0][0] - rows[2][0] * rows[0][2],
+            rows[2][0] * rows[0][1] - rows[2][1] * rows[0][0],
+        ),
+        (
+            rows[0][1] * rows[1][2] - rows[0][2] * rows[1][1],
+            rows[0][2] * rows[1][0] - rows[0][0] * rows[1][2],
+            rows[0][0] * rows[1][1] - rows[0][1] * rows[1][0],
+        ),
+    )
+    axis = next((vector for vector in candidates if vector != (0, 0, 0)), (0, 0, 0))
+    gcd = 0
+    for entry in axis:
+        value = abs(entry)
+        gcd = value if gcd == 0 else _gcd(gcd, value)
+    if gcd > 1:
+        axis = (axis[0] // gcd, axis[1] // gcd, axis[2] // gcd)
+    if axis < (0, 0, 0):
+        axis = (-axis[0], -axis[1], -axis[2])
+    return axis
+
+
+def _gcd(left: int, right: int) -> int:
+    while right:
+        left, right = right, left % right
+    return abs(left)
+
+
+def apply_intmat(matrix: IntMat, vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        matrix[row][0] * vector[0] + matrix[row][1] * vector[1] + matrix[row][2] * vector[2]
+        for row in range(3)
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; G, α, φ0, Sω, β are theorem data")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact Q(i) and integer 3x3 matrices; no adopted action")
+    print("negative_scope: φ0 is unfaithful; uniqueness is conditional on a faithful action")
+
+    group = proper_cubic_group()
+    group_set = set(group)
+    count = proper_cubic_count()
+    checks.check(
+        "identity-proper-cubic-count",
+        "|G|=24 via proper_cubic_count()",
+        count == 24 and count == len(group_set),
+    )
+    checks.check(
+        "thm1-signed-perm-pool",
+        "48 signed permutation matrices before the det=+1 cut",
+        len(all_signed_permutation_matrices()) == 48,
+    )
+    checks.check(
+        "thm1-generators-in-G",
+        "Rx, Ry, Rz, Sω lie in G",
+        RX in group_set
+        and RY in group_set
+        and RZ in group_set
+        and SW in group_set
+        and all(is_signed_permutation(matrix) and det3(matrix) == 1 for matrix in (RX, RY, RZ, SW)),
+    )
+    checks.check(
+        "thm1-group-closed",
+        "G is closed under multiplication and transpose-inverse",
+        all(mat3_mul(left, right) in group_set for left in group for right in group)
+        and all(mat3_transpose(matrix) in group_set for matrix in group)
+        and identity3() in group_set,
+    )
+
+    checks.check("qi-i-square", "i^2 = -1", I_UNIT * I_UNIT == -ONE)
+    checks.check(
+        "pauli-involutions",
+        "σx^2 = σy^2 = σz^2 = I",
+        mat2_mul(SX, SX) == identity2()
+        and mat2_mul(SY, SY) == identity2()
+        and mat2_mul(SZ, SZ) == identity2(),
+    )
+    checks.check(
+        "pauli-hermitian",
+        "each Pauli is Hermitian",
+        mat2_adj(SX) == SX and mat2_adj(SY) == SY and mat2_adj(SZ) == SZ,
+    )
+    checks.check(
+        "pauli-rh-triad",
+        "σx σy = i σz",
+        mat2_mul(SX, SY) == mat2_scale(I_UNIT, SZ),
+    )
+
+    alpha_rx = alpha_on(RX)
+    checks.check(
+        "identity-alpha-rx-sigmay",
+        "α_Rx(σy) = σz via alpha_rx_on_sigmay()",
+        alpha_rx_on_sigmay() == SZ and alpha_rx[1] == SZ,
+    )
+    checks.check(
+        "thm2-alpha-rx-images",
+        "α_Rx(σx)=σx, α_Rx(σz)=-σy",
+        alpha_rx[0] == SX and alpha_rx[2] == mat2_neg(SY),
+    )
+    checks.check(
+        "thm2-alpha-hom",
+        "α_R ∘ α_S = α_{RS} on all of G",
+        all(
+            compose_auto(alpha_on(left), alpha_on(right)) == alpha_on(mat3_mul(left, right))
+            for left in group
+            for right in group
+        ),
+    )
+    checks.check(
+        "identity-alpha-faithful",
+        "is_faithful(α) holds",
+        is_faithful(alpha_on),
+    )
+    checks.check(
+        "identity-phi0-unfaithful",
+        "is_faithful(φ0) fails",
+        not is_faithful(phi0_on),
+    )
+    checks.check(
+        "mutation-phi0-injective-fails",
+        "predicate φ0 is injective must fail",
+        not is_faithful(phi0_on),
+    )
+    checks.check(
+        "mutation-alpha-rx-id-fails",
+        "predicate α_Rx == id must fail",
+        alpha_rx != identity_auto() and RX != identity3(),
+    )
+
+    sw_inv = mat3_transpose(SW)
+    checks.check(
+        "thm4-sw-order-3",
+        "Sω^3 = I and det(Sω)=+1",
+        mat3_mul(SW, mat3_mul(SW, SW)) == identity3()
+        and det3(SW) == 1
+        and mat3_mul(SW, sw_inv) == identity3(),
+    )
+    checks.check(
+        "identity-conjugator",
+        "conjugator_exhibits_beta() holds",
+        conjugator_exhibits_beta(),
+    )
+    beta_rx = alpha_on(mat3_mul(SW, mat3_mul(RX, sw_inv)))
+    conjugated_rx = compose_auto(alpha_on(SW), compose_auto(alpha_on(RX), alpha_on(sw_inv)))
+    checks.check(
+        "thm4-beta-rx-formula",
+        "β_Rx = α_{Sω Rx Sω^{-1}} equals the conjugated action",
+        beta_rx == conjugated_rx,
+    )
+    checks.check(
+        "mutation-beta-eq-alpha-fails",
+        "predicate β_Rx == α_Rx must fail",
+        beta_rx != alpha_rx,
+    )
+    checks.check(
+        "mutation-no-conjugator-fails",
+        "predicate no conjugator must fail",
+        conjugator_exhibits_beta() and conjugated_rx == beta_rx,
+    )
+    checks.check(
+        "thm4-beta-faithful",
+        "is_faithful(β) holds",
+        is_faithful(lambda rotation: alpha_on(mat3_mul(SW, mat3_mul(rotation, sw_inv)))),
+    )
+    checks.check(
+        "thm4-axes",
+        "axis(α_Rx)=ê_x and axis(β_Rx)=Sω ê_x=ê_y",
+        plus_one_axis(RX) == (1, 0, 0)
+        and plus_one_axis(mat3_mul(SW, mat3_mul(RX, sw_inv))) == (0, 1, 0)
+        and apply_intmat(SW, (1, 0, 0)) == (0, 1, 0),
+    )
+    checks.check(
+        "thm3-rx-ry-is-sw",
+        "Rx Ry = Sω, so the cube 120° relation holds on the nose",
+        mat3_mul(RX, RY) == SW,
+    )
+    checks.check(
+        "thm3-frame-of-alpha",
+        "α axes are the standard right-handed frame",
+        plus_one_axis(RX) == (1, 0, 0)
+        and plus_one_axis(RY) == (0, 1, 0)
+        and plus_one_axis(RZ) == (0, 0, 1),
+    )
+
+    memo_names_standard_action = (
+        "standard action" in axiom
+        or "Bloch action" in axiom
+        or "α_R" in axiom
+        or "faithful unital" in axiom
+    )
+    checks.check(
+        "mutation-memo-names-action-fails",
+        "predicate live memo names the standard action as axiom content must fail",
+        not memo_names_standard_action
+        and "proper cubic rotations about each site" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom,
+    )
+    checks.check(
+        "mutation-lattice-named-fails",
+        "predicate note claims Lattice-named action must fail",
+        "Lattice-named" not in note,
+    )
+    checks.check(
+        "thm5-quoted-lattice-qubit",
+        "note quotes live Lattice and Qubit, including the Cl(3,0) non-structure sentence",
+        "proper cubic rotations about each site" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "No possibility is privileged" in note
+        and "adds no further primitive structure" in note
+        and "conditional on requiring a faithful" in note,
+    )
+    checks.check(
+        "thm5-not-required",
+        "note states the axioms do not require a faithful action and do not adopt α",
+        "do not require a faithful action" in note
+        and "does not adopt" in note
+        and "Qubit remains `M_2(C)`" in note,
+    )
+    forbidden = (
+        "axioms supply",
+        "we adopt",
+        "exhausted",
+        "closes the route",
+        "only route",
+        "flip Qubit",
+        "Qubit is M_3",
+        "#6268",
+        "#6272",
+        "#6273",
+    )
+    checks.check(
+        "boundary-forbidden-phrases",
+        "note omits the forbidden close-the-route and adoption phrases",
+        all(phrase not in note for phrase in forbidden)
+        and "one conjugacy class" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "note carries bounded-support status and no hypothetical axiom adoption",
+        "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/FAITHFUL_CUBE_ACTION_ON_M2_IS_UNIQUE_UP_TO_CONJUGACY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in self_source,
+    )
+    qcd_ok = "QCD is unused" in note or "not QCD" in note or "No color or QCD" in note
+    checks.check(
+        "thm6-not-qcd-color",
+        "QCD appears only as a negation / unused boundary",
+        qcd_ok
+        and "Qubit remains `M_2(C)`" in note
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+
+    print("per_element: checked exactly — each of the 24 proper cubic matrices is a det=+1 signed permutation")
+    print("per_site: checked exactly — α and β are unital *-actions on one-site M_2(C) over Q(i)")
+    print("per_mode: checked exactly — φ0 is unfaithful; α and β are faithful and conjugate")
+    print("per_block: checked exactly — uniqueness is one conjugacy class, conditional on faithfulness")
+    print("lattice_wide: checked and not executed — no action is adopted and none is required by the axioms")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Faithful unital *-actions of the concrete proper cubic group `G` (`|G|=24`) on one-site `M_2(C)` form **one conjugacy class**. The trivial action `φ0` is not faithful. The displayed Bloch action `α` is faithful and not adopted. Live Lattice and Qubit do not require a faithful action and do not privilege a frame.

This is L3 uniqueness-up-to-conjugacy, not leftover-char of `φ0` vs `φAd`, and not Aut-selection of the SWAP corner.

## Runner

`scripts/faithful_cube_action_on_m2_is_unique_up_to_conjugacy_2026_08_14.py`

`TOTAL: PASS=32 FAIL=0`

## Notes

- No axiom edit, no QCD, no Qubit flip.
- Campaign `toe-lphys-20260812`.
- Source-only: note + runner + cache + citation manifest.