### PR TITLE
science(toe): cut failed gravity reconstruction shortcuts

### DIFF
--- a/docs/ADMISSIBILITY_REFLECTED_CURVATURE_GRAVITY_PHYSICAL_RECONSTRUCTION_CUT_GATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/ADMISSIBILITY_REFLECTED_CURVATURE_GRAVITY_PHYSICAL_RECONSTRUCTION_CUT_GATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,629 @@
+---
+claim_id: admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: >-
+  For the supplied twenty-two-edge reflected curvature action Q_mu at
+  mu=1/1024, the raw analytic continuation q=(k,0,0,-i omega) has two real
+  even-sector complete-edge poles at k=1.25 with opposite local-cross
+  spectral-residue signs.  At k=1.27,1.28,1.29,1.30 the pair leaves the real
+  frequency axis as conjugate complete-edge poles, and at k=1.32 it returns
+  as two real poles with the residue signs exchanged.  On the declared
+  constant nonmetric-complement line-metric reduction, Q_mu has three spatial
+  configuration channels rather than Block 53's two: the Einstein
+  Hamiltonian-constraint row is absent, the extra channel is indefinite, and
+  a conserved static temporal-edge source couples to it.  On the distinct
+  momentum-orthogonal line-metric reduction, all 728 nonzero L=9 spatial
+  modes retain an exact two-dimensional analytic TT interface, but 276 modes
+  have a negative static TT eigenvalue and 174 have a negative kinetic TT
+  eigenvalue, with identical counts at mu=1/2048,1/1024,2/1024.  At the cubic
+  corner the line-metric chart has rank eight and aliases both supplied site
+  TT directions into exact edge gauge.  A rank-three triangle-connection
+  auxiliary factorization exists exactly, but eliminating it reproduces the
+  same Q_mu raw-edge marginal and therefore inherits every raw-edge moment,
+  including Block 74's transfer obstruction.  These facts retire only the
+  supplied raw-marginal auxiliary rewrite and the two declared line-metric
+  canonical identifications as positive complete reconstructions of Q_mu.
+  A changed cross action, changed physical quotient, independent canonical
+  carrier, constrained Pachner/tent evolution, Palatini/connection action,
+  other Lorentzian continuation, nonlinear/nonflat completion, selected
+  Record clock, axiom adoption, audit retention, obligation retirement, and
+  TOE percentage movement are not claimed.
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_reflected_plaquette_curvature_record_ricci_source_intertwiner_boundary_bounded_theorem_note_2026-08-11
+  - admissibility_repaired_regge_full_edge_finite_frequency_pole_survival_boundary_bounded_theorem_note_2026-08-11
+  - admissibility_two_tt_split_step_record_frontier_causal_macro_update_lstar_boundary_bounded_theorem_note_2026-08-11
+  - admissibility_cycle713_record_stress_block44_ir_reflected_carrier_boundary_bounded_theorem_note_2026-08-13
+  - admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_bounded_theorem_note_2026-08-14
+runner: scripts/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.py
+---
+
+# Reflected Curvature Gravity Physical-Reconstruction Cut Gate
+
+**Date:** 2026-08-14
+
+**Type:** `bounded_theorem`
+
+**Status:** route-discrimination result; unaudited; unretained; no canonical
+axiom is edited
+
+TOE accounting: **zero retained-obligation retirement, zero TOE percentage
+movement**.  The result makes significant gravity-route progress by locating
+the current failure in the physical constraint/projector completion rather
+than in the existence of every infrared tensor pole.
+
+## Result up front
+
+Block 74 established a constructive but incomplete gravity conjunction.  The
+local reflected action
+
+\[
+ Q_\mu(q)=Q_{\rm union}(q)+\mu D(-q)^T D(q),
+ \qquad \mu=\frac1{1024},                               \tag{1}
+\]
+
+repairs the `13 -> 10` constant-metric fiber, preserves exact displacement
+Ward identities, solves all 6,528 supplied Record-source modes, and retains
+the Newtonian residue.  Its direct raw-edge covariance nevertheless fails
+necessary positive-transfer moment tests.  The shortest remaining question
+was whether a canonical or connection rewrite could keep the constructive
+data and remove the transfer failure.
+
+This cut gate finds the mechanism.
+
+1. The expected tensor-like pole is real and has positive local spectral
+   weight in the infrared and across much of the axis.  It is therefore wrong
+   to say that the gravity tensor branch is absent everywhere.
+2. In the even/cross sector it has an opposite-residue companion.  The two
+   real poles collide, leave the real frequency axis over the sampled
+   intermediate band, and re-emerge with their residue signs exchanged.
+3. The constant-complement metric reduction explains the companion: the
+   repair lifts the old fifth null by turning the Einstein lapse-constraint
+   channel into a third, indefinite, source-coupled configuration channel.
+4. A second, momentum-orthogonal canonical pullback has exactly two analytic
+   TT coordinates at every tested spatial momentum, but broad full-zone
+   negative static and kinetic sectors.  At the cubic corner the line-metric
+   carrier aliases both site-TT directions into displacement gauge.
+5. The exact rank-three connection/auxiliary rewrite changes none of this if
+   its elimination preserves the raw `Q_mu` edge marginal.  Every raw-edge
+   moment, including the Block 74 negative Hankel witnesses, is inherited.
+
+The exact shipped conclusion is:
+
+> The present `Q_mu` repair is not an exact positive completion of the
+> separately supplied Block 53 two-TT Hamiltonian on either declared
+> line-metric canonical interface, and an exact-marginal auxiliary connection
+> rewrite cannot repair its raw-edge transfer.  The next action must change
+> the constraint/projector law, the cross action, or the physical carrier.
+
+This is **not a gravity no-go**.  It does not exclude a changed physical
+quotient, changed cross action, independent site/canonical tensor carrier,
+Pachner/tent-move constraint evolution, Palatini action, BRST construction,
+Floquet/unitary real-time law, or nonlinear/nonflat repair.
+
+## Inputs and non-imports
+
+| input | consumed | explicitly not imported |
+|---|---|---|
+| [minimal axioms](MINIMAL_AXIOMS_2026-06-29.md) | Admissibility's dynamics-neutral boundary | a Hamiltonian, transfer, physical inner product, gravity action, or clock |
+| [Block 49](ADMISSIBILITY_REFLECTED_PLAQUETTE_CURVATURE_RECORD_RICCI_SOURCE_INTERTWINER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md) | exact local curvature row `D` and line-metric map `M(q)` | a selected coefficient, canonical phase space, or connection dynamics |
+| [Block 50](ADMISSIBILITY_REPAIRED_REGGE_FULL_EDGE_FINITE_FREQUENCY_POLE_SURVIVAL_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md) | analytic bordered-pole method and warning that pole survival is not transfer positivity | numerical authority for the different reflected action |
+| [Block 53](ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md) | a separately supplied positive two-TT canonical target | an intertwiner from (1), a Dirac reduction, or a selected cadence |
+| [Block 68](ADMISSIBILITY_CYCLE713_RECORD_STRESS_BLOCK44_IR_REFLECTED_CARRIER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-13.md) | exact Record-source covectors and the source-bearing comparison | source-to-constraint normalization or physical density |
+| [Block 74](ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_RECORD_SOURCE_TWO_STEP_TRANSFER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md) | the complete reflected action, source/Newton gates, and raw-edge moment obstruction | a selected physical action, canonical quotient, or general gravity negative |
+
+Every continuation, complement, norm, and finite sample used below is named.
+No parent is promoted to retained status.
+
+## 1. Exact analytic axis quotient
+
+For the twenty-two reflected edge directions, let `P_e` exchange the spatial
+`y,z` labels and let `P_g` exchange the corresponding displacement
+parameters.  On
+
+\[
+ q=(k,0,0,-i\omega),                                   \tag{2}
+\]
+
+the raw Laurent symbol obeys
+
+\[
+ [P_e,Q_\mu(q)]=0,\qquad P_eG(q)=G(q)P_g.              \tag{3}
+\]
+
+The even edge/gauge dimensions are `(16,3)` and the odd dimensions are
+`(6,1)`.  For orthonormal sector bases `(U_sigma,V_sigma)`, the runner uses
+the analytic bordered operator
+
+\[
+ B_\sigma(k,\omega)=
+ \begin{pmatrix}
+ -U_\sigma^TQ_\mu(q)U_\sigma & U_\sigma^TG(-q)V_\sigma\\
+ V_\sigma^TG(q)^TU_\sigma & 0
+ \end{pmatrix}.                                        \tag{4}
+\]
+
+The transpose and `-q` are essential.  Hermitian symmetrization after making
+`q_t` complex would solve a different problem.  A zero of (4) is accepted
+only when the border multiplier is negligible and its edge component is a
+null of the complete `22 x 22` analytic symbol.
+
+## 2. Pole collision and residue exchange
+
+The local same-time even-sector cross row is
+
+\[
+ o_\times=\sqrt2 e_{y+z}-e_y-e_z,\qquad
+ o_\times^TG(q)=0.                                     \tag{5}
+\]
+
+Let `C_x(k,omega)` be its complete gauge-bordered covariance.  At a simple
+positive-frequency pole, define the signed spectral diagnostic
+
+\[
+ w=-\mathop{\rm Res}_{\omega=\omega_*} C_\times(k,\omega). \tag{6}
+\]
+
+The minus sign makes `w>0` for the standard positive scalar covariance
+`1/(kappa^2-4 sinh^2(omega/2))`.  This is a necessary spectral-sign
+diagnostic under the declared Euclidean/Lorentzian identification, not an
+already selected physical norm.
+
+On the two sides of the collision band, the complete-edge roots and weights
+are:
+
+| `k` | lower `omega` | lower `w` | upper `omega` | upper `w` |
+|---:|---:|---:|---:|---:|
+| `1.25` | `1.1181701530` | `+0.8066630` | `1.1591729562` | `-0.0657882` |
+| `1.32` | `1.1162297367` | `-0.0536456` | `1.1596204772` | `+0.7524286` |
+
+Thus there is not one isolated globally positive branch.  The positive and
+negative weights exchange between the ordered real roots.
+
+At four interior momenta, solving from both sides of the real axis gives:
+
+| `k` | conjugate even-sector poles |
+|---:|---:|
+| `1.27` | `1.138274443 +/- 0.0081323 i` |
+| `1.28` | `1.138133327 +/- 0.0123613 i` |
+| `1.29` | `1.138028949 +/- 0.0118066 i` |
+| `1.30` | `1.137960179 +/- 0.0053869 i` |
+
+The normalized bordered smallest singular values are below `1e-14`, the
+next singular values remain separated, border multipliers are negligible,
+and the complete-edge null residuals are below the declared runner tolerance.
+This is a sampled open band, not an analytic determination of its exact
+endpoints.  It is nevertheless enough to reject a real positive transfer
+whose complete even-sector spectrum is identified with this raw
+continuation.
+
+The collision also reconciles the apparently conflicting positive evidence.
+Coarse points at `k=0.4`, `pi/2`, and `pi` have real positive tensor-like
+poles.  Block 74's negative moment Grams were not saying that every such pole
+was absent; they were detecting the opposite-sign/complex companion content
+of the complete covariance.
+
+## 3. Constant-complement Dirac reduction
+
+Let `N_0` be the twelve-dimensional orthonormal complement to the constant
+metric tangent `M(0)`.  The declared stationary reduction is
+
+\[
+ C=N_0^TQ_\mu N_0,                                     \tag{7}
+\]
+
+\[
+ E=M(-q)^TQ_\mu M(q)
+  -M(-q)^TQ_\mu N_0 C^{-1}N_0^TQ_\mu M(q).             \tag{8}
+\]
+
+Split the ten metric coordinates as six Frobenius-orthonormal spatial tensor
+coordinates `x` and
+
+\[
+ a=(h_{tt},h_{xt},h_{yt},h_{zt}).                       \tag{9}
+\]
+
+Stationary elimination of `a` gives
+
+\[
+ K=E_{ss}-E_{sa}E_{aa}^{+}E_{as}.                       \tag{10}
+\]
+
+At `q=(0.4,0,0,0)`, the ranks are:
+
+| object | rank | Hermitian inertia `(negative,positive,zero)` |
+|---|---:|---:|
+| `Q_mu` | `18` | `(14,4,4)` |
+| `C` | `12` | `(10,2,0)` |
+| `E` | `6` | `(4,2,4)` |
+| `E_aa` | `3` | `(2,1,1)` |
+| `K` | `3` | `(2,1,3)` |
+
+The three nulls of `K` are spatial displacement gauge, so its gauge quotient
+contains three configuration channels, not Block 53's two.
+
+The contrast with the linearized Einstein kernel is exact on this interface.
+Under the same split, its temporal block has rank two and two left nulls.  One
+is gauge; the other gives the nonzero row
+
+\[
+ (0,0.04,0.04,0,0,0),                                  \tag{11}
+\]
+
+which imposes `h_yy+h_zz=0`.  For (8), `E_aa` has only one numerical null and
+
+\[
+ \ker(E_{aa}^\dagger)^\dagger E_{as}=0                 \tag{12}
+\]
+
+at the runner tolerance.  The curvature repair lifted the old fifth null by
+making this channel auxiliary; it did not restore the Einstein Hamiltonian
+constraint.
+
+In the `[plus,cross,transverse scalar]` basis, `-K` has eigenvalues
+
+\[
+ (-0.0180170869,\ 0.0258477155,\ 0.0387271003),         \tag{13}
+\]
+
+and the cross/scalar mixing magnitude is `0.0117489630`.  A static temporal
+edge source is exactly Ward compatible.  After the same two Schur
+eliminations it couples to the cross and transverse-scalar coordinates with
+magnitudes approximately `(0.210823,0.276254)` and has amplitude above `0.30`
+in the negative eigenchannel.  The extra channel therefore cannot be dropped
+while silently retaining the supplied source response.
+
+This conclusion is scoped to `N_0`.  A different complement/projector changes
+the canonical coordinates and is a new physical-law input, not an algebraic
+refutation of (7)-(13).
+
+## 4. Momentum-orthogonal full-zone cut
+
+A natural rival canonical chart defines at each real `q`
+
+\[
+ N(q)=\ker M(q)^\dagger                                  \tag{14}
+\]
+
+and repeats (8) with Hermitian products.  The metric-coordinate displacement
+columns are exactly
+
+\[
+ h^{(a)}_{ij}=i(q_i\delta_{ja}+q_j\delta_{ia}),
+ \qquad M(q)h^{(a)}=G_a(q).                              \tag{15}
+\]
+
+The equality follows coefficient by coefficient from the line factor
+`exp(i v.q/2) sinc(v.q/2)`.  It is verified on every nonzero `L=9` spatial
+mode.  Removing the spatial gauge span and trace leaves exactly two analytic
+TT coordinates at all 728 modes.
+
+For their embedding `T(k)`, define
+
+\[
+ B_\mu(k)=-T^\dagger E_\mu(k,0)T,                       \tag{16}
+\]
+
+\[
+ A_\mu(k)=-\frac12\partial_{q_t}^2
+    [T^\dagger E_\mu(k,q_t)T]_{q_t=0}.                  \tag{17}
+\]
+
+The runner evaluates (17) with a symmetric lattice second difference.  The
+complete census is:
+
+| `mu` | modes with `lambda_min(B)<0` | modes with `lambda_min(A)<0` |
+|---:|---:|---:|
+| `1/2048` | `276 / 728` | `174 / 728` |
+| `1/1024` | `276 / 728` | `174 / 728` |
+| `2/1024` | `276 / 728` | `174 / 728` |
+
+At `k=(4 pi/9,0,-4 pi/9)`, the central-coefficient static eigenvalues are
+
+\[
+ (-47.0338053,\ 0.5998321).                             \tag{18}
+\]
+
+At `k=(2 pi/9)(3,4,-3)`, the kinetic eigenvalues are approximately
+
+\[
+ (-3.497\,10^3,\ 0.162298).                             \tag{19}
+\]
+
+The large magnitude in (19) occurs near a nonmetric-complement inertia
+crossing; it is not interpreted as a measured energy.  The negative counts,
+the hostile static sign, and the existence of the crossing are the robust
+cut.  The result is not a claim that every conceivable canonical projector
+has negative energy.
+
+## 5. Exact cubic-corner carrier alias
+
+At `q=(pi,pi,pi,0)`, the line factor for a spatial edge with `n` nonzero
+components is
+
+\[
+ f_n=\exp(i n\pi/2)\frac{\sin(n\pi/2)}{n\pi/2},
+\quad f_0=1,\ f_1=\frac{2i}{\pi},\ f_2=0,\
+f_3=\frac{2i}{3\pi}.                                   \tag{20}
+\]
+
+For a spatial TT tensor `h` with `h u=0`, `tr h=0`, and `u=(1,1,1)`, only the
+single-axis edges survive.  Their image equals displacement gauge with
+
+\[
+ \xi_i=-\frac{i}{2\pi}h_{ii},\qquad \xi_t=0.            \tag{21}
+\]
+
+The two-axis edges vanish by `f_2=0`; the body diagonal vanishes by
+`u^T h u=0` and `sum_i xi_i=0`.  Numerically, `rank M=8`, both TT carrier
+columns remain independent, and their distance from `span G` is below
+`1e-12`.  Hence `Q_mu M h=0` for both even though the complete edge symbol has
+only its usual displacement gauge nulls.
+
+The separately supplied site tensor of Block 53 remains a viable independent
+carrier.  What fails is deriving its full-zone TT fiber injectively through
+this particular line-metric chart.
+
+## 6. Exact auxiliary/connection boundary
+
+Block 49's centered curvature row has the exact triangle factorization
+
+\[
+ T_i^+\ell=\sqrt2\ell_{i+t}-\ell_i-e^{iq_i}\ell_t,
+\tag{22}
+\]
+
+\[
+ T_i^-\ell=\sqrt2 e^{iq_t}\ell_{i-t}
+             -e^{iq_t}\ell_i-\ell_t,                   \tag{23}
+\]
+
+\[
+ D_i(q)\ell=e^{-i(q_i+q_t)/2}(T_i^++T_i^-)\ell.         \tag{24}
+\]
+
+At zero momentum `rank D=3`, so fewer than three regular scalar auxiliaries
+cannot generate the rank-three correction.  Three variables `c_i` give
+
+\[
+ S[\ell,c]=\frac12\ell^TQ_{\rm union}\ell
+ +\mu\|c-D\ell\|^2+\mu\|c\|^2.                         \tag{25}
+\]
+
+Eliminating `c=D ell/2` gives exactly (1).  The runner checks (24) and the
+Schur equality below `1e-13` at a generic momentum.
+
+This exact rewrite inherits every raw-edge moment.  More generally, if a
+joint theory has a nonnegative transfer `T` and integrates its auxiliaries to
+the same raw `ell` marginal, then for any time-zero raw-edge observable
+
+\[
+ C_n=\langle O\Omega,T^nO\Omega\rangle                 \tag{26}
+\]
+
+must obey
+
+\[
+ \sum_{ij}\bar a_i C_{i+j}a_j
+ =\left\|\sum_i a_iT^iO\Omega\right\|^2\ge0,           \tag{27}
+\]
+
+and the corresponding shifted Gram is nonnegative.  Marginalization changes
+neither side for `O=O(ell)`.  Block 74's negative raw-edge Grams therefore
+exclude every positive exact-marginal auxiliary rewrite, not only (25).
+
+A connection theory remains live only if it changes the physical quotient,
+observable, signature/contour, constraint system, or action.  A Palatini or
+nonmetricity law that keeps connection variables physical is not an
+exact-marginal rewrite and is outside this negative.
+
+## 7. Decision surface and next experiment
+
+There is no contradiction with Lattice, Qubit, Admissibility, or Record.  The
+minimal axioms deliberately do not select the missing physical-law tuple
+
+\[
+ (\text{carrier},\text{constraints},P_{\rm phys},
+  \Omega_{\rm symplectic}\text{ or inner product},
+  H\text{ or transfer},J_{\rm Record},\text{cadence}).   \tag{28}
+\]
+
+No canonical axiom is edited.  The present evidence identifies an extensional
+`L_phys` decision surface downstream of Admissibility; it does not show that a
+fifth ontology axiom is required.
+
+The highest-value next gravity search is a **Dirac-signature-first replacement
+action**, not another infrared fit.  Before the expensive source battery, a
+candidate must pass:
+
+1. exact four-column Ward identities and the `13 -> 10` constant repair;
+2. a regular nonmetric complement across the declared full zone;
+3. `rank(E_aa)=2`, two temporal nulls, and one nonzero Hamiltonian-constraint
+   row rather than the three-channel pattern above;
+4. exactly two constrained/gauge spatial modes with positive static and
+   kinetic forms and a complete positive residue matrix; and
+5. only then the 6,528 Record sources, Newton residue, positive transfer,
+   explicit cadence, and nonlinear constraint propagation.
+
+Stop an action class at its first convention-robust hostile counterexample.
+If no tightly parameterized replacement is available, the higher-leverage
+pivot is one cross-lane end-to-end `L_phys` composition rather than a broad
+coefficient search.
+
+## TOE lanes
+
+Scores move only on retained obligation retirement:
+
+| lane | repository | physical | autonomous | ceiling |
+|---|---:|---:|---:|---:|
+| operational / Records | 95% | 92% | 50% | 99% |
+| causal / time | 76% | 72% | 41% | 99% |
+| inertia / matter | 95% | 96% | 75% | 99% |
+| gravity / source / resources | 70% | 45% | 29% | 94% |
+| Born / history | 84% | 63% | 34% | 99% |
+
+There is **no TOE percentage movement**.  Significant progress is the route
+cut: the tensor-like branch exists, but the present repair couples it to an
+opposite-residue scalar channel because the physical Hamiltonian constraint
+and projector are missing.  Exact-marginal connection repackaging and the two
+declared canonical charts no longer merit further investment.
+
+## No-Go Discipline gate
+
+**Gate outcome: PASS** for the narrow retirement of (a) exact raw-marginal
+auxiliary rewrites of `Q_mu`, (b) the constant-complement Block-53
+identification, and (c) the momentum-orthogonal line-metric canonical
+identification.  The gate fails—and the claim is demoted—for gravity in
+general, every canonical projector, changed action/quotient, every
+connection theory, every continuation, nonlinear gravity, axiom amendment,
+or TOE closure.
+
+### N1 — Alternative-route enumeration and normalization
+
+| route | object / mechanism / terminal | result | marker |
+|---|---|---|---|
+| R1 raw `Q_mu` transfer | raw edge marginal / direct positive transfer / physical spectrum | Block 74 moment negative; pole collision localizes mechanism | **ATTEMPTED — CLOSED for this marginal** |
+| R2 constant-complement canonical | `M,N_0` / stationary Dirac reduction / Block 53 two TT | three channels, lost constraint, indefinite source-coupled scalar | **ATTEMPTED — CLOSED for this chart** |
+| R3 momentum-orthogonal canonical | `M,N(q)` / analytic TT pullback / positive full-zone two TT | broad negative `A,B`; corner alias | **ATTEMPTED — CLOSED for this chart** |
+| R4 exact auxiliary connection | three or more auxiliaries / eliminate to same marginal / positive transfer | inherits every raw-edge moment | **ATTEMPTED — CLOSED for exact marginal** |
+| R5 changed cross action | new local Ward/reflection action / restore Dirac signature / source-bearing transfer | prescribed cheap gate, not constructed | **UNTESTED — OPEN** |
+| R6 changed physical quotient | constraints/BRST/projector / remove companion physically / positive residue matrix | no selected projector | **UNTESTED — OPEN** |
+| R7 independent canonical carrier | Block 53 site tensor or Pachner/tent phase space / constraint evolution / Record source | not intertwined with edge action | **UNTESTED — OPEN** |
+| R8 Palatini/connection law | physical connection and compatibility constraints / changed marginal / two positive TT pairs | no selected group, signature, symplectic form, or source | **UNTESTED — OPEN** |
+| R9 Lorentzian/Floquet law | real-time phase space / no raw Euclidean identification / unitary Record cadence | not supplied | **UNTESTED — OPEN** |
+| R10 nonlinear/nonflat completion | constraint algebra and self-coupling / complete source backreaction / retained gravity | Block 62 is only partial ray evidence | **UNTESTED — OPEN** |
+
+R5-R10 forbid a broad canonical, connection, or gravity no-go.
+
+### N2 — Wall-independence audit
+
+The walls are atomized as
+
+```text
+W1 = action/cross coefficient
+W2 = nonmetric complement or physical projector
+W3 = Hamiltonian and momentum constraint algebra
+W4 = symplectic form, inner product, and spectral sign
+W5 = Record source normalization and constraint coupling
+W6 = clock, cadence, and transfer/update
+W7 = nonlinear/nonflat closure
+W8 = audit retention and empirical selection
+```
+
+No wall implies another.  The pole collision diagnoses W3-W4 on one supplied
+action but does not select W1 or W2.  The source witness ties W3 to W5 for the
+declared chart without selecting the physical normalization.  The connection
+marginal theorem ties W2-W4 only when the marginal is held exactly fixed.
+W6-W8 remain independent and open.  No conjunction of these walls is counted
+as one hidden score gain.
+
+### N3 — Hidden-wall and convention scan
+
+The following are conditional inputs, not authority:
+
+- `mu` and the `D(-q)^T D(q)` cross action;
+- the standard analytic continuation (2);
+- a raw local edge observable as the Euclidean physical field;
+- the constant or momentum-orthogonal nonmetric complement;
+- Euclidean least-squares coordinate diagnostics;
+- the finite pole sample and the `L=9` spatial grid;
+- the symmetric finite-difference kinetic extraction;
+- flat linearization and a single axis for the collision;
+- Block 53's independently supplied site tensor and cadence; and
+- the absence of a selected nonlinear constraint algebra and Record clock.
+
+Changing any load-bearing item creates a new route to test.  The runner does
+not turn a numerical complement singularity into a universal energy.
+
+### N4 — Residual matching and retained positives
+
+The negative does not erase:
+
+| positive datum | retained scope in this packet | unresolved residual |
+|---|---|---|
+| `13 -> 10` repair | exact zero-mode algebra | physical constraint channel |
+| Ward/reflection structure | exact supplied linear action | nonlinear constraint algebra |
+| 6,528 source solves | exact supplied covectors | physical density/cadence |
+| Newton residue | static infrared response | selected coupling/nonlinear gravity |
+| real positive tensor-like poles | genuine partial branch evidence | complete residue matrix and companion |
+| Block 53 positive update | existence for a supplied site tensor | derivation/intertwiner from edge action |
+| Block 62 nonlinear Ward signal | tested ray and source tensor | angular/full-zone propagation |
+
+The strongest positive interpretation is preserved: gravity-like propagation
+survives locally, while the complete physical reduction is missing.
+
+### N5 — Rhetoric and granularity audit
+
+The strongest allowed statement is: “the supplied repair trades its old null
+defect for an extra scalar/constraint defect on two declared canonical
+interfaces, and an exact-marginal auxiliary rewrite cannot cure the raw-edge
+transfer.”  It is not: “gravity fails,” “Regge calculus fails,” “canonical or
+connection gravity is impossible,” “the complex pole is measured
+instability,” “Block 53 is false,” “an axiom edit is forced,” or “TOE moves.”
+
+The runner prints per-element, per-site, per-mode, per-block, and lattice-wide
+scope lines.  Its `N5_CERTIFICATE` states the exact finite inventory.
+
+### N6 — Partial-closure path scan
+
+| path | constructive content | exact next terminal |
+|---|---|---|
+| replacement cross action | source/Newton/repair parents give strong regression tests | pass Dirac signature and full-zone positivity first |
+| constrained canonical | real tensor-like pole gives a target subbundle | derive local projector, symplectic form, source constraint, cadence |
+| independent site tensor | Block 53 supplies positive two-TT evolution | derive source/action and edge observable dictionary |
+| connection/Palatini | exact triangle rows supply compatibility stencils | change physical marginal and pass two-mode Krein/sign gate |
+| cross-lane `L_phys` | CP/Born, Records, current, and TT update components exist separately | one total law with no silent reset/copy/erasure |
+
+Repeating low-momentum dispersion fits is below all five paths in leverage.
+
+### N7 — Steelman and strongest surviving escape
+
+The steelman is that raw Euclidean edge lengths are not the physical Hilbert
+coordinates.  In constrained gravity, lapse/shift, conformal directions,
+ghost determinants, boundary terms, and physical observables are fixed only
+after a Dirac/BRST or canonical construction.  A complex root of the raw
+continuation need not be a measured instability, and a momentum-dependent
+orthogonal complement need not be local.  The exact-marginal theorem is
+irrelevant to a Palatini theory whose connection remains physical and whose
+metric marginal is not `Q_mu`.
+
+That objection is correct and defines the surviving route.  The shortest
+positive escape is a new constraint/projector law screened by the cheap
+Dirac-signature gate in Section 7.  It must then carry the existing source,
+Newton, transfer, cadence, and nonlinear tests end to end.
+
+### N8 — Cross-cycle echo audit
+
+| echo | relation | authority here? |
+|---|---|---|
+| Block 49 | supplies exact `D` and `M`; direct parent | yes, within its bounded claim |
+| Block 50 | found tensor-like poles and small phases in a different single-orientation action | method only; no numerical import |
+| Block 53 | proves a positive two-TT site update can exist | target only; no edge intertwiner |
+| Block 62 | nonlinear `k^3` Ward signal survives a difficult source test | portfolio support only |
+| Block 68 | supplies exact source battery and edge covectors | direct parent |
+| Block 74 | supplies repaired action and raw-moment obstruction | direct parent |
+| earlier EC/connection blocks | warn of mass intercept and negative connection direction for another law | comparator only; not a connection no-go |
+
+No located result supplies the tuple (28).  The present collision, Dirac rank,
+full-zone census, corner alias, and marginal theorem are independent controls
+on different proposed shortcuts, not repeated votes for a broad negative.
+
+## Verification
+
+Run:
+
+```text
+python3 scripts/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.py
+```
+
+The baseline must end with `TOTAL: PASS=12 FAIL=0`.  Each mutation must fail at
+least one named check:
+
+```text
+erase_complex_pair flip_residue restore_constraint wrong_gauge_phase
+constant_complement axis_corner note_scope
+```
+
+Independent audit is required before retention, obligation retirement, an
+axiom update, or TOE percentage movement.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15824,
- "node_count": 5515,
+ "edge_count": 15830,
+ "node_count": 5516,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -549,6 +549,10 @@
   "admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_bounded_theorem_note_2026-08-14": {
    "deps_hash": "955b4d89980a",
    "out_degree": 5
+  },
+  "admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "cb785bbdf571",
+   "out_degree": 6
   },
   "admissibility_reflected_plaquette_curvature_record_ricci_source_intertwiner_boundary_bounded_theorem_note_2026-08-11": {
    "deps_hash": "a8af90b7b0d5",

--- a/logs/runner-cache/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.txt
+++ b/logs/runner-cache/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.py
+runner_sha256: cd7dde6546d422097103e55b01eacb6e68d9989667c6e9287649291d20e1bbc1
+input_fingerprint_sha256: 9b63bbdeb7cce81ff651b19ce3384414bc33af5e4bb893108e0adf2e7fb5485b
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 5.59
+status: ok
+----- stdout -----
+[PASS] A-authority-and-parent-bindings: the actual axiom boundary and Blocks 49, 50, 53, 68, and 74 are bound without dynamics p...
+[PASS] B-exact-axis-sector-and-gauge-split: the reflected action has exact 16+6 edge and 3+1 gauge y/z sectors on the analytic axis
+       sector dims=(16, 6)/(3, 1); symmetry error=1.776e-15
+[PASS] C-two-real-pole-pairs-are-complete-edge-nulls: two isolated real even-sector poles exist on each side of the hostile collision band
+       frequencies=1.118170153,1.159172956,1.116229737,1.159620477; max null=5.208e-17
+[PASS] D-open-sampled-complex-pole-band: the two real poles leave the real axis as a conjugate pair at four interior momenta
+       |Im omega|=0.00813229,0.01236130,0.01180658,0.00538686; conjugacy=5.421e-13
+[PASS] E-opposite-residue-companion-and-sign-exchange: the local cross observable has one positive and one negative spectral weight which excha...
+       -Res_E C=0.806663005,-0.065788193,-0.053645577,0.752428552; side error=3.815e-06
+[PASS] F-repair-loses-einstein-hamiltonian-constraint: the constant-complement metric Schur has only a gauge lapse null while Einstein has one ...
+       ranks=(18, 12, 6, 3, 3); repaired constraint=3.377e-16; Einstein=0.056568542
+[PASS] G-extra-indefinite-source-coupled-channel: the three-channel quotient is indefinite, mixes TT with scalar, and the conserved static...
+       eig=-0.018017087,0.025847716,0.038727100; source eig=0.314648,0.000000,0.147511
+[PASS] H-exact-line-metric-gauge-and-two-tt-interface: the raw-momentum metric gauge identity and two-dimensional analytic TT quotient hold on ...
+       modes=728; gauge identity=4.518e-16; TT dims=(2,)
+[PASS] I-full-zone-canonical-schur-positivity-killed: the orthogonal metric Schur has the same broad negative static and kinetic census at thr...
+       counts=((276, 174), (276, 174), (276, 174)); hostile B=(-47.03380526326737, 0.5998320680300548); hostile A=(-3496.805578054081, 0.16229808283052913)
+[PASS] J-cubic-corner-two-tt-carrier-alias: both site-TT directions map into exact edge gauge at the cubic corner while the metric c...
+       rank(M/F)=(8, 2); gauge residual=1.271e-16; QF=3.476e-15
+[PASS] K-rank-three-connection-rewrite-is-exact-marginal: the exact triangle-connection stencil and rank-three positive auxiliary Schur reduce bac...
+       rank D0=3; Schur=4.965e-16; stencil=2.220e-16
+[PASS] L-physical-boundary-and-no-go-discipline: the narrow route retirement passes N1 through N8 and preserves changed-action and change...
+N5_CERTIFICATE: 22 edges, four exact gauge columns, two axis sectors, twelve nonmetric directions, 12 hostile poles, 728 spatial modes, three mu values, and two TT coordinates are resolved
+per_element: checked every reflected edge, gauge column, metric coordinate, auxiliary row, and local TT observable
+per_site: the supplied translation-invariant reflected Block-74 action and Block-49 line-metric chart are used unchanged
+per_mode: checked the explicit pole-collision sample and all nonzero L=9 spatial momenta at three coefficients
+per_block: checked analytic poles/residues, Dirac ranks, source coupling, full-zone TT Schurs, corner alias, and auxiliary elimination
+lattice_wide: no continuum momentum theorem, nonlinear constraint algebra, selected clock, physical inner product, or complete Record dynamics is inferred
+scope_boundary: route cut for the supplied Q_mu raw-edge marginal and two declared canonical charts; not canonical/connection gravity, axiom, or TOE closure
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.py
+++ b/scripts/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.py
@@ -1,0 +1,939 @@
+#!/usr/bin/env python3
+"""Block 75: discriminate the shortest physical gravity reconstructions.
+
+The runner keeps the complete twenty-two-edge reflected action from Block 74.
+It resolves a finite-frequency collision between a positive tensor-like pole
+and an opposite-residue companion, tests two explicit canonical reductions,
+and checks the rank-minimal auxiliary/connection rewrite.  The result is a
+boundary on these supplied interfaces, not a no-go for canonical, connection,
+or lattice gravity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import sys
+
+import numpy as np
+from scipy.linalg import null_space
+from scipy.optimize import root
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_TIMEOUT_SEC = 240
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_REFLECTED_CURVATURE_GRAVITY_PHYSICAL_RECONSTRUCTION_"
+    "CUT_GATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+BLOCK49_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_REFLECTED_PLAQUETTE_CURVATURE_RECORD_RICCI_SOURCE_"
+    "INTERTWINER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md"
+)
+BLOCK50_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_REPAIRED_REGGE_FULL_EDGE_FINITE_FREQUENCY_POLE_"
+    "SURVIVAL_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md"
+)
+BLOCK53_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_"
+    "UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md"
+)
+BLOCK68_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_CYCLE713_RECORD_STRESS_BLOCK44_IR_REFLECTED_CARRIER_"
+    "BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+BLOCK74_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_RECORD_SOURCE_TWO_STEP_"
+    "TRANSFER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+PREMISE_PATH = ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_REFLECTED_CURVATURE_GRAVITY_PHYSICAL_RECONSTRUCTION_CUT_GATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/ADMISSIBILITY_REFLECTED_PLAQUETTE_CURVATURE_RECORD_RICCI_SOURCE_INTERTWINER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md",
+    "docs/ADMISSIBILITY_REPAIRED_REGGE_FULL_EDGE_FINITE_FREQUENCY_POLE_SURVIVAL_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md",
+    "docs/ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md",
+    "docs/ADMISSIBILITY_CYCLE713_RECORD_STRESS_BLOCK44_IR_REFLECTED_CARRIER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_RECORD_SOURCE_TWO_STEP_TRANSFER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "scripts/admissibility_repaired_regge_full_edge_schur_ir_lorentzian_constraint_tt_boundary_2026_08_11.py",
+    "scripts/admissibility_regge_reflected_orientation_common_metric_transfer_gate_boundary_2026_08_11.py",
+    "scripts/admissibility_reflected_plaquette_curvature_record_ricci_source_intertwiner_boundary_2026_08_11.py",
+    "scripts/admissibility_two_tt_split_step_record_frontier_causal_macro_update_lstar_boundary_2026_08_11.py",
+    "scripts/admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_2026_08_14.py",
+    "scripts/admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_2026_08_14.py",
+)
+
+sys.path.insert(0, str(ROOT / "scripts"))
+import admissibility_repaired_regge_full_edge_schur_ir_lorentzian_constraint_tt_boundary_2026_08_11 as block44  # noqa: E402
+import admissibility_regge_reflected_orientation_common_metric_transfer_gate_boundary_2026_08_11 as block48  # noqa: E402
+import admissibility_reflected_plaquette_curvature_record_ricci_source_intertwiner_boundary_2026_08_11 as block49  # noqa: E402
+import admissibility_two_tt_split_step_record_frontier_causal_macro_update_lstar_boundary_2026_08_11 as block53  # noqa: E402
+import admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_2026_08_14 as block74  # noqa: E402
+
+
+MU_VALUES = (1.0 / 2048.0, 1.0 / 1024.0, 2.0 / 1024.0)
+MU = MU_VALUES[1]
+OUTER_POLES = (
+    (1.25, (1.118, 1.159)),
+    (1.32, (1.116, 1.160)),
+)
+COMPLEX_POLES = (
+    (1.27, 1.138 + 0.008j, 1.138 - 0.008j),
+    (1.28, 1.138 + 0.012j, 1.138 - 0.012j),
+    (1.29, 1.138 + 0.012j, 1.138 - 0.012j),
+    (1.30, 1.138 + 0.006j, 1.138 - 0.006j),
+)
+GRID_SIZE = 9
+KINETIC_STEP = 1.0e-3
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition, detail: str = "") -> None:
+        ok = bool(condition)
+        short = statement if len(statement) <= 91 else statement[:88] + "..."
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {short}")
+        if detail:
+            clipped = detail if len(detail) <= 168 else detail[:165] + "..."
+            print(f"       {clipped}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+@dataclass(frozen=True)
+class Sector:
+    name: str
+    edge_basis: np.ndarray
+    gauge_basis: np.ndarray
+    observable: np.ndarray
+    tt_vector: np.ndarray
+
+
+@dataclass(frozen=True)
+class PoleDatum:
+    wave_number: float
+    frequency: complex
+    solver_success: bool
+    determinant_residual: float
+    bordered_null_ratio: float
+    next_singular_ratio: float
+    multiplier_ratio: float
+    edge_null_ratio: float
+    spectral_weights: tuple[complex, complex]
+
+
+@dataclass(frozen=True)
+class DiracCertificate:
+    ranks: tuple[int, int, int, int, int]
+    inertias: tuple[tuple[int, int, int], ...]
+    repaired_constraint_norm: float
+    einstein_constraint_rank: int
+    einstein_constraint_norm: float
+    quotient_eigenvalues: tuple[float, float, float]
+    tt_scalar_mixing: float
+    source_components: tuple[float, float, float]
+    source_eigencomponents: tuple[float, float, float]
+    source_ward: float
+
+
+@dataclass(frozen=True)
+class ZoneCertificate:
+    modes: int
+    gauge_identity_error: float
+    tt_dimensions: tuple[int, ...]
+    negative_counts: tuple[tuple[int, int], ...]
+    minimum_static: tuple[float, ...]
+    minimum_kinetic: tuple[float, ...]
+    hostile_static: tuple[float, float]
+    hostile_kinetic: tuple[float, float]
+
+
+def flat(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").lower().split())
+
+
+def matrix_rank(matrix: np.ndarray, tolerance: float = 1.0e-9) -> int:
+    return int(np.linalg.matrix_rank(matrix, tol=tolerance))
+
+
+def inertia(matrix: np.ndarray, tolerance: float = 1.0e-9) -> tuple[int, int, int]:
+    eigenvalues = np.linalg.eigvalsh(0.5 * (matrix + matrix.conj().T))
+    return (
+        int(np.sum(eigenvalues < -tolerance)),
+        int(np.sum(eigenvalues > tolerance)),
+        int(np.sum(np.abs(eigenvalues) <= tolerance)),
+    )
+
+
+def spatial_embedding() -> tuple[np.ndarray, tuple[np.ndarray, ...]]:
+    pairs = ((0, 0), (1, 1), (2, 2), (0, 1), (0, 2), (1, 2))
+    embedding = np.zeros((len(block48.HCOMPS), 6), dtype=float)
+    tensors = []
+    for column, pair in enumerate(pairs):
+        value = 1.0 if pair[0] == pair[1] else 1.0 / np.sqrt(2.0)
+        embedding[block48.HCOMPS.index(pair), column] = value
+        tensor = np.zeros((3, 3), dtype=float)
+        tensor[pair] = value
+        if pair[0] != pair[1]:
+            tensor[pair[::-1]] = value
+        tensors.append(tensor)
+    return embedding, tuple(tensors)
+
+
+SPATIAL_EMBEDDING, SPATIAL_TENSORS = spatial_embedding()
+TEMPORAL_EMBEDDING = np.zeros((len(block48.HCOMPS), 4), dtype=float)
+for _column, _pair in enumerate(((3, 3), (0, 3), (1, 3), (2, 3))):
+    TEMPORAL_EMBEDDING[block48.HCOMPS.index(_pair), _column] = 1.0
+
+
+def swap_matrix(vectors: np.ndarray, left: int, right: int) -> np.ndarray:
+    integer_vectors = np.asarray(vectors, dtype=int)
+    result = np.zeros((len(integer_vectors), len(integer_vectors)), dtype=float)
+    for column, vector in enumerate(integer_vectors):
+        image = vector.copy()
+        image[left], image[right] = image[right], image[left]
+        matches = np.flatnonzero(np.all(integer_vectors == image, axis=1))
+        if len(matches) != 1:
+            raise AssertionError("coordinate-swap image is not unique")
+        result[matches[0], column] = 1.0
+    return result
+
+
+def sign_basis(involution: np.ndarray, sign: int) -> np.ndarray:
+    eigenvalues, eigenvectors = np.linalg.eigh(involution)
+    return eigenvectors[:, np.isclose(eigenvalues, float(sign))]
+
+
+def sector_data(
+    union: block48.ReflectionUnion,
+) -> tuple[tuple[Sector, Sector], np.ndarray, np.ndarray]:
+    directions = np.asarray(union.directions, dtype=int)
+    edge_swap = swap_matrix(directions, 1, 2)
+    gauge_swap = np.eye(4)
+    gauge_swap[[1, 2]] = gauge_swap[[2, 1]]
+    plus, cross = block74.local_tt_observables(union, "")
+
+    tt_cross = np.zeros(len(block48.HCOMPS), dtype=float)
+    tt_cross[block48.HCOMPS.index((1, 2))] = 1.0 / np.sqrt(2.0)
+    tt_plus = np.zeros(len(block48.HCOMPS), dtype=float)
+    tt_plus[block48.HCOMPS.index((1, 1))] = 1.0 / np.sqrt(2.0)
+    tt_plus[block48.HCOMPS.index((2, 2))] = -1.0 / np.sqrt(2.0)
+
+    sectors = (
+        Sector(
+            "even",
+            sign_basis(edge_swap, +1),
+            sign_basis(gauge_swap, +1),
+            cross,
+            tt_cross,
+        ),
+        Sector(
+            "odd",
+            sign_basis(edge_swap, -1),
+            sign_basis(gauge_swap, -1),
+            plus,
+            tt_plus,
+        ),
+    )
+    return sectors, edge_swap, gauge_swap
+
+
+def action_symbol(
+    union: block48.ReflectionUnion,
+    momentum: np.ndarray,
+    mu: float = MU,
+) -> np.ndarray:
+    return block74.cross_action_symbol(union, momentum, mu, "")
+
+
+def axis_momentum(wave_number: float, frequency: complex) -> np.ndarray:
+    return np.asarray((wave_number, 0.0, 0.0, -1j * frequency), dtype=complex)
+
+
+def bordered_operator(
+    union: block48.ReflectionUnion,
+    wave_number: float,
+    frequency: complex,
+    sector: Sector,
+) -> np.ndarray:
+    momentum = axis_momentum(wave_number, frequency)
+    symbol = -action_symbol(union, momentum)
+    right_gauge = (
+        sector.edge_basis.T
+        @ block48.union_gauge_map(union, momentum)
+        @ sector.gauge_basis
+    )
+    left_gauge = (
+        sector.edge_basis.T
+        @ block48.union_gauge_map(union, -momentum)
+        @ sector.gauge_basis
+    )
+    reduced = sector.edge_basis.T @ symbol @ sector.edge_basis
+    zeros = np.zeros(
+        (sector.gauge_basis.shape[1], sector.gauge_basis.shape[1]), dtype=complex
+    )
+    return np.block([[reduced, left_gauge], [right_gauge.T, zeros]])
+
+
+def solve_pole(
+    union: block48.ReflectionUnion,
+    wave_number: float,
+    initial: complex,
+    sector: Sector,
+) -> tuple[complex, bool, float]:
+    scale = float(np.linalg.norm(bordered_operator(union, wave_number, initial, sector)))
+
+    def determinant_pair(values: np.ndarray) -> np.ndarray:
+        frequency = complex(values[0], values[1])
+        determinant = np.linalg.det(
+            bordered_operator(union, wave_number, frequency, sector) / scale
+        )
+        return np.asarray((determinant.real, determinant.imag), dtype=float)
+
+    result = root(
+        determinant_pair,
+        np.asarray((initial.real, initial.imag), dtype=float),
+        method="hybr",
+        options={"xtol": 1.0e-12},
+    )
+    return complex(result.x[0], result.x[1]), bool(result.success), float(
+        np.linalg.norm(result.fun)
+    )
+
+
+def analytic_covariance(
+    union: block48.ReflectionUnion,
+    wave_number: float,
+    frequency: complex,
+    observable: np.ndarray,
+) -> complex:
+    momentum = axis_momentum(wave_number, frequency)
+    symbol = -action_symbol(union, momentum)
+    right_gauge = block48.union_gauge_map(union, momentum)
+    left_gauge = block48.union_gauge_map(union, -momentum)
+    bordered = np.block(
+        [
+            [symbol, left_gauge],
+            [right_gauge.T, np.zeros((4, 4), dtype=complex)],
+        ]
+    )
+    response = np.linalg.solve(
+        bordered, np.concatenate((observable, np.zeros(4, dtype=complex)))
+    )
+    return complex(observable.T @ response[: len(union.directions)])
+
+
+def pole_datum(
+    union: block48.ReflectionUnion,
+    wave_number: float,
+    initial: complex,
+    sector: Sector,
+    mutation: str,
+) -> PoleDatum:
+    frequency, success, determinant_residual = solve_pole(
+        union, wave_number, initial, sector
+    )
+    momentum = axis_momentum(wave_number, frequency)
+    symbol = -action_symbol(union, momentum)
+    bordered = bordered_operator(union, wave_number, frequency, sector)
+    _, singular_values, right_vectors = np.linalg.svd(bordered)
+    null_vector = right_vectors.conj().T[:, -1]
+    edge_count = sector.edge_basis.shape[1]
+    sector_edge = null_vector[:edge_count]
+    multipliers = null_vector[edge_count:]
+    edge_vector = sector.edge_basis @ sector_edge
+    edge_vector /= np.linalg.norm(edge_vector)
+
+    delta = 1.0e-7
+    weights = tuple(
+        -(sign * delta)
+        * analytic_covariance(
+            union, wave_number, frequency + sign * delta, sector.observable
+        )
+        for sign in (-1, +1)
+    )
+    if mutation == "flip_residue":
+        weights = tuple(-value for value in weights)
+
+    return PoleDatum(
+        wave_number=wave_number,
+        frequency=frequency,
+        solver_success=success,
+        determinant_residual=determinant_residual,
+        bordered_null_ratio=float(singular_values[-1] / singular_values[0]),
+        next_singular_ratio=float(singular_values[-2] / singular_values[0]),
+        multiplier_ratio=float(
+            np.linalg.norm(multipliers) / np.linalg.norm(sector_edge)
+        ),
+        edge_null_ratio=float(np.linalg.norm(symbol @ edge_vector) / np.linalg.norm(symbol)),
+        spectral_weights=(complex(weights[0]), complex(weights[1])),
+    )
+
+
+def constant_nonmetric_schur(
+    union: block48.ReflectionUnion,
+    momentum: np.ndarray,
+    nonmetric: np.ndarray,
+    mu: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    q = np.asarray(momentum, dtype=complex)
+    symbol = action_symbol(union, q, mu)
+    metric = block49.union_line_metric_map(union, q)
+    left_metric = block49.union_line_metric_map(union, -q).T
+    complement = nonmetric.T @ symbol @ nonmetric
+    effective = (
+        left_metric @ symbol @ metric
+        - left_metric
+        @ symbol
+        @ nonmetric
+        @ np.linalg.solve(complement, nonmetric.T @ symbol @ metric)
+    )
+    return effective, complement, symbol
+
+
+def dirac_certificate(
+    union: block48.ReflectionUnion,
+    mutation: str,
+) -> DiracCertificate:
+    momentum = np.asarray((0.4, 0.0, 0.0, 0.0), dtype=complex)
+    metric_zero = block49.union_line_metric_map(union, np.zeros(4))
+    nonmetric = null_space(metric_zero.T, rcond=1.0e-12)
+    effective, complement, symbol = constant_nonmetric_schur(
+        union, momentum, nonmetric, MU
+    )
+
+    spatial = SPATIAL_EMBEDDING
+    temporal = TEMPORAL_EMBEDDING
+    spatial_block = spatial.T @ effective @ spatial
+    mixing = spatial.T @ effective @ temporal
+    temporal_block = temporal.T @ effective @ temporal
+    temporal_inverse = np.linalg.pinv(temporal_block, rcond=1.0e-10)
+    reduced = spatial_block - mixing @ temporal_inverse @ mixing.conj().T
+
+    repaired_left_null = null_space(
+        temporal_block.conj().T, rcond=1.0e-10
+    )
+    repaired_constraint_norm = float(
+        np.linalg.norm(repaired_left_null.conj().T @ (temporal.T @ effective @ spatial))
+    )
+
+    einstein = -0.5 * block44.einstein_action_pairing(
+        np.asarray((0.4, 0.0, 0.0, 0.0)), np.eye(4)
+    )
+    einstein_temporal = temporal.T @ einstein @ temporal
+    einstein_left_null = null_space(
+        einstein_temporal.conj().T, rcond=1.0e-10
+    )
+    einstein_constraints = (
+        einstein_left_null.conj().T @ (temporal.T @ einstein @ spatial)
+    )
+
+    plus = np.asarray((0.0, 1.0, -1.0, 0.0, 0.0, 0.0)) / np.sqrt(2.0)
+    cross = np.asarray((0.0, 0.0, 0.0, 0.0, 0.0, 1.0))
+    scalar = np.asarray((0.0, 1.0, 1.0, 0.0, 0.0, 0.0)) / np.sqrt(2.0)
+    quotient = np.column_stack((plus, cross, scalar))
+    quotient_form = quotient.conj().T @ (-reduced) @ quotient
+    quotient_eigenvalues, quotient_vectors = np.linalg.eigh(quotient_form)
+    tt_scalar_mixing = float(abs(quotient_form[1, 2]))
+
+    edge_index = {direction: slot for slot, direction in enumerate(union.directions)}
+    source = np.zeros(len(union.directions), dtype=complex)
+    source[edge_index[(0, 0, 0, 1)]] = 2.0
+    metric = block49.union_line_metric_map(union, momentum)
+    left_metric = block49.union_line_metric_map(union, -momentum).T
+    effective_source = (
+        left_metric @ source
+        - left_metric
+        @ symbol
+        @ nonmetric
+        @ np.linalg.solve(complement, nonmetric.T @ source)
+    )
+    spatial_source = (
+        spatial.T @ effective_source
+        - mixing @ temporal_inverse @ (temporal.T @ effective_source)
+    )
+    quotient_source = quotient.conj().T @ spatial_source
+    eigen_source = quotient_vectors.conj().T @ quotient_source
+
+    if mutation == "restore_constraint":
+        repaired_constraint_norm = float(np.linalg.norm(einstein_constraints))
+
+    return DiracCertificate(
+        ranks=(
+            matrix_rank(symbol),
+            matrix_rank(complement),
+            matrix_rank(effective),
+            matrix_rank(temporal_block),
+            matrix_rank(reduced),
+        ),
+        inertias=tuple(
+            inertia(item)
+            for item in (symbol, complement, effective, temporal_block, reduced)
+        ),
+        repaired_constraint_norm=repaired_constraint_norm,
+        einstein_constraint_rank=matrix_rank(einstein_constraints),
+        einstein_constraint_norm=float(np.linalg.norm(einstein_constraints)),
+        quotient_eigenvalues=tuple(float(item) for item in quotient_eigenvalues),
+        tt_scalar_mixing=tt_scalar_mixing,
+        source_components=tuple(float(abs(item)) for item in quotient_source),
+        source_eigencomponents=tuple(float(abs(item)) for item in eigen_source),
+        source_ward=float(
+            np.linalg.norm(source.conj() @ block48.union_gauge_map(union, momentum))
+        ),
+    )
+
+
+def metric_gauge_coordinates(momentum: np.ndarray, mutation: str) -> np.ndarray:
+    q = np.asarray(momentum, dtype=float)
+    if mutation == "wrong_gauge_phase":
+        q = 2.0 * np.sin(q / 2.0)
+    result = np.zeros((len(block48.HCOMPS), 4), dtype=complex)
+    for column in range(4):
+        for row, (left, right) in enumerate(block48.HCOMPS):
+            result[row, column] = 1j * (
+                q[left] * int(right == column) + q[right] * int(left == column)
+            )
+    return result
+
+
+def spatial_tt_basis(momentum: np.ndarray) -> np.ndarray:
+    k = np.asarray(momentum, dtype=float)
+    rows = [np.asarray([np.trace(tensor) for tensor in SPATIAL_TENSORS])]
+    rows.extend(
+        np.asarray([(tensor @ k)[axis] for tensor in SPATIAL_TENSORS])
+        for axis in range(3)
+    )
+    return null_space(np.asarray(rows), rcond=1.0e-11)
+
+
+def orthogonal_metric_schur(
+    union: block48.ReflectionUnion,
+    momentum: np.ndarray,
+    mu: float,
+    constant_complement: np.ndarray | None,
+) -> np.ndarray:
+    q = np.asarray(momentum, dtype=complex)
+    symbol = action_symbol(union, q, mu)
+    metric = block49.union_line_metric_map(union, q)
+    nonmetric = (
+        null_space(metric.conj().T, rcond=1.0e-11)
+        if constant_complement is None
+        else constant_complement
+    )
+    complement = nonmetric.conj().T @ symbol @ nonmetric
+    return (
+        metric.conj().T @ symbol @ metric
+        - metric.conj().T
+        @ symbol
+        @ nonmetric
+        @ np.linalg.solve(complement, nonmetric.conj().T @ symbol @ metric)
+    )
+
+
+def tt_forms(
+    union: block48.ReflectionUnion,
+    spatial_momentum: np.ndarray,
+    mu: float,
+    constant_complement: np.ndarray | None,
+) -> tuple[np.ndarray, np.ndarray]:
+    k = np.asarray(spatial_momentum, dtype=float)
+    tensor = SPATIAL_EMBEDDING @ spatial_tt_basis(k)
+    values = []
+    for temporal in (0.0, KINETIC_STEP, -KINETIC_STEP):
+        effective = orthogonal_metric_schur(
+            union, np.concatenate((k, (temporal,))), mu, constant_complement
+        )
+        values.append(tensor.conj().T @ effective @ tensor)
+    static = -0.5 * (values[0] + values[0].conj().T)
+    kinetic = -(
+        0.5 * (values[1] + values[2]) - values[0]
+    ) / (4.0 * np.sin(KINETIC_STEP / 2.0) ** 2)
+    kinetic = 0.5 * (kinetic + kinetic.conj().T)
+    return static, kinetic
+
+
+def zone_certificate(
+    union: block48.ReflectionUnion,
+    mutation: str,
+) -> ZoneCertificate:
+    metric_zero = block49.union_line_metric_map(union, np.zeros(4))
+    constant_complement = (
+        null_space(metric_zero.T, rcond=1.0e-12)
+        if mutation == "constant_complement"
+        else None
+    )
+    gauge_identity_error = 0.0
+    tt_dimensions: set[int] = set()
+    negative_counts = [[0, 0] for _ in MU_VALUES]
+    minimum_static = [np.inf for _ in MU_VALUES]
+    minimum_kinetic = [np.inf for _ in MU_VALUES]
+    modes = 0
+
+    for integer_mode in np.ndindex((GRID_SIZE, GRID_SIZE, GRID_SIZE)):
+        centered = np.asarray(integer_mode, dtype=int) - GRID_SIZE // 2
+        if np.all(centered == 0):
+            continue
+        modes += 1
+        k = 2.0 * np.pi * centered / GRID_SIZE
+        q = np.concatenate((k, (0.0,)))
+        metric = block49.union_line_metric_map(union, q)
+        gauge = block48.union_gauge_map(union, q)
+        gauge_coordinates = metric_gauge_coordinates(q, mutation)
+        gauge_identity_error = max(
+            gauge_identity_error, float(np.max(np.abs(metric @ gauge_coordinates - gauge)))
+        )
+        tt_dimensions.add(spatial_tt_basis(k).shape[1])
+        for slot, mu in enumerate(MU_VALUES):
+            static, kinetic = tt_forms(union, k, mu, constant_complement)
+            static_minimum = float(np.linalg.eigvalsh(static)[0])
+            kinetic_minimum = float(np.linalg.eigvalsh(kinetic)[0])
+            negative_counts[slot][0] += int(static_minimum < -1.0e-7)
+            negative_counts[slot][1] += int(kinetic_minimum < -1.0e-5)
+            minimum_static[slot] = min(minimum_static[slot], static_minimum)
+            minimum_kinetic[slot] = min(minimum_kinetic[slot], kinetic_minimum)
+
+    hostile_static = tuple(
+        float(item)
+        for item in np.linalg.eigvalsh(
+            tt_forms(
+                union,
+                2.0 * np.pi * np.asarray((2, 0, -2)) / GRID_SIZE,
+                MU,
+                constant_complement,
+            )[0]
+        )
+    )
+    hostile_kinetic = tuple(
+        float(item)
+        for item in np.linalg.eigvalsh(
+            tt_forms(
+                union,
+                2.0 * np.pi * np.asarray((3, 4, -3)) / GRID_SIZE,
+                MU,
+                constant_complement,
+            )[1]
+        )
+    )
+    return ZoneCertificate(
+        modes=modes,
+        gauge_identity_error=gauge_identity_error,
+        tt_dimensions=tuple(sorted(tt_dimensions)),
+        negative_counts=tuple(tuple(item) for item in negative_counts),
+        minimum_static=tuple(float(item) for item in minimum_static),
+        minimum_kinetic=tuple(float(item) for item in minimum_kinetic),
+        hostile_static=hostile_static,
+        hostile_kinetic=hostile_kinetic,
+    )
+
+
+def corner_alias_certificate(
+    union: block48.ReflectionUnion,
+    mutation: str,
+) -> tuple[int, int, float, float]:
+    spatial = (
+        np.asarray((np.pi, 0.0, 0.0))
+        if mutation == "axis_corner"
+        else np.asarray((np.pi, np.pi, np.pi))
+    )
+    momentum = np.concatenate((spatial, (0.0,)))
+    tt = null_space(block53.tt_constraint(spatial), rcond=1.0e-11)
+    metric = block49.union_line_metric_map(union, momentum)
+    carrier = metric @ SPATIAL_EMBEDDING @ tt
+    gauge = block48.union_gauge_map(union, momentum)
+    fitted = gauge @ np.linalg.lstsq(gauge, carrier, rcond=None)[0]
+    symbol = action_symbol(union, momentum)
+    return (
+        matrix_rank(metric),
+        matrix_rank(carrier),
+        float(np.linalg.norm(carrier - fitted)),
+        float(np.linalg.norm(symbol @ carrier)),
+    )
+
+
+def auxiliary_certificate(
+    union: block48.ReflectionUnion,
+) -> tuple[int, float, float]:
+    momentum = np.asarray((0.37, -0.21, 0.14, 0.42), dtype=complex)
+    right = block49.centered_curvature_intertwiner(union, momentum)
+    left = block49.centered_curvature_intertwiner(union, -momentum).T
+    base = block48.union_symbol(union, momentum)
+    edge_block = base + 2.0 * MU * left @ right
+    joint_right = -2.0 * MU * left
+    joint_left = -2.0 * MU * right
+    auxiliary = 4.0 * MU * np.eye(3)
+    schur = edge_block - joint_right @ np.linalg.solve(auxiliary, joint_left)
+    target = action_symbol(union, momentum)
+    schur_error = float(np.max(np.abs(schur - target)))
+
+    index = {direction: slot for slot, direction in enumerate(union.directions)}
+    reconstructed = np.zeros_like(right)
+    for spatial in range(3):
+        axis = np.zeros(4, dtype=int)
+        axis[spatial] = 1
+        time = np.asarray((0, 0, 0, 1), dtype=int)
+        forward = tuple(axis + time)
+        reflected = tuple(axis - time)
+        plus = np.zeros(len(union.directions), dtype=complex)
+        minus = np.zeros(len(union.directions), dtype=complex)
+        plus[index[forward]] = np.sqrt(2.0)
+        plus[index[tuple(axis)]] = -1.0
+        plus[index[tuple(time)]] = -np.exp(1j * momentum[spatial])
+        minus[index[reflected]] = np.sqrt(2.0) * np.exp(1j * momentum[3])
+        minus[index[tuple(axis)]] = -np.exp(1j * momentum[3])
+        minus[index[tuple(time)]] = -1.0
+        reconstructed[spatial] = (
+            np.exp(-0.5j * (momentum[spatial] + momentum[3])) * (plus + minus)
+        )
+    connection_error = float(np.max(np.abs(reconstructed - right)))
+    zero_rank = matrix_rank(
+        block49.centered_curvature_intertwiner(union, np.zeros(4)), 1.0e-12
+    )
+    return zero_rank, schur_error, connection_error
+
+
+def main() -> int:
+    checks = Checks()
+    mutation = os.environ.get("TOE_MUTATION", "")
+    note = flat(NOTE_PATH)
+    axioms = flat(AXIOM_PATH)
+    block49_note = flat(BLOCK49_PATH)
+    block50_note = flat(BLOCK50_PATH)
+    block53_note = flat(BLOCK53_PATH)
+    block68_note = flat(BLOCK68_PATH)
+    block74_note = flat(BLOCK74_PATH)
+
+    checks.check(
+        "A-authority-and-parent-bindings",
+        "the actual axiom boundary and Blocks 49, 50, 53, 68, and 74 are bound without dynamics promotion",
+        all((ROOT / path).exists() for path in AUDIT_INPUT_PATHS)
+        and "does not choose a hamiltonian or transfer operator" in axioms
+        and "exact three-component intertwiner exists" in block49_note
+        and "sampled finite-frequency survival" in block50_note
+        and "stable finite-depth causal two-tt update exists" in block53_note
+        and "6,528" in block68_note
+        and "direct covariance fails necessary" in block74_note,
+    )
+
+    union = block48.build_reflection_union()
+    sectors, edge_swap, gauge_swap = sector_data(union)
+    symmetry_error = 0.0
+    for frequency in (1.118, 1.138 + 0.012j, 1.160):
+        momentum = axis_momentum(1.28, frequency)
+        symbol = action_symbol(union, momentum)
+        gauge = block48.union_gauge_map(union, momentum)
+        symmetry_error = max(
+            symmetry_error,
+            float(np.max(np.abs(edge_swap @ symbol - symbol @ edge_swap))),
+            float(np.max(np.abs(edge_swap @ gauge - gauge @ gauge_swap))),
+        )
+    checks.check(
+        "B-exact-axis-sector-and-gauge-split",
+        "the reflected action has exact 16+6 edge and 3+1 gauge y/z sectors on the analytic axis",
+        len(union.directions) == 22
+        and tuple(item.edge_basis.shape[1] for item in sectors) == (16, 6)
+        and tuple(item.gauge_basis.shape[1] for item in sectors) == (3, 1)
+        and np.max(np.abs(edge_swap @ edge_swap - np.eye(22))) < 1.0e-15
+        and symmetry_error < 2.0e-13,
+        f"sector dims={(16, 6)}/{(3, 1)}; symmetry error={symmetry_error:.3e}",
+    )
+
+    even = sectors[0]
+    outer = tuple(
+        pole_datum(union, wave_number, complex(initial), even, mutation)
+        for wave_number, initials in OUTER_POLES
+        for initial in initials
+    )
+    checks.check(
+        "C-two-real-pole-pairs-are-complete-edge-nulls",
+        "two isolated real even-sector poles exist on each side of the hostile collision band",
+        all(item.solver_success for item in outer)
+        and max(item.determinant_residual for item in outer) < 1.0e-14
+        and max(abs(item.frequency.imag) for item in outer) < 5.0e-10
+        and max(item.bordered_null_ratio for item in outer) < 1.0e-14
+        and min(item.next_singular_ratio for item in outer) > 2.0e-5
+        and max(item.multiplier_ratio for item in outer) < 1.0e-12
+        and max(item.edge_null_ratio for item in outer) < 1.0e-14,
+        "frequencies=" + ",".join(f"{item.frequency.real:.9f}" for item in outer)
+        + f"; max null={max(item.bordered_null_ratio for item in outer):.3e}",
+    )
+
+    hostile_inputs = (
+        COMPLEX_POLES
+        if mutation != "erase_complex_pair"
+        else ((1.25, 1.118 + 0j, 1.159 + 0j),) * len(COMPLEX_POLES)
+    )
+    hostile = tuple(
+        (
+            pole_datum(union, wave_number, complex(upper), even, mutation),
+            pole_datum(union, wave_number, complex(lower), even, mutation),
+        )
+        for wave_number, upper, lower in hostile_inputs
+    )
+    conjugacy_error = max(
+        abs(pair[0].frequency - pair[1].frequency.conjugate()) for pair in hostile
+    )
+    hostile_phases = tuple(abs(pair[0].frequency.imag) for pair in hostile)
+    checks.check(
+        "D-open-sampled-complex-pole-band",
+        "the two real poles leave the real axis as a conjugate pair at four interior momenta",
+        all(item.solver_success for pair in hostile for item in pair)
+        and conjugacy_error < 2.0e-9
+        and min(hostile_phases) > 4.0e-3
+        and max(hostile_phases) < 2.0e-2
+        and max(
+            item.bordered_null_ratio for pair in hostile for item in pair
+        )
+        < 1.0e-14
+        and max(item.edge_null_ratio for pair in hostile for item in pair) < 1.0e-14,
+        "|Im omega|=" + ",".join(f"{item:.8f}" for item in hostile_phases)
+        + f"; conjugacy={conjugacy_error:.3e}",
+    )
+
+    mean_weights = tuple(
+        float(np.mean([value.real for value in item.spectral_weights]))
+        for item in outer
+    )
+    side_error = max(
+        abs(item.spectral_weights[0] - item.spectral_weights[1]) for item in outer
+    )
+    checks.check(
+        "E-opposite-residue-companion-and-sign-exchange",
+        "the local cross observable has one positive and one negative spectral weight which exchange branches",
+        mean_weights[0] > 0.70
+        and mean_weights[1] < -0.04
+        and mean_weights[2] < -0.04
+        and mean_weights[3] > 0.70
+        and side_error < 2.0e-4,
+        "-Res_E C=" + ",".join(f"{item:.9f}" for item in mean_weights)
+        + f"; side error={side_error:.3e}",
+    )
+
+    dirac = dirac_certificate(union, mutation)
+    checks.check(
+        "F-repair-loses-einstein-hamiltonian-constraint",
+        "the constant-complement metric Schur has only a gauge lapse null while Einstein has one constraint row",
+        dirac.ranks == (18, 12, 6, 3, 3)
+        and dirac.inertias[2] == (4, 2, 4)
+        and dirac.inertias[3] == (2, 1, 1)
+        and dirac.inertias[4] == (2, 1, 3)
+        and dirac.repaired_constraint_norm < 1.0e-12
+        and dirac.einstein_constraint_rank == 1
+        and 0.05 < dirac.einstein_constraint_norm < 0.06,
+        f"ranks={dirac.ranks}; repaired constraint={dirac.repaired_constraint_norm:.3e}; Einstein={dirac.einstein_constraint_norm:.9f}",
+    )
+    checks.check(
+        "G-extra-indefinite-source-coupled-channel",
+        "the three-channel quotient is indefinite, mixes TT with scalar, and the conserved static source reaches both",
+        dirac.quotient_eigenvalues[0] < -0.018
+        and dirac.quotient_eigenvalues[1] > 0.025
+        and dirac.quotient_eigenvalues[2] > 0.038
+        and dirac.tt_scalar_mixing > 0.011
+        and dirac.source_components[1] > 0.20
+        and dirac.source_components[2] > 0.27
+        and dirac.source_eigencomponents[0] > 0.30
+        and dirac.source_eigencomponents[2] > 0.14
+        and dirac.source_ward < 1.0e-14,
+        "eig=" + ",".join(f"{item:.9f}" for item in dirac.quotient_eigenvalues)
+        + "; source eig="
+        + ",".join(f"{item:.6f}" for item in dirac.source_eigencomponents),
+    )
+
+    zone = zone_certificate(union, mutation)
+    checks.check(
+        "H-exact-line-metric-gauge-and-two-tt-interface",
+        "the raw-momentum metric gauge identity and two-dimensional analytic TT quotient hold on all 728 modes",
+        zone.modes == 728
+        and zone.gauge_identity_error < 2.0e-13
+        and zone.tt_dimensions == (2,),
+        f"modes={zone.modes}; gauge identity={zone.gauge_identity_error:.3e}; TT dims={zone.tt_dimensions}",
+    )
+    checks.check(
+        "I-full-zone-canonical-schur-positivity-killed",
+        "the orthogonal metric Schur has the same broad negative static and kinetic census at three mu values",
+        zone.negative_counts == ((276, 174), (276, 174), (276, 174))
+        and max(zone.minimum_static) < -40.0
+        and max(zone.minimum_kinetic) < -3000.0
+        and zone.hostile_static[0] < -47.0
+        and zone.hostile_static[1] > 0.59
+        and zone.hostile_kinetic[0] < -3000.0
+        and zone.hostile_kinetic[1] > 0.16,
+        f"counts={zone.negative_counts}; hostile B={zone.hostile_static}; hostile A={zone.hostile_kinetic}",
+    )
+
+    corner = corner_alias_certificate(union, mutation)
+    checks.check(
+        "J-cubic-corner-two-tt-carrier-alias",
+        "both site-TT directions map into exact edge gauge at the cubic corner while the metric chart drops to rank eight",
+        corner[0] == 8
+        and corner[1] == 2
+        and corner[2] < 1.0e-12
+        and corner[3] < 1.0e-12,
+        f"rank(M/F)={corner[:2]}; gauge residual={corner[2]:.3e}; QF={corner[3]:.3e}",
+    )
+
+    auxiliary = auxiliary_certificate(union)
+    checks.check(
+        "K-rank-three-connection-rewrite-is-exact-marginal",
+        "the exact triangle-connection stencil and rank-three positive auxiliary Schur reduce back to Q_mu",
+        auxiliary[0] == 3
+        and auxiliary[1] < 1.0e-13
+        and auxiliary[2] < 1.0e-13
+        and "inherits every raw-edge moment" in note,
+        f"rank D0={auxiliary[0]}; Schur={auxiliary[1]:.3e}; stencil={auxiliary[2]:.3e}",
+    )
+
+    checks.check(
+        "L-physical-boundary-and-no-go-discipline",
+        "the narrow route retirement passes N1 through N8 and preserves changed-action and changed-quotient escapes",
+        mutation != "note_scope"
+        and all(f"### n{index}" in note for index in range(1, 9))
+        and "gate outcome: pass" in note.replace("**", "")
+        and all(
+            phrase in note
+            for phrase in (
+                "not a gravity no-go",
+                "changed physical quotient",
+                "changed cross action",
+                "no canonical axiom is edited",
+                "no toe percentage movement",
+            )
+        ),
+    )
+
+    print(
+        "N5_CERTIFICATE: 22 edges, four exact gauge columns, two axis sectors, twelve nonmetric directions, 12 hostile poles, 728 spatial modes, three mu values, and two TT coordinates are resolved"
+    )
+    print(
+        "per_element: checked every reflected edge, gauge column, metric coordinate, auxiliary row, and local TT observable"
+    )
+    print(
+        "per_site: the supplied translation-invariant reflected Block-74 action and Block-49 line-metric chart are used unchanged"
+    )
+    print(
+        "per_mode: checked the explicit pole-collision sample and all nonzero L=9 spatial momenta at three coefficients"
+    )
+    print(
+        "per_block: checked analytic poles/residues, Dirac ranks, source coupling, full-zone TT Schurs, corner alias, and auxiliary elimination"
+    )
+    print(
+        "lattice_wide: no continuum momentum theorem, nonlinear constraint algebra, selected clock, physical inner product, or complete Record dynamics is inferred"
+    )
+    print(
+        "scope_boundary: route cut for the supplied Q_mu raw-edge marginal and two declared canonical charts; not canonical/connection gravity, axiom, or TOE closure"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

Block 75 resolves why the repaired reflected gravity action does not yet yield a positive two-TT physical theory.

- finds an opposite-residue even-sector companion: two real complete-edge poles become a complex-conjugate pair at four interior momenta and return with residue signs exchanged
- shows the constant-complement metric reduction has three configuration channels, loses the Einstein Hamiltonian-constraint row, and couples a conserved static source to the negative extra channel
- performs the full nonzero L=9 spatial census on the momentum-orthogonal TT chart: 276/728 negative static modes and 174/728 negative kinetic modes at all three tested mu values
- proves both site-TT directions alias into exact edge gauge at the cubic corner
- gives the exact rank-three triangle-connection auxiliary factorization and proves that any exact raw-edge marginal rewrite inherits the Block 74 moment obstruction

This retires only the supplied raw-marginal auxiliary rewrite and two declared line-metric canonical identifications. Changed action, changed physical quotient, independent canonical carrier, and Palatini/connection routes remain open. No axiom edit, obligation retirement, or TOE percentage movement is claimed.

## Verification

- baseline: TOTAL: PASS=12 FAIL=0
- seven independent mutations: each FAIL=1
- runner cache fresh
- vocabulary lint clean
- audit lint: no errors
- enforced repo invariants: zero link violations; citation graph delta acknowledged