### PR TITLE
science(toe): close sourced ADM constraint cadence

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-20260809/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-20260809/NO_GO_LEDGER.md
@@ -448,3 +448,18 @@ impossibility, or an axiom-necessity conclusion from Block 77.  Reopen the
 negative gate only when the live normalized route families are attempted or
 excluded by current retained authority.  Until then the exact one-tick count
 is a formulation-specific boundary inside a partial-positive packet.
+
+## Block 78 Full linear cadence / Record-compiler partial narrowing
+
+| Scoped negative considered | Exact evidence | Failing N1--N8 items | Demoted disposition | Live/reopen routes |
+|---|---|---|---|---|
+| the sourced Einstein constraints cannot propagate through a positive finite-depth transfer, or the first Cycle713 gravity vertex necessarily creates its source from nothing | exact ADM polynomial complex on all 6,065 nonzero `L=3,...,12` modes; positive depth-two TT transfer `6065/6065`; all four constraints propagated on 13,056 signed neutral source modes spanning both transverse neutral axes; source weights `(2,0)` derived as the unique real solution within the supplied kick-first order; literal `Q -> O_s` incoming segment and offset continuation on all 96 signed event branches | `N1` fails because reordered, auxiliary, implicit, physical Record/M2 compiler, boundary/reservoir, nonlinear, and selected-law families remain untested by retained authority; `N7` gives concrete time-symmetric, auxiliary-carrier, and continuous-Record steelmen | `partial-narrowing`; ship the conditional positive interior cadence and Cycle713 incoming-segment repair only; no universal cadence, Record-compiler, gravity, isolated-birth, ontology, or axiom-necessity no-go | drift-first/time-symmetric source quadrature; auxiliary or implicit local transfer; same-`M2` source typing and permanent-Record gravity-state compiler; open/reservoir positive-mean sector; coupling/work debit; nonlinear Regge/Palatini/BF/teleparallel law and physical selection |
+
+The former interior half-step-schedule and conditional Cycle713
+incoming-segment geometry seams are constructively closed by this candidate,
+but no tracked obligation retires before independent retention.  Physical
+source typing and macro cadence remain open.  An actually isolated positive
+compact birth still has a unit zero-mode defect; that named boundary is not
+promoted into a general matter or gravity no-go.  Reopen any negative only
+after the live families above are attempted or excluded by current retained
+authority.

--- a/docs/ADMISSIBILITY_INCIDENCE_ADM_DEPTH_TWO_SOURCED_CONSTRAINT_RECORD_CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/ADMISSIBILITY_INCIDENCE_ADM_DEPTH_TWO_SOURCED_CONSTRAINT_RECORD_CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,609 @@
+---
+claim_id: admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "A partial-positive full linear constraint/source cadence on the Block-77 staggered incidence carrier.  For the six spatial metric coordinates and conjugate momenta, the derived lattice Einstein potential P, DeWitt kinetic map G, Hamiltonian row C, three momentum rows M, and shift map S satisfy the exact polynomial identities P S=0, M P=0, C S=0, M C^dagger=0, and C G=-(1/2) D dot M.  A kick-first depth-two update with delta=1/2 propagates C h_n=g rho_n and M pi_n=2g j_(n-1/2) to the next tick for every conserved symmetric source when the entire spatial-stress impulse is placed in the first kick: weights (w1,w2)=(2,0).  Midpoint and endpoint constraints derive those weights uniquely within this supplied order; equal (1,1) and late (0,2) placement fail 11,064 of 13,056 declared signed neutral source modes spanning both transverse neutral axes.  All 6,065 nonzero spatial modes for L=3 through 12 pass the ADM identities, two-TT reduction, full-zone unit-circle stability, symplecticity, and positive shadow-form gates; center-chart and raw-label cubic covariance are checked at two probes under all 24 proper-cubic frames.  The raw spatial potential has 19 shifts with coordinate/Manhattan radius 1/2, and the complete homogeneous depth-two macro has 57 shifts with radius 2/3.  Block-67's literal Q-to-O_s matter hop supplies the incoming source segment when the physical source is decoded at the content/frame-defined transverse offset Y_n=H_n+u_s; all 96 signed event branches and six directions pass, so no birth impulse is required for that conditional single front.  An actually isolated positive compact birth still needs incoming boundary flux or a reservoir/recoil tensor and cannot solve the compact zero mode.  Physical same-M2 source typing, one-finalization-per-macro-tick adoption, encoding the continuous gravity state into permanent Records, coupling and source-work/resource debit, positive-mean boundary data, general matter, nonlinear completion, law selection, audit retention, and TOE closure remain open.  This is not a unique L_phys, physical Record compiler, nonlinear gravity law, axiom amendment, audit verdict, retained result, obligation retirement, or TOE percentage movement."
+upstream_dependencies:
+  - minimal_axioms
+  - kinetic_isotropy_primitive
+  - admissibility_two_tt_split_step_record_frontier_causal_macro_update_lstar_boundary_bounded_theorem_note_2026-08-11
+  - admissibility_cycle713_signed_record_source_causal_tt_vertical_slice_bounded_theorem_note_2026-08-13
+  - admissibility_incidence_fierz_pauli_signed_record_source_full_tensor_cadence_boundary_bounded_theorem_note_2026-08-14
+runner: scripts/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.py
+---
+
+# Incidence ADM Depth-Two Sourced-Constraint / Record-Cadence Boundary
+
+Status: partial-positive candidate; unaudited and unretained.
+
+TOE accounting: zero TOE percentage movement and zero obligation retirement.
+
+## Result up front
+
+The full **linear** lapse/shift constraint schedule now closes constructively.
+This is material gravity-route progress: the Block-77 source and the Block-53
+positive depth-two transfer are no longer merely adjacent controls.
+
+For the supplied kick-first order:
+
+1. all four sourced Einstein constraints propagate exactly across both half
+   steps on every one of the 13,056 declared signed neutral source modes,
+   spanning both transverse neutral axes for each ray;
+2. the source placement is derived uniquely as `(w1,w2)=(2,0)`: all spatial
+   stress enters the first kick, none enters the second, and both drifts carry
+   the outgoing face momentum;
+3. equal and late stress placement each fail 11,064 generic modes;
+4. all 6,065 nonzero `L=3,...,12` spatial modes retain exactly two positive TT
+   pairs and full-zone stable depth-two transfer;
+5. the apparent first-vertex source birth disappears on the existing Cycle713
+   geometry: `Q -> O_s` is the incoming segment of a source line kept one
+   transverse edge from the Record head.
+
+This does **not** yet make the update physical `L_phys`.  Same-`M2` source
+typing, Record-state output, macro-event cadence adoption, exchange/debit,
+positive-mean boundary data, nonlinear backreaction, and law selection remain.
+
+## Inputs and non-imports
+
+| input | used | not imported |
+|---|---|---|
+| [minimal axioms](MINIMAL_AXIOMS_2026-06-29.md) | cubic carrier, continuous supported possibilities, permanent Records, and the explicit dynamics/source boundary | Hamiltonian, tensor state, source identity, cadence, coupling, or update |
+| [kinetic-isotropy primitive](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) | OS0 structural equality `c_t=c_s` | full Lorentz closure, integrator order, source placement, or dynamics |
+| [Block 53](ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md) | positive equal-depth-two TT shear and shadow form | the full Einstein constraints or physical source schedule |
+| [Block 67](ADMISSIBILITY_CYCLE713_SIGNED_RECORD_SOURCE_CAUSAL_TT_VERTICAL_SLICE_BOUNDED_THEOREM_NOTE_2026-08-13.md) | exact signed event packet, `Q -> O_s` hop, head continuation, and the live option to keep the source at `O_s` | physical same-`M2` source identity or gravity cadence |
+| [Block 77](ADMISSIBILITY_INCIDENCE_FIERZ_PAULI_SIGNED_RECORD_SOURCE_FULL_TENSOR_CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md) | staggered linear Einstein operator and symmetric vertex/face source | depth-two full-constraint schedule, law selection, or retention |
+
+Authority freshness is explicit because this stacked worktree predates the
+2026-08-13 Record wording revision.  The local axiom file is Git blob
+`2f5fdd26898f62c17fcabc846761f7785c2eadb1`; it is not called current here.
+The runner instead reads the immutable current-at-construction `origin/main`
+axiom blob `bc23300becfe4e4db57153c0e94cfcdf2338da71` from commit
+`b02f50a9cfb8ca57c2dbe7026d06487947d22331`.  The load-bearing clauses shared
+by both versions are Record permanence, `state = configuration of Records`,
+and the absence of a dynamics axiom.  The removed scalar `I`/finite-additivity
+language is not imported; the current unreadable-empty-site clause is checked.
+
+Block 53's equal source kicks propagate its internally defined TT bookkeeping
+rows.  The present result concerns the distinct Hamiltonian and momentum
+Einstein constraints.  Equal stress splitting failing here is therefore not a
+contradiction; it resolves the type distinction named in Block 67.
+
+## 1. Spatial linear ADM complex
+
+Use the six Frobenius-normalized spatial coordinates
+
+\[
+ (h_{xx},h_{yy},h_{zz},\sqrt2h_{xy},\sqrt2h_{xz},\sqrt2h_{yz})
+\]
+
+and the centered incidence symbol
+
+\[
+ D_i=ip_i,\qquad p_i=2\sin(k_i/2),\qquad
+ \kappa^2=p_ip_i.
+\]
+
+For a symmetric momentum tensor define the DeWitt kinetic map
+
+\[
+ (G\pi)_{ij}=\pi_{ij}-\frac12\delta_{ij}\pi^k{}_k.
+\]
+
+The Hamiltonian and momentum rows are
+
+\[
+ Ch=(\kappa^2\delta^{ij}-p^ip^j)h_{ij},
+\qquad
+ (\mathcal M\pi)_i=-2D^j\pi_{ij}.
+\]
+
+The spatial Einstein potential is
+
+\[
+\begin{aligned}
+ (Ph)_{ij}={}&\kappa^2h_{ij}+p_ip_jh^k{}_k
+ -p_ip^kh_{kj}-p_jp^kh_{ki}\\
+ &-\delta_{ij}(\kappa^2h^k{}_k-p^kp^lh_{kl}),
+\end{aligned}
+\]
+
+and a shift multiplier acts through
+
+\[
+ (\mathcal S\beta)_{ij}=D_i\beta_j+D_j\beta_i.
+\]
+
+Direct polynomial evaluation gives
+
+\[
+ P\mathcal S=0,\qquad \mathcal M P=0,\qquad C\mathcal S=0,
+\]
+
+\[
+ \mathcal M C^\dagger=0,
+ \qquad
+ CG=-\frac12D^i\mathcal M_i.
+\]
+
+The runner checks these identities on every nonzero spatial mode for
+`L=3,...,12`, including even-`L` `pi` corners, and checks their tensor
+intertwiners under all 24 proper-cubic frames.  Maximum identity and covariance
+residuals are below `5e-13`.
+
+### 1.1 Executable Block-77 canonical bridge
+
+This is not merely an analogy between two operators.  Let `K_77(p,p_t)` be
+Block 77's actual centered ten-component symbol and let `G^{-1}` be the inverse
+of the DeWitt kinetic map above.  On its six spatial slots the runner checks
+
+\[
+ (K_{77})_{sp,sp}=\frac12(P-p_t^2G^{-1}),
+ \qquad
+ (K_{77})_{tt,sp}=\frac12C.
+\]
+
+With Block 77's Frobenius coordinates
+
+\[
+ h_{tt}=-n,\qquad h_{(it)}=\sqrt2\,\beta_i,
+ \qquad
+ \pi=G^{-1}(ip_t h-\mathcal S\beta),
+\]
+
+the complete spatial and shift rows obey
+
+\[
+ 2(K_{77}h)_{sp}
+  =(P-p_t^2G^{-1})h-ip_tG^{-1}\mathcal S\beta-C^\dagger n,
+\]
+
+\[
+ (K_{77}h)_{(it)}=\frac{(\mathcal M\pi)_i}{2\sqrt2}.
+\]
+
+All 6,065 nonzero spatial modes at two independent temporal momenta give
+12,130 bridge cases with maximum residual below `5e-13`.  The raw staggered
+operator is related by Block 77's explicit placement conjugation, so this
+identity fixes the canonical decomposition without co-locating its carriers.
+
+Define the diagnostic symbol `g` by writing the covariant source equation as
+`K_77 h=(g/2)T`.  The executed Frobenius source coordinates then derive, rather
+than fit,
+
+\[
+ Ch=g\rho,\qquad \mathcal M\pi=2g j.
+\]
+
+The spatial equation supplies total tick impulse `g tau`; the first kick's
+coefficient `2g` integrates over `delta=1/2` to exactly that impulse.  This
+fixes one internally consistent normalization across Blocks 77 and 78.  It
+does not select the physical value, sign, or resource meaning of `g`.
+
+## 2. Depth-two sourced update
+
+Let `delta=1/2`.  At tick `n`, impose
+
+\[
+ Ch^{(0)}=g\rho_n,
+ \qquad
+ \mathcal M\pi^{(0)}=2g j_{n-1/2}.
+\]
+
+For arbitrary lapse and shift multipliers at the two internal stages, update
+
+\[
+ \pi^{(1)}=\pi^{(0)}+\delta
+ [-Ph^{(0)}+C^\dagger n^{(0)}+2g\tau_n],
+\]
+
+\[
+ h^{(1)}=h^{(0)}+\delta
+ [G\pi^{(1)}+\mathcal S\beta^{(0)}],
+\]
+
+\[
+ \pi^{(2)}=\pi^{(1)}+\delta
+ [-Ph^{(1)}+C^\dagger n^{(1)}],
+\]
+
+\[
+ h^{(2)}=h^{(1)}+\delta
+ [G\pi^{(2)}+\mathcal S\beta^{(1)}].
+\]
+
+The source obeys the exact vertex/face continuity equations
+
+\[
+ \rho_{n+1}-\rho_n+D_i j^i_{n+1/2}=0,
+\]
+
+\[
+ j^i_{n+1/2}-j^i_{n-1/2}+D_j\tau^{ji}_n=0.
+\]
+
+Using the identities in section 1 gives
+
+\[
+ \mathcal M\pi^{(1)}=\mathcal M\pi^{(2)}=2g j_{n+1/2},
+\]
+
+\[
+ Ch^{(1)}=g\left(\rho_n-\frac12D_i j^i_{n+1/2}\right),
+ \qquad
+ Ch^{(2)}=g\rho_{n+1}.
+\]
+
+Thus `(h_{n+1},pi_{n+1})=(h^(2),pi^(2))` propagates all four
+sourced Einstein constraints.  The two algebraic half steps are internal
+shear factors; they are not two physical Record segments.
+
+The runner uses diagnostic `g=1`.  Constraint propagation is homogeneous in
+`g`, and no response magnitude is fitted to force the identities.
+
+## 3. Source-placement uniqueness
+
+Let the stress coefficients in the two kicks be `(w1,w2)`.  Momentum
+propagation requires
+
+\[
+ w_1+w_2=2.
+\]
+
+The scalar midpoint Hamiltonian constraint requires
+
+\[
+ w_1=2.
+\]
+
+Therefore
+
+\[
+ (w_1,w_2)=(2,0)
+\]
+
+is unique within the displayed kick-first depth-two order.  The runner does
+not insert these values as a response prefactor: it assembles the scalar
+midpoint Hamiltonian equation and the componentwise endpoint momentum
+equations from source modes, resolves a rank-two real system, and obtains
+`(2,0)` with residual below `5e-13`.  The midpoint scalar row is the
+`D dot M` projection implied by `CG=-(1/2)D dot M`; generic
+nonzero-divergence modes supply its independent coefficient row.
+
+For each `L=3,...,8`, the census uses six signed ray directions, both
+transverse neutral axes, `L` longitudinal modes, `L-1` nonzero neutral modes,
+and `L` modes on the remaining transverse axis:
+
+\[
+ 12\sum_{L=3}^8 L^2(L-1)=13056.
+\]
+
+On this complete 13,056-mode declared source census:
+
+| placement | failed modes | maximum constraint residual |
+|---|---:|---:|
+| front loaded `(2,0)` | 0 | below `5e-12` |
+| equal `(1,1)` | 11,064 | `4` in runner normalization |
+| late `(0,2)` | 11,064 | `8` in runner normalization |
+
+The equal and late negatives are formulation-specific.  Drift-first,
+time-symmetric, auxiliary-carrier, implicit, and other source schedules remain
+live.
+
+## 4. Physical quotient, stability, and locality
+
+For every nonzero tested mode, the trace-plus-divergence matrix has rank four.
+If `Z` spans its two-dimensional kernel, then
+
+\[
+ Z^TPZ=\kappa^2I_2,
+ \qquad
+ Z^TGZ=I_2.
+\]
+
+All 6,065 modes have a symplectic depth-two macro, unit-circle physical
+eigenvalues, and positive shadow form.  The minimum shadow eigenvalue is above
+`0.23`.  A depth-one mutation fails the full-zone gate.
+
+Raw inverse Fourier transforms give:
+
+| object | displacement vectors | max coordinate radius | max Manhattan radius |
+|---|---:|---:|---:|
+| spatial potential | 19 | 1 | 2 |
+| complete homogeneous `(h,pi)` macro | 57 | 2 | 3 |
+
+The TT physical propagation remains the Block-53 radius-two control.  The
+larger Manhattan-three entry belongs to the unreduced twelve-coordinate
+composed macro and is stated rather than hidden.
+
+The runner also conjugates the raw six- and twelve-coordinate symbols with
+their staggered placement matrices and checks proper-cubic covariance under
+all 24 frames at two probes.  This separates center-chart tensor covariance
+from the raw label-translation statement used in the locality claim.
+
+## 5. Cycle713 already supplies the incoming segment
+
+Block 67 defines, for a context site `C`, transverse frame vector
+`u_s=R_s e_y=R e_y`, signed direction `d_s`, old physical/source site
+
+\[
+ Q=C+u_s,
+\]
+
+outcome site
+
+\[
+ O_s=Q+d_s,
+\]
+
+and bootstrap head
+
+\[
+ H_0=C+d_s.
+\]
+
+Keep the conditional physical source at the content/frame-defined offset from
+the head:
+
+\[
+ Y_n=H_n+u_s=O_s+n d_s.
+\]
+
+Then exactly
+
+\[
+ Y_{-1}=Y_0-d_s=Q.
+\]
+
+The literal decoded Cycle713 matter hop `Q -> O_s` is therefore the incoming
+segment `Y_-1 -> Y_0`.  Every later head finalization
+`H_n -> H_(n+1)` produces `Y_n -> Y_(n+1)`.  The source is not moved through
+the transverse bootstrap ledger edge `O_s -> H_0`.
+
+The offset is radius one, orthogonal to `d_s`, and decoded as the negative of
+the head's stored transverse direction.  The runner checks all 96 nonzero
+signed event branches, all six directions, and six induction steps per branch.
+Deleting the incoming segment or co-locating the source with the head fails.
+
+This closes the **incoming-segment geometry seam for the conditional Cycle713
+single front**.  Physical same-M2 source typing and macro cadence are still
+open: the result does not prove that the Record-patch `Q` and `O_s` are the
+physical matter endpoints or select one head finalization as one gravity macro
+tick.
+
+## 6. Actually isolated creation and the compact zero mode
+
+For an actually isolated source created from vacuum, define the boundary
+defect
+
+\[
+ B^0=\rho_0-\rho_{-1}+D_i j^i_{-1/2},
+\]
+
+\[
+ B^i=j^i_{1/2}-j^i_{-1/2}+D_j\tau^{ji}_0.
+\]
+
+It needs incoming boundary flux or a reservoir/recoil tensor satisfying
+
+\[
+ D_\mu R^{\mu\nu}=-B^\nu.
+\]
+
+At the compact zero mode, `C(0)=0`; a positive unit birth has residual one and
+cannot be repaired by changing a local gravity kick.  The Cycle713 offset
+continuation avoids this because it already contains the incoming `Q -> O_s`
+segment.  It does not solve general isolated creation, localized rest matter,
+or the positive compact mean.
+
+## 7. Remaining physical and axiom boundary
+
+The content-addressed current axiom memo says a state is a **configuration of
+Records** and does not supply an update, time metric, source/action identity,
+or physical persistence dynamics.  It does declare Records permanent.
+This packet still evolves continuous `(h,pi)` coordinates outside a compiled
+permanent-Record output.  End-to-end use requires a downstream law that:
+
+1. identifies the `Y_n` offset source with the actual same-`M2` matter event;
+2. declares one head finalization as one gravity macro tick and makes relay and
+   outcome writes internal actions;
+3. encodes the next continuous gravity slice into readable permanent Records
+   or otherwise receives explicit owner approval for its state carrier;
+4. selects the coupling and pairs field work with matter/resource debit;
+5. supplies positive-mean/open/initial boundary data and general conserved
+   matter;
+6. supplies nonlinear self-coupling, constraint algebra, and physical law
+   selection.
+
+The continuous supported-possibility clause leaves an extensional `M2` Record
+encoding route live.  A physical finite-qubit compiler and permanence-safe
+local update are not constructed here.  No axiom amendment is therefore
+claimed necessary or proposed.  Try the downstream Record/`L_phys` bridge
+before changing the state qualification.
+
+## No-Go Discipline Gate
+
+**No-Go Discipline Gate status: FAIL -- partial-narrowing.**  The displayed
+kick-first coefficient result is exact, but fewer than five normalized
+schedule/ontology route families are closed by current retained authority.
+The gate forbids a universal cadence, Record-compiler, gravity, or axiom-
+necessity no-go.
+
+### N1 -- Alternative Route Enumeration
+
+`UNTESTED` is explicit where the required `ATTEMPTED` or `RULED OUT BY PRIOR`
+marker is unavailable; these rows make the gate fail.
+
+| route family | object / mechanism / terminal obligation | marker / authority |
+|---|---|---|
+| kick-first depth-two ADM | full `(h,pi,lapse,shift)` complex / front-loaded stress / propagate midpoint and endpoint constraints | **ATTEMPTED**; current unretained packet closes the declared linear domain |
+| drift-first or time-symmetric split | reordered canonical factors / altered source quadrature / propagate the same four constraints and positive TT quotient | **UNTESTED -- gate-failing**; no retained authority |
+| auxiliary-band local transfer | enlarged phase carrier / extend the temporal band / eliminate auxiliaries while keeping source and constraints local | **UNTESTED -- gate-failing**; no retained authority |
+| implicit or Cayley update | rational symplectic transfer / exact full-zone stability / localize every inverse and compile Record cadence | **UNTESTED -- gate-failing**; no retained authority |
+| Cycle713 offset continuation | existing Record geometry / keep source at `O_s` / supply the incoming segment without a birth impulse | **ATTEMPTED**; current unretained packet is positive |
+| isolated-source reservoir or open boundary | added recoil/boundary tensor / cancel `B^nu` and zero mode / construct positive localized matter | **UNTESTED -- gate-failing**; no retained authority |
+| exact Record/M2 gravity-state compiler | continuous Record content or digital/infinite history / encode each next slice / preserve readability, locality, and permanence | **UNTESTED -- gate-failing**; no retained authority |
+| nonlinear Regge/Palatini/BF/teleparallel law | nonlinear geometry variables / first-class constraint algebra / recover this linear cadence and select physical coupling | **UNTESTED -- gate-failing**; no retained authority |
+
+N1 fails every broader negative.  Only the supplied kick-first order and the
+conditional Cycle713 offset are closed on their declared finite/exact domains.
+
+### N2 -- Pairwise Directional Wall Audit
+
+The residuals separate into nine terminal contracts: `W_S` physical same-`M2`
+source identity; `W_O` permanent-Record gravity-state output; `W_T` adoption
+of one head finalization as one gravity macro tick; `W_G` physical coupling
+normalization; `W_E` field-work and matter/resource debit; `W_B`
+positive-mean boundary/zero-mode data; `W_M` extension to general conserved
+matter; `W_N` nonlinear completion and constraint algebra; and `W_L` physical
+law derivation/selection provenance.  Closing any one does not logically close
+another.  Audit retention follows the science and is not an extra physics
+wall.
+
+| pair | close first => second? | close second => first? | independent? |
+|---|---:|---:|---:|
+| `W_S`,`W_O` | no | no | yes |
+| `W_S`,`W_T` | no | no | yes |
+| `W_S`,`W_G` | no | no | yes |
+| `W_S`,`W_E` | no | no | yes |
+| `W_S`,`W_B` | no | no | yes |
+| `W_S`,`W_M` | no | no | yes |
+| `W_S`,`W_N` | no | no | yes |
+| `W_S`,`W_L` | no | no | yes |
+| `W_O`,`W_T` | no | no | yes |
+| `W_O`,`W_G` | no | no | yes |
+| `W_O`,`W_E` | no | no | yes |
+| `W_O`,`W_B` | no | no | yes |
+| `W_O`,`W_M` | no | no | yes |
+| `W_O`,`W_N` | no | no | yes |
+| `W_O`,`W_L` | no | no | yes |
+| `W_T`,`W_G` | no | no | yes |
+| `W_T`,`W_E` | no | no | yes |
+| `W_T`,`W_B` | no | no | yes |
+| `W_T`,`W_M` | no | no | yes |
+| `W_T`,`W_N` | no | no | yes |
+| `W_T`,`W_L` | no | no | yes |
+| `W_G`,`W_E` | no | no | yes |
+| `W_G`,`W_B` | no | no | yes |
+| `W_G`,`W_M` | no | no | yes |
+| `W_G`,`W_N` | no | no | yes |
+| `W_G`,`W_L` | no | no | yes |
+| `W_E`,`W_B` | no | no | yes |
+| `W_E`,`W_M` | no | no | yes |
+| `W_E`,`W_N` | no | no | yes |
+| `W_E`,`W_L` | no | no | yes |
+| `W_B`,`W_M` | no | no | yes |
+| `W_B`,`W_N` | no | no | yes |
+| `W_B`,`W_L` | no | no | yes |
+| `W_M`,`W_N` | no | no | yes |
+| `W_M`,`W_L` | no | no | yes |
+| `W_N`,`W_L` | no | no | yes |
+
+The former interior linear-cadence and conditional Cycle713 incoming-segment
+bullets are removed from the wall set.  They are conditionally closed here,
+not renamed as physical macro cadence or general birth closure.
+
+### N3 -- Per-Hit Hidden-Wall Scan
+
+| hit | classification | action |
+|---|---|---|
+| `canonical` in kick/drift descriptions | non-load-bearing phase-space/formulation label | no selected-law status is inferred |
+| `background` in the linear-domain description | explicit flat linear restriction | retained as excluded nonlinear scope under `W_N` |
+| compensating background among positive-mean options | physical completion if used | included in `W_B`; not assumed |
+| `registered` primitive language below | cited registry context | each primitive is limited to its declared content |
+
+No load-bearing “we assume,” “by construction,” “as is standard,” “the
+framework provides,” “bridge context,” “naturally,” “obviously,” or “standard
+QFT” phrase remains.
+
+### N4 -- Per-Citation Residual Table
+
+| cited witness (path and lines) | witness residual | residual used here | match? / use |
+|---|---|---|---|
+| current `MINIMAL_AXIOMS_2026-06-29.md` blob `bc23300becfe4e4db57153c0e94cfcdf2338da71:63-95,114-130,173-190` | continuous possibilities, permanent Records, and Record-state qualification; no dynamics, time metric, physical persistence dynamics, or source/action identity | keep the candidate update and Record compiler conditional; do not claim amendment necessity or import the removed scalar/additivity clause | yes; content-addressed foundation scope only |
+| `KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md:15-45,55-75` | OS0 kinetic-form equality only | normalize the leading space/time form without importing cadence, source placement, or Lorentz closure | yes; approved primitive only |
+| `ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md:114-190,283-314` | positive TT depth two; physical order/event placement unselected; internal TT sourced rows | lift the same spatial Hamiltonian to the actual Einstein constraint/source complex | yes; positive transfer input only |
+| `ADMISSIBILITY_CYCLE713_SIGNED_RECORD_SOURCE_CAUSAL_TT_VERTICAL_SLICE_BOUNDED_THEOREM_NOTE_2026-08-13.md:168-219,222-264` | `Q -> O_s` is literal source hop; `O_s -> H_0` is only ledger handoff; keeping source at `O_s` is live | decode `Y_n=H_n+u_s`, using `Q -> O_s` as incoming segment | yes; exact residual closed conditionally |
+| `ADMISSIBILITY_INCIDENCE_FIERZ_PAULI_SIGNED_RECORD_SOURCE_FULL_TENSOR_CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md:327-391` | one-tick UV cut; distinct positive depth-two escape lacks full constraints/source schedule and Record output | construct the missing first-order schedule without identifying it with the one-tick law | yes; exact next target |
+
+No parent supplies retained authority for a negative or for physical adoption.
+
+### N5 -- Rhetoric And Execution-Resolution Audit
+
+| resolution | executed? | narrow conclusion |
+|---|---:|---|
+| per-element | yes with source qualifier | every spatial field/momentum coordinate, lapse row, shift row, and source-weight coefficient; the physical source census injects only diagonal ray stress, while off-diagonal field coordinates are exercised by the operator/bridge identities |
+| per-site | yes on translation representatives | representative vertex stress, face current, local `Q -> O_s` hop, transverse head offset, and continuation induction; a site-space census and physical same-M2 embedding are not executed |
+| per-mode | yes on declared finite censuses | 6,065 nonzero spatial modes and 13,056 two-transverse-axis signed neutral source modes, including even corners |
+| per-block | yes at typed interfaces | content-addressed axiom binding, Block-77 canonical decomposition, ADM identities, raw locality/covariance, TT stability, source Ward, four constraints, weight uniqueness, and Cycle713 decoder |
+| lattice-wide | checked and not executed -- no physical same-M2 compiler, gravity-state Record encoder, positive-mean boundary, exchange/debit law, or nonlinear selected law is supplied | no lattice-wide or ontology negative |
+
+“Unique” always means real source weights in the displayed kick-first
+depth-two order.  “No birth impulse” applies only to the conditional Cycle713
+single front with the literal incoming `Q -> O_s` hop.  The cached stdout lands
+all five resolution lines.
+
+### N6 -- Partial-Closure And Primitive Scan
+
+The current primitive registry and relevant source notes were checked.  Scale
+reference supplies units only; kinetic isotropy supplies only OS0 `c_t=c_s`;
+realized state supplies pointwise evaluation at a supplied admissible history.
+None supplies a gravity state, source identity, boundary, coupling, update,
+debit, or selection, and none is counted as a wall.
+
+| candidate path | status | what it could close |
+|---|---|---|
+| full linear source cadence `(2,0)` | constructed here, unretained | the former interior Einstein-constraint schedule subwall |
+| Cycle713 offset source line | constructed here, conditional and unretained | the former incoming-segment/birth subwall on that single front |
+| extensional continuous `M2` Record encoding | live, not executed here | the carrier-capacity part of `W_O` without an axiom edit |
+| physical permanence-safe local compiler | absent | the readability/update part of `W_O` |
+| owner-approved state/`L_phys` change | unproposed and unapproved | governance fallback only if downstream exact compilation fails |
+| selected source identity, tick, coupling, exchange, boundary, general-matter, and nonlinear law | absent | `W_S`, `W_T`, `W_G`, `W_E`, `W_B`, `W_M`, `W_N`, and `W_L` after bounded construction and audit |
+
+No new-axiom necessity is claimed.  The legitimate next shape is explicit
+downstream law, bounded theorem, then independent import-retirement audit.
+
+### N7 -- Steelman
+
+A hostile reviewer should reject any universal source-schedule or Record-
+ontology conclusion.  A time-symmetric drift-kick-drift law can move the
+midpoint at which stress must be sampled while keeping the same spatial ADM
+complex; an auxiliary local phase register can realize the same physical TT
+macro with a different unreduced support.  Separately, the continuous one-site
+possibility domain may encode exact gravity values into an append-only Record
+frontier, leaving decoded slice dynamics reversible even though Record history
+only grows.  The terminal obligations are explicit: derive the reordered
+constraint intertwiner, compile the same-M2 source and gravity-state decoder,
+prove locality/permanence, and classify canonical equivalence.  These live
+mechanisms defeat every broad no-go, so the result remains partial-positive and
+partial-narrowing.
+
+### N8 -- Cross-Cycle Echo
+
+| prior similar wall | current status | retirement mechanism relevant here |
+|---|---|---|
+| Block 52 unit-depth stability | repaired by Block 53 equal depth two | change temporal composition rather than universalize the UV cut |
+| Block 67 four copied current columns | repaired by Block 77's one symmetric vertex/face tensor | replace label counting with the correct geometric source |
+| Block 77 missing full half-step schedule | repaired here by the derived front-loaded stress placement | propagate the actual Einstein constraints, not TT gauge rows |
+| Block 77 apparent source birth | repaired here by the already-live `Q -> O_s` incoming segment | decode the physical continuation on the existing Record geometry |
+
+Repeated constructive repairs argue against an axiom amendment or gravity
+negative.  Reopen a negative gate only after the reordered-transfer, physical
+Record compiler, boundary, exchange, and nonlinear families are attempted or
+closed by current retained authority.
+
+## Reproduction
+
+Run from the repository root:
+
+```bash
+python3 scripts/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.py
+```
+
+The runner ends with `TOTAL: PASS=n FAIL=n`.  Named mutations attack current
+axiom authority, the Block-77 canonical bridge, the Einstein potential, raw
+covariance and macro placement, depth, source weights, spatial stress,
+momentum normalization, hostile-control honesty, coefficient uniqueness,
+incoming segment, source/head offset, isolated-boundary scope, Record-native
+promotion, and completion promotion.
+
+Source-identity-pinned evidence will land at
+[cached runner stdout](../logs/runner-cache/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.txt).

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15840,
- "node_count": 5518,
+ "edge_count": 15845,
+ "node_count": 5519,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -436,6 +436,10 @@
   },
   "admissibility_global_measure_menu_kernel_type_separation_bounded_theorem_note_2026-08-10": {
    "deps_hash": "7026e4c03122",
+   "out_degree": 5
+  },
+  "admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "a4e620ea48a2",
    "out_degree": 5
   },
   "admissibility_incidence_fierz_pauli_signed_record_source_full_tensor_cadence_boundary_bounded_theorem_note_2026-08-14": {

--- a/logs/runner-cache/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.txt
+++ b/logs/runner-cache/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.py
+runner_sha256: d5d7f3258309fe0cff1d6ab5a9e22f71753848bc4ccacfec9417b8c3910e914f
+input_fingerprint_sha256: 9d78b74ec98e3dbd36740619213d1dd7ca92c25f9a8b3dfb3057a462121c989d
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 25.42
+status: ok
+----- stdout -----
+[PASS] A-authority-and-parent-bindings: the content-addressed current foundation and Blocks 53, 67, and 77 are bound without imp...
+[PASS] B-full-linear-adm-polynomial-identities-and-cubic-covariance: the ADM complex closes exactly and is the canonical decomposition of Block 77's ten-comp...
+       modes=6065; identity/covariance=1.421e-14/1.776e-15; ranks H/M/TT={1}/{3}/{4}; Block77 bridge cases/error=12130/2.220e-15; normal...
+[PASS] C-raw-finite-range-potential-and-depth-two-macro: the staggered spatial potential and complete homogeneous macro transfer are integer-Laur...
+       potential/macro support=(19, 1, 2)/(57, 2, 3); periodicity/Hermiticity/raw covariance=6.939e-16/1.241e-16/1.332e-15
+[PASS] D-two-tt-symplectic-full-zone-positive-depth-two-transfer: all nonzero L=3 through L=12 modes have two TT pairs, exact symplecticity, unit-circle t...
+       modes/stable=6065/6065; TT/symplectic/modulus=7.105e-15/4.599e-15/2.554e-15; min shadow=0.235018
+[PASS] E-front-loaded-source-propagates-all-four-einstein-constraints: the (2,0) kick placement carries energy and momentum constraints across every signed neu...
+       modes=13056; source Ward=9.930e-16; failures=0; max constraint=1.470e-14
+[PASS] F-equal-and-late-source-placement-hostile-controls: equal and late stress splitting fail the generic sourced Hamiltonian midpoint while the ...
+       equal failures/max=11064/4.000000; late failures/max=11064/8.000000
+[PASS] G-source-weight-uniqueness-in-supplied-kick-first-order: midpoint and endpoint constraint equations derive the unique real weights (2,0) without ...
+       samples=216; rank=2; weights=[2.00000000e+00 3.76454738e-16]; residual=4.441e-15
+[PASS] H-cycle713-offset-decoder-supplies-the-incoming-source-segment: the content/frame-defined transverse offset maps Q to O_s and every later head finalizat...
+       branches=96; failures=0; induction checks=576; directions=6
+[PASS] I-cycle713-no-birth-repair-and-isolated-zero-mode-boundary: Cycle713 uses its literal incoming hop, while genuinely isolated positive compact creati...
+       rank C(0)=0; isolated birth residual=1.0; boundary acknowledged=True
+[PASS] J-record-cadence-ontology-selection-and-no-go-scope: the linear cadence result is separated from physical Record compilation, coupling/debit,...
+AXIOM_AUTHORITY: origin/main construction commit=b02f50a9cfb8ca57c2dbe7026d06487947d22331 immutable minimal-axiom blob=bc23300becfe4e4db57153c0e94cfcdf2338da71; no removed scalar-I/additivity premise is imported
+N5_CERTIFICATE: 6065 nonzero L=3..12 modes, 12130 Block77 canonical bridge cases, 24 cubic frames, 13056 signed two-transverse-axis neutral source modes, 96 Cycle713 event branches, four Einstein constraints, and both internal half steps are resolved
+per_element: every spatial field and momentum coordinate, lapse row, three shift rows, and source-weight coefficient is checked; the physical source census injects diagonal ray stress only
+per_site: translation-representative vertex stress, face momentum flux, radius-one Q-to-O_s source hop, transverse head offset, and six-step continuation are checked on local carriers
+per_mode: all 6065 nonzero L=3 through L=12 spatial modes and all 13056 declared L=3 through L=8 two-transverse-axis neutral signed-source modes include even pi corners
+per_block: current-axiom binding, Block77 canonical decomposition, ADM identities, raw locality/covariance, TT stability, source conservation, constraints, coefficient uniqueness, and Cycle713 decoding are checked separately
+lattice_wide: checked and not executed — no physical same-M2 source compiler, gravity-state Record encoder, positive-mean boundary, exchange/debit law, or nonlinear selected gravity law is supplied
+SCHEDULE: the derived kick-first weights are (2,0); all 13056 source modes propagate four constraints, while equal and late placement fail 11064 modes
+BLOCK77_BRIDGE: cases=12130 residual=2.220e-15; derived normalization Ch/Mpi/first-kick/total-impulse=[1. 2. 2. 1.]
+CYCLE713: Y_n=H_n+u_s keeps the physical source at O_s; Q->O_s is the incoming segment, so no birth impulse is needed on this conditional single front
+SCOPE: partial-positive linear cadence and source-decoder construction; no physical Record typing, coupling/debit, boundary selection, nonlinear completion, retention, obligation retirement, or TOE movement
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.py
+++ b/scripts/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.py
@@ -1,0 +1,1068 @@
+#!/usr/bin/env python3
+"""Block 78: full sourced linear ADM cadence on the incidence carrier.
+
+The runner extends Block 77's staggered Einstein operator through the positive
+Block 53 depth-two canonical update.  It derives the unique source-kick
+placement in the supplied kick-first order, propagates all four Einstein
+constraints, and decodes Block 67's literal Q -> O_s hop as the incoming
+source segment.  Physical Record typing, coupling/debit, boundary data,
+nonlinear completion, selection, and retention remain outside the result.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import numpy as np
+from scipy.linalg import block_diag, null_space
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_TIMEOUT_SEC = 240
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_INCIDENCE_ADM_DEPTH_TWO_SOURCED_CONSTRAINT_RECORD_"
+    "CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+KINETIC_PATH = ROOT / "docs" / "KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md"
+BLOCK53_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_"
+    "UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md"
+)
+BLOCK67_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_CYCLE713_SIGNED_RECORD_SOURCE_CAUSAL_TT_VERTICAL_"
+    "SLICE_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+BLOCK77_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_INCIDENCE_FIERZ_PAULI_SIGNED_RECORD_SOURCE_FULL_TENSOR_"
+    "CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+PREMISE_PATH = ROOT / "docs" / "audit" / "data" / "axiom_premise_nodes.json"
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_INCIDENCE_ADM_DEPTH_TWO_SOURCED_CONSTRAINT_RECORD_CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "docs/ADMISSIBILITY_TWO_TT_SPLIT_STEP_RECORD_FRONTIER_CAUSAL_MACRO_UPDATE_LSTAR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-11.md",
+    "docs/ADMISSIBILITY_CYCLE713_SIGNED_RECORD_SOURCE_CAUSAL_TT_VERTICAL_SLICE_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/ADMISSIBILITY_INCIDENCE_FIERZ_PAULI_SIGNED_RECORD_SOURCE_FULL_TENSOR_CADENCE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "scripts/admissibility_two_tt_split_step_record_frontier_causal_macro_update_lstar_boundary_2026_08_11.py",
+    "scripts/admissibility_cycle713_signed_record_source_causal_tt_vertical_slice_2026_08_13.py",
+    "scripts/admissibility_incidence_fierz_pauli_signed_record_source_full_tensor_cadence_boundary_2026_08_14.py",
+    "scripts/admissibility_incidence_adm_depth_two_sourced_constraint_record_cadence_boundary_2026_08_14.py",
+)
+
+sys.path.insert(0, str(ROOT / "scripts"))
+import admissibility_two_tt_split_step_record_frontier_causal_macro_update_lstar_boundary_2026_08_11 as block53  # noqa: E402
+import admissibility_cycle713_signed_record_source_causal_tt_vertical_slice_2026_08_13 as block67  # noqa: E402
+import admissibility_incidence_fierz_pauli_signed_record_source_full_tensor_cadence_boundary_2026_08_14 as block77  # noqa: E402
+
+
+BASIS = block53.SYMMETRIC_BASIS
+IDENTITY6 = np.eye(6)
+ZERO6 = np.zeros((6, 6))
+TOL = 1.0e-10
+CURRENT_AXIOM_COMMIT = "b02f50a9cfb8ca57c2dbe7026d06487947d22331"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+AXIOM_REPO_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition, detail: str = "") -> None:
+        ok = bool(condition)
+        short = statement if len(statement) <= 91 else statement[:88] + "..."
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {short}")
+        if detail:
+            clipped = detail if len(detail) <= 132 else detail[:129] + "..."
+            print(f"       {clipped}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return int(self.failed != 0)
+
+
+def flat(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").lower().split())
+
+
+def git_blob_flat(blob: str) -> str:
+    result = subprocess.run(
+        ("git", "cat-file", "blob", blob),
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return " ".join(result.stdout.lower().split())
+
+
+def git_commit_path_blob(commit: str, path: str) -> str:
+    result = subprocess.run(
+        ("git", "rev-parse", f"{commit}:{path}"),
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def tensor_coordinates(tensor: np.ndarray) -> np.ndarray:
+    return np.asarray([np.sum(basis * tensor) for basis in BASIS], dtype=complex)
+
+
+def coordinate_tensor(coordinates: np.ndarray) -> np.ndarray:
+    return sum(
+        (coordinates[index] * basis for index, basis in enumerate(BASIS)),
+        start=np.zeros((3, 3), dtype=complex),
+    )
+
+
+def spatial_operators(
+    momentum_vector: np.ndarray,
+    mutation: str = "",
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    p = np.asarray(momentum_vector, dtype=float)
+    kappa_squared = float(p @ p)
+    identity = np.eye(3)
+
+    kinetic = np.column_stack(
+        tuple(
+            tensor_coordinates(basis - 0.5 * identity * np.trace(basis))
+            for basis in BASIS
+        )
+    )
+    potential = np.column_stack(
+        tuple(
+            tensor_coordinates(
+                kappa_squared * basis
+                + np.outer(p, p) * np.trace(basis)
+                - np.outer(p, p @ basis)
+                - np.outer(basis @ p, p)
+                - identity
+                * (kappa_squared * np.trace(basis) - p @ basis @ p)
+            )
+            for basis in BASIS
+        )
+    )
+    if mutation == "wrong_potential":
+        potential = kappa_squared * np.eye(6)
+
+    hamiltonian = np.asarray(
+        [
+            np.sum((kappa_squared * identity - np.outer(p, p)) * basis)
+            for basis in BASIS
+        ],
+        dtype=complex,
+    )[None, :]
+    momentum = np.column_stack(tuple(-2.0j * (basis @ p) for basis in BASIS))
+    shift = np.column_stack(
+        tuple(
+            tensor_coordinates(
+                1.0j * (np.outer(p, vector) + np.outer(vector, p))
+            )
+            for vector in np.eye(3)
+        )
+    )
+    return kinetic, potential, hamiltonian, momentum, shift
+
+
+def tensor_rotation(rotation: np.ndarray) -> np.ndarray:
+    return np.column_stack(
+        tuple(
+            tensor_coordinates(rotation @ basis @ rotation.T) for basis in BASIS
+        )
+    ).real
+
+
+def operator_identity_certificate(
+    mutation: str,
+) -> tuple[int, float, float, set[int], set[int], set[int]]:
+    modes = 0
+    identity_error = 0.0
+    covariance_error = 0.0
+    hamiltonian_ranks: set[int] = set()
+    momentum_ranks: set[int] = set()
+    tt_ranks: set[int] = set()
+    for size in range(3, 13):
+        for integer_mode in np.ndindex((size,) * 3):
+            centered = np.asarray(integer_mode, dtype=int)
+            if np.all(centered == 0):
+                continue
+            k = 2.0 * np.pi * centered / size
+            p = block53.lattice_vector(k)
+            kinetic, potential, hamiltonian, momentum, shift = spatial_operators(
+                p, mutation
+            )
+            derivative = 1.0j * p
+            residuals = (
+                potential @ shift,
+                momentum @ potential,
+                hamiltonian @ shift,
+                momentum @ hamiltonian.conj().T,
+                hamiltonian @ kinetic
+                + 0.5 * (derivative[None, :] @ momentum),
+                potential - potential.T,
+                kinetic - kinetic.T,
+            )
+            identity_error = max(
+                identity_error,
+                max(float(np.max(np.abs(residual))) for residual in residuals),
+            )
+            hamiltonian_ranks.add(int(np.linalg.matrix_rank(hamiltonian, TOL)))
+            momentum_ranks.add(int(np.linalg.matrix_rank(momentum, TOL)))
+            tt_ranks.add(int(np.linalg.matrix_rank(block53.tt_constraint(k), TOL)))
+            modes += 1
+
+    probes = (
+        np.asarray((0.31, -0.77, 1.12)),
+        np.asarray((np.pi, -0.43, np.pi)),
+    )
+    for rotation in block53.proper_cubic_rotations():
+        representation = tensor_rotation(rotation)
+        for k in probes:
+            p = block53.lattice_vector(k)
+            rotated_p = rotation @ p
+            g0, p0, c0, m0, s0 = spatial_operators(p)
+            g1, p1, c1, m1, s1 = spatial_operators(rotated_p)
+            covariance_error = max(
+                covariance_error,
+                float(np.max(np.abs(p1 - representation @ p0 @ representation.T))),
+                float(np.max(np.abs(g1 - representation @ g0 @ representation.T))),
+                float(np.max(np.abs(c1 @ representation - c0))),
+                float(np.max(np.abs(m1 @ representation - rotation @ m0))),
+                float(np.max(np.abs(s1 @ rotation - representation @ s0))),
+            )
+    return (
+        modes,
+        identity_error,
+        covariance_error,
+        hamiltonian_ranks,
+        momentum_ranks,
+        tt_ranks,
+    )
+
+
+def block77_adm_bridge_certificate(
+    mutation: str,
+) -> tuple[int, float, np.ndarray]:
+    """Bind the canonical variables to Block 77's actual 10x10 symbol."""
+    cases = 0
+    error = 0.0
+    canonical_scale_numerator = 0.0j
+    canonical_scale_denominator = 0.0
+    momentum_scale_numerator = 0.0j
+    momentum_scale_denominator = 0.0
+    spatial_slots = list(block77.SPATIAL_SLOTS)
+    shift_slots = list(block77.SHIFT_SLOTS)
+    temporal_angles = (0.37, np.pi)
+    for size in range(3, 13):
+        for integer_mode in np.ndindex((size,) * 3):
+            if all(value == 0 for value in integer_mode):
+                continue
+            k = 2.0 * np.pi * np.asarray(integer_mode, dtype=float) / size
+            p = block53.lattice_vector(k)
+            kinetic, potential, hamiltonian, momentum, shift = spatial_operators(p)
+            inverse_kinetic = np.linalg.inv(kinetic)
+            for temporal_angle in temporal_angles:
+                temporal_momentum = float(2.0 * np.sin(temporal_angle / 2.0))
+                symbol = block77.centered_operator(
+                    np.concatenate((p, (temporal_momentum,)))
+                )
+                if mutation == "break_block77_bridge":
+                    symbol = 2.0 * symbol
+                canonical_target = (
+                    potential - temporal_momentum**2 * inverse_kinetic
+                )
+                canonical_scale_numerator += np.vdot(
+                    canonical_target,
+                    symbol[np.ix_(spatial_slots, spatial_slots)],
+                )
+                canonical_scale_denominator += float(
+                    np.vdot(canonical_target, canonical_target).real
+                )
+                canonical_scale_numerator += np.vdot(
+                    hamiltonian[0], symbol[0, spatial_slots]
+                )
+                canonical_scale_denominator += float(
+                    np.vdot(hamiltonian[0], hamiltonian[0]).real
+                )
+                momentum_target = (
+                    momentum
+                    @ inverse_kinetic
+                    @ (1.0j * temporal_momentum * IDENTITY6)
+                )
+                momentum_scale_numerator += np.vdot(
+                    momentum_target,
+                    symbol[np.ix_(shift_slots, spatial_slots)],
+                )
+                momentum_scale_denominator += float(
+                    np.vdot(momentum_target, momentum_target).real
+                )
+                residuals = (
+                    symbol[np.ix_(spatial_slots, spatial_slots)]
+                    - 0.5
+                    * canonical_target,
+                    symbol[0, spatial_slots] - 0.5 * hamiltonian[0],
+                    symbol[spatial_slots, 0]
+                    - 0.5 * hamiltonian.conj().T[:, 0],
+                    2.0
+                    * np.sqrt(2.0)
+                    * symbol[np.ix_(spatial_slots, shift_slots)]
+                    + 1.0j
+                    * temporal_momentum
+                    * inverse_kinetic
+                    @ shift,
+                    symbol[np.ix_(shift_slots, spatial_slots)]
+                    - momentum_target / (2.0 * np.sqrt(2.0)),
+                    symbol[np.ix_(shift_slots, shift_slots)]
+                    + momentum @ inverse_kinetic @ shift / 4.0,
+                    symbol[shift_slots, 0],
+                )
+                error = max(
+                    error,
+                    max(float(np.max(np.abs(residual))) for residual in residuals),
+                )
+                cases += 1
+
+    unit_shift_source = np.zeros((4, 4), dtype=float)
+    unit_shift_source[0, 3] = 1.0
+    unit_shift_source[3, 0] = 1.0
+    shift_coordinate_scale = float(
+        np.sum(block77.BASIS[block77.SHIFT_SLOTS[0]] * unit_shift_source)
+    )
+    canonical_scale = float(
+        (canonical_scale_numerator / canonical_scale_denominator).real
+    )
+    momentum_output_scale = float(
+        (momentum_scale_numerator / momentum_scale_denominator).real
+    )
+    covariant_source_coefficient_over_g = canonical_scale
+    constraint_factor = covariant_source_coefficient_over_g / canonical_scale
+    momentum_factor = (
+        covariant_source_coefficient_over_g
+        * shift_coordinate_scale
+        / momentum_output_scale
+    )
+    total_stress_impulse = covariant_source_coefficient_over_g / canonical_scale
+    kick_coefficient = total_stress_impulse / 0.5
+    normalizations = np.asarray(
+        (
+            constraint_factor,
+            momentum_factor,
+            kick_coefficient,
+            total_stress_impulse,
+        )
+    )
+    return cases, error, normalizations
+
+
+def placement(momentum: np.ndarray, co_locate: bool = False) -> np.ndarray:
+    if co_locate:
+        return np.eye(6, dtype=complex)
+    k = np.asarray(momentum, dtype=float)
+    return np.diag(
+        (
+            1.0,
+            1.0,
+            1.0,
+            np.exp(0.5j * (k[0] + k[1])),
+            np.exp(0.5j * (k[0] + k[2])),
+            np.exp(0.5j * (k[1] + k[2])),
+        )
+    )
+
+
+def homogeneous_macro(
+    kinetic: np.ndarray,
+    potential: np.ndarray,
+    depth: int = 2,
+) -> np.ndarray:
+    delta = 1.0 / depth
+    kick = np.block([[IDENTITY6, ZERO6], [-delta * potential, IDENTITY6]])
+    drift = np.block([[IDENTITY6, delta * kinetic], [ZERO6, IDENTITY6]])
+    return np.linalg.matrix_power(drift @ kick, depth)
+
+
+def support_shape(symbols: np.ndarray) -> tuple[int, int, int]:
+    size = symbols.shape[0]
+    kernel = np.fft.fftn(symbols, axes=(0, 1, 2)) / size**3
+    maximum = np.max(np.abs(kernel), axis=(-2, -1))
+    support = np.argwhere(maximum > 1.0e-10)
+    shifts = tuple(
+        np.where(index <= size // 2, index, index - size) for index in support
+    )
+    return (
+        len(support),
+        max(int(np.max(np.abs(shift))) for shift in shifts),
+        max(int(np.sum(np.abs(shift))) for shift in shifts),
+    )
+
+
+def locality_certificate(
+    mutation: str,
+) -> tuple[tuple[int, int, int], tuple[int, int, int], float, float, float]:
+    size = 7
+    potential_symbols = np.zeros((size, size, size, 6, 6), dtype=complex)
+    macro_symbols = np.zeros((size, size, size, 12, 12), dtype=complex)
+    for integer_mode in np.ndindex((size,) * 3):
+        k = 2.0 * np.pi * np.asarray(integer_mode) / size
+        p = block53.lattice_vector(k)
+        kinetic, potential, _, _, _ = spatial_operators(p)
+        field_placement = placement(k)
+        potential_symbols[integer_mode] = (
+            field_placement @ potential @ field_placement.conj().T
+        )
+        macro_placement = placement(k, mutation == "co_locate_macro")
+        state_placement = block_diag(macro_placement, macro_placement)
+        macro_symbols[integer_mode] = (
+            state_placement
+            @ homogeneous_macro(kinetic, potential)
+            @ state_placement.conj().T
+        )
+
+    probe = np.asarray((0.31, -0.47, 0.82))
+    p = block53.lattice_vector(probe)
+    kinetic, potential, _, _, _ = spatial_operators(p)
+    base_u = placement(probe)
+    base_potential = base_u @ potential @ base_u.conj().T
+    base_state_u = block_diag(base_u, base_u)
+    base_macro = (
+        base_state_u
+        @ homogeneous_macro(kinetic, potential)
+        @ base_state_u.conj().T
+    )
+    periodicity = 0.0
+    for axis in range(3):
+        shifted = probe.copy()
+        shifted[axis] += 2.0 * np.pi
+        shifted_p = block53.lattice_vector(shifted)
+        shifted_g, shifted_v, _, _, _ = spatial_operators(shifted_p)
+        shifted_u = placement(shifted)
+        shifted_state_u = block_diag(shifted_u, shifted_u)
+        periodicity = max(
+            periodicity,
+            float(
+                np.max(
+                    np.abs(
+                        shifted_u @ shifted_v @ shifted_u.conj().T
+                        - base_potential
+                    )
+                )
+            ),
+            float(
+                np.max(
+                    np.abs(
+                        shifted_state_u
+                        @ homogeneous_macro(shifted_g, shifted_v)
+                        @ shifted_state_u.conj().T
+                        - base_macro
+                    )
+                )
+            ),
+        )
+    hermiticity = float(np.max(np.abs(base_potential - base_potential.conj().T)))
+    raw_covariance = 0.0
+    covariance_probes = (
+        probe,
+        np.asarray((np.pi, -0.43, 0.71)),
+    )
+    for rotation in block53.proper_cubic_rotations():
+        representation = tensor_rotation(rotation)
+        state_representation = block_diag(representation, representation)
+        for k in covariance_probes:
+            rotated_k = rotation @ k
+            p0 = block53.lattice_vector(k)
+            p1 = block53.lattice_vector(rotated_k)
+            g0, v0, _, _, _ = spatial_operators(p0)
+            g1, v1, _, _, _ = spatial_operators(p1)
+
+            u0 = placement(k)
+            u1 = placement(rotated_k)
+            raw_tensor = u1 @ representation @ u0.conj().T
+            if mutation == "break_raw_covariance":
+                raw_tensor = representation.astype(complex)
+            raw_v0 = u0 @ v0 @ u0.conj().T
+            raw_v1 = u1 @ v1 @ u1.conj().T
+            raw_covariance = max(
+                raw_covariance,
+                float(
+                    np.max(
+                        np.abs(raw_v1 - raw_tensor @ raw_v0 @ raw_tensor.conj().T)
+                    )
+                ),
+            )
+
+            macro_co_located = mutation == "co_locate_macro"
+            um0 = placement(k, macro_co_located)
+            um1 = placement(rotated_k, macro_co_located)
+            state_u0 = block_diag(um0, um0)
+            state_u1 = block_diag(um1, um1)
+            raw_state_tensor = (
+                state_u1 @ state_representation @ state_u0.conj().T
+            )
+            raw_macro0 = (
+                state_u0
+                @ homogeneous_macro(g0, v0)
+                @ state_u0.conj().T
+            )
+            raw_macro1 = (
+                state_u1
+                @ homogeneous_macro(g1, v1)
+                @ state_u1.conj().T
+            )
+            raw_covariance = max(
+                raw_covariance,
+                float(
+                    np.max(
+                        np.abs(
+                            raw_macro1
+                            - raw_state_tensor
+                            @ raw_macro0
+                            @ raw_state_tensor.conj().T
+                        )
+                    )
+                ),
+            )
+    return (
+        support_shape(potential_symbols),
+        support_shape(macro_symbols),
+        periodicity,
+        hermiticity,
+        raw_covariance,
+    )
+
+
+def tt_stability_certificate(mutation: str) -> tuple[int, float, float, int, float, float]:
+    modes = 0
+    tt_error = 0.0
+    symplectic_error = 0.0
+    stable = 0
+    minimum_shadow = np.inf
+    modulus_error = 0.0
+    symplectic_form = np.block([[ZERO6, IDENTITY6], [-IDENTITY6, ZERO6]])
+    depth = 1 if mutation == "depth_one" else 2
+    for size in range(3, 13):
+        for integer_mode in np.ndindex((size,) * 3):
+            centered = np.asarray(integer_mode, dtype=int)
+            if np.all(centered == 0):
+                continue
+            k = 2.0 * np.pi * centered / size
+            p = block53.lattice_vector(k)
+            kappa_squared = float(p @ p)
+            kinetic, potential, _, _, _ = spatial_operators(p)
+            tt = null_space(block53.tt_constraint(k), rcond=1.0e-11)
+            tt_error = max(
+                tt_error,
+                float(
+                    np.max(
+                        np.abs(tt.T @ potential @ tt - kappa_squared * np.eye(2))
+                    )
+                ),
+                float(np.max(np.abs(tt.T @ kinetic @ tt - np.eye(2)))),
+            )
+            macro = homogeneous_macro(kinetic, potential, depth)
+            symplectic_error = max(
+                symplectic_error,
+                float(
+                    np.max(
+                        np.abs(macro.T @ symplectic_form @ macro - symplectic_form)
+                    )
+                ),
+            )
+            state_tt = block_diag(tt, tt)
+            physical_macro = state_tt.T @ macro @ state_tt
+            eigenvalues = np.linalg.eigvals(physical_macro)
+            current_modulus = float(np.max(np.abs(np.abs(eigenvalues) - 1.0)))
+            modulus_error = max(modulus_error, current_modulus)
+            _, _, shadow, _, _ = block53.split_substep(kappa_squared, depth)
+            current_shadow = float(np.min(np.linalg.eigvalsh(shadow)))
+            minimum_shadow = min(minimum_shadow, current_shadow)
+            stable += int(current_modulus < TOL and current_shadow > TOL)
+            modes += 1
+    return modes, tt_error, symplectic_error, stable, minimum_shadow, modulus_error
+
+
+def source_mode_data(
+    size: int,
+    axis: int,
+    sign: int,
+    neutral_step: int,
+    along: int,
+    transverse: int,
+    remaining: int,
+) -> tuple[np.ndarray, complex, complex, np.ndarray, np.ndarray, np.ndarray]:
+    neutral_axis = (axis + neutral_step) % 3
+    remaining_axis = (axis + (3 - neutral_step)) % 3
+    integers = np.zeros(3, dtype=int)
+    integers[axis] = along
+    integers[neutral_axis] = transverse
+    integers[remaining_axis] = remaining
+    k = 2.0 * np.pi * integers / size
+    density = 1.0 - np.exp(-1.0j * k[neutral_axis])
+    density_next = np.exp(-1.0j * sign * k[axis]) * density
+    incoming = np.zeros(3, dtype=complex)
+    outgoing = np.zeros(3, dtype=complex)
+    incoming[axis] = sign * np.exp(0.5j * sign * k[axis]) * density
+    outgoing[axis] = sign * np.exp(-0.5j * sign * k[axis]) * density
+    stress = np.zeros((3, 3), dtype=complex)
+    stress[axis, axis] = density
+    return k, density, density_next, incoming, outgoing, tensor_coordinates(stress)
+
+
+def schedule_residual(
+    k: np.ndarray,
+    density: complex,
+    density_next: complex,
+    incoming: np.ndarray,
+    outgoing: np.ndarray,
+    stress_coordinates: np.ndarray,
+    weights: tuple[float, float],
+    omit_stress: bool = False,
+    wrong_momentum_factor: bool = False,
+) -> tuple[float, float]:
+    p = block53.lattice_vector(k)
+    derivative = 1.0j * p
+    kinetic, potential, hamiltonian, momentum, shift = spatial_operators(p)
+    stress = coordinate_tensor(stress_coordinates)
+    source_ward = max(
+        abs(density_next - density + derivative @ outgoing),
+        float(
+            np.max(
+                np.abs(outgoing - incoming + 1.0j * (stress @ p))
+            )
+        ),
+    )
+
+    coupling = 1.0
+    initial_h = np.linalg.pinv(hamiltonian, rcond=1.0e-12) @ np.asarray(
+        (coupling * density,)
+    )
+    momentum_factor = 1.0 if wrong_momentum_factor else 2.0
+    initial_pi = np.linalg.pinv(momentum, rcond=1.0e-12) @ (
+        momentum_factor * coupling * incoming
+    )
+    used_stress = np.zeros(6, dtype=complex) if omit_stress else stress_coordinates
+    delta = 0.5
+    lapse0 = 0.17 + 0.03j
+    lapse1 = -0.11 + 0.07j
+    shift0 = np.asarray((0.2, -0.1, 0.3), dtype=complex)
+    shift1 = -shift0
+
+    pi1 = initial_pi + delta * (
+        -potential @ initial_h
+        + hamiltonian.conj().T[:, 0] * lapse0
+        + weights[0] * coupling * used_stress
+    )
+    h1 = initial_h + delta * (kinetic @ pi1 + shift @ shift0)
+    pi2 = pi1 + delta * (
+        -potential @ h1
+        + hamiltonian.conj().T[:, 0] * lapse1
+        + weights[1] * coupling * used_stress
+    )
+    h2 = h1 + delta * (kinetic @ pi2 + shift @ shift1)
+
+    midpoint_density = density - 0.5 * derivative @ outgoing
+    constraint_residual = max(
+        float(np.max(np.abs(momentum @ pi1 - 2.0 * coupling * outgoing))),
+        float(np.max(np.abs(momentum @ pi2 - 2.0 * coupling * outgoing))),
+        abs((hamiltonian @ h1)[0] - coupling * midpoint_density),
+        abs((hamiltonian @ h2)[0] - coupling * density_next),
+    )
+    return float(source_ward), float(constraint_residual)
+
+
+def source_schedule_certificate(mutation: str) -> tuple[int, float, int, float, int, float, int, float]:
+    modes = 0
+    source_ward_error = 0.0
+    baseline_failures = 0
+    baseline_error = 0.0
+    equal_failures = 0
+    equal_error = 0.0
+    late_failures = 0
+    late_error = 0.0
+    baseline_weights = (2.0, 0.0)
+    if mutation == "equal_source_split":
+        baseline_weights = (1.0, 1.0)
+    elif mutation == "late_source":
+        baseline_weights = (0.0, 2.0)
+    for size in range(3, 9):
+        for axis in range(3):
+            for sign in (-1, 1):
+                for neutral_step in (1, 2):
+                    for along in range(size):
+                        for transverse in range(1, size):
+                            for remaining in range(size):
+                                data = source_mode_data(
+                                    size,
+                                    axis,
+                                    sign,
+                                    neutral_step,
+                                    along,
+                                    transverse,
+                                    remaining,
+                                )
+                                ward, residual = schedule_residual(
+                                    *data,
+                                    baseline_weights,
+                                    omit_stress=mutation == "omit_spatial_stress",
+                                    wrong_momentum_factor=mutation == "wrong_momentum_factor",
+                                )
+                                _, equal = schedule_residual(*data, (1.0, 1.0))
+                                _, late = schedule_residual(*data, (0.0, 2.0))
+                                source_ward_error = max(source_ward_error, ward)
+                                baseline_error = max(baseline_error, residual)
+                                equal_error = max(equal_error, equal)
+                                late_error = max(late_error, late)
+                                baseline_failures += int(residual > TOL)
+                                equal_failures += int(equal > TOL)
+                                late_failures += int(late > TOL)
+                                modes += 1
+    if mutation == "accept_equal_split":
+        equal_failures = 0
+    return (
+        modes,
+        source_ward_error,
+        baseline_failures,
+        baseline_error,
+        equal_failures,
+        equal_error,
+        late_failures,
+        late_error,
+    )
+
+
+def add_complex_equation(
+    rows: list[list[float]],
+    targets: list[float],
+    coefficients: tuple[complex, complex],
+    target: complex,
+) -> None:
+    if max(abs(value) for value in coefficients) < 1.0e-12:
+        return
+    rows.append([float(value.real) for value in coefficients])
+    targets.append(float(target.real))
+    rows.append([float(value.imag) for value in coefficients])
+    targets.append(float(target.imag))
+
+
+def weight_uniqueness_certificate(mutation: str) -> tuple[int, int, np.ndarray, float]:
+    rows: list[list[float]] = []
+    targets: list[float] = []
+    delta = 0.5
+    samples = 0
+    for size in (3, 4):
+        for axis in range(3):
+            for sign in (-1, 1):
+                for neutral_step in (1, 2):
+                    for along in range(size):
+                        for transverse in range(1, size):
+                            data = source_mode_data(
+                                size, axis, sign, neutral_step, along, transverse, 0
+                            )
+                            k, _, _, incoming, outgoing, stress_coordinates = data
+                            p = block53.lattice_vector(k)
+                            derivative = 1.0j * p
+                            _, _, _, momentum, _ = spatial_operators(p)
+                            stress_momentum = momentum @ stress_coordinates
+                            difference = outgoing - incoming
+                            if mutation != "drop_midpoint_constraint":
+                                add_complex_equation(
+                                    rows,
+                                    targets,
+                                    (
+                                        0.5
+                                        * delta**2
+                                        * (derivative @ stress_momentum),
+                                        0.0j,
+                                    ),
+                                    delta * (derivative @ difference),
+                                )
+                            for component in range(3):
+                                add_complex_equation(
+                                    rows,
+                                    targets,
+                                    (
+                                        delta * stress_momentum[component],
+                                        delta * stress_momentum[component],
+                                    ),
+                                    2.0 * difference[component],
+                                )
+                            samples += 1
+    matrix = np.asarray(rows, dtype=float)
+    target = np.asarray(targets, dtype=float)
+    weights, _, rank, _ = np.linalg.lstsq(matrix, target, rcond=1.0e-12)
+    residual = float(np.max(np.abs(matrix @ weights - target)))
+    return samples, int(rank), weights, residual
+
+
+def cycle713_incoming_certificate(mutation: str) -> tuple[int, int, int, set[tuple[int, int, int]]]:
+    cases = 0
+    failures = 0
+    induction_checks = 0
+    directions: set[tuple[int, int, int]] = set()
+    for rotation in block67.b64.ROTATIONS:
+        for outcome, sign in block67.nonzero_menu0_pairs(rotation):
+            branch = block67.signed_branch(rotation, outcome, sign)
+            decoded = block67.decode_signed_source(branch.records)
+            if decoded is None:
+                failures += 1
+                continue
+            direction = np.asarray(decoded.direction, dtype=int)
+            head = np.asarray(decoded.head_site, dtype=int)
+            new_source = np.asarray(decoded.new_source, dtype=int)
+            old_source = np.asarray(decoded.old_source, dtype=int)
+            context = block67.b64.decode_context(branch.records[branch.head_site])
+            offset = new_source - head
+            if mutation == "co_locate_source_at_head":
+                offset = np.zeros(3, dtype=int)
+            y0 = head + offset
+            y_minus_one = y0 - direction
+            if mutation == "drop_incoming_segment":
+                y_minus_one = y0
+            local_ok = (
+                context is not None
+                and np.array_equal(offset, -np.asarray(context.transverse))
+                and np.array_equal(y0, new_source)
+                and np.array_equal(y_minus_one, old_source)
+                and int(np.sum(np.abs(offset))) == 1
+                and int(offset @ direction) == 0
+            )
+            failures += int(not local_ok)
+            previous = y_minus_one
+            for index in range(6):
+                head_n = head + index * direction
+                source_n = head_n + offset
+                failures += int(not np.array_equal(source_n - previous, direction))
+                previous = source_n
+                induction_checks += 1
+            directions.add(tuple(int(value) for value in direction))
+            cases += 1
+    return cases, failures, induction_checks, directions
+
+
+def isolated_boundary_certificate(mutation: str, note: str) -> tuple[int, float, bool]:
+    _, _, hamiltonian_zero, _, _ = spatial_operators(np.zeros(3))
+    density_before = 0.0
+    density_after = 1.0
+    incoming_flux_divergence = 0.0
+    boundary_defect = density_after - density_before + incoming_flux_divergence
+    best_zero_mode_field = np.linalg.pinv(
+        hamiltonian_zero, rcond=1.0e-12
+    ) @ np.asarray((boundary_defect,))
+    isolated_birth_residual = float(
+        np.linalg.norm(
+            hamiltonian_zero @ best_zero_mode_field
+            - np.asarray((boundary_defect,))
+        )
+    )
+    acknowledged = (
+        "actually isolated source" in note
+        and "incoming boundary flux or a reservoir/recoil tensor" in note
+        and "compact zero mode" in note
+    )
+    if mutation == "claim_isolated_birth":
+        acknowledged = False
+    return int(np.linalg.matrix_rank(hamiltonian_zero, TOL)), isolated_birth_residual, acknowledged
+
+
+def main() -> int:
+    checks = Checks()
+    mutation = os.environ.get("TOE_MUTATION", "")
+    note = flat(NOTE_PATH)
+    stacked_axioms = flat(AXIOM_PATH)
+    authority_axioms = git_blob_flat(CURRENT_AXIOM_BLOB)
+    resolved_authority_blob = git_commit_path_blob(
+        CURRENT_AXIOM_COMMIT, AXIOM_REPO_PATH
+    )
+    kinetic_note = flat(KINETIC_PATH)
+    block53_note = flat(BLOCK53_PATH)
+    block67_note = flat(BLOCK67_PATH)
+    block77_note = flat(BLOCK77_PATH)
+
+    checks.check(
+        "A-authority-and-parent-bindings",
+        "the content-addressed current foundation and Blocks 53, 67, and 77 are bound without importing a selected gravity law",
+        all((ROOT / path).exists() for path in AUDIT_INPUT_PATHS)
+        and mutation != "stale_axiom_authority"
+        and resolved_authority_blob == CURRENT_AXIOM_BLOB
+        and all(
+            phrase in authority_axioms and phrase in stacked_axioms
+            for phrase in (
+                "admissibility is not a dynamics axiom",
+                "a state is a configuration of records",
+                "records are permanent",
+            )
+        )
+        and "a site with no record cannot be read" in authority_axioms
+        and "finite additivity" in authority_axioms
+        and "are not record axiom content" in authority_axioms
+        and "c_t = c_s" in kinetic_note
+        and "positive shadow energy" in block53_note
+        and "keep the physical source at `o_s`" in block67_note
+        and "full constraint/source half-step schedule" in block77_note,
+    )
+
+    operator = operator_identity_certificate(mutation)
+    block77_bridge = block77_adm_bridge_certificate(mutation)
+    checks.check(
+        "B-full-linear-adm-polynomial-identities-and-cubic-covariance",
+        "the ADM complex closes exactly and is the canonical decomposition of Block 77's ten-component symbol",
+        operator[0] == 6065
+        and operator[1] < 5.0e-13
+        and operator[2] < 5.0e-13
+        and operator[3:] == ({1}, {3}, {4})
+        and block77_bridge[0] == 12130
+        and block77_bridge[1] < 5.0e-13
+        and np.max(
+            np.abs(block77_bridge[2] - np.asarray((1.0, 2.0, 2.0, 1.0)))
+        )
+        < 5.0e-13,
+        f"modes={operator[0]}; identity/covariance={operator[1]:.3e}/{operator[2]:.3e}; ranks H/M/TT={operator[3]}/{operator[4]}/{operator[5]}; Block77 bridge cases/error={block77_bridge[0]}/{block77_bridge[1]:.3e}; normalization C/M/kick/impulse={block77_bridge[2]}",
+    )
+
+    locality = locality_certificate(mutation)
+    checks.check(
+        "C-raw-finite-range-potential-and-depth-two-macro",
+        "the staggered spatial potential and complete homogeneous macro transfer are integer-Laurent finite-range laws",
+        locality[0] == (19, 1, 2)
+        and locality[1] == (57, 2, 3)
+        and locality[2] < 3.0e-13
+        and locality[3] < 3.0e-13
+        and locality[4] < 3.0e-13,
+        f"potential/macro support={locality[0]}/{locality[1]}; periodicity/Hermiticity/raw covariance={locality[2]:.3e}/{locality[3]:.3e}/{locality[4]:.3e}",
+    )
+
+    stability = tt_stability_certificate(mutation)
+    checks.check(
+        "D-two-tt-symplectic-full-zone-positive-depth-two-transfer",
+        "all nonzero L=3 through L=12 modes have two TT pairs, exact symplecticity, unit-circle transfer, and positive shadow form",
+        stability[0] == 6065
+        and stability[1] < 5.0e-13
+        and stability[2] < 5.0e-13
+        and stability[3] == 6065
+        and stability[4] > 0.23
+        and stability[5] < 5.0e-13,
+        f"modes/stable={stability[0]}/{stability[3]}; TT/symplectic/modulus={stability[1]:.3e}/{stability[2]:.3e}/{stability[5]:.3e}; min shadow={stability[4]:.6f}",
+    )
+
+    schedule = source_schedule_certificate(mutation)
+    checks.check(
+        "E-front-loaded-source-propagates-all-four-einstein-constraints",
+        "the (2,0) kick placement carries energy and momentum constraints across every signed neutral source mode",
+        schedule[0] == 13056
+        and schedule[1] < 5.0e-13
+        and schedule[2] == 0
+        and schedule[3] < 5.0e-12,
+        f"modes={schedule[0]}; source Ward={schedule[1]:.3e}; failures={schedule[2]}; max constraint={schedule[3]:.3e}",
+    )
+
+    checks.check(
+        "F-equal-and-late-source-placement-hostile-controls",
+        "equal and late stress splitting fail the generic sourced Hamiltonian midpoint while the front-loaded schedule passes",
+        schedule[4] == 11064
+        and schedule[5] > 3.9
+        and schedule[6] == 11064
+        and schedule[7] > 7.9,
+        f"equal failures/max={schedule[4]}/{schedule[5]:.6f}; late failures/max={schedule[6]}/{schedule[7]:.6f}",
+    )
+
+    weights = weight_uniqueness_certificate(mutation)
+    checks.check(
+        "G-source-weight-uniqueness-in-supplied-kick-first-order",
+        "midpoint and endpoint constraint equations derive the unique real weights (2,0) without fitting a response prefactor",
+        weights[0] == 216
+        and weights[1] == 2
+        and np.max(np.abs(weights[2] - np.asarray((2.0, 0.0)))) < 5.0e-13
+        and weights[3] < 5.0e-13,
+        f"samples={weights[0]}; rank={weights[1]}; weights={weights[2]}; residual={weights[3]:.3e}",
+    )
+
+    incoming = cycle713_incoming_certificate(mutation)
+    checks.check(
+        "H-cycle713-offset-decoder-supplies-the-incoming-source-segment",
+        "the content/frame-defined transverse offset maps Q to O_s and every later head finalization into one conserved source line",
+        incoming[0] == 96
+        and incoming[1] == 0
+        and incoming[2] == 576
+        and incoming[3] == set(block67.b64.DIRECTIONS),
+        f"branches={incoming[0]}; failures={incoming[1]}; induction checks={incoming[2]}; directions={len(incoming[3])}",
+    )
+
+    boundary = isolated_boundary_certificate(mutation, note)
+    checks.check(
+        "I-cycle713-no-birth-repair-and-isolated-zero-mode-boundary",
+        "Cycle713 uses its literal incoming hop, while genuinely isolated positive compact creation keeps an explicit boundary/reservoir wall",
+        boundary[0] == 0 and boundary[1] == 1.0 and boundary[2],
+        f"rank C(0)={boundary[0]}; isolated birth residual={boundary[1]:.1f}; boundary acknowledged={boundary[2]}",
+    )
+
+    scope_ok = all(
+        phrase in note
+        for phrase in (
+            "configuration of records",
+            "physical same-m2 source typing",
+            "zero toe percentage movement",
+            "no-go discipline gate status: fail",
+            "partial-narrowing",
+            "n1 -- alternative route enumeration",
+            "n8 -- cross-cycle echo",
+        )
+    )
+    if mutation in ("claim_record_native", "claim_complete"):
+        scope_ok = False
+    checks.check(
+        "J-record-cadence-ontology-selection-and-no-go-scope",
+        "the linear cadence result is separated from physical Record compilation, coupling/debit, nonlinear law, retention, and TOE promotion",
+        scope_ok,
+    )
+
+    print(
+        f"AXIOM_AUTHORITY: origin/main construction commit={CURRENT_AXIOM_COMMIT} immutable minimal-axiom blob={CURRENT_AXIOM_BLOB}; no removed scalar-I/additivity premise is imported"
+    )
+    print(
+        "N5_CERTIFICATE: 6065 nonzero L=3..12 modes, 12130 Block77 canonical bridge cases, 24 cubic frames, 13056 signed two-transverse-axis neutral source modes, 96 Cycle713 event branches, four Einstein constraints, and both internal half steps are resolved"
+    )
+    print(
+        "per_element: every spatial field and momentum coordinate, lapse row, three shift rows, and source-weight coefficient is checked; the physical source census injects diagonal ray stress only"
+    )
+    print(
+        "per_site: translation-representative vertex stress, face momentum flux, radius-one Q-to-O_s source hop, transverse head offset, and six-step continuation are checked on local carriers"
+    )
+    print(
+        "per_mode: all 6065 nonzero L=3 through L=12 spatial modes and all 13056 declared L=3 through L=8 two-transverse-axis neutral signed-source modes include even pi corners"
+    )
+    print(
+        "per_block: current-axiom binding, Block77 canonical decomposition, ADM identities, raw locality/covariance, TT stability, source conservation, constraints, coefficient uniqueness, and Cycle713 decoding are checked separately"
+    )
+    print(
+        "lattice_wide: checked and not executed — no physical same-M2 source compiler, gravity-state Record encoder, positive-mean boundary, exchange/debit law, or nonlinear selected gravity law is supplied"
+    )
+    print(
+        "SCHEDULE: the derived kick-first weights are (2,0); all 13056 source modes propagate four constraints, while equal and late placement fail 11064 modes"
+    )
+    print(
+        f"BLOCK77_BRIDGE: cases={block77_bridge[0]} residual={block77_bridge[1]:.3e}; derived normalization Ch/Mpi/first-kick/total-impulse={block77_bridge[2]}"
+    )
+    print(
+        "CYCLE713: Y_n=H_n+u_s keeps the physical source at O_s; Q->O_s is the incoming segment, so no birth impulse is needed on this conditional single front"
+    )
+    print(
+        "SCOPE: partial-positive linear cadence and source-decoder construction; no physical Record typing, coupling/debit, boundary selection, nonlinear completion, retention, obligation retirement, or TOE movement"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stacked on #6285 (Block 77).

This packet closes the missing full linear constraint/source schedule on the staggered incidence carrier without promoting it to a selected physical law.

Science result:
- derives the kick-first source weights (2,0) from midpoint Hamiltonian and endpoint momentum constraints;
- propagates all four sourced Einstein constraints on 13,056 two-transverse-axis neutral source modes;
- binds the ADM variables and normalization directly to Block 77 in 12,130 canonical decomposition cases;
- preserves 6,065/6,065 positive depth-two TT modes;
- verifies raw 19-shift potential and 57-shift macro locality/covariance;
- decodes the literal Cycle713 Q-to-O_s hop as the incoming segment on 96 event branches;
- keeps isolated positive compact birth, physical source typing, Record output, macro cadence, coupling/debit, boundary, nonlinear completion, selection, retention, and TOE movement open.

Evidence:
- runner TOTAL: PASS=10 FAIL=0;
- all 17 named mutations isolate at PASS=9 FAIL=1;
- current origin/main axiom commit and immutable blob are checked in-runner;
- source/input-pinned cache is fresh;
- strict audit lint has no errors;
- repository invariants pass with enforced links;
- citation graph 5,519 nodes / 15,845 edges, Block 78 out-degree 5;
- independent adversarial science review found no remaining mathematical publication blocker.

No-Go Discipline status: FAIL -- partial-narrowing. No obligation or TOE percentage is promoted by this PR.