### PR TITLE
feat(formdraw): PVM draw for lock content on the 3-site line

### DIFF
--- a/docs/L0_FORMATION_PVM_DRAW_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/L0_FORMATION_PVM_DRAW_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,99 @@
+---
+claim_id: l0_formation_pvm_draw_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the displayed 3-site line, an unread site with n≠0 has k=|3n|^2 and lock-content projectors P± of H=aσx+bσy+cσz. The two legal contents have traces Tr(ρP±)=(3±√k)/6. At the seed, C has k=1 and traces 2/3 and 1/3. Both contents leave occupancy 1, so R still forms on the next step. This replaces a=1 sign(n) by the displayed PVM. Not Born, not a unique member, not axiom text."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/l0_formation_pvm_draw_2026_08_14.py
+---
+
+# Formation Content Is A Displayed PVM Draw
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact `Q` traces for lock content on the displayed 3-site
+line. Not axiom text.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/l0_formation_pvm_draw_2026_08_14.py`](../scripts/l0_formation_pvm_draw_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Keep the #6290 occupancy step. Change only how a new lock chooses
+content. At an unread site with `n ≠ 0` write `k = |3n|^2` and
+`H = a σ_x + b σ_y + c σ_z`. The two legal contents are the
+rank-1 projectors `P_± = (√k I ± H)/(2√k)`. With
+`ρ = (I + H/3)/2` one has `Tr(ρ P_±) = (3 ± √k)/6`.
+
+On the seed `(−, ·, ·)` the center has `n_x = −1/3`, `k = 1`,
+traces `2/3` and `1/3`. Either content occupies the center, so
+the right site still forms on step 2. Later `n` is occupancy-only.
+
+This is still a comparator, not a TOE.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Q traces replace a=1 sign(n) by the displayed PVM on the 3-site line."
+trace_class: frontier_discovery
+target_claim_id: l0_formation_pvm_draw
+target_blocker_text: "intstep locks sign(n) with a=1; measure is disconnected"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit; cube+PVM joint update remains open"
+conditional_surface_status: "exact for the displayed 3-site line comparator"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+> When present, a record locks exactly one admissible local possibility.
+
+Those sentences do not name this draw.
+
+## Theorem 1 — seed kernel
+
+Seed `(−, ·, ·)`. Center has `n_x = −1/3`, `k = 1`, `H = −σ_x`.
+
+## Theorem 2 — traces
+
+`Tr(ρ P_+) = 2/3` and `Tr(ρ P_-) = 1/3`. Sum is `1`.
+
+## Theorem 3 — occupancy, not content, drives the next menu
+
+Both legal contents occupy the center. Step 2 forms the right site
+in either case.
+
+## Theorem 4 — not a TOE
+
+Quoted Qubit, Admissibility, and Record do not name the draw.
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “traces are `1/2, 1/2`” must fail.
+2. Predicate “a `+` content at `C` blocks `R`” must fail.
+3. Predicate “empty seed forms `C`” must fail.
+
+Identity gates: `nx(site, locks)`, `pvm_probs(a,b,c)`, `step(locks)`.
+
+## Honest-auditor / Boundary
+
+One line, `k=1` traces, occupancy-blind recoil. This note authors no
+audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No Born derivation.
+- Qubit remains `M_2(C)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11612,6 +11612,10 @@
   },
   "kubo_range_of_validity_note": {
    "deps_hash": "ba29b296b2a4",
+   "out_degree": 1
+  },
+  "l0_formation_pvm_draw_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a": {

--- a/logs/runner-cache/l0_formation_pvm_draw_2026_08_14.txt
+++ b/logs/runner-cache/l0_formation_pvm_draw_2026_08_14.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/l0_formation_pvm_draw_2026_08_14.py
+runner_sha256: 57eae5eb3da8ca7db1d5ea5d9f56ed6c66661c7da4326c6faaad05ad368d198a
+input_fingerprint_sha256: 8d95691d4078b2788531eca3102b13d9ca5dd2c45195e522647f6f6091a40da4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact Q traces for k=1 lock content
+negative_scope: comparator draw, not Born
+PASS: thm1-nx seed C has n_x=-1/3 and k=1
+PASS: thm2-tr Tr(ρP±) are 2/3 and 1/3
+PASS: thm3-both-form-R either content at C forms R on the next occupancy step
+PASS: thm3-empty empty seed forms nothing
+PASS: mutation-half-fails predicate traces are 1/2,1/2 must fail
+PASS: mutation-plus-blocks-fails predicate + at C blocks R must fail
+PASS: quoted note quotes Qubit, Admissibility, and lock
+PASS: boundary comparator not TOE, no forbidden phrases
+PASS: memo-silent axioms do not name the PVM draw
+PASS: gates identity gates and AUDIT_INPUT_PATHS
+per_element: checked exactly — k=1 H=-σx projectors
+per_site: checked exactly — C traces; R forms for both contents
+per_mode: checked exactly — occupancy step plus displayed PVM
+per_block: checked exactly — measure, not a=1
+lattice_wide: checked and not executed — not Born
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/l0_formation_pvm_draw_2026_08_14.py
+++ b/scripts/l0_formation_pvm_draw_2026_08_14.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""PVM draw for lock content on the displayed 3-site line."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "L0_FORMATION_PVM_DRAW_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/L0_FORMATION_PVM_DRAW_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+L, C, R = 0, 1, 2
+MINUS, PLUS, NONE = "-", "+", None
+THIRD = Fraction(-1, 3)
+
+
+def occupancy(locks: tuple) -> tuple[int, int, int]:
+    """Identity gate."""
+    return tuple(0 if lock is NONE else 1 for lock in locks)
+
+
+def nx(site: int, locks: tuple) -> Fraction:
+    """Identity gate."""
+    occ = occupancy(locks)
+    left = occ[site - 1] if site > L else 0
+    right = occ[site + 1] if site < R else 0
+    return Fraction(right - left, 3)
+
+
+def step(locks: tuple) -> tuple:
+    """Identity gate: occupancy update; content of a new lock is not chosen here."""
+    out = []
+    for site, lock in enumerate(locks):
+        if lock is not NONE:
+            out.append(lock)
+            continue
+        out.append(MINUS if nx(site, locks) != 0 else NONE)
+    return tuple(out)
+
+
+def madd(a, b):
+    return ((a[0][0] + b[0][0], a[0][1] + b[0][1]), (a[1][0] + b[1][0], a[1][1] + b[1][1]))
+
+
+def mmul(a, b):
+    return (
+        (a[0][0] * b[0][0] + a[0][1] * b[1][0], a[0][0] * b[0][1] + a[0][1] * b[1][1]),
+        (a[1][0] * b[0][0] + a[1][1] * b[1][0], a[1][0] * b[0][1] + a[1][1] * b[1][1]),
+    )
+
+
+def mscale(c, a):
+    return ((c * a[0][0], c * a[0][1]), (c * a[1][0], c * a[1][1]))
+
+
+def I2():
+    z, o = Fraction(0), Fraction(1)
+    return ((o, z), (z, o))
+
+
+def SX():
+    z, o = Fraction(0), Fraction(1)
+    return ((z, o), (o, z))
+
+
+def pvm_probs(a: int, b: int, c: int):
+    """Identity gate: Tr(ρ P±) for H=aσx (k=1 displayed case uses b=c=0)."""
+    if b != 0 or c != 0:
+        raise ValueError("displayed runner checks the k=1 seed only")
+    h = mscale(Fraction(a), SX())
+    half = Fraction(1, 2)
+    pplus = mscale(half, madd(I2(), h))
+    pminus = mscale(half, madd(I2(), mscale(Fraction(-1), h)))
+    rho = mscale(half, madd(I2(), mscale(Fraction(1, 3), h)))
+    tr_p = rho[0][0] * pplus[0][0] + rho[0][1] * pplus[1][0] + rho[1][0] * pplus[0][1] + rho[1][1] * pplus[1][1]
+    tr_m = rho[0][0] * pminus[0][0] + rho[0][1] * pminus[1][0] + rho[1][0] * pminus[0][1] + rho[1][1] * pminus[1][1]
+    return tr_p, tr_m
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact Q traces for k=1 lock content")
+    print("negative_scope: comparator draw, not Born")
+
+    seed = (MINUS, NONE, NONE)
+    checks.check("thm1-nx", "seed C has n_x=-1/3 and k=1", nx(C, seed) == THIRD)
+    tp, tm = pvm_probs(-1, 0, 0)
+    checks.check("thm2-tr", "Tr(ρP±) are 2/3 and 1/3", tp == Fraction(2, 3) and tm == Fraction(1, 3) and tp + tm == 1)
+    plus_c = (MINUS, PLUS, NONE)
+    minus_c = (MINUS, MINUS, NONE)
+    checks.check(
+        "thm3-both-form-R",
+        "either content at C forms R on the next occupancy step",
+        step(plus_c)[R] is not NONE and step(minus_c)[R] is not NONE,
+    )
+    checks.check("thm3-empty", "empty seed forms nothing", step((NONE, NONE, NONE)) == (NONE, NONE, NONE))
+    checks.check("mutation-half-fails", "predicate traces are 1/2,1/2 must fail", tp != Fraction(1, 2))
+    checks.check("mutation-plus-blocks-fails", "predicate + at C blocks R must fail", step(plus_c)[R] is not NONE)
+    checks.check(
+        "quoted",
+        "note quotes Qubit, Admissibility, and lock",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note
+        and "locks exactly one admissible local possibility" in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "therefore Born", "exhausted", "closes the route", "Lattice-named")
+    checks.check(
+        "boundary",
+        "comparator not TOE, no forbidden phrases",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name the PVM draw", "PVM draw" not in four and "formdraw" not in four)
+    checks.check(
+        "gates",
+        "identity gates and AUDIT_INPUT_PATHS",
+        "def nx(" in self_source
+        and "def pvm_probs(" in self_source
+        and "def step(" in self_source
+        and AUDIT_INPUT_PATHS == (
+            "docs/L0_FORMATION_PVM_DRAW_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — k=1 H=-σx projectors")
+    print("per_site: checked exactly — C traces; R forms for both contents")
+    print("per_mode: checked exactly — occupancy step plus displayed PVM")
+    print("per_block: checked exactly — measure, not a=1")
+    print("lattice_wide: checked and not executed — not Born")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Campaign `toe-lphys-20260812`. Puts the #6291 `k=1` PVM into the #6290 line step: unread `n≠0` lock *content* is a draw from `Tr(ρP±)=(3±1)/6`, not `a=1` sign(`n`). Both contents at `C` are legal. Occupancy of `C` is 1 either way, so `R` still forms. Empty seed forms nothing.

Not Born. Not a unique member. Not axiom text. `L0` remains a comparator.

## What changed

- Note: `docs/L0_FORMATION_PVM_DRAW_BOUNDED_THEOREM_NOTE_2026-08-14.md`
- Runner: `scripts/l0_formation_pvm_draw_2026_08_14.py`
- Cache: `logs/runner-cache/l0_formation_pvm_draw_2026_08_14.txt`

## Verification

```bash
python3 scripts/l0_formation_pvm_draw_2026_08_14.py
# TOTAL: PASS=10 FAIL=0
```

## Trace

Retires “intstep locks sign(`n`) with `a=1`” as the content rule on the displayed line. Later `n` still depends only on occupancy. No axiom PR.
