### PR TITLE
feat(linespd): speed-1 formation wave on a 5-site line

### DIFF
--- a/docs/FIVE_SITE_LINE_SPEED_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/FIVE_SITE_LINE_SPEED_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,96 @@
+---
+claim_id: five_site_line_speed_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On a displayed 5-site line the occupancy step has speed 1: a seed lock at site 0 makes site i form at step i and not earlier. After t steps, sites 0..t are locked and t+1..4 are unread. Source/tick go 0,1,2,3,4,4. The empty line is a fixed point. This is a light-cone bound on composition, not Newton, not axiom text."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/five_site_line_speed_2026_08_14.py
+---
+
+# Five-Site Line, Speed One
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock snapshots on five sites. Not axiom text.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/five_site_line_speed_2026_08_14.py`](../scripts/five_site_line_speed_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Sites `0,1,2,3,4` on a line. `n_x = (o_right − o_left)/3`. Locked
+sites stay. An unread site forms iff `n_x ≠ 0`.
+
+Seed lock at site `0`. Site `i` first has `n_x ≠ 0` when site
+`i−1` is occupied, so it forms at step `i` and not earlier.
+After `t` steps the locked set is `{0,…,t}`. Step 5 is the
+identity. Source/tick: `0 → 1 → 2 → 3 → 4 → 4`.
+
+This is still a comparator, not a TOE.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact speed-1 formation wave on a displayed 5-site line."
+trace_class: frontier_discovery
+target_claim_id: five_site_line_speed
+target_blocker_text: "composition is only two ticks / three sites"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed 5-site line"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site never carries more than one record; records are permanent.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences do not name this wave.
+
+## Theorem 1 — cone
+
+For each `t = 0,…,4`, after `t` steps sites `0..t` are locked
+and sites `t+1..4` are unread.
+
+## Theorem 2 — site 3 is unread until step 3
+
+At `t = 1`, site 3 has `n_x = 0`. At `t = 2` it is still unread
+but `n_x ≠ 0`. At `t = 3` it is locked.
+
+## Theorem 3 — permanence and empty
+
+Step 5 does not form. The empty line is a fixed point.
+
+## Theorem 4 — not a TOE
+
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “site 3 forms at step 2” must fail.
+2. Predicate “step 5 increments source” must fail.
+3. Predicate “empty line forms site 0” must fail.
+
+Identity gates: `nx(site, locks)`, `step(locks)`, `locked_prefix(locks)`.
+
+## Honest-auditor / Boundary
+
+Five sites, six snapshots, exact `Q`. Not Newton. This note
+authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No continuum light cone.
+- Qubit remains `M_2(C)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4693,6 +4693,10 @@
   "first_order_coframe_unconditionality_no_go_theorem_note_2026-04-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "five_site_line_speed_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "fixed_field_complex_grown_basin_v2_note": {
    "deps_hash": "9b334c2c3616",

--- a/logs/runner-cache/five_site_line_speed_2026_08_14.txt
+++ b/logs/runner-cache/five_site_line_speed_2026_08_14.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/five_site_line_speed_2026_08_14.py
+runner_sha256: d48a9ff2b0f22a9ee80690adc8a38b4733ea3bbb7b691500374fbc65b3e2de57
+input_fingerprint_sha256: 7c018a51d713dbbe0571364f3636f3e538c57c189e7b4d6a9f6c94848c410966
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact Q 5-site speed-1 wave
+negative_scope: line comparator, not a TOE
+PASS: thm1-cone after t steps, prefix t+1 is locked
+PASS: thm2-site3-t1 at t=1 site 3 has n_x=0 and is unread
+PASS: thm2-site3-t2 at t=2 site 3 is unread with n_x≠0
+PASS: thm2-site3-t3 site 3 forms at step 3
+PASS: thm3-step5 step 5 is identity
+PASS: thm3-source source/tick are 0,1,2,3,4,4
+PASS: thm3-empty empty line is a fixed point
+PASS: mutation-early-fails predicate site 3 forms at step 2 must fail
+PASS: mutation-step5-fails predicate step 5 increments source must fail
+PASS: mutation-empty-fails predicate empty forms site 0 must fail
+PASS: quoted note quotes lock, permanence, and NN distribution
+PASS: boundary not TOE, no forbidden phrases
+PASS: memo-silent axioms do not name the 5-site wave
+PASS: gates identity gates and AUDIT_INPUT_PATHS
+per_element: checked exactly — five sites, n_x
+per_site: checked exactly — cone, site 3 delay, empty
+per_mode: checked exactly — speed-1 composition
+per_block: checked exactly — light-cone, not recoil-as-menu
+lattice_wide: checked and not executed — no law adopted
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/five_site_line_speed_2026_08_14.py
+++ b/scripts/five_site_line_speed_2026_08_14.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Five-site occupancy wave with speed 1."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "FIVE_SITE_LINE_SPEED_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/FIVE_SITE_LINE_SPEED_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+N = 5
+NONE = None
+LOCK = "-"
+
+
+def occupancy(locks: tuple) -> tuple:
+    return tuple(0 if x is NONE else 1 for x in locks)
+
+
+def nx(site: int, locks: tuple) -> Fraction:
+    """Identity gate."""
+    occ = occupancy(locks)
+    left = occ[site - 1] if site > 0 else 0
+    right = occ[site + 1] if site < N - 1 else 0
+    return Fraction(right - left, 3)
+
+
+def step(locks: tuple) -> tuple:
+    """Identity gate."""
+    out = []
+    for site, lock in enumerate(locks):
+        if lock is not NONE:
+            out.append(lock)
+        else:
+            out.append(LOCK if nx(site, locks) != 0 else NONE)
+    return tuple(out)
+
+
+def locked_prefix(locks: tuple) -> int:
+    """Identity gate: number of leading locks, or -1 if a hole exists."""
+    count = 0
+    seen_unread = False
+    for lock in locks:
+        if lock is not NONE:
+            if seen_unread:
+                return -1
+            count += 1
+        else:
+            seen_unread = True
+    return count
+
+
+def formed(before: tuple, after: tuple) -> int:
+    return sum(1 for b, a in zip(before, after) if b is NONE and a is not NONE)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact Q 5-site speed-1 wave")
+    print("negative_scope: line comparator, not a TOE")
+
+    state = (LOCK,) + (NONE,) * 4
+    snapshots = [state]
+    source = [0]
+    for _ in range(5):
+        nxt = step(state)
+        source.append(source[-1] + formed(state, nxt))
+        state = nxt
+        snapshots.append(state)
+
+    cone_ok = all(locked_prefix(snapshots[t]) == t + 1 for t in range(5))
+    checks.check("thm1-cone", "after t steps, prefix t+1 is locked", cone_ok)
+    checks.check("thm2-site3-t1", "at t=1 site 3 has n_x=0 and is unread", snapshots[1][3] is NONE and nx(3, snapshots[1]) == 0)
+    checks.check("thm2-site3-t2", "at t=2 site 3 is unread with n_x≠0", snapshots[2][3] is NONE and nx(3, snapshots[2]) != 0)
+    checks.check("thm2-site3-t3", "site 3 forms at step 3", snapshots[3][3] is not NONE)
+    checks.check("thm3-step5", "step 5 is identity", snapshots[5] == snapshots[4] and source[5] == 4)
+    checks.check("thm3-source", "source/tick are 0,1,2,3,4,4", source == [0, 1, 2, 3, 4, 4])
+    empty = (NONE,) * 5
+    checks.check("thm3-empty", "empty line is a fixed point", step(empty) == empty)
+    checks.check("mutation-early-fails", "predicate site 3 forms at step 2 must fail", snapshots[2][3] is NONE)
+    checks.check("mutation-step5-fails", "predicate step 5 increments source must fail", source[5] == source[4])
+    checks.check("mutation-empty-fails", "predicate empty forms site 0 must fail", step(empty)[0] is NONE)
+    checks.check(
+        "quoted",
+        "note quotes lock, permanence, and NN distribution",
+        "locks exactly one admissible local possibility" in note
+        and "records are permanent" in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "Lattice-named", "exhausted", "closes the route")
+    checks.check(
+        "boundary",
+        "not TOE, no forbidden phrases",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name the 5-site wave", "5-site" not in four and "linespd" not in four)
+    checks.check(
+        "gates",
+        "identity gates and AUDIT_INPUT_PATHS",
+        "def nx(" in self_source
+        and "def step(" in self_source
+        and "def locked_prefix(" in self_source
+        and AUDIT_INPUT_PATHS == (
+            "docs/FIVE_SITE_LINE_SPEED_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — five sites, n_x")
+    print("per_site: checked exactly — cone, site 3 delay, empty")
+    print("per_mode: checked exactly — speed-1 composition")
+    print("per_block: checked exactly — light-cone, not recoil-as-menu")
+    print("lattice_wide: checked and not executed — no law adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Campaign `toe-lphys-20260812`. Five-site line, seed at site 0: a formation wave of speed 1. After `t` steps, sites `0..t` are locked. Site `i` has `n_x=0` until site `i−1` is occupied, so it never forms earlier than step `i`. Step 5 is identity. Source/tick `0,1,2,3,4,4`. Empty line is a fixed point.

Light-cone / finite speed, not recoil as a menu table. Not Newton. Not a TOE.

## What changed

- Note: `docs/FIVE_SITE_LINE_SPEED_BOUNDED_THEOREM_NOTE_2026-08-14.md`
- Runner: `scripts/five_site_line_speed_2026_08_14.py`
- Cache: `logs/runner-cache/five_site_line_speed_2026_08_14.txt`

## Verification

```bash
python3 scripts/five_site_line_speed_2026_08_14.py
# TOTAL: PASS=14 FAIL=0
```

## Trace

Retires “composition is only the two-tick recstack / 3-site intstep.” No axiom PR.
