### PR TITLE
feat(stepcov): cube occupancy step commutes with a 90° rotation

### DIFF
--- a/docs/CUBE_STEP_ROTATION_COVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/CUBE_STEP_ROTATION_COVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,106 @@
+---
+claim_id: cube_step_rotation_covariance_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the displayed 2×2×2 cube, the occupancy step commutes with the 90° rotation (x,y,z)↦(1−y,x,z) about the cube center: R(step(s))=step(R(s)) on all 256 occupancy configurations. A seed at (0,0,0) rotates to a seed at another corner and the formation pattern rotates with it. Empty cube is fixed. Covariance of the update, not of n. Not a TOE, not axiom text."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cube_step_rotation_covariance_2026_08_14.py
+---
+
+# Cube Step Commutes With A 90° Rotation
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact covariance of the `{0,1}^3` occupancy update
+under one proper-cube generator. Not axiom text.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cube_step_rotation_covariance_2026_08_14.py`](../scripts/cube_step_rotation_covariance_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Same 2×2×2 occupancy step as the cube6nn comparator: locked
+sites stay; unread sites form iff `n≠0`; off-cube occupancy is
+`0`. A 90° rotation about `z` through the cube center acts by
+
+```text
+(x, y, z) ↦ (1 − y, x, z)
+```
+
+on `{0,1}^3`. For every one of the 256 occupancy configurations,
+`R(step(s))=step(R(s))`.
+
+A seed at `(0,0,0)` rotates to a seed at another corner; the
+formation pattern rotates with it. The empty cube is fixed.
+
+This is covariance of the *update*, not of `n`. Not a TOE.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact R(step(s))=step(R(s)) on all 256 cube occupancies."
+trace_class: frontier_discovery
+target_claim_id: cube_step_rotation_covariance
+target_blocker_text: "the cube step picks an origin"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed 2x2x2 cube and one 90° generator"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site never carries more than one record; records are permanent.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences do not name this covariance.
+
+## Theorem 1 — rotation of the cube
+
+`(x,y,z)↦(1−y,x,z)` is a permutation of `{0,1}^3` of order 4.
+
+## Theorem 2 — all 256 configs
+
+`R(step(s))=step(R(s))` on every occupancy configuration.
+
+## Theorem 3 — seed rotates
+
+Seed `(0,0,0)` maps to `(1,0,0)`. The step-1 trio rotates with it.
+
+## Theorem 4 — empty cube
+
+The empty cube is a fixed point of both `R` and `step`.
+
+## Theorem 5 — not a TOE
+
+Quoted Record and Admissibility do not name the covariance.
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “some config fails `R∘step=step∘R`” must fail.
+2. Predicate “seed stays at `(0,0,0)` under `R`” must fail.
+3. Predicate “note adopts the cube step” must fail.
+
+Identity gates: `rotate`, `n_at`, `step`.
+
+## Honest-auditor / Boundary
+
+256 configurations, one generator, exact `Q`. This note
+authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No Born derivation.
+- Qubit remains `M_2(C)`.

--- a/logs/runner-cache/cube_step_rotation_covariance_2026_08_14.txt
+++ b/logs/runner-cache/cube_step_rotation_covariance_2026_08_14.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/cube_step_rotation_covariance_2026_08_14.py
+runner_sha256: fb6cf5fa0a9fa7ed025039268cd11f690d22d50dfbc538020cedee12267f8424
+input_fingerprint_sha256: c1efbc9e7d86fcc2e41a54454144860654615fe3d22972e23ca5a5ecc088169d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact Q cube-step covariance
+negative_scope: update covariance, not a TOE
+PASS: thm1-perm R is a 4-cycle on the z=0 face and permutes the cube
+PASS: thm2-256 R(step(s))=step(R(s)) on all 256 configs
+PASS: thm3-seed R sends seed (0,0,0) to (1,0,0)
+PASS: thm3-pattern rotated step-1 equals step of rotated seed
+PASS: thm4-empty empty cube is fixed by R and step
+PASS: mutation-cov-fails predicate some config fails covariance must fail
+PASS: mutation-seed-stay-fails predicate seed stays at origin under R must fail
+PASS: quoted note quotes lock, permanence, and NN distribution
+PASS: boundary not TOE, no forbidden phrases
+PASS: memo-silent axioms do not name the covariance
+PASS: gates identity gates present
+per_element: checked exactly — 256 occupancy configs
+per_site: checked exactly — 8 cube sites
+per_mode: checked exactly — one 90° generator
+per_block: checked exactly — covariance of step, not of n
+lattice_wide: checked and not executed — not a TOE
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cube_step_rotation_covariance_2026_08_14.py
+++ b/scripts/cube_step_rotation_covariance_2026_08_14.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Occupancy step commutes with a cube-center 90° rotation."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "CUBE_STEP_ROTATION_COVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CUBE_STEP_ROTATION_COVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+SITES = tuple((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+NONE = None
+MARK = "-"
+
+
+def rotate(site: tuple) -> tuple:
+    """Identity gate: (x,y,z) -> (1-y, x, z)."""
+    x, y, z = site
+    return (1 - y, x, z)
+
+
+def rotate_cfg(locks: dict) -> dict:
+    return {rotate(s): locks[s] for s in SITES}
+
+
+def n_at(site: tuple, locks: dict) -> tuple:
+    """Identity gate."""
+    occ = {s: 0 if locks[s] is NONE else 1 for s in SITES}
+    out = []
+    for e in AXES:
+        plus = (site[0] + e[0], site[1] + e[1], site[2] + e[2])
+        minus = (site[0] - e[0], site[1] - e[1], site[2] - e[2])
+        op = occ[plus] if plus in occ else 0
+        om = occ[minus] if minus in occ else 0
+        out.append(Fraction(op - om, 3))
+    return tuple(out)
+
+
+def step(locks: dict) -> dict:
+    """Identity gate."""
+    out = {}
+    for site in SITES:
+        if locks[site] is not NONE:
+            out[site] = locks[site]
+            continue
+        n = n_at(site, locks)
+        out[site] = NONE if n == (0, 0, 0) else MARK
+    return out
+
+
+def cfg_from_mask(mask: int) -> dict:
+    return {s: (MARK if mask & (1 << i) else NONE) for i, s in enumerate(SITES)}
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact Q cube-step covariance")
+    print("negative_scope: update covariance, not a TOE")
+
+    orbit = [(0, 0, 0)]
+    for _ in range(3):
+        orbit.append(rotate(orbit[-1]))
+    checks.check("thm1-perm", "R is a 4-cycle on the z=0 face and permutes the cube",
+                 len(set(orbit)) == 4 and all(rotate(rotate(rotate(rotate(s)))) == s for s in SITES) and set(rotate(s) for s in SITES) == set(SITES))
+
+    failed = 0
+    for mask in range(256):
+        s = cfg_from_mask(mask)
+        left = rotate_cfg(step(s))
+        right = step(rotate_cfg(s))
+        if left != right:
+            failed += 1
+    checks.check("thm2-256", "R(step(s))=step(R(s)) on all 256 configs", failed == 0)
+
+    seed = {s: NONE for s in SITES}
+    seed[(0, 0, 0)] = MARK
+    checks.check("thm3-seed", "R sends seed (0,0,0) to (1,0,0)", rotate((0, 0, 0)) == (1, 0, 0))
+    s1 = step(seed)
+    rs1 = rotate_cfg(s1)
+    rseed = rotate_cfg(seed)
+    checks.check("thm3-pattern", "rotated step-1 equals step of rotated seed", rs1 == step(rseed) and rseed[(1, 0, 0)] == MARK)
+    empty = {s: NONE for s in SITES}
+    checks.check("thm4-empty", "empty cube is fixed by R and step", rotate_cfg(empty) == empty and step(empty) == empty)
+    checks.check("mutation-cov-fails", "predicate some config fails covariance must fail", failed == 0)
+    checks.check("mutation-seed-stay-fails", "predicate seed stays at origin under R must fail", rotate((0, 0, 0)) != (0, 0, 0))
+    checks.check(
+        "quoted",
+        "note quotes lock, permanence, and NN distribution",
+        "locks exactly one admissible local possibility" in note
+        and "records are permanent" in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note,
+    )
+    forbidden = ("Lattice-named", "we adopt", "L_phys", "0.5934", "pairing-on-J", "exhausted", "closes the route", "only route")
+    checks.check(
+        "boundary",
+        "not TOE, no forbidden phrases",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name the covariance", "stepcov" not in four and "R(step" not in four)
+    checks.check(
+        "gates",
+        "identity gates present",
+        "def rotate(" in self_source
+        and "def n_at(" in self_source
+        and "def step(" in self_source
+        and NOTE_PATH.is_file()
+        and AUDIT_INPUT_PATHS[0].endswith("CUBE_STEP_ROTATION_COVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-14.md"),
+    )
+    print("per_element: checked exactly — 256 occupancy configs")
+    print("per_site: checked exactly — 8 cube sites")
+    print("per_mode: checked exactly — one 90° generator")
+    print("per_block: checked exactly — covariance of step, not of n")
+    print("lattice_wide: checked and not executed — not a TOE")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Campaign `toe-lphys-20260812`. On the displayed `2×2×2` cube, the occupancy step commutes with the 90° rotation `(x,y,z)↦(1−y,x,z)` about the cube center: `R(step(s))=step(R(s))` on all 256 occupancy configurations. A seed at `(0,0,0)` rotates to another corner and the formation pattern rotates with it. Empty cube is fixed.

Covariance of the *update*, not of `n`. Not a TOE. Not axiom text.

## What changed

- Note: `docs/CUBE_STEP_ROTATION_COVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-14.md`
- Runner: `scripts/cube_step_rotation_covariance_2026_08_14.py`
- Cache: `logs/runner-cache/cube_step_rotation_covariance_2026_08_14.txt`

## Verification

```bash
python3 scripts/cube_step_rotation_covariance_2026_08_14.py
# TOTAL: PASS=11 FAIL=0
```

## Trace

Retires “the cube step picks an origin.” No axiom PR.
