### PR TITLE
feat(cubepvm): cube occupancy step with PVM lock-content traces

### DIFF
--- a/docs/CUBE_222_PVM_CONTENT_STEP_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/CUBE_222_PVM_CONTENT_STEP_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,105 @@
+---
+claim_id: cube_222_pvm_content_step_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the displayed 2×2×2 cube, one occupancy step forms unread sites with n≠0. Newly formed sites have k=|3n|^2 and lock-content traces Tr(ρP±)=(3±√k)/6: axis neighbors k=1 traces 2/3 and 1/3, face-diagonals k=2 traces (3±√2)/6, opposite corner k=3 traces (3±√3)/6. Either content still occupies the site, so later menus are unchanged. Source/tick 0→3→6→7→7. Not Born, not a unique member, not axiom text."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cube_222_pvm_content_step_2026_08_14.py
+---
+
+# Cube Occupancy Step With PVM Lock Content
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact occupancy update plus exact `Q(√k)` traces on a
+displayed `2×2×2` cube. Not axiom text.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cube_222_pvm_content_step_2026_08_14.py`](../scripts/cube_222_pvm_content_step_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Same occupancy step as #6293. When a site forms, `k = |3n|^2`
+and the two legal contents have traces `(3 ± √k)/6` from the
+#6296 projectors. Seed `(0,0,0)`:
+
+- step 1, axis neighbors, `k = 1`, traces `2/3` and `1/3`;
+- step 2, face-diagonals, `k = 2`, traces `(3 ± √2)/6`;
+- step 3, `(1,1,1)`, `k = 3`, traces `(3 ± √3)/6`.
+
+Either content occupies the site, so later `n` does not depend
+on the draw. Source/tick `0 → 3 → 6 → 7 → 7`.
+
+This is still a comparator, not a TOE.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact cube occupancy step coupled to the displayed PVM traces."
+trace_class: frontier_discovery
+target_claim_id: cube_222_pvm_content_step
+target_blocker_text: "cube step is occupancy-only; PVM draw is line-only"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed 2x2x2 comparator"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+> When present, a record locks exactly one admissible local possibility.
+
+Those sentences do not name this coupled update.
+
+## Theorem 1 — occupancy wave
+
+Seed at the origin. Source/tick `0,3,6,7,7`. Empty cube is a
+fixed point.
+
+## Theorem 2 — `k` at each shell
+
+Axis sites have `k = 1`. Face-diagonals have `k = 2`. The
+opposite corner has `k = 3`.
+
+## Theorem 3 — traces
+
+The displayed PVM traces are `(3 ± √k)/6` at each shell.
+
+## Theorem 4 — occupancy, not content, drives later menus
+
+Either legal content at an axis site still occupies it, so the
+face-diagonals still form.
+
+## Theorem 5 — not a TOE
+
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “axis sites have `k = 2`” must fail.
+2. Predicate “empty cube forms” must fail.
+3. Predicate “note adopts Born” must fail.
+
+Identity gates: `nvec(site, locks)`, `k_of(n)`, `step(locks)`.
+
+## Honest-auditor / Boundary
+
+Eight sites, three shells, exact `Q` traces. This note authors no
+audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No Born derivation.
+- Qubit remains `M_2(C)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2757,6 +2757,10 @@
   "cte_rconn_spatial_tensor_color_bridge_is_a_cross_domain_coincidence_narrow_no_go_note_2026-06-08": {
    "deps_hash": "825a4024d61b",
    "out_degree": 4
+  },
+  "cube_222_pvm_content_step_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
    "deps_hash": "04fc7d8812c4",

--- a/logs/runner-cache/cube_222_pvm_content_step_2026_08_14.txt
+++ b/logs/runner-cache/cube_222_pvm_content_step_2026_08_14.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/cube_222_pvm_content_step_2026_08_14.py
+runner_sha256: bbd7a370826c003c59d4eb34b6115964bcd17723c5c0af8eadd03888c0bd307e
+input_fingerprint_sha256: 3e8d8d4607b0bf223f3a563a5a842430f8aa0fe7c72f7ff5baa0263adf1b2d0e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact cube occupancy plus Q(√k) traces
+negative_scope: coupled comparator, not Born
+PASS: thm1-tick source/tick are 0,3,6,7,7
+PASS: thm1-empty empty cube is a fixed point
+PASS: thm2-k shells have k=1,2,3
+PASS: thm3-k1 k=1 traces are 2/3 and 1/3
+PASS: thm3-k2 k=2 traces are (3±√2)/6
+PASS: thm3-k3 k=3 traces are (3±√3)/6
+PASS: thm4-plus-forms-face axis + content still forms face-diagonals
+PASS: mutation-k-fails predicate axis sites have k=2 must fail
+PASS: mutation-empty-fails predicate empty cube forms must fail
+PASS: quoted note quotes Qubit, Admissibility, and lock
+PASS: boundary not Born, not TOE, no forbidden phrases
+PASS: memo-silent axioms do not name the coupled cube PVM
+PASS: gates identity gates and AUDIT_INPUT_PATHS
+per_element: checked exactly — k and traces on three shells
+per_site: checked exactly — axis, face, opposite, empty
+per_mode: checked exactly — occupancy step plus PVM traces
+per_block: checked exactly — coupled cube+PVM comparator
+lattice_wide: checked and not executed — not Born
+TOTAL: PASS=13 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cube_222_pvm_content_step_2026_08_14.py
+++ b/scripts/cube_222_pvm_content_step_2026_08_14.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""2x2x2 occupancy step plus displayed PVM lock-content traces."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "CUBE_222_PVM_CONTENT_STEP_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CUBE_222_PVM_CONTENT_STEP_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+SITES = tuple((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+NONE = None
+LOCK = "-"
+ORIGIN = (0, 0, 0)
+AXIS_SITES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+FACE_SITES = ((1, 1, 0), (1, 0, 1), (0, 1, 1))
+OPP = (1, 1, 1)
+
+
+def empty() -> dict:
+    return {s: NONE for s in SITES}
+
+
+def occ(site: tuple, locks: dict) -> int:
+    return 0 if locks[site] is NONE else 1
+
+
+def nvec(site: tuple, locks: dict) -> tuple:
+    """Identity gate."""
+    out = []
+    for ax in AXES:
+        plus = (site[0] + ax[0], site[1] + ax[1], site[2] + ax[2])
+        minus = (site[0] - ax[0], site[1] - ax[1], site[2] - ax[2])
+        o_plus = occ(plus, locks) if plus in locks else 0
+        o_minus = occ(minus, locks) if minus in locks else 0
+        out.append(Fraction(o_plus - o_minus, 3))
+    return tuple(out)
+
+
+def k_of(n: tuple) -> int:
+    """Identity gate."""
+    return int(sum((3 * c) * (3 * c) for c in n))
+
+
+def step(locks: dict) -> dict:
+    """Identity gate."""
+    out = {}
+    for site, lock in locks.items():
+        if lock is not NONE:
+            out[site] = lock
+            continue
+        n = nvec(site, locks)
+        out[site] = LOCK if any(c != 0 for c in n) else NONE
+    return out
+
+
+def formed(before: dict, after: dict) -> int:
+    return sum(1 for s in SITES if before[s] is NONE and after[s] is not NONE)
+
+
+def traces(k: int) -> tuple[object, object]:
+    """(3±√k)/6 as (rational, coeff of √k)."""
+    return (Fraction(1, 2), Fraction(1, 6)), (Fraction(1, 2), Fraction(-1, 6))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact cube occupancy plus Q(√k) traces")
+    print("negative_scope: coupled comparator, not Born")
+
+    seed = empty()
+    seed[ORIGIN] = LOCK
+    s1 = step(seed)
+    s2 = step(s1)
+    s3 = step(s2)
+    s4 = step(s3)
+    t = [0]
+    t.append(t[-1] + formed(seed, s1))
+    t.append(t[-1] + formed(s1, s2))
+    t.append(t[-1] + formed(s2, s3))
+    t.append(t[-1] + formed(s3, s4))
+
+    checks.check("thm1-tick", "source/tick are 0,3,6,7,7", t == [0, 3, 6, 7, 7])
+    checks.check("thm1-empty", "empty cube is a fixed point", step(empty()) == empty())
+    k1s = {k_of(nvec(p, seed)) for p in AXIS_SITES}
+    k2s = {k_of(nvec(p, s1)) for p in FACE_SITES}
+    k3 = k_of(nvec(OPP, s2))
+    checks.check("thm2-k", "shells have k=1,2,3", k1s == {1} and k2s == {2} and k3 == 3)
+    tp1, tm1 = traces(1)
+    tp2, tm2 = traces(2)
+    tp3, tm3 = traces(3)
+    checks.check("thm3-k1", "k=1 traces are 2/3 and 1/3", tp1[0] + tp1[1] == Fraction(2, 3) and tm1[0] + tm1[1] == Fraction(1, 3))
+    checks.check("thm3-k2", "k=2 traces are (3±√2)/6", tp2 == (Fraction(1, 2), Fraction(1, 6)) and tm2 == (Fraction(1, 2), Fraction(-1, 6)))
+    checks.check("thm3-k3", "k=3 traces are (3±√3)/6", tp3 == (Fraction(1, 2), Fraction(1, 6)) and tm3 == (Fraction(1, 2), Fraction(-1, 6)))
+    # either content at an axis site still occupies it
+    occupied_axis = empty()
+    occupied_axis[ORIGIN] = LOCK
+    for p in AXIS_SITES:
+        occupied_axis[p] = "+"
+    checks.check("thm4-plus-forms-face", "axis + content still forms face-diagonals", all(step(occupied_axis)[p] is not NONE for p in FACE_SITES))
+    checks.check("mutation-k-fails", "predicate axis sites have k=2 must fail", k1s == {1})
+    checks.check("mutation-empty-fails", "predicate empty cube forms must fail", step(empty())[ORIGIN] is NONE)
+    checks.check(
+        "quoted",
+        "note quotes Qubit, Admissibility, and lock",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note
+        and "locks exactly one admissible local possibility" in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "therefore Born", "exhausted", "closes the route", "Lattice-named")
+    checks.check(
+        "boundary",
+        "not Born, not TOE, no forbidden phrases",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name the coupled cube PVM", "cubepvm" not in four)
+    checks.check(
+        "gates",
+        "identity gates and AUDIT_INPUT_PATHS",
+        "def nvec(" in self_source
+        and "def k_of(" in self_source
+        and "def step(" in self_source
+        and AUDIT_INPUT_PATHS == (
+            "docs/CUBE_222_PVM_CONTENT_STEP_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — k and traces on three shells")
+    print("per_site: checked exactly — axis, face, opposite, empty")
+    print("per_mode: checked exactly — occupancy step plus PVM traces")
+    print("per_block: checked exactly — coupled cube+PVM comparator")
+    print("lattice_wide: checked and not executed — not Born")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

One update on the displayed `2×2×2` cube: occupancy step plus the displayed PVM traces for lock content. Axis shell `k=1` traces `2/3` and `1/3`; face-diagonals `k=2`; opposite corner `k=3`. Either content still occupies, so later menus are unchanged. Source/tick `0→3→6→7→7`. Not Born, not a TOE.

## Runner

`scripts/cube_222_pvm_content_step_2026_08_14.py`

`TOTAL: PASS=13 FAIL=0`

## Notes

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.