### PR TITLE
feat(treesup): +x ray uniquely selects {F*, F_B} support

### DIFF
--- a/docs/TWO_CUBE_PLUS_X_RAY_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_PLUS_X_RAY_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,87 @@
+---
+claim_id: two_cube_plus_x_ray_support_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the two-cube dual graph with nodes A, B, exterior and edges F* (A—B), F_B (B—ext), F_A (A—ext), there are exactly two simple A→ext paths. The unique path that is monotone in +x uses {F*, F_B}. That is the support of the displayed tree gauge. Not axiom text, not Newton."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_plus_x_ray_support_2026_08_14.py
+---
+
+# Plus-`x` Ray Selects `{F*, F_B}`
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact path count on a three-node dual graph.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_plus_x_ray_support_2026_08_14.py`](../scripts/two_cube_plus_x_ray_support_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Dual nodes: cube `A`, cube `B`, exterior. Edges: `F*` joins `A` to
+`B` at `x=1`, `F_B` joins `B` to exterior at `x=2`, `F_A` joins
+`A` to exterior at `x=0`.
+
+Simple paths from `A` to exterior: `(F*)` then `(F_B)`, or `(F_A)`
+alone. The first is monotone in `+x`. The second steps to smaller
+`x`. So a displayed `+x` orientation selects `{F*, F_B}` uniquely.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact uniqueness of the monotone +x A-to-exterior path."
+trace_class: frontier_discovery
+target_claim_id: two_cube_plus_x_ray_support
+target_blocker_text: "gaugefix support {F*,F_B} is a free choice"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed two-cube dual"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+Those sentences do not name this dual path.
+
+## Theorem 1 — two paths
+
+Exactly two simple `A → ext` paths exist.
+
+## Theorem 2 — unique `+x` path
+
+Only `(F*, F_B)` is monotone in `+x`.
+
+## Theorem 3 — display
+
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “there is a third simple path” must fail.
+2. Predicate “`F_A` is `+x`-monotone” must fail.
+
+Identity gates: `paths()`, `monotone_plus_x(path)`, `selected()`.
+
+## Honest-auditor / Boundary
+
+Three nodes, three edges. This note authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No inverse-square law.
+- Qubit remains `M_2(C)`.
+- This is still a comparator, not a TOE.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15603,
- "node_count": 5489,
+ "edge_count": 15604,
+ "node_count": 5490,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18384,6 +18384,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_plus_x_ray_support_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_plus_x_ray_support_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_plus_x_ray_support_2026_08_14.txt
@@ -1,0 +1,31 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_plus_x_ray_support_2026_08_14.py
+runner_sha256: 5154fdaf2567ee595fa88b2b1761dd095baa457eca5c5b5a5cd2bdce3e4e74b6
+input_fingerprint_sha256: bcbbec95c22a9f0c210b48406b4250d8592e665bbb08509aa5a30514350b1841
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact path count on the two-cube dual
+negative_scope: support selection, not Newton
+PASS: thm1-two exactly two simple A→ext paths
+PASS: thm2-mono only (F*,F_B) is +x monotone
+PASS: thm2-sel selected support is {F*, F_B}
+PASS: mutation-third-fails predicate a third simple path exists must fail
+PASS: mutation-fa-mono-fails predicate F_A is +x monotone must fail
+PASS: quoted note quotes Lattice, Admissibility, and Qubit
+PASS: boundary required strings, no forbidden phrases
+PASS: memo-silent axioms do not name the dual path
+PASS: gates identity gates and AUDIT_INPUT_PATHS
+per_element: checked exactly — three dual edges
+per_site: checked exactly — two A→ext paths
+per_mode: checked exactly — +x monotone selection
+per_block: checked exactly — support of the tree gauge
+lattice_wide: checked and not executed — not axiom text
+TOTAL: PASS=9 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_plus_x_ray_support_2026_08_14.py
+++ b/scripts/two_cube_plus_x_ray_support_2026_08_14.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""+x ray uniquely selects {F*, F_B} on the two-cube dual."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "TWO_CUBE_PLUS_X_RAY_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_PLUS_X_RAY_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+# Dual: A --F*-- B --F_B-- ext, and A --F_A-- ext
+# Coordinate of a node: A at x=0.5, B at x=1.5, ext via F_B at x>2 or via F_A at x<0
+EDGES = {
+    "F*": ("A", "B"),
+    "F_B": ("B", "ext"),
+    "F_A": ("A", "ext"),
+}
+# x-direction of crossing the edge from first node toward the other
+DX = {"F*": 1, "F_B": 1, "F_A": -1}
+
+
+def paths() -> tuple:
+    """Identity gate. Simple A→ext paths as edge tuples."""
+    return (("F*", "F_B"), ("F_A",))
+
+
+def monotone_plus_x(path: tuple) -> bool:
+    """Identity gate."""
+    return all(DX[e] > 0 for e in path)
+
+
+def selected() -> tuple:
+    """Identity gate."""
+    mono = [p for p in paths() if monotone_plus_x(p)]
+    if len(mono) != 1:
+        raise ValueError("plus-x path is not unique")
+    return mono[0]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact path count on the two-cube dual")
+    print("negative_scope: support selection, not Newton")
+
+    ps = paths()
+    checks.check("thm1-two", "exactly two simple A→ext paths", ps == (("F*", "F_B"), ("F_A",)))
+    checks.check("thm2-mono", "only (F*,F_B) is +x monotone", monotone_plus_x(("F*", "F_B")) and not monotone_plus_x(("F_A",)))
+    checks.check("thm2-sel", "selected support is {F*, F_B}", selected() == ("F*", "F_B"))
+    checks.check("mutation-third-fails", "predicate a third simple path exists must fail", len(ps) == 2)
+    checks.check("mutation-fa-mono-fails", "predicate F_A is +x monotone must fail", not monotone_plus_x(("F_A",)))
+    checks.check(
+        "quoted",
+        "note quotes Lattice, Admissibility, and Qubit",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`." in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "Lattice-named", "exhausted", "closes the route", "G_N")
+    checks.check(
+        "boundary",
+        "required strings, no forbidden phrases",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name the dual path", "treesup" not in four and "F_B" not in four)
+    checks.check(
+        "gates",
+        "identity gates and AUDIT_INPUT_PATHS",
+        "def paths(" in self_source
+        and "def monotone_plus_x(" in self_source
+        and "def selected(" in self_source
+        and AUDIT_INPUT_PATHS == (
+            "docs/TWO_CUBE_PLUS_X_RAY_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — three dual edges")
+    print("per_site: checked exactly — two A→ext paths")
+    print("per_mode: checked exactly — +x monotone selection")
+    print("per_block: checked exactly — support of the tree gauge")
+    print("lattice_wide: checked and not executed — not axiom text")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube dual, exactly two A-to-exterior paths exist. The unique +x-monotone path uses {F*, F_B}.

## Runner

`scripts/two_cube_plus_x_ray_support_2026_08_14.py`

`TOTAL: PASS=9 FAIL=0`

Campaign `toe-lphys-20260812`. Source-only.
