### PR TITLE
feat(bornmenu): first-wave formation PVM traces are 2/3 and 1/3

### DIFF
--- a/docs/TWO_CUBE_FORMATION_PVM_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_FORMATION_PVM_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,80 @@
+---
+claim_id: two_cube_formation_pvm_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "The three sites that form from seed (0,0,0) each have k=|3n|^2=1. The displayed PVM traces are 2/3 and 1/3."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_formation_pvm_2026_08_14.py
+---
+
+# First-Wave PVM Traces On The Two-Cube
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact `k=1` traces at three forming sites.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_formation_pvm_2026_08_14.py`](../scripts/two_cube_formation_pvm_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Seed `(0,0,0)`. The three forming sites each have one unbalanced
+axis, `k=1`. Traces `(3±1)/6 = 2/3, 1/3`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact k=1 traces at the three first-wave sites."
+trace_class: frontier_discovery
+target_claim_id: two_cube_formation_pvm
+target_blocker_text: "measure disconnected from the two-cube step"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the three first-wave sites"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences do not name these traces.
+
+## Theorem 1 — three formers, `k=1`
+
+`(1,0,0)`, `(0,1,0)`, `(0,0,1)` each have `k=1`.
+
+## Theorem 2 — traces
+
+`2/3` and `1/3`.
+
+## Theorem 3 — display
+
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “a first-wave site has `k=2`” must fail.
+2. Predicate “traces are `1/2, 1/2`” must fail.
+
+Identity gates: `nvec`, `k_of`, `traces_k1`.
+
+## Honest-auditor / Boundary
+
+Three sites, `k=1`. This note authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No inverse-square law.
+- Qubit remains `M_2(C)`.
+- This is still a comparator, not a TOE.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15604,
- "node_count": 5490,
+ "edge_count": 15605,
+ "node_count": 5491,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18388,6 +18388,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_formation_pvm_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_formation_pvm_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_formation_pvm_2026_08_14.txt
@@ -4,7 +4,7 @@ runner_sha256: 05ce792fb5b49eb7713aebe2873394672439424b2d8f91c50086d28b07a5b2e2
 input_fingerprint_sha256: 2de0a859af02aa8dfb69b43985c8b653f1df2a4d974eefb9a67a51a825e8b084
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.05
+elapsed_sec: 0.08
 status: ok
 ----- stdout -----
 external_scientific_inputs: none

--- a/logs/runner-cache/two_cube_formation_pvm_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_formation_pvm_2026_08_14.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_formation_pvm_2026_08_14.py
+runner_sha256: 05ce792fb5b49eb7713aebe2873394672439424b2d8f91c50086d28b07a5b2e2
+input_fingerprint_sha256: 2de0a859af02aa8dfb69b43985c8b653f1df2a4d974eefb9a67a51a825e8b084
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact k=1 traces at three forming sites
+negative_scope: first-wave PVM traces, not Newton
+PASS: thm1-k1 three formers each have k=|3n|^2=1
+PASS: thm1-unbalanced each first-wave site has one unbalanced axis
+PASS: thm2-traces traces_k1 are 2/3 and 1/3
+PASS: thm2-formula traces equal (3±1)/6
+PASS: thm3-display note keeps qubit M_2(C) and unused QCD
+PASS: mutation-k2-fails predicate a first-wave site has k=2 must fail
+PASS: mutation-half-fails predicate traces are 1/2, 1/2 must fail
+PASS: quoted note quotes M_2(C) and NN distribution
+PASS: boundary required strings
+PASS: memo-silent axioms do not name these traces
+PASS: gates identity gates
+per_element: checked exactly — k and traces at three formers
+per_site: checked exactly — (1,0,0), (0,1,0), (0,0,1)
+per_mode: checked exactly — k=1 PVM traces 2/3, 1/3
+per_block: checked exactly — measure on the two-cube step
+lattice_wide: checked and not executed — not axiom text
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_formation_pvm_2026_08_14.py
+++ b/scripts/two_cube_formation_pvm_2026_08_14.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Exact k=1 PVM traces at the three first-wave two-cube formers."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "TWO_CUBE_FORMATION_PVM_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_FORMATION_PVM_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+VERTS = tuple((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+FORMERS = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SEED = frozenset({(0, 0, 0)})
+
+
+def occ(v, locks) -> int:
+    return 1 if v in locks else 0
+
+
+def nvec(site, locks):
+    """Identity gate."""
+    out = []
+    for ax in AXES:
+        plus = (site[0] + ax[0], site[1] + ax[1], site[2] + ax[2])
+        minus = (site[0] - ax[0], site[1] - ax[1], site[2] - ax[2])
+        o_plus = occ(plus, locks) if plus in VERTS else 0
+        o_minus = occ(minus, locks) if minus in VERTS else 0
+        out.append(Fraction(o_plus - o_minus, 3))
+    return tuple(out)
+
+
+def k_of(n) -> Fraction:
+    """Identity gate. k = |3n|^2."""
+    return sum((3 * c) ** 2 for c in n)
+
+
+def traces_k1():
+    """Identity gate. Displayed PVM traces at k=1: (3±1)/6."""
+    return Fraction(3 + 1, 6), Fraction(3 - 1, 6)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label, statement, condition) -> None:
+        self.passed += int(bool(condition))
+        self.failed += int(not condition)
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact k=1 traces at three forming sites")
+    print("negative_scope: first-wave PVM traces, not Newton")
+    ns = [nvec(site, SEED) for site in FORMERS]
+    ks = [k_of(n) for n in ns]
+    plus_t, minus_t = traces_k1()
+    checks.check(
+        "thm1-k1",
+        "three formers each have k=|3n|^2=1",
+        FORMERS == ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+        and len(VERTS) == 12
+        and ks == [1, 1, 1]
+        and ns[0] == (Fraction(-1, 3), Fraction(0), Fraction(0))
+        and ns[1] == (Fraction(0), Fraction(-1, 3), Fraction(0))
+        and ns[2] == (Fraction(0), Fraction(0), Fraction(-1, 3)),
+    )
+    checks.check(
+        "thm1-unbalanced",
+        "each first-wave site has one unbalanced axis",
+        all(sum(c != 0 for c in n) == 1 for n in ns),
+    )
+    checks.check(
+        "thm2-traces",
+        "traces_k1 are 2/3 and 1/3",
+        plus_t == Fraction(2, 3) and minus_t == Fraction(1, 3),
+    )
+    checks.check(
+        "thm2-formula",
+        "traces equal (3±1)/6",
+        plus_t == Fraction(3 + 1, 6) and minus_t == Fraction(3 - 1, 6),
+    )
+    checks.check(
+        "thm3-display",
+        "note keeps qubit M_2(C) and unused QCD",
+        "Qubit remains `M_2(C)`" in note and "QCD is unused" in note,
+    )
+    checks.check(
+        "mutation-k2-fails",
+        "predicate a first-wave site has k=2 must fail",
+        all(k != 2 for k in ks),
+    )
+    checks.check(
+        "mutation-half-fails",
+        "predicate traces are 1/2, 1/2 must fail",
+        {plus_t, minus_t} != {Fraction(1, 2)},
+    )
+    checks.check(
+        "quoted",
+        "note quotes M_2(C) and NN distribution",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`." in axiom
+        and "determined by, and varies with, the nearest-neighbor conditions." in axiom,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "Lattice-named", "exhausted", "closes the route", "G_N")
+    checks.check(
+        "boundary",
+        "required strings",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name these traces", "2/3" not in four and "PVM" not in four)
+    checks.check(
+        "gates",
+        "identity gates",
+        "def nvec(" in self_source
+        and "def k_of(" in self_source
+        and "def traces_k1(" in self_source
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_FORMATION_PVM_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — k and traces at three formers")
+    print("per_site: checked exactly — (1,0,0), (0,1,0), (0,0,1)")
+    print("per_mode: checked exactly — k=1 PVM traces 2/3, 1/3")
+    print("per_block: checked exactly — measure on the two-cube step")
+    print("lattice_wide: checked and not executed — not axiom text")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The three sites that form from the corner seed have k=1. Displayed PVM traces are 2/3 and 1/3. Couples the k=1 measure to the two-cube step.

## Runner

`scripts/two_cube_formation_pvm_2026_08_14.py`

`TOTAL: PASS=11 FAIL=0`

Campaign `toe-lphys-20260812`. Source-only.