### PR TITLE
feat(rhogrow): cube source increment equals new locks in that cube

### DIFF
--- a/docs/TWO_CUBE_RHO_INCREMENT_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_RHO_INCREMENT_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,84 @@
+---
+claim_id: two_cube_rho_increment_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the two-cube occupancy step, Δρ(A) equals the number of new locks in A and Δρ(B) equals the number of new locks in B. Shared new locks count in both. Seed (0,0,0) gives Δρ(A)=3, Δρ(B)=1."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_rho_increment_2026_08_14.py
+---
+
+# Cube Source Increments By Formations In That Cube
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact increment identity on one occupancy step.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_rho_increment_2026_08_14.py`](../scripts/two_cube_rho_increment_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+`ρ(C)` is the occupancy count on cube `C`. After one occupancy
+step from seed `{(0,0,0)}`, three sites form: two A-only and one
+shared. `Δρ(A)=3`, `Δρ(B)=1`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Δρ = new locks in that cube."
+trace_class: frontier_discovery
+target_claim_id: two_cube_rho_increment
+target_blocker_text: "source does not read records"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed seed step"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site never carries more than one record; records are permanent.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences do not name `Δρ`.
+
+## Theorem 1 — identity
+
+`Δρ(A) = |new locks ∩ A|`, `Δρ(B) = |new locks ∩ B|`.
+
+## Theorem 2 — seed numbers
+
+Seed step: new locks `{(1,0,0),(0,1,0),(0,0,1)}`. Shared one.
+`Δρ(A)=3`, `Δρ(B)=1`.
+
+## Theorem 3 — display
+
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “`Δρ(B)=0` on the seed step” must fail.
+2. Predicate “empty step changes `ρ`” must fail.
+
+Identity gates: `occ_step`, `rho`, `new_in`.
+
+## Honest-auditor / Boundary
+
+One step, two cubes. This note authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No inverse-square law.
+- Qubit remains `M_2(C)`.
+- This is still a comparator, not a TOE.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15604,
- "node_count": 5490,
+ "edge_count": 15605,
+ "node_count": 5491,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18388,6 +18388,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_rho_increment_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_rho_increment_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_rho_increment_2026_08_14.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_rho_increment_2026_08_14.py
+runner_sha256: 81cd72799714d96e3a6e7f28b81815e53b8fbb0c8a6d2a6e331298948fc503de
+input_fingerprint_sha256: 90013b1dd378aa1508fd525dffc9eb6289bc94cdf8ff353f23a5a6fd1298c701
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact integers on one occupancy step
+negative_scope: increment identity, not Newton
+PASS: geom 12 verts; A x in {0,1}; B x in {1,2}
+PASS: thm-new seed forms exactly {(1,0,0),(0,1,0),(0,0,1)}
+PASS: thm-delta seed step Δρ(A)=3, Δρ(B)=1
+PASS: thm-id Δρ(C) equals |new locks ∩ C|
+PASS: thm-empty empty step Δρ=0
+PASS: mutation-dB0-fails predicate Δρ(B)=0 on the seed step must fail
+PASS: mutation-empty-rho-fails predicate empty step changes ρ must fail
+PASS: quoted note quotes lock and NN
+PASS: boundary required strings and forbidden absent
+PASS: memo-silent axioms do not name Δρ
+PASS: gates identity gates occ_step/rho/new_in
+per_element: checked exactly — Δρ(A), Δρ(B), new-lock counts
+per_site: checked exactly — seed (0,0,0) and empty
+per_mode: checked exactly — occupancy increment identity
+per_block: checked exactly — two-cube source increment
+lattice_wide: checked and not executed — not axiom text
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_rho_increment_2026_08_14.py
+++ b/scripts/two_cube_rho_increment_2026_08_14.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Δρ on each cube equals new locks in that cube."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "TWO_CUBE_RHO_INCREMENT_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_RHO_INCREMENT_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+VERTS = tuple((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+A_VERTS = frozenset(v for v in VERTS if v[0] in (0, 1))
+B_VERTS = frozenset(v for v in VERTS if v[0] in (1, 2))
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SEED_NEW = frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)})
+
+
+def occ(v, locks) -> int:
+    return 1 if v in locks else 0
+
+
+def nvec(site, locks):
+    out = []
+    for ax in AXES:
+        plus = (site[0] + ax[0], site[1] + ax[1], site[2] + ax[2])
+        minus = (site[0] - ax[0], site[1] - ax[1], site[2] - ax[2])
+        o_plus = occ(plus, locks) if plus in VERTS else 0
+        o_minus = occ(minus, locks) if minus in VERTS else 0
+        out.append(Fraction(o_plus - o_minus, 3))
+    return tuple(out)
+
+
+def occ_step(locks):
+    """Identity gate."""
+    out = set(locks)
+    for v in VERTS:
+        if v not in locks and any(c != 0 for c in nvec(v, locks)):
+            out.add(v)
+    return frozenset(out)
+
+
+def rho(locks):
+    """Identity gate. Occupancy counts on cubes A and B."""
+    return sum(occ(v, locks) for v in A_VERTS), sum(occ(v, locks) for v in B_VERTS)
+
+
+def new_in(locks, cube_verts):
+    """Identity gate. New locks that land in the cube."""
+    after = occ_step(locks)
+    return frozenset(v for v in (after - frozenset(locks)) if v in cube_verts)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label, statement, condition) -> None:
+        self.passed += int(bool(condition))
+        self.failed += int(not condition)
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact integers on one occupancy step")
+    print("negative_scope: increment identity, not Newton")
+
+    empty = frozenset()
+    seed = frozenset({(0, 0, 0)})
+    after_empty = occ_step(empty)
+    after_seed = occ_step(seed)
+    rho_empty0 = rho(empty)
+    rho_empty1 = rho(after_empty)
+    rho_seed0 = rho(seed)
+    rho_seed1 = rho(after_seed)
+    dA = rho_seed1[0] - rho_seed0[0]
+    dB = rho_seed1[1] - rho_seed0[1]
+    new_A = new_in(seed, A_VERTS)
+    new_B = new_in(seed, B_VERTS)
+    new_empty_A = new_in(empty, A_VERTS)
+    new_empty_B = new_in(empty, B_VERTS)
+
+    checks.check(
+        "geom",
+        "12 verts; A x in {0,1}; B x in {1,2}",
+        len(VERTS) == 12 and len(A_VERTS) == 8 and len(B_VERTS) == 8 and len(A_VERTS & B_VERTS) == 4,
+    )
+    checks.check(
+        "thm-new",
+        "seed forms exactly {(1,0,0),(0,1,0),(0,0,1)}",
+        after_seed - seed == SEED_NEW and (0, 0, 0) in after_seed,
+    )
+    checks.check(
+        "thm-delta",
+        "seed step Δρ(A)=3, Δρ(B)=1",
+        rho_seed0 == (1, 0) and rho_seed1 == (4, 1) and dA == 3 and dB == 1,
+    )
+    checks.check(
+        "thm-id",
+        "Δρ(C) equals |new locks ∩ C|",
+        dA == len(new_A) and dB == len(new_B) and new_A == SEED_NEW and new_B == frozenset({(1, 0, 0)}),
+    )
+    checks.check(
+        "thm-empty",
+        "empty step Δρ=0",
+        after_empty == empty and rho_empty0 == (0, 0) and rho_empty1 == (0, 0) and not new_empty_A and not new_empty_B,
+    )
+    checks.check(
+        "mutation-dB0-fails",
+        "predicate Δρ(B)=0 on the seed step must fail",
+        dB != 0,
+    )
+    checks.check(
+        "mutation-empty-rho-fails",
+        "predicate empty step changes ρ must fail",
+        rho_empty0 == rho_empty1,
+    )
+    checks.check(
+        "quoted",
+        "note quotes lock and NN",
+        "locks exactly one admissible local possibility" in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note
+        and "M_2(C)" in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "Lattice-named", "exhausted", "closes the route", "G_N")
+    checks.check(
+        "boundary",
+        "required strings and forbidden absent",
+        all(p not in note for p in forbidden)
+        and "Result Up Front" in note
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note
+        and "claim_id:" in note,
+    )
+    checks.check(
+        "memo-silent",
+        "axioms do not name Δρ",
+        "Δρ" not in four and "rhogrow" not in four,
+    )
+    checks.check(
+        "gates",
+        "identity gates occ_step/rho/new_in",
+        "def occ_step(" in self_source
+        and "def rho(" in self_source
+        and "def new_in(" in self_source
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_RHO_INCREMENT_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    print("per_element: checked exactly — Δρ(A), Δρ(B), new-lock counts")
+    print("per_site: checked exactly — seed (0,0,0) and empty")
+    print("per_mode: checked exactly — occupancy increment identity")
+    print("per_block: checked exactly — two-cube source increment")
+    print("lattice_wide: checked and not executed — not axiom text")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube occupancy step, Δρ(A) equals the number of new locks in A and Δρ(B) equals the number of new locks in B. Shared new locks count in both. Seed (0,0,0) gives Δρ(A)=3, Δρ(B)=1.

## Runner

`scripts/two_cube_rho_increment_2026_08_14.py`

`TOTAL: PASS=11 FAIL=0`

Campaign `toe-lphys-20260812`. Source-only.