### PR TITLE
feat(extvac): off-patch occupancy 0 is load-bearing

### DIFF
--- a/docs/TWO_CUBE_EXTERIOR_VACUUM_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_EXTERIOR_VACUUM_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,110 @@
+---
+claim_id: two_cube_exterior_vacuum_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the displayed two-cube occupancy step, off-patch occupancy defaults to 0. From seed (0,0,0), the B-front site (2,0,0) has n=0 and does not form. If the virtual neighbor (3,0,0) is occupied, n_x at (2,0,0) equals (1-0)/3 ≠ 0 and the site forms. The displayed exterior vacuum is why B-only sites stay unread on step 1."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_exterior_vacuum_2026_08_14.py
+---
+
+# Exterior Vacuum Is Load-Bearing On The Two-Cube Occupancy Step
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact `n` and formation on one seed step, with and without a
+displayed off-patch occupancy.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_exterior_vacuum_2026_08_14.py`](../scripts/two_cube_exterior_vacuum_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Twelve vertices, two cubes sharing `x=1`. Occupancy step: locked
+sites stay; unread sites form iff `n ≠ 0`. The three-axis field is
+
+`n_i(x) = (occ(x+e_i) − occ(x−e_i))/3`.
+
+Off-patch occupancy defaults to `0`. That default is the displayed
+exterior vacuum. It is extra bookkeeping, not axiom text.
+
+Seed `{(0,0,0)}`. The B-front site `(2,0,0)` has vacuum neighbors
+on every axis, so `n=(0,0,0)` and it does not form. Every B-only
+site stays unread on this step.
+
+If the virtual neighbor `(3,0,0)` is occupied, then
+`n_x(2,0,0)=(1−0)/3=1/3 ≠ 0` and `(2,0,0)` forms. The vacuum
+exterior is therefore load-bearing for the unread B-only sites.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact n and formation at the B-front, with default off-patch occupancy 0 versus a displayed occupied exterior."
+trace_class: frontier_discovery
+target_claim_id: two_cube_exterior_vacuum
+target_blocker_text: "off-patch occupancy is implicit"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed seed step and one exterior witness"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site never carries more than one record; records are permanent.
+
+> A site with no record cannot be read.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences do not name off-patch occupancy or this vacuum default.
+
+## Theorem 1 — default vacuum, B-front unread
+
+Default off-patch occupancy is `0`. On the seed, `n` at `(2,0,0)`
+is `(0,0,0)`. The site does not form. All four B-only vertices
+stay unread after one `occ_step`.
+
+## Theorem 2 — occupied exterior forms the B-front
+
+If the virtual neighbor `(3,0,0)` is occupied, then
+`n_x(2,0,0)=(1−0)/3 ≠ 0`. The B-front forms. The other three
+B-only sites remain unread under that one-site exterior.
+
+## Theorem 3 — load-bearing
+
+The displayed vacuum exterior is why B-only sites stay unread on
+step 1. Occupying `(3,0,0)` is enough to form `(2,0,0)`. The
+unread B-front is not a seed-distance identity independent of the
+off-patch default.
+
+## Theorem 4 — display
+
+The exterior map is displayed extra. Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “`(2,0,0)` forms from the seed under default vacuum” must fail.
+2. Predicate “occupied `(3,0,0)` leaves `n=0` at `(2,0,0)`” must fail.
+
+Identity gates: `n_at_Bfront`, `forms_if_exterior`.
+The step gate `occ_step` accepts an optional exterior map.
+
+## Honest-auditor / Boundary
+
+One seed, one B-front, one exterior witness. This note authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No inverse-square law.
+- Qubit remains `M_2(C)`.
+- This is still a comparator, not a TOE.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15604,
- "node_count": 5490,
+ "edge_count": 15605,
+ "node_count": 5491,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18388,6 +18388,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_exterior_vacuum_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_exterior_vacuum_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_exterior_vacuum_2026_08_14.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_exterior_vacuum_2026_08_14.py
+runner_sha256: aad760ad088eaf4b968b20da844cd9b8e1934862832f287c3a394630b31ee292
+input_fingerprint_sha256: 1ca439bcdb14a20228ba675a991c0f03ec28d245025c5be427c9207a38880400
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact n and formation at the B-front
+negative_scope: exterior vacuum load-bearing, not Newton
+PASS: thm1-n0 default vacuum gives n=0 at B-front
+PASS: thm1-noform (2,0,0) does not form from the seed
+PASS: thm1-Bonly all B-only sites stay unread on step 1
+PASS: thm2-nx occupied (3,0,0) gives n_x=(1-0)/3
+PASS: thm2-forms occupied exterior forms the B-front
+PASS: thm2-other-Bonly other B-only sites stay unread under that one-site exterior
+PASS: mutation-forms-fails predicate (2,0,0) forms under default vacuum must fail
+PASS: mutation-n0-fails predicate occupied (3,0,0) leaves n=0 at B-front must fail
+PASS: quoted note quotes lock, permanence, unread, NN
+PASS: boundary required strings
+PASS: memo-silent axioms do not name off-patch occupancy
+PASS: gates identity gates
+per_element: checked exactly — n at the B-front
+per_site: checked exactly — seed step with and without exterior (3,0,0)
+per_mode: checked exactly — default off-patch occupancy 0
+per_block: checked exactly — exterior vacuum load-bearing
+lattice_wide: checked and not executed — not axiom text
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_exterior_vacuum_2026_08_14.py
+++ b/scripts/two_cube_exterior_vacuum_2026_08_14.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Exterior vacuum is load-bearing on the two-cube occupancy step."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "TWO_CUBE_EXTERIOR_VACUUM_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_EXTERIOR_VACUUM_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+VERTS = tuple((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+B_ONLY = tuple(v for v in VERTS if v[0] == 2)
+BFRONT = (2, 0, 0)
+EXT_PLUS = (3, 0, 0)
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def occ_at(site, locks, exterior=None) -> int:
+    """On-patch occupancy from locks; off-patch defaults to 0."""
+    if site in VERTS:
+        return 1 if site in locks else 0
+    if not exterior:
+        return 0
+    if isinstance(exterior, dict):
+        return int(bool(exterior.get(site, 0)))
+    return int(site in exterior)
+
+
+def nvec(site, locks, exterior=None):
+    out = []
+    for ax in AXES:
+        plus = (site[0] + ax[0], site[1] + ax[1], site[2] + ax[2])
+        minus = (site[0] - ax[0], site[1] - ax[1], site[2] - ax[2])
+        out.append(Fraction(occ_at(plus, locks, exterior) - occ_at(minus, locks, exterior), 3))
+    return tuple(out)
+
+
+def occ_step(locks, exterior=None):
+    """Occupancy step. Optional exterior map; off-patch occupancy defaults to 0."""
+    out = set(locks)
+    for v in VERTS:
+        if v not in locks and any(c != 0 for c in nvec(v, locks, exterior)):
+            out.add(v)
+    return frozenset(out)
+
+
+def n_at_Bfront(locks, exterior=None):
+    """Identity gate: n at the B-front (2,0,0)."""
+    return nvec(BFRONT, locks, exterior)
+
+
+def forms_if_exterior(locks, exterior):
+    """Identity gate: whether (2,0,0) forms under the given exterior map."""
+    return BFRONT not in locks and any(c != 0 for c in n_at_Bfront(locks, exterior))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label, statement, condition) -> None:
+        self.passed += int(bool(condition))
+        self.failed += int(not condition)
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact n and formation at the B-front")
+    print("negative_scope: exterior vacuum load-bearing, not Newton")
+    seed = frozenset({(0, 0, 0)})
+    ext_occ = frozenset({EXT_PLUS})
+    s1 = occ_step(seed)
+    s1_ext = occ_step(seed, exterior=ext_occ)
+    n0 = n_at_Bfront(seed)
+    n_ext = n_at_Bfront(seed, exterior=ext_occ)
+    checks.check(
+        "thm1-n0",
+        "default vacuum gives n=0 at B-front",
+        n0 == (Fraction(0), Fraction(0), Fraction(0)),
+    )
+    checks.check(
+        "thm1-noform",
+        "(2,0,0) does not form from the seed",
+        BFRONT not in s1 and not forms_if_exterior(seed, None),
+    )
+    checks.check(
+        "thm1-Bonly",
+        "all B-only sites stay unread on step 1",
+        all(v not in s1 for v in B_ONLY),
+    )
+    checks.check(
+        "thm2-nx",
+        "occupied (3,0,0) gives n_x=(1-0)/3",
+        n_ext == (Fraction(1, 3), Fraction(0), Fraction(0)),
+    )
+    checks.check(
+        "thm2-forms",
+        "occupied exterior forms the B-front",
+        forms_if_exterior(seed, ext_occ) and BFRONT in s1_ext,
+    )
+    checks.check(
+        "thm2-other-Bonly",
+        "other B-only sites stay unread under that one-site exterior",
+        all(v not in s1_ext for v in B_ONLY if v != BFRONT),
+    )
+    checks.check(
+        "mutation-forms-fails",
+        "predicate (2,0,0) forms under default vacuum must fail",
+        BFRONT not in s1,
+    )
+    checks.check(
+        "mutation-n0-fails",
+        "predicate occupied (3,0,0) leaves n=0 at B-front must fail",
+        n_ext != (Fraction(0), Fraction(0), Fraction(0)),
+    )
+    checks.check(
+        "quoted",
+        "note quotes lock, permanence, unread, NN",
+        "locks exactly one admissible local possibility" in note
+        and "records are permanent" in note
+        and "A site with no record cannot be read." in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "Lattice-named", "exhausted", "closes the route", "G_N")
+    checks.check(
+        "boundary",
+        "required strings",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name off-patch occupancy", "off-patch" not in four and "exterior vacuum" not in four)
+    checks.check(
+        "gates",
+        "identity gates",
+        "def occ_step(" in self_source
+        and "def n_at_Bfront(" in self_source
+        and "def forms_if_exterior(" in self_source
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_EXTERIOR_VACUUM_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — n at the B-front")
+    print("per_site: checked exactly — seed step with and without exterior (3,0,0)")
+    print("per_mode: checked exactly — default off-patch occupancy 0")
+    print("per_block: checked exactly — exterior vacuum load-bearing")
+    print("lattice_wide: checked and not executed — not axiom text")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

If the +x exterior of B is occupied, (2,0,0) has n≠0 at the seed and forms. The displayed vacuum exterior is why B-only sites stay unread on step 1.

## Runner

`scripts/two_cube_exterior_vacuum_2026_08_14.py`

`TOTAL: PASS=12 FAIL=0`

Campaign `toe-lphys-20260812`. Source-only.