### PR TITLE
feat(seedclass): classify one-site seeds on the two-cube

### DIFF
--- a/docs/TWO_CUBE_SEED_CLASS_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_SEED_CLASS_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,113 @@
+---
+claim_id: two_cube_seed_class_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "Among the 12 single-site seeds on the displayed two-cube, the four A-only sites (x=0) each form 3 sites, the four shared sites (x=1) each form 4 sites, and the four B-only sites (x=2) each form 3 sites. This is a classification of one-site seeds under the displayed occupancy step, not a new patch and not a gauge clone."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_seed_class_2026_08_14.py
+---
+
+# Single-Site Seed Classes On The Two-Cube
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact formation counts for twelve single-site seeds.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_seed_class_2026_08_14.py`](../scripts/two_cube_seed_class_2026_08_14.py)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Twelve vertices, two cubes sharing `x=1`. Occupancy step: locked
+sites stay; unread sites form iff `n ≠ 0`. Off-patch occupancy is
+`0`. The twelve single-site seeds fall into three classes by the
+`x` coordinate of the seed.
+
+A-only corners (`x=0`, four sites) each form 3 unread sites.
+Shared vertices (`x=1`, four sites) each form 4 unread sites.
+B-only corners (`x=2`, four sites) each form 3 unread sites.
+
+The count is the number of on-patch nearest neighbors of the seed:
+three at an A-only or B-only corner, four at a shared face vertex.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact formation counts on all twelve single-site seeds of the two-cube occupancy step."
+trace_class: frontier_discovery
+target_claim_id: two_cube_seed_class
+target_blocker_text: "one-site seeds on the two-cube are unclassified"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit"
+conditional_surface_status: "exact for the displayed twelve single-site seeds"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Live Parent Quotes
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site never carries more than one record; records are permanent.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences do not name these seed classes.
+
+## Theorem 1 — twelve single-site seeds
+
+The displayed vertices are
+
+```text
+A-only:  (0,0,0) (0,0,1) (0,1,0) (0,1,1)
+shared:  (1,0,0) (1,0,1) (1,1,0) (1,1,1)
+B-only:  (2,0,0) (2,0,1) (2,1,0) (2,1,1)
+```
+
+Each vertex is one single-site seed. There are twelve.
+
+## Theorem 2 — A-only seeds form 3
+
+Each of the four `x=0` seeds forms exactly three unread sites.
+Example: seed `(0,0,0)` forms `{(1,0,0),(0,1,0),(0,0,1)}`.
+
+## Theorem 3 — shared seeds form 4
+
+Each of the four `x=1` seeds forms exactly four unread sites.
+Example: seed `(1,0,0)` forms `{(0,0,0),(2,0,0),(1,1,0),(1,0,1)}`.
+
+## Theorem 4 — B-only seeds form 3
+
+Each of the four `x=2` seeds forms exactly three unread sites.
+Example: seed `(2,0,0)` forms `{(1,0,0),(2,1,0),(2,0,1)}`.
+
+## Theorem 5 — display
+
+Qubit remains `M_2(C)`. QCD is unused.
+
+## Mutations
+
+1. Predicate “an A-only seed forms 4” must fail.
+2. Predicate “a shared seed forms 3” must fail.
+3. Predicate “all twelve seeds form the same number” must fail.
+
+Identity gates: `formed_from`, `class_counts`.
+
+## Honest-auditor / Boundary
+
+Twelve seeds, three classes, two integers per class. This note
+authors no audit verdict.
+
+## What This Does Not Claim
+
+- No unique member. No axiom text. No inverse-square law.
+- Qubit remains `M_2(C)`.
+- This is still a comparator, not a TOE.
+- Not a new occupancy patch. Not a gauge clone.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15604,
- "node_count": 5490,
+ "edge_count": 15605,
+ "node_count": 5491,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18388,6 +18388,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_seed_class_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_seed_class_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_seed_class_2026_08_14.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_seed_class_2026_08_14.py
+runner_sha256: 78ef286e88aa74e119cab3449758ba258dff0d65837f0790b36e70a20581a77e
+input_fingerprint_sha256: b5b1077f08109ba4d21b664f6de7160444ffb855b97621cd18e987abe9e79ad9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none
+package_local_integrity_reads: runner, note, axiom memo
+measure_boundary: exact integers on twelve single-site seeds
+negative_scope: seed-class census, not Newton
+PASS: thm1-twelve twelve single-site seeds partition as 4+4+4
+PASS: thm2-a-only A-only x=0: 4 sites, each forms 3
+PASS: thm3-shared shared x=1: 4 sites, each forms 4
+PASS: thm4-b-only B-only x=2: 4 sites, each forms 3
+PASS: thm-class-counts class_counts is the 4/3, 4/4, 4/3 census
+PASS: mutation-a-only-forms-4-fails predicate A-only seed forms 4 must fail
+PASS: mutation-shared-forms-3-fails predicate shared seed forms 3 must fail
+PASS: mutation-uniform-fails predicate all twelve seeds form the same number must fail
+PASS: quoted note quotes lock, permanence, NN
+PASS: boundary required strings
+PASS: memo-silent axioms do not name the seed class
+PASS: gates identity gates
+per_element: checked exactly — formed-site set of each single-site seed
+per_site: checked exactly — all twelve vertices as seeds
+per_mode: checked exactly — A-only / shared / B-only classes
+per_block: checked exactly — formation count vs seed x-class
+lattice_wide: checked and not executed — not axiom text
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_seed_class_2026_08_14.py
+++ b/scripts/two_cube_seed_class_2026_08_14.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Classify one-site seeds on the two-cube occupancy step."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "TWO_CUBE_SEED_CLASS_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_SEED_CLASS_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+VERTS = tuple((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+A_ONLY = tuple(v for v in VERTS if v[0] == 0)
+SHARED = tuple(v for v in VERTS if v[0] == 1)
+B_ONLY = tuple(v for v in VERTS if v[0] == 2)
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+EXPECTED_CLASS_COUNTS = {
+    "A-only": (4, 3),
+    "shared": (4, 4),
+    "B-only": (4, 3),
+}
+
+
+def occ(v, locks) -> int:
+    return 1 if v in locks else 0
+
+
+def nvec(site, locks):
+    out = []
+    for ax in AXES:
+        plus = (site[0] + ax[0], site[1] + ax[1], site[2] + ax[2])
+        minus = (site[0] - ax[0], site[1] - ax[1], site[2] - ax[2])
+        o_plus = occ(plus, locks) if plus in VERTS else 0
+        o_minus = occ(minus, locks) if minus in VERTS else 0
+        out.append(Fraction(o_plus - o_minus, 3))
+    return tuple(out)
+
+
+def occ_step(locks):
+    out = set(locks)
+    for v in VERTS:
+        if v not in locks and any(c != 0 for c in nvec(v, locks)):
+            out.add(v)
+    return frozenset(out)
+
+
+def formed_from(seed) -> frozenset:
+    """Identity gate."""
+    before = frozenset({seed})
+    return occ_step(before) - before
+
+
+def seed_class(seed) -> str:
+    if seed[0] == 0:
+        return "A-only"
+    if seed[0] == 1:
+        return "shared"
+    return "B-only"
+
+
+def class_counts() -> dict[str, tuple[int, int]]:
+    """Identity gate."""
+    sizes: dict[str, list[int]] = {"A-only": [], "shared": [], "B-only": []}
+    for seed in VERTS:
+        sizes[seed_class(seed)].append(len(formed_from(seed)))
+    out: dict[str, tuple[int, int]] = {}
+    for name, values in sizes.items():
+        common = values[0] if values and all(v == values[0] for v in values) else -1
+        out[name] = (len(values), common)
+    return out
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label, statement, condition) -> None:
+        self.passed += int(bool(condition))
+        self.failed += int(not condition)
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    four = axiom.split("## The Four Framework Axioms", 1)[-1].split("## Qualification", 1)[0]
+    print("external_scientific_inputs: none")
+    print("package_local_integrity_reads: runner, note, axiom memo")
+    print("measure_boundary: exact integers on twelve single-site seeds")
+    print("negative_scope: seed-class census, not Newton")
+    counts = class_counts()
+    a_forms = {len(formed_from(seed)) for seed in A_ONLY}
+    s_forms = {len(formed_from(seed)) for seed in SHARED}
+    b_forms = {len(formed_from(seed)) for seed in B_ONLY}
+    seed000 = formed_from((0, 0, 0))
+    seed100 = formed_from((1, 0, 0))
+    seed200 = formed_from((2, 0, 0))
+    checks.check(
+        "thm1-twelve",
+        "twelve single-site seeds partition as 4+4+4",
+        len(VERTS) == 12 and len(A_ONLY) == 4 and len(SHARED) == 4 and len(B_ONLY) == 4,
+    )
+    checks.check(
+        "thm2-a-only",
+        "A-only x=0: 4 sites, each forms 3",
+        a_forms == {3} and counts["A-only"] == (4, 3) and seed000 == frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)}),
+    )
+    checks.check(
+        "thm3-shared",
+        "shared x=1: 4 sites, each forms 4",
+        s_forms == {4} and counts["shared"] == (4, 4) and seed100 == frozenset({(0, 0, 0), (2, 0, 0), (1, 1, 0), (1, 0, 1)}),
+    )
+    checks.check(
+        "thm4-b-only",
+        "B-only x=2: 4 sites, each forms 3",
+        b_forms == {3} and counts["B-only"] == (4, 3) and seed200 == frozenset({(1, 0, 0), (2, 1, 0), (2, 0, 1)}),
+    )
+    checks.check(
+        "thm-class-counts",
+        "class_counts is the 4/3, 4/4, 4/3 census",
+        counts == EXPECTED_CLASS_COUNTS,
+    )
+    checks.check("mutation-a-only-forms-4-fails", "predicate A-only seed forms 4 must fail", a_forms != {4})
+    checks.check("mutation-shared-forms-3-fails", "predicate shared seed forms 3 must fail", s_forms != {3})
+    checks.check(
+        "mutation-uniform-fails",
+        "predicate all twelve seeds form the same number must fail",
+        not (a_forms == s_forms == b_forms),
+    )
+    checks.check(
+        "quoted",
+        "note quotes lock, permanence, NN",
+        "locks exactly one admissible local possibility" in note
+        and "records are permanent" in note
+        and "determined by, and varies with, the nearest-neighbor conditions." in note,
+    )
+    forbidden = ("we adopt", "L_phys", "0.5934", "Lattice-named", "exhausted", "closes the route", "G_N")
+    checks.check(
+        "boundary",
+        "required strings",
+        all(p not in note for p in forbidden)
+        and "not a TOE" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "This note authors no audit verdict" in note
+        and "QCD is unused" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"' in note
+        and "Honest-auditor / Boundary" in note,
+    )
+    checks.check("memo-silent", "axioms do not name the seed class", "seed class" not in four and "seedclass" not in four)
+    checks.check(
+        "gates",
+        "identity gates",
+        "def formed_from(" in self_source
+        and "def class_counts(" in self_source
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_SEED_CLASS_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    print("per_element: checked exactly — formed-site set of each single-site seed")
+    print("per_site: checked exactly — all twelve vertices as seeds")
+    print("per_mode: checked exactly — A-only / shared / B-only classes")
+    print("per_block: checked exactly — formation count vs seed x-class")
+    print("lattice_wide: checked and not executed — not axiom text")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 12 single-site seeds, A-only corners form 3, shared vertices form 4, B-only corners form 3. Classification, not a new patch.

## Runner

`scripts/two_cube_seed_class_2026_08_14.py`

`TOTAL: PASS=12 FAIL=0`

Campaign `toe-lphys-20260812`. Source-only.