### PR TITLE
feat(octid): 24 cube rotations are not C24 or D12

### DIFF
--- a/docs/CUBE_ROTATION_GROUP_NOT_CYCLIC_DIHEDRAL_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/CUBE_ROTATION_GROUP_NOT_CYCLIC_DIHEDRAL_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,194 @@
+---
+claim_id: cube_rotation_group_not_cyclic_dihedral_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "Let G be the 24-element set of 3x3 signed permutation matrices with det=+1. Element orders in G lie in {1,2,3,4} only, the maximum is 4, and G has an order-4 element. Therefore G is not cyclic of order 24 and is not dihedral of order 24. The argument uses only matrix orders in G. It does not classify all order-24 subgroups of SO(3) and does not adopt an M_2 action."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py
+---
+
+# The 24 Cube Rotations Are Not `C_24` And Not `D_12`
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact integer order census of one displayed 24-element matrix
+set `G`. No classification of all order-24 subgroups of `SO(3)`. No
+`M_2` action. No Qubit rewrite.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py`](../scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `G` be the set of all `3 × 3` signed permutation matrices with
+`det = +1`. Each row and each column has a single nonzero entry in
+`{+1, −1}`. There are `3! · 2^3 = 48` signed permutation matrices, and
+exactly those with determinant `+1` belong to `G`. Direct listing gives
+`|G| = 24`.
+
+The order of `R ∈ G` is the least integer `k > 0` with `R^k = I`.
+Enumeration of all 24 elements yields only the orders `1, 2, 3, 4`,
+with multiplicities `1`, `9`, `8`, and `6` respectively. The maximum is
+`4`, realized by a `90°` rotation about a coordinate axis. In particular
+`G` has at least one element of order `4`, and no element of order `12`
+or `24`.
+
+`C_24` has an element of order `24`. Therefore `G` is not cyclic of
+order `24`.
+
+`D_12`, the dihedral group of order `24`, has a cyclic subgroup of
+order `12`, hence an element of order `12`. `G` has no element of order
+`12`, so `G` has no cyclic subgroup of order `12`. Therefore `G` is not
+dihedral of order `24`.
+
+The proof uses only this order census in `G`. It does not use an action
+on the four space diagonals, and it is independent of the `S_4`-via-
+diagonals isomorphism.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact enumeration of matrix orders in the displayed 24-element set G shows that G is not C_24 and not D_12."
+trace_class: negative_route_pruning
+target_claim_id: cube_rotation_group_not_cyclic_dihedral
+target_blocker_text: "whether the 24-element cube-rotation set is C_24 or D_12"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded algebraic claim"
+conditional_surface_status: "exact for the displayed 24-element matrix set G; no SO(3) classification and no M_2 action"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target And Proof Obligations
+
+**Exact target.** For the displayed set `G`, prove `|G| = 24`, prove that
+every element order lies in `{1, 2, 3, 4}`, prove that the maximum order
+is `4` and is attained, and conclude that `G` is neither `C_24` nor
+`D_12`.
+
+| Obligation | Disposition |
+|---|---|
+| list of all `det = +1` signed permutation matrices | proved here; `|G| = 24` |
+| element orders by repeated product until `I` | proved here; only `1, 2, 3, 4` |
+| existence of an order-`4` element | proved here by a coordinate-axis `90°` matrix |
+| `G` is not `C_24` | Theorem 1 |
+| `G` is not `D_12` | Theorem 2 |
+
+Boundary cases stay open on purpose. Other 24-element subsets of `SO(3)`,
+improper signed permutations (`det = −1`), and any action on a one-site
+algebra are outside the target. No terminal lemma for the two identifications
+is left open.
+
+## Inputs And Support Inventory
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the
+  Lattice vocabulary that names proper cubic rotations about each site. As the
+  registered `minimal_axioms` premise, it is not a bounded-status source.
+- `G` is displayed matrix data: the `3 × 3` signed permutation matrices of
+  determinant `+1`. Entries lie in `Z`.
+- No measured, fitted, observational, literature, or other phenomenological
+  value is used.
+- No `M_2` representation, menu, or Record rule is an input.
+
+## Exact Objects
+
+Work in `M_3(Z)`. A signed permutation matrix has, in each row and each
+column, exactly one nonzero entry, and that entry is `+1` or `−1`.
+
+```text
+G = { R in M_3(Z) : R is a signed permutation matrix and det(R) = +1 }.
+```
+
+Matrix products and determinants are the ordinary integer formulas. The
+identity is `I = ((1,0,0), (0,1,0), (0,0,1))`. A displayed order-`4`
+witness, a `90°` rotation about the third coordinate axis, is
+
+```text
+R_* = ((0,-1,0), (1,0,0), (0,0,1)).
+```
+
+Direct products give `R_*^2 = ((-1,0,0), (0,-1,0), (0,0,1))`,
+`R_*^3 = ((0,1,0), (-1,0,0), (0,0,1))`, and `R_*^4 = I`, while no
+smaller positive exponent is `I`.
+
+## Theorem 1 — `G` is not cyclic of order 24
+
+The `48` signed permutation matrices split by determinant into two sets
+of equal size. Restricting to `det = +1` lists `24` distinct matrices,
+so `|G| = 24`.
+
+For each `R ∈ G` the products `R, R^2, …` are computed in `M_3(Z)` until
+`I` appears. The first return occurs at an exponent in `{1, 2, 3, 4}`
+for every listed matrix. In particular the maximum order in `G` is `4`,
+attained by `R_*` and by the other coordinate-axis `90°` rotations.
+
+A cyclic group of order `24` has an element of order `24`. `G` has none.
+Therefore `G` is not isomorphic to `C_24`.
+
+## Theorem 2 — `G` is not dihedral of order 24
+
+Write `D_12` for the dihedral group of order `24`. That group contains
+the cyclic rotation subgroup of a regular 12-gon, a cyclic subgroup of
+order `12`. Any cyclic subgroup of order `12` is generated by an element
+of order `12`.
+
+The census of Theorem 1 shows that `G` has no element of order `12`.
+Therefore `G` has no cyclic subgroup of order `12`, and `G` is not
+isomorphic to `D_12`.
+
+## Physical-Interpretation Boundary
+
+The proved output is the pair of non-identifications `G ≇ C_24` and
+`G ≇ D_12`. This note does not assign `G` a one-site algebra action and
+does not change the Qubit sentence. `G` is displayed matrix data, not
+axiom content, and no additional axiom is proposed.
+
+## Mutation Checks
+
+1. Replace the maximum-order target `4` by `24`: the listed orders still
+   stop at `4`.
+2. Assert an element of order `12`: none of the 24 matrices returns at
+   exponent `12` as a first return.
+3. Drop the determinant filter: the unsigned-sign listing has 48 matrices
+   and is not the displayed set `G`.
+
+## What This Does Not Claim
+
+- This note does not classify all order-24 subgroups of SO(3).
+- This note does not adopt an `M_2` action.
+- No Qubit rewrite.
+- No claim that `G` is the unique 24-element subgroup of `SO(3)`.
+- No use of the action on four space diagonals, and no reliance on an
+  `S_4` isomorphism.
+- Improper signed permutations are not included in `G`.
+- No Record, Admissibility, or menu-selection claim.
+
+These are scope boundaries, not a census of every finite subgroup of
+`SO(3)`.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice structure alone.
+
+Their dependency role is limited to the repository's Lattice vocabulary
+that names proper cubic rotations. This theorem separately supplies the
+matrix set `G` and its order census.
+
+## Runner Contract
+
+The companion runner lists all 24 matrices in `G`, computes each order by
+repeated integer product until `I`, asserts `|G| = 24`, asserts that the
+maximum order is `4`, asserts that the number of order-`4` elements is at
+least one, and asserts that no listed order is `12` or `24`. Declared
+review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15609,
- "node_count": 5492,
+ "edge_count": 15610,
+ "node_count": 5493,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2769,6 +2769,10 @@
   "cte_rconn_spatial_tensor_color_bridge_is_a_cross_domain_coincidence_narrow_no_go_note_2026-06-08": {
    "deps_hash": "825a4024d61b",
    "out_degree": 4
+  },
+  "cube_rotation_group_not_cyclic_dihedral_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
    "deps_hash": "04fc7d8812c4",

--- a/logs/runner-cache/cube_rotation_group_not_cyclic_dihedral_2026_08_14.txt
+++ b/logs/runner-cache/cube_rotation_group_not_cyclic_dihedral_2026_08_14.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py
+runner_sha256: 39d8394de8bfbde11f610d376ffc7363b5d39e035915609a5efd0404422a1f34
+input_fingerprint_sha256: 841f77d52ff619a241a61c4dd7823959b21c2c1db155b01cb6db8485a2d8fc76
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact Z matrix orders only
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: integer 3x3 arithmetic; no floating-point inputs
+claim_boundary: G is not C_24 and not D_12; no SO(3) census; no M_2 action
+|G|=24
+order_counts: 1:1, 2:9, 3:8, 4:6
+max_order=4
+PASS: signed-count-48 there are 48 signed permutation matrices
+PASS: all-signed-perm every generated matrix is a signed permutation
+PASS: g-cardinality |G|=24
+PASS: g-det-plus-one every element of G has det = +1
+PASS: identity-in-g I is in G
+PASS: axis-90-in-g the displayed 90° axis matrix is in G
+PASS: axis-90-order-4 the displayed 90° axis matrix has order 4
+PASS: orders-only-1234 orders in G are a subset of {1,2,3,4}
+PASS: max-order-4 max order in G is 4
+PASS: order-4-exists G has at least one element of order 4
+PASS: no-order-12 G has no element of order 12
+PASS: no-order-24 G has no element of order 24
+PASS: not-c24 G is not cyclic of order 24
+PASS: not-d12 G is not dihedral of order 24
+PASS: note-forbidden-substrings note avoids the dispatch-forbidden substrings
+PASS: lattice-quotes Live Parent Quotes are the two Lattice sentences
+PASS: lattice-quotes-live quoted Lattice sentences are live on the axiom memo
+PASS: parents-axiom-memo-only declared parents are the axiom memo only
+PASS: note-contract machine status, theorems, and stated non-claims are source-visible
+PASS: no-qubit-rewrite the one-site algebra sentence is not rewritten
+PASS: no-cache-write this runner writes no cache path
+per_element: each of the 24 matrices has a computed finite order in {1,2,3,4}
+per_site: the statement is about one 3x3 matrix set, not a site algebra
+per_mode: only the displayed G is classified as not C_24 and not D_12
+per_block: no SO(3) classification block is executed
+lattice_wide: checked and not executed — no lattice-wide law is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py
+++ b/scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Exact order census of the 24 proper 3x3 signed permutation matrices.
+
+G is enumerated over Z. Element orders are least k>0 with R^k = I.
+No cache write, no citation manifest, no axiom edit.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "CUBE_ROTATION_GROUP_NOT_CYCLIC_DIHEDRAL_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CUBE_ROTATION_GROUP_NOT_CYCLIC_DIHEDRAL_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+IDENTITY: Matrix = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+# 90° about the third coordinate axis: a displayed order-4 witness.
+AXIS_90: Matrix = ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+
+LATTICE_QUOTE_SITES = (
+    "Physical sites are the points of the cubic lattice `Z^3`, with "
+    "nearest-neighbor adjacency, standard translations, and proper cubic "
+    "rotations about each site."
+)
+LATTICE_QUOTE_NO_PRIVILEGE = (
+    "No site is privileged. Sites are distinguished by the supplied lattice "
+    "structure alone."
+)
+
+FORBIDDEN_NOTE_SUBSTRINGS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "we adopt",
+    "Codex",
+    "L_phys",
+)
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(
+            left[row][0] * right[0][col]
+            + left[row][1] * right[1][col]
+            + left[row][2] * right[2][col]
+            for col in range(3)
+        )
+        for row in range(3)
+    )
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def is_signed_permutation(matrix: Matrix) -> bool:
+    for row in matrix:
+        if sorted(abs(entry) for entry in row) != [0, 0, 1]:
+            return False
+    for col in range(3):
+        if sorted(abs(matrix[row][col]) for row in range(3)) != [0, 0, 1]:
+            return False
+    return True
+
+
+def enumerate_signed_permutation_matrices() -> list[Matrix]:
+    matrices: list[Matrix] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = []
+            for row in range(3):
+                entries = [0, 0, 0]
+                entries[perm[row]] = signs[row]
+                rows.append(tuple(entries))
+            matrices.append(tuple(rows))  # type: ignore[arg-type]
+    return matrices
+
+
+def proper_signed_permutations() -> list[Matrix]:
+    return [matrix for matrix in enumerate_signed_permutation_matrices() if det3(matrix) == 1]
+
+
+def collapsed(text: str) -> str:
+    return " ".join(text.split())
+
+
+def element_order(matrix: Matrix) -> int:
+    power = matrix
+    for order in range(1, 25):
+        if power == IDENTITY:
+            return order
+        power = mat_mul(power, matrix)
+    raise ArithmeticError("no order at most 24; G would not be a finite subgroup of order 24")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; exact Z matrix orders only")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: integer 3x3 arithmetic; no floating-point inputs")
+    print("claim_boundary: G is not C_24 and not D_12; no SO(3) census; no M_2 action")
+
+    all_signed = enumerate_signed_permutation_matrices()
+    group = proper_signed_permutations()
+    unique = set(group)
+    orders = [element_order(matrix) for matrix in group]
+    order_set = set(orders)
+    counts = Counter(orders)
+    max_order = max(orders)
+    order_four_count = counts[4]
+
+    print(f"|G|={len(unique)}")
+    print("order_counts: " + ", ".join(f"{order}:{counts[order]}" for order in sorted(counts)))
+    print(f"max_order={max_order}")
+
+    checks.check("signed-count-48", "there are 48 signed permutation matrices", len(all_signed) == 48)
+    checks.check(
+        "all-signed-perm",
+        "every generated matrix is a signed permutation",
+        all(is_signed_permutation(matrix) for matrix in all_signed),
+    )
+    checks.check("g-cardinality", "|G|=24", len(group) == 24 and len(unique) == 24)
+    checks.check(
+        "g-det-plus-one",
+        "every element of G has det = +1",
+        all(det3(matrix) == 1 for matrix in group),
+    )
+    checks.check("identity-in-g", "I is in G", IDENTITY in unique)
+    checks.check("axis-90-in-g", "the displayed 90° axis matrix is in G", AXIS_90 in unique)
+    checks.check("axis-90-order-4", "the displayed 90° axis matrix has order 4", element_order(AXIS_90) == 4)
+    checks.check("orders-only-1234", "orders in G are a subset of {1,2,3,4}", order_set <= {1, 2, 3, 4})
+    checks.check("max-order-4", "max order in G is 4", max_order == 4)
+    checks.check("order-4-exists", "G has at least one element of order 4", order_four_count >= 1)
+    checks.check("no-order-12", "G has no element of order 12", 12 not in order_set and counts[12] == 0)
+    checks.check("no-order-24", "G has no element of order 24", 24 not in order_set and counts[24] == 0)
+    checks.check(
+        "not-c24",
+        "G is not cyclic of order 24",
+        len(unique) == 24 and 24 not in order_set,
+    )
+    checks.check(
+        "not-d12",
+        "G is not dihedral of order 24",
+        len(unique) == 24 and 12 not in order_set,
+    )
+
+    forbidden_hits = [needle for needle in FORBIDDEN_NOTE_SUBSTRINGS if needle in note]
+    checks.check(
+        "note-forbidden-substrings",
+        "note avoids the dispatch-forbidden substrings",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "lattice-quotes",
+        "Live Parent Quotes are the two Lattice sentences",
+        LATTICE_QUOTE_SITES in note and LATTICE_QUOTE_NO_PRIVILEGE in note,
+    )
+    checks.check(
+        "lattice-quotes-live",
+        "quoted Lattice sentences are live on the axiom memo",
+        LATTICE_QUOTE_SITES in collapsed(axiom)
+        and LATTICE_QUOTE_NO_PRIVILEGE in collapsed(axiom),
+    )
+    checks.check(
+        "parents-axiom-memo-only",
+        "declared parents are the axiom memo only",
+        "Parents:** the live axiom memo" in note
+        and "MINIMAL_AXIOMS_2026-06-29.md" in note
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/CUBE_ROTATION_GROUP_NOT_CYCLIC_DIHEDRAL_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "note-contract",
+        "machine status, theorems, and stated non-claims are source-visible",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "target_claim_type: bounded_theorem",
+                "**Type:** bounded_theorem",
+                "## Theorem 1",
+                "## Theorem 2",
+                "not cyclic of order 24",
+                "not dihedral of order 24",
+                "does not classify all order-24 subgroups of SO(3)",
+                "does not adopt an `M_2` action",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        )
+        and "new axiom" not in note.lower(),
+    )
+    checks.check(
+        "no-qubit-rewrite",
+        "the one-site algebra sentence is not rewritten",
+        "algebraic presentation" not in note.replace(
+            "The full one-site possibility domain has algebraic presentation `M_2(C)`.",
+            "",
+        ),
+    )
+    checks.check(
+        "no-cache-write",
+        "this runner writes no cache path",
+        "cache" not in self_source.lower() or "No cache write" in self_source,
+    )
+
+    print("per_element: each of the 24 matrices has a computed finite order in {1,2,3,4}")
+    print("per_site: the statement is about one 3x3 matrix set, not a site algebra")
+    print("per_mode: only the displayed G is classified as not C_24 and not D_12")
+    print("per_block: no SO(3) classification block is executed")
+    print("lattice_wide: checked and not executed — no lattice-wide law is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The 24-element set G of 3×3 signed permutation matrices with det=+1 has orders only in {1,2,3,4} (counts 1,9,8,6). Max order is 4, so G is not C_24 and not D_12.

## Runner

`scripts/cube_rotation_group_not_cyclic_dihedral_2026_08_14.py`

`TOTAL: PASS=21 FAIL=0`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.