### PR TITLE
feat(l1draw): realized first-wave PVM labels do not feed n

### DIFF
--- a/docs/TWO_CUBE_L1_DRAW_DOES_NOT_FEED_N_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_L1_DRAW_DOES_NOT_FEED_N_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,263 @@
+---
+claim_id: two_cube_l1_draw_does_not_feed_n_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the supplied twelve-vertex two-cube patch, after one L1 tick from the seed, assigning first-wave lock labels + or − leaves occupancy 1 at every first-wave site. The occupancy kernel n at every unread site before tick 2 is therefore the same for the all-+ assignment and the mixed assignment with (1,0,0)=+ and the other first-wave sites −. The tick-2 formation set is independent of that realized PVM content. L1 is displayed, not adopted. No physical identification is asserted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py
+---
+
+# Two-Cube `L1` Realized Draw Does Not Feed `n`
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact occupancy and occupancy-kernel identities after one displayed
+`L1` tick on a supplied twelve-vertex two-cube patch. First-wave lock labels
+are realized `P+`/`P−` content. Occupancy stays `1` in both displayed
+assignments. Qubit remains `M_2(C)`. `L1` is displayed executable data, not
+adopted law.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py`](../scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Work on the finite vertex set of two unit cubes that share a face:
+
+```text
+A = [0,1]^3,     B = [1,2] × [0,1] × [0,1].
+```
+
+The twelve vertices are the union of the eight vertices of `A` and the eight
+vertices of `B`. Occupancy off this patch is `0`. The displayed member `L1`
+uses the occupancy kernel
+
+```text
+n_μ = (o_{+μ} − o_{-μ}) / 3.
+```
+
+Locked sites stay locked. An unread patch site forms if and only if `n ≠ 0`.
+On the seed `{(0,0,0)}` the first-wave sites are `(1,0,0)`, `(0,1,0)`, and
+`(0,0,1)`. Each has `k = |3n|^2 = 1`. The one-site spectral traces in `Q` are
+
+```text
+Tr(ρ P+) = (3+1)/6 = 2/3,     Tr(ρ P−) = (3−1)/6 = 1/3.
+```
+
+`L1` records those traces. This note then assigns each first-wave site a lock
+label `+` or `−`: the realized projector content at that site. Two assignments
+are displayed:
+
+- all `+`;
+- mixed: `(1,0,0) = +` and the other first-wave sites `−`.
+
+Occupancy is `1` at every first-wave site in both assignments. The lock label
+is record content, not a change of occupancy.
+
+**Theorem.** After the first tick, `n` at every unread patch site is the same
+for both assignments. The tick-2 formation set is therefore independent of
+the realized PVM content. That set is
+
+```text
+{(1,1,0), (1,0,1), (0,1,1), (2,0,0)}
+```
+
+in both branches.
+
+This is not a new family of `k` projectors and not a three-site line draw.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Z/Q identities: first-wave PVM labels do not change occupancy, so n before tick 2 and the tick-2 formation set are assignment-independent on the supplied twelve-vertex patch."
+trace_class: frontier_discovery
+target_claim_id: two_cube_l1_draw_does_not_feed_n
+target_blocker_text: "whether realized first-wave PVM content feeds the occupancy kernel before tick 2"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the supplied twelve-vertex patch and the two displayed first-wave assignments; L1 is displayed, not adopted"
+hypothetical_axiom_status: not proposed
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded algebraic claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the four live axiom sentences quoted below. They
+  are quoted without rewrite. No map in this note is a Lattice map. Qubit is
+  not rewritten.
+- **Explicit theorem-domain condition:** the twelve-vertex two-cube patch,
+  off-patch occupancy `0`, the `L1` occupancy kernel, first-wave `k=1` traces
+  in `Q`, and the two displayed lock-label assignments are supplied
+  mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selecting `L1` as a physical law, lifting it off
+  the supplied patch, or adopting a Born reading of the traces remain
+  separate, open obligations.
+
+## Exact Objects
+
+All runner coefficients are exact integers or `Fraction` values. No float is
+used. First-wave traces stay in `Q` because `k=1`.
+
+Occupancy `o(v)` is `1` on a lock in the patch and `0` otherwise, including
+every off-patch neighbor. A first-wave lock label `+` or `−` does not change
+`o(v)`. The kernel `n` is a triple in `Q^3` computed from occupancy alone.
+
+The one-site traces use the live Qubit presentation `M_2(C)`. They are
+displayed spectral weights, not a change of the one-site algebra and not a
+new projector family.
+
+## Exact Target And Proof Obligations
+
+The exact target is to compare the two displayed first-wave assignments after
+one `L1` tick from the seed.
+
+The obligation graph is:
+
+1. the patch has twelve vertices;
+2. on the seed, each first-wave site has `k=1` and traces `2/3`, `1/3`;
+3. occupancy at every first-wave site is `1` under both assignments;
+4. `n` at every unread patch site before tick 2 is the same in both
+   assignments;
+5. the forming set after tick 1 is
+   `{(1,1,0), (1,0,1), (0,1,1), (2,0,0)}` in both branches.
+
+All five obligations are closed below and in the runner. There is no missing
+lemma for this bounded display.
+
+## Theorem 1 — first-wave sites after the seed tick
+
+Start with locks `{(0,0,0)}`. At `(1,0,0)` the only nonzero neighbor occupancy
+is `o(0,0,0)=1` on the `-x` bond, so
+
+```text
+n = (−1/3, 0, 0),     k = 1.
+```
+
+At `(0,1,0)` one has `n = (0, −1/3, 0)` and `k=1`. At `(0,0,1)` one has
+`n = (0, 0, −1/3)` and `k=1`. Each of these three sites lies in the
+twelve-vertex set, is unread, and has `n ≠ 0`, so each forms. After the tick
+the locked set is
+
+```text
+{(0,0,0), (1,0,0), (0,1,0), (0,0,1)}.
+```
+
+The `k=1` traces are `(3±1)/6`, hence `2/3` and `1/3`. Their sum is `1`.
+
+## Theorem 2 — occupancy is `1` for both displayed assignments
+
+Assign each first-wave site a lock label `+` or `−`. The two displayed
+assignments are
+
+```text
+all-+ :  (1,0,0) ↦ +,  (0,1,0) ↦ +,  (0,0,1) ↦ +
+mixed :  (1,0,0) ↦ +,  (0,1,0) ↦ −,  (0,0,1) ↦ −
+```
+
+In both assignments every first-wave site is locked, so `o=1` there. The
+seed remains occupied. Occupancy off the patch remains `0`. The label is
+realized PVM content at an already-formed site. It is not a signed occupancy
+and it is not a new `k` projector.
+
+## Theorem 3 — `n` before tick 2 is assignment-independent
+
+The kernel `n` at an unread site is a function of neighbor occupancies. Those
+occupancies after tick 1 are the same function of the locked set in both
+assignments. Therefore `n` at every unread patch site is the same pair of
+triples.
+
+Explicit values, identical in both branches:
+
+```text
+(1,1,0) : n = (−1/3, −1/3, 0)
+(1,0,1) : n = (−1/3, 0, −1/3)
+(0,1,1) : n = (0, −1/3, −1/3)
+(2,0,0) : n = (−1/3, 0, 0)
+(1,1,1) : n = (0, 0, 0)
+(2,1,0) : n = (0, 0, 0)
+(2,0,1) : n = (0, 0, 0)
+(2,1,1) : n = (0, 0, 0)
+```
+
+If a minus label were misread as vacant occupancy, `n` at `(1,1,0)` and at
+`(0,1,1)` would change. That mutation is not the `L1` occupancy rule.
+
+## Theorem 4 — tick-2 formation set is the same in both branches
+
+An unread site forms if and only if `n ≠ 0`. From the table of Theorem 3 the
+forming set after tick 1 is
+
+```text
+{(1,1,0), (1,0,1), (0,1,1), (2,0,0)}
+```
+
+in both assignments. The four remaining unread patch sites stay unread. The
+tick-2 formation set is therefore independent of the realized first-wave PVM
+content.
+
+## Physical-Interpretation Boundary
+
+The proved output is the displayed comparison on the supplied patch. This
+note does not adopt `L1` as axiom content and does not rewrite Qubit. The
+one-site algebra remains `M_2(C)`. The lock labels are displayed projector
+content. They are not a physical selection rule and not a new projector
+family.
+
+## Mutation Checks
+
+Two non-equivalences guard the load-bearing conclusions:
+
+1. a minus lock label is not vacant occupancy: treating `(0,1,0)` as
+   unoccupied changes `n` at `(1,1,0)` and at `(0,1,1)`;
+2. the tick-2 formation set is not the first-wave set
+   `{(1,0,0), (0,1,0), (0,0,1)}`.
+
+## What This Does Not Claim
+
+- `L1` is displayed, not adopted.
+- No inverse-square rule is claimed.
+- Qubit remains `M_2(C)`.
+- The occupancy kernel is not a Lattice map.
+- Realized first-wave labels are not a new family of `k` projectors.
+- The comparison is not a three-site line draw.
+- Occupancy remains a `{0,1}` function of the locked set; it is not signed
+  by the lock label.
+- The identities are not a continuum lift and not a physical selection of
+  this member.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+> Records form.
+
+Their dependency role is limited to the repository's site, one-site algebra,
+nearest-neighbor, and formation vocabulary. This theorem separately supplies
+the patch, the occupancy kernel, the first-wave traces, and the two displayed
+lock-label assignments.
+
+## Runner Contract
+
+The companion runner identity-gates every helper and recomputes `n` from
+occupancy at every unread patch site in both assignments. It checks that
+occupancy is `1` under both labelings, that the two `n` tables agree, that
+the forming set after tick 1 is the four-site set above in both branches,
+quotes the four live axiom sentences, and records the import boundary.
+Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15645,
- "node_count": 5505,
+ "edge_count": 15646,
+ "node_count": 5506,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18444,6 +18444,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_l1_draw_does_not_feed_n_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_l1_draw_does_not_feed_n_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_l1_draw_does_not_feed_n_2026_08_14.txt
@@ -1,0 +1,76 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py
+runner_sha256: ac6fd54634d6ce145151ff0239997c4208ba926d034e10309b57e7f9799b1db3
+input_fingerprint_sha256: a4d16c66298ec9e41a1e189cd335f25a7f17c519f266a6c10511e09748e1bcfe
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact occupancy arithmetic on a supplied 12-vertex patch
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: exact integers and Fraction; PVM traces restricted to k=1
+claim_boundary: realized first-wave labels do not feed n; L1 is displayed, not adopted
+PASS: id-patch-count patch-count identity
+PASS: id-first-wave-on-patch first-wave-on-patch identity
+PASS: id-off-patch-occupancy off-patch-occupancy identity
+PASS: id-empty-forms-none empty-forms-none identity
+PASS: id-n-at-100 n-at-100 identity
+PASS: id-n-at-010 n-at-010 identity
+PASS: id-n-at-001 n-at-001 identity
+PASS: id-k-at-100 k-at-100 identity
+PASS: id-k-at-010 k-at-010 identity
+PASS: id-k-at-001 k-at-001 identity
+PASS: id-forming-set-tick1 forming-set-tick1 identity
+PASS: id-trace-plus trace-plus identity
+PASS: id-trace-minus trace-minus identity
+PASS: id-traces-sum traces-sum identity
+PASS: id-tick1-lock-count tick1-lock-count identity
+PASS: id-unread-count unread-count identity
+PASS: id-occ-plus-100 occ-plus-100 identity
+PASS: id-occ-mixed-100 occ-mixed-100 identity
+PASS: id-label-ignored-100 label-ignored-100 identity
+PASS: id-occ-plus-010 occ-plus-010 identity
+PASS: id-occ-mixed-010 occ-mixed-010 identity
+PASS: id-label-ignored-010 label-ignored-010 identity
+PASS: id-occ-plus-001 occ-plus-001 identity
+PASS: id-occ-mixed-001 occ-mixed-001 identity
+PASS: id-label-ignored-001 label-ignored-001 identity
+PASS: id-expected-n-covers-unread expected-n-covers-unread identity
+PASS: thm-n-assignment-independent n at every unread site before tick 2 is the same for both assignments
+PASS: id-n-plus-011 n-plus-011 identity
+PASS: id-n-mixed-011 n-mixed-011 identity
+PASS: id-n-plus-101 n-plus-101 identity
+PASS: id-n-mixed-101 n-mixed-101 identity
+PASS: id-n-plus-110 n-plus-110 identity
+PASS: id-n-mixed-110 n-mixed-110 identity
+PASS: id-n-plus-111 n-plus-111 identity
+PASS: id-n-mixed-111 n-mixed-111 identity
+PASS: id-n-plus-200 n-plus-200 identity
+PASS: id-n-mixed-200 n-mixed-200 identity
+PASS: id-n-plus-201 n-plus-201 identity
+PASS: id-n-mixed-201 n-mixed-201 identity
+PASS: id-n-plus-210 n-plus-210 identity
+PASS: id-n-mixed-210 n-mixed-210 identity
+PASS: id-n-plus-211 n-plus-211 identity
+PASS: id-n-mixed-211 n-mixed-211 identity
+PASS: id-form-plus form-plus identity
+PASS: id-form-mixed form-mixed identity
+PASS: id-form-bare form-bare identity
+PASS: thm-formation-independent tick-2 formation set is independent of realized PVM content
+PASS: thm-occupancy-one-both occupancy is 1 at every first-wave site in both assignments
+PASS: mutation-minus-is-not-vacant treating a minus label as vacant changes n at (1,1,0) and (0,1,1)
+PASS: mutation-not-first-wave-set tick-2 formation set is not the first-wave set
+PASS: live-parent-quotes the note quotes all four live axiom sentences without rewrite
+PASS: machine-status-contract bounded-support status and hypothetical_axiom_status: not proposed
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: note-hygiene L1 is displayed; Qubit stays M_2(C); forbidden strings absent
+per_element: occupancy, n, and k=1 traces are recomputed at each first-wave site
+per_site: n at every unread patch site is compared across the two assignments
+per_mode: P+ and P- traces are the two spectral weights at k=1
+per_block: tick-2 formation set is checked in both branches
+lattice_wide: checked and not executed — the claim is the supplied 12-vertex patch
+TOTAL: PASS=54 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py
+++ b/scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Exact checks that realized first-wave PVM labels do not feed n.
+
+Same L1 occupancy kernel as the two-cube integrated member. After tick 1,
+lock labels +/− at first-wave sites leave occupancy 1. The kernel n at every
+unread site, and the tick-2 formation set, are identical for the all-+
+assignment and the mixed assignment. Every helper is identity-gated.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_CUBE_L1_DRAW_DOES_NOT_FEED_N_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_L1_DRAW_DOES_NOT_FEED_N_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Site = tuple[int, int, int]
+Locks = frozenset[Site]
+Vec3 = tuple[Fraction, Fraction, Fraction]
+Assignment = dict[Site, str]
+
+AXES: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+ZERO_N: Vec3 = (Fraction(0), Fraction(0), Fraction(0))
+SEED: Site = (0, 0, 0)
+FIRST_WAVE: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+TICK2_FORMATION: Locks = frozenset({(1, 1, 0), (1, 0, 1), (0, 1, 1), (2, 0, 0)})
+
+
+def add_site(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def cube_a_vertices() -> frozenset[Site]:
+    return frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+
+
+def cube_b_vertices() -> frozenset[Site]:
+    return frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+
+
+def patch_vertices() -> frozenset[Site]:
+    return cube_a_vertices() | cube_b_vertices()
+
+
+def occupancy(site: Site, locks: Locks) -> int:
+    if site not in patch_vertices():
+        return 0
+    return 1 if site in locks else 0
+
+
+def occupancy_with_labels(site: Site, locks: Locks, assignment: Assignment) -> int:
+    """Occupancy ignores realized PVM labels: a labeled lock still has o=1."""
+    if site not in patch_vertices():
+        return 0
+    if site in locks:
+        if site in assignment:
+            label = assignment[site]
+            if label not in ("+", "-"):
+                raise ValueError(f"lock label must be + or -, got {label!r}")
+        return 1
+    return 0
+
+
+def n_vector(site: Site, locks: Locks, assignment: Assignment | None = None) -> Vec3:
+    occ = occupancy if assignment is None else (
+        lambda neighbor, _locks=locks, _asg=assignment: occupancy_with_labels(
+            neighbor, _locks, _asg
+        )
+    )
+    components = []
+    for axis in AXES:
+        plus = occ(add_site(site, axis), locks)
+        minus = occ(add_site(site, (-axis[0], -axis[1], -axis[2])), locks)
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+def k_value(n: Vec3) -> int:
+    squared = sum((3 * component) ** 2 for component in n)
+    if squared.denominator != 1:
+        raise ValueError(f"k left Q: {squared}")
+    return int(squared)
+
+
+def site_forms(site: Site, locks: Locks, assignment: Assignment | None = None) -> bool:
+    if site in locks or site not in patch_vertices():
+        return False
+    return n_vector(site, locks, assignment) != ZERO_N
+
+
+def spectral_traces(k: int) -> tuple[Fraction, Fraction]:
+    if k != 1:
+        raise ValueError("PVM traces restricted to k=1 so the runner stays in Q")
+    root = 1
+    return Fraction(3 + root, 6), Fraction(3 - root, 6)
+
+
+def forming_sites(locks: Locks, assignment: Assignment | None = None) -> Locks:
+    return frozenset(
+        site for site in patch_vertices() if site_forms(site, locks, assignment)
+    )
+
+
+def unread_sites(locks: Locks) -> Locks:
+    return frozenset(site for site in patch_vertices() if site not in locks)
+
+
+def all_plus() -> Assignment:
+    return {site: "+" for site in FIRST_WAVE}
+
+
+def mixed_assignment() -> Assignment:
+    return {(1, 0, 0): "+", (0, 1, 0): "-", (0, 0, 1): "-"}
+
+
+def signed_occupancy_mutation(site: Site, locks: Locks, assignment: Assignment) -> int:
+    """Mutation: treat a minus label as vacant. Not the L1 occupancy rule."""
+    if site not in patch_vertices():
+        return 0
+    if site not in locks:
+        return 0
+    if site in assignment and assignment[site] == "-":
+        return 0
+    return 1
+
+
+def n_under_signed_mutation(site: Site, locks: Locks, assignment: Assignment) -> Vec3:
+    components = []
+    for axis in AXES:
+        plus = signed_occupancy_mutation(add_site(site, axis), locks, assignment)
+        minus = signed_occupancy_mutation(
+            add_site(site, (-axis[0], -axis[1], -axis[2])), locks, assignment
+        )
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def identity_gate(self, name: str, computed: object, expected: object) -> None:
+        self.check(f"id-{name}", f"{name} identity", computed == expected)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; exact occupancy arithmetic on a supplied 12-vertex patch")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: exact integers and Fraction; PVM traces restricted to k=1")
+    print("claim_boundary: realized first-wave labels do not feed n; L1 is displayed, not adopted")
+
+    patch = patch_vertices()
+    seed_locks: Locks = frozenset({SEED})
+    empty: Locks = frozenset()
+    plus_asg = all_plus()
+    mixed_asg = mixed_assignment()
+
+    checks.identity_gate("patch-count", len(patch), 12)
+    checks.identity_gate("first-wave-on-patch", all(site in patch for site in FIRST_WAVE), True)
+    checks.identity_gate("off-patch-occupancy", occupancy((-1, 0, 0), seed_locks), 0)
+    checks.identity_gate("empty-forms-none", forming_sites(empty), empty)
+
+    n_x = n_vector((1, 0, 0), seed_locks)
+    n_y = n_vector((0, 1, 0), seed_locks)
+    n_z = n_vector((0, 0, 1), seed_locks)
+    checks.identity_gate("n-at-100", n_x, (Fraction(-1, 3), Fraction(0), Fraction(0)))
+    checks.identity_gate("n-at-010", n_y, (Fraction(0), Fraction(-1, 3), Fraction(0)))
+    checks.identity_gate("n-at-001", n_z, (Fraction(0), Fraction(0), Fraction(-1, 3)))
+    checks.identity_gate("k-at-100", k_value(n_x), 1)
+    checks.identity_gate("k-at-010", k_value(n_y), 1)
+    checks.identity_gate("k-at-001", k_value(n_z), 1)
+    checks.identity_gate("forming-set-tick1", forming_sites(seed_locks), frozenset(FIRST_WAVE))
+
+    plus, minus = spectral_traces(1)
+    checks.identity_gate("trace-plus", plus, Fraction(2, 3))
+    checks.identity_gate("trace-minus", minus, Fraction(1, 3))
+    checks.identity_gate("traces-sum", plus + minus, Fraction(1))
+
+    after_tick1: Locks = seed_locks | frozenset(FIRST_WAVE)
+    unread = unread_sites(after_tick1)
+    checks.identity_gate("tick1-lock-count", len(after_tick1), 4)
+    checks.identity_gate("unread-count", len(unread), 8)
+
+    for site in FIRST_WAVE:
+        checks.identity_gate(
+            f"occ-plus-{site[0]}{site[1]}{site[2]}",
+            occupancy_with_labels(site, after_tick1, plus_asg),
+            1,
+        )
+        checks.identity_gate(
+            f"occ-mixed-{site[0]}{site[1]}{site[2]}",
+            occupancy_with_labels(site, after_tick1, mixed_asg),
+            1,
+        )
+        checks.identity_gate(
+            f"label-ignored-{site[0]}{site[1]}{site[2]}",
+            occupancy_with_labels(site, after_tick1, plus_asg),
+            occupancy_with_labels(site, after_tick1, mixed_asg),
+        )
+
+    expected_n: dict[Site, Vec3] = {
+        (1, 1, 0): (Fraction(-1, 3), Fraction(-1, 3), Fraction(0)),
+        (1, 0, 1): (Fraction(-1, 3), Fraction(0), Fraction(-1, 3)),
+        (0, 1, 1): (Fraction(0), Fraction(-1, 3), Fraction(-1, 3)),
+        (2, 0, 0): (Fraction(-1, 3), Fraction(0), Fraction(0)),
+        (1, 1, 1): ZERO_N,
+        (2, 1, 0): ZERO_N,
+        (2, 0, 1): ZERO_N,
+        (2, 1, 1): ZERO_N,
+    }
+    checks.identity_gate("expected-n-covers-unread", frozenset(expected_n), unread)
+
+    n_plus = {site: n_vector(site, after_tick1, plus_asg) for site in unread}
+    n_mixed = {site: n_vector(site, after_tick1, mixed_asg) for site in unread}
+    n_bare = {site: n_vector(site, after_tick1) for site in unread}
+
+    same_n = n_plus == n_mixed == n_bare == expected_n
+    checks.check(
+        "thm-n-assignment-independent",
+        "n at every unread site before tick 2 is the same for both assignments",
+        same_n,
+    )
+    for site in sorted(unread):
+        tag = f"{site[0]}{site[1]}{site[2]}"
+        checks.identity_gate(f"n-plus-{tag}", n_plus[site], expected_n[site])
+        checks.identity_gate(f"n-mixed-{tag}", n_mixed[site], expected_n[site])
+
+    form_plus = forming_sites(after_tick1, plus_asg)
+    form_mixed = forming_sites(after_tick1, mixed_asg)
+    form_bare = forming_sites(after_tick1)
+    checks.identity_gate("form-plus", form_plus, TICK2_FORMATION)
+    checks.identity_gate("form-mixed", form_mixed, TICK2_FORMATION)
+    checks.identity_gate("form-bare", form_bare, TICK2_FORMATION)
+    checks.check(
+        "thm-formation-independent",
+        "tick-2 formation set is independent of realized PVM content",
+        form_plus == form_mixed == form_bare == TICK2_FORMATION,
+    )
+    checks.check(
+        "thm-occupancy-one-both",
+        "occupancy is 1 at every first-wave site in both assignments",
+        all(
+            occupancy_with_labels(site, after_tick1, plus_asg) == 1
+            and occupancy_with_labels(site, after_tick1, mixed_asg) == 1
+            for site in FIRST_WAVE
+        ),
+    )
+
+    mutated_110 = n_under_signed_mutation((1, 1, 0), after_tick1, mixed_asg)
+    mutated_011 = n_under_signed_mutation((0, 1, 1), after_tick1, mixed_asg)
+    checks.check(
+        "mutation-minus-is-not-vacant",
+        "treating a minus label as vacant changes n at (1,1,0) and (0,1,1)",
+        mutated_110 != n_mixed[(1, 1, 0)] and mutated_011 != n_mixed[(0, 1, 1)],
+    )
+    checks.check(
+        "mutation-not-first-wave-set",
+        "tick-2 formation set is not the first-wave set",
+        form_plus != frozenset(FIRST_WAVE),
+    )
+
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    qubit_quote = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    admissibility_quote = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_quote = "Records form."
+    axiom_flat = " ".join(axiom.split())
+    checks.check(
+        "live-parent-quotes",
+        "the note quotes all four live axiom sentences without rewrite",
+        all(
+            quote in axiom_flat and quote in note
+            for quote in (
+                lattice_quote,
+                qubit_quote,
+                admissibility_quote,
+                record_quote,
+            )
+        ),
+    )
+    checks.check(
+        "machine-status-contract",
+        "bounded-support status and hypothetical_axiom_status: not proposed",
+        "actual_current_surface_status: bounded-support" in note
+        and "hypothetical_axiom_status: not proposed" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_L1_DRAW_DOES_NOT_FEED_N_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "note-hygiene",
+        "L1 is displayed; Qubit stays M_2(C); forbidden strings absent",
+        "L1 is displayed, not adopted" in note
+        and "Qubit remains `M_2(C)`" in note
+        and all(token not in note for token in forbidden)
+        and "we adopt" not in note.lower()
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+
+    print("per_element: occupancy, n, and k=1 traces are recomputed at each first-wave site")
+    print("per_site: n at every unread patch site is compared across the two assignments")
+    print("per_mode: P+ and P- traces are the two spectral weights at k=1")
+    print("per_block: tick-2 formation set is checked in both branches")
+    print("lattice_wide: checked and not executed — the claim is the supplied 12-vertex patch")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Occupancy stays 1 under both displayed first-wave lock labels, so n before tick 2 and the tick-2 formation set are assignment-independent. TOTAL: PASS=54 FAIL=0

## Runner

`scripts/two_cube_l1_draw_does_not_feed_n_2026_08_14.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
