### PR TITLE
feat(l1gaus2): tree gauge stays source-complete after two L1 ticks

### DIFF
--- a/docs/TWO_CUBE_L1_TREE_GAUGE_TWO_TICK_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_L1_TREE_GAUGE_TWO_TICK_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,366 @@
+---
+claim_id: two_cube_l1_tree_gauge_two_tick_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "Conditional on the displayed two-site two-face incidence and the displayed L1 source ticks, the tree-gauge assignment φ(F*)=ρ(A), φ(F_B)=ρ(A)+ρ(B) solves g=ρ after tick 1 with integers (4,1) and after tick 2 with integers (7,4). The 2×2 incidence is invertible, so that assignment is the unique integer solution at each tick. No third face and no −x ray are introduced. The four axioms supply none of the incidence, the decoder, or the tick values."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py
+---
+
+# Two-Site Tree Gauge Stays Source-Complete After Two L1 Ticks
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact integer incidence algebra on one displayed two-site tree
+with two faces. The L1 ticks are displayed source values, not an axiom
+consequence.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py`](../scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py)
+
+Framework context on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+Lattice names sites of `Z^3`; it does not name this two-face incidence, the
+Gauss decoder, or an L1 source tick. This cycle writes no runner cache and no
+citation manifest.
+
+## Result Up Front
+
+Investment: composition of the Gauss decoder. Gauge-fix uniqueness for a
+fixed source `ρ` is a static linear-algebra fact on this tree. This note
+checks the update: after each displayed L1 tick the same assignment
+
+```text
+φ(F*) = ρ(A)
+φ(F_B) = ρ(A) + ρ(B)
+```
+
+still solves `g = ρ`.
+
+The displayed incidence, the same two-site tree used by the recurrent
+gravity decoder, is
+
+```text
+g_A := φ(F*)
+g_B := −φ(F*) + φ(F_B)
+```
+
+Substituting the tree gauge gives `g_A = ρ(A)` and `g_B = ρ(B)` for every
+integer pair `(ρ(A), ρ(B))`. After tick 1 the displayed source is `(4, 1)`.
+After tick 2 it is `(7, 4)`. In both cases `g = ρ` holds with those integers.
+
+This is not a two-cube-gauge clone: the tested object has two faces only.
+There is no third face and no `−x` ray.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer identities show the displayed tree gauge solves g=ρ after each of two displayed L1 source ticks, and the 2×2 incidence is invertible. No physical gravity identification is supplied."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: "after each L1 tick, does the same tree-gauge assignment still solve g=ρ on the two-site two-face incidence?"
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "test whether a separately supplied longer tick sequence or a larger tree still has a unique source-complete decoder; no physical consumer is claimed here"
+conditional_surface_status: "exact for the displayed two-site incidence and the two displayed integer ticks; other complexes, gauges, and physical identifications remain separate"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Support Boundary
+
+- **Framework context:** Lattice names the cubic site set. Qubit names
+  one-site `M_2(C)`. Admissibility names one nearest-neighbor rule. Record
+  names content-only readout. None of these supplies a face incidence, a
+  flux `φ`, a source `ρ`, a Gauss decoder, or an L1 tick.
+- **Explicit bounded mathematical input:** two sites `{A, B}`, two faces
+  `{F*, F_B}`, the displayed incidence, the tree-gauge decoder, and the two
+  integer source ticks `(4, 1)` then `(7, 4)`.
+- **External physics inputs:** none. There is no measured, fitted,
+  literature, normalization, scale, or observational constant.
+- **Physical-identification boundary:** no map from this decoder to a
+  physical gravitational constraint, Newtonian kernel, or continuum Gauss
+  law is supplied.
+
+## Exact Objects
+
+Write integer sources `ρ(A), ρ(B) ∈ Z` and integer face fluxes
+`φ(F*), φ(F_B) ∈ Z`. The Gauss readout is the displayed incidence
+
+```text
+g_A := φ(F*)
+g_B := −φ(F*) + φ(F_B)
+```
+
+In matrix form, with column order `(φ(F*), φ(F_B))` and row order
+`(g_A, g_B)`,
+
+```text
+M = [[ 1, 0],
+     [-1, 1]]
+```
+
+so `(g_A, g_B)^T = M (φ(F*), φ(F_B))^T`. The determinant is `1`, and the
+unique inverse is
+
+```text
+M^{-1} = [[1, 0],
+          [1, 1]]
+```
+
+The tree-gauge decoder is exactly that inverse applied to `ρ`:
+
+```text
+φ(F*) = ρ(A)
+φ(F_B) = ρ(A) + ρ(B)
+```
+
+An L1 tick is a separately supplied update of the integer pair `ρ`. This
+note displays two ticks and does not derive a tick law:
+
+| tick | `ρ(A)` | `ρ(B)` |
+|---|---:|---:|
+| 1 | 4 | 1 |
+| 2 | 7 | 4 |
+
+The face set is `{F*, F_B}`. No third face is named. No `−x` ray is named.
+
+No axiom is edited. The incidence, decoder, and ticks are displayed
+mathematical inputs, not a proposed Lattice rewrite and not a registered
+primitive.
+
+## Exact Target And Obligation Graph
+
+**Exact target.** After each displayed L1 tick, decide whether the tree
+gauge still solves `g = ρ`, and whether that solution is unique on this
+incidence.
+
+| Obligation | Role | Disposition |
+|---|---|---|
+| displayed incidence `g_A = φ(F*)`, `g_B = −φ(F*) + φ(F_B)` | definition | used as written |
+| tree gauge `φ(F*)=ρ(A)`, `φ(F_B)=ρ(A)+ρ(B)` | decoder | used as written |
+| `g = ρ` for every integer `ρ` | Theorem 1 | proved; runner checks a finite integer sample including both ticks |
+| after tick 1, `g = ρ = (4, 1)` | Theorem 2 | proved |
+| after tick 2, `g = ρ = (7, 4)` | Theorem 2 | proved |
+| uniqueness of `φ` given `g` | Theorem 3 | `det M = 1` |
+| third face or `−x` ray | out of scope | not introduced |
+| physical gravity identification | out of scope | no such map is supplied |
+
+## Theorem 1 — Tree gauge solves the incidence identically
+
+For every integer pair `(ρ(A), ρ(B))`, the tree-gauge assignment satisfies
+`g = ρ`.
+
+Proof. Substitute `φ(F*) = ρ(A)` and `φ(F_B) = ρ(A) + ρ(B)` into the
+displayed incidence:
+
+```text
+g_A = φ(F*) = ρ(A)
+g_B = −φ(F*) + φ(F_B) = −ρ(A) + (ρ(A) + ρ(B)) = ρ(B)
+```
+
+The identity is algebraic and does not use the numerical values of a tick.
+
+## Theorem 2 — Source-completeness after two L1 ticks
+
+After tick 1 and after tick 2, `g = ρ` holds with the displayed integers
+`(4, 1)` then `(7, 4)`.
+
+Proof. Theorem 1 applies to every integer pair, so it applies to both
+displayed ticks. Explicitly:
+
+Tick 1. `ρ = (4, 1)`, so `φ(F*) = 4` and `φ(F_B) = 5`. Then
+`g_A = 4` and `g_B = −4 + 5 = 1`.
+
+Tick 2. `ρ = (7, 4)`, so `φ(F*) = 7` and `φ(F_B) = 11`. Then
+`g_A = 7` and `g_B = −7 + 11 = 4`.
+
+The decoder is therefore source-complete after each of the two updates. The
+same assignment rule is reused; only the source values change.
+
+## Theorem 3 — Uniqueness survives the update
+
+Given any integer pair `g`, there is exactly one integer pair `φ` on
+`{F*, F_B}` with that Gauss readout. In particular the tree gauge is the
+unique solution of `g = ρ` after each displayed tick.
+
+Proof. `det M = 1 · 1 − 0 · (−1) = 1`, so `M` is invertible over `Z`. The
+unique solution is `φ = M^{-1} g`, which is the tree gauge when `g = ρ`.
+Invertibility does not depend on the value of `ρ`, so uniqueness is
+preserved by any source update, including the two displayed L1 ticks.
+
+Static uniqueness given one `ρ` is this invertibility. Composition with the
+update is Theorem 2 plus the same invertibility at the new `ρ`.
+
+## Not A Two-Cube-Gauge Clone
+
+A two-cube gauge problem would introduce at least one further face and a
+`−x` ray. The object tested here has exactly the two faces `F*` and `F_B`
+and the two sites `A` and `B`. The runner checks that the note and the
+decoder domain name no third face and no `−x` ray.
+
+## Physical-Identification Boundary
+
+The four axioms do not name a Gauss decoder or an L1 tick. Hosting a unique
+source-complete tree gauge on this two-face incidence is a type fact about a
+displayed integer map. No claim about continuum gravity, a Newtonian
+kernel, or a physical constraint algebra is made.
+
+## Falsifiers And Mutation Targets
+
+The predicate `g == ρ` after tick 1 must hold for `(4, 1)`.
+The predicate `g == ρ` after tick 2 must hold for `(7, 4)`.
+The predicate `det M == 1` must hold.
+The predicates “a third face is used” and “a `−x` ray is used” must fail.
+
+All five are runner-checked by constructing `M` and the two decoded ticks.
+
+## No-Go Discipline Gate
+
+There is no universal negative claim. The only local negative boundary is
+that a third-face or `−x`-ray reading is outside the tested object. Routes
+below try to defeat `g = ρ` after the two ticks or to smuggle a two-cube
+clone.
+
+### N1 — materially distinct routes
+
+| Route family | Exact attack | Exact outcome | Marker |
+|---|---|---|---|
+| Drop the minus on `F*` | use `g_B := φ(F*) + φ(F_B)` | tick 1 would give `g_B = 9 ≠ 1` | **ATTEMPTED** |
+| Swap the tree assignment | set `φ(F*)=ρ(B)`, `φ(F_B)=ρ(A)` | tick 1 would give `g = (1, 3) ≠ (4, 1)` | **ATTEMPTED** |
+| Freeze the tick-1 flux | reuse `φ = (4, 5)` at tick 2 | `g` would stay `(4, 1) ≠ (7, 4)` | **ATTEMPTED** |
+| Attribute uniqueness to one `ρ` only | recompute `det M` after both ticks | `det M = 1` at both sources | **ATTEMPTED** |
+| Import a third face | search the decoder domain for a third face name | domain is `{F*, F_B}` | **ATTEMPTED** |
+| Import a `−x` ray | search the tested object for a `−x` ray | none is named | **ATTEMPTED** |
+
+These are routes against one local identity. They do not enumerate routes to
+a physical gravitational theory, because no such negative claim is made.
+
+### N2 — wall independence and collapse
+
+There is no multi-wall claim. Incidence, decoder substitution, and
+invertibility are independent checks of the same source-completeness fact,
+not three walls.
+
+| Raw pair | First closes second? | Second closes first? | Collapse |
+|---|---:|---:|---|
+| Theorem 1 identity / tick-1 numbers | yes | no | the tick is a specialization |
+| Theorem 1 identity / tick-2 numbers | yes | no | the tick is a specialization |
+| `det M = 1` / unique tree gauge | yes | yes | invertibility definition |
+
+Collapsed obstruction set: `{g = ρ after each displayed tick}`. No physical
+identification is counted as a wall.
+
+### N3 — hidden-condition scan
+
+| Item | Classification |
+|---|---|
+| two sites `{A, B}` and two faces `{F*, F_B}` | explicit bounded mathematical input |
+| displayed incidence `M` | explicit test matrix, not attributed to the axioms |
+| tree-gauge decoder | explicit inverse of `M` |
+| L1 ticks `(4, 1)` and `(7, 4)` | explicit displayed integers, not a derived tick law |
+| integer coefficient ring `Z` | explicit; runner uses exact integers |
+| third face, `−x` ray, two-cube gauge | scope non-claims; not part of the object |
+| observations or fitted constants | none |
+
+The scan found no hidden condition beyond the now-explicit incidence,
+decoder, and ticks. No continuum limit, Newtonian kernel, or empirical mass
+is used.
+
+### N4 — source residual matching
+
+| Source and locator | Residual addressed there | Residual here | Match and limit |
+|---|---|---|---|
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), Lattice and Record clauses | cubic sites and content-only readout | displayed two-face incidence | no residual match; used only for framework context |
+| this note, Theorems 1–3 and paired runner | displayed `M`, decoder, and two ticks | `g = ρ` after each tick | exact match; self-contained current-cycle calculation |
+
+No prior no-go is used as authority. The incidence identities, the two
+ticks, and invertibility are proved here.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed claim | Claim not made |
+|---|---|---|
+| per element | entries of `M`, `M^{-1}`, and the two decoded flux pairs | no classification of every integer matrix |
+| per site | the two displayed sites `A` and `B` only | no lattice-wide source law |
+| per mode | the two faces `F*` and `F_B` | no third-face or ray mode |
+| per block | one two-site tree after two ticks | no physical constraint identification |
+| lattice-wide | checked and not executed: the theorem supplies no lattice-wide decoder | no lattice-wide existence or no-go |
+
+The wording is therefore restricted to the displayed tree. The paired
+runner prints the five canonical resolution-certificate lines with the same
+boundary. This cycle writes no cache file.
+
+### N6 — live partial-closure paths
+
+1. A longer tick sequence with a separately supplied update rule is a
+   separate question and remains open here.
+2. A larger tree, a loop, or a two-cube complex would change `M`; this note
+   tests only the displayed two-face tree.
+3. A different gauge slice could solve `g = ρ` on a larger complex with a
+   kernel; this incidence has trivial kernel.
+4. A separate retained derivation or explicitly approved primitive could
+   supply a physical Gauss-law identification; this theorem neither assumes
+   nor forecloses such work.
+5. Merely naming the decoder “gravity” would be a labeling convention, not
+   a derivation, so this note does not use that retirement path.
+
+Scale reference, kinetic isotropy, and realized state were checked in the
+premise registry. None is load-bearing here, and none is counted as a wall.
+No new axiom is claimed to be necessary.
+
+### N7 — concrete-mechanism steelman
+
+The strongest objection says that static uniqueness already gives `g = ρ`
+at every `ρ`, so a two-tick check is empty. The objection correctly
+identifies that Theorem 1 is `ρ`-independent, but it does not defeat the
+scoped claim. The investment is composition of the decoder with an update:
+the same assignment must be re-evaluated on the new integers, and a frozen
+tick-1 flux fails at tick 2. The terminal obligation is exactly that
+re-evaluation, which the N1 routes close. Steelman disposition: **CLOSED**.
+
+### N8 — cross-cycle echo
+
+| Echo | Status/mechanism checked | Could it retire this identity? |
+|---|---|---|
+| [`TWO_ENDPOINT_GAUSS_LAW_INVARIANCE_PROFILE_BOUNDED_THEOREM_NOTE_2026-06-05.md`](TWO_ENDPOINT_GAUSS_LAW_INVARIANCE_PROFILE_BOUNDED_THEOREM_NOTE_2026-06-05.md) | endpoint dressing of link operators against model Gauss generators | no; that surface is an operator commutant profile, not this integer tree decoder |
+| two-cube gauge with a third face and a `−x` ray | a larger complex, not the tested object | no; cloning that complex would change `M` |
+
+The search found no convention that makes `g ≠ ρ` on this incidence after
+the displayed ticks. It did find live alternative complexes, so no broader
+no-go is asserted.
+
+N1–N8 disposition: **PASS** for the exact source-completeness of the
+displayed tree gauge after the two L1 ticks. The packet grants no standing
+to any broader negative claim.
+
+## Excluded Broader Claims
+
+This note makes none of the following claims:
+
+- “the axioms derive a physical Gauss law”
+- “this is a two-cube gauge theorem”
+- “a third face or `−x` ray is required”
+- “an L1 tick law is derived from Admissibility or Record”
+- “an axiom update is necessary”
+- “this constructs continuum gravity”
+
+The shipped claim is only: conditional on the displayed two-site two-face
+incidence, the tree-gauge decoder solves `g = ρ` after tick 1 with integers
+`(4, 1)` and after tick 2 with integers `(7, 4)`, and that solution is
+unique.
+
+## Provenance
+
+Framework context on `origin/main`: the axiom memo only. The runner binds
+
+`AUDIT_INPUT_PATHS = (this note, docs/MINIMAL_AXIOMS_2026-06-29.md)`
+
+as a string-literal tuple. This cycle writes no citation manifest and no
+runner cache. Neither omitted artifact is a scientific premise.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15645,
- "node_count": 5505,
+ "edge_count": 15647,
+ "node_count": 5506,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18445,6 +18445,10 @@
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
    "out_degree": 1
+  },
+  "two_cube_l1_tree_gauge_two_tick_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "5135391598d2",
+   "out_degree": 2
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {
    "deps_hash": "bd71c5f30cb7",

--- a/logs/runner-cache/two_cube_l1_tree_gauge_two_tick_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_l1_tree_gauge_two_tick_2026_08_14.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py
+runner_sha256: 8fb353e335db875fd60ce3330031c7b4920496a24f7f4aaef223913c9c4af6e6
+input_fingerprint_sha256: efccd8336a2f221ca2a329d856118dc6abc2398416de5213ea22b2d3dcf28d12
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none; no observational, fitted, literature, scale, or normalization value is used
+explicit_bounded_inputs: the two-site two-face incidence, tree-gauge decoder, and displayed L1 ticks (4,1) then (7,4)
+framework_context: Lattice names Z^3 sites only; the incidence, decoder, and ticks are not attributed to the axioms
+package_local_integrity_reads: the proposed source note is read for claim-surface consistency
+measure_boundary: exact integer incidence algebra only
+negative_scope: only a third-face or -x-ray reading is refused; no broader gravity identification no-go is asserted
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the declared note-plus-axiom tuple
+PASS: source-lattice the axiom memo names cubic-lattice sites and does not name this decoder
+PASS: note-incidence the note displays the two-site incidence
+PASS: note-tree-gauge the note displays the tree-gauge assignment
+PASS: thm1-identity tree gauge solves g=ρ for every sampled integer pair
+PASS: thm2-tick1 after tick 1, φ=(4,5) and g=ρ=(4,1)
+PASS: thm2-tick2 after tick 2, φ=(7,11) and g=ρ=(7,4)
+PASS: thm2-composition the same decoder is reapplied; frozen tick-1 flux fails at tick 2
+PASS: thm3-invertible the 2x2 incidence has determinant 1 and inverse equal to the tree gauge
+PASS: n1-wrong-sign dropping the minus on F* fails tick 1
+PASS: n1-swapped-gauge swapping the tree assignment fails tick 1
+PASS: two-face-domain the decoder domain is exactly the two faces F* and F_B
+PASS: not-two-cube-clone the tested object names no third face and no -x ray
+PASS: forbidden-strings note and runner omit the forbidden gravity and slogan strings
+PASS: machine-status-contract the source uses the required bounded-support, trace, and propose-ratify status fields
+PASS: note-negative-scope the note separates the two-tick identity from physical-identification non-claims
+PASS: canonical-nonmutation the axiom memo does not contain the tree incidence or the displayed ticks
+PASS: no-go-gate the exact local boundary carries a complete source-visible N1-N8 disposition
+PASS: no-cache-no-manifest this cycle declares that it writes no runner cache and no citation manifest
+per_element: entries of M, M^{-1}, and the two decoded flux pairs are evaluated exactly
+per_site: the supplied object is the two displayed sites A and B, not a lattice-wide source law
+per_mode: the two faces F* and F_B are resolved; no third face or -x ray is introduced
+per_block: one two-site tree after two L1 ticks is tested; no physical identification is inferred
+lattice_wide: checked and not executed — the theorem supplies no lattice-wide decoder
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py
+++ b/scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Exact checks: two-site tree gauge stays source-complete after two L1 ticks.
+
+Integer incidence only. No axiom edit, no cache write, no network, no
+citation manifest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_CUBE_L1_TREE_GAUGE_TWO_TICK_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_L1_TREE_GAUGE_TWO_TICK_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+TICK_1 = (4, 1)
+TICK_2 = (7, 4)
+FACES = ("F*", "F_B")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def gauss(phi_star: int, phi_b: int) -> tuple[int, int]:
+    """Displayed incidence: g_A := φ(F*), g_B := −φ(F*) + φ(F_B)."""
+
+    return phi_star, -phi_star + phi_b
+
+
+def tree_gauge(rho_a: int, rho_b: int) -> tuple[int, int]:
+    """Tree gauge: φ(F*)=ρ(A), φ(F_B)=ρ(A)+ρ(B)."""
+
+    return rho_a, rho_a + rho_b
+
+
+def decode(rho: tuple[int, int]) -> tuple[tuple[int, int], tuple[int, int]]:
+    flux = tree_gauge(*rho)
+    return flux, gauss(*flux)
+
+
+def det2(matrix: tuple[tuple[int, int], tuple[int, int]]) -> int:
+    return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0]
+
+
+def matvec(matrix: tuple[tuple[int, int], tuple[int, int]], vec: tuple[int, int]) -> tuple[int, int]:
+    return (
+        matrix[0][0] * vec[0] + matrix[0][1] * vec[1],
+        matrix[1][0] * vec[0] + matrix[1][1] * vec[1],
+    )
+
+
+INCIDENCE = ((1, 0), (-1, 1))
+INVERSE = ((1, 0), (1, 1))
+
+
+@dataclass
+class Checks:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note).replace("> ", "")
+    source_text = note
+
+    print(
+        "external_scientific_inputs: none; no observational, fitted, literature, "
+        "scale, or normalization value is used"
+    )
+    print(
+        "explicit_bounded_inputs: the two-site two-face incidence, tree-gauge "
+        "decoder, and displayed L1 ticks (4,1) then (7,4)"
+    )
+    print(
+        "framework_context: Lattice names Z^3 sites only; the incidence, decoder, "
+        "and ticks are not attributed to the axioms"
+    )
+    print("package_local_integrity_reads: the proposed source note is read for claim-surface consistency")
+    print("measure_boundary: exact integer incidence algebra only")
+    print(
+        "negative_scope: only a third-face or -x-ray reading is refused; no broader "
+        "gravity identification no-go is asserted"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the declared note-plus-axiom tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_L1_TREE_GAUGE_TWO_TICK_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "source-lattice",
+        "the axiom memo names cubic-lattice sites and does not name this decoder",
+        "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "tree-gauge decoder" not in axiom
+        and "φ(F*)" not in axiom,
+    )
+    checks.check(
+        "note-incidence",
+        "the note displays the two-site incidence",
+        "g_A := φ(F*)" in note and "g_B := −φ(F*) + φ(F_B)" in note,
+    )
+    checks.check(
+        "note-tree-gauge",
+        "the note displays the tree-gauge assignment",
+        "φ(F*) = ρ(A)" in note and "φ(F_B) = ρ(A) + ρ(B)" in note,
+    )
+
+    sample = ((0, 0), (1, 0), (0, 1), (-3, 5), TICK_1, TICK_2)
+    checks.check(
+        "thm1-identity",
+        "tree gauge solves g=ρ for every sampled integer pair",
+        all(decode(rho)[1] == rho for rho in sample),
+    )
+
+    flux1, g1 = decode(TICK_1)
+    flux2, g2 = decode(TICK_2)
+    checks.check(
+        "thm2-tick1",
+        "after tick 1, φ=(4,5) and g=ρ=(4,1)",
+        flux1 == (4, 5) and g1 == TICK_1 == (4, 1),
+    )
+    checks.check(
+        "thm2-tick2",
+        "after tick 2, φ=(7,11) and g=ρ=(7,4)",
+        flux2 == (7, 11) and g2 == TICK_2 == (7, 4),
+    )
+    checks.check(
+        "thm2-composition",
+        "the same decoder is reapplied; frozen tick-1 flux fails at tick 2",
+        gauss(*flux1) != TICK_2 and decode(TICK_2)[1] == TICK_2,
+    )
+    checks.check(
+        "thm3-invertible",
+        "the 2x2 incidence has determinant 1 and inverse equal to the tree gauge",
+        det2(INCIDENCE) == 1
+        and matvec(INVERSE, TICK_1) == flux1
+        and matvec(INVERSE, TICK_2) == flux2
+        and matvec(INCIDENCE, flux1) == TICK_1
+        and matvec(INCIDENCE, flux2) == TICK_2,
+    )
+    checks.check(
+        "n1-wrong-sign",
+        "dropping the minus on F* fails tick 1",
+        flux1[0] + flux1[1] != TICK_1[1],
+    )
+    checks.check(
+        "n1-swapped-gauge",
+        "swapping the tree assignment fails tick 1",
+        gauss(TICK_1[1], TICK_1[0]) != TICK_1,
+    )
+    checks.check(
+        "two-face-domain",
+        "the decoder domain is exactly the two faces F* and F_B",
+        FACES == ("F*", "F_B") and len(FACES) == 2,
+    )
+    checks.check(
+        "not-two-cube-clone",
+        "the tested object names no third face and no -x ray",
+        "no third face" in normalized_note
+        and "no `−x` ray" in note
+        and "third face" not in axiom,
+    )
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-strings",
+        "note and runner omit the forbidden gravity and slogan strings",
+        all(token not in source_text for token in forbidden),
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required bounded-support, trace, and propose-ratify status fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "trace_class: frontier_discovery",
+                "target_claim_id: null",
+                "next_trace_action:",
+                "hypothetical_axiom_status: null",
+                "**Type:** bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "note-negative-scope",
+        "the note separates the two-tick identity from physical-identification non-claims",
+        all(
+            phrase in normalized_note
+            for phrase in (
+                "not a two-cube-gauge clone",
+                "no map from this decoder to a physical gravitational constraint",
+                "No claim about continuum gravity",
+                "an axiom update is necessary",
+            )
+        ),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo does not contain the tree incidence or the displayed ticks",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "φ(F*)",
+                "φ(F_B)",
+                "g_A :=",
+                "(4, 1)",
+                "(7, 4)",
+                "tree gauge",
+            )
+        ),
+    )
+    checks.check(
+        "no-go-gate",
+        "the exact local boundary carries a complete source-visible N1-N8 disposition",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") >= 5
+        and "Collapsed obstruction set: `{g = ρ after each displayed tick}`" in note
+        and "Steelman disposition: **CLOSED**" in note
+        and "N1–N8 disposition: **PASS**" in note
+        and "## Excluded Broader Claims" in note,
+    )
+    checks.check(
+        "no-cache-no-manifest",
+        "this cycle declares that it writes no runner cache and no citation manifest",
+        "writes no runner cache" in normalized_note
+        and "writes no citation manifest" in normalized_note,
+    )
+
+    print("per_element: entries of M, M^{-1}, and the two decoded flux pairs are evaluated exactly")
+    print("per_site: the supplied object is the two displayed sites A and B, not a lattice-wide source law")
+    print("per_mode: the two faces F* and F_B are resolved; no third face or -x ray is introduced")
+    print("per_block: one two-site tree after two L1 ticks is tested; no physical identification is inferred")
+    print("lattice_wide: checked and not executed — the theorem supplies no lattice-wide decoder")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

After each displayed L1 tick the tree-gauge assignment still solves g=rho, with integers (4,1) then (7,4). The 2x2 incidence is invertible. No third face and no -x ray. TOTAL: PASS=19 FAIL=0

## Runner

`scripts/two_cube_l1_tree_gauge_two_tick_2026_08_14.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
