### PR TITLE
feat(l1k2): second-wave L1 formations have k in {1,2}

### DIFF
--- a/docs/TWO_CUBE_L1_SECOND_WAVE_K_BOUNDED_THEOREM_NOTE_2026-08-14.md
+++ b/docs/TWO_CUBE_L1_SECOND_WAVE_K_BOUNDED_THEOREM_NOTE_2026-08-14.md
@@ -1,0 +1,238 @@
+---
+claim_id: two_cube_l1_second_wave_k_bounded_theorem_note_2026-08-14
+claim_type: bounded_theorem
+claim_scope: "On the supplied twelve-vertex two-cube patch, after tick 1 of displayed member L1 locks {(0,0,0),(1,0,0),(0,1,0),(0,0,1)}, the four unread sites (1,1,0), (1,0,1), (0,1,1), (2,0,0) form, their integer 3n and k=|3n|^2 are the displayed table with k in {1,2}, and every other unread patch site has n=0. L1 is displayed, not adopted. No spectral traces are claimed at k=2."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_l1_second_wave_k_2026_08_14.py
+---
+
+# Two-Cube `L1` Second-Wave Spectral `k`
+
+**Date:** 2026-08-14
+**Type:** bounded_theorem
+**Scope:** exact integer `3n` and `k = |3n|^2` at tick 2 of one displayed
+member `L1` on a supplied twelve-vertex two-cube patch. `L1` is displayed
+executable data, not adopted law. Qubit remains `M_2(C)`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_l1_second_wave_k_2026_08_14.py`](../scripts/two_cube_l1_second_wave_k_2026_08_14.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Work on the finite vertex set of two unit cubes that share a face:
+
+```text
+A = [0,1]^3,     B = [1,2] × [0,1] × [0,1].
+```
+
+The twelve vertices are the union of the eight vertices of `A` and the eight
+vertices of `B`. Occupancy off this patch is `0`.
+
+`L1` is one occupancy-step map. An unread site carries the integer bond
+imbalance
+
+```text
+(3n)_μ = o_{+μ} − o_{-μ} ∈ Z,
+```
+
+equivalently `n_μ = (o_{+μ} − o_{-μ}) / 3`. Locked sites stay locked. An
+unread patch site forms if and only if `n ≠ 0`. For a forming site the
+spectral integer is
+
+```text
+k = |3n|^2 ∈ Z.
+```
+
+This note stays in `Z`: it records `3n` and `k`, and it does not evaluate
+one-site traces at `k=2`.
+
+After tick 1 the locked set is
+
+```text
+{(0,0,0), (1,0,0), (0,1,0), (0,0,1)}.
+```
+
+The second-wave table on the four forming unread sites is
+
+| site | `3n` | `k` |
+|---|---|---|
+| `(1,1,0)` | `(-1,-1,0)` | `2` |
+| `(1,0,1)` | `(-1,0,-1)` | `2` |
+| `(0,1,1)` | `(0,-1,-1)` | `2` |
+| `(2,0,0)` | `(-1,0,0)` | `1` |
+
+Those four form. Every other unread patch site has `n = 0` and does not
+form. The second-wave values of `k` are exactly `{1,2}`. This is the tick-2
+table. It is not the first-wave identity that every seed-neighbor lock has
+`k=1`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Z identities for 3n and k=|3n|^2 on the four tick-2 forming sites of one displayed occupancy member, plus vanishing n on the remaining unread patch sites."
+trace_class: frontier_discovery
+target_claim_id: two_cube_l1_second_wave_k
+target_blocker_text: "spectral k at tick 2 of L1 on the two-cube patch"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the supplied twelve-vertex patch after the displayed tick-1 lock set; L1 is displayed, not adopted; no k=2 traces"
+hypothetical_axiom_status: not proposed
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded algebraic claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the four live axiom sentences quoted below. They
+  are quoted without rewrite. No map in this note is a Lattice map. Qubit is
+  not rewritten.
+- **Explicit theorem-domain condition:** the twelve-vertex two-cube patch,
+  off-patch occupancy `0`, the occupancy kernel, the tick-1 lock set, and the
+  integer rule `k = |3n|^2` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selecting this member as a physical law, lifting
+  it off the supplied patch, or identifying `k` with a continuum wavenumber
+  remain separate, open obligations.
+
+## Exact Objects
+
+All runner coefficients are exact integers. No float is used. The runner
+never leaves `Z` for `3n` or `k`.
+
+Occupancy `o(v)` is `1` on a lock in the patch and `0` otherwise, including
+every off-patch neighbor. The vector `3n` is a triple in `Z^3`. Locked sites
+are not re-tested for formation.
+
+The four first-wave locks are used only as the tick-1 configuration from
+which tick-2 `n` is read. Their own first-wave `k=1` identity is not the
+claim of this note.
+
+## Exact Target And Proof Obligations
+
+The exact target is to evaluate `3n` and `k` at every unread patch site after
+tick 1, and to check the second-wave table by exact integer arithmetic.
+
+The obligation graph is:
+
+1. the patch has twelve vertices;
+2. the same occupancy kernel that forms the three on-patch axis neighbors
+   from the seed produces the tick-1 lock set
+   `{(0,0,0),(1,0,0),(0,1,0),(0,0,1)}`;
+3. at that configuration the four sites `(1,1,0)`, `(1,0,1)`, `(0,1,1)`,
+   `(2,0,0)` have the displayed `3n` and `k`;
+4. those four are unread and have `n ≠ 0`, so they form;
+5. every other unread patch site has `n = 0`, so it does not form.
+
+All five obligations are closed below and in the runner. There is no missing
+lemma for this bounded display.
+
+## Theorem 1 — tick-1 lock set on the twelve-vertex patch
+
+`A` has eight vertices with coordinates in `{0,1}^3`. `B` has eight vertices
+with `x ∈ {1,2}` and `y,z ∈ {0,1}`. The union has twelve sites, all in
+`Z^3`. Off-patch occupancy is the supplied value `0`.
+
+Start with locks `{(0,0,0)}`. The three on-patch axis neighbors have
+`3n ≠ 0` and form. Every other unread patch site has vanishing neighbor
+occupancy on the seed, hence `n = 0`. After that step the locked set is
+
+```text
+{(0,0,0), (1,0,0), (0,1,0), (0,0,1)}.
+```
+
+The remainder of the note takes this lock set as the tick-1 configuration.
+
+## Theorem 2 — second-wave `3n` and `k`
+
+Occupancy is `1` on the four tick-1 locks and `0` elsewhere. Nearest-neighbor
+occupancies at the four unread sites of the table are:
+
+```text
+(1,1,0):  o_{-x}=1, o_{-y}=1, else 0  ⇒  3n = (-1,-1,0),  k = 1+1+0 = 2
+(1,0,1):  o_{-x}=1, o_{-z}=1, else 0  ⇒  3n = (-1, 0,-1),  k = 1+0+1 = 2
+(0,1,1):  o_{-y}=1, o_{-z}=1, else 0  ⇒  3n = ( 0,-1,-1),  k = 0+1+1 = 2
+(2,0,0):  o_{-x}=1,           else 0  ⇒  3n = (-1, 0, 0),  k = 1+0+0 = 1
+```
+
+Each of these four sites lies in the twelve-vertex set, is unread, and has
+`n ≠ 0`, so each forms. The four values of `k` are exactly `{1,2}`.
+
+## Theorem 3 — no other unread patch site has `n ≠ 0`
+
+The unread patch sites after tick 1 that are not in the table are
+
+```text
+(1,1,1), (2,1,0), (2,0,1), (2,1,1).
+```
+
+At each of these four sites every on-patch neighbor is still unread and
+every off-patch neighbor has occupancy `0`, so `3n = (0,0,0)` and `n = 0`.
+They do not form.
+
+The four tick-1 locks stay locked and are not new formations. Therefore the
+tick-2 formation set is exactly the four-site table, and `k` on that set is
+exactly the displayed integers.
+
+## Physical-Interpretation Boundary
+
+The proved output is the tick-2 `k` table of the displayed member on the
+supplied patch. This note does not adopt `L1` as axiom content and does not
+rewrite Qubit. The one-site algebra remains `M_2(C)`. The integer `k` is
+`|3n|^2` at a forming site. It is not a one-site trace and it is not a
+continuum wavenumber.
+
+## Mutation Checks
+
+Three non-equivalences guard the load-bearing conclusions:
+
+1. second-wave `k` is not uniformly `1`: three of the four forming sites have
+   `k=2`;
+2. `(2,0,0)` has `k=1`, distinct from the three face-diagonal values `k=2`;
+3. `k` is the integer `|3n|^2`, not a one-site trace.
+
+## What This Does Not Claim
+
+- `L1` is displayed, not adopted.
+- No inverse-square rule is claimed.
+- Qubit remains `M_2(C)`.
+- The occupancy kernel is not a Lattice map.
+- This is the tick-2 table, not the first-wave `k=1` identity.
+- No one-site traces are evaluated at `k=2`.
+- The identities are not a continuum lift and not a physical selection of
+  this member.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+> Records form.
+
+Their dependency role is limited to the repository's site, one-site algebra,
+nearest-neighbor, and formation vocabulary. This theorem separately supplies
+the patch, the occupancy kernel, the tick-1 lock set, and the integer rule
+`k = |3n|^2`.
+
+## Runner Contract
+
+The companion runner identity-gates every helper and recomputes `3n` and `k`
+from occupancy at every unread patch site after tick 1. It checks the four
+forming sites against the displayed table, checks that every other unread
+patch site has `n = 0`, quotes the four live axiom sentences, and records the
+import boundary. Declared review inputs are this note and the axiom memo
+only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15645,
- "node_count": 5505,
+ "edge_count": 15646,
+ "node_count": 5506,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18444,6 +18444,10 @@
   },
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
+   "out_degree": 1
+  },
+  "two_cube_l1_second_wave_k_bounded_theorem_note_2026-08-14": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {

--- a/logs/runner-cache/two_cube_l1_second_wave_k_2026_08_14.txt
+++ b/logs/runner-cache/two_cube_l1_second_wave_k_2026_08_14.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_l1_second_wave_k_2026_08_14.py
+runner_sha256: 732102ac02abde16c78e78441d435ae0aefbad3ea8e47027ae57226f45591721
+input_fingerprint_sha256: e18b285def6728dbde41100b78304b12e1fca2cf691189741bb4c0f679586da4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact Z occupancy arithmetic on a supplied 12-vertex patch
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: exact integers; k = |3n|^2 stays in Z
+claim_boundary: L1 is displayed executable data, not adopted law
+PASS: id-patch-count patch-count identity
+PASS: id-cube-a-count cube-a-count identity
+PASS: id-cube-b-count cube-b-count identity
+PASS: id-off-patch-occupancy off-patch-occupancy identity
+PASS: id-seed-occupancy seed-occupancy identity
+PASS: id-tick1-locks-from-seed tick1-locks-from-seed identity
+PASS: id-tick1-lock-count tick1-lock-count identity
+PASS: id-3n-at-110 3n-at-110 identity
+PASS: id-k-at-110 k-at-110 identity
+PASS: 3n-in-Z-110 3n at (1, 1, 0) is an integer triple
+PASS: id-3n-at-101 3n-at-101 identity
+PASS: id-k-at-101 k-at-101 identity
+PASS: 3n-in-Z-101 3n at (1, 0, 1) is an integer triple
+PASS: id-3n-at-011 3n-at-011 identity
+PASS: id-k-at-011 k-at-011 identity
+PASS: 3n-in-Z-011 3n at (0, 1, 1) is an integer triple
+PASS: id-3n-at-200 3n-at-200 identity
+PASS: id-k-at-200 k-at-200 identity
+PASS: 3n-in-Z-200 3n at (2, 0, 0) is an integer triple
+PASS: id-forming-set forming-set identity
+PASS: id-forming-count forming-count identity
+PASS: id-other-unread other-unread identity
+PASS: thm-no-other-unread-n every other unread patch site has 3n = 0
+PASS: thm-second-wave-table the four forming sites have the displayed 3n and k
+PASS: thm-k-in-1-2 second-wave k values are exactly {1, 2}
+PASS: thm-locked-stay tick-1 locks remain locked and do not re-form
+PASS: k-from-3n-squares k is the sum of squares of the integer components of 3n
+PASS: mutation-k-not-uniform-1 second-wave k is not uniformly 1
+PASS: mutation-k-is-not-a-trace k is |3n|^2 in Z, distinct from any one-site trace value
+PASS: live-parent-quotes the note quotes all four live axiom sentences without rewrite
+PASS: machine-status-contract bounded-support status and hypothetical_axiom_status: not proposed
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: note-hygiene L1 is displayed; Qubit stays M_2(C); k stays in Z; forbidden strings absent
+per_element: 3n and k = |3n|^2 are recomputed at each unread patch site
+per_site: formation is unread and n nonzero; locked sites stay
+per_mode: k is the integer |3n|^2; no traces at k=2
+per_block: tick-2 formation set is the four-site table
+lattice_wide: checked and not executed — the claim is the supplied 12-vertex patch
+TOTAL: PASS=33 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_l1_second_wave_k_2026_08_14.py
+++ b/scripts/two_cube_l1_second_wave_k_2026_08_14.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Exact integer checks for L1 second-wave k on the two-cube patch.
+
+After tick 1 locks the seed and three axis neighbors, recompute 3n in Z and
+k = |3n|^2 at every unread patch site. Every helper is identity-gated:
+replacing a helper formula fails the corresponding check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "TWO_CUBE_L1_SECOND_WAVE_K_BOUNDED_THEOREM_NOTE_2026-08-14.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_L1_SECOND_WAVE_K_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Site = tuple[int, int, int]
+Locks = frozenset[Site]
+Vec3 = tuple[int, int, int]
+
+AXES: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+ZERO_3N: Vec3 = (0, 0, 0)
+SEED: Site = (0, 0, 0)
+FIRST_WAVE: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+TICK1_LOCKS: Locks = frozenset({SEED, (1, 0, 0), (0, 1, 0), (0, 0, 1)})
+SECOND_WAVE: tuple[Site, Site, Site, Site] = (
+    (1, 1, 0),
+    (1, 0, 1),
+    (0, 1, 1),
+    (2, 0, 0),
+)
+SECOND_WAVE_TABLE: dict[Site, tuple[Vec3, int]] = {
+    (1, 1, 0): ((-1, -1, 0), 2),
+    (1, 0, 1): ((-1, 0, -1), 2),
+    (0, 1, 1): ((0, -1, -1), 2),
+    (2, 0, 0): ((-1, 0, 0), 1),
+}
+
+
+def add_site(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def cube_a_vertices() -> frozenset[Site]:
+    return frozenset(
+        (x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1)
+    )
+
+
+def cube_b_vertices() -> frozenset[Site]:
+    return frozenset(
+        (x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1)
+    )
+
+
+def patch_vertices() -> frozenset[Site]:
+    return cube_a_vertices() | cube_b_vertices()
+
+
+def occupancy(site: Site, locks: Locks) -> int:
+    if site not in patch_vertices():
+        return 0
+    return 1 if site in locks else 0
+
+
+def three_n(site: Site, locks: Locks) -> Vec3:
+    components = []
+    for axis in AXES:
+        plus = occupancy(add_site(site, axis), locks)
+        minus = occupancy(add_site(site, (-axis[0], -axis[1], -axis[2])), locks)
+        components.append(plus - minus)
+    return (components[0], components[1], components[2])
+
+
+def k_value(vec: Vec3) -> int:
+    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]
+
+
+def site_forms(site: Site, locks: Locks) -> bool:
+    if site in locks or site not in patch_vertices():
+        return False
+    return three_n(site, locks) != ZERO_3N
+
+
+def forming_sites(locks: Locks) -> Locks:
+    return frozenset(site for site in patch_vertices() if site_forms(site, locks))
+
+
+def unread_patch_sites(locks: Locks) -> Locks:
+    return frozenset(site for site in patch_vertices() if site not in locks)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        if result:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def identity_gate(self, name: str, computed: object, expected: object) -> None:
+        self.check(f"id-{name}", f"{name} identity", computed == expected)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; exact Z occupancy arithmetic on a supplied 12-vertex patch")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: exact integers; k = |3n|^2 stays in Z")
+    print("claim_boundary: L1 is displayed executable data, not adopted law")
+
+    patch = patch_vertices()
+    seed_locks: Locks = frozenset({SEED})
+
+    checks.identity_gate("patch-count", len(patch), 12)
+    checks.identity_gate("cube-a-count", len(cube_a_vertices()), 8)
+    checks.identity_gate("cube-b-count", len(cube_b_vertices()), 8)
+    checks.identity_gate("off-patch-occupancy", occupancy((-1, 0, 0), TICK1_LOCKS), 0)
+    checks.identity_gate("seed-occupancy", occupancy(SEED, TICK1_LOCKS), 1)
+
+    tick1_from_seed = seed_locks | forming_sites(seed_locks)
+    checks.identity_gate("tick1-locks-from-seed", tick1_from_seed, TICK1_LOCKS)
+    checks.identity_gate("tick1-lock-count", len(TICK1_LOCKS), 4)
+
+    for site, (expected_3n, expected_k) in SECOND_WAVE_TABLE.items():
+        computed_3n = three_n(site, TICK1_LOCKS)
+        computed_k = k_value(computed_3n)
+        label = "".join(str(coord) for coord in site)
+        checks.identity_gate(f"3n-at-{label}", computed_3n, expected_3n)
+        checks.identity_gate(f"k-at-{label}", computed_k, expected_k)
+        checks.check(
+            f"3n-in-Z-{label}",
+            f"3n at {site} is an integer triple",
+            all(isinstance(component, int) for component in computed_3n),
+        )
+
+    new_at_tick2 = forming_sites(TICK1_LOCKS)
+    checks.identity_gate("forming-set", new_at_tick2, frozenset(SECOND_WAVE))
+    checks.identity_gate("forming-count", len(new_at_tick2), 4)
+
+    other_unread = unread_patch_sites(TICK1_LOCKS) - frozenset(SECOND_WAVE)
+    checks.identity_gate(
+        "other-unread",
+        other_unread,
+        frozenset({(1, 1, 1), (2, 1, 0), (2, 0, 1), (2, 1, 1)}),
+    )
+    checks.check(
+        "thm-no-other-unread-n",
+        "every other unread patch site has 3n = 0",
+        all(three_n(site, TICK1_LOCKS) == ZERO_3N for site in other_unread)
+        and other_unread.isdisjoint(new_at_tick2),
+    )
+    checks.check(
+        "thm-second-wave-table",
+        "the four forming sites have the displayed 3n and k",
+        all(
+            (three_n(site, TICK1_LOCKS), k_value(three_n(site, TICK1_LOCKS)))
+            == SECOND_WAVE_TABLE[site]
+            for site in SECOND_WAVE
+        )
+        and new_at_tick2 == frozenset(SECOND_WAVE),
+    )
+    checks.check(
+        "thm-k-in-1-2",
+        "second-wave k values are exactly {1, 2}",
+        {k_value(three_n(site, TICK1_LOCKS)) for site in SECOND_WAVE} == {1, 2},
+    )
+    checks.check(
+        "thm-locked-stay",
+        "tick-1 locks remain locked and do not re-form",
+        all(not site_forms(site, TICK1_LOCKS) for site in TICK1_LOCKS)
+        and TICK1_LOCKS.isdisjoint(new_at_tick2),
+    )
+    checks.check(
+        "k-from-3n-squares",
+        "k is the sum of squares of the integer components of 3n",
+        k_value((-1, -1, 0)) == 2 and k_value((-1, 0, 0)) == 1,
+    )
+    checks.check(
+        "mutation-k-not-uniform-1",
+        "second-wave k is not uniformly 1",
+        k_value(three_n((1, 1, 0), TICK1_LOCKS)) == 2
+        and k_value(three_n((2, 0, 0), TICK1_LOCKS)) == 1,
+    )
+    checks.check(
+        "mutation-k-is-not-a-trace",
+        "k is |3n|^2 in Z, distinct from any one-site trace value",
+        k_value(three_n((1, 1, 0), TICK1_LOCKS)) == 2
+        and "k = |3n|^2" in note
+        and "No one-site traces are evaluated at `k=2`" in note,
+    )
+
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    qubit_quote = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    admissibility_quote = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_quote = "Records form."
+    axiom_flat = " ".join(axiom.split())
+    checks.check(
+        "live-parent-quotes",
+        "the note quotes all four live axiom sentences without rewrite",
+        all(
+            quote in axiom_flat and quote in note
+            for quote in (
+                lattice_quote,
+                qubit_quote,
+                admissibility_quote,
+                record_quote,
+            )
+        ),
+    )
+    checks.check(
+        "machine-status-contract",
+        "bounded-support status and hypothetical_axiom_status: not proposed",
+        "actual_current_surface_status: bounded-support" in note
+        and "hypothetical_axiom_status: not proposed" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_CUBE_L1_SECOND_WAVE_K_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE", "L_phys", "we adopt", "Codex")
+    checks.check(
+        "note-hygiene",
+        "L1 is displayed; Qubit stays M_2(C); k stays in Z; forbidden strings absent",
+        "L1 is displayed, not adopted" in note
+        and "Qubit remains `M_2(C)`" in note
+        and "k = |3n|^2 ∈ Z" in note
+        and "√" not in note
+        and all(token not in note for token in forbidden)
+        and "we adopt" not in note.lower()
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+
+    print("per_element: 3n and k = |3n|^2 are recomputed at each unread patch site")
+    print("per_site: formation is unread and n nonzero; locked sites stay")
+    print("per_mode: k is the integer |3n|^2; no traces at k=2")
+    print("per_block: tick-2 formation set is the four-site table")
+    print("lattice_wide: checked and not executed — the claim is the supplied 12-vertex patch")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

After tick 1, the four forming unread sites have the displayed 3n and k table with k in {1,2}. No other unread patch site has n nonzero. TOTAL: PASS=33 FAIL=0

## Runner

`scripts/two_cube_l1_second_wave_k_2026_08_14.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
