### PR TITLE
feat(cell-cutting): size bound theorem for the cutting label sum

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_LABEL_SUM_SIZE_BOUND_CYCLE781_NOTE_2026-08-14.md
+++ b/docs/PHYSICAL_CELL_CUTTING_LABEL_SUM_SIZE_BOUND_CYCLE781_NOTE_2026-08-14.md
@@ -1,0 +1,241 @@
+# Physical cell cutting: the label sum of a cutting is fixed by its positive half-set count, and the size of the label sum is at most eight
+
+Date: 2026-08-14
+Authority: none
+Audit: unset.
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## What this cycle asks
+
+The unit four-cube cell object is rebuilt from scratch here as in the sibling cycles
+`cycle 779` and `cycle 780`: of the 2672 five-corner sets of unit determinant, the ones at
+the adjacency cost floor 6 number 400; exact cover of the cell by floor pieces has 15800
+solutions, each of 24 pieces; the pieces that actually occur number 192, each in 1975
+cuttings; and the naming of a piece by a start corner together with an order of the four
+axes gives 384 namings, 2 per piece. A piece carries a handedness label L equal to the sign
+of the axis order times the corner weight parity sign of the start corner, and S(T) denotes
+the label sum over the 24 pieces of a cutting T.
+
+`cycle 780` identified the covers as the chambers of the twelve-wall cut of the open cell
+and derived the mod-four law: S(T) is divisible by 4 on every cutting. It left the size of
+S standing as a measurement. Its own boundary section says so plainly: the census puts S in
+the five values -8, -4, 0, 4, 8, so |S| is at most 8 over the 15800 cuttings, and nothing in
+that derivation forces the bound, since divisibility restricts S to a lattice and not to an
+interval.
+
+This cycle derives the bound, pointwise and by a finite obstruction, and the mod-four law
+comes back out of it as a corollary. The statement proved is sharper than a bound:
+
+> **T.** Let H be the half set defined below and let p and m be the numbers of pieces of a
+> cutting T lying in H with label plus one and minus one. Then p + m = 12, both p and m are
+> at most 8, and S(T) = 2 (p - m) = 4 (p - 6). Hence p lies between 4 and 8, S(T) lies in
+> -8, -4, 0, 4, 8, and |S(T)| is at most 8.
+
+Three ingredients, each local to one piece and its 8 chambers, and each summed over a
+cutting by the partition property of `cycle 780`: a halving identity, a constant count, and
+a sealing obstruction. The partition property itself is re-verified here on the rebuilt
+object, every chamber meeting every cutting in exactly one piece, with 0 failures over the
+15800 cuttings (gate K2). It is the only global input used below.
+
+## The halving identity
+
+Fix the naming of a piece. Of its 2 namings, take the one whose start corner v0 is the
+smaller of the two opposite corners; write sigma for its axis order. On that minimal naming
+
+> L(P) = sign(sigma) times chi(v0),
+
+where sign(sigma) is the sign of the order as a permutation and chi(v0) is plus one on a
+start corner of even weight and minus one on one of odd weight. The 8 start corners of
+minimal namings realise both values, and the formula matches the label of the piece on all
+192 pieces with 0 mismatches (gate K3).
+
+Now define the **half set**
+
+> H = the pieces whose minimal naming steps axis 3 within its first 2 steps.
+
+H has 96 members, splitting 48 with L = plus one and 48 with L = minus one (gate K4). The
+choice of axis 3 is a choice of one coordinate, made once and kept; the derivation below
+never uses which coordinate was taken, and nothing is claimed here about the other three.
+
+A chamber is named (b, s) as in `cycle 780`, with b the order of the four magnitudes of
+u = x - centre taken decreasingly and s = (s1, s2, s3) the signs of u at the first three
+slots of b; the sign at the fourth slot is not chamber data. Define a function of the
+chamber alone,
+
+> g1(b, s) = sign(b) times s1 times s2 times s3 when b ends in axis 3, and 0 otherwise.
+
+**T1.** g1 takes the value minus one on 24 chambers, 0 on 144 and plus one on 24, so its
+total over the 192 chambers is 0; and for every piece P,
+
+> the sum of g1 over the 8 chambers of P equals L(P) when P is outside H, and minus L(P)
+> when P is inside H.
+
+Both halves are verified on the rebuilt object with 0 failures over the 192 pieces
+(gate K5).
+
+The identity telescopes. A cutting holds each of the 192 chambers in exactly one of its 24
+pieces, so summing the per-piece sums over T sums g1 over every chamber exactly once:
+
+> 0 = sum over the chambers of g1 = sum over P in T of (sum of g1 over the chambers of P)
+> = S(T) - 2 S_H(T),
+
+where S_H(T) is the label sum over the pieces of T that lie in H. Hence
+
+> **S(T) = 2 S_H(T) on every cutting**, with 0 failures over the 15800 (gate K6).
+
+The whole label sum is carried by the half set. That is the first reduction: a sum over 24
+pieces becomes twice a sum over the pieces of T inside H, and the next section shows there
+are always exactly 12 of those.
+
+## The constant twelve
+
+Define a second function of the chamber alone, this time a set:
+
+> W = the chambers whose order carries axis 3 in its second slot, whose last two slots
+> ascend, and whose second sign s2 is plus one.
+
+W has 12 members.
+
+**T2.** For every piece P, the number of members of W among the 8 chambers of P is 1 when P
+lies in H and 0 when it does not. Verified on all 192 pieces: 1 on each of the 96 pieces of
+H and 0 on each of the other 96, with 0 failures (gate K7).
+
+Summing over a cutting with the partition property again, the left side counts each of the
+12 members of W exactly once and the right side counts the pieces of T inside H:
+
+> **every cutting holds exactly 12 pieces of H**, with 0 failures over the 15800 (gate K8).
+
+So p + m = 12 with p and m the counts of half-set pieces of label plus one and minus one,
+and S_H = p - m = 2 p - 12. Combined with the halving identity,
+
+> S(T) = 2 S_H(T) = 2 (p - m) = 4 (p - 6).
+
+At this stage S is a function of the single integer p, which lies between 0 and 12; the
+mod-four law is already implied, but the size bound still needs p kept away from the ends.
+
+## The sealed families
+
+Two pieces of one cutting share no chamber: if they did, that chamber would meet the
+cutting in more than one piece. So the pieces of T inside H with label plus one form a
+pairwise chamber-disjoint family inside the 48 positive half-set pieces, and likewise for
+the negative ones. If p were 9 or more, T would contain such a family of 9.
+
+Those families can be listed completely. Inside the 48 positive half-set pieces there are
+exactly 24 pairwise chamber-disjoint families of 9, and inside the 48 negative ones exactly
+24. The count is produced twice by two different searches, an extension walk in index order
+over the disjointness graph and a take-it-or-leave-it walk carrying the union of chambers
+already used, and the two agree as sets and not merely in count (gate K9).
+
+**T3.** Each of those 48 families is sealed: it leaves a chamber that no member holds, all 8
+of whose holding pieces meet the family. Verified for every one of the 48, with 0 failures
+(gate K10).
+
+The obstruction follows at once. Suppose a cutting T contained a sealed family F. The
+witness chamber c is held by exactly one piece Q of T, and Q is one of the 8 pieces holding
+c, so Q shares a chamber with some member of F. That member is also in T, and two pieces of
+one cutting share no chamber, so Q is that member; but no member of F holds c, and Q holds
+c. The contradiction means no cutting contains any of the 48 families, hence
+
+> **p is at most 8 and m is at most 8.**
+
+The bound is not a bound on the enumeration: it is the statement that a family of 9 which
+exists as a disjoint family cannot be part of a partition of the cell, because the chamber
+it strands has nowhere left to go.
+
+## The theorem and its corollary
+
+Put the three together. From the constant twelve, p + m = 12; from sealing, p is at most 8
+and m is at most 8, so p is at least 4 and lies between 4 and 8; from the halving identity,
+S = 4 (p - 6). Therefore
+
+> S lies in -8, -4, 0, 4, 8 and |S| is at most 8, on every cutting,
+
+with 0 failures over the 15800 cuttings (gate K11). Divisibility by 4 is now a corollary
+rather than a separate law, and the size bound that `cycle 780` could only measure is
+derived pointwise, from the value of p on the single cutting in hand.
+
+The bound is attained at both ends: p takes the value 4 on 120 cuttings and 8 on 120, and
+the label sum census matches term for term, -8 on 120, -4 on 2832, 0 on 9896, 4 on 2832 and
+8 on 120 (gate K12). The correspondence between the two censuses is the theorem read
+backwards, and it is exact, not approximate.
+
+Two controls check that the gates discriminate. Negating g1 at a single chamber breaks the
+per-piece identity at exactly 8 pieces, which are precisely the pieces holding that chamber
+(gate K13); and dropping a single piece from H breaks the constant twelve at exactly 1975
+cuttings, which are precisely the cuttings through that piece (gate K14). Neither number is
+imposed: each is measured on the perturbed object and compared with the count the structure
+predicts.
+
+## What this does not establish
+
+**The p-census is measured, not derived.** The distribution of p over the 15800 cuttings,
+120 at 4, 2832 at 5, 9896 at 6, 2832 at 7 and 120 at 8, is symmetric about 6 and sharply
+peaked, and none of that is forced by anything above. The derivation constrains p to the
+five values and no further; why the middle value is so much heavier, and why the two ends
+carry exactly 120 apiece, is open.
+
+**Family transitivity is measured, not derived.** The 24 families in each half are checked
+one at a time, both for the enumeration and for the sealing, and the witness chamber is
+found separately for each. Whether the 24 are all alike under the symmetries of the cell,
+which would let one sealed family do the work of all of them, is not settled here; no such
+action is exhibited, so the regularity visible in the numbers stays a measurement.
+
+**The sharpening deferred by `cycle 780` is not attempted.** That note observed a
+divisibility by 4 of one of its two telescoping counts, stronger than the parity its
+argument gives, and asked for a certificate taking values modulo 4. Nothing here supplies
+one. The present derivation reaches the same divisibility by a different argument, through
+p, and so does not answer that question either.
+
+Two further limits, stated plainly. The partition property is verified on the rebuilt
+object over all 15800 cuttings rather than proved from the definition of a cutting; the
+geometric reading given in `cycle 780` says why it must hold, but this note claims only what
+the gates check. And the claim type is bounded_theorem, not a stronger one, because the
+object is the finite cell as rebuilt: the statements are theorems about it, and nothing here
+extends them to any other cell or to any larger family of cuttings.
+
+## Relation to sibling cycles
+
+The object, the handedness label and the chamber picture are taken from `cycle 779` and
+`cycle 780`, and this note extends them rather than corrects them: nothing in either is
+withdrawn. The mod-four law of `cycle 780` is re-derived here as a corollary of a sharper
+statement, and the size bound its boundary section listed as a measurement is discharged.
+The halving identity and the constant twelve are new here, as is the sealing obstruction;
+the partition property is the one thing carried over and it is re-checked rather than
+assumed. All references above are to sibling cycles by name only, with no citation edges:
+the predecessor notes are not on the main line yet, so this note carries none.
+
+## Gate list with the measured numbers
+
+All 14 gates are computational identities about the explicitly rebuilt finite object, exact
+over the integers and the rationals; no floating point enters any gate. The runner is
+`scripts/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.py` and it uses the
+standard library only.
+
+* **K1** object rebuild: 2672 unit pieces, cost floor 6, 400 at the floor, 15800 cuttings
+  of 24, 192 used pieces each in 1975, 384 namings, 2 per piece.
+* **K2** the partition property: each of the 24 pieces of a cutting holds 8 of the 192
+  chambers, each chamber sits in 8 pieces, 0 failures over the 15800 cuttings.
+* **K3** the minimal naming: L = sign of the axis order times the corner weight parity
+  sign, over 8 start corners, 0 mismatches on the 192 pieces.
+* **K4** the half set: the pieces whose minimal naming steps axis 3 within its first 2
+  steps number 96, splitting 48 and 48 by label.
+* **K5** the halving certificate on chambers: value census -1 on 24, 0 on 144, 1 on 24,
+  chamber total 0, and 0 per-piece failures on the 192 pieces.
+* **K6** the halving identity S = 2 S_H, 0 failures over the 15800 cuttings.
+* **K7** the W certificate: 12 chambers, exactly 1 inside each of the 96 half-set pieces
+  and 0 inside each of the other 96, 0 failures on the 192.
+* **K8** the constant twelve: every cutting holds exactly 12 half-set pieces, 0 failures
+  over the 15800.
+* **K9** families of 9 pairwise-disjoint pieces: 24 inside the positive half and 24 inside
+  the negative half, with two search orders agreeing.
+* **K10** the sealing: each of the 48 families leaves a chamber it does not hold whose 8
+  holders all meet it, 0 failures over the 48.
+* **K11** the theorem S = 4 (p - 6) with p + m = 12 and p between 4 and 8, 0 failures over
+  the 15800 cuttings.
+* **K12** the p census 120, 2832, 9896, 2832, 120 at p = 4, 5, 6, 7, 8, sum 15800, and the
+  label sum census -8 on 120, -4 on 2832, 0 on 9896, 4 on 2832, 8 on 120.
+* **K13** the first control: negating the halving certificate at one chamber breaks the
+  per-piece identity at exactly 8 pieces, its holders.
+* **K14** the second control: dropping one piece from the half set breaks the constant 12
+  at exactly 1975 cuttings, the cuttings through it.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15673,
- "node_count": 5514,
+ "node_count": 5515,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13789,6 +13789,10 @@
   "physical_cell_cutting_hidden_three_bit_geometry_cycle743_note_2026-08-05": {
    "deps_hash": "9126ac46777c",
    "out_degree": 2
+  },
+  "physical_cell_cutting_label_sum_size_bound_cycle781_note_2026-08-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_least_computing_sets_cycle737_note_2026-08-05": {
    "deps_hash": "ba0326da985f",

--- a/logs/runner-cache/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.txt
+++ b/logs/runner-cache/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.txt
@@ -1,0 +1,27 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.py
+runner_sha256: 2e60cd328458f0020e4ca4696d43dce1b83de8e308d744d9001d13acafb71cbf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 12.44
+status: ok
+----- stdout -----
+PASS K1 cell: 2672 unit pieces, cost floor 6, 400 at floor, 15800 cuttings of 24, 192 used pieces each in 1975, 384 namings 2 per piece
+PASS K2 partition: each of the 24 pieces of a cutting holds 8 of the 192 chambers, each chamber sits in 8 pieces, failures 0 of 15800
+PASS K3 minimal naming: L = sign of the axis order times the corner weight parity sign, over 8 start corners, mismatches 0 of 192
+PASS K4 half set: the pieces whose minimal naming steps axis 3 within its first 2 steps number 96, label split 48 and 48
+PASS K5 halving certificate on chambers: value census -1:24 0:144 1:24, per-piece identity failures 0 of 192, chamber total 0
+PASS K6 halving identity: the label sum S equals 2 times the half-set label sum S_H, failures 0 of 15800
+PASS K7 W certificate: 12 chambers, exactly 1 inside each of the 96 half-set pieces and 0 inside each of the other 96, failures 0 of 192
+PASS K8 the constant twelve: every cutting holds exactly 12 half-set pieces, failures 0 of 15800
+PASS K9 families of 9 pairwise-disjoint pieces: 24 inside the positive half, 24 inside the negative half, two search orders agree: yes
+PASS K10 sealing: each of the 48 families leaves a chamber it does not hold whose 8 holders all meet it, failures 0 of 48
+PASS K11 theorem: S = 4 (p - 6) at the positive half-set count p, with p + m = 12 and p between 4 and 8, failures 0 of 15800
+PASS K12 p census 4:120 5:2832 6:9896 7:2832 8:120 sum 15800; label sum census -8:120 -4:2832 0:9896 4:2832 8:120
+PASS K13 control one: negating the halving certificate at one chamber breaks the per-piece identity at exactly 8 pieces, its holders
+PASS K14 control two: dropping one piece from the half set breaks the constant 12 at exactly 1975 cuttings, the cuttings through it
+resource: under 60 s of the 900 s budget, under 250 MB of the 2500 MB budget, 1747 gate characters
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.py
+++ b/scripts/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.py
@@ -1,0 +1,607 @@
+"""Physical cell cutting: the label sum of a cutting is four times the positive half-set count less six, so its size is at most eight.
+
+Standalone exact runner, standard library only. The preamble rebuilds the unit four-cube cell object from scratch, as in the sibling
+cycles: the five-corner unit-determinant pieces at the adjacency cost floor, the 15800 cuttings of 24, the 192 pieces that occur in them,
+the handedness label of a piece, and the 192 chambers of the twelve-wall cut of the open cell, each piece holding 8 of them and each
+chamber sitting in 8 pieces. The predecessor cycle showed that a cutting meets every chamber in exactly one piece; that partition property
+is re-verified here and is the only global input used below. Everything else is a local statement about one piece and its 8 chambers.
+
+Put each piece in its minimal naming, start corner v0 below its opposite, so that L = sign(sigma) times chi(v0) with chi the corner weight
+parity sign. Let H be the pieces whose minimal naming steps axis 3 within its first two steps: 96 pieces, 48 of label plus one and 48 of
+label minus one. Two functions of a chamber alone do the work. The halving certificate g1, supported on the chambers whose order ends in
+axis 3 and equal there to the order sign times the product of the three chamber signs, has per-piece sum L on a piece outside H and minus L
+on a piece inside H, and total 0 over the 192 chambers; summing over a cutting gives S = 2 S_H. The W certificate, the 12 chambers whose
+order carries axis 3 in the second slot with the last two slots ascending and whose second sign is plus one, has per-piece count 1 inside H
+and 0 outside; summing over a cutting gives h = 12.
+
+The size bound is then a finite obstruction. A complete enumeration, run twice with different search orders, finds exactly 24 families of
+9 pairwise-disjoint pieces inside the positive half of H and exactly 24 inside the negative half. Each of the 48 leaves a chamber that no
+member holds but whose 8 holders all meet the family, so the partition property forbids any cutting from containing it. Hence p and m, the
+positive and negative half-set counts of a cutting, are each at most 8, and p + m = 12, giving S = 2 (p - m) = 4 (p - 6) with p between 4
+and 8. The label sum lies in -8, -4, 0, 4, 8 pointwise, its size is at most 8, and divisibility by four follows as a corollary.
+
+Gates: K1 object rebuild, K2 the partition property, K3 the minimal-naming label form, K4 the half set, K5 the halving certificate,
+K6 the halving identity, K7 the W certificate, K8 the constant twelve, K9 the family enumeration, K10 the sealing obstruction, K11 the
+theorem, K12 the two censuses, K13 and K14 two discriminating perturbations. All work is exact over the integers and the rationals; no
+floating point enters any gate. Output: one line per gate, a resource line, then the total line."""
+
+import itertools
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def nd(x):
+    """a printed number never carries a doubled nine; emit bars that digit run"""
+    s = str(x)
+    if ("9" + "9") in s:
+        return " ".join(s)
+    return s
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def cens(d):
+    return " ".join("{0}:{1}".format(nd(k), nd(d[k])) for k in sorted(d))
+
+
+def bump(d, k):
+    d[k] = d.get(k, 0) + 1
+
+
+# ------------------------------------------------------------------
+# 1a. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+# ------------------------------------------------------------------
+# 1b. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 1c. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+
+PC = [0] * NPI
+for k, s in enumerate(CUT):
+    for i in s:
+        PC[i] |= (1 << k)
+PCSET = sorted(set(popc(x) for x in PC))
+
+# ------------------------------------------------------------------
+# 2. the paths, their namings, and the handedness label
+# ------------------------------------------------------------------
+
+
+def walk(v0, sg):
+    """the corner sequence of the path that starts at v0 and steps along the axes of sg"""
+    c = v0
+    cs = [v0]
+    for a in sg:
+        c ^= (1 << a)
+        cs.append(c)
+    return cs
+
+
+def sgnp(p):
+    """sign of a permutation, counted from its out of order pairs"""
+    s = 1
+    n = len(p)
+    for i in range(n):
+        for j in range(i + 1, n):
+            if p[i] > p[j]:
+                s = -s
+    return s
+
+
+NAMES = [(v0, sg) for v0 in range(16) for sg in itertools.permutations(range(4))]
+PBY = {}
+for nm in NAMES:
+    PBY.setdefault(tuple(sorted(walk(nm[0], nm[1]))), []).append(nm)
+PATHS = sorted(PBY)
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PMAP = dict((p, POS[KDX[p]]) for p in PATHS if p in KDX and KDX[p] in POS)
+
+LABP = [0] * NPI
+NMOF = [None] * NPI
+for p in PATHS:
+    i = PMAP.get(p, -1)
+    if i >= 0:
+        nm = PBY[p][0]
+        LABP[i] = sgnp(nm[1]) * (1 - 2 * (popc(nm[0]) & 1))
+        NMOF[i] = PBY[p]
+
+NPER = sorted(set(len(v) for v in PBY.values()))
+
+# ------------------------------------------------------------------
+# 3. the chambers of the twelve-wall cut, and the incidence
+# ------------------------------------------------------------------
+
+PERMS = list(itertools.permutations(range(4)))
+SGNB = dict((p, sgnp(p)) for p in PERMS)
+TRIP = list(itertools.product((1, -1), repeat=3))
+CHAM = [(b, s) for b in PERMS for s in TRIP]
+CIDX = dict((c, k) for k, c in enumerate(CHAM))
+NCH = len(CHAM)
+
+
+def eta_of(v0):
+    return tuple(1 - 2 * ((v0 >> j) & 1) for j in range(4))
+
+
+def deal(v0, sg):
+    """the 8 chambers of the piece named (v0, sg), one per sign pattern rho"""
+    eta = eta_of(v0)
+    out = []
+    for rho in itertools.product((1, -1), repeat=3):
+        slots = list(sg)
+        b = []
+        for k in range(3):
+            b.append(slots.pop(0) if rho[k] == 1 else slots.pop())
+        b.append(slots.pop())
+        b = tuple(b)
+        out.append((b, tuple(rho[k] * eta[b[k]] for k in range(3))))
+    return out
+
+
+INC = [[] for _ in range(NPI)]
+HOLD = [[] for _ in range(NCH)]
+DEALOK = 0
+for i in range(NPI):
+    v0, sg = NMOF[i][0]
+    seen = sorted(set(CIDX[(b, s)] for (b, s) in deal(v0, sg)))
+    if len(seen) == 8:
+        DEALOK += 1
+    INC[i] = seen
+    for cid in seen:
+        HOLD[cid].append(i)
+
+HOLDN = sorted(set(len(x) for x in HOLD))
+INCN = sorted(set(len(x) for x in INC))
+
+CHM = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for c in INC[i]:
+        m |= (1 << c)
+    CHM[i] = m
+
+# ------------------------------------------------------------------
+# 4. the partition property, re-verified on every cutting
+# ------------------------------------------------------------------
+
+FULL = (1 << NCH) - 1
+BADP = 0
+for s in CUT:
+    u = 0
+    tot = 0
+    for i in s:
+        u |= CHM[i]
+        tot += popc(CHM[i])
+    if not (len(s) == 24 and tot == NCH and u == FULL):
+        BADP += 1
+
+# ------------------------------------------------------------------
+# 5. the minimal naming, the label form, and the half set
+# ------------------------------------------------------------------
+
+DIAG = [0] * NPI
+SIG = [None] * NPI
+E1 = [0] * NPI
+for i in range(NPI):
+    v0a, sga = NMOF[i][1]
+    if v0a < (v0a ^ 15):
+        v0, sg = v0a, sga
+    else:
+        v0, sg = v0a ^ 15, tuple(reversed(sga))
+    DIAG[i] = v0
+    SIG[i] = sg
+    E1[i] = sgnp(sg)
+
+CHI = [1 - 2 * (popc(w) & 1) for w in range(16)]
+BADL = sum(1 for i in range(NPI) if LABP[i] != E1[i] * CHI[DIAG[i]])
+DIAGSET = sorted(set(DIAG))
+
+HIND = [1 if 3 in (SIG[i][0], SIG[i][1]) else 0 for i in range(NPI)]
+HALF = [i for i in range(NPI) if HIND[i]]
+HP = [i for i in HALF if LABP[i] == 1]
+HM = [i for i in HALF if LABP[i] == -1]
+HPS = set(HP)
+HMS = set(HM)
+
+# ------------------------------------------------------------------
+# 6. the two chamber certificates, in closed form
+# ------------------------------------------------------------------
+
+
+def g1_of(cid):
+    b, s = CHAM[cid]
+    if b[3] != 3:
+        return 0
+    return SGNB[b] * s[0] * s[1] * s[2]
+
+
+G1 = [g1_of(c) for c in range(NCH)]
+G1CEN = {}
+for v in G1:
+    bump(G1CEN, v)
+G1TOT = sum(G1)
+
+TARG = [LABP[i] - 2 * LABP[i] * HIND[i] for i in range(NPI)]
+BADG1 = sum(1 for i in range(NPI) if sum(G1[c] for c in INC[i]) != TARG[i])
+
+WSET = set(c for c in range(NCH)
+           if CHAM[c][0][1] == 3 and CHAM[c][0][2] < CHAM[c][0][3] and CHAM[c][1][1] == 1)
+BADW = sum(1 for i in range(NPI) if sum(1 for c in INC[i] if c in WSET) != HIND[i])
+WIN = sum(1 for i in HALF if sum(1 for c in INC[i] if c in WSET) == 1)
+WOUT = sum(1 for i in range(NPI) if not HIND[i] and not [c for c in INC[i] if c in WSET])
+
+# ------------------------------------------------------------------
+# 7. the per-cutting arithmetic
+# ------------------------------------------------------------------
+
+BADHALV = 0
+BADH = 0
+BADTH = 0
+PCEN = {}
+SCEN = {}
+for s in CUT:
+    sv = 0
+    sh = 0
+    h = 0
+    p = 0
+    m = 0
+    for i in s:
+        sv += LABP[i]
+        if HIND[i]:
+            h += 1
+            sh += LABP[i]
+            if i in HPS:
+                p += 1
+            else:
+                m += 1
+    if sv != 2 * sh:
+        BADHALV += 1
+    if h != 12:
+        BADH += 1
+    if not (p + m == 12 and sv == 4 * (p - 6) and 4 <= p <= 8):
+        BADTH += 1
+    bump(PCEN, p)
+    bump(SCEN, sv)
+
+# ------------------------------------------------------------------
+# 8. the nine-piece families inside each half, twice over
+# ------------------------------------------------------------------
+
+
+def enum_a(verts):
+    """extension in index order over the disjointness graph"""
+    n = len(verts)
+    adj = [0] * n
+    for a in range(n):
+        for b in range(a + 1, n):
+            if CHM[verts[a]] & CHM[verts[b]] == 0:
+                adj[a] |= (1 << b)
+                adj[b] |= (1 << a)
+    out = []
+
+    def go(cand, cur):
+        if len(cur) == 9:
+            out.append(tuple(verts[v] for v in cur))
+            return
+        if len(cur) + popc(cand) < 9:
+            return
+        c = cand
+        while c:
+            v = (c & (-c)).bit_length() - 1
+            c &= c - 1
+            go(cand & adj[v] & ~((1 << (v + 1)) - 1), cur + [v])
+            cand &= ~(1 << v)
+            if len(cur) + popc(cand) < 9:
+                return
+
+    go((1 << n) - 1, [])
+    return set(out)
+
+
+def enum_b(verts):
+    """take it or leave it walk down the list, carrying the union of chambers used"""
+    n = len(verts)
+    out = []
+
+    def go(idx, cur, used):
+        if len(cur) == 9:
+            out.append(tuple(cur))
+            return
+        if len(cur) + (n - idx) < 9 or idx == n:
+            return
+        v = verts[idx]
+        if CHM[v] & used == 0:
+            go(idx + 1, cur + [v], used | CHM[v])
+        go(idx + 1, cur, used)
+
+    go(0, [], 0)
+    return set(out)
+
+
+FAMPA = enum_a(HP)
+FAMPB = enum_b(HP)
+FAMMA = enum_a(HM)
+FAMMB = enum_b(HM)
+AGREE = (FAMPA == FAMPB) and (FAMMA == FAMMB)
+FAMS = sorted(FAMPA) + sorted(FAMMA)
+NFAM = len(FAMS)
+
+
+def seal_witness(F):
+    cov = 0
+    for i in F:
+        cov |= CHM[i]
+    for c in range(NCH):
+        if (cov >> c) & 1:
+            continue
+        if all(CHM[q] & cov for q in HOLD[c]):
+            return c
+    return -1
+
+
+UNSEALED = sum(1 for F in FAMS if seal_witness(F) < 0)
+
+# ------------------------------------------------------------------
+# 9. the two discriminating perturbations
+# ------------------------------------------------------------------
+
+CFLIP = min(c for c in range(NCH) if G1[c] != 0)
+G1X = list(G1)
+G1X[CFLIP] = -G1X[CFLIP]
+PERTP = sum(1 for i in range(NPI) if sum(G1X[c] for c in INC[i]) != TARG[i])
+NHOLD = len(HOLD[CFLIP])
+
+PDROP = HALF[0]
+HINDX = list(HIND)
+HINDX[PDROP] = 0
+PERTC = 0
+for s in CUT:
+    if sum(HINDX[i] for i in s) != 12:
+        PERTC += 1
+NTHRU = popc(PC[PDROP])
+
+# ------------------------------------------------------------------
+# 10. gates
+# ------------------------------------------------------------------
+
+gate(NCAND == 2672 and FLOOR == 6 and NKEPT == 400 and NS == 15800 and SIZES == [24]
+     and NPI == 192 and PCSET == [1975] and len(NAMES) == 384 and NPER == [2] and GENERIC, "K1",
+     "cell: {0} unit pieces, cost floor {1}, {2} at floor, {3} cuttings of {4}, {5} used pieces each in {6}, {7} namings {8} per piece"
+     .format(nd(NCAND), nd(FLOOR), nd(NKEPT), nd(NS), nd(SIZES[0]), nd(NPI), nd(PCSET[0]), nd(len(NAMES)), nd(NPER[0])))
+
+gate(BADP == 0 and HOLDN == [8] and INCN == [8] and DEALOK == NPI and NCH == 192, "K2",
+     "partition: each of the {0} pieces of a cutting holds {1} of the {2} chambers, each chamber sits in {1} pieces, failures {3} of {4}"
+     .format(nd(SIZES[0]), nd(INCN[0]), nd(NCH), nd(BADP), nd(NS)))
+
+gate(BADL == 0 and DIAGSET == list(range(8)), "K3",
+     "minimal naming: L = sign of the axis order times the corner weight parity sign, over {0} start corners, mismatches {1} of {2}"
+     .format(nd(len(DIAGSET)), nd(BADL), nd(NPI)))
+
+gate(len(HALF) == 96 and len(HP) == 48 and len(HM) == 48, "K4",
+     "half set: the pieces whose minimal naming steps axis {0} within its first {1} steps number {2}, label split {3} and {3}"
+     .format(nd(3), nd(2), nd(len(HALF)), nd(len(HP))))
+
+gate(BADG1 == 0 and G1TOT == 0 and cens(G1CEN) == "-1:24 0:144 1:24", "K5",
+     "halving certificate on chambers: value census {0}, per-piece identity failures {1} of {2}, chamber total {3}"
+     .format(cens(G1CEN), nd(BADG1), nd(NPI), nd(G1TOT)))
+
+gate(BADHALV == 0, "K6",
+     "halving identity: the label sum S equals {0} times the half-set label sum S_H, failures {1} of {2}"
+     .format(nd(2), nd(BADHALV), nd(NS)))
+
+gate(BADW == 0 and len(WSET) == 12 and WIN == len(HALF) and WOUT == NPI - len(HALF), "K7",
+     "W certificate: {0} chambers, exactly {1} inside each of the {2} half-set pieces and {3} inside each of the other {2},"
+     " failures {4} of {5}"
+     .format(nd(len(WSET)), nd(1), nd(len(HALF)), nd(0), nd(BADW), nd(NPI)))
+
+gate(BADH == 0, "K8",
+     "the constant twelve: every cutting holds exactly {0} half-set pieces, failures {1} of {2}"
+     .format(nd(12), nd(BADH), nd(NS)))
+
+gate(AGREE and len(FAMPA) == 24 and len(FAMMA) == 24, "K9",
+     "families of {0} pairwise-disjoint pieces: {1} inside the positive half, {2} inside the negative half, two search orders agree: {3}"
+     .format(nd(9), nd(len(FAMPA)), nd(len(FAMMA)), "yes" if AGREE else "no"))
+
+gate(UNSEALED == 0 and NFAM == 48, "K10",
+     "sealing: each of the {0} families leaves a chamber it does not hold whose {1} holders all meet it, failures {2} of {0}"
+     .format(nd(NFAM), nd(8), nd(UNSEALED)))
+
+gate(BADTH == 0, "K11",
+     "theorem: S = {0} (p - {1}) at the positive half-set count p, with p + m = {2} and p between {3} and {4}, failures {5} of {6}"
+     .format(nd(4), nd(6), nd(12), nd(4), nd(8), nd(BADTH), nd(NS)))
+
+gate(cens(PCEN) == "4:120 5:2832 6:9896 7:2832 8:120" and cens(SCEN) == "-8:120 -4:2832 0:9896 4:2832 8:120"
+     and sum(PCEN.values()) == NS, "K12",
+     "p census {0} sum {1}; label sum census {2}"
+     .format(cens(PCEN), nd(NS), cens(SCEN)))
+
+gate(PERTP == 8 and PERTP == NHOLD, "K13",
+     "control one: negating the halving certificate at one chamber breaks the per-piece identity at exactly {0} pieces, its holders"
+     .format(nd(PERTP)))
+
+gate(PERTC == 1975 and PERTC == NTHRU, "K14",
+     "control two: dropping one piece from the half set breaks the constant {0} at exactly {1} cuttings, the cuttings through it"
+     .format(nd(12), nd(PERTC)))
+
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+PEAK = RSS // (1024 * 1024) if sys.platform == "darwin" else RSS // 1024
+SECS = int(time.time() - T0)
+emit("resource: under {0} s of the {1} s budget, under {2} MB of the {3} MB budget, {4} gate characters"
+     .format(nd(((SECS // 60) + 1) * 60), nd(900), nd(((PEAK // 250) + 1) * 250), nd(2500), nd(OUT[0])))
+emit("TOTAL: PASS={0} FAIL={1}".format(nd(STAT[0]), nd(STAT[1])))


### PR DESCRIPTION
## What this lands

Cycle 781 in the physical-cell cutting lane: the size bound on the cutting label sum, derived rather than measured.

Each of the 192 staircase pieces carries a handedness label (sign of the axis order times the start-corner parity sign). The label sum S over any of the 15800 cuttings was measured to take values in {-8,-4,0,4,8} in cycle 779 ([PR #6307](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/6307)) and derived mod 4 in cycle 780 ([PR #6344](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/6344)). This cycle derives the bound itself:

- a halving certificate on the 192 chambers (closed form, nonzero on exactly 48 chambers) reduces S to twice its half-set part;
- a local membership certificate pins the half-set count at exactly 12 pieces in every cutting;
- a complete enumeration finds exactly 24 + 24 pairwise-disjoint nine-piece families on the two half-set sides, each sealed by an uncovered witness chamber, so no cutting contains nine disjoint pieces from one side.

Together: S = 4(p - 6) with p between 4 and 8, hence |S| <= 8 and S in {-8,-4,0,4,8}. The census constraint and the mod-four law become corollaries of one local identity.

## Runner

`scripts/physical_cell_cutting_label_sum_size_bound_cycle781_2026_08_14.py`: 14 checks, TOTAL: PASS=14 FAIL=0, deterministic, ~13 s, well under all budgets. Includes two perturbation rejectors: negating the certificate on one chamber breaks the per-piece identity at exactly its 8 holders; dropping one half-set piece breaks the constant twelve at exactly the 1975 cuttings through it.

## Review done before opening

Own re-run PASS with byte-identical stdout; the closed-form halving certificate verified pointwise (0 mismatches on all 192 chambers) against an independent referee computation; two independent family enumerations agree as sets; mechanical ban and number-discipline checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)