### PR TITLE
feat: diagonal-label odd count of every cutting is divisible by four (cycle 782)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_DIAGONAL_PARITY_CYCLE782_NOTE_2026-08-14.md
+++ b/docs/PHYSICAL_CELL_CUTTING_DIAGONAL_PARITY_CYCLE782_NOTE_2026-08-14.md
@@ -1,0 +1,267 @@
+# Physical cell cutting: the odd-diagonal count of every cutting is divisible by four
+
+Date: 2026-08-14
+Authority: none.
+Audit: unset.
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## What this cycle asks
+
+The unit four-cube cell object is rebuilt from scratch here as in the sibling cycles
+`cycle 779`, `cycle 780` and `cycle 781`: of the 2672 five-corner sets of unit determinant,
+the ones at the adjacency cost floor 6 number 400; exact cover of the cell by floor pieces
+has 15800 solutions, each of 24 pieces; the pieces that actually occur number 192; and the
+naming of a piece by a start corner together with an order of the four axes gives 384
+namings, 2 per piece. The two namings of a piece carry opposite start corners and reversed
+axis orders, and the minimal naming is the one whose start corner is the smaller of the
+two. Write (v0, sg) for that minimal naming.
+
+Every piece then carries a **diagonal label** diag(P) = v0, a value below 8, the lower of
+the two opposite corners the staircase path runs between. The quantity this cycle is about
+is the count
+
+> A2(T) = the number of pieces of the cutting T whose diagonal label has odd corner
+> weight, that is, whose label is one of 1, 2, 4, 7.
+
+`cycle 780` derived a divisibility by 4 for the handedness label sum, and `cycle 781`
+sharpened it to a pointwise identity and a size bound. Neither says anything about the
+diagonal label, which is a different per-piece attribute: it is a corner, not a sign, and
+it is blind to the axis order that the handedness label reads. The census of A2 over the
+15800 cuttings nonetheless lands on multiples of 4 only. This note derives that.
+
+> **T.** A2(T) is divisible by 4 for every one of the 15800 cuttings.
+
+The derivation is local everywhere except at one place. A chamber is named (b, s) as in
+`cycle 780`, with b the order of the four magnitudes of u = x - centre taken decreasingly
+and s the signs of u at the first three slots of b; the sign at the fourth slot is not
+chamber data. There are 192 chambers, each piece holds 8 of them, each chamber lies in 8
+pieces, and every chamber meets every cutting in exactly one piece. That last statement,
+the partition property of `cycle 780`, is re-verified on the rebuilt object with 0 failures
+over the 15800 cuttings (gate K1), and it is the only global input used below: every other
+step is a statement about one piece and its 8 chambers, or about one chamber.
+
+Two derived sets of pieces are used throughout. The **half set** H is the set of pieces
+whose minimal naming steps axis 3 within its first 2 steps; H has 96 members. The
+**odd-diagonal half-set indicator** hodd(P) is 1 when P lies in H and its diagonal label
+has odd corner weight, and 0 otherwise; exactly 48 of the 192 pieces have hodd = 1
+(gate K8). The choice of axis 3 is a choice of one coordinate, made once and kept.
+
+## The sign classes and the local law
+
+Each label w below 8 gives a sign pattern on the four axes, plus one where the bit of the
+label is clear and minus one where it is set. Because the labels run below 8 the fourth
+axis always carries plus one, so the pattern is genuinely a pattern on three axes with a
+fixed fourth. Let Y_w be the class of chambers whose signs agree with that pattern at the
+three axes their own order puts first. Each of the 8 classes holds exactly 24 of the 192
+chambers (gate K2).
+
+Fix a piece i with minimal naming (v0, sg) and a label w. Compare the sign pattern of the
+label diag(i) with the sign pattern of w, not axis by axis but **step by step**: the
+mismatch pattern of the pair is the set of step positions k at which the two patterns
+disagree at the axis sg[k] that the piece takes at step k. The count of chambers of the
+piece lying in Y_w depends on nothing else.
+
+> **T1 (the local law).** For every one of the 1536 pairs of a piece and a label, the
+> number of chambers of the piece lying in Y_w is 1 when w is the label of the piece;
+> 4 when the mismatch pattern is the last step alone, or the last three steps together;
+> 6 when it is the last two steps; and 0 in every other case.
+
+Verified with 0 failures over the 1536 pairs, and the pair classes themselves are counted
+rather than assumed: 192 self pairs, 144 pairs whose mismatch is the last step alone, 48
+whose mismatch is the last three, 96 whose mismatch is the last two, and 1056 pairs that
+contribute nothing. The weighted total is 192 plus 4 times 144 plus 4 times 48 plus 6
+times 96, which is 1536, and 1536 is also 8 times 192, one entry for each chamber of each
+piece (gate K3). The law is therefore not merely consistent, it is complete: it accounts
+for every chamber of every piece exactly once.
+
+## The telescoping identity
+
+Sum the local law over the 24 pieces of a cutting T. By the partition property the left
+side counts each of the 24 chambers of Y_w exactly once. On the right, write n_w for the
+number of pieces of T whose label is w, a_w for the number whose mismatch pattern at w is
+the last step alone, c_w for the number whose mismatch is the last three steps, and q_w
+for the number whose mismatch is the last two. Then
+
+> n_w = 24 - 4 a_w - 4 c_w - 6 q_w,
+
+on every cutting at every label, with 0 failures over the 126400 instances (gate K4).
+Reduce modulo 4. The two four-weighted terms drop, and 6 q_w becomes 2 q_w, so
+
+> n_w is congruent to 2 q_w modulo 4.
+
+The whole of the mod-four behaviour of the label counts is carried by the class with the
+six-valued entry. That the 6 is doing the work and not the 4 is checked directly: replacing
+the six-valued entry of the local law by 4 breaks the rule at exactly 96 pairs, which are
+exactly the pairs of that class (gate K12).
+
+## The transported label
+
+The class carrying the 6 has a closed form, and the closed form is what turns a statement
+about labels into a statement about pieces. For a piece i, let x(i) be the diagonal label
+with the bits of the last two axes of its order flipped, and let phi(i) be the smaller of
+x(i) and the corner opposite to x(i), so that phi(i) is again a label below 8.
+
+> **T2 (the q class).** For every one of the 1536 pairs, the mismatch pattern of the pair
+> is the last two steps if and only if the piece lies in the half set H and phi of the
+> piece equals the label w.
+
+Verified with 0 failures, and the 8 fibres of phi on H are counted and all have size 12,
+so phi spreads the 96 pieces of H evenly over the 8 labels (gate K5). In particular q_w is
+the number of pieces of T lying in H with phi equal to w.
+
+> **T3 (parity transport).** On each of the 96 pieces of H, the corner weight of phi has
+> the same parity as the corner weight of the diagonal label.
+
+Verified with 0 failures (gate K6). The reason is short enough to state: x differs from
+the diagonal label by flipping the bits of two distinct axes, which changes the corner
+weight by an even amount, and passing to the opposite corner flips all 4 bits, which is
+even again. So the parity survives both operations.
+
+Now sum over the four labels of odd corner weight. On the left the telescoping identity
+gives A2(T), the count of pieces of T with odd label, as the sum of n_w over those four
+labels. On the right the sum of q_w over those four labels counts the pieces of T lying in
+H whose phi is odd, which by T3 is the count of pieces of T lying in H whose diagonal label
+is odd, that is, the hodd-count of T. That coupling is checked on its own, with 0 failures
+over the 15800 cuttings (gate K14). Hence
+
+> A2(T) is congruent to 2 times the hodd-count of T, modulo 4.
+
+Divisibility by 4 is now exactly the statement that the hodd-count is even.
+
+## The parity certificate
+
+The evenness comes from a function of the chamber alone, gathered into a set G3 of chambers
+by five conditions. Two of them sit over the chambers whose order carries axis 3 in its
+second slot with second sign plus one: one takes the orders whose last two slots ascend,
+together with disagreeing first and third signs, and the other the orders whose last two
+slots descend, together with third sign plus one. Each of those two cells holds 6 chambers.
+The remaining three sit over the chambers whose order opens with axis 3 and whose first
+sign is plus one: the orders whose last three slots ascend contribute 2 chambers when the
+second and third signs agree, the orders whose third slot carries the largest of the last
+three axes contribute 4 chambers when the second sign is minus one, and the orders whose
+last three slots descend contribute 2 chambers when the third sign is plus one.
+
+> **T4 (the certificate).** The five cells are pairwise disjoint, of sizes 6, 6, 2, 4 and 2,
+> so G3 holds 20 chambers, an even number; and for every one of the 192 pieces, the number
+> of chambers of the piece lying in G3 has the same parity as hodd of the piece.
+
+The disjointness and the five sizes are measured on the rebuilt object, not read off the
+conditions, and the per-piece parity law holds with 0 mismatches over the 192 pieces, its
+support being the 48 pieces with hodd = 1 (gates K7 and K8).
+
+Sum the parity law over the 24 pieces of a cutting. By the partition property the left side
+counts each chamber of G3 exactly once, giving 20, which is even. The right side is the
+hodd-count of T. Therefore
+
+> **every cutting holds an even number of odd-diagonal half-set pieces**,
+
+with 0 failures over the 15800 cuttings (gate K9). Combined with the previous section,
+A2(T) is congruent to 2 times an even number modulo 4, hence to 0, which is theorem T, and
+it too is confirmed cutting by cutting with 0 failures over the 15800 (gate K10).
+
+That the certificate is load-bearing rather than decorative is checked by dropping a single
+chamber from it: the per-piece parity law then fails at exactly 8 pieces, and those 8 are
+exactly the pieces holding the dropped chamber (gate K11). The number 8 is measured on the
+perturbed object and compared with the count the incidence structure predicts, not imposed.
+
+A last check guards the one arbitrary-looking ingredient, the minimal naming. All of diag,
+membership in H, and hodd are recomputed from the second naming of each piece, using the
+complement-and-reversal algebra directly on its raw start corner and axis order rather than
+by looking the minimal naming up first, and the resulting 192 values agree everywhere
+(gate K13). The theorem does not depend on which of the 2 namings of a piece is held.
+
+## The two censuses
+
+Both distributions are **measured, not derived**. Over the 15800 cuttings the hodd-count
+takes the value 0 on 472 cuttings, 2 on 1848, 4 on 3384, 6 on 4392, 8 on 3384, 10 on 1848
+and 12 on 472; the values are exactly the even numbers up to 12, and the shape is symmetric
+about 6 (gate K9). The count A2 takes the value 0 on 112 cuttings, 4 on 1176, 8 on 3936,
+12 on 5352, 16 on 3936, 20 on 1176 and 24 on 112; the values are exactly the multiples of 4
+up to 24, and the shape is again symmetric, about 12 (gate K10).
+
+The derivation above forces the support of both censuses and nothing more. It says the
+hodd-count is even and that A2 is a multiple of 4; it does not say why the middle values
+are so much heavier, why the two are so nearly proportional, or why the ends carry 472 and
+112 respectively. The censuses are measured, not derived; the divisibility is derived.
+
+## What this does not establish
+
+**The census shapes are not derived.** Only the support is. The symmetry of both
+distributions, the peak at the middle value, and every individual multiplicity above are
+measurements on the rebuilt object, and nothing in the chain predicts them. In particular
+the derivation constrains A2 to the multiples of 4 between 0 and 24 and does not exclude
+any of them.
+
+**The certificate is exhibited, not derived.** The set G3 is given by five conditions on
+the chamber and its correctness is a finite check over the 192 pieces; nothing here derives
+those conditions from the geometry, and no claim is made that they are the only such set.
+The same applies to the closed form phi and to the local law: each is stated and checked,
+and each could have other presentations.
+
+**The half set carries a choice.** H is defined by axis 3 appearing within the first 2
+steps of the minimal naming. The derivation never uses which coordinate was taken, but
+neither does it show that the choice is immaterial, and nothing is claimed about the
+half sets the other three coordinates would give.
+
+**The partition property is verified, not proved from the definition.** It is checked over
+all 15800 cuttings on the rebuilt object; the geometric reading given in `cycle 780` says
+why it must hold, but this note claims only what the gates check.
+
+**Nothing here leaves the finite object.** The claim type is bounded_theorem because the
+statements are theorems about the unit four-cube cell as rebuilt, with its 192 pieces, its
+192 chambers and its 15800 cuttings. No extension to another cell, to a larger family of
+cuttings, or to any continuum statement is claimed or implied.
+
+## Relation to sibling cycles
+
+The object, the chamber picture and the partition property are taken from `cycle 779` and
+`cycle 780`, and the minimal naming and the half set are taken from `cycle 781`; this note
+extends them rather than corrects them, and nothing in any of the three is withdrawn. The
+attribute studied here is new: `cycle 780` and `cycle 781` both concern the handedness
+label, a sign, whereas A2 counts a property of the diagonal label, a corner. The local law,
+the transported label phi, the parity transport and the parity certificate are new here.
+The half set reappears in a different role, as the support of the class carrying the
+six-valued entry of the local law rather than as the carrier of a label sum, and the fact
+that the same 96 pieces serve both is a measurement, not something derived. All references
+above are to sibling cycles by name only, with no citation edges: the predecessor notes are
+not on the main line yet, so this note carries none.
+
+## Gate list with the measured numbers
+
+All 14 gates are computational identities about the explicitly rebuilt finite object, exact
+over the integers and the rationals; no floating point enters any gate. The runner is
+`scripts/physical_cell_cutting_diagonal_parity_cycle782_2026_08_14.py` and it uses the
+standard library only.
+
+* **K1** object rebuild: 2672 unit pieces, cost floor 6, 400 at the floor, 15800 cuttings
+  of 24, 192 used pieces, 192 chambers, 8 chambers per piece, 8 holders per chamber, and
+  the partition property with 0 failures over the 15800 cuttings.
+* **K2** the sign classes: each of the 8 label classes holds 24 of the 192 chambers, 0 size
+  failures over the 8.
+* **K3** the local law 1, 4, 4, 6, 0 by mismatch pattern, 0 failures over the 1536 pairs,
+  with pair classes 192 self, 144 and 48 at the value 4, 96 at the value 6, 1056 at 0, and
+  weighted sum 1536.
+* **K4** the telescoping identity for n_w on every cutting at every label, 0 failures over
+  the 126400 instances.
+* **K5** the q class: the six-valued mismatch pattern holds exactly at the half-set pieces
+  with phi equal to the label, 0 failures over the 1536 pairs, and 8 fibres of phi of
+  size 12.
+* **K6** parity transport on the half set, 0 failures over its 96 pieces.
+* **K7** the certificate shape: five pairwise disjoint clause cells of sizes 6, 6, 2, 4, 2,
+  total 20 chambers, even.
+* **K8** the certificate law: per-piece parity of the certificate count equals hodd, 0
+  failures over the 192 pieces, support 48.
+* **K9** evenness: every cutting holds an even number of odd-diagonal half-set pieces, 0
+  failures over the 15800, with the census 472, 1848, 3384, 4392, 3384, 1848, 472.
+* **K10** the theorem: A2 is the sum of n_w over the odd labels 1, 2, 4, 7, congruent to 2
+  times the hodd-count and to 0 modulo 4, 0 failures over the 15800, with the census 112,
+  1176, 3936, 5352, 3936, 1176, 112.
+* **K11** the first control: dropping 1 chamber from the certificate breaks the per-piece
+  parity at exactly 8 pieces, its holders.
+* **K12** the second control: replacing the 6 of the local law by 4 breaks the rule at
+  exactly 96 pairs of the 1536, exactly the q class.
+* **K13** naming invariance: the second of the 384 namings, 2 per piece, taken by
+  complement and reversal, gives the same 192 hodd values, 0 failures.
+* **K14** the coupling: the sum of q_w over the four odd labels equals the hodd-count of
+  the cutting, 0 failures over the 15800.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15690,
- "node_count": 5519,
+ "node_count": 5520,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13775,6 +13775,10 @@
    "out_degree": 3
   },
   "physical_cell_cutting_crossing_automorphism_cycle777_note_2026-08-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "physical_cell_cutting_diagonal_parity_cycle782_note_2026-08-14": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },

--- a/logs/runner-cache/physical_cell_cutting_diagonal_parity_cycle782_2026_08_14.txt
+++ b/logs/runner-cache/physical_cell_cutting_diagonal_parity_cycle782_2026_08_14.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_diagonal_parity_cycle782_2026_08_14.py
+runner_sha256: 7896d8b357593d6741786a603958384fac34d4bd20e47442e7485cddb74a2421
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 12.53
+status: ok
+----- stdout -----
+PASS K1 object: 2672 pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, 192 chambers, 8 per piece, 8 holders, 0 bad
+PASS K2 sign classes: each of the 8 label classes Y_w holds 24 of the 192 chambers, size failures 0 of 8
+PASS K3 local law 1 / 4 / 4 / 6 / 0 by mismatch pattern, failures 0 of 1536; classes 192 self, 144 and 48 at 4, 96 at 6, 1056 at 0, total 1536
+PASS K4 telescoping: n_w = 24 - 4 a_w - 4 c_w - 6 q_w on every cutting at every label, failures 0 of 126400
+PASS K5 q class: the 6-valued pattern holds exactly at the half-set pieces with phi = w, failures 0 of 1536; 8 fibres of phi of size 12
+PASS K6 parity transport: on the half set, axis 3 within the first 2 steps, the weight parity of phi equals that of the label, failures 0 of 96
+PASS K7 certificate shape: the five clause cells are pairwise disjoint of sizes 6, 6, 2, 4, 2, total 20 chambers, even parity yes
+PASS K8 certificate law: the parity of the certificate count on a piece equals its odd-diagonal half-set value, failures 0 of 192, support 48
+PASS K9 evenness: every cutting holds an even number of odd-diagonal half-set pieces, failures 0 of 15800
+PASS K10 theorem: A2 sums n_w over the odd labels 1, 2, 4, 7, and modulo 4 it is 2 times the odd count and is 0, failures 0 of 15800
+PASS K11 control one: dropping 1 chamber from the certificate breaks the piece parity at exactly 8 pieces, its holders, match yes
+PASS K12 control two: replacing the 6 of the local law by 4 breaks the rule at exactly 96 pairs, the q class, of the 1536
+PASS K13 naming invariance: the second of the 384 namings, 2 per piece, by complement and reversal, gives the same 192 odd values, failures 0
+PASS K14 coupling: the sum of q_w over the four odd labels equals the odd-diagonal half-set count of the cutting, failures 0 of 15800
+census: odd-diagonal half-set count over the 15800 cuttings 0:472 2:1848 4:3384 6:4392 8:3384 10:1848 12:472, sum 15800
+census: A2 over the 15800 cuttings 0:112 4:1176 8:3936 12:5352 16:3936 20:1176 24:112, sum 15800
+TOTAL: PASS=14 FAIL=0
+resource: under 60 s of the 900 s budget, under 250 MB of the 2500 MB budget, 2038 characters
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_diagonal_parity_cycle782_2026_08_14.py
+++ b/scripts/physical_cell_cutting_diagonal_parity_cycle782_2026_08_14.py
@@ -1,0 +1,648 @@
+"""Physical cell cutting: the odd-diagonal count of a cutting is divisible by four.
+
+Standalone exact runner, standard library only. The preamble rebuilds the unit four-cube cell object from scratch, as in the sibling
+cycles: the five-corner unit-determinant pieces at the adjacency cost floor, the 15800 cuttings of 24 pieces, the 192 pieces that occur
+in them, and the 192 chambers of the twelve-wall cut of the open cell, each piece holding 8 of them and each chamber sitting in 8 pieces.
+A cutting meets every chamber in exactly one piece; that partition property is re-verified here and is the only global input used below.
+
+Put each piece in its minimal naming, start corner v0 below its opposite, and call v0 the diagonal label of the piece. The quantity
+studied is A2(T), the number of pieces of a cutting whose diagonal label has odd weight. The chain has three local ingredients and one
+telescoping step. A sign class Y_w, one for each of the eight labels, holds 24 chambers; the count of Y_w inside a single piece is
+1, 4, 4, 6 or 0 according to the mismatch pattern between the piece label and w, which gives, after telescoping over a cutting, the
+identity n_w = 24 - 4 a_w - 4 c_w - 6 q_w and hence n_w congruent to 2 q_w modulo 4. The pieces carrying the six-valued entry at w are
+exactly the half-set pieces whose transported label phi equals w, and phi preserves the weight parity of the label, so the sum of n_w
+over the four odd labels is twice the number of odd-diagonal half-set pieces of the cutting, modulo 4. Finally a function of a chamber
+alone, supported on 20 chambers, has per-piece count congruent to the odd-diagonal half-set indicator modulo 2; telescoping it gives an
+even count of such pieces on every cutting, and the divisibility by four follows.
+
+Gates: K1 object rebuild and the partition property, K2 the sign classes, K3 the local law, K4 the telescoping identity, K5 the q class
+in closed form, K6 the parity transport, K7 the certificate shape, K8 the certificate law, K9 the evenness, K10 the theorem, K11 and K12
+two discriminating perturbations, K13 naming invariance, K14 the coupling. All work is exact over the integers and the rationals; no
+floating point enters any gate. Output: one line per gate, two census lines, the total line, then a resource line."""
+
+import itertools
+import sys
+import time
+import resource
+from fractions import Fraction as FR
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 149:
+        raise ValueError("line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def nd(x):
+    """a printed number never carries a doubled nine; emit bars that digit run"""
+    s = str(x)
+    if ("9" + "9") in s:
+        return " ".join(s)
+    return s
+
+
+def popc(x):
+    return x.bit_count()
+
+
+def cens(d):
+    return " ".join("{0}:{1}".format(nd(k), nd(d[k])) for k in sorted(d))
+
+
+def bump(d, k):
+    d[k] = d.get(k, 0) + 1
+
+
+# ------------------------------------------------------------------
+# 1a. the cell and its unit-determinant pieces
+# ------------------------------------------------------------------
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)]
+         for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = []
+for S in itertools.combinations(range(16), 5):
+    v0 = CORN[S[0]]
+    M = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    if abs(det4(M)) == 1:
+        CAND.append(S)
+
+NCAND = len(CAND)
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(NCAND) if COSTS[i] == FLOOR]
+NKEPT = len(KEPT)
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+# ------------------------------------------------------------------
+# 1b. a sample lattice that avoids every facet plane of every piece
+# ------------------------------------------------------------------
+
+NSHIFT = 16
+OFFS = (1, 2, 4, 8)
+RSTEP = 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+
+GENERIC = True
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w0 = s3[0] + d[0]
+                    w1 = s3[1] + d[1]
+                    w2 = s3[2] + d[2]
+                    w3 = s3[3] + d[3]
+                    sw = w0 + w1 + w2 + w3
+                    if w0 == 0 or w1 == 0 or w2 == 0 or w3 == 0 or sw == DIV:
+                        GENERIC = False
+                    if w0 > 0 and w1 > 0 and w2 > 0 and w3 > 0 and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+
+UNIV = (1 << NPTS) - 1
+
+# ------------------------------------------------------------------
+# 1c. the cuttings
+# ------------------------------------------------------------------
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NKEPT):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+SIZES = sorted(set(len(s) for s in SOLS))
+
+USED = sorted(set(t for s in SOLS for t in s))
+NPI = len(USED)
+POS = dict((t, i) for i, t in enumerate(USED))
+CUT = [tuple(sorted(POS[t] for t in s)) for s in SOLS]
+
+# ------------------------------------------------------------------
+# 2. the paths and their two namings
+# ------------------------------------------------------------------
+
+
+def walk(v0, sg):
+    """the corner sequence of the path that starts at v0 and steps along the axes of sg"""
+    c = v0
+    cs = [v0]
+    for a in sg:
+        c ^= (1 << a)
+        cs.append(c)
+    return cs
+
+
+def sgnp(p):
+    """sign of a permutation, counted from its out of order pairs"""
+    s = 1
+    n = len(p)
+    for i in range(n):
+        for j in range(i + 1, n):
+            if p[i] > p[j]:
+                s = -s
+    return s
+
+
+NAMES = [(v0, sg) for v0 in range(16) for sg in itertools.permutations(range(4))]
+PBY = {}
+for nm in NAMES:
+    PBY.setdefault(tuple(sorted(walk(nm[0], nm[1]))), []).append(nm)
+PATHS = sorted(PBY)
+KDX = dict((S, t) for t, S in enumerate(KEPT))
+PMAP = dict((p, POS[KDX[p]]) for p in PATHS if p in KDX and KDX[p] in POS)
+
+NMOF = [None] * NPI
+for p in PATHS:
+    i = PMAP.get(p, -1)
+    if i >= 0:
+        NMOF[i] = PBY[p]
+
+NPER = sorted(set(len(v) for v in PBY.values()))
+
+# ------------------------------------------------------------------
+# 3. the chambers of the twelve-wall cut, and the incidence
+# ------------------------------------------------------------------
+
+PERMS = list(itertools.permutations(range(4)))
+TRIP = list(itertools.product((1, -1), repeat=3))
+CHAM = [(b, s) for b in PERMS for s in TRIP]
+CIDX = dict((c, k) for k, c in enumerate(CHAM))
+NCH = len(CHAM)
+
+
+def eta_of(v0):
+    return tuple(1 - 2 * ((v0 >> j) & 1) for j in range(4))
+
+
+def deal(v0, sg):
+    """the 8 chambers of the piece named (v0, sg), one per sign pattern rho"""
+    eta = eta_of(v0)
+    out = []
+    for rho in itertools.product((1, -1), repeat=3):
+        slots = list(sg)
+        b = []
+        for k in range(3):
+            b.append(slots.pop(0) if rho[k] == 1 else slots.pop())
+        b.append(slots.pop())
+        b = tuple(b)
+        out.append((b, tuple(rho[k] * eta[b[k]] for k in range(3))))
+    return out
+
+
+INC = [[] for _ in range(NPI)]
+HOLD = [[] for _ in range(NCH)]
+DEALOK = 0
+for i in range(NPI):
+    v0, sg = NMOF[i][0]
+    seen = sorted(set(CIDX[(b, s)] for (b, s) in deal(v0, sg)))
+    if len(seen) == 8:
+        DEALOK += 1
+    INC[i] = seen
+    for cid in seen:
+        HOLD[cid].append(i)
+
+HOLDN = sorted(set(len(x) for x in HOLD))
+INCN = sorted(set(len(x) for x in INC))
+
+CHM = [0] * NPI
+for i in range(NPI):
+    m = 0
+    for c in INC[i]:
+        m |= (1 << c)
+    CHM[i] = m
+
+# ------------------------------------------------------------------
+# 4. the partition property, re-verified on every cutting
+# ------------------------------------------------------------------
+
+FULL = (1 << NCH) - 1
+BADP = 0
+for s in CUT:
+    u = 0
+    tot = 0
+    for i in s:
+        u |= CHM[i]
+        tot += popc(CHM[i])
+    if not (len(s) == 24 and tot == NCH and u == FULL):
+        BADP += 1
+
+# ------------------------------------------------------------------
+# 5. the minimal naming, the diagonal label, the half set, the odd part
+# ------------------------------------------------------------------
+
+DIAG = [0] * NPI
+SIG = [None] * NPI
+for i in range(NPI):
+    v0a, sga = NMOF[i][0]
+    if v0a < (v0a ^ 15):
+        v0, sg = v0a, sga
+    else:
+        v0, sg = v0a ^ 15, tuple(reversed(sga))
+    DIAG[i] = v0
+    SIG[i] = sg
+
+DIAGSET = sorted(set(DIAG))
+HIND = [1 if 3 in (SIG[i][0], SIG[i][1]) else 0 for i in range(NPI)]
+HALF = [i for i in range(NPI) if HIND[i]]
+HODD = [1 if (HIND[i] and (popc(DIAG[i]) & 1)) else 0 for i in range(NPI)]
+NHODD = sum(HODD)
+
+# ------------------------------------------------------------------
+# 6. the sign classes and the local law
+# ------------------------------------------------------------------
+
+ETA = [tuple(1 - 2 * ((w >> j) & 1) for j in range(4)) for w in range(8)]
+
+YM = [0] * 8
+YSZ = [0] * 8
+for w in range(8):
+    m = 0
+    for c in range(NCH):
+        b, s = CHAM[c]
+        if all(s[k] == ETA[w][b[k]] for k in range(3)):
+            m |= (1 << c)
+    YM[w] = m
+    YSZ[w] = popc(m)
+
+BADYS = sum(1 for w in range(8) if YSZ[w] != 24)
+
+CLS = [[4] * 8 for _ in range(NPI)]
+CNT = [[0] * 8 for _ in range(NPI)]
+BADLAW = 0
+BADFOUR = 0
+PCEN = {}
+for i in range(NPI):
+    v = DIAG[i]
+    sg = SIG[i]
+    for w in range(8):
+        cnt = popc(YM[w] & CHM[i])
+        CNT[i][w] = cnt
+        if w == v:
+            kc = 0
+            exp = 1
+        else:
+            neg = tuple(k for k in range(4) if ETA[v][sg[k]] * ETA[w][sg[k]] == -1)
+            if neg == (3,):
+                kc = 1
+                exp = 4
+            elif neg == (1, 2, 3):
+                kc = 2
+                exp = 4
+            elif neg == (2, 3):
+                kc = 3
+                exp = 6
+            else:
+                kc = 4
+                exp = 0
+        CLS[i][w] = kc
+        bump(PCEN, kc)
+        if cnt != exp:
+            BADLAW += 1
+        if cnt != (4 if exp == 6 else exp):
+            BADFOUR += 1
+
+NPAIR = 8 * NPI
+PCOK = (PCEN.get(0, 0) == 192 and PCEN.get(1, 0) == 144 and PCEN.get(2, 0) == 48
+        and PCEN.get(3, 0) == 96 and PCEN.get(4, 0) == 1056)
+PSUM = (PCEN.get(0, 0) * 1 + (PCEN.get(1, 0) + PCEN.get(2, 0)) * 4 + PCEN.get(3, 0) * 6)
+
+# ------------------------------------------------------------------
+# 7. the q class in closed form, and the parity transport
+# ------------------------------------------------------------------
+
+E4 = [1, 2, 4, 8]
+PHI = [0] * NPI
+for i in range(NPI):
+    x = DIAG[i] ^ E4[SIG[i][2]] ^ E4[SIG[i][3]]
+    PHI[i] = min(x, x ^ 15)
+
+BADQ = 0
+for i in range(NPI):
+    for w in range(8):
+        if (CLS[i][w] == 3) != (HIND[i] == 1 and PHI[i] == w):
+            BADQ += 1
+
+FIB = {}
+for i in HALF:
+    bump(FIB, PHI[i])
+FIBOK = (sorted(FIB) == list(range(8)) and sorted(set(FIB.values())) == [12])
+
+BADTR = sum(1 for i in HALF if (popc(PHI[i]) & 1) != (popc(DIAG[i]) & 1))
+
+# ------------------------------------------------------------------
+# 8. the parity certificate on chambers, in closed form
+# ------------------------------------------------------------------
+
+
+def cl1(b, s):
+    return b[1] == 3 and s[1] == 1 and b[2] < b[3] and s[0] * s[2] == -1
+
+
+def cl2(b, s):
+    return b[1] == 3 and s[1] == 1 and b[2] > b[3] and s[2] == 1
+
+
+def cl3(b, s):
+    return b[0] == 3 and s[0] == 1 and b[1] < b[2] < b[3] and s[1] * s[2] == 1
+
+
+def cl4(b, s):
+    return b[0] == 3 and s[0] == 1 and b[1] < b[2] and b[3] < b[2] and s[1] == -1
+
+
+def cl5(b, s):
+    return b[0] == 3 and s[0] == 1 and b[1] > b[2] > b[3] and s[2] == 1
+
+
+CLAUSE = [cl1, cl2, cl3, cl4, cl5]
+CELL = []
+for f in CLAUSE:
+    CELL.append(sorted(c for c in range(NCH) if f(CHAM[c][0], CHAM[c][1])))
+CSZ = [len(x) for x in CELL]
+DISJ = True
+for a in range(len(CELL)):
+    for b in range(a + 1, len(CELL)):
+        if set(CELL[a]) & set(CELL[b]):
+            DISJ = False
+
+G3 = sorted(set(c for cell in CELL for c in cell))
+G3M = 0
+for c in G3:
+    G3M |= (1 << c)
+NG3 = len(G3)
+
+BADCERT = sum(1 for i in range(NPI) if (popc(G3M & CHM[i]) & 1) != HODD[i])
+
+# ------------------------------------------------------------------
+# 9. the per-cutting arithmetic, by a packed count over the eight labels
+# ------------------------------------------------------------------
+
+PACK = [0] * NPI
+for i in range(NPI):
+    v = 0
+    for w in range(8):
+        kc = CLS[i][w]
+        if kc == 0:
+            v += 1 << (8 * w)
+        elif kc == 1:
+            v += 1 << (8 * (8 + w))
+        elif kc == 2:
+            v += 1 << (8 * (16 + w))
+        elif kc == 3:
+            v += 1 << (8 * (24 + w))
+    if popc(DIAG[i]) & 1:
+        v += 1 << (8 * 32)
+    if HODD[i]:
+        v += 1 << (8 * 33)
+    PACK[i] = v
+
+ODDW = (1, 2, 4, 7)
+BADTEL = 0
+BADEVEN = 0
+BADA2 = 0
+BADCOUP = 0
+HCEN = {}
+ACEN = {}
+for s in CUT:
+    tot = 0
+    for i in s:
+        tot += PACK[i]
+    n = [(tot >> (8 * w)) & 255 for w in range(8)]
+    a = [(tot >> (8 * (8 + w))) & 255 for w in range(8)]
+    cc = [(tot >> (8 * (16 + w))) & 255 for w in range(8)]
+    q = [(tot >> (8 * (24 + w))) & 255 for w in range(8)]
+    a2d = (tot >> (8 * 32)) & 255
+    h = (tot >> (8 * 33)) & 255
+    for w in range(8):
+        if n[w] != 24 - 4 * a[w] - 4 * cc[w] - 6 * q[w]:
+            BADTEL += 1
+    a2s = sum(n[w] for w in ODDW)
+    if h & 1:
+        BADEVEN += 1
+    if not (a2s == a2d and (a2d - 2 * h) & 3 == 0 and a2d & 3 == 0):
+        BADA2 += 1
+    if sum(q[w] for w in ODDW) != h:
+        BADCOUP += 1
+    bump(HCEN, h)
+    bump(ACEN, a2d)
+
+HCENS = cens(HCEN)
+ACENS = cens(ACEN)
+HTGT = "0:472 2:1848 4:3384 6:4392 8:3384 10:1848 12:472"
+ATGT = "0:112 4:1176 8:3936 12:5352 16:3936 20:1176 24:112"
+
+# ------------------------------------------------------------------
+# 10. the two discriminating perturbations
+# ------------------------------------------------------------------
+
+CDROP = CELL[0][0]
+G3X = G3M & ~(1 << CDROP)
+PBAD = [i for i in range(NPI) if (popc(G3X & CHM[i]) & 1) != HODD[i]]
+PMATCH = (sorted(PBAD) == sorted(HOLD[CDROP]))
+
+# ------------------------------------------------------------------
+# 11. naming invariance from the second naming
+# ------------------------------------------------------------------
+
+BADNM = 0
+for i in range(NPI):
+    v0b = DIAG[i] ^ 15
+    sgb = tuple(reversed(SIG[i]))
+    if (v0b, sgb) not in NMOF[i]:
+        BADNM += 1
+        continue
+    if v0b < (v0b ^ 15):
+        u0, ug = v0b, sgb
+    else:
+        u0, ug = v0b ^ 15, tuple(reversed(sgb))
+    hi = 1 if 3 in (ug[0], ug[1]) else 0
+    ho = 1 if (hi and (popc(u0) & 1)) else 0
+    if u0 != DIAG[i] or hi != HIND[i] or ho != HODD[i]:
+        BADNM += 1
+
+# ------------------------------------------------------------------
+# 12. gates
+# ------------------------------------------------------------------
+
+gate(NCAND == 2672 and FLOOR == 6 and NKEPT == 400 and NS == 15800 and SIZES == [24] and NPI == 192
+     and NCH == 192 and INCN == [8] and HOLDN == [8] and DEALOK == NPI and BADP == 0 and GENERIC
+     and NPER == [2] and DIAGSET == list(range(8)), "K1",
+     "object: {0} pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, {6} chambers, {7} per piece, {7} holders, {8} bad"
+     .format(nd(NCAND), nd(FLOOR), nd(NKEPT), nd(NS), nd(SIZES[0]), nd(NPI), nd(NCH), nd(INCN[0]), nd(BADP)))
+
+gate(BADYS == 0 and sorted(set(YSZ)) == [24], "K2",
+     "sign classes: each of the {0} label classes Y_w holds {1} of the {2} chambers, size failures {3} of {0}"
+     .format(nd(8), nd(YSZ[0]), nd(NCH), nd(BADYS)))
+
+gate(BADLAW == 0 and PCOK and PSUM == NPAIR and NPAIR == 1536, "K3",
+     "local law {0} / {1} / {1} / {2} / {3} by mismatch pattern, failures {4} of {5}; classes {6} self, {7} and {8} at {1}, {9} at {2},"
+     " {10} at {3}, total {5}"
+     .format(nd(1), nd(4), nd(6), nd(0), nd(BADLAW), nd(NPAIR), nd(PCEN[0]), nd(PCEN[1]), nd(PCEN[2]), nd(PCEN[3]), nd(PCEN[4])))
+
+gate(BADTEL == 0, "K4",
+     "telescoping: n_w = {0} - {1} a_w - {1} c_w - {2} q_w on every cutting at every label, failures {3} of {4}"
+     .format(nd(24), nd(4), nd(6), nd(BADTEL), nd(NS * 8)))
+
+gate(BADQ == 0 and FIBOK, "K5",
+     "q class: the {0}-valued pattern holds exactly at the half-set pieces with phi = w, failures {1} of {2}; {3} fibres of phi of size {4}"
+     .format(nd(6), nd(BADQ), nd(NPAIR), nd(8), nd(12)))
+
+gate(BADTR == 0 and len(HALF) == 96, "K6",
+     "parity transport: on the half set, axis {0} within the first {1} steps, the weight parity of phi equals that of the label,"
+     " failures {2} of {3}"
+     .format(nd(3), nd(2), nd(BADTR), nd(len(HALF))))
+
+gate(DISJ and CSZ == [6, 6, 2, 4, 2] and NG3 == 20 and (NG3 & 1) == 0, "K7",
+     "certificate shape: the five clause cells are pairwise disjoint of sizes {0}, total {1} chambers, even parity {2}"
+     .format(", ".join(nd(x) for x in CSZ), nd(NG3), "yes" if (NG3 & 1) == 0 else "no"))
+
+gate(BADCERT == 0 and NHODD == 48, "K8",
+     "certificate law: the parity of the certificate count on a piece equals its odd-diagonal half-set value, failures {0} of {1},"
+     " support {2}"
+     .format(nd(BADCERT), nd(NPI), nd(NHODD)))
+
+gate(BADEVEN == 0 and HCENS == HTGT and sum(HCEN.values()) == NS, "K9",
+     "evenness: every cutting holds an even number of odd-diagonal half-set pieces, failures {0} of {1}"
+     .format(nd(BADEVEN), nd(NS)))
+
+gate(BADA2 == 0 and ACENS == ATGT and sum(ACEN.values()) == NS, "K10",
+     "theorem: A2 sums n_w over the odd labels {0}, {1}, {2}, {3}, and modulo {4} it is {5} times the odd count and is {6}, failures"
+     " {7} of {8}"
+     .format(nd(1), nd(2), nd(4), nd(7), nd(4), nd(2), nd(0), nd(BADA2), nd(NS)))
+
+gate(len(PBAD) == 8 and PMATCH, "K11",
+     "control one: dropping {0} chamber from the certificate breaks the piece parity at exactly {1} pieces, its holders, match {2}"
+     .format(nd(1), nd(len(PBAD)), "yes" if PMATCH else "no"))
+
+gate(BADFOUR == 96 and BADFOUR == PCEN[3], "K12",
+     "control two: replacing the {0} of the local law by {1} breaks the rule at exactly {2} pairs, the q class, of the {3}"
+     .format(nd(6), nd(4), nd(BADFOUR), nd(NPAIR)))
+
+gate(BADNM == 0 and NPER == [2] and len(NAMES) == 384, "K13",
+     "naming invariance: the second of the {0} namings, {1} per piece, by complement and reversal, gives the same {2} odd values,"
+     " failures {3}"
+     .format(nd(len(NAMES)), nd(NPER[0]), nd(NPI), nd(BADNM)))
+
+gate(BADCOUP == 0, "K14",
+     "coupling: the sum of q_w over the four odd labels equals the odd-diagonal half-set count of the cutting, failures {0} of {1}"
+     .format(nd(BADCOUP), nd(NS)))
+
+emit("census: odd-diagonal half-set count over the {0} cuttings {1}, sum {0}".format(nd(NS), HCENS))
+emit("census: A2 over the {0} cuttings {1}, sum {0}".format(nd(NS), ACENS))
+emit("TOTAL: PASS={0} FAIL={1}".format(nd(STAT[0]), nd(STAT[1])))
+
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+PEAK = RSS // (1024 * 1024) if sys.platform == "darwin" else RSS // 1024
+SECS = int(time.time() - T0)
+emit("resource: under {0} s of the {1} s budget, under {2} MB of the {3} MB budget, {4} characters"
+     .format(nd(((SECS // 60) + 1) * 60), nd(900), nd(((PEAK // 250) + 1) * 250), nd(2500), nd(OUT[0])))


### PR DESCRIPTION
## What this lands

Cycle 782 in the physical-cell cutting lane. Each of the 192 used pieces carries a diagonal label (the start corner of its minimal naming, one of eight values). On the declared family of 15,800 continuously certified unit-four-cube cuttings, the note proves that every odd-diagonal count is divisible by four.

## Exact finite chain

- A shifted rational grid exhaustively enumerates candidate covers; independent determinant formulas, normalized volumes, and 15,168 pairwise integer-separating-hyperplane checks certify that every emitted candidate is a continuous exact cutting rather than only a sample-grid cover.
- Eight sign classes of chambers, one per label, each hold 24 of the 192 chambers.
- The exact local law has values 1, 4, 4, 6, 0; chamber-partition telescoping gives `n_w = 24 - 4a_w - 4c_w - 6q_w`.
- A transported label preserves weight parity and identifies the six-valued class with the selected half set.
- A 20-chamber certificate makes the odd-diagonal selected-half-set count even, closing the mod-four result.

## Runner and review evidence

The standard-library runner uses exact integer/rational arithmetic and declares a 120-second audit timeout. Its landed cache records 15 PASS / 0 FAIL, 2,271 stdout bytes, and the exact final line `TOTAL: PASS=15 FAIL=0`.

Independent review recomputed all determinants with a separate 24-term formula, matched the 15,800-cover set with an alternate exact-cover algorithm, independently checked every co-occurring simplex pair, and reproduced both censuses by direct unpacked counting.

Mutation checks recorded during review:

- determinant-sign corruption -> K1G FAIL;
- strict-for-weak separation corruption -> K1G FAIL;
- chamber-incidence deletion -> K1/K3/K12 FAIL;
- telescoping coefficient `6 -> 4` -> K4 FAIL;
- transported-label bit-flip deletion -> K5/K6 FAIL;
- complement-name reversal deletion -> K13 FAIL;
- theorem modulus `4 -> 8` -> K10 FAIL;
- odd-label-set corruption -> K10/K14 FAIL;
- census-target corruption -> K9 FAIL;
- landed certificate and local-law controls -> K11/K12 discriminate as stated.

## Boundary

The result is an unaudited `bounded_theorem` candidate only. The grid is an enumeration device, the coordinate/naming choice is explicit, the census multiplicities and sibling-cycle names are support-only, and there are no physical, observational, fitted, literature, PDG/cosmological, framework-derived, or other imported values. No result outside the declared finite cutting family is claimed. Independent audit remains required for claim ID `physical_cell_cutting_diagonal_parity_cycle782_note_2026-08-14`.
