### PR TITLE
feat(cycle786): facet alphabet, heavy parity law, and the forty period-one cuttings

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_FACET_ALPHABET_HEAVY_PARITY_CYCLE786_NOTE_2026-08-14.md
+++ b/docs/PHYSICAL_CELL_CUTTING_FACET_ALPHABET_HEAVY_PARITY_CYCLE786_NOTE_2026-08-14.md
@@ -1,0 +1,288 @@
+# Physical cell cutting: the facet alphabet, heavy parity, and the forty period-one cuttings
+
+Date: 2026-08-14
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: test whether the boundary alphabet and the parity charge it carries have a canonical downstream consumer; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: exact finite alphabet, census, GF(2) rank and orbit results for the declared unit four-cube object; no physical or lattice-wide identification`
+- `audit_required_before_effective_retained: true`
+- `bare_retained_allowed: false`
+
+## Inputs and scope
+
+The declared finite object consists of the 16 corners of the unit four-cube, the
+five-corner determinant-one pieces built on them, the pieces surviving at the adjacency-cost
+floor, the cuttings assembled from those pieces, the pieces that actually occur in a cutting,
+and the 384 signed coordinate maps of the cell. These are finite-scope object choices, not
+imported physical primitives. Every integer below is derived by the linked runner from that
+object alone.
+
+There are no load-bearing literature, empirical, fitted, external-data, or repository-derived
+scientific inputs. The runner uses the standard library only, performs no file input or
+output, draws no random numbers, and carries out every load-bearing check in integer or exact
+rational arithmetic. It rebuilds the whole object from the corner list before any gate runs.
+
+The exact target of this cycle is the interface, that is the boundary reading of the object:
+the alphabet of facet dissections the cuttings induce, the laws that alphabet obeys, and the
+parity charge it carries. The proof obligations are:
+
+1. certify the facet-face lemma — every used piece cuts exactly two facet faces, and they lie
+   on distinct axes;
+2. certify the alphabet — exactly 16 facet dissections, the same 16 on every slot;
+3. exhibit the intrinsic heavy and light split of the letters by diagonal profile;
+4. derive the two-valued slot multiplicity law from the boundary group action;
+5. derive the symmetry of the interface matrix from the coordinate reflection, and record its
+   entry, trace, gluing and row-sum censuses;
+6. record the self-match censuses over all four axes;
+7. derive the even-heavy parity law and locate its charge in the blind space recorded in
+   `PHYSICAL_CELL_CUTTING_SHADOW_RANK_UNSEEN_SWAP_CYCLE754_NOTE_2026-08-09`;
+8. gate the impossibility of a strictly per-piece certificate for that law; and
+9. identify the period-one cuttings, their orbits and their letter profiles.
+
+Each obligation is discharged below and by a named hard gate in the runner. This note makes
+no claim about arbitrary cell-cutting systems, physical dynamics, or a lattice-wide
+construction.
+
+## The exact finite object
+
+Gate K1. The cell has 2672 five-corner subsets of unit determinant, 400 of them at the
+adjacency-cost floor 6, and those 400 assemble into exactly 15800 cuttings of 24 pieces each.
+Exactly 192 of the 400 occur in some cutting; the remaining kept pieces occur in none. The
+runner derives all six of these anchors from the corner list, using the same candidate
+enumeration, floor selection and exact-cover order as the earlier cycles of this lane. The
+enumeration of cuttings is the declared object of the lane and is inherited as such; this note
+adds no new tiling certificate and rests none of its results on one.
+
+## The facet-face lemma
+
+Gate K2. A facet face of a piece is a set of four of its five corners lying in one boundary
+hyperplane `x_a = c` with `c` in `{0, 1}`; those four corners project, along the axis `a`, to a
+unit tetrahedron of the boundary three-cube.
+
+Two facet faces on the same axis are impossible. They would require four corners in `x_a = 0`
+and four in `x_a = 1`; the two hyperplanes are disjoint, so that is `4 + 4 = 8` distinct
+corners, and a piece has only five. Hence a piece carries at most one facet face per axis, and
+whenever it carries two they sit on distinct axes. That the count is exactly two for every used
+piece is measured, not derived: the runner checks all 192 and finds exactly two faces on each,
+on distinct axes in every case, with all 384 faces lying in the 24-tetrahedron support of the
+alphabet below.
+
+Each used piece therefore has a well-defined unordered slot-pair, the pair of `(axis, side)`
+slots its two faces occupy. The 192 pieces spread over exactly 24 such pairs with exactly 8
+pieces on each, and `24 x 8 = 192`.
+
+## Facet dissections and the alphabet
+
+Gates K3 and K4. Fix a cutting and one of the 8 boundary three-cubes. Of the 24 pieces, exactly
+6 contribute a face there, and their 6 projected tetrahedra are distinct — checked on all
+`15800 x 8 = 126400` facet slots with 0 misses. Each cutting thus dissects each boundary
+three-cube into 6 unit tetrahedra.
+
+Over all 15800 cuttings and all 8 slots exactly 16 distinct dissections occur, and the set of
+dissections occurring is the same 16 on every one of the 8 slots. These 16 are the letters of
+the facet alphabet. Their combined tetrahedron support has exactly 24 members, and the runner
+fixes a canonical order on those 24 and a canonical numbering of the 16 letters; every index
+quoted below refers to those two orders.
+
+## Tetrahedron structure and the intrinsic heavy and light split
+
+Gate K5. Each of the 24 tetrahedra contains exactly one antipodal corner pair of the
+three-cube, that is exactly one main diagonal, and each of the 4 main diagonals lies in exactly
+6 of them. A letter therefore carries a diagonal profile: the multiset of the diagonals of its
+6 tetrahedra.
+
+Exactly 4 letters are single-diagonal — all six of their tetrahedra share one diagonal — and
+the assignment of diagonal to letter is a bijection onto the 4 diagonals, with canonical map
+`{1: 2, 6: 3, 8: 1, 15: 0}`. The other 12 letters split `(3, 3)` over an unordered pair of
+diagonals, exactly 2 letters for each of the 6 pairs. This split is intrinsic to the alphabet:
+it is read off the letters themselves and uses no information about how often they occur.
+
+## The multiplicity law
+
+Gates K6 and K7. On a fixed slot each letter occurs in a definite number of cuttings. The
+census is identical on every one of the 8 slots: 12 letters of multiplicity 862 and 4 of
+multiplicity 1364, with `12*862 + 4*1364 = 15800`. The heavy letters, defined as those of
+multiplicity 1364, are exactly the 4 single-diagonal letters.
+
+Two-valuedness is derived, not merely observed. The maps of the order-384 cell group that
+carry a fixed facet to itself form a subgroup of order 48, and the runner certifies that the
+maps they induce on the boundary three-cube are exactly the 48 signed coordinate maps of that
+cube, with no strays. Such a map sends cuttings to cuttings and sends the letter at that slot
+to its own image, so slot multiplicity is constant along the orbits of the 48 induced maps on
+the 16 letters. The runner certifies that the 16 letters are closed under those maps, with 0
+failures, and that they fall into exactly 2 orbits, of sizes 12 and 4. At most 2 multiplicity
+values can therefore occur on a slot, and the census shows exactly 2. The 4-element orbit is
+the single-diagonal one, because the induced maps permute the 4 diagonals and so preserve the
+property of being single-diagonal; the heavy letters are that orbit.
+
+## The interface matrix and its symmetry
+
+Gate K8. For each axis `a`, let `N_a` be the `16 x 16` integer matrix whose `(k, l)` entry
+counts the cuttings whose letter on side 0 of axis `a` is `k` and whose letter on side 1 is
+`l`.
+
+`N_a` is symmetric on every axis, and this is derived. The reflection `r_a` of the coordinate
+`a` lies in the order-384 group; it carries cuttings to cuttings, exchanges the two facets of
+axis `a`, and leaves the remaining three coordinates alone, so it leaves the projected
+dissections unchanged and merely swaps the two letters of axis `a`. The map `s -> r_a(s)` is
+therefore a bijection of the `(k, l)` cell onto the `(l, k)` cell. The runner certifies the
+key-swap property directly, on all 4 axes and all 15800 cuttings, with 0 misses, and then
+confirms the symmetry entrywise.
+
+The entry-value census of `N_a` is the same for all four axes:
+`{18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}`. On the diagonal a
+light letter carries 100 and a heavy letter 200, so the trace is `12*100 + 4*200 = 2000` on
+every axis. Every heavy row decomposes as `200 + 3*104 + 6*92 + 6*50 = 1364`, recovering that
+letter's multiplicity as its row sum.
+
+Gluing along axis `a` pairs cuttings whose facing letters agree. The number of such pairs is
+`12*862*862 + 4*1364*1364 = 16358512` on every axis. Since the number of partners of a cutting
+is the multiplicity of its own facing letter, the row-sum census over the 15800 cuttings is
+`{862: 10344, 1364: 5456}`, with `12*862 = 10344` and `4*1364 = 5456`.
+
+## Self-match laws
+
+Gate K9. A cutting self-matches on axis `a` when its two letters on that axis agree, that is
+when it contributes to the trace of `N_a`; there are 2000 such cuttings on each axis. Call the
+number of axes on which a cutting self-matches its weight. The weight census over all 15800
+cuttings is `{0: 9504, 1: 4672, 2: 1584, 4: 40}` — weight 3 never occurs. The absence of weight
+3 is a complete measurement over the whole census; no structural derivation of it is claimed
+here.
+
+The refined counts are: singleton weight 1168 for each of the 4 axes, pair weight 264 for each
+of the 6 axis pairs, and `1168 + 3*264 + 40 = 2000` recovers the per-axis trace. Splitting by
+whether the matching letter is heavy (H) or light (L), weight 2 gives `HH 384`, `HL 768`,
+`LL 432`, and weight 1 gives `H 1600`, `L 3072`.
+
+## The even-heavy parity law
+
+Gate K10. The number of heavy letters a cutting shows across its 8 slots has census
+`{0: 1200, 2: 7872, 4: 6240, 6: 480, 8: 8}`: no cutting shows an odd heavy count. The
+derivation runs in three steps and is global, not slot by slot.
+
+First, the letter system. Introduce one unknown `psi(t)` over GF(2) for each of the 24
+tetrahedra and one equation per letter — the sum of `psi` over that letter's 6 tetrahedra
+equals 1 if the letter is heavy and 0 otherwise. Row reduction gives rank 10, consistency, and
+a solution space of dimension 14. The runner exhibits the explicit solution read off the
+reduced form, with pivot columns `[0, 1, 2, 3, 4, 6, 8, 12, 14, 18]` and support
+`[0, 2, 3, 4, 8, 12, 14, 18]` in the canonical tetrahedron order, and verifies all 16 letter
+equations on it.
+
+Second, the face-multiset identity. For every cutting, the multiset of the 48 facet faces of
+its 24 pieces equals the multiset union of the 6 tetrahedra of each of its 8 letters — checked
+on all 15800 cuttings with 0 violations. Modulo 2 the heavy count of a cutting is therefore the
+sum of `psi` over its 8 letters, hence the sum of `psi` over those 48 faces, hence the sum over
+its 24 pieces of `psi(f1) + psi(f2)`. A piece contributes 1 exactly when its two faces disagree
+on `psi`. Writing `O` for the fixed set of such pieces, `|O| = 88`, the heavy count of a cutting
+is congruent modulo 2 to the size of its intersection with `O`.
+
+Third, the blind space. The cutting-indicator matrix over the 192 used pieces, one row per
+cutting, has GF(2) rank 88, so its orthocomplement has dimension 104. The runner collects an
+88-row basis during the reduction and checks that `O` meets each basis row evenly; every
+cutting row is a GF(2) sum of basis rows, so `O` meets every cutting evenly. The gate also
+confirms this directly on all 15800 cuttings, 0 odd. The parity law follows for the entire
+census at once.
+
+The mod-2 rank 88 and orthocomplement dimension 104 agree with the exact rational rank and
+kernel dimension of the same incidence recorded in
+`PHYSICAL_CELL_CUTTING_SHADOW_RANK_UNSEEN_SWAP_CYCLE754_NOTE_2026-08-09`; the runner re-derives
+the mod-2 statement itself and imports nothing from that note. `O` is a weight-88 vector of
+that orthocomplement, the blind space of the earlier cycles, so the parity law reads as a
+boundary charge carried by the blind space.
+
+## No strictly per-piece certificate
+
+Gate K10, sharp negative. Adjoining to the letter system the per-piece equality rows
+`psi(f1) = psi(f2)`, one for each of the 192 used pieces, makes the system inconsistent: the
+rank rises to 23 of a possible 24 and no solution exists. Exactly 2 of those 192 rows are
+trivial, because for 2 pieces the two facet faces project to the same tetrahedron of the
+boundary three-cube; the other 190 are not, and the inconsistency comes from them. So there is
+no assignment
+that both reads the heavy bit correctly on letters and makes every piece individually
+conservative — the parity law is genuinely global at piece level, and the mismatch set `O` is
+not removable by a better choice of `psi`.
+
+In the other direction, appending all 15800 cutting functionals to the letter system leaves
+the rank at 10 and leaves it consistent. The cutting rows lie in the span of the letter rows,
+which, through the face-multiset identity, is another reading of the parity law itself.
+
+## The forty period-one cuttings
+
+Gates K11 and K12. Exactly 40 cuttings have weight 4, that is self-match on all four axes. For
+such a cutting the induced dissections on the two facets of every axis agree, so the dissection
+of the cell boundary is invariant under the unit translation of each axis; consequently all
+integer translates of the cutting meet face to face and each of the 40 tiles four-space
+periodically with 1 cell per period. The runner exhibits 1 witness per orbit and re-checks
+letter equality on both sides of all 4 axes for it.
+
+Under the order-384 cell group the 40 fall into exactly 2 orbits, of sizes 8 and 32, with
+stabiliser orders 48 and 12; the orbit-stabiliser arithmetic `8*48 = 384` and `32*12 = 384`
+checks out on both. The axis-letter profiles are constant on each orbit: the size-8 orbit is
+all-heavy, profile `(H, H, H, H)`, and coincides exactly with the 8 cuttings of heavy count 8
+in the parity census above; the size-32 orbit has profile `(H, L, L, L)`. The most symmetric
+period-one cuttings are thus precisely the extreme cell of the parity census, which is a
+positive identification of two independently defined sets of size 8, not a coincidence of
+counts.
+
+## Boundary and honest reading
+
+Measured, not derived, at the declared finite scope: that every used piece cuts exactly two
+facet faces; the multiplicity values 862 and 1364 themselves; every census value quoted above,
+including the entry, trace, gluing, row-sum, self-match, weight and heavy-count censuses; and
+the absence of weight 3.
+
+Derived at the declared finite scope: the distinct-axes half of the facet-face lemma; the
+symmetry of every interface matrix; the two-valuedness of slot multiplicity, from the induced
+order-48 boundary group and its 2 letter orbits; the even-heavy parity law, together with the
+placement of its charge in the blind space; the impossibility of a strictly per-piece
+certificate for that law; and the period-one tiling property of the 40.
+
+All of the above are computational identities of the declared unit four-cube object and its
+15800 cuttings. No physical, dynamical, or lattice-wide identification is claimed, no continuum
+limit is taken, and nothing here is asserted about cell-cutting systems outside the declared
+object.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.py](../scripts/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.txt](../logs/runner-cache/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget,
+typically finishes in about a minute, and stays well under one gigabyte. Its final line is
+`TOTAL: PASS=25 FAIL=0`, and it exits nonzero if any gate fails.
+
+## Review record and boundary
+
+- The runner prints only censuses, ranks, orbit data and derived identities; the full
+  interface matrix is deliberately not printed, so the note quotes its entry census, trace and
+  heavy-row decomposition instead.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a
+  commit cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries, the appropriate review classification is **bounded support** for the
+declared exact finite object.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13803,6 +13803,10 @@
    "out_degree": 3
   },
   "physical_cell_cutting_crossing_automorphism_cycle777_note_2026-08-11": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_note_2026-08-14": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },

--- a/logs/runner-cache/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.txt
+++ b/logs/runner-cache/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.py
+runner_sha256: 1fec7d760d4265edfd339b1161b749263da44b31bd95636f332921360a7502c3
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 12.17
+status: ok
+----- stdout -----
+PASS K1 the cell has 2672 unit-determinant five-corner pieces, adjacency cost floor 6, 400 kept, 15800 cuttings of 24, 192 used pieces
+PASS K2 all 192 used pieces cut exactly 2 facet faces, on distinct axes, and all 384 faces are among the 24 boundary tetrahedra
+PASS K2 the 192 pieces spread over exactly 24 slot-pairs with 8 pieces each, and 24 times 8 = 192
+PASS K3 every one of the 15800 cuttings cuts 6 pieces and 6 distinct tetrahedra on each of the 8 facets, 126400 slots, 0 misses
+PASS K4 the facet alphabet has exactly 16 dissections and the same 16 letters occur on every one of the 8 slots
+PASS K5 the letters use 24 tetrahedra, each holding exactly 1 antipodal corner pair, with 6 tetrahedra on each of the 4 main diagonals
+PASS K5 4 single-diagonal letters, bijection {1: 2, 6: 3, 8: 1, 15: 0} to the diagonals; other 12 split (3, 3), 2 per diagonal pair
+PASS K6 the 16 letters are closed under the order-48 signed maps of the boundary three-cube, 0 failures, and split into orbits [12, 4]
+PASS K6 the slot holder inside the order-384 cell group has 48 maps inducing all 48 signed maps of the boundary three-cube, 0 strays
+PASS K7 the slot multiplicity census is {862: 12, 1364: 4} on every one of the 8 slots, and 12 times 862 plus 4 times 1364 is 15800
+PASS K7 the heavy keys, defined as the keys of slot multiplicity 1364, are [1, 6, 8, 15] and are exactly the single-diagonal letters
+PASS K8 the reflection of a coordinate sends all 15800 cuttings to cuttings and swaps the two letters of its own axis, 4 axes, 0 misses
+PASS K8 interface matrix symmetric on all 4 axes; entry census {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}
+PASS K8 trace 2000 is 12 times 100 plus 4 times 200; every heavy row is 200 plus 3 times 104 plus 6 times 92 plus 6 times 50, giving 1364
+PASS K8 the gluing relation has 16358512 pairs on every axis, with the row-sum census {862: 10344, 1364: 5456} over cuttings
+PASS K9 self-matching holds for 2000 cuttings on each axis, with weight census {0: 9504, 1: 4672, 2: 1584, 4: 40}, and weight 3 never occurs
+PASS K9 singleton 1168 on each axis and 264 on each of the 6 axis pairs; weight 2 gives HH 384 HL 768 LL 432, weight 1 H 1600 L 3072
+PASS K10 the heavy-slot census over all cuttings is {0: 1200, 2: 7872, 4: 6240, 6: 480, 8: 8}, so no cutting shows an odd number of heavy letters
+PASS K10 letter system rank 10, consistent, solution dim 14, pivots [0, 1, 2, 3, 4, 6, 8, 12, 14, 18], psi support [0, 2, 3, 4, 8, 12, 14, 18]
+PASS K10 psi verifies all 16 letter equations and the face-multiset identity holds on all 15800 cuttings with 0 violations
+PASS K10 the mismatch set has 88 pieces and meets every cutting evenly, 0 odd; the cutting matrix has rank 88 over GF(2), left 104
+PASS K10 letters plus 15800 cutting rows keep rank 10, consistent; the 192 per-piece rows, 2 of them trivial, 190 not, give rank 23 inconsistent
+PASS K11 exactly 40 cuttings match on all 4 axes; two orbits of sizes [8, 32] with holder orders [48, 12], and 8 times 48 is 384
+PASS K11 the size 8 orbit is all-heavy HHHH and equals the 8 cuttings of heavy count 8; the size 32 orbit is HLLL throughout
+PASS K12 one witness per orbit, letters [15, 8, 8, 8] and [14, 10, 8, 0], matching on both sides of all 4 axes; each has period one
+resource: under 60 s, under 250 MB
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.py
+++ b/scripts/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.py
@@ -1,0 +1,640 @@
+"""Physical cell cutting: the facet alphabet, the even-heavy parity law, and the forty period-one cuttings.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, and the order-384 group of signed
+coordinate maps of the cell. Nothing outside that finite object enters any gate.
+
+The work of this cycle is the interface, that is the boundary reading of the object. A used piece meets the boundary in facet faces: four
+of its five corners lying in a hyperplane of the cell and forming a unit tetrahedron of the projected three-cube. A five-corner piece
+cannot place four corners in each of two parallel hyperplanes, so two such faces must sit on distinct axes; the measured count of faces is
+exactly two for every used piece. Every cutting therefore dissects each of the eight boundary three-cubes into six tetrahedra. Only 16 such
+dissections ever occur, the same 16 on every facet, and they are the letters of a finite alphabet. Four letters are single-diagonal, their
+six tetrahedra all sharing one main diagonal of the three-cube, and those four turn out to be exactly the letters of slot multiplicity
+1364; the other twelve split three and three over a pair of diagonals and carry multiplicity 862.
+
+Two structural laws follow. The interface matrix of an axis is symmetric because the reflection of that coordinate lies in the group, maps
+cuttings to cuttings, exchanges the two facets of the axis and leaves the projected dissections alone. And the number of heavy letters a
+cutting shows is always even: there is a bookkeeping bit psi on the 24 boundary tetrahedra whose sum over the six tetrahedra of a letter
+reads that letter's heavy bit, the multiset of the 48 piece faces of a cutting equals the multiset union of its eight letters, so the heavy
+count is the number of pieces whose two faces disagree on psi, and that mismatch set of 88 pieces is orthogonal over GF(2) to an 88-row
+basis of the cutting span. No strictly per-piece certificate exists: adjoining the 192 per-piece equality rows makes the letter system
+inconsistent, so the law is global at piece level.
+
+Finally the cuttings whose letters agree on both sides of all four axes, the forty, extend to a face-to-face tiling of four-space with one
+cell per period; under the order-384 group they form two orbits, of sizes 8 and 32.
+
+Gates K1 to K12, one or more lines each, then a resource line and the total line. Any failure exits nonzero."""
+
+import itertools
+import sys
+import time
+import resource
+from collections import Counter
+from fractions import Fraction as FR
+
+AUDIT_TIMEOUT_SEC = 900
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+UIDX = {t: i for i, t in enumerate(USED)}
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+
+FACE = {}
+for t in USED:
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+SIX = 0
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            fl = [FACE[(t, a, c)] for t in s if (t, a, c) in FACE]
+            if len(fl) == 6 and len(set(fl)) == 6:
+                SIX += 1
+            d[(a, c)] = frozenset(fl)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda f: sorted(sorted(t) for t in f))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+TETS = sorted({t for K in ALLK for t in K}, key=lambda f: sorted(f))
+TN = {t: i for i, t in enumerate(TETS)}
+NT = len(TETS)
+TSET = set(TETS)
+
+PFACE = {}
+for (t, a, c), f in FACE.items():
+    PFACE.setdefault(t, []).append(f)
+
+gate(len(CAND) == 2672 and FLOOR == 6 and len(KEPT) == 400 and NS == 15800 and NU == 192
+     and PSIZE == 1 and CSIZE == 24, "K1",
+     "the cell has 2672 unit-determinant five-corner pieces, adjacency cost floor 6, 400 kept, 15800 cuttings of 24, 192 used pieces")
+
+# ---------------------------------------------------------------- K2 the facet-face lemma
+
+SLOTS = {}
+NFOK = 0
+AXOK = 0
+FIN = 0
+for t in USED:
+    sl = [(a, c) for a in range(4) for c in (0, 1) if (t, a, c) in FACE]
+    if len(sl) == 2:
+        NFOK += 1
+        if sl[0][0] != sl[1][0]:
+            AXOK += 1
+    for k in sl:
+        if FACE[(t, k[0], k[1])] in TSET:
+            FIN += 1
+    SLOTS[t] = frozenset(sl)
+SPC = Counter(SLOTS.values())
+SPCEN = Counter(SPC.values())
+
+gate(NFOK == 192 and AXOK == 192 and FIN == 384 and NT == 24, "K2",
+     "all 192 used pieces cut exactly 2 facet faces, on distinct axes, and all 384 faces are among the 24 boundary tetrahedra")
+gate(len(SPC) == 24 and set(SPCEN) == {8} and SPCEN[8] == 24, "K2",
+     "the 192 pieces spread over exactly 24 slot-pairs with 8 pieces each, and 24 times 8 = 192")
+
+# ---------------------------------------------------------------- K3, K4 the alphabet
+
+SLOTSETS = [set(KEY[i][(a, c)] for i in range(NS)) for a in range(4) for c in (0, 1)]
+SAME = all(x == SLOTSETS[0] for x in SLOTSETS)
+
+gate(SIX == NS * 8 and SIX == 126400, "K3",
+     "every one of the 15800 cuttings cuts 6 pieces and 6 distinct tetrahedra on each of the 8 facets, 126400 slots, 0 misses")
+gate(NL == 16 and SAME and len(SLOTSETS[0]) == 16, "K4",
+     "the facet alphabet has exactly 16 dissections and the same 16 letters occur on every one of the 8 slots")
+
+# ---------------------------------------------------------------- K5 tetra structure and the intrinsic split
+
+DIAGS = [((0, 0, 0), (1, 1, 1)), ((1, 0, 0), (0, 1, 1)), ((0, 1, 0), (1, 0, 1)), ((0, 0, 1), (1, 1, 0))]
+TDIAG = {}
+ONEP = 0
+for t in TETS:
+    ds = [i for i, (p, q) in enumerate(DIAGS) if p in t and q in t]
+    if len(ds) == 1:
+        ONEP += 1
+        TDIAG[t] = ds[0]
+DCEN = Counter(TDIAG.values())
+
+SING = {}
+PAIRC = Counter()
+for i, K in enumerate(ALLK):
+    c = Counter(TDIAG[t] for t in K)
+    if len(c) == 1:
+        SING[i] = next(iter(c))
+    elif sorted(c.values()) == [3, 3]:
+        PAIRC[tuple(sorted(c))] += 1
+SINGOK = (SING == {1: 2, 6: 3, 8: 1, 15: 0}) and sorted(SING.values()) == [0, 1, 2, 3]
+
+gate(NT == 24 and ONEP == 24 and dict(DCEN) == {0: 6, 1: 6, 2: 6, 3: 6}, "K5",
+     "the letters use 24 tetrahedra, each holding exactly 1 antipodal corner pair, with 6 tetrahedra on each of the 4 main diagonals")
+gate(len(SING) == 4 and SINGOK and sum(PAIRC.values()) == 12 and len(PAIRC) == 6
+     and set(PAIRC.values()) == {2}, "K5",
+     "4 single-diagonal letters, bijection {0} to the diagonals; other 12 split (3, 3), 2 per diagonal pair".format(dshow(SING)))
+
+# ---------------------------------------------------------------- K6 the boundary group
+
+P3 = list(itertools.permutations(range(3)))
+G48 = [(p, m) for p in P3 for m in range(8)]
+FC3 = [tuple((i >> b) & 1 for b in range(3)) for i in range(8)]
+
+
+def act3(g, v):
+    p, m = g
+    return tuple(v[p[i]] ^ ((m >> p[i]) & 1) for i in range(3))
+
+
+def actk(g, key):
+    return frozenset(frozenset(act3(g, v) for v in tet) for tet in key)
+
+
+KFAIL = 0
+KORB = []
+SEENK = set()
+for k in ALLK:
+    if KN[k] in SEENK:
+        continue
+    o = set()
+    for g in G48:
+        kk = actk(g, k)
+        if kk not in KN:
+            KFAIL += 1
+            continue
+        o.add(KN[kk])
+    SEENK |= o
+    KORB.append(sorted(o))
+KORBS = [len(o) for o in KORB]
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+FACECORN = [v for v in range(16) if CORN[v][0] == 0]
+HOLD = []
+for g in G384:
+    if all(CORN[actcorner(g, v)][0] == 0 for v in FACECORN):
+        HOLD.append(g)
+INDH = set()
+for g in HOLD:
+    INDH.add(tuple(tuple(CORN[actcorner(g, v)][1:]) for v in FACECORN))
+INDG = set()
+for g in G48:
+    INDG.add(tuple(act3(g, CORN[v][1:]) for v in FACECORN))
+
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+PMAP = {}
+PBAD = 0
+for g in G384:
+    mp = {}
+    ok = True
+    for t in USED:
+        tt = KIDX.get(frozenset(actcorner(g, v) for v in KEPT[t]))
+        if tt is None:
+            ok = False
+            break
+        mp[t] = tt
+    if ok:
+        PMAP[g] = mp
+    else:
+        PBAD += 1
+
+gate(KFAIL == 0 and sorted(KORBS, reverse=True) == [12, 4] and len(KORB) == 2, "K6",
+     "the 16 letters are closed under the order-48 signed maps of the boundary three-cube, 0 failures, and split into orbits [12, 4]")
+gate(len(HOLD) == 48 and len(INDH) == 48 and INDH == INDG and len(INDG) == 48 and PBAD == 0, "K6",
+     "the slot holder inside the order-384 cell group has 48 maps inducing all 48 signed maps of the boundary three-cube, 0 strays")
+
+# ---------------------------------------------------------------- K7 the multiplicity law
+
+MULT = []
+for a in range(4):
+    for c in (0, 1):
+        MULT.append(Counter(KEY[i][(a, c)] for i in range(NS)))
+MCEN = [dict(sorted(Counter(m.values()).items())) for m in MULT]
+MSAME = all(x == MCEN[0] for x in MCEN)
+MVAL = sorted(MCEN[0])
+HEAVY = set(k for k in MULT[0] if MULT[0][k] == MVAL[-1])
+HSAME = all(set(k for k in m if m[k] == MVAL[-1]) == HEAVY for m in MULT)
+IDOK = (MCEN[0][MVAL[0]] * MVAL[0] + MCEN[0][MVAL[-1]] * MVAL[-1] == NS)
+
+gate(MSAME and MCEN[0] == {862: 12, 1364: 4} and IDOK, "K7",
+     "the slot multiplicity census is {0} on every one of the 8 slots, and 12 times 862 plus 4 times 1364 is 15800".format(
+         dshow(MCEN[0])))
+gate(HSAME and sorted(HEAVY) == [1, 6, 8, 15] and HEAVY == set(SING) and MVAL[-1] == 1364, "K7",
+     "the heavy keys, defined as the keys of slot multiplicity 1364, are {0} and are exactly the single-diagonal letters".format(
+         sorted(HEAVY)))
+
+# ---------------------------------------------------------------- K8 the interface matrix
+
+SWBAD = 0
+for a in range(4):
+    mp = PMAP[(tuple(range(4)), 1 << a)]
+    for i in range(NS):
+        j = SIDX.get(frozenset(mp[t] for t in SOLS[i]))
+        if j is None or KEY[j][(a, 0)] != KEY[i][(a, 1)] or KEY[j][(a, 1)] != KEY[i][(a, 0)]:
+            SWBAD += 1
+
+NMAT = []
+ECEN = []
+SYM = 0
+TRC = []
+for a in range(4):
+    J = Counter((KEY[i][(a, 0)], KEY[i][(a, 1)]) for i in range(NS))
+    M = [[J[(x, y)] for y in range(16)] for x in range(16)]
+    NMAT.append(M)
+    ECEN.append(dict(sorted(Counter(M[x][y] for x in range(16) for y in range(16)).items())))
+    if all(M[x][y] == M[y][x] for x in range(16) for y in range(16)):
+        SYM += 1
+    TRC.append(sum(M[x][x] for x in range(16)))
+
+ESAME = all(e == ECEN[0] for e in ECEN)
+DLIGHT = set(NMAT[a][x][x] for a in range(4) for x in range(16) if x not in HEAVY)
+DHEAVY = set(NMAT[a][x][x] for a in range(4) for x in range(16) if x in HEAVY)
+HROW = [dict(sorted(Counter(NMAT[a][x]).items())) for a in range(4) for x in sorted(HEAVY)]
+HRSAME = all(h == HROW[0] for h in HROW)
+HRSUM = sum(k * HROW[0][k] for k in HROW[0])
+
+GLUE = [sum(MULT[2 * a][k] * MULT[2 * a + 1][k] for k in range(16)) for a in range(4)]
+RSUM = [dict(sorted(Counter(MULT[2 * a][KEY[i][(a, 1)]] for i in range(NS)).items())) for a in range(4)]
+RSAME = all(r == RSUM[0] for r in RSUM)
+
+gate(SWBAD == 0, "K8",
+     "the reflection of a coordinate sends all 15800 cuttings to cuttings and swaps the two letters of its own axis, 4 axes, 0 misses")
+gate(SYM == 4 and ESAME and ECEN[0] == {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}, "K8",
+     "interface matrix symmetric on all 4 axes; entry census {0}".format(dshow(ECEN[0])))
+gate(set(TRC) == {2000} and DLIGHT == {100} and DHEAVY == {200} and 12 * 100 + 4 * 200 == 2000
+     and HRSAME and HROW[0] == {50: 6, 92: 6, 104: 3, 200: 1} and HRSUM == 1364, "K8",
+     "trace 2000 is 12 times 100 plus 4 times 200; every heavy row is 200 plus 3 times 104 plus 6 times 92 plus 6 times 50, giving 1364")
+gate(set(GLUE) == {16358512} and 12 * 862 * 862 + 4 * 1364 * 1364 == 16358512 and RSAME
+     and RSUM[0] == {862: 10344, 1364: 5456}, "K8",
+     "the gluing relation has 16358512 pairs on every axis, with the row-sum census {0} over cuttings".format(dshow(RSUM[0])))
+
+# ---------------------------------------------------------------- K9 the self-match laws
+
+MATCH = [tuple(a for a in range(4) if KEY[i][(a, 0)] == KEY[i][(a, 1)]) for i in range(NS)]
+WCEN = dict(sorted(Counter(len(m) for m in MATCH).items()))
+SGL = dict(sorted(Counter(m[0] for m in MATCH if len(m) == 1).items()))
+PRC = dict(sorted(Counter(m for m in MATCH if len(m) == 2).items()))
+PERAX = [sum(1 for m in MATCH if a in m) for a in range(4)]
+W2 = Counter()
+for i in range(NS):
+    if len(MATCH[i]) == 2:
+        W2["".join(sorted("H" if KEY[i][(a, 0)] in HEAVY else "L" for a in MATCH[i]))] += 1
+W1 = Counter()
+for i in range(NS):
+    if len(MATCH[i]) == 1:
+        W1["H" if KEY[i][(MATCH[i][0], 0)] in HEAVY else "L"] += 1
+
+gate(set(PERAX) == {2000} and WCEN == {0: 9504, 1: 4672, 2: 1584, 4: 40} and 3 not in WCEN, "K9",
+     "self-matching holds for 2000 cuttings on each axis, with weight census {0}, and weight 3 never occurs".format(dshow(WCEN)))
+gate(set(SGL.values()) == {1168} and len(SGL) == 4 and set(PRC.values()) == {264} and len(PRC) == 6
+     and dict(W2) == {"HH": 384, "HL": 768, "LL": 432} and dict(W1) == {"H": 1600, "L": 3072}, "K9",
+     "singleton 1168 on each axis and 264 on each of the 6 axis pairs; weight 2 gives HH 384 HL 768 LL 432, weight 1 H 1600 L 3072")
+
+# ---------------------------------------------------------------- K10 the parity law
+
+HCEN = dict(sorted(Counter(sum(1 for a in range(4) for c in (0, 1) if KEY[i][(a, c)] in HEAVY)
+                           for i in range(NS)).items()))
+ODD = sum(HCEN[k] for k in HCEN if k & 1)
+
+LETR = []
+for i, K in enumerate(ALLK):
+    m = 0
+    for t in K:
+        m ^= (1 << TN[t])
+    LETR.append((m, 1 if i in HEAVY else 0))
+
+R = list(LETR)
+PIVC = []
+rr = 0
+for col in range(NT):
+    p = None
+    for j in range(rr, len(R)):
+        if (R[j][0] >> col) & 1:
+            p = j
+            break
+    if p is None:
+        continue
+    R[rr], R[p] = R[p], R[rr]
+    for j in range(len(R)):
+        if j != rr and ((R[j][0] >> col) & 1):
+            R[j] = (R[j][0] ^ R[rr][0], R[j][1] ^ R[rr][1])
+    PIVC.append(col)
+    rr += 1
+LCONS = not any(m == 0 and b == 1 for m, b in R)
+PSI = 0
+for j in range(rr):
+    if R[j][1]:
+        PSI |= (1 << PIVC[j])
+SUPP = [i for i in range(NT) if (PSI >> i) & 1]
+LOK = sum(1 for i, K in enumerate(ALLK)
+          if (sum((PSI >> TN[t]) & 1 for t in K) & 1) == (1 if i in HEAVY else 0))
+
+OM = 0
+for t, fs in PFACE.items():
+    if ((PSI >> TN[fs[0]]) & 1) != ((PSI >> TN[fs[1]]) & 1):
+        OM |= (1 << UIDX[t])
+OSZ = bin(OM).count("1")
+
+FMBAD = 0
+for i, s in enumerate(SOLS):
+    faces = Counter()
+    for t in s:
+        f1, f2 = PFACE[t]
+        faces[f1] += 1
+        faces[f2] += 1
+    lets = Counter()
+    for a in range(4):
+        for c in (0, 1):
+            for tet in ALLK[KEY[i][(a, c)]]:
+                lets[tet] += 1
+    if faces != lets:
+        FMBAD += 1
+
+CUTM = []
+for s in SOLS:
+    m = 0
+    for t in s:
+        m |= (1 << UIDX[t])
+    CUTM.append(m)
+ODIR = sum(1 for cm in CUTM if bin(cm & OM).count("1") & 1)
+PIVU = {}
+BROWS = []
+for idx, cm in enumerate(CUTM):
+    m = cm
+    while m:
+        h = m.bit_length() - 1
+        if h in PIVU:
+            m ^= PIVU[h]
+        else:
+            PIVU[h] = m
+            BROWS.append(idx)
+            break
+BOK = all(bin(CUTM[i] & OM).count("1") & 1 == 0 for i in BROWS)
+
+
+def elim(rows):
+    piv = {}
+    incons = False
+    for m, b in rows:
+        while m:
+            h = m.bit_length() - 1
+            if h in piv:
+                pm, pb = piv[h]
+                m ^= pm
+                b ^= pb
+            else:
+                piv[h] = (m, b)
+                break
+        if m == 0 and b == 1:
+            incons = True
+    return len(piv), incons
+
+
+CUTR = []
+for s in SOLS:
+    m = 0
+    for t in s:
+        f1, f2 = PFACE[t]
+        m ^= (1 << TN[f1]) ^ (1 << TN[f2])
+    CUTR.append((m, 0))
+PROWS = [((1 << TN[fs[0]]) ^ (1 << TN[fs[1]]), 0) for fs in PFACE.values()]
+PTRIV = sum(1 for m, b in PROWS if m == 0)
+RA, IA = elim(LETR)
+RB, IB = elim(LETR + CUTR)
+RC, IC = elim(LETR + CUTR + PROWS)
+
+gate(HCEN == {0: 1200, 2: 7872, 4: 6240, 6: 480, 8: 8} and ODD == 0, "K10",
+     "the heavy-slot census over all cuttings is {0}, so no cutting shows an odd number of heavy letters".format(dshow(HCEN)))
+gate(rr == 10 and LCONS and NT - rr == 14 and PIVC == [0, 1, 2, 3, 4, 6, 8, 12, 14, 18]
+     and SUPP == [0, 2, 3, 4, 8, 12, 14, 18], "K10",
+     "letter system rank 10, consistent, solution dim 14, pivots {0}, psi support {1}".format(PIVC, SUPP))
+gate(LOK == 16 and FMBAD == 0, "K10",
+     "psi verifies all 16 letter equations and the face-multiset identity holds on all 15800 cuttings with 0 violations")
+gate(OSZ == 88 and ODIR == 0 and len(PIVU) == 88 and NU - len(PIVU) == 104 and BOK and len(BROWS) == 88, "K10",
+     "the mismatch set has 88 pieces and meets every cutting evenly, 0 odd; the cutting matrix has rank 88 over GF(2), left 104")
+gate(RA == 10 and not IA and RB == 10 and not IB and RC == 23 and IC and len(PROWS) == NU
+     and PTRIV == 2 and len(PROWS) - PTRIV == 190, "K10",
+     "letters plus 15800 cutting rows keep rank 10, consistent; the 192 per-piece rows, 2 of them trivial, 190 not, give rank 23 inconsistent")
+
+# ---------------------------------------------------------------- K11, K12 the forty
+
+ALL40 = [i for i in range(NS) if len(MATCH[i]) == 4]
+ORB = []
+SEEN40 = set()
+for i in ALL40:
+    if i in SEEN40:
+        continue
+    o = set()
+    st = 0
+    for g in G384:
+        j = SIDX[frozenset(PMAP[g][t] for t in SOLS[i])]
+        o.add(j)
+        if j == i:
+            st += 1
+    SEEN40 |= o
+    ORB.append((sorted(o), st))
+OSIZE = sorted(len(o) for o, st in ORB)
+OSTAB = sorted(st for o, st in ORB)
+IN40 = all(set(o) <= set(ALL40) for o, st in ORB)
+PROF = {}
+for o, st in ORB:
+    pr = set()
+    for i in o:
+        pr.add("".join(sorted("H" if KEY[i][(a, 0)] in HEAVY else "L" for a in range(4))))
+    PROF[len(o)] = sorted(pr)
+H8 = set(i for i in range(NS) if sum(1 for a in range(4) for c in (0, 1) if KEY[i][(a, c)] in HEAVY) == 8)
+EQ8 = any(set(o) == H8 and len(o) == 8 for o, st in ORB)
+
+gate(len(ALL40) == 40 and IN40 and OSIZE == [8, 32] and OSTAB == [12, 48]
+     and 8 * 48 == 384 and 32 * 12 == 384, "K11",
+     "exactly 40 cuttings match on all 4 axes; two orbits of sizes [8, 32] with holder orders [48, 12], and 8 times 48 is 384")
+gate(PROF.get(8) == ["HHHH"] and PROF.get(32) == ["HLLL"] and EQ8 and len(H8) == 8, "K11",
+     "the size 8 orbit is all-heavy HHHH and equals the 8 cuttings of heavy count 8; the size 32 orbit is HLLL throughout")
+
+WIT = []
+WOK = 0
+for o, st in sorted(ORB, key=lambda z: len(z[0])):
+    i = o[0]
+    ls = [KEY[i][(a, 0)] for a in range(4)]
+    if all(KEY[i][(a, 0)] == KEY[i][(a, 1)] for a in range(4)):
+        WOK += 1
+    WIT.append(ls)
+
+gate(WOK == 2 and len(WIT) == 2, "K12",
+     "one witness per orbit, letters {0} and {1}, matching on both sides of all 4 axes; each has period one".format(WIT[0], WIT[1]))
+
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+PEAK = RSS // (1024 * 1024) if sys.platform == "darwin" else RSS // 1024
+emit("resource: under {0} s, under {1} MB".format(((int(time.time() - T0) // 60) + 1) * 60, ((PEAK // 250) + 1) * 250))
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

Source-only triple for cycle 786 of the lane, plus a separate `audit-infra:` commit acknowledging the new note in the citation-graph manifest (the sole sanctioned `docs/audit/data` change):

- `docs/PHYSICAL_CELL_CUTTING_FACET_ALPHABET_HEAVY_PARITY_CYCLE786_NOTE_2026-08-14.md`
- `scripts/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.py`
- `logs/runner-cache/physical_cell_cutting_facet_alphabet_heavy_parity_cycle786_2026_08_14.txt`

## The science

Working on the unit four-cube cell: 2672 candidate five-corner pieces of unit determinant, 400 kept at the adjacency-cost floor 6, 15800 exact covers by 24 pieces, 192 used pieces, order-384 cell symmetry group. All checks in exact integer/rational arithmetic on geometry rebuilt from the corner list.

- **Facet-face lemma.** Every used piece has exactly two boundary facet faces, and they lie on distinct axes in every case (distinctness is derived from a corner count; the exactly-two count is measured). The 24 slot-pairs carry 8 pieces each: 24 x 8 = 192.
- **The facet alphabet.** Each facet of each cutting induces a dissection of its boundary three-cube into 6 distinct tetrahedra. Across all 15800 cuttings and 8 facet slots (126400 checks), exactly **16 letters** occur — the same sixteen on every slot.
- **An intrinsic split, identified twice.** Exactly 4 letters contain a main-diagonal edge (one each, in bijection with the 4 main diagonals); the other 12 letters carry two diagonal-free classes. Independently, the multiplicity census on every slot is two-valued: 12 letters at 862, 4 at 1364 (12·862 + 4·1364 = 15800). The runner derives the heavy set from the census and finds it **equal** to the single-diagonal set — two independent definitions, one set.
- **Two-valuedness is derived, not observed.** The subgroup of the cell group holding a facet has order 48 and induces all 48 signed maps of the boundary cube; the letter orbits under it are of sizes 12 and 4, so at most two multiplicity values can occur.
- **The interface matrix.** Gluing along an axis pairs cuttings whose facing letters agree: 12·862² + 4·1364² = 16358512 pairs per axis. The letter-pair matrix is symmetric — forced by the coordinate reflection, verified with 0 misses on 4 x 15800 cuttings — with trace 2000 = 12·100 + 4·200 and heavy row sum 1364 = 200 + 3·104 + 6·92 + 6·50.
- **The even-heavy parity law, derived.** Every cutting shows an **even** number of heavy letters on its 8 facet slots. The chain: an explicit bookkeeping bit on the 24 boundary tetrahedra solves all sixteen letter equations; the face-multiset identity (verified on all 15800 cuttings) converts a cutting's heavy parity into the parity of its intersection with one fixed 88-piece set; and that set is orthogonal to the entire cutting span — checked directly on all 15800 cuttings and again on an 88-row basis. The cutting matrix has binary rank 88 with orthocomplement dimension 104, matching the exact rational rank recorded at cycle 754; the runner re-derives this itself and imports nothing.
- **A sharp negative.** No strictly per-piece certificate exists: the per-piece equal-contribution system is inconsistent (rank 23; 2 trivial rows among the 192 disclosed), so the parity law is genuinely global — it lives on the cutting span, not on individual pieces.
- **The forty period-one cuttings.** Exactly 40 cuttings self-match on all four axes, and each of them tiles four-space with one cell per period. Under the order-384 group they form two orbits, sizes 8 and 32 (stabiliser orders 48 and 12). The size-8 orbit is **exactly** the set of cuttings whose facet slots are all heavy — a positive identification of two independently defined sets, not a coincidence of counts.

Honest boundary: the exactly-two facet-face count, the specific census values, and the absence of self-match weight 3 are complete measurements at the declared finite scope; no structural derivation of them is claimed.

## Verification

- Runner: stdlib only, exact arithmetic, no file I/O; my own independent re-run exits 0 with `TOTAL: PASS=25 FAIL=0` and byte-identical output to the cache.
- Independent execution per written spec with executor self-check, followed by my own adversarial review: line-by-line read of note and runner, a fabrication hunt (heavy set derived from the census, bookkeeping bit solved by actual row reduction, all censuses computed from rebuilt geometry, every gate discriminating), and a mechanical banned-language/number-discipline sweep with 0 flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
