### PR TITLE
feat(cell-cutting): interface transfer spectrum, exact factorization, evenness law (cycle 787)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_INTERFACE_TRANSFER_SPECTRUM_CYCLE787_NOTE_2026-08-14.md
+++ b/docs/PHYSICAL_CELL_CUTTING_INTERFACE_TRANSFER_SPECTRUM_CYCLE787_NOTE_2026-08-14.md
@@ -1,0 +1,245 @@
+# Physical cell cutting: the interface transfer operator, its exact spectrum, and strip growth
+
+Date: 2026-08-14
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: test whether the growth eigenvalue and the positive eigenvector class weights have a canonical downstream consumer; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: exact spectrum, integer invariants, strip counts and evenness certificates for the interface transfer operator of the declared unit four-cube object; no physical or lattice-wide identification`
+- `audit_required_before_effective_retained: true`
+- `bare_retained_allowed: false`
+
+## Scope and objects
+
+The declared finite object consists of the 16 corners of the unit four-cube, the 2672
+five-corner pieces of determinant one built on them, the 400 pieces surviving at the adjacency
+cost floor 6, the 15800 cuttings assembled from 24 such pieces each, the 192 pieces that occur
+in some cutting, and the 384 signed coordinate maps of the cell. These are finite-scope object
+choices, not imported physical primitives. There are no load-bearing literature, empirical,
+fitted, external-data, or repository-derived scientific inputs. The linked runner uses the
+standard library only, performs no file input or output, draws no random numbers, and carries
+out every load-bearing check in integer or exact rational arithmetic; it rebuilds the whole
+object from the corner list before any gate runs, so every integer below is recomputed here
+rather than carried in.
+
+Each cutting dissects every one of the 8 boundary three-cubes into 6 tetrahedra, and only 16
+such dissections ever occur. They are the letters of the facet alphabet, and the letter set is
+literally the same 16 on all 8 slots. A letter is either light, occurring on a given slot in
+862 cuttings, or heavy, occurring in 1364; 12 letters are light and 4 are heavy, and
+12 x 862 + 4 x 1364 = 15800. The alphabet, its multiplicities and the parity law it carries
+are the subject of the sibling note
+`PHYSICAL_CELL_CUTTING_FACET_ALPHABET_HEAVY_PARITY_CYCLE786_NOTE_2026-08-14`; every fact of
+that kind used below is recomputed by this cycle's own runner from the object, not cited.
+
+## The transfer operator
+
+Fix an axis a. Every cutting shows one letter on side 0 of that axis and one letter on side 1,
+so the cuttings distribute over ordered letter pairs. The interface transfer operator of the
+axis is the 16 by 16 integer matrix whose entry in row k and column j is the number of cuttings
+whose letter on side 0 is k and whose letter on side 1 is j.
+
+The four axes give the same matrix entry for entry, on all 256 entries with 0 misses. This is
+an equality, not a conjugacy: the cell group permutes the axes and therefore conjugates one
+axis matrix into another by a letter relabelling, which by itself would only force the four
+matrices to be similar. That the relabelling can be taken to be the identity on the alphabet is
+a certified computation of this object. One matrix, written T below, therefore carries the
+whole interface.
+
+T is symmetric, T[k][j] = T[j][k], on all 256 entries. Its row sums are exactly the letter
+multiplicities, so the row-sum census is 12 rows of 862 and 4 rows of 1364. Its entry census is
+{18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}; the least entry is
+18, so T is strictly positive, meaning every ordered letter pair is actually realised by some
+cutting. Its trace is 2000, that is 2 x 1000, and each of the 16 diagonal entries is even on
+its own.
+
+## Commutation and the pair orbits
+
+The maps of the cell that hold the chosen axis are the 96 signed coordinate maps whose
+coordinate permutation fixes that axis. Such a map sends the pair of bounding hyperplanes of
+the axis to itself, and it acts on the remaining three coordinates by one signed map of the
+three-cube. That single three-cube map is applied to both boundary cubes at once: the axis sign
+bit decides only whether the two sides keep their names or trade them, and it never enters the
+transverse action. So each holding map carries one letter map of the alphabet, the same on both
+sides. The runner checks this mechanism directly on 15800 cuttings x 48 maps x 2 sides with 0
+misses.
+
+The 48 letter maps obtained from the side-preserving half are distinct, contain the identity,
+are closed under composition, and each permutes the 16 letters, so they form a group of order
+48 acting on the alphabet. Because the letters follow the cuttings, T is invariant under this
+group acting on rows and columns simultaneously: 0 misses. Equivalently, T lies in the algebra
+of matrices commuting with all the letter maps, and that algebra has dimension twelve, because
+the group has exactly 12 orbits on ordered letter pairs. The orbits have sizes
+[4,12,12,12,12,12,24,24,24,24,48,48] and carry the constant entries
+[200,18,18,90,100,104,50,50,92,92,36,52]. Only 9 distinct values appear on the 12 orbits: the
+values 18, 50 and 92 each occur on two different orbits, so equal entries do not always mean
+equivalent pairs, and orbit membership is finer than the entry census.
+
+## The exact spectrum
+
+The characteristic polynomial of T factors exactly over the integers as
+
+`(t - 50)^2 (t - 42)^2 (t - 10)^3 (t + 54) (t^2 - 1090 t + 53968) (t^2 - 250 t + 7728)^3`
+
+with degrees 2 + 2 + 3 + 1 + 2 + 6 = 16. Three independent computations certify it. First, the
+factored form is compared against the determinant of t I - T at all 17 points t = 0 to 16;
+since both sides are of degree 16, agreement at 17 points is an identity, not a sample. Second,
+the eigenspace dimensions are computed as exact kernel dimensions: 2 at 50, 2 at 42, 3 at 10, 1
+at -54, and 2 and 6 at the two quadratic factors, summing to 16. Because the multiplicities are
+attained by the kernels, T is diagonalisable and its minimal polynomial is the product of the 6
+distinct factors, of degree 8; the runner confirms that this product annihilates T and that
+each of the 6 single-factor drops leaves a nonzero matrix, so the test is fully discriminating
+and no smaller product would do.
+
+Third, both quadratics are irreducible with square-free discriminant:
+1090^2 - 4 x 53968 = 972228 = 4 x 243057 with 243057 = 3 x 81019, 81019 prime and not divisible
+by 3; and 250^2 - 4 x 7728 = 31588 = 4 x 7897 with 7897 = 53 x 149. So the eigenvalues outside
+the integers live in the two real quadratic fields adjoining the square roots of 243057 and
+7897, and nothing is approximated anywhere.
+
+## The class block and the growth eigenvalue
+
+Split the alphabet by weight into the 12 light letters and the 4 heavy ones. The number of
+cuttings joining a letter to a whole class does not depend on which letter of a class one
+starts from: a light row sends 578 to the light class and 284 to the heavy class, and a heavy
+row sends 852 to the light class and 512 to the heavy class, with 578 + 284 = 862 and
+852 + 512 = 1364. The class split is therefore an equitable partition, and its two-by-two block
+has trace 1090 and determinant 53968, which is exactly the quadratic factor
+t^2 - 1090 t + 53968 of the characteristic polynomial.
+
+Write w for the positive square root of 243057. The block eigenvalue is 545 + w, and the vector
+with light component 284 and heavy component w - 33 is an exact eigenvector of the block over
+the ring adjoining w: both sides of the eigenvalue equation agree entry for entry, with no
+rounding. The vector is strictly positive because 1089 < 243057. Bracketing w between
+consecutive integers, 493^2 = 243049 < 243057 < 244036 = 494^2, so 1038 < 545 + w < 1039. Every
+other eigenvalue is smaller in size than 214: the integer ones are 50, 42, 10 and -54, the
+companion root 545 - w is below 52, and the other quadratic contributes 125 plus or minus a
+number below 89, since 88^2 = 7744 < 7897 < 7921 = 89^2. The gap between 214 and 1038 is
+therefore certified by integer comparisons alone, and the growth eigenvalue is simple and
+dominant.
+
+The positive eigenvector weights heavy letters more heavily than their share of the cuttings
+would suggest. The weight ratio is (w - 33) to 284, while the multiplicity ratio is 1364 to
+862; the first exceeds the second exactly when 862 x w exceeds 284 x 1364 + 33 x 862 = 415822,
+which after squaring is the integer inequality 862^2 x 243057 = 180602045508 > 172907935684 =
+415822^2. So a heavy letter carries strictly more growth weight per letter than its raw
+frequency, and the certificate is an exact integer comparison.
+
+## Closed strips
+
+Stack cells along the chosen axis and require the letters to match across each interface. A
+closed strip of n cells is a cyclic sequence of n cuttings in which the side-1 letter of each
+matches the side-0 letter of the next, cyclically, so the number of closed strips of n cells is
+the trace of the n-th power of T. For n = 1 the condition is that a single cutting shows the
+same letter on both sides of the axis; the runner counts those cuttings directly and finds the
+trace value 2000, which is why the trace has a counting meaning and not merely a spectral one.
+
+The counts for n = 1 to 6 are 2000, 1233040, 1148284352, 1167237515200, 1206389522378240 and
+1251135002657559808. As a cross-check on the factored characteristic polynomial, the same six
+numbers are regenerated from the power-sum recurrence driven by the expanded coefficients, with
+0 misses; the two routes share no arithmetic. Since the growth eigenvalue is simple and
+dominant, the counts multiply by a factor between 1038 and 1039 for each further cell, and the
+class weights above say how that growth is shared between light and heavy letters.
+
+## Integer invariants
+
+The invariant factors of T over the integers are eleven copies of 2, then 210, 420, 19320,
+96600 and 17594917200, each dividing the next. Their product is
+5931574826283246551040000000, which equals the absolute value of the determinant, and the
+determinant itself is negative, as it must be, since -54 is the only negative eigenvalue and it
+is simple. The same absolute value is the spectral product 50^2 x 42^2 x 10^3 x 54 x 53968 x
+7728^3, so the invariant-factor route and the spectral route agree. Every invariant factor is
+even, and the largest is 17594917200 = 2^4 x 3^4 x 5^2 x 7 x 23 x 3373.
+
+## Evenness
+
+Every one of the 256 entries of T is even. Most of that statement is derived, and the runner is
+explicit about which part is not.
+
+Group the cuttings into the 256 fibers of the ordered letter pair they show on the axis, so the
+fiber over a pair has exactly the size given by the corresponding entry. A holding map keeps a
+fiber to itself precisely when its letter map fixes both letters of the pair, if the map
+preserves the two sides, or exchanges them, if the map trades the sides; the runner cross-checks
+this criterion against the direct test on every fiber and every one of the 96 maps with 0
+mismatches. If some map keeping a fiber acts on it with no fixed point and with every orbit of
+size 2, that map pairs the fiber with itself and the entry is even. Counting such free-pairing
+witnesses per fiber gives the census {0: 48, 1: 156, 2: 48, 4: 4}, so 208 of the 256 fibers
+have at least one witness and their entries are even by an explicit pairing.
+
+The cleanest special case is the axis reversal that flips the chosen coordinate and leaves the
+other three alone. Its letter map is the identity, it trades the two sides, and it fixes 0 of
+the 15800 cuttings, so it pairs every diagonal fiber freely and all 16 diagonal entries are
+even for that single reason.
+
+The remaining 48 fibers are exactly one orbit: the size-48 orbit of pairs whose entry is 36.
+There the negative is sharp. Not only does no map act freely on those fibers, but 0 of the 48
+fibers admit any of the 96 holding maps whose orbits on the fiber are all of even size, which
+is the weakest condition under which a group element could certify evenness at all. Their
+entries are even, but that fact is measured, not derived: the symmetry mechanism provably
+cannot supply a certificate there, and any derivation of it must come from outside the group
+action.
+
+## Boundary and honest reading
+
+Measured, not derived, at the declared finite scope: the entries of T themselves and every
+census quoted above, including the entry census, the row-sum census and the free-pairing
+census; the entrywise equality of the four axis matrices, which is stronger than the conjugacy
+the cell group supplies; the class-block values 578, 284, 852 and 512; the factorisation of the
+characteristic polynomial as a factorisation of this particular matrix; and the evenness of the
+48 entries in the entry-36 orbit.
+
+Derived at the declared finite scope: the mechanism by which a holding map acts by one letter
+map on both boundary cubes; the consequent invariance of T under the group of order 48 and its
+constancy on the 12 pair orbits; diagonalisability and the degree-8 minimal polynomial, from
+the certified kernel dimensions; the identification of the class block with a quadratic factor;
+the exact eigenvector, the bracketing between 1038 and 1039, the domination gap and the heavy
+over-weighting inequality; the reading of traces of powers as closed strip counts; and the
+evenness of the entries on 208 of the 256 fibers.
+
+All of the above are computational identities of the declared unit four-cube object and its
+15800 cuttings. No physical, dynamical, or lattice-wide identification is claimed, no continuum
+limit is taken, no growth statement is transported to any infinite system, and nothing here is
+asserted about cell-cutting systems outside the declared object.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.py](../scripts/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.txt](../logs/runner-cache/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, typically
+finishes in well under a minute, and stays far under one gigabyte. Its final line is
+`TOTAL: PASS=22 FAIL=0`, and it exits nonzero if any gate fails.
+
+## Review record and boundary
+
+- The runner prints censuses, orbit data, spectral certificates and derived identities only;
+  the full interface matrix is deliberately not printed, so the note quotes its entry census,
+  row sums, trace and class block instead.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a
+  commit cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries, the appropriate review classification is **bounded support** for the
+declared exact finite object.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13829,6 +13829,10 @@
   "physical_cell_cutting_hidden_three_bit_geometry_cycle743_note_2026-08-05": {
    "deps_hash": "9126ac46777c",
    "out_degree": 2
+  },
+  "physical_cell_cutting_interface_transfer_spectrum_cycle787_note_2026-08-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_least_computing_sets_cycle737_note_2026-08-05": {
    "deps_hash": "ba0326da985f",

--- a/logs/runner-cache/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.txt
+++ b/logs/runner-cache/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.py
+runner_sha256: 021ed984e906a0ec0607e0a6ac55802e36a87cedce223d033ef5a99cbe562b0d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 14.94
+status: ok
+----- stdout -----
+PASS G1 the cell has 2672 unit-determinant five-corner pieces, cost floor 6, 400 kept, 15800 cuttings of 24, 192 used, group order 384
+PASS G2 the facet alphabet has 16 letters, the same 16 on all 8 slots, with slot multiplicity census {862: 12, 1364: 4}
+PASS G3 axis equality T_0 = T_1 = T_2 = T_3 entry for entry, 4 axes over all 256 entries, 0 misses
+PASS G4 the transfer operator is symmetric, T[k][j] = T[j][k] on all 256 entries, 0 misses
+PASS G5 every row sum is that letter's multiplicity, census {862: 12, 1364: 4}, and 12 x 862 + 4 x 1364 = 15800
+PASS G6 entry census {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}, least entry 18, strictly positive
+PASS G7 trace 2000 with all 16 diagonal entries even, so the trace is 2 x 1000
+PASS G8 the 48 letter maps of the facet holder form a group; letters follow the cuttings on 15800 cuttings x 48 maps x 2 sides, 0 misses
+PASS G9 commutation 0 misses; 12 pair orbits, sizes [4,12,12,12,12,12,24,24,24,24,48,48], entries [200,18,18,90,100,104,50,50,92,92,36,52]
+PASS G10 class block: light rows (578, 284), heavy rows (852, 512); block trace 1090, block determinant 53968
+PASS G11 the factored characteristic polynomial matches det(t I - T) at all 17 points t = 0 to 16, an identity in degree 16
+PASS G12 kernel dimensions 2, 2, 3, 1 at 50, 42, 10, -54 and 2, 6 at the two quadratics, summing to 16
+PASS G13 the minimal polynomial has degree 8 and annihilates T, and each of the 6 single-factor drops leaves a nonzero matrix
+PASS G14 1090^2 - 4 x 53968 = 972228 = 4 x 243057 = 4 x 3 x 81019, 81019 prime; 250^2 - 4 x 7728 = 31588 = 4 x 7897 = 4 x 53 x 149
+PASS G15 the vector (284, w - 33) with w x w = 243057 is exact for the class block at eigenvalue 545 + w; positive since 1089 < 243057
+PASS G16 493^2 = 243049 < 243057 < 244036 = 494^2 and 88^2 = 7744 < 7897 < 7921 = 89^2, so 125 + sqrt 7897 < 214 < 1038 < 545 + w < 1039
+PASS G17 heavy over-weighting 862^2 x 243057 = 180602045508 > 172907935684 = 415822^2 with 415822 = 284 x 1364 + 33 x 862
+PASS G18 closed strip counts for n = 1 to 6: 2000, 1233040, 1148284352, 1167237515200, 1206389522378240, 1251135002657559808
+PASS G19 the power-sum recurrence from the expanded characteristic polynomial reproduces all 6 strip counts, 0 misses
+PASS G20 invariant factors: eleven 2s, 210, 420, 19320, 96600, 17594917200 = 2^4 x 3^4 x 5^2 x 7 x 23 x 3373; det -5931574826283246551040000000
+PASS G21 all 256 entries even; the axis-zero flip fixes 0 cuttings, swaps sides; free pairings {0: 48, 1: 156, 2: 48, 4: 4} on 208 fibers
+PASS G22 the 48 fibers with no free pairing are exactly the entry-36 orbit, and 0 of them admit any of the 96 holding maps with even orbits
+resource: under 60 s, under 250 MB
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.py
+++ b/scripts/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.py
@@ -1,0 +1,698 @@
+"""Physical cell cutting: the interface transfer operator, its exact spectrum, and strip growth.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, and the order-384 group of signed
+coordinate maps of the cell. Nothing outside that finite object enters any gate.
+
+The work of this cycle is the interface transfer operator of one axis. Every cutting dissects each of the eight boundary three-cubes into
+six tetrahedra, and only 16 such dissections ever occur; they are the letters of the facet alphabet. For an axis a the 16 by 16 integer
+matrix T_a counts, in entry (k, j), the cuttings whose letter on side 0 of a is k and whose letter on side 1 is j. The four axes give the
+same matrix entry for entry, so one matrix T carries the whole interface.
+
+The gates certify: the matrix and its censuses; the mechanism by which the maps holding a facet act by one letter map on both boundary
+cubes, hence the twelve-dimensional commuting algebra and the twelve orbits on ordered letter pairs; the exact factored characteristic
+polynomial with its kernel dimensions and a fully discriminating minimal-polynomial test; the class block and the growth eigenvalue with
+exact certificates in the ring adjoining the square root of 243057; the closed strip counts of one to six cells and their recurrence
+cross-check; the invariant factors and the determinant; and the evenness theorem for the entries, derived on 208 of the 256 fibers by an
+explicit free pairing and left as a measurement on the remaining orbit of 48, where the group mechanism provably cannot certify it.
+
+Gates G1 to G22, one line each, then a resource line and the total line. Any failure exits nonzero."""
+
+import itertools
+import sys
+import time
+import resource
+from collections import Counter
+from fractions import Fraction as FR
+
+AUDIT_TIMEOUT_SEC = 900
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def lshow(v):
+    return "[" + ",".join("{0}".format(x) for x in v) + "]"
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FR(C[r][c]) for c in range(n)] + [FR(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+
+FACE = {}
+for t in USED:
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda f: sorted(sorted(t) for t in f))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+gate(len(CAND) == 2672 and FLOOR == 6 and len(KEPT) == 400 and NS == 15800 and NU == 192
+     and PSIZE == 1 and CSIZE == 24 and len(G384) == 384, "G1",
+     "the cell has 2672 unit-determinant five-corner pieces, cost floor 6, 400 kept, 15800 cuttings of 24, 192 used, group order 384")
+
+# ---------------------------------------------------------------- G2 the alphabet
+
+SLOTSETS = [set(KEY[i][(a, c)] for i in range(NS)) for a in range(4) for c in (0, 1)]
+SAME = all(x == SLOTSETS[0] for x in SLOTSETS)
+MULT = [Counter(KEY[i][(a, c)] for i in range(NS)) for a in range(4) for c in (0, 1)]
+MCEN = dict(sorted(Counter(MULT[0].values()).items()))
+MSAME = all(m == MULT[0] for m in MULT)
+
+gate(NL == 16 and SAME and len(SLOTSETS) == 8 and len(SLOTSETS[0]) == 16 and MSAME
+     and MCEN == {862: 12, 1364: 4}, "G2",
+     "the facet alphabet has 16 letters, the same 16 on all 8 slots, with slot multiplicity census {0}".format(dshow(MCEN)))
+
+# ---------------------------------------------------------------- G3 to G7 the transfer operator
+
+TMS = []
+for a in range(4):
+    J = Counter((KEY[i][(a, 0)], KEY[i][(a, 1)]) for i in range(NS))
+    TMS.append([[J[(x, y)] for y in range(16)] for x in range(16)])
+TR = TMS[0]
+AXEQ = sum(1 for a in range(4) for x in range(16) for y in range(16) if TMS[a][x][y] != TR[x][y])
+SYMM = sum(1 for x in range(16) for y in range(16) if TR[x][y] != TR[y][x])
+RSUM = [sum(TR[k]) for k in range(16)]
+RCEN = dict(sorted(Counter(RSUM).items()))
+RMULT = all(RSUM[k] == MULT[0][k] for k in range(16))
+ECEN = dict(sorted(Counter(TR[x][y] for x in range(16) for y in range(16)).items()))
+TRC = sum(TR[x][x] for x in range(16))
+DEVEN = sum(1 for x in range(16) if (TR[x][x] & 1) == 0)
+
+gate(AXEQ == 0 and len(TMS) == 4 and 16 * 16 == 256, "G3",
+     "axis equality T_0 = T_1 = T_2 = T_3 entry for entry, 4 axes over all 256 entries, 0 misses")
+gate(SYMM == 0, "G4", "the transfer operator is symmetric, T[k][j] = T[j][k] on all 256 entries, 0 misses")
+gate(RMULT and RCEN == {862: 12, 1364: 4} and 12 * 862 + 4 * 1364 == NS, "G5",
+     "every row sum is that letter's multiplicity, census {0}, and 12 x 862 + 4 x 1364 = 15800".format(dshow(RCEN)))
+gate(ECEN == {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}
+     and min(ECEN) == 18, "G6",
+     "entry census {0}, least entry 18, strictly positive".format(dshow(ECEN)))
+gate(TRC == 2000 and DEVEN == 16 and 2 * 1000 == TRC, "G7",
+     "trace 2000 with all 16 diagonal entries even, so the trace is 2 x 1000")
+
+# ---------------------------------------------------------------- G8, G9 the holding maps
+
+STAB = [(p, m) for (p, m) in G384 if p[0] == 0]
+NONSW = [g for g in STAB if not (g[1] & 1)]
+SWAPS = [g for g in STAB if (g[1] & 1)]
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def act3(g, pt):
+    p, m = g
+    return tuple(pt[p[i + 1] - 1] ^ ((m >> p[i + 1]) & 1) for i in range(3))
+
+
+PSI = {}
+PERM = {}
+PBAD = 0
+for g in STAB:
+    ps = tuple(KN[frozenset(frozenset(act3(g, v) for v in tet) for tet in ALLK[li])] for li in range(16))
+    if sorted(ps) != list(range(16)):
+        PBAD += 1
+    PSI[g] = ps
+    mp = {t: KIDX[frozenset(actcorner(g, v) for v in KEPT[t])] for t in USED}
+    PERM[g] = [SIDX[frozenset(mp[t] for t in s)] for s in SOLS]
+
+MECH = 0
+for g in NONSW:
+    ps = PSI[g]
+    pm = PERM[g]
+    for i in range(NS):
+        if KEY[pm[i]][(0, 0)] != ps[KEY[i][(0, 0)]] or KEY[pm[i]][(0, 1)] != ps[KEY[i][(0, 1)]]:
+            MECH += 1
+PSET = set(PSI[g] for g in NONSW)
+CLOS = all(tuple(a[b[i]] for i in range(16)) in PSET for a in PSET for b in PSET)
+IDIN = tuple(range(16)) in PSET
+
+gate(len(STAB) == 96 and len(NONSW) == 48 and len(SWAPS) == 48 and PBAD == 0 and len(PSET) == 48
+     and CLOS and IDIN and MECH == 0, "G8",
+     "the 48 letter maps of the facet holder form a group; letters follow the cuttings on 15800 cuttings x 48 maps x 2 sides, 0 misses")
+
+COMM = 0
+for g in NONSW:
+    ps = PSI[g]
+    for k in range(16):
+        for j in range(16):
+            if TR[ps[k]][ps[j]] != TR[k][j]:
+                COMM += 1
+SEENP = set()
+ORB = []
+for k in range(16):
+    for j in range(16):
+        if (k, j) in SEENP:
+            continue
+        o = set()
+        for g in NONSW:
+            ps = PSI[g]
+            o.add((ps[k], ps[j]))
+        SEENP |= o
+        vals = set(TR[a][b] for a, b in o)
+        ORB.append((len(o), sorted(vals)))
+FLAT = sorted((n, v[0]) for n, v in ORB)
+CONST = all(len(v) == 1 for n, v in ORB)
+TGT = [(4, 200), (12, 18), (12, 18), (12, 90), (12, 100), (12, 104), (24, 50), (24, 50),
+       (24, 92), (24, 92), (48, 36), (48, 52)]
+
+gate(COMM == 0 and len(ORB) == 12 and CONST and FLAT == TGT and len(set(e for n, e in FLAT)) == 9
+     and sum(n for n, e in FLAT) == 256, "G9",
+     "commutation 0 misses; 12 pair orbits, sizes {0}, entries {1}".format(
+         lshow([n for n, e in FLAT]), lshow([e for n, e in FLAT])))
+
+# ---------------------------------------------------------------- G10 the class block
+
+LIGHT = [k for k in range(16) if RSUM[k] == 862]
+HEAVY = [k for k in range(16) if RSUM[k] == 1364]
+LL = set(sum(TR[k][j] for j in LIGHT) for k in LIGHT)
+LH = set(sum(TR[k][j] for j in HEAVY) for k in LIGHT)
+HL = set(sum(TR[k][j] for j in LIGHT) for k in HEAVY)
+HH = set(sum(TR[k][j] for j in HEAVY) for k in HEAVY)
+BLK = [[578, 284], [852, 512]]
+BOK = (LL == {578} and LH == {284} and HL == {852} and HH == {512})
+BTR = BLK[0][0] + BLK[1][1]
+BDT = BLK[0][0] * BLK[1][1] - BLK[0][1] * BLK[1][0]
+
+gate(BOK and len(LIGHT) == 12 and len(HEAVY) == 4 and BTR == 1090 and BDT == 53968
+     and 578 + 284 == 862 and 852 + 512 == 1364, "G10",
+     "class block: light rows (578, 284), heavy rows (852, 512); block trace 1090, block determinant 53968")
+
+# ---------------------------------------------------------------- G11 to G14 the exact spectrum
+
+N = 16
+ID = [[1 if i == j else 0 for j in range(N)] for i in range(N)]
+
+
+def fdet(M):
+    A = [[FR(x) for x in row] for row in M]
+    d = FR(1)
+    for c in range(N):
+        p = -1
+        for r in range(c, N):
+            if A[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return FR(0)
+        if p != c:
+            A[c], A[p] = A[p], A[c]
+            d = -d
+        pv = A[c][c]
+        d *= pv
+        for r in range(c + 1, N):
+            if A[r][c] != 0:
+                f = A[r][c] / pv
+                A[r] = [A[r][k] - f * A[c][k] for k in range(N)]
+    return d
+
+
+def frank(M):
+    A = [[FR(x) for x in row] for row in M]
+    rk = 0
+    for c in range(N):
+        p = -1
+        for r in range(rk, N):
+            if A[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            continue
+        A[rk], A[p] = A[p], A[rk]
+        pv = A[rk][c]
+        for r in range(N):
+            if r != rk and A[r][c] != 0:
+                f = A[r][c] / pv
+                A[r] = [A[r][k] - f * A[rk][k] for k in range(N)]
+        rk += 1
+    return rk
+
+
+def mmul(A, B):
+    return [[sum(A[i][k] * B[k][j] for k in range(N)) for j in range(N)] for i in range(N)]
+
+
+def shift(lam):
+    return [[TR[i][j] - (lam if i == j else 0) for j in range(N)] for i in range(N)]
+
+
+TR2 = mmul(TR, TR)
+
+
+def quadm(b, c):
+    return [[TR2[i][j] - b * TR[i][j] + (c if i == j else 0) for j in range(N)] for i in range(N)]
+
+
+def facval(t):
+    return ((t - 50) ** 2 * (t - 42) ** 2 * (t - 10) ** 3 * (t + 54)
+            * (t * t - 1090 * t + 53968) * (t * t - 250 * t + 7728) ** 3)
+
+
+PTS = 0
+for t in range(17):
+    if fdet([[(t if i == j else 0) - TR[i][j] for j in range(N)] for i in range(N)]) == facval(t):
+        PTS += 1
+
+KD = [N - frank(shift(lam)) for lam in (50, 42, 10, -54)]
+KQ = [N - frank(quadm(1090, 53968)), N - frank(quadm(250, 7728))]
+
+FACT = [shift(50), shift(42), shift(10), shift(-54), quadm(1090, 53968), quadm(250, 7728)]
+
+
+def fprod(idxs):
+    A = ID
+    for i in idxs:
+        A = mmul(A, FACT[i])
+    return A
+
+
+ANN = all(x == 0 for r in fprod(range(6)) for x in r)
+DROPS = sum(1 for d in range(6) if any(x != 0 for r in fprod([i for i in range(6) if i != d]) for x in r))
+
+D1 = 1090 * 1090 - 4 * 53968
+D2 = 250 * 250 - 4 * 7728
+
+
+def isprime(n):
+    if n < 2:
+        return False
+    d = 2
+    while d * d <= n:
+        if n - (n // d) * d == 0:
+            return False
+        d += 1
+    return True
+
+
+SF1 = (D1 == 972228 and D1 == 4 * 243057 and 243057 == 3 * 81019 and isprime(81019)
+       and 81019 - (81019 // 3) * 3 != 0)
+SF2 = (D2 == 31588 and D2 == 4 * 7897 and 7897 == 53 * 149 and isprime(53) and isprime(149))
+
+gate(PTS == 17, "G11",
+     "the factored characteristic polynomial matches det(t I - T) at all 17 points t = 0 to 16, an identity in degree 16")
+gate(KD == [2, 2, 3, 1] and KQ == [2, 6] and sum(KD) + sum(KQ) == 16, "G12",
+     "kernel dimensions 2, 2, 3, 1 at 50, 42, 10, -54 and 2, 6 at the two quadratics, summing to 16")
+gate(ANN and DROPS == 6, "G13",
+     "the minimal polynomial has degree 8 and annihilates T, and each of the 6 single-factor drops leaves a nonzero matrix")
+gate(SF1 and SF2, "G14",
+     "1090^2 - 4 x 53968 = 972228 = 4 x 243057 = 4 x 3 x 81019, 81019 prime; 250^2 - 4 x 7728 = 31588 = 4 x 7897 = 4 x 53 x 149")
+
+# ---------------------------------------------------------------- G15 to G17 the growth eigenvalue
+
+WSQ = 243057
+
+
+def wmul(x, y):
+    return (x[0] * y[0] + x[1] * y[1] * WSQ, x[0] * y[1] + x[1] * y[0])
+
+
+VEC = [(284, 0), (-33, 1)]
+LAM = (545, 1)
+LHS = [(BLK[r][0] * VEC[0][0] + BLK[r][1] * VEC[1][0], BLK[r][0] * VEC[0][1] + BLK[r][1] * VEC[1][1])
+       for r in range(2)]
+RHS = [wmul(LAM, VEC[0]), wmul(LAM, VEC[1])]
+POSV = (33 * 33 == 1089 and 1089 < WSQ)
+BR1 = (493 * 493 == 243049 and 243049 < WSQ and WSQ < 244036 and 244036 == 494 * 494)
+BR2 = (88 * 88 == 7744 and 7744 < 7897 and 7897 < 7921 and 7921 == 89 * 89)
+BND = max(50, 42, 10, 54, 545 - 493, 125 + 89)
+DOM = (BND == 214 and BND < 1038 and 545 + 493 == 1038 and 545 + 494 == 1039)
+KCERT = 284 * 1364 + 33 * 862
+OVW = (862 * 862 * WSQ == 180602045508 and KCERT * KCERT == 172907935684
+       and 180602045508 > 172907935684 and KCERT == 415822)
+
+gate(LHS == RHS and POSV and VEC[0][0] == 284 and LAM == (545, 1), "G15",
+     "the vector (284, w - 33) with w x w = 243057 is exact for the class block at eigenvalue 545 + w; positive since 1089 < 243057")
+gate(BR1 and BR2 and DOM, "G16",
+     "493^2 = 243049 < 243057 < 244036 = 494^2 and 88^2 = 7744 < 7897 < 7921 = 89^2, so 125 + sqrt 7897 < 214 < 1038 < 545 + w < 1039")
+gate(OVW, "G17",
+     "heavy over-weighting 862^2 x 243057 = 180602045508 > 172907935684 = 415822^2 with 415822 = 284 x 1364 + 33 x 862")
+
+# ---------------------------------------------------------------- G18, G19 closed strips
+
+STRIP = []
+PW = [r[:] for r in TR]
+for n in range(1, 7):
+    if n > 1:
+        PW = mmul(PW, TR)
+    STRIP.append(sum(PW[i][i] for i in range(N)))
+SELF = sum(1 for i in range(NS) if KEY[i][(0, 0)] == KEY[i][(0, 1)])
+STGT = [2000, 1233040, 1148284352, 1167237515200, 1206389522378240, 1251135002657559808]
+
+
+def pmul(a, b):
+    out = [0] * (len(a) + len(b) - 1)
+    for i, x in enumerate(a):
+        if x:
+            for j, y in enumerate(b):
+                out[i + j] += x * y
+    return out
+
+
+CO = [1]
+for f, e in (([1, -50], 2), ([1, -42], 2), ([1, -10], 3), ([1, 54], 1),
+             ([1, -1090, 53968], 1), ([1, -250, 7728], 3)):
+    for _ in range(e):
+        CO = pmul(CO, f)
+PSUM = []
+for n in range(1, 7):
+    s = -n * CO[n]
+    for k in range(1, n):
+        s -= CO[k] * PSUM[n - k - 1]
+    PSUM.append(s)
+
+gate(STRIP == STGT and STRIP[0] == SELF and len(CO) == 17, "G18",
+     "closed strip counts for n = 1 to 6: {0}".format(", ".join("{0}".format(x) for x in STRIP)))
+gate(PSUM == STRIP, "G19",
+     "the power-sum recurrence from the expanded characteristic polynomial reproduces all 6 strip counts, 0 misses")
+
+# ---------------------------------------------------------------- G20 invariant factors
+
+
+def invfac(M):
+    A = [row[:] for row in M]
+    res = []
+    for s in range(N):
+        while True:
+            piv = None
+            best = None
+            for i in range(s, N):
+                for j in range(s, N):
+                    v = A[i][j]
+                    if v != 0 and (best is None or abs(v) < best):
+                        best = abs(v)
+                        piv = (i, j)
+            if piv is None:
+                break
+            i0, j0 = piv
+            A[s], A[i0] = A[i0], A[s]
+            for r in range(N):
+                A[r][s], A[r][j0] = A[r][j0], A[r][s]
+            p = A[s][s]
+            done = True
+            for i in range(s + 1, N):
+                if A[i][s] != 0:
+                    q = A[i][s] // p
+                    for j in range(s, N):
+                        A[i][j] -= q * A[s][j]
+                    if A[i][s] != 0:
+                        done = False
+            for j in range(s + 1, N):
+                if A[s][j] != 0:
+                    q = A[s][j] // p
+                    for i in range(s, N):
+                        A[i][j] -= q * A[i][s]
+                    if A[s][j] != 0:
+                        done = False
+            if done:
+                bad = None
+                for i in range(s + 1, N):
+                    for j in range(s + 1, N):
+                        if A[i][j] - (A[i][j] // p) * p != 0:
+                            bad = i
+                            break
+                    if bad is not None:
+                        break
+                if bad is None:
+                    break
+                for j in range(s, N):
+                    A[s][j] += A[bad][j]
+        res.append(abs(A[s][s]))
+    return res
+
+
+INF = invfac(TR)
+CHAIN = all(INF[i] != 0 and INF[i + 1] - (INF[i + 1] // INF[i]) * INF[i] == 0 for i in range(N - 1))
+PROD = 1
+for x in INF:
+    PROD *= x
+DET = int(fdet(TR))
+EVF = 50 ** 2 * 42 ** 2 * 10 ** 3 * 54 * 53968 * 7728 ** 3
+TAIL = [210, 420, 19320, 96600, 17594917200]
+INFOK = (INF == [2] * 11 + TAIL and 17594917200 == 2 ** 4 * 3 ** 4 * 5 ** 2 * 7 * 23 * 3373
+         and all((x & 1) == 0 for x in INF))
+
+gate(INFOK and CHAIN and DET < 0 and PROD == -DET and PROD == EVF and PROD == 5931574826283246551040000000,
+     "G20",
+     "invariant factors: eleven 2s, {0} = 2^4 x 3^4 x 5^2 x 7 x 23 x 3373; det {1}".format(
+         ", ".join("{0}".format(x) for x in TAIL), DET))
+
+# ---------------------------------------------------------------- G21, G22 evenness
+
+ALLEVEN = all((TR[x][y] & 1) == 0 for x in range(16) for y in range(16))
+R0 = ((0, 1, 2, 3), 1)
+RFIX = sum(1 for i in range(NS) if PERM[R0][i] == i)
+RID = (PSI[R0] == tuple(range(16)))
+RSW = sum(1 for i in range(NS) if KEY[PERM[R0][i]][(0, 0)] != KEY[i][(0, 1)]
+          or KEY[PERM[R0][i]][(0, 1)] != KEY[i][(0, 0)])
+
+FIB = {}
+for i in range(NS):
+    FIB.setdefault((KEY[i][(0, 0)], KEY[i][(0, 1)]), []).append(i)
+FSET = {k: set(v) for k, v in FIB.items()}
+SIZEOK = all(len(FIB.get((x, y), [])) == TR[x][y] for x in range(16) for y in range(16))
+WIT = {}
+AEV = {}
+CRIT = 0
+for kj in FIB:
+    k, j = kj
+    F = FIB[kj]
+    S = FSET[kj]
+    w = 0
+    ae = 0
+    for g in STAB:
+        pm = PERM[g]
+        held = all(pm[c] in S for c in F)
+        ps = PSI[g]
+        if g[1] & 1:
+            pred = (ps[k] == j and ps[j] == k)
+        else:
+            pred = (ps[k] == k and ps[j] == j)
+        if held != pred:
+            CRIT += 1
+        if not held:
+            continue
+        if all(pm[c] != c and pm[pm[c]] == c for c in F):
+            w += 1
+        seen = set()
+        ok = True
+        for c in F:
+            if c in seen:
+                continue
+            x = c
+            cyc = 0
+            while True:
+                seen.add(x)
+                x = pm[x]
+                cyc += 1
+                if x == c:
+                    break
+            if cyc & 1:
+                ok = False
+                break
+        if ok:
+            ae += 1
+    WIT[kj] = w
+    AEV[kj] = ae
+WCEN = dict(sorted(Counter(WIT.values()).items()))
+PAIRED = sum(1 for v in WIT.values() if v > 0)
+ZERO = set(kj for kj in WIT if WIT[kj] == 0)
+ZENT = set(TR[k][j] for k, j in ZERO)
+ORB36 = []
+SEENQ = set()
+for k in range(16):
+    for j in range(16):
+        if (k, j) in SEENQ:
+            continue
+        o = set()
+        for g in NONSW:
+            ps = PSI[g]
+            o.add((ps[k], ps[j]))
+        SEENQ |= o
+        if len(o) == 48 and all(TR[a][b] == 36 for a, b in o):
+            ORB36.append(o)
+ZAEV = sum(AEV[kj] for kj in ZERO)
+
+gate(ALLEVEN and RFIX == 0 and RID and RSW == 0 and len(FIB) == 256 and SIZEOK and CRIT == 0
+     and WCEN == {0: 48, 1: 156, 2: 48, 4: 4} and PAIRED == 208, "G21",
+     "all 256 entries even; the axis-zero flip fixes 0 cuttings, swaps sides; free pairings {0} on 208 fibers".format(dshow(WCEN)))
+gate(len(ZERO) == 48 and ZENT == {36} and len(ORB36) == 1 and ZERO == ORB36[0] and ZAEV == 0, "G22",
+     "the 48 fibers with no free pairing are exactly the entry-36 orbit, and 0 of them admit any of the 96 holding maps with even orbits")
+
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+PEAK = RSS // (1024 * 1024) if sys.platform == "darwin" else RSS // 1024
+emit("resource: under {0} s, under {1} MB".format(((int(time.time() - T0) // 60) + 1) * 60, ((PEAK // 250) + 1) * 250))
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

Source-only triple for cycle 787 of the lane, plus a separate `audit-infra:` commit acknowledging the new note in the citation-graph manifest (the sole sanctioned `docs/audit/data` change):

- `docs/PHYSICAL_CELL_CUTTING_INTERFACE_TRANSFER_SPECTRUM_CYCLE787_NOTE_2026-08-14.md`
- `scripts/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.py`
- `logs/runner-cache/physical_cell_cutting_interface_transfer_spectrum_cycle787_2026_08_14.txt`

## The science

Working on the unit four-cube cell: 2672 candidate five-corner pieces of unit determinant, 400 kept at the adjacency-cost floor 6, 15800 exact covers by 24 pieces, 192 used pieces, order-384 cell symmetry group, sixteen-letter facet alphabet with the 12-light/4-heavy split from the previous cycle. All checks in exact integer/rational arithmetic on geometry rebuilt from the corner list.

- **The transfer matrix.** For each axis, the 16 x 16 letter-pair matrix counts covers by the letters on the two opposite facet slots. The four axis matrices are **equal as matrices** (not merely conjugate), symmetric, and strictly positive (minimum entry 18); row sums reproduce the multiplicity census (12 rows at 862, 4 at 1364), trace 2000, and the entries take exactly 9 distinct values.
- **Commutation, derived.** Every facet-holding symmetry of the cell induces the **same** signed three-cube map on both boundary cubes — a mechanism verified with 0 misses on the non-swapping half and a full held-versus-predicted cross-check covering the swapping half. Hence the matrix commutes with the whole order-48 boundary letter action, forcing constancy on the 12 letter-pair orbits; the algebra of matrices commuting with all 48 letter maps has dimension 12, so the matrix is as symmetric as its size permits.
- **Exact spectrum, certified.** The characteristic polynomial factors over the integers as (x-50)^2 (x-42)^2 (x-10)^3 (x+54) (x^2-1090x+53968) (x^2-250x+7728)^3, certified by exact fraction-elimination determinant comparison at 17 points, kernel-dimension counts summing to 16, and a degree-8 squarefree annihilating polynomial whose six single-factor drops are each nonzero. The growth eigenvalue 545+sqrt(243057) is simple, bracketed strictly between 1038 and 1039, and dominates every other eigenvalue magnitude (all at most 214) — all in integer arithmetic.
- **The light/heavy class block.** Summing rows over the light and heavy letter classes gives a constant 2 x 2 block [[578,284],[852,512]] whose quadratic is exactly the leading factor above — the growth of the interface is carried by the class split found in the previous cycle. The positive eigenvector over-weights heavy letters relative to their multiplicity, proved by an exact integer inequality.
- **Closed strips counted two ways.** Traces of powers count closed cyclic strips of glued covers; the runner computes n = 1..6 from matrix powers and re-derives the same six numbers from a power-sum recurrence on the expanded factored polynomial — two computations sharing no arithmetic, agreeing exactly (first entries 2000 and 1233040; trace anchored to the independently computed diagonal sum).
- **Integer invariants.** The invariant-factor chain is 2 repeated eleven times, then 210, 420, 19320, 96600, 17594917200 — all even, with product equal to the determinant's absolute value; the determinant is negative, matching the single negative eigenvalue -54.
- **An evenness law with a sharp boundary.** Every entry of the matrix is even. A derived mechanism — the axis flip fixes no cover and trades sides with the identity letter map, giving a free pairing on every diagonal fiber — proves evenness for 208 of the 256 fibers. The 48 fibers with no free pairing are **exactly** the entry-36 orbit, and none of them admits any of the 96 holding maps acting with all-even orbits: the evenness of that one orbit is measured, not derived, and is named as the honest wall.

Honest boundary: the specific entry values and censuses, the axis-equality of the four matrices, the class-block values, the polynomial identity itself, and entry-36 evenness are complete measurements at the declared finite scope; the commutation mechanism, orbit constancy, diagonalisability, spectrum certification, eigenvector inequalities, strip-count identity, and the 208-fiber evenness mechanism are derived.

## Verification

- Runner: stdlib only, exact arithmetic, no file I/O; my own independent re-run exits 0 with `TOTAL: PASS=22 FAIL=0` and byte-identical output to the cache.
- Independent execution per written spec with executor self-check, followed by my own adversarial review: line-by-line read of note and runner, a fabrication hunt (matrix built from enumerated covers, spectrum certified against exact determinant evaluation rather than assumed, strip counts double-computed by disjoint methods, every gate discriminating), and a mechanical banned-language/number-discipline sweep with 0 flags. The review caught and fixed one misstatement — the minimal-polynomial degree (eight, not nine as my spec had it); gates were unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
