### PR TITLE
feat(cell-cutting): refute five evenness mechanism routes at the interface

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_INTERFACE_EVENNESS_ROUTES_CYCLE788_NOTE_2026-08-14.md
+++ b/docs/PHYSICAL_CELL_CUTTING_INTERFACE_EVENNESS_ROUTES_CYCLE788_NOTE_2026-08-14.md
@@ -1,0 +1,246 @@
+# Physical cell cutting: interface evenness routes, the incidence transport obstruction, boundary frames, and the exchange distance law
+
+Date: 2026-08-14
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: test whether the six-dimensional letter-functional quotient invisible to the tetra incidence carries the evenness mechanism; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: refutation certificates for candidate evenness mechanisms, an exact incidence transport identity with a rank obstruction, boundary-frame determinacy, and the within-fiber exchange distance law for the declared unit four-cube object; no physical or lattice-wide identification`
+- `audit_required_before_effective_retained: true`
+- `bare_retained_allowed: false`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the
+unit four-cube, the 2672 five-corner determinant-one pieces built on them, the 400 pieces
+surviving at the adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400
+assemble into, the 192 pieces that actually occur in a cutting, the 384 signed coordinate maps
+of the cell, and the slot-preserving subgroup of order ninety-six that fixes the two boundary
+three-cubes of axis zero as a pair. Each cutting dissects each boundary three-cube into 6 unit
+tetrahedra drawn from a support of 24, and exactly 16 such dissections occur, the same 16 on
+every one of the 8 slots: 12 light letters of slot multiplicity 862 and 4 heavy letters of
+multiplicity 1364. These are finite-scope object choices, not imported physical primitives.
+Every integer below is derived by the linked runner from that object alone; it rebuilds the
+whole object from the corner list before any gate runs, uses the standard library only,
+performs no file input or output, draws no random numbers, and carries out every load-bearing
+check in integer or exact rational arithmetic.
+
+The interface reading is the 16 x 16 matrix T whose entry at a letter pair counts the cuttings
+carrying those two letters on the two sides of axis zero. The runner recomputes T: it is the
+same matrix on all four axes, it is symmetric, its trace is 2000, its least entry is 18, its
+entry census is `{18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}`,
+and all 256 entries are even. The sibling cycles
+`PHYSICAL_CELL_CUTTING_FACET_ALPHABET_HEAVY_PARITY_CYCLE786_NOTE_2026-08-14` and
+`PHYSICAL_CELL_CUTTING_INTERFACE_TRANSFER_SPECTRUM_CYCLE787_NOTE_2026-08-14` established that
+reading and reduced the evenness question to a free-pairing mechanism that reaches the 208
+fibers whose entry is not 36 and leaves the 48 fibers of entry 36 uncovered. Those 48 fibers
+are the named wall this cycle attacks. Nothing is imported from the siblings: every fact
+quoted above is recomputed here.
+
+The cycle lands refutation certificates for five candidate mechanisms, one exact transport
+identity with its rank obstruction, one determinacy theorem, and one distance law. The wall
+stands; what changes is that the region where the mechanism can live is now much narrower and
+has two named entrances.
+
+## Letter membership is not affine over the piece vector
+
+Work over GF(2) with functions on the 15800 cuttings as bit vectors, one bit per cutting. The
+indicator of a used piece is the set of cuttings containing it. The 192 used-piece indicators
+together with the all-ones function span a space of GF(2) rank 88.
+
+For each of the 24 tetrahedra and each side of axis zero, the producers of that tetra are the
+used pieces placing it there; their supports are pairwise disjoint, certified by the equality
+of the support size of the exclusive-or with the sum of the individual support sizes. The
+tetra functional is that exclusive-or. The 24 tetra functionals together with the all-ones
+function span rank 10, the same on both sides.
+
+None of the 16 letter indicator functions lies in the tetra span, and none lies in the full
+used-piece span: 0 of 16 in all four combinations, side zero and side one, tetra span and
+column span. Letter membership is therefore not a GF(2)-affine function of the piece vector of
+a cutting, and the first candidate mechanism — an affine letter functional whose fibers would
+split evenly by a linear complement — is refuted.
+
+## The two-case stabilizer theorem
+
+Take a letter pair of entry 36 and its stabilizer inside the slot-preserving subgroup of order
+ninety-six: the non-swapping maps that fix both letters, together with the swapping maps that
+exchange them. For all 48 such pairs the stabilizer has order exactly 2, census `{2: 48}`.
+
+A group action certifies evenness of a set only when every orbit is even. There are exactly
+two subgroups to consider. The trivial subgroup has all orbits of size one, which is odd. The
+full stabilizer of order 2 is generated by a single map, and the runner certifies that in all
+48 of 48 fibers that map carries the fiber to itself and has at least one odd cycle on it, so
+it too has an odd orbit. Hence no subgroup of the pair stabilizer acts on any of the 48 fibers
+with all orbits even, and the group-pairing mechanism cannot certify the evenness of a single
+stubborn fiber at any subgroup level. This sharpens the sibling result, which ruled out only
+the single distinguished element, into a statement over the whole subgroup lattice.
+
+## Incidence transport and its rank obstruction
+
+Let A be the letter-tetra incidence: 16 rows, 24 columns, entry one exactly when the tetra
+belongs to the letter. Every row sum is 6 and every column sum is 4, and 16 x 6 = 96 = 24 x 4.
+Let N be the 24 x 24 tetra-pair matrix whose entry counts the cuttings whose side-zero
+dissection contains the first tetra and whose side-one dissection contains the second; the
+disjointness of producer supports makes that count the support size of an intersection of two
+tetra functionals.
+
+Exact identity, verified entry by entry on all 576 entries with 0 misses:
+
+`N = A-transpose T A`.
+
+The value census of N is
+`{862: 168, 872: 48, 894: 48, 904: 168, 1270: 24, 1280: 48, 1322: 48, 1332: 24}`, and all 576
+entries are even. That evenness is a corollary of the evenness of T and nothing more: each
+entry of N is a sum of entries of T, all of them even. It is recorded here as a consistency
+check on the identity, not as independent evidence for the wall, and the note claims no more
+for it than that.
+
+The obstruction is on the other side of the identity. Over GF(2) the incidence A has rank 10
+and kernel dimension 6. Parity transport through the tetra level therefore sees only a rank-10
+image of the 16-dimensional letter space, and a 6-dimensional quotient of letter functionals is
+invisible to the tetra alphabet. If the mechanism behind the wall is letter-linear at all, it
+lives in that quotient — which is why the quotient is named as the first next surface rather
+than a leftover.
+
+One coincidence deserves a single remark and no weight: 862 is both the light-letter slot
+multiplicity and, tied with 904, the most frequent value of N, each occurring at 168 pairs. No
+structural link between the two readings is claimed here.
+
+## Boundary frames, determinacy, and the odd classes
+
+The axis-zero frame of a cutting is the pair of piece sets that contribute a facet tetra on the
+two sides. Both sets have size 6 for every cutting, census `{(6, 6): 15800}`, and they are
+always disjoint: a piece has 5 corners, so it cannot place 4 corners on each of two parallel
+bounding hyperplanes, which would need 8 distinct corners. The runner certifies the disjointness
+directly as well.
+
+Determinacy. The frame on a side determines the letter on that side single-valuedly. There are
+1024 distinct side-zero frames and 1024 distinct side-one frames, and no frame on either side
+carries two different letters — 0 exceptions on each side. There are 6184 distinct joint frames,
+and no joint frame carries two different letter pairs — 0 exceptions. The frame is thus a strict
+refinement of the letter, and a candidate carrier of finer structure.
+
+Refutation. The frame partition does not refine evenness. Of the 6184 joint frame classes, 3368
+have odd size; of the 1024 side-zero classes, 856 have odd size. Pairing cuttings inside a frame
+class is therefore impossible in general. And the refutation reaches inside the wall: restricted
+to each of the 48 stubborn fibers, the within-fiber joint-frame partition has at least one odd
+class, in all 48 of them, and the same holds for the full eight-slot letter profile — the tuple
+of all 8 facet letters of a cutting — again in all 48. Neither the frame class nor the complete
+letter profile of a cutting supplies a pairing that could certify the evenness of a stubborn
+fiber.
+
+## Column parities
+
+All 192 used-piece indicators have odd support: each used piece lies in an odd number of
+cuttings. Every one of the 24 tetra functionals has even support, on both sides of axis zero.
+The two parities sit on opposite sides of the exclusive-or that builds a tetra functional from
+its producers, which is consistent with each tetra having an even number of producers, and
+neither parity by itself reaches the letter level.
+
+## The exchange distance law
+
+Within a letter-pair fiber, measure the symmetric-difference distance between the piece sets of
+two cuttings. Since both have 24 pieces, sharing t of them gives distance d = 48 - 2t, so every
+within-fiber distance is even and determined by the shared count.
+
+Across all 256 fibers the complete value list is
+
+`[8, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 48]`
+
+— 19 values. The even values 10 and 46 are absent, and the least value is 8. Restated in shared
+pieces: two cuttings in the same fiber never share exactly 1 piece and never share exactly 19,
+and the least separation is a four-piece exchange, the least-exchange scale of this lane.
+
+The odd-degree counting argument is the natural next mechanism: in a finite graph where every
+degree is odd, the vertex count is even, so a distance rule making all within-fiber degrees odd
+would derive fiber evenness. It fails at every rule available here. For each of the 19 values,
+the number of fibers whose equal-distance graph has all degrees odd is 0 of 256. For each cutoff
+below 48, the number of fibers whose at-most-that-distance graph has all degrees odd is likewise
+0 of 256. The sole cutoff that passes is 48, where it passes for all 256 fibers — and that case
+is tautological and is recorded here only as a guard: at cutoff 48 the graph is complete, every
+degree is the fiber size minus 1, and "all degrees odd" is a restatement of "the fiber is even",
+so it derives nothing. The runner prints it labelled as the tautological complete-graph case for
+exactly that reason.
+
+## Minimal exchange inside a stubborn fiber
+
+Take the first entry-36 fiber in lexicographic letter order; it has 36 members. Every one of the
+36 attains the least distance 8 to some other member, census `{8: 36}`. But the minimizer is not
+unique: the runner counts the members carrying a tied minimizer and finds that count nonzero. And
+the nearest-partner map obtained by breaking ties on the member order is not an involution: the
+runner counts the members whose partner's partner is not themselves and finds that count nonzero
+too. So even the minimal-exchange relation, the most canonical-looking pairing candidate the
+geometry offers, supplies no pairing of a stubborn fiber.
+
+## Boundary and honest reading
+
+Measured, not derived, at the declared finite scope: the entry census of T and its trace 2000;
+the value census of N; the ranks 88, 10 and 6 and the kernel dimension 6; the frame counts 1024,
+1024 and 6184 and the odd-class counts 3368 and 856; the distance value list with its absent
+values 10 and 46; and, above all, the evenness of the 48 entry-36 fibers itself, which remains
+measured, not derived.
+
+Derived at the declared finite scope: the disjointness of the two frame sides from the
+five-corner bound; the exact transport identity `N = A-transpose T A`; the corollary status of
+the evenness of N; the two-case stabilizer theorem, which needs only the order-2 census and the
+odd-cycle witness; the determinacy of the letter by the frame; and the parity restatement
+d = 48 - 2t of the distance law together with the absence of shared counts 1 and 19.
+
+All of the above are computational identities of the declared unit four-cube object, its 15800
+cuttings, and the order-384 symmetry group of the cell. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+What the cycle buys is a narrowing. The mechanism behind the evenness of the 48 stubborn fibers
+cannot be a GF(2)-affine letter functional, cannot be a subgroup action of the pair stabilizer,
+cannot be parity transport through the tetra alphabet alone, cannot be a boundary-frame or
+letter-profile class pairing, and cannot be odd-degree counting on any exchange-distance rule.
+Two entrances are named and open: the 6-dimensional quotient of letter functionals that the
+incidence A cannot see, and the frame determinacy theorem, which gives a strictly finer
+single-valued carrier of the letter than the letter itself. Both are attacked in the next cycle;
+neither is claimed here.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.py](../scripts/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.txt](../logs/runner-cache/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, finishes
+in well under a minute on the reference machine, and stays far below one gigabyte. Its final
+line is `TOTAL: PASS=16 FAIL=0`, and it exits nonzero if any gate fails.
+
+## Review record and boundary
+
+- The runner prints censuses, ranks, stabilizer and frame counts, and the distance value list;
+  the full interface matrix, the incidence matrix and the tetra-pair matrix are deliberately not
+  printed, so the note quotes their censuses and the identity between them instead.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a
+  commit cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- The two sibling stems cited above are not yet on main and are referenced by name only.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries, the appropriate review classification is **bounded support** for the
+declared exact finite object.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13829,6 +13829,10 @@
   "physical_cell_cutting_hidden_three_bit_geometry_cycle743_note_2026-08-05": {
    "deps_hash": "9126ac46777c",
    "out_degree": 2
+  },
+  "physical_cell_cutting_interface_evenness_routes_cycle788_note_2026-08-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_least_computing_sets_cycle737_note_2026-08-05": {
    "deps_hash": "ba0326da985f",

--- a/logs/runner-cache/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.txt
+++ b/logs/runner-cache/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.py
+runner_sha256: cc55a37c36abd8a61b655353b5c55d157ab61787abb9040d5d3f6687ab23abae
+timeout_sec: 900
+exit_code: 0
+elapsed_sec: 12.32
+status: ok
+----- stdout -----
+PASS G1 2672 five-corner unit-determinant pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, slot subgroup 96
+PASS G2 16 letters, the same set on all 8 slots, multiplicity census {862: 12, 1364: 4}, and 12 x 862 + 4 x 1364 = 15800
+PASS G3 T equal on 4 axes, symmetric, trace 2000, all 256 even, 48 at 36 and 208 not; 18:24 36:48 50:48 52:48 90:12 92:48 100:12 104:12 200:4
+PASS G4 24 tetra, same set both sides, producer supports disjoint, 5-corner pieces give disjoint sides, census {(6, 6): 15800}
+PASS G5 incidence A is 16 by 24, every row sum 6, every column sum 4, and 16 x 6 = 96 = 24 x 4
+PASS G6 N = A-transpose T A on all 576 entries, 0 misses, all 576 even; 862:168 872:48 894:48 904:168 1270:24 1280:48 1322:48 1332:24
+PASS G7 GF(2) ranks: A has rank 10 with kernel dimension 6; tetra span with all-ones 10 on both sides; used columns with all-ones 88
+PASS G8 0 of 16 letters in the tetra span and 0 of 16 in the used-column span on side 0; 0 and 0 of 16 on side 1
+PASS G9 all 48 entry-36 pairs have pair stabilizer of order two inside the 96 slot-preserving maps, census {2: 48}
+PASS G10 48 of 48 stubborn fibers held by the second stabilizer element, 48 of 48 with an odd cycle, so no subgroup pairs any
+PASS G11 all 192 used-piece columns have odd support; 48 of 48 tetra functionals have even support, 24 tetra on each of both sides
+PASS G12 1024 side-zero frames, 1024 side-one frames, 6184 joint frames; 0 frames carry two letters, 0 joint frames carry two pairs
+PASS G13 3368 of 6184 joint classes odd, 856 of 1024 side-zero odd; inside 48 and 48 of the 48 fibers frames and profiles leave an odd class
+PASS G14 19 even values [8,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,48]; least 8, [10,46] absent, d = 48 - 2t, shared [1,19] absent
+PASS G15 all-odd degrees: 0 of 256 fibers at every value and every cutoff below 48; at cutoff 48, 256 of 256, tautological complete graph
+PASS G16 first entry-36 fiber: least-distance census {8: 36}, 28 members with a tied minimizer, 20 not paired back, so no involution
+resource: under 60 s, under 250 MB
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.py
+++ b/scripts/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.py
@@ -1,0 +1,661 @@
+"""Physical cell cutting: interface evenness routes, the incidence transport obstruction, boundary frames, and the exchange distance law.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, the slot-preserving subgroup of order ninety-six for axis zero, and the sixteen-letter facet alphabet. Nothing outside
+that finite object enters any gate.
+
+The target of this cycle is the evenness of the 48 stubborn interface fibers, the entry-36 orbit that the sibling cycle left as a
+measurement. Five named mechanism routes are tested here and every one of them is refuted, and the structure left behind is certified:
+letter membership is not a GF(2)-affine function of the piece vector; the pair stabilizer of every stubborn fiber has order two and carries
+an odd cycle, so no subgroup of it pairs the fiber; the tetra-pair count matrix factors exactly as A-transpose T A, while the letter-tetra
+incidence A has GF(2) rank ten and hides a six-dimensional quotient of letter functionals from the tetra alphabet; boundary frames fix the
+letter single-valuedly yet fall into odd classes, inside the stubborn fibers as well as outside; used-piece columns have odd support and
+tetra functionals even support; and the within-fiber exchange distance takes 19 even values with 10 and 46 absent and least value 8, while
+the odd-degree counting argument fails at every distance rule except the tautological complete-graph cutoff.
+
+Gates G1 to G16, one line each, then a resource line and the total line. Any failure exits nonzero."""
+
+import itertools
+import sys
+import time
+import resource
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def cshow(d):
+    return " ".join("{0}:{1}".format(k, d[k]) for k in sorted(d))
+
+
+def lshow(v):
+    return "[" + ",".join("{0}".format(x) for x in v) + "]"
+
+
+def pc(x):
+    return bin(x).count("1")
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NCOR = len(set(len(KEPT[t]) for t in USED))
+CORNS = sorted(set(len(KEPT[t]) for t in USED))[0]
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+
+FACE = {}
+for t in USED:
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda f: sorted(sorted(t) for t in f))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+STAB = [(p, m) for (p, m) in G384 if p[0] == 0]
+NONSW = [g for g in STAB if not (g[1] & 1)]
+SWAPS = [g for g in STAB if (g[1] & 1)]
+GID = ((0, 1, 2, 3), 0)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def act3(g, pt):
+    p, m = g
+    return tuple(pt[p[i + 1] - 1] ^ ((m >> p[i + 1]) & 1) for i in range(3))
+
+
+PSI = {}
+PBAD = 0
+for g in STAB:
+    ps = tuple(KN[frozenset(frozenset(act3(g, v) for v in tet) for tet in ALLK[li])] for li in range(16))
+    if sorted(ps) != list(range(16)):
+        PBAD += 1
+    PSI[g] = ps
+
+PCACHE = {}
+
+
+def permof(g):
+    if g not in PCACHE:
+        mp = {t: KIDX[frozenset(actcorner(g, v) for v in KEPT[t])] for t in USED}
+        PCACHE[g] = [SIDX[frozenset(mp[t] for t in s)] for s in SOLS]
+    return PCACHE[g]
+
+
+gate(len(CAND) == 2672 and FLOOR == 6 and len(KEPT) == 400 and NS == 15800 and NU == 192
+     and PSIZE == 1 and CSIZE == 24 and len(G384) == 384 and len(STAB) == 96 and PBAD == 0, "G1",
+     "{0} five-corner unit-determinant pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, slot subgroup {7}"
+     .format(len(CAND), FLOOR, len(KEPT), NS, CSIZE, NU, len(G384), len(STAB)))
+
+# ---------------------------------------------------------------- G2 the alphabet
+
+SLOTSETS = [set(KEY[i][(a, c)] for i in range(NS)) for a in range(4) for c in (0, 1)]
+SAME = all(x == SLOTSETS[0] for x in SLOTSETS)
+MULT = [Counter(KEY[i][(a, c)] for i in range(NS)) for a in range(4) for c in (0, 1)]
+MCEN = dict(sorted(Counter(MULT[0].values()).items()))
+MSAME = all(m == MULT[0] for m in MULT)
+
+MEXPR = " + ".join("{0} x {1}".format(MCEN[k], k) for k in sorted(MCEN))
+MSUM = sum(k * MCEN[k] for k in MCEN)
+
+gate(NL == 16 and SAME and len(SLOTSETS) == 8 and len(SLOTSETS[0]) == 16 and MSAME
+     and MCEN == {862: 12, 1364: 4} and MSUM == NS and NS == 15800, "G2",
+     "{0} letters, the same set on all {1} slots, multiplicity census {2}, and {3} = {4}"
+     .format(NL, len(SLOTSETS), dshow(MCEN), MEXPR, MSUM))
+
+# ---------------------------------------------------------------- G3 the interface matrix
+
+TMS = []
+for a in range(4):
+    J = Counter((KEY[i][(a, 0)], KEY[i][(a, 1)]) for i in range(NS))
+    TMS.append([[J[(x, y)] for y in range(16)] for x in range(16)])
+TR = TMS[0]
+AXEQ = sum(1 for a in range(4) for x in range(16) for y in range(16) if TMS[a][x][y] != TR[x][y])
+SYMM = sum(1 for x in range(16) for y in range(16) if TR[x][y] != TR[y][x])
+ECEN = dict(sorted(Counter(TR[x][y] for x in range(16) for y in range(16)).items()))
+TRC = sum(TR[x][x] for x in range(16))
+NEVEN = sum(1 for x in range(16) for y in range(16) if (TR[x][y] & 1) == 0)
+N36 = sum(1 for x in range(16) for y in range(16) if TR[x][y] == 36)
+NOT36 = 16 * 16 - N36
+
+gate(AXEQ == 0 and SYMM == 0 and TRC == 2000 and NEVEN == 256 and N36 == 48 and NOT36 == 208
+     and min(ECEN) == 18
+     and ECEN == {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}, "G3",
+     "T equal on {0} axes, symmetric, trace {1}, all {2} even, {3} at 36 and {4} not; {5}"
+     .format(len(TMS), TRC, NEVEN, N36, NOT36, cshow(ECEN)))
+
+# ---------------------------------------------------------------- G4 the tetra alphabet and its producers
+
+TALL = sorted({tet for L in ALLK for tet in L}, key=lambda f: sorted(f))
+TIX = {tet: a for a, tet in enumerate(TALL)}
+NT_LEN = len(TALL)
+SIDE0 = set(FACE[(t, 0, 0)] for t in USED if (t, 0, 0) in FACE)
+SIDE1 = set(FACE[(t, 0, 1)] for t in USED if (t, 0, 1) in FACE)
+
+BITS = [0] * len(KEPT)
+for i, s in enumerate(SOLS):
+    b = 1 << i
+    for t in s:
+        BITS[t] |= b
+COL = [BITS[t] for t in USED]
+ALLONE = (1 << NS) - 1
+
+PRODS = [[[] for _ in range(NT_LEN)], [[] for _ in range(NT_LEN)]]
+for t in USED:
+    for s in (0, 1):
+        f = FACE.get((t, 0, s))
+        if f is not None:
+            PRODS[s][TIX[f]].append(t)
+
+NT = [[0] * NT_LEN, [0] * NT_LEN]
+DJ = 0
+for s in (0, 1):
+    for a in range(NT_LEN):
+        v = 0
+        tot = 0
+        for t in PRODS[s][a]:
+            v ^= BITS[t]
+            tot += pc(BITS[t])
+        NT[s][a] = v
+        if pc(v) != tot:
+            DJ += 1
+
+FRM0 = []
+FRM1 = []
+PCEN = Counter()
+OVER = 0
+for s in SOLS:
+    p0 = frozenset(t for t in s if (t, 0, 0) in FACE)
+    p1 = frozenset(t for t in s if (t, 0, 1) in FACE)
+    FRM0.append(p0)
+    FRM1.append(p1)
+    PCEN[(len(p0), len(p1))] += 1
+    if p0 & p1:
+        OVER += 1
+PCEN = dict(PCEN)
+
+gate(NT_LEN == 24 and SIDE0 == set(TALL) and SIDE1 == set(TALL) and DJ == 0 and OVER == 0
+     and NCOR == 1 and CORNS == 5 and PCEN == {(6, 6): 15800}, "G4",
+     "{0} tetra, same set both sides, producer supports disjoint, {1}-corner pieces give disjoint sides, census {2}"
+     .format(NT_LEN, CORNS, dshow(PCEN)))
+
+# ---------------------------------------------------------------- G5 the letter-tetra incidence
+
+AM = [[1 if TALL[a] in ALLK[k] else 0 for a in range(NT_LEN)] for k in range(16)]
+ARS = set(sum(AM[k]) for k in range(16))
+ACS = set(sum(AM[k][a] for k in range(16)) for a in range(NT_LEN))
+
+RS = sorted(ARS)[0]
+CS = sorted(ACS)[0]
+
+gate(len(AM) == 16 and NT_LEN == 24 and ARS == {6} and ACS == {4} and len(AM) * RS == NT_LEN * CS
+     and len(AM) * RS == 96, "G5",
+     "incidence A is {0} by {1}, every row sum {2}, every column sum {3}, and {0} x {2} = {4} = {1} x {3}"
+     .format(len(AM), NT_LEN, RS, CS, len(AM) * RS))
+
+# ---------------------------------------------------------------- G6 the transport identity
+
+NM = [[pc(NT[0][a] & NT[1][b]) for b in range(NT_LEN)] for a in range(NT_LEN)]
+MIS = 0
+for a in range(NT_LEN):
+    for b in range(NT_LEN):
+        tot = 0
+        for k in range(16):
+            if AM[k][a]:
+                row = TR[k]
+                for j in range(16):
+                    if AM[j][b]:
+                        tot += row[j]
+        if tot != NM[a][b]:
+            MIS += 1
+NCEN = dict(sorted(Counter(NM[a][b] for a in range(NT_LEN) for b in range(NT_LEN)).items()))
+NEV = sum(1 for a in range(NT_LEN) for b in range(NT_LEN) if (NM[a][b] & 1) == 0)
+
+gate(MIS == 0 and NEV == 576 and NT_LEN * NT_LEN == 576
+     and NCEN == {862: 168, 872: 48, 894: 48, 904: 168, 1270: 24, 1280: 48, 1322: 48, 1332: 24}, "G6",
+     "N = A-transpose T A on all {0} entries, {1} misses, all {2} even; {3}"
+     .format(NT_LEN * NT_LEN, MIS, NEV, cshow(NCEN)))
+
+# ---------------------------------------------------------------- G7 the GF(2) ranks
+
+
+def badd(basis, v):
+    while v:
+        b = v.bit_length() - 1
+        if b in basis:
+            v ^= basis[b]
+        else:
+            basis[b] = v
+            return True
+    return False
+
+
+def inspan(basis, v):
+    while v:
+        b = v.bit_length() - 1
+        if b not in basis:
+            return False
+        v ^= basis[b]
+    return True
+
+
+BA = {}
+for k in range(16):
+    r = 0
+    for a in range(NT_LEN):
+        if AM[k][a]:
+            r |= (1 << a)
+    badd(BA, r)
+RKA = len(BA)
+KERA = 16 - RKA
+
+BT = [{}, {}]
+for s in (0, 1):
+    for a in range(NT_LEN):
+        badd(BT[s], NT[s][a])
+    badd(BT[s], ALLONE)
+RKT = [len(BT[0]), len(BT[1])]
+
+BC = {}
+for v in COL:
+    badd(BC, v)
+badd(BC, ALLONE)
+RKC = len(BC)
+
+gate(RKA == 10 and KERA == 6 and RKT == [10, 10] and RKC == 88, "G7",
+     "GF(2) ranks: A has rank {0} with kernel dimension {1}; tetra span with all-ones {2} on both sides; used columns with all-ones {3}"
+     .format(RKA, KERA, RKT[0], RKC))
+
+# ---------------------------------------------------------------- G8 letter non-affinity
+
+LET = [[0] * 16, [0] * 16]
+for i in range(NS):
+    b = 1 << i
+    LET[0][KEY[i][(0, 0)]] |= b
+    LET[1][KEY[i][(0, 1)]] |= b
+AFF = []
+for s in (0, 1):
+    AFF.append(sum(1 for k in range(16) if inspan(BT[s], LET[s][k])))
+    AFF.append(sum(1 for k in range(16) if inspan(BC, LET[s][k])))
+LSUM = sum(1 for s in (0, 1) for k in range(16) if pc(LET[s][k]) == sum(TR[k]))
+
+gate(AFF == [0, 0, 0, 0] and LSUM == 32 and NL == 16, "G8",
+     "{0} of {4} letters in the tetra span and {1} of {4} in the used-column span on side 0; {2} and {3} of {4} on side 1"
+     .format(AFF[0], AFF[1], AFF[2], AFF[3], NL))
+
+# ---------------------------------------------------------------- G9, G10 the pair stabilizer
+
+FIB = {}
+for i in range(NS):
+    FIB.setdefault((KEY[i][(0, 0)], KEY[i][(0, 1)]), []).append(i)
+E36 = sorted(kj for kj in FIB if TR[kj[0]][kj[1]] == 36)
+
+SCEN = Counter()
+IDOK = 0
+HELD = 0
+ODDCYC = 0
+for kj in E36:
+    k, j = kj
+    st = []
+    for g in STAB:
+        ps = PSI[g]
+        if g[1] & 1:
+            keep = (ps[k] == j and ps[j] == k)
+        else:
+            keep = (ps[k] == k and ps[j] == j)
+        if keep:
+            st.append(g)
+    SCEN[len(st)] += 1
+    if GID in st:
+        IDOK += 1
+    rest = [g for g in st if g != GID]
+    if len(rest) != 1:
+        continue
+    pm = permof(rest[0])
+    F = FIB[kj]
+    S = set(F)
+    if not all(pm[c] in S for c in F):
+        continue
+    HELD += 1
+    seen = set()
+    for c in F:
+        if c in seen:
+            continue
+        x = c
+        cyc = 0
+        while True:
+            seen.add(x)
+            x = pm[x]
+            cyc += 1
+            if x == c:
+                break
+        if cyc & 1:
+            ODDCYC += 1
+            break
+SCEN = dict(SCEN)
+
+gate(len(E36) == 48 and SCEN == {2: 48} and IDOK == len(E36), "G9",
+     "all {0} entry-36 pairs have pair stabilizer of order two inside the {1} slot-preserving maps, census {2}"
+     .format(len(E36), len(STAB), dshow(SCEN)))
+gate(HELD == 48 and ODDCYC == 48 and len(E36) == 48, "G10",
+     "{0} of {2} stubborn fibers held by the second stabilizer element, {1} of {2} with an odd cycle, so no subgroup pairs any"
+     .format(HELD, ODDCYC, len(E36)))
+
+# ---------------------------------------------------------------- G11 column parities
+
+ODDCOL = sum(1 for v in COL if (pc(v) & 1))
+EVT = sum(1 for s in (0, 1) for a in range(NT_LEN) if (pc(NT[s][a]) & 1) == 0)
+
+gate(ODDCOL == 192 and EVT == 48 and NT_LEN * 2 == 48, "G11",
+     "all {0} used-piece columns have odd support; {1} of {2} tetra functionals have even support, {3} tetra on each of both sides"
+     .format(ODDCOL, EVT, NT_LEN * 2, NT_LEN))
+
+# ---------------------------------------------------------------- G12, G13 boundary frames
+
+JOINT = [(FRM0[i], FRM1[i]) for i in range(NS)]
+L0 = {}
+L1 = {}
+LJ = {}
+for i in range(NS):
+    L0.setdefault(FRM0[i], set()).add(KEY[i][(0, 0)])
+    L1.setdefault(FRM1[i], set()).add(KEY[i][(0, 1)])
+    LJ.setdefault(JOINT[i], set()).add((KEY[i][(0, 0)], KEY[i][(0, 1)]))
+BAD0 = sum(1 for v in L0.values() if len(v) > 1)
+BAD1 = sum(1 for v in L1.values() if len(v) > 1)
+BADJ = sum(1 for v in LJ.values() if len(v) > 1)
+C0 = Counter(FRM0)
+CJ = Counter(JOINT)
+ODD0 = sum(1 for v in C0.values() if v & 1)
+ODDJ = sum(1 for v in CJ.values() if v & 1)
+
+WF = 0
+WP = 0
+for kj in E36:
+    cf = Counter(JOINT[i] for i in FIB[kj])
+    cp = Counter(tuple(KEY[i][(a, c)] for a in range(4) for c in (0, 1)) for i in FIB[kj])
+    if any(v & 1 for v in cf.values()):
+        WF += 1
+    if any(v & 1 for v in cp.values()):
+        WP += 1
+
+gate(len(L0) == 1024 and len(L1) == 1024 and len(LJ) == 6184 and BAD0 == 0 and BAD1 == 0 and BADJ == 0, "G12",
+     "{0} side-zero frames, {1} side-one frames, {2} joint frames; {3} frames carry two letters, {4} joint frames carry two pairs"
+     .format(len(L0), len(L1), len(LJ), BAD0 + BAD1, BADJ))
+gate(ODDJ == 3368 and ODD0 == 856 and len(CJ) == 6184 and len(C0) == 1024 and WF == 48 and WP == 48, "G13",
+     "{0} of {1} joint classes odd, {2} of {3} side-zero odd; inside {4} and {5} of the {6} fibers frames and profiles leave an odd class"
+     .format(ODDJ, len(CJ), ODD0, len(C0), WF, WP, len(E36)))
+
+# ---------------------------------------------------------------- G14, G15, G16 the exchange distance law
+
+DCEN = Counter()
+NV = 49
+ODDV = [0] * NV
+ODDC = [0] * NV
+REPKJ = E36[0]
+REP = None
+for kj in sorted(FIB):
+    F = FIB[kj]
+    n = len(F)
+    sets = [CSET[i] for i in F]
+    cnts = [Counter() for _ in range(n)]
+    for x in range(n):
+        sx = sets[x]
+        cx = cnts[x]
+        for y in range(x + 1, n):
+            d = 48 - 2 * len(sx & sets[y])
+            cx[d] += 1
+            cnts[y][d] += 1
+            DCEN[d] += 1
+    pref = []
+    for c in cnts:
+        acc = 0
+        row = []
+        for v in range(NV):
+            acc += c.get(v, 0)
+            row.append(acc)
+        pref.append(row)
+    for v in range(NV):
+        av = True
+        ac = True
+        for x in range(n):
+            if not (cnts[x].get(v, 0) & 1):
+                av = False
+            if not (pref[x][v] & 1):
+                ac = False
+            if not av and not ac:
+                break
+        if av:
+            ODDV[v] += 1
+        if ac:
+            ODDC[v] += 1
+    if kj == REPKJ:
+        REP = (F, sets, [dict(c) for c in cnts])
+
+VALS = sorted(DCEN)
+DTGT = [8, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 48]
+DEV = all((v & 1) == 0 for v in VALS)
+DMAX = 2 * CSIZE
+MISSV = [v for v in range(min(VALS), max(VALS) + 1, 2) if v not in DCEN]
+SHARE = sorted((DMAX - v) // 2 for v in MISSV)
+
+gate(VALS == DTGT and len(VALS) == 19 and MISSV == [10, 46] and SHARE == [1, 19] and min(VALS) == 8
+     and DEV and DMAX == 48, "G14",
+     "{0} even values {1}; least {2}, {3} absent, d = {4} - 2t, shared {5} absent"
+     .format(len(VALS), lshow(VALS), min(VALS), lshow(MISSV), DMAX, lshow(SHARE)))
+gate(max(ODDV) == 0 and max(ODDC[c] for c in range(DMAX)) == 0 and ODDC[DMAX] == 256 and len(FIB) == 256, "G15",
+     "all-odd degrees: {0} of {1} fibers at every value and every cutoff below {2}; at cutoff {2}, {3} of {1}, tautological complete graph"
+     .format(max(ODDV), len(FIB), DMAX, ODDC[DMAX]))
+
+RF, RSETS, RCNT = REP
+RN = len(RF)
+DMAT = [[0] * RN for _ in range(RN)]
+for x in range(RN):
+    for y in range(x + 1, RN):
+        d = 48 - 2 * len(RSETS[x] & RSETS[y])
+        DMAT[x][y] = d
+        DMAT[y][x] = d
+MINS = []
+PART = []
+MULTI = 0
+AGREE = 0
+for x in range(RN):
+    best = min(DMAT[x][y] for y in range(RN) if y != x)
+    MINS.append(best)
+    if best == min(RCNT[x]):
+        AGREE += 1
+    # ties are broken by the lowest within-fiber member index, which is cover order
+    ms = [y for y in range(RN) if y != x and DMAT[x][y] == best]
+    PART.append(ms[0])
+    if len(ms) > 1:
+        MULTI += 1
+NONINV = [x for x in range(RN) if PART[PART[x]] != x]
+MCEN2 = dict(sorted(Counter(MINS).items()))
+
+gate(RN == 36 and MCEN2 == {8: 36} and AGREE == RN and MULTI > 0 and len(NONINV) > 0, "G16",
+     "first entry-36 fiber: least-distance census {0}, {1} members with a tied minimizer, {2} not paired back, so no involution"
+     .format(dshow(MCEN2), MULTI, len(NONINV)))
+
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+PEAK = RSS // (1024 * 1024) if sys.platform == "darwin" else RSS // 1024
+emit("resource: under {0} s, under {1} MB".format(((int(time.time() - T0) // 60) + 1) * 60, ((PEAK // 250) + 1) * 250))
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

Source-only triple for cycle 788 of the lane, plus a separate `audit-infra:` commit acknowledging the new note in the citation-graph manifest (the sole sanctioned `docs/audit/data` change):

- `docs/PHYSICAL_CELL_CUTTING_INTERFACE_EVENNESS_ROUTES_CYCLE788_NOTE_2026-08-14.md`
- `scripts/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.py`
- `logs/runner-cache/physical_cell_cutting_interface_evenness_routes_cycle788_2026_08_14.txt`

## The science

Working on the unit four-cube cell: 2672 candidate five-corner pieces of unit determinant, 400 kept at the adjacency-cost floor 6, 15800 exact covers by 24 pieces, 192 used pieces, order-384 cell symmetry group, sixteen-letter facet alphabet, and the transfer matrix from the previous cycle — even in every entry, with the entry-36 orbit (48 fibers) as the named wall where evenness is measured, not derived. This cycle asks **what mechanism produces the evenness** and refutes five candidate routes, all in exact integer/GF(2) arithmetic on geometry rebuilt from the corner list.

- **Letters are not linear in the pieces.** Over GF(2), the sixteen letter indicator vectors on covers are compared against the span of the 192 used-piece columns (rank 88 with the all-ones vector adjoined) and against the span of the 24 tetra functionals per side (rank 10 each): **0 of 16 letters lie in either span, on either side**. No GF(2)-affine functional of the piece content computes a letter, so evenness cannot be a linear-algebra corollary at the letter level.
- **No symmetry pairs the wall.** For each of the 48 uncovered fibers, the subgroup of the 96 facet-holding maps fixing the letter pair has order **exactly 2** (census: all 48 at order 2), and in every fiber the nontrivial element acts with at least one odd cycle. Since any pairing subgroup would have to act with all-even orbits, **no subgroup of the cell symmetry group pairs any uncovered fiber** — a two-case theorem covering the wall completely.
- **Letter evenness is a corollary, not a mechanism.** With A the 16 x 24 letter-tetra incidence matrix (row sums 6, col sums 4), the letter-pair count matrix N satisfies **N = A^T T A exactly** (0 misses of 576 entries), where T is the piece-level transfer matrix. So N-evenness follows from T-evenness by transport and carries no independent information. A has GF(2) rank 10 with kernel dimension 6: a **six-dimensional invisible letter-functional quotient** that the piece level cannot see — named as the next surface. (N's value census puts 862 and 904 tied at 168 apiece; the note flags the tie as an unexplained coincidence.)
- **Frames determine letters but do not pair the wall.** Every cover meets each boundary cube in a six-piece producer set on each side (census: all 15800 covers at (6,6), sides disjoint by a five-corner argument). The induced boundary frame is **single-valued onto the letter**: 1024 side-0 classes and 6184 joint classes, 0 exceptions — frame determinacy holds, a finer carrier than the letter. But as an evenness mechanism it fails: 3368 of 6184 joint classes are odd, 856 of 1024 side-0 classes are odd, and **inside the wall all 48 fibers have odd classes under both the within-fiber joint-frame partition and the full eight-slot profile partition**.
- **Column parities.** All 192 used-piece columns have odd support over the 15800 covers, and all 24 tetra functionals have even support on both sides — certified structure the mechanism hunt must respect.
- **The exchange-distance law.** Any two covers differ in an even number of pieces: d = 48 - 2t where t is the shared count, taking exactly 19 values, the even numbers from 8 to 48 with 10 and 46 absent — two covers never share exactly 1 or exactly 19 pieces, and the least exchange swaps four pieces. Odd-degree counting on the exchange graph is refuted **at every distance-value rule (0 of 256 pass) and every cutoff below 48**; the cutoff-48 pass is the tautological complete graph and is guarded as such in the note.
- **Inside a representative fiber.** In the first entry-36 fiber (36 members), every member's nearest partner sits at distance 8, but the least-distance pairing is neither unique (tied minimizers exist) nor involutive — nearest-partner matching supplies no free pairing either.

Honest boundary: the censuses, ranks, class counts, and parities are complete measurements at the declared finite scope; the two-case stabilizer theorem, the N = A^T T A identity, frame determinacy, and the distance law are derived. The evenness of the entry-36 orbit itself remains measured, not derived — this cycle narrows the mechanism space by five refuted routes and names two open entrances: the six-dimensional invisible letter-functional quotient and frame determinacy as a finer carrier.

## Verification

- Runner: stdlib only, exact arithmetic, no file I/O; my own independent re-run exits 0 with `TOTAL: PASS=16 FAIL=0` and byte-identical output to the cache.
- Independent execution per written spec with executor self-check, followed by my own adversarial review: line-by-line read of note and runner, a fabrication hunt (the N = A^T T A check crosses two implementations sharing no arithmetic, the stabilizer walk is computed on the rebuilt group, the distance scan is complete over all values and cutoffs, every gate discriminating), and a mechanical banned-language/number-discipline sweep with 0 flags. The review caught and fixed two defects: one interior gate was tightened from an at-least-one condition to the exact count the note cites (forty-eight, both partitions), and the runner docstring's route count was corrected to match the note (five refuted routes, not six — the column parities and the distance law are certified structure, not refuted mechanisms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
