### PR TITLE
feat(cycle789): free-fold parity reduction on the interface wall fibers

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_INTERFACE_FREE_FOLD_REDUCTION_CYCLE789_NOTE_2026-08-14.md
+++ b/docs/PHYSICAL_CELL_CUTTING_INTERFACE_FREE_FOLD_REDUCTION_CYCLE789_NOTE_2026-08-14.md
@@ -1,0 +1,268 @@
+# Physical cell cutting: the free fold reduction, full-group rigidity at the interface wall, and the quotient that sees the heavy letters
+
+Date: 2026-08-14
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: enumerate the folded cuttings directly in the quotient of the cell by the free involution and test whether the evenness of the folded count is forced there; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: exact stabilizer rigidity in the whole cell group, a free involution on the declared unit four-cube object, the parity reduction of the stubborn interface fibers, two refutation certificates, and the letter-functional quotient; no physical or lattice-wide identification`
+- `audit_required_before_effective_retained: true`
+- `bare_retained_allowed: false`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the
+unit four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 pieces that
+survive at the adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400
+assemble into, the 192 pieces that occur in at least one cutting, the 384 signed coordinate maps
+of the cell, and the slot-preserving subgroup of order ninety-six that holds the two boundary
+three-cubes of axis zero as a pair. Each cutting dissects each boundary three-cube into a
+tetrahedral pattern drawn from a support of 24; exactly 16 such patterns occur, the same 16 on
+each of the 8 slots, split as 12 light letters of slot multiplicity 862 and 4 heavy letters of
+multiplicity 1364. Reading the pair of letters on the two slots of axis zero gives the interface
+matrix, whose trace is 2000 and which has exactly 48 entries equal to 36. Those 48 entries are
+the wall this lane has been working against: each of the 48 fibers holds 36 cuttings, every
+interface entry is even, and that evenness has never been derived.
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+derived by the linked runner from that object alone: it rebuilds the whole object from the
+corner list before any gate runs, uses the standard library only, performs no file input or
+output, uses no randomness, and gates each recomputed census against the value stated here so
+that a wrong object would fail rather than pass quietly.
+
+One framing duty applies to every census below and is stated once here rather than repeated.
+The 48 wall entries form a single orbit under the induced action of the side-preserving slot
+maps on letter pairs, so any quantity attached to a fiber is automatically constant across the
+48. Per-fiber uniformity is therefore a corollary of that transitivity, not independent
+evidence; the runner nevertheless recomputes each census over all 48 fibers separately, because
+the transitivity is itself one of the measured facts and should not be assumed while it is
+being used.
+
+## Stabilizer rigidity in the whole cell group
+
+The previous cycle worked inside the slot-preserving subgroup of order ninety-six, where each
+wall fiber was already known to have a setwise stabilizer of order two. The natural worry is
+that this order-two answer is an artefact of having restricted the group: a larger stabilizer
+in the full cell group would change what a fold can mean. It does not.
+
+Every one of the 384 signed coordinate maps of the cell permutes the 15800 cuttings — the
+runner checks bijectivity on the nose for each map and finds no defect. Computing the setwise
+stabilizer of each wall fiber inside that full group gives the census {2: 48}: order exactly
+two for all 48 fibers, the same order as inside the subgroup of order ninety-six. Moreover the
+single nontrivial element of each stabilizer lies inside that subgroup in all 48 cases, and in
+all 48 cases it is side-swapping: it exchanges the two boundary slots of axis zero. Widening
+the group from ninety-six to 384 adds no element to any wall stabilizer.
+
+This is the sense in which the fold is canonical. Each wall fiber carries exactly one
+nontrivial symmetry of the cell, that symmetry reverses the two sides of the interface, and
+there is no larger symmetry to be found by enlarging the group.
+
+## The fold acts freely on the geometry
+
+Call the nontrivial stabilizer element of a fiber its fold. The fold is free wherever it can be
+tested. On corners its cycle type census is {(2, 8): 48}: eight two-orbits, no fixed corner, in
+all 48 fibers. On the 400 kept pieces it fixes none — the fixed-piece census over the 48 folds
+is {0: 48} — and therefore splits them into 200 two-orbits. It carries the 192 used pieces to
+themselves in all 48 fibers and splits them into 96 two-orbits.
+
+Freeness on pieces is what makes the fold useful rather than merely present. A symmetry that
+fixed some pieces could act on a cutting by rearranging a fixed part and leaving a remainder,
+and a fixed cutting would then carry no parity information. Here nothing at all is fixed below
+the level of a whole cutting.
+
+## The parity reduction and the sharpened wall
+
+On its own fiber of 36 cuttings, each fold has 14 fixed cuttings and 11 two-cycles, so
+36 = 14 + 2 x 11. The fixed-count census is {14: 48} and there are no longer cycles anywhere.
+The congruence this yields is derived, not measured: the size of a fiber and the number of
+cuttings the fold holds fixed differ by twice the number of two-cycles, so the fiber size is
+even exactly when the folded count is even. The wall moves inward by that congruence — the
+question "why is 36 even" becomes the strictly smaller question "why is 14 even".
+
+The 48 folded sets are pairwise disjoint, giving 672 distinct fold-invariant cuttings across
+the wall. Because the fold is free on pieces, a cutting it holds fixed cannot contain a piece
+the fold fixes; the fold must instead pair the 24 pieces of that cutting among themselves. The
+runner confirms exactly this over all 672 invariant cuttings: the fixed-piece census is
+{0: 672} and the swapped-pair census is {12: 672}. Every fold-invariant cutting is 12 swapped
+piece-pairs and nothing else.
+
+That is the reduction the cycle buys. It replaces a statement about 36 cuttings with a
+statement about 14 cuttings that each decompose into 12 disjoint pairs, and it does so by a
+derived congruence rather than by a re-measurement. The evenness of 14 is itself measured, not
+derived; nothing below removes that gap.
+
+## No free element and the rigidity of the folded set
+
+Two natural continuations of the reduction fail, and both failures are exact.
+
+The first would be to find an element of the cell group acting on a fiber with no fixed cutting
+at all — a genuinely free action, which would make the fiber size even for the plainest
+possible reason. No such element exists: over all 48 fibers, the number of fibers admitting a
+group element that acts without a fixed cutting is 0. The stabilizers have order two, and their
+nontrivial elements always fix 14 cuttings.
+
+The second would be to iterate: having reduced 36 to 14, look for a symmetry of the folded set
+that pairs its members. On the sample fiber, exactly 2 of the 384 maps hold the 14 folded
+cuttings as a set, and both of them act as the identity on those 14. Nothing in the symmetry of
+the cell pairs the folded cuttings, so the reduction does not repeat. The 14 folded cuttings
+between them use 80 of the used pieces, and their common part is empty, so they are not
+variations on a shared core.
+
+## Two refutations recorded as honest misses
+
+Neither of the two most plausible mechanisms for the evenness of 14 survives.
+
+The first candidate is a pairing by boundary frames. Reading, for each cutting, the pair of
+piece sets that carry the two boundary three-cubes gives a partition of each fiber into joint
+frame classes. In all 48 fibers there are 14 such classes with size multiset
+[1,1,1,2,2,2,2,2,2,3,3,5,5,5], of which 8 are odd, and the fold permutes the classes with the
+crosstab (4, 4, 2, 4) of held-odd, swapped-odd, held-even and swapped-even classes. The
+coincidence of the two counts — 14 classes and 14 folded cuttings — invites a bijection, and
+there is none: the distribution of folded cuttings per class is {0: 8, 1: 1, 2: 2, 3: 3} in all
+48 fibers, so eight classes contain no folded cutting at all while one class contains three.
+All 14 folded cuttings lie inside the 6 classes the fold holds, which is a genuine constraint,
+but it is far weaker than a pairing.
+
+The second candidate is an odd-degree counting argument. Build a graph on the 14 folded
+cuttings of a fiber by joining two of them when their shared-piece count is exactly t, and a
+second family by joining them when the shared count is at least t. Over the whole admissible
+range this gives 49 distinct rules, and if any of them made every degree odd, the evenness of
+14 would follow immediately from the parity of the degree sum. Every one of the 49 rules fails:
+the all-degrees-odd pass count is 0 of 48 fibers for each. The best any non-tautological rule
+achieves is 10 odd degrees out of 14.
+
+One rule does pass in all 48 fibers and is excluded on principle rather than on evidence: the
+at-least-zero rule, which joins every pair and therefore gives every member degree 13. That
+rule has all degrees odd precisely when the number of members is even, which is the statement
+it would be used to establish. Counting it as a mechanism would be circular, so it is recorded
+here as tautological, excluded, and reported as such by the runner rather than silently
+dropped.
+
+## The quotient sees the heavy letters and not the wall
+
+The final probe asks whether the alphabet itself carries the missing parity. Each of the 16
+letters is a set of tetrahedral pieces drawn from a support of 24, giving a letter-tetra
+incidence matrix with row sums 6 and column sums 4. Over the two-element field it has rank 10
+and its left kernel has dimension 6, so there are 64 functionals vanishing on every letter's
+incidence row. Evaluating all 64 on the 16 letters sorts the letters into exactly 10 types: 6
+two-letter classes and 4 singletons.
+
+The singletons are exactly the 4 heavy letters of multiplicity 1364, and the 12 light letters
+of multiplicity 862 fall into the 6 pairs. Nothing in the construction of the kernel knows
+about slot multiplicities, so this is a real coincidence of two independent readings of the
+alphabet: a rank computation over the two-element field reproduces the heavy-light split that
+the cutting count produces. The kernel is also stable under the folds — all 48 induced letter
+maps carry it to itself, and they induce only 6 distinct letter maps between them — with orbit
+census {1: 2, 3: 2, 4: 2, 6: 2, 12: 3} on the 64 functionals, 11 orbits, and exactly 2
+functionals held pointwise by all of them.
+
+The quotient nevertheless does not see the wall. Grouping letter pairs into orbits under the
+48 side-preserving letter maps gives 12 orbits, each carrying a single interface value, and the
+48 wall entries form one of them. Reading off each orbit's signature in the letter types gives
+only 7 distinct signatures among the 12 orbits, and the wall signature is shared: the entry-36
+orbit and the entry-52 orbit have the same signature, and so do the entry-90 and entry-100
+orbits. Whatever distinguishes the wall from its neighbours in the interface reading, the
+letter-functional quotient cannot express it.
+
+## Distances inside the folded set
+
+For orientation, the 14 folded cuttings of the sample fiber are spread out rather than
+clustered. With the exchange distance of two cuttings read off from the number of pieces they
+share, the census over the 91 pairs is 8:11, 12:1, 16:10, 20:5, 24:4, 28:14, 32:4, 36:14,
+40:10, 44:6 and 48:12. Twelve of the 91 pairs are fully apart, sharing no piece at all.
+
+The single nearest pair, at distance 12, shares 18 pieces, and 9 of its 12 swapped pairs
+coincide, so even the two most similar folded cuttings differ in a quarter of their pairing.
+Across the 14 folded cuttings only 40 distinct swapped pairs occur out of the 96 two-orbits
+available on used pieces, so the folded set draws on a restricted part of the pairing structure
+without concentrating on any small part of it.
+
+## Boundary and honest reading
+
+Measured, not derived, at the declared finite scope: the stabilizer census {2: 48} in the full
+cell group; the corner cycle type {(2, 8): 48} and the free action on kept and used pieces; the
+fixed-count census {14: 48}; the frame-class size multiset and crosstab; the 49 refuted counting
+rules; the rank 10 and kernel dimension 6 of the incidence matrix together with the coincidence
+of its 4 singleton types with the 4 heavy letters; the orbit and signature censuses of the
+quotient; the distance census over the 91 pairs; and, above all, the evenness of the folded
+count 14 itself, which remains measured, not derived.
+
+Derived at the declared finite scope: the congruence 36 = 14 + 2 x 11 and with it the reduction
+of the evenness of a fiber to the evenness of its folded count; the decomposition of every one
+of the 672 fold-invariant cuttings into 12 swapped piece-pairs with no fixed piece, which
+follows from freeness on pieces; the disjointness of the 48 folded sets; the exclusion of the
+at-least-zero rule as tautological; and the constancy of every per-fiber census, which follows
+from the single-orbit transitivity of the 48 wall entries.
+
+All of the above are computational identities of the declared unit four-cube object, its 15800
+cuttings, and the order-384 symmetry group of the cell. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+What the cycle buys is a strictly smaller wall and a cleaner statement of it. The evenness of
+36 is no longer a bare measurement: it reduces, by a derived congruence, to the evenness of 14,
+and those 14 cuttings are now known concretely as the fold-invariant ones, each a set of 12
+swapped piece-pairs. What the cycle does not buy is the evenness of 14. The cell symmetry does
+not pair the folded cuttings, boundary frames do not pair them, no shared-count rule makes
+their degrees odd, and the letter-functional quotient cannot even separate the wall from its
+neighbours.
+
+## Next entrance
+
+The named next entrance is direct enumeration in the quotient. Because the fold acts freely on
+the 192 used pieces with 96 two-orbits, a fold-invariant cutting is exactly a selection of 12
+of those two-orbits that tiles the cell, and the folded count is the number of such selections.
+That is a smaller and more rigid counting problem than the one this lane has been attacking,
+and it is stated entirely inside the declared object. Whether its evenness is forced there is
+open; nothing about it is claimed in this note.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.py](../scripts/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.txt](../logs/runner-cache/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, finishes
+in well under a minute on the reference machine, and stays far below one gigabyte. Its final
+line is `TOTAL: PASS=14 FAIL=0`, and it exits nonzero if any gate fails.
+
+## Review record and boundary
+
+- The runner prints censuses, cycle types, ranks and the distance value list; the interface
+  matrix, the incidence matrix and the fiber membership lists are deliberately not printed, so
+  the note quotes their censuses and the identities between them instead.
+- The pair orbits of the letter-functional probe are taken under the side-preserving slot maps
+  acting on both coordinates, and the signature of an orbit is the set of letter-type pairs it
+  meets. Both choices are stated because other group and signature choices give other orbit
+  counts; the blindness result is reported for the stated choice only.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a
+  commit cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- The sibling stems `PHYSICAL_CELL_CUTTING_INTERFACE_EVENNESS_ROUTES_CYCLE788_NOTE_2026-08-14`
+  and `PHYSICAL_CELL_CUTTING_INTERFACE_TRANSFER_SPECTRUM_CYCLE787_NOTE_2026-08-14` are not yet
+  on main and are referenced by name only.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13829,6 +13829,10 @@
   "physical_cell_cutting_hidden_three_bit_geometry_cycle743_note_2026-08-05": {
    "deps_hash": "9126ac46777c",
    "out_degree": 2
+  },
+  "physical_cell_cutting_interface_free_fold_reduction_cycle789_note_2026-08-14": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_least_computing_sets_cycle737_note_2026-08-05": {
    "deps_hash": "ba0326da985f",

--- a/logs/runner-cache/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.txt
+++ b/logs/runner-cache/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.txt
@@ -1,0 +1,32 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.py
+runner_sha256: a19abaa0bb6ccb4cf9f5bb77bdc42b515e14bb6f8b794fcd95bcac9db84f6ea9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 22.90
+status: ok
+----- stdout -----
+PASS G1 2672 five-corner unit-volume pieces, cost floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, slot subgroup 96
+PASS G2 16 letters on each of 8 slots, multiplicity census {862: 12, 1364: 4}, trace 2000, 48 entries at 36, 48 fibers of 36 cuttings
+PASS G3 all 384 maps permute the 15800 cuttings, 0 defects; setwise fiber stabilizer census {2: 48}, all inside the 96, side-swapping 48 of 48
+PASS G4 corner cycle types {(2, 8): 48} at 0 fixed corners; fixed kept pieces {0: 48}; 200 kept and 96 used two-orbits, used set closed 48 of 48
+PASS G5 each fold fixes 14 of its 36 cuttings and pairs the rest, 36 = 14 + 2 x 11; census {14: 48}; 672 folded cuttings, all distinct
+PASS G6 each of the 672 folded cuttings splits into 12 swapped piece-pairs with no fixed piece: censuses {0: 672} and {12: 672}
+PASS G7 each fiber is held setwise by 2 of the 384 maps and no more; fibers carrying a fold with no fixed cutting: 0 of 48
+PASS G8 on the sample fiber 2 of the 384 maps hold the 14 folded cuttings and both act as the identity on them; support 80, common part 0
+PASS G9 exchange distances over the 91 folded pairs: 8:11 12:1 16:10 20:5 24:4 28:14 32:4 36:14 40:10 44:6 48:12
+G9 detail: the one distance-12 pair shares 18 pieces and 9 of 12 swapped pairs; 12 pairs fully apart; 40 swapped pairs of 96
+PASS G10 in all 48 fibers 14 joint frame classes of sizes [1,1,1,2,2,2,2,2,2,3,3,5,5,5], 8 of them odd, split (4, 4, 2, 4)
+G10 detail: folded cuttings per class {0: 8, 1: 1, 2: 2, 3: 3}; the class map is well defined in 48 fibers, each folded cutting in a held class
+PASS G11 49 shared-count rules on the 14 folded cuttings all pass 0 of 48 fibers; the at-least-zero rule passes 48 of 48 at degree 13
+G11 detail: the at-least-zero rule is the complete graph, tautological and excluded; the best other rule makes 10 of 14 degrees odd
+PASS G12 incidence 16 by 24, row sums 6, column sums 4, rank 10 over two elements, kernel dimension 6, 64 functionals, 10 letter types
+G12 detail: types 0+9 2+4 3+14 5+10 7+12 11+13 and singletons [1,6,8,15], exactly the 4 letters of multiplicity 1364
+PASS G13 all 48 folds hold the kernel and induce 6 distinct letter maps; orbit census {1: 2, 3: 2, 4: 2, 6: 2, 12: 3}, 11 orbits, 2 held pointwise
+PASS G14 12 pair orbits under the 48 side-preserving letter maps, the 48 wall entries one orbit; 7 distinct kernel signatures
+G14 detail: the wall signature is shared with the entry-52 orbit and entry-90 matches entry-100, so the wall is not singled out
+resource: under 60 s, under 250 MB
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.py
+++ b/scripts/physical_cell_cutting_interface_free_fold_reduction_cycle789_2026_08_14.py
@@ -1,0 +1,759 @@
+"""Physical cell cutting: the free fold reduction, full-group rigidity, the parity reduction, and quotient structure at the interface wall.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, the slot-preserving subgroup of order ninety-six for axis zero, and the sixteen-letter facet alphabet. Nothing outside
+that finite object enters any gate.
+
+The target of this cycle is again the evenness of the 48 stubborn interface fibers, the entry-36 orbit of the interface reading. The cover
+action is extended to the whole cell group and the fold element of each stubborn fiber is exhibited: widening the group from ninety-six to
+384 adds no element, the fold acts freely on corners, on kept pieces and on used pieces, and it therefore folds each stubborn fiber onto a
+smaller invariant set with no fixed piece anywhere. That reduction, two refutations that keep it honest, the distance structure of the
+folded set, and the letter-functional quotient that sees the heavy letters but not the wall are the content of the gates below.
+
+Gates G1 to G14, one line each with a few detail lines, then a resource line and the total line. Any failure exits nonzero."""
+
+import itertools
+import sys
+import time
+import resource
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+T0 = time.time()
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def cshow(d):
+    return " ".join("{0}:{1}".format(k, d[k]) for k in sorted(d))
+
+
+def lshow(v):
+    return "[" + ",".join("{0}".format(x) for x in v) + "]"
+
+
+def pc(x):
+    return bin(x).count("1")
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NCOR = len(set(len(KEPT[t]) for t in USED))
+CORNS = sorted(set(len(KEPT[t]) for t in USED))[0]
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+
+FACE = {}
+for t in USED:
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda f: sorted(sorted(t) for t in f))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+STAB = [(p, m) for (p, m) in G384 if p[0] == 0]
+NONSW = [g for g in STAB if not (g[1] & 1)]
+SWAPS = [g for g in STAB if (g[1] & 1)]
+GID = ((0, 1, 2, 3), 0)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def act3(g, pt):
+    p, m = g
+    return tuple(pt[p[i + 1] - 1] ^ ((m >> p[i + 1]) & 1) for i in range(3))
+
+
+PSI = {}
+PBAD = 0
+for g in STAB:
+    ps = tuple(KN[frozenset(frozenset(act3(g, v) for v in tet) for tet in ALLK[li])] for li in range(16))
+    if sorted(ps) != list(range(16)):
+        PBAD += 1
+    PSI[g] = ps
+
+PCACHE = {}
+
+
+def permof(g):
+    if g not in PCACHE:
+        mp = {t: KIDX[frozenset(actcorner(g, v) for v in KEPT[t])] for t in USED}
+        PCACHE[g] = [SIDX[frozenset(mp[t] for t in s)] for s in SOLS]
+    return PCACHE[g]
+
+
+# ================================================================ G1 the declared object
+
+gate(len(CAND) == 2672 and FLOOR == 6 and len(KEPT) == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24
+     and NU == 192 and NCOR == 1 and CORNS == 5 and len(G384) == 384 and len(STAB) == 96 and PBAD == 0, "G1",
+     "{0} five-corner unit-volume pieces, cost floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, slot subgroup {7}"
+     .format(len(CAND), FLOOR, len(KEPT), NS, CSIZE, NU, len(G384), len(STAB)))
+
+# ================================================================ G2 the alphabet and the wall
+
+MULT = [Counter(KEY[i][(a, c)] for i in range(NS)) for a in range(4) for c in (0, 1)]
+NSLOT = len(MULT)
+MSAME = all(m == MULT[0] for m in MULT)
+MCEN = dict(sorted(Counter(MULT[0].values()).items()))
+HEAVY = sorted(k for k in range(NL) if MULT[0][k] == 1364)
+JC = Counter((KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS))
+TR = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TR[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TR[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault((KEY[i][(0, 0)], KEY[i][(0, 1)]), []).append(i)
+E36 = sorted(kj for kj in FIB if TR[kj[0]][kj[1]] == 36)
+FSZ = sorted(set(len(FIB[kj]) for kj in E36))
+NF = len(E36)
+WSZ = FSZ[0]
+
+gate(NL == 16 and MSAME and NSLOT == 8 and MCEN == {862: 12, 1364: 4} and len(HEAVY) == 4
+     and TRC == 2000 and N36 == 48 and NF == 48 and FSZ == [36], "G2",
+     "{0} letters on each of {1} slots, multiplicity census {2}, trace {3}, {4} entries at {5}, {6} fibers of {5} cuttings"
+     .format(NL, NSLOT, dshow(MCEN), TRC, N36, WSZ, NF))
+
+# ================================================================ G3 the whole cell group on the cuttings
+
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+POS = [dict((c, x) for x, c in enumerate(F)) for F in FL]
+REPI = 0
+SSET = set(STAB)
+STCNT = [0] * NF
+NTRIV = [[] for _ in range(NF)]
+REPIMG = []
+DEFECT = 0
+for g in G384:
+    pm = permof(g)
+    PCACHE.clear()
+    if len(set(pm)) != NS:
+        DEFECT += 1
+    REPIMG.append([pm[c] for c in FL[REPI]])
+    for f in range(NF):
+        S = FS[f]
+        ok = True
+        for c in FL[f]:
+            if pm[c] not in S:
+                ok = False
+                break
+        if ok:
+            STCNT[f] += 1
+            if g != GID:
+                NTRIV[f].append((g, [POS[f][pm[c]] for c in FL[f]]))
+
+SCEN = dict(sorted(Counter(STCNT).items()))
+NONE1 = sum(1 for f in range(NF) if len(NTRIV[f]) == 1)
+INSUB = sum(1 for f in range(NF) for (g, im) in NTRIV[f] if g in SSET)
+SIDESW = sum(1 for f in range(NF) for (g, im) in NTRIV[f] if g[0][0] == 0 and (g[1] & 1))
+
+gate(DEFECT == 0 and SCEN == {2: 48} and NONE1 == 48 and INSUB == 48 and SIDESW == 48, "G3",
+     "all {0} maps permute the {1} cuttings, {2} defects; setwise fiber stabilizer census {3}, all inside the {4}, side-swapping {5} of {6}"
+     .format(len(G384), NS, DEFECT, dshow(SCEN), len(STAB), SIDESW, NF))
+
+# ================================================================ G4 the fold on corners, kept pieces, used pieces
+
+GS = [NTRIV[f][0][0] for f in range(NF)]
+IMG = [NTRIV[f][0][1] for f in range(NF)]
+US = set(USED)
+NK = len(KEPT)
+CTYPE = Counter()
+CFIX = Counter()
+KFIX = Counter()
+KORB = Counter()
+UORB = Counter()
+UCLOSED = 0
+MPS = []
+for f in range(NF):
+    g = GS[f]
+    cyc = Counter()
+    seen = set()
+    for v in range(len(CORN)):
+        if v in seen:
+            continue
+        x = v
+        n = 0
+        while True:
+            seen.add(x)
+            x = actcorner(g, x)
+            n += 1
+            if x == v:
+                break
+        cyc[n] += 1
+    CTYPE[tuple(sorted(cyc.items()))] += 1
+    CFIX[cyc.get(1, 0)] += 1
+    mp = dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in range(NK))
+    MPS.append(mp)
+    KFIX[sum(1 for t in range(NK) if mp[t] == t)] += 1
+    KORB[len(set(frozenset((t, mp[t])) for t in range(NK)))] += 1
+    UORB[len(set(frozenset((t, mp[t])) for t in USED))] += 1
+    if all(mp[t] in US for t in USED):
+        UCLOSED += 1
+
+
+def cyshow(d):
+    return "{" + ", ".join("({0}, {1}): {2}".format(k[0][0], k[0][1], d[k]) for k in sorted(d)) + "}"
+
+
+CT1 = len(CTYPE) == 1 and len(sorted(CTYPE)[0]) == 1
+gate(CT1 and sorted(CTYPE)[0] == ((2, 8),) and CTYPE[((2, 8),)] == 48 and CFIX == {0: 48} and KFIX == {0: 48}
+     and KORB == {200: 48} and UORB == {96: 48} and UCLOSED == 48, "G4",
+     "corner cycle types {0} at {1} fixed corners; fixed kept pieces {2}; {3} kept and {4} used two-orbits, used set closed {5} of {6}"
+     .format(cyshow(CTYPE), sorted(CFIX)[0], dshow(KFIX), sorted(KORB)[0], sorted(UORB)[0], UCLOSED, NF))
+
+# ================================================================ G5 the parity reduction on each fiber
+
+FIXC = Counter()
+TWOC = Counter()
+LONG = 0
+FIXSETS = []
+for f in range(NF):
+    im = IMG[f]
+    n = len(im)
+    fx = [x for x in range(n) if im[x] == x]
+    tw = 0
+    for x in range(n):
+        if im[x] != x:
+            if im[im[x]] == x:
+                tw += 1
+            else:
+                LONG += 1
+    FIXC[len(fx)] += 1
+    TWOC[tw // 2] += 1
+    FIXSETS.append([FL[f][x] for x in fx])
+ALLFIX = [c for F in FIXSETS for c in F]
+NFIX = sorted(FIXC)[0]
+NTWO = sorted(TWOC)[0]
+
+gate(FIXC == {14: 48} and TWOC == {11: 48} and LONG == 0 and len(ALLFIX) == 672 and len(set(ALLFIX)) == 672
+     and WSZ == NFIX + 2 * NTWO, "G5",
+     "each fold fixes {0} of its {1} cuttings and pairs the rest, {1} = {0} + 2 x {2}; census {3}; {4} folded cuttings, all distinct"
+     .format(NFIX, WSZ, NTWO, dshow(FIXC), len(ALLFIX)))
+
+# ================================================================ G6 no fixed piece inside a folded cutting
+
+PFIX = Counter()
+PSWAP = Counter()
+for f in range(NF):
+    mp = MPS[f]
+    for c in FIXSETS[f]:
+        s = SOLS[c]
+        PFIX[sum(1 for t in s if mp[t] == t)] += 1
+        PSWAP[len(set(frozenset((t, mp[t])) for t in s))] += 1
+
+gate(PFIX == {0: 672} and PSWAP == {12: 672}, "G6",
+     "each of the {0} folded cuttings splits into {1} swapped piece-pairs with no fixed piece: censuses {2} and {3}"
+     .format(len(ALLFIX), sorted(PSWAP)[0], dshow(PFIX), dshow(PSWAP)))
+
+# ================================================================ G7 no free element on any fiber
+
+FREEF = 0
+for f in range(NF):
+    for (g, im) in NTRIV[f]:
+        if all(im[x] != x for x in range(len(im))):
+            FREEF += 1
+            break
+
+gate(FREEF == 0 and set(STCNT) == set([2]), "G7",
+     "each fiber is held setwise by {0} of the {1} maps and no more; fibers carrying a fold with no fixed cutting: {2} of {3}"
+     .format(sorted(set(STCNT))[0], len(G384), FREEF, NF))
+
+# ================================================================ G8 rigidity of the folded set
+
+RFIX = FIXSETS[REPI]
+RFIXS = set(RFIX)
+SRC = FL[REPI]
+KEEPFIX = 0
+ACTID = 0
+for gi in range(len(G384)):
+    im = REPIMG[gi]
+    imgset = set(im[x] for x in range(len(SRC)) if SRC[x] in RFIXS)
+    if imgset == RFIXS:
+        KEEPFIX += 1
+        if all(im[x] == SRC[x] for x in range(len(SRC)) if SRC[x] in RFIXS):
+            ACTID += 1
+SUP = set()
+INTER = None
+for c in RFIX:
+    s = set(SOLS[c])
+    SUP |= s
+    INTER = s if INTER is None else (INTER & s)
+
+gate(KEEPFIX == 2 and ACTID == 2 and len(RFIX) == 14 and len(SUP) == 80 and len(INTER) == 0, "G8",
+     "on the sample fiber {0} of the {1} maps hold the {2} folded cuttings and both act as the identity on them; support {3}, common part {4}"
+     .format(KEEPFIX, len(G384), len(RFIX), len(SUP), len(INTER)))
+
+# ================================================================ G9 distances inside the folded set
+
+RSETS = [CSET[c] for c in RFIX]
+DC = Counter()
+PAIR12 = []
+DISJ = 0
+for x in range(len(RFIX)):
+    for y in range(x + 1, len(RFIX)):
+        sh = len(RSETS[x] & RSETS[y])
+        DC[2 * CSIZE - 2 * sh] += 1
+        if 2 * CSIZE - 2 * sh == 12:
+            PAIR12.append((x, y, sh))
+        if sh == 0:
+            DISJ += 1
+NPAIR = len(RFIX) * (len(RFIX) - 1) // 2
+MPREP = MPS[REPI]
+SP = [set(frozenset((t, MPREP[t])) for t in SOLS[c]) for c in RFIX]
+ALLSP = set()
+for s in SP:
+    ALLSP |= s
+AVAIL = len(set(frozenset((t, MPREP[t])) for t in USED))
+SH12 = PAIR12[0][2] if len(PAIR12) == 1 else -1
+SW12 = len(SP[PAIR12[0][0]] & SP[PAIR12[0][1]]) if len(PAIR12) == 1 else -1
+DTARG = {8: 11, 12: 1, 16: 10, 20: 5, 24: 4, 28: 14, 32: 4, 36: 14, 40: 10, 44: 6, 48: 12}
+
+gate(dict(DC) == DTARG and sum(DC.values()) == NPAIR and NPAIR == 91 and len(PAIR12) == 1 and SH12 == 18
+     and SW12 == 9 and DISJ == 12 and len(ALLSP) == 40 and AVAIL == 96, "G9",
+     "exchange distances over the {0} folded pairs: {1}".format(NPAIR, cshow(DC)))
+emit("G9 detail: the one distance-{0} pair shares {1} pieces and {2} of {3} swapped pairs; {4} pairs fully apart; {5} swapped pairs of {6}"
+     .format(12, SH12, SW12, sorted(PSWAP)[0], DISJ, len(ALLSP), AVAIL))
+
+# ================================================================ G10 joint frame classes on the folded set
+
+FRM0 = []
+FRM1 = []
+for s in SOLS:
+    FRM0.append(frozenset(t for t in s if (t, 0, 0) in FACE))
+    FRM1.append(frozenset(t for t in s if (t, 0, 1) in FACE))
+JOINT = [(FRM0[i], FRM1[i]) for i in range(NS)]
+
+CLSN = Counter()
+SIZEMS = Counter()
+ODDCL = Counter()
+CROSS = Counter()
+FIXDIST = Counter()
+INSIDE = 0
+WELLDEF = 0
+for f in range(NF):
+    F = FL[f]
+    im = IMG[f]
+    cls = {}
+    order = []
+    for c in F:
+        k = JOINT[c]
+        if k not in cls:
+            cls[k] = len(order)
+            order.append(k)
+    lab = [cls[JOINT[c]] for c in F]
+    nc = len(order)
+    CLSN[nc] += 1
+    sizes = Counter(lab)
+    SIZEMS[tuple(sorted(sizes.values()))] += 1
+    ODDCL[sum(1 for v in sizes.values() if v & 1)] += 1
+    cmap = {}
+    ok = True
+    for x in range(len(F)):
+        a = lab[x]
+        b = lab[im[x]]
+        if a in cmap and cmap[a] != b:
+            ok = False
+        cmap[a] = b
+    if ok:
+        WELLDEF += 1
+    fo = so = fe = se = 0
+    for a in range(nc):
+        odd = sizes[a] & 1
+        if cmap[a] == a:
+            fo, fe = (fo + 1, fe) if odd else (fo, fe + 1)
+        else:
+            so, se = (so + 1, se) if odd else (so, se + 1)
+    CROSS[(fo, so, fe, se)] += 1
+    fixin = Counter()
+    fixcls = set()
+    for x in range(len(F)):
+        if im[x] == x:
+            fixin[lab[x]] += 1
+            fixcls.add(lab[x])
+    FIXDIST[tuple(sorted(Counter(fixin.get(a, 0) for a in range(nc)).items()))] += 1
+    if all(cmap[a] == a for a in fixcls):
+        INSIDE += 1
+SMS = sorted(SIZEMS)[0]
+CRS = sorted(CROSS)[0]
+FDD = dict(sorted(FIXDIST)[0])
+
+gate(CLSN == {14: 48} and len(SIZEMS) == 1 and SMS == (1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 5, 5, 5) and ODDCL == {8: 48}
+     and len(CROSS) == 1 and CRS == (4, 4, 2, 4) and WELLDEF == 48 and len(FIXDIST) == 1
+     and FDD == {0: 8, 1: 1, 2: 2, 3: 3} and INSIDE == 48, "G10",
+     "in all {0} fibers {1} joint frame classes of sizes {2}, {3} of them odd, split ({4}, {5}, {6}, {7})"
+     .format(NF, sorted(CLSN)[0], lshow(SMS), sorted(ODDCL)[0], CRS[0], CRS[1], CRS[2], CRS[3]))
+emit("G10 detail: folded cuttings per class {0}; the class map is well defined in {1} fibers, each folded cutting in a held class"
+     .format(dshow(FDD), WELLDEF))
+
+# ================================================================ G11 the degree-parity refutation
+
+NV = 25
+EXACT = [0] * NV
+ATL = [0] * (NV + 1)
+MAXODD = 0
+DEG0 = set()
+for f in range(NF):
+    FX = FIXSETS[f]
+    n = len(FX)
+    sets = [CSET[c] for c in FX]
+    cnt = [Counter() for _ in range(n)]
+    for x in range(n):
+        for y in range(x + 1, n):
+            sh = len(sets[x] & sets[y])
+            cnt[x][sh] += 1
+            cnt[y][sh] += 1
+    suf = []
+    for c in cnt:
+        acc = 0
+        row = [0] * (NV + 1)
+        for v in range(NV - 1, -1, -1):
+            acc += c.get(v, 0)
+            row[v] = acc
+        suf.append(row)
+    for v in range(NV):
+        no = sum(1 for x in range(n) if cnt[x].get(v, 0) & 1)
+        if no == n:
+            EXACT[v] += 1
+        MAXODD = max(MAXODD, no)
+    for v in range(NV):
+        no = sum(1 for x in range(n) if suf[x][v] & 1)
+        if no == n:
+            ATL[v] += 1
+        if v >= 1:
+            MAXODD = max(MAXODD, no)
+    DEG0 |= set(suf[x][0] for x in range(n))
+NRULE = NV + NV - 1
+
+gate(max(EXACT) == 0 and max(ATL[1:]) == 0 and ATL[0] == 48 and DEG0 == set([13]) and MAXODD == 10, "G11",
+     "{0} shared-count rules on the {1} folded cuttings all pass {2} of {3} fibers; the at-least-zero rule passes {3} of {3} at degree {4}"
+     .format(NRULE, len(RFIX), max(EXACT), NF, sorted(DEG0)[0]))
+emit("G11 detail: the at-least-zero rule is the complete graph, tautological and excluded; the best other rule makes {0} of {1} degrees odd"
+     .format(MAXODD, len(RFIX)))
+
+# ================================================================ G12 the letter-tetra incidence and its left kernel
+
+TALL = sorted(set(tet for L in ALLK for tet in L), key=lambda ff: sorted(ff))
+NT = len(TALL)
+AM = [[1 if TALL[a] in ALLK[k] else 0 for a in range(NT)] for k in range(NL)]
+RSUM = sorted(set(sum(r) for r in AM))
+CSUM = sorted(set(sum(AM[k][a] for k in range(NL)) for a in range(NT)))
+ROWS = []
+for k in range(NL):
+    r = 0
+    for a in range(NT):
+        if AM[k][a]:
+            r |= (1 << a)
+    ROWS.append(r)
+BASIS = {}
+KER = []
+for k in range(NL):
+    x, tg = ROWS[k], 1 << k
+    while x:
+        b = x.bit_length() - 1
+        if b in BASIS:
+            x ^= BASIS[b][0]
+            tg ^= BASIS[b][1]
+        else:
+            BASIS[b] = (x, tg)
+            x = 0
+            break
+    else:
+        KER.append(tg)
+RKA = len(BASIS)
+FUNCS = []
+for mask in range(1 << len(KER)):
+    v = 0
+    for b in range(len(KER)):
+        if (mask >> b) & 1:
+            v ^= KER[b]
+    FUNCS.append(v)
+MISS = 0
+for v in FUNCS:
+    acc = 0
+    for k in range(NL):
+        if (v >> k) & 1:
+            acc ^= ROWS[k]
+    if acc != 0:
+        MISS += 1
+SIG = dict((k, tuple((u >> k) & 1 for u in KER)) for k in range(NL))
+CLS = {}
+for k in range(NL):
+    CLS.setdefault(SIG[k], []).append(k)
+CLASSES = sorted(CLS.values())
+SING = [c[0] for c in CLASSES if len(c) == 1]
+PAIRS = [c for c in CLASSES if len(c) == 2]
+
+gate(NT == 24 and RSUM == [6] and CSUM == [4] and RKA == 10 and len(KER) == 6 and len(FUNCS) == 64
+     and len(set(FUNCS)) == 64 and MISS == 0 and len(CLASSES) == 10 and len(PAIRS) == 6 and SING == HEAVY, "G12",
+     "incidence {0} by {1}, row sums {2}, column sums {3}, rank {4} over two elements, kernel dimension {5}, {6} functionals, {7} letter types"
+     .format(NL, NT, RSUM[0], CSUM[0], RKA, len(KER), len(FUNCS), len(CLASSES)))
+emit("G12 detail: types {0} and singletons {1}, exactly the {2} letters of multiplicity {3}"
+     .format(" ".join("+".join("{0}".format(k) for k in c) for c in PAIRS), lshow(SING), len(SING), 1364))
+
+# ================================================================ G13 the kernel under the folds
+
+PSIL = [PSI[GS[f]] for f in range(NF)]
+NDIST = len(set(PSIL))
+KSET = set(FUNCS)
+INV = 0
+for ps in PSIL:
+    if all(sum(1 << ps[k] for k in range(NL) if (u >> k) & 1) in KSET for u in FUNCS):
+        INV += 1
+PAR = dict((u, u) for u in FUNCS)
+
+
+def find(a):
+    while PAR[a] != a:
+        PAR[a] = PAR[PAR[a]]
+        a = PAR[a]
+    return a
+
+
+for ps in PSIL:
+    for u in FUNCS:
+        w = sum(1 << ps[k] for k in range(NL) if (u >> k) & 1)
+        ra, rb = find(u), find(w)
+        if ra != rb:
+            PAR[ra] = rb
+ORB = Counter(find(u) for u in FUNCS)
+OCEN = dict(sorted(Counter(ORB.values()).items()))
+FIXALL = sum(1 for u in FUNCS if all(sum(1 << ps[k] for k in range(NL) if (u >> k) & 1) == u for ps in PSIL))
+
+gate(INV == 48 and NDIST == 6 and OCEN == {1: 2, 3: 2, 4: 2, 6: 2, 12: 3} and len(ORB) == 11 and FIXALL == 2, "G13",
+     "all {0} folds hold the kernel and induce {1} distinct letter maps; orbit census {2}, {3} orbits, {4} held pointwise"
+     .format(INV, NDIST, dshow(OCEN), len(ORB), FIXALL))
+
+# ================================================================ G14 pair orbits and the kernel signature
+
+CLSID = {}
+for ci, c in enumerate(CLASSES):
+    for k in c:
+        CLSID[k] = ci
+PARP = {}
+for k in range(NL):
+    for j in range(NL):
+        PARP[(k, j)] = (k, j)
+
+
+def findp(a):
+    while PARP[a] != a:
+        PARP[a] = PARP[PARP[a]]
+        a = PARP[a]
+    return a
+
+
+for g in NONSW:
+    ps = PSI[g]
+    for k in range(NL):
+        for j in range(NL):
+            ra, rb = findp((k, j)), findp((ps[k], ps[j]))
+            if ra != rb:
+                PARP[ra] = rb
+GRP = {}
+for k in range(NL):
+    for j in range(NL):
+        GRP.setdefault(findp((k, j)), []).append((k, j))
+ROWSIG = []
+for r in GRP:
+    mem = GRP[r]
+    vals = sorted(set(TR[a][b] for (a, b) in mem))
+    ss = tuple(sorted(set(tuple(sorted((CLSID[a], CLSID[b]))) for (a, b) in mem)))
+    ROWSIG.append((vals[0], len(vals), len(mem), ss))
+SIGSET = set(r[3] for r in ROWSIG)
+S36 = [r for r in ROWSIG if r[0] == 36]
+S52 = [r for r in ROWSIG if r[0] == 52]
+S90 = [r for r in ROWSIG if r[0] == 90]
+S100 = [r for r in ROWSIG if r[0] == 100]
+SHARE36 = sorted((r[0], r[2]) for r in ROWSIG if r[3] == S36[0][3]) if S36 else []
+ONEVAL = all(r[1] == 1 for r in ROWSIG)
+
+gate(len(GRP) == 12 and ONEVAL and len(S36) == 1 and S36[0][2] == 48 and len(SIGSET) == 7
+     and S36[0][3] == S52[0][3] and S90[0][3] == S100[0][3] and SHARE36 == [(36, 48), (52, 48)], "G14",
+     "{0} pair orbits under the {1} side-preserving letter maps, the {2} wall entries one orbit; {3} distinct kernel signatures"
+     .format(len(GRP), len(NONSW), S36[0][2], len(SIGSET)))
+emit("G14 detail: the wall signature is shared with the entry-{0} orbit and entry-{1} matches entry-{2}, so the wall is not singled out"
+     .format(S52[0][0], S90[0][0], S100[0][0]))
+
+# ================================================================ totals
+
+RSS = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+PEAK = RSS // (1024 * 1024) if sys.platform == "darwin" else RSS // 1024
+emit("resource: under {0} s, under {1} MB".format(((int(time.time() - T0) // 60) + 1) * 60, ((PEAK // 250) + 1) * 250))
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with its sixteen corners, the four hundred kept unit-determinant five-corner pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet on each of the eight interface slots, and the forty-eight transfer-matrix entries at thirty-six — the named wall, whose evenness is measured, not derived. The cell group has order three hundred eighty-four; the slot-preserving subgroup has order ninety-six.

- **Stabilizer rigidity in the whole cell group.** Every one of the forty-eight wall fibers is held setwise by exactly one nontrivial map out of all three hundred eighty-four — and that map is always side-swapping and always lies inside the slot-preserving subgroup of order ninety-six. The wall's symmetry is as small as it could be, and it is the same shape in every fiber.
- **The fold is free.** The fiber's one nontrivial symmetry acts on the sixteen corners in eight two-cycles with no fixed corner, fixes none of the four hundred kept pieces, and closes the one hundred ninety-two used pieces into ninety-six two-orbits.
- **The parity reduction.** Acting on its own fiber of thirty-six cuttings, the fold fixes fourteen and pairs the remaining twenty-two, in every fiber: thirty-six equals fourteen plus twice eleven. The six hundred seventy-two folded cuttings are all distinct, and each one splits into twelve swapped piece-pairs with no fixed piece. The wall question "why is thirty-six even" reduces to "why is fourteen even" — a strictly smaller object. The evenness of fourteen is itself measured, not derived; nothing in the note removes that gap.
- **No shortcut exists.** No fiber carries a map acting freely on its cuttings (which would have derived evenness outright), and on the sample fiber the fourteen folded cuttings are rigid: only two maps of the three hundred eighty-four hold them, and both act as the identity on them.
- **Two refutations, reported as refutations.** The joint frame classes give fourteen classes per fiber but no bijection with the fourteen folded cuttings (eight classes hold none). Forty-nine shared-count degree rules on the folded sets all fail in every fiber; the single all-passing rule is the complete graph, which is tautological and excluded.
- **The quotient sees the heavy letters, not the wall.** The letter-tetra incidence has a six-dimensional kernel over two elements whose letter types recover exactly the four heavy letters. All forty-eight folds hold the kernel, but the wall orbit's kernel signature is shared with the entry-fifty-two orbit — the quotient is blind to the wall.

The honest boundary: everything here is an exact finite computational identity on the declared object, and nothing wider. The reduction relocates the evenness question; it does not close it. The named next entrance is direct enumeration of fold-invariant cuttings in the quotient, where a fold-invariant cutting is a selection of twelve of the ninety-six used-piece two-orbits that tiles the cell.

## Verification

- Runner re-run by the orchestrator in a clean shell: exit 0, `TOTAL: PASS=14 FAIL=0`, all fourteen gates recomputing their censuses from the rebuilt geometry.
- Full note read plus line-by-line runner review (fabrication hunt over both halves; every gate checked to discriminate; all printing routed through the guarded emitter).
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags (forbidden-string sweep, numeral containment, link inventory, line-length and stdout budgets).
- Adversarial probe on the quotient claim: an independent recomputation refuted the executor's side-suggestion that a multiset-valued kernel signature separates the wall orbit from the entry-fifty-two orbit — it does not, and the probe's exhaustion argument shows no kernel-type-valued statistic of any kind can separate the colliding orbits. The note's scoped blindness statement stands unchanged; the refutation strengthens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
