### PR TITLE
feat(cell-cutting): fiber linearization law, every wall fiber cover problem is a coset minimum-weight problem (cycle 792)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_FIBER_LINEARIZATION_LAW_CYCLE792_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_FIBER_LINEARIZATION_LAW_CYCLE792_NOTE_2026-08-15.md
@@ -1,0 +1,164 @@
+# The fiber linearization law: every wall fiber cover problem is a coset minimum-weight problem
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: derive the single fiber-independent weight census, or at least the parity of its minimum-weight count, from the kernel and its coset alone, beginning with whether the pairwise-distinct row systems carry one census because their kernel-and-coset pairs are equivalent under a relabelling of rows; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, at every wall fiber of the declared finite cell, of the rank and kernel of the fiber's point-row incidence over the field with two elements, of the coset carrying its cover solutions, of the weight census of that coset, of the identification of the fold-held cuttings with the coset minimum-weight members and with its exact covers, and of the complete refutation of translation carriers at both the fiber and the native level; no physical or lattice-wide identification`
+- `audit_required_before_effective_retained: true`
+- `bare_retained_allowed: false`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the
+unit four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive
+at the adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into,
+the 192 pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell.
+The pair of tetrahedral letters on the two slots of axis zero, drawn from a 16-letter alphabet,
+gives the interface matrix of trace 2000 with exactly 48 entries equal to 36. Each of those 48
+fibers holds 36 cuttings and is held setwise by exactly 2 of the 384 maps. Its nontrivial holder
+is that fiber's fold; the 48 folds are involutions and collapse to 6 distinct maps with serving
+census `{8: 6}`, and each fold holds 14 of its own fiber's 36 cuttings.
+
+The stem `PHYSICAL_CELL_CUTTING_SINGLE_FIBER_COVER_RIGIDITY_CYCLE791_NOTE_2026-08-15` is not yet
+on main and is referenced by name only. On one sample fiber it determined the whole group of row
+permutations preserving the cover instance, found the induced group on the 14 to have order 2 with
+no free involution among its elements, and found the only geometrically carried element to be the
+identity — so no permutation symmetry of that instance accounts for the evenness of 14. Its named
+entrance was to leave group actions and take the linear structure over the field with two
+elements. This note takes it, and takes it at all 48 fibers rather than one.
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+recomputed by the linked runner from that object alone: it rebuilds the object from the corner
+list before any gate runs, uses the standard library only, performs no file input or output and no
+randomness, and gates each recomputed value against the value stated here.
+
+## The law
+
+- **Per-fiber linearization.** Each fold cuts the 400 kept pieces into 200 two-orbits, with 0
+  singletons and 0 two-orbits whose two pieces share an interior sample point. Each of the fiber's
+  14 fold-held cuttings is an exact union of exactly 12 of those two-orbits, and exactly 40 of the
+  200 occur across the 14, so each held cutting is a weight-12 vector over the field with two
+  elements on 40 rows. Let N be the 625 by 40 point-row incidence matrix. At every one of the 48
+  fibers the rank of N is 32 and its kernel has dimension 8; the kernel is an even-weight code,
+  all 256 of its vectors having even weight; and the 13 differences of the held vectors from the
+  first all lie in the kernel and span it entirely. The affine hull of the 14 solutions is
+  therefore the full 256-element coset, and all 256 of its members solve the all-ones system.
+
+- **The exact characterization.** Exact cover in the integer sense — every one of the 625 sample
+  points lying in exactly one selected row — forces the all-ones system over the field with two
+  elements, so every exact cover of a 40-row instance lies in that coset. Inside the coset the
+  minimum weight is 12, the weight-12 members are exactly the 14 held vectors, and the members
+  that are genuine exact covers are exactly the same 14. Hence each 40-row instance has exactly
+  14 exact covers and they are the fiber's 14 fold-held cuttings: the count 14 is a coset
+  minimum-weight count.
+
+- **The universality.** One and the same weight census
+  `{12: 14, 14: 11, 16: 37, 18: 29, 20: 55, 22: 45, 24: 51, 26: 11, 28: 3}` — 1 distinct census
+  over the 48 fibers, of total 256 — while the 48 instances are pairwise distinct objects: 48
+  distinct fold-and-row-set pairs, 48 distinct 14-solution systems, and 672 held cuttings in the
+  union, which is 48 times 14, so no cutting is held in two fibers. Within a fold the 8 served
+  fibers share rows with census `{12: 24, 14: 24, 18: 48, 20: 24, 22: 48}` over the 168 within-fold
+  pairs: between 12 and 22 of the 40 rows in common, never all 40.
+
+- **The refuted translation.** A nonzero vector that translates the 14-solution set onto itself
+  must carry the first solution into the set, so the 13 differences are the complete candidate
+  list — nothing outside it can translate. All 13 fail at every fiber: 0 of 624 tests pass. The
+  same refutation holds natively, before any fiber is singled out: the sample fold holds 336 of
+  the 15800 cuttings, each an exact union of 12 of its 200 two-orbits, and of the 335 candidate
+  translations of that 336-element system, 0 pass. Together with the previous cycle, the parity
+  carrier of the evenness of 14 is neither a permutation symmetry of the instance nor a
+  translation of its solution set.
+
+## What the wall now asks
+
+The wall question was "why is 14 even". It is now exactly "why is the minimum-weight count of this
+one census even" — and it is one question rather than 48, because the census does not depend on
+the fiber even though the 48 instances are pairwise distinct. The cover problem has been replaced
+without residue by a coset problem: a kernel of dimension 8 over the field with two elements, one
+coset of it, and the count of minimum-weight members in that coset. Nothing about the parity of
+that count follows from what is proved here; what follows is that the parity question may now be
+asked of a linear object of dimension 8 rather than of a cover search over 400 pieces.
+
+## Boundary and honest reading
+
+Measured, not derived, at the declared finite scope: the weight census itself; the rows-per-point
+census `{2: 235, 3: 108, 4: 186, 5: 64, 6: 32}` of the sample fiber at letter pair `(0,4)`; the
+rank 32 and the kernel dimension 8; the within-fold row-sharing census; and, above all, the
+per-fiber count 14, whose evenness remains measured, not derived.
+
+Derived at the declared finite scope: that each fiber's cover problem is exactly a coset
+minimum-weight problem, since the weight-12 members of the coset and its exact covers are the same
+14 vectors at all 48 fibers; that the affine hull of the 14 is the whole coset, since the 13
+differences span the full kernel; that the count of exact covers of each 40-row instance is
+exactly 14; that the 48 instances are pairwise distinct while carrying 1 census; and that no
+nonzero translation preserves any of the 48 solution systems or the native 336-element system,
+the candidate lists of 13 and of 335 being complete.
+
+All of the above are computational identities of the declared unit four-cube object, its 15800
+cuttings, and the order-384 symmetry group of the cell. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+## Next entrance
+
+Derive the census — or at least the parity of its minimum-weight count — from the kernel and its
+coset alone. The first recon question is whether the 48 pairwise-distinct row systems carry one
+census because the 48 kernel-and-coset pairs are equivalent under a relabelling of rows, and if
+so, what carries that equivalence: the cell group cannot, since it already fails to move one
+fiber's solutions. If the equivalence is real but uncarried by the cell group, the parity question
+descends to a single kernel of dimension 8 and its distinguished coset, where a weight-count
+argument has room to work. Nothing about the outcome is claimed here.
+
+## Review record and boundary
+
+- Rows are the two-orbits of the 400 kept pieces under each fiber's own fold, and solutions are
+  that fiber's fold-held cuttings written as row sets. Both conventions are fixed before any
+  computation runs, and every statement is made for all 48 fibers, not for a chosen one.
+- Membership of the exact covers in the coset is not assumed from the standard linear-algebra
+  containment: the runner checks all 256 coset members against the all-ones system and against the
+  integer exact-cover condition point by point, and separately verifies each of the 14 held
+  cuttings as an exact cover of the 625 sample points.
+- The candidate lists for a translation are complete by the argument stated, so 0 passes refutes
+  translation carriers outright rather than reporting a failed search.
+- The runner prints censuses and counts; the incidence matrices, the row lists and the solution
+  vectors are not printed, so the note quotes censuses and identities instead.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a
+  commit cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.py](../scripts/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.txt](../logs/runner-cache/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, finishes in
+well under a minute on the reference machine, and stays far below one gigabyte. Its final line is
+`TOTAL: PASS=12 FAIL=0`, and it exits nonzero if any gate fails.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13809,6 +13809,10 @@
   "physical_cell_cutting_family_separator_cycle749_note_2026-08-08": {
    "deps_hash": "bca611691dd8",
    "out_degree": 1
+  },
+  "physical_cell_cutting_fiber_linearization_law_cycle792_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_flip_partner_carrier_bracket_cycle747_note_2026-08-08": {
    "deps_hash": "58892f7fde6e",

--- a/logs/runner-cache/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.py
+runner_sha256: b3ad3e99d2b17c8f076ac699d7a4d3a2e2006f4a41898ffade0bf6cdd0922881
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 14.74
+status: ok
+----- stdout -----
+PASS G1 2672 pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, 16 letters, trace 2000, 48 entries at 36
+PASS G2 each of the 48 fibers is held setwise by exactly 2 of the 384 cell maps; the 48 folds are 6 distinct involutions, census {8: 6}
+PASS G3 each of the 6 folds cuts the 400 kept pieces into 200 two-orbits, with 0 singletons and 0 interior overlaps inside an orbit
+PASS G4 at all 48 fibers the fold holds 14 cuttings, each an exact union of 12 two-orbits, and 40 rows occur
+G4 detail: all 672 held cuttings cover each of the 625 sample points exactly once, and 0 points are left uncovered
+G4 detail: the sample fiber at letter pair (0,4) has rows-per-point census {2: 235, 3: 108, 4: 186, 5: 64, 6: 32}
+PASS G5 the 625 by 40 incidence over the field with two elements has rank 32 and kernel dimension 8 at every fiber, 1 distinct tuple
+PASS G6 the kernel basis of 8 vectors annihilates the incidence at 48 of 48 fibers; all 256 kernel vectors have even weight at 48 of 48
+PASS G7 the 13 differences lie in the kernel and span dimension 8 at 48 of 48 fibers; all 256 coset members solve the all-ones system
+PASS G8 the 48 fibers carry 1 distinct coset weight census, of total 256 and minimum weight 12
+G8 detail: that one census is {12: 14, 14: 11, 16: 37, 18: 29, 20: 55, 22: 45, 24: 51, 26: 11, 28: 3}
+PASS G9 the minimum-weight members and the exact covers of the coset are both exactly the 14 held cuttings at 48 of 48 fibers
+G9 detail: every exact cover of a 40-row instance solves the all-ones system, so each instance has exactly 14 exact covers
+PASS G10 the complete candidate list of 13 nonzero translations per fiber, 624 tests over the 48 fibers, gives 0 preserved systems
+PASS G11 the sample fold holds 336 of the 15800 cuttings, each a union of 12 of its 200 two-orbits; 335 candidates give 0 preserved systems
+PASS G12 48 distinct fold and row-set pairs, 48 distinct solution systems, 672 cuttings in the union, 168 within-fold fiber pairs
+G12 detail: the within-fold row-set intersection census is {12: 24, 14: 24, 18: 48, 20: 24, 22: 48}, never 40 at any pair
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.py
+++ b/scripts/physical_cell_cutting_fiber_linearization_law_cycle792_2026_08_15.py
@@ -1,0 +1,551 @@
+"""Physical cell cutting: every wall fiber cover problem is one coset minimum-weight problem over the field with two elements.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, and the sixteen-letter facet alphabet on the two slots of axis zero. Nothing outside that finite object enters any gate.
+
+The previous cycle settled the group side on a single fiber. This cycle takes the linear side on all 48 of them. For each fiber the fold is
+its unique nontrivial setwise holder, the rows are the two-orbits of the 400 kept pieces under that fold, the fold-held cuttings become
+vectors over the field with two elements, and the exact cover condition becomes an all-ones linear system whose solution set is one coset of
+the kernel. Gates G1 to G12, one line each with a few detail lines, then the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def popc(x):
+    return bin(x).count("1")
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NK = len(KEPT)
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+GID = ((0, 1, 2, 3), 0)
+
+FACE = {}
+for t in range(NK):
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda f: sorted(sorted(t) for t in f))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def compose(a, b):
+    p, m = a
+    q, n = b
+    r = tuple(q[p[i]] for i in range(4))
+    k = n
+    for j in range(4):
+        if (m >> j) & 1:
+            k ^= (1 << q[j])
+    return (r, k)
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+def rref(rows, ncols):
+    mat = [r for r in rows if r]
+    piv = []
+    r = 0
+    for c in range(ncols):
+        p = -1
+        for i in range(r, len(mat)):
+            if (mat[i] >> c) & 1:
+                p = i
+                break
+        if p < 0:
+            continue
+        mat[r], mat[p] = mat[p], mat[r]
+        for i in range(len(mat)):
+            if i != r and ((mat[i] >> c) & 1):
+                mat[i] ^= mat[r]
+        piv.append(c)
+        r += 1
+    return mat[:r], piv
+
+
+# ================================================================ G1 the declared object, the alphabet and the wall
+
+PAIROF = [(KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS)]
+JC = Counter(PAIROF)
+TRM = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TRM[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TRM[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(PAIROF[i], []).append(i)
+E36 = sorted(kj for kj in FIB if TRM[kj[0]][kj[1]] == 36)
+NF = len(E36)
+FSZ = sorted(set(len(FIB[kj]) for kj in E36))
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NL == 16 and TRC == 2000 and N36 == 48 and NF == 48 and FSZ == [36], "G1",
+     "{0} pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, {7} letters, trace {8}, {9} entries at {10}"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, len(G384), NL, TRC, N36, 36))
+
+# ================================================================ G2 the fold of every fiber
+
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+WALL = sorted(set(c for F in FL for c in F))
+POSW = {c: i for i, c in enumerate(WALL)}
+FOLD = [None] * NF
+STCNT = [0] * NF
+DEFECT = 0
+for g in G384:
+    mp = piecemap(g, USED)
+    if len(set(mp.values())) != NU:
+        DEFECT += 1
+    img = [SIDX[frozenset(mp[t] for t in SOLS[c])] for c in WALL]
+    for f in range(NF):
+        S = FS[f]
+        ok = True
+        for c in FL[f]:
+            if img[POSW[c]] not in S:
+                ok = False
+                break
+        if ok:
+            STCNT[f] += 1
+            if g != GID:
+                FOLD[f] = g
+
+DIST = sorted(set(FOLD))
+FIDX = {g: i for i, g in enumerate(DIST)}
+SERVE = dict(sorted(Counter(Counter(FOLD).values()).items()))
+INVOL = sum(1 for g in DIST if compose(g, g) == GID and g != GID)
+GREP = ((0, 3, 2, 1), 15)
+
+gate(DEFECT == 0 and set(STCNT) == set([2]) and len(WALL) == 1728 and len(DIST) == 6 and SERVE == {8: 6}
+     and INVOL == 6 and GREP in DIST, "G2",
+     "each of the {0} fibers is held setwise by exactly {1} of the {2} cell maps; the {0} folds are {3} distinct involutions, census {4}"
+     .format(NF, sorted(set(STCNT))[0], len(G384), len(DIST), dshow(SERVE)))
+
+# ================================================================ G3 the two-orbit table of each fold
+
+MPKS = []
+ORBS = []
+OIDX = []
+SING = 0
+OVL = 0
+NORB = set()
+for g in DIST:
+    mpk = piecemap(g, range(NK))
+    orbs = []
+    seen = set()
+    for t in range(NK):
+        if t in seen:
+            continue
+        u = mpk[t]
+        seen.add(t)
+        seen.add(u)
+        if u == t:
+            SING += 1
+        if MASK[t] & MASK[u]:
+            OVL += 1
+        orbs.append((t, u))
+    oi = {}
+    for i in range(len(orbs)):
+        oi[orbs[i][0]] = i
+        oi[orbs[i][1]] = i
+    MPKS.append(mpk)
+    ORBS.append(orbs)
+    OIDX.append(oi)
+    NORB.add(len(orbs))
+
+gate(len(MPKS) == 6 and NORB == set([200]) and SING == 0 and OVL == 0, "G3",
+     "each of the {0} folds cuts the {1} kept pieces into {2} two-orbits, with {3} singletons and {4} interior overlaps inside an orbit"
+     .format(len(DIST), NK, sorted(NORB)[0], SING, OVL))
+
+# ================================================================ the per-fiber linear systems
+
+GFIBS = [f for f in range(NF) if FOLD[f] == GREP]
+REPF = GFIBS[0]
+RPAIR = E36[REPF]
+CEN8 = {12: 14, 14: 11, 16: 37, 18: 29, 20: 55, 22: 45, 24: 51, 26: 11, 28: 3}
+
+HELD = []
+ROWN = set()
+UNI12 = 0
+G4PT = 0
+BARE = 0
+RKS = set()
+KOK = 0
+KEVEN = 0
+SPAN = 0
+COSET1 = 0
+CENS = set()
+MINOK = 0
+COVOK = 0
+NCOV = set()
+TCAND = 0
+TPASS = 0
+ROWKEY = []
+REPCEN = {}
+
+for f in range(NF):
+    fi = FIDX[FOLD[f]]
+    mpk = MPKS[fi]
+    oi = OIDX[fi]
+    orbs = ORBS[fi]
+    held = [c for c in FL[f] if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+    HELD.append(frozenset(held))
+    raw = []
+    for c in held:
+        s = set(SOLS[c])
+        rr = frozenset(oi[t] for t in s)
+        if len(rr) == 12 and all(orbs[i][0] in s and orbs[i][1] in s for i in rr):
+            UNI12 += 1
+        raw.append(rr)
+    rowg = sorted(set().union(*raw))
+    nr = len(rowg)
+    ROWN.add(nr)
+    ROWKEY.append((fi, frozenset(rowg)))
+    rpos = {r: i for i, r in enumerate(rowg)}
+    vecs = []
+    for rr in raw:
+        v = 0
+        for r in rr:
+            v |= (1 << rpos[r])
+        vecs.append(v)
+    sup = [MASK[orbs[rowg[i]][0]] | MASK[orbs[rowg[i]][1]] for i in range(nr)]
+    pat = []
+    for p in range(NPTS):
+        q = 0
+        for i in range(nr):
+            if (sup[i] >> p) & 1:
+                q |= (1 << i)
+        pat.append(q)
+    BARE += sum(1 for q in pat if q == 0)
+    for v in vecs:
+        if all(popc(q & v) == 1 for q in pat):
+            G4PT += 1
+    if f == REPF:
+        REPCEN = dict(sorted(Counter(popc(q) for q in pat).items()))
+    red, piv = rref(pat, nr)
+    rk = len(red)
+    RKS.add((nr, rk, nr - rk))
+    pset = set(piv)
+    kb = []
+    for fc in range(nr):
+        if fc in pset:
+            continue
+        v = (1 << fc)
+        for i in range(rk):
+            if (red[i] >> fc) & 1:
+                v |= (1 << piv[i])
+        kb.append(v)
+    if len(kb) == nr - rk and all(all((popc(q & v) & 1) == 0 for q in pat) for v in kb):
+        KOK += 1
+    kern = [0]
+    for b in kb:
+        kern = kern + [x ^ b for x in kern]
+    if len(set(kern)) == 2 ** len(kb) and all((popc(x) & 1) == 0 for x in kern):
+        KEVEN += 1
+    x1 = vecs[0]
+    diffs = [x1 ^ vecs[k] for k in range(1, len(vecs))]
+    dred, dpiv = rref(diffs, nr)
+    if all(all((popc(q & d) & 1) == 0 for q in pat) for d in diffs) and len(dred) == nr - rk:
+        SPAN += 1
+    coset = [x1 ^ x for x in kern]
+    odd = 0
+    cov = set()
+    for x in coset:
+        cnt = [popc(q & x) for q in pat]
+        if all((c & 1) == 1 for c in cnt):
+            odd += 1
+        if all(c == 1 for c in cnt):
+            cov.add(x)
+    if odd == len(coset):
+        COSET1 += 1
+    cen = dict(sorted(Counter(popc(x) for x in coset).items()))
+    CENS.add(tuple(sorted(cen.items())))
+    if min(cen) == 12 and set(x for x in coset if popc(x) == 12) == set(vecs):
+        MINOK += 1
+    if cov == set(vecs):
+        COVOK += 1
+    NCOV.add(len(cov))
+    sv = set(vecs)
+    for d in diffs:
+        TCAND += 1
+        if set(x ^ d for x in sv) == sv:
+            TPASS += 1
+
+NH = sorted(set(len(h) for h in HELD))
+NR = sorted(ROWN)[0]
+RKT = sorted(RKS)[0]
+CEN1 = dict(sorted(CENS)[0]) if len(CENS) == 1 else {}
+
+gate(NH == [14] and UNI12 == 48 * 14 and ROWN == set([40]) and G4PT == 48 * 14 and BARE == 0
+     and REPCEN == {2: 235, 3: 108, 4: 186, 5: 64, 6: 32}, "G4",
+     "at all {0} fibers the fold holds {1} cuttings, each an exact union of {2} two-orbits, and {3} rows occur"
+     .format(NF, NH[0], 12, NR))
+emit("G4 detail: all {0} held cuttings cover each of the {1} sample points exactly once, and {2} points are left uncovered"
+     .format(G4PT, NPTS, BARE))
+emit("G4 detail: the sample fiber at letter pair ({0},{1}) has rows-per-point census {2}"
+     .format(RPAIR[0], RPAIR[1], dshow(REPCEN)))
+
+gate(len(RKS) == 1 and RKT == (40, 32, 8), "G5",
+     "the {0} by {1} incidence over the field with two elements has rank {2} and kernel dimension {3} at every fiber, {4} distinct tuple"
+     .format(NPTS, RKT[0], RKT[1], RKT[2], len(RKS)))
+
+gate(KOK == 48 and KEVEN == 48, "G6",
+     "the kernel basis of {0} vectors annihilates the incidence at {1} of {2} fibers; all {3} kernel vectors have even weight at {4} of {2}"
+     .format(RKT[2], KOK, NF, 2 ** RKT[2], KEVEN))
+
+gate(SPAN == 48 and COSET1 == 48, "G7",
+     "the {0} differences lie in the kernel and span dimension {1} at {2} of {3} fibers; all {4} coset members solve the all-ones system"
+     .format(14 - 1, RKT[2], SPAN, NF, 2 ** RKT[2]))
+
+gate(len(CENS) == 1 and CEN1 == CEN8 and sum(CEN1.values()) == 256 and min(CEN1) == 12, "G8",
+     "the {0} fibers carry {1} distinct coset weight census, of total {2} and minimum weight {3}"
+     .format(NF, len(CENS), sum(CEN1.values()), min(CEN1)))
+emit("G8 detail: that one census is {0}".format(dshow(CEN1)))
+
+gate(MINOK == 48 and COVOK == 48 and NCOV == set([14]), "G9",
+     "the minimum-weight members and the exact covers of the coset are both exactly the {0} held cuttings at {1} of {2} fibers"
+     .format(NH[0], COVOK, NF))
+emit("G9 detail: every exact cover of a {0}-row instance solves the all-ones system, so each instance has exactly {1} exact covers"
+     .format(NR, sorted(NCOV)[0]))
+
+gate(TCAND == 48 * 13 and TPASS == 0, "G10",
+     "the complete candidate list of {0} nonzero translations per fiber, {1} tests over the {2} fibers, gives {3} preserved systems"
+     .format(13, TCAND, NF, TPASS))
+
+# ================================================================ G11 the same refutation at the native level
+
+fi = FIDX[GREP]
+mpk = MPKS[fi]
+orbs = ORBS[fi]
+oi = OIDX[fi]
+NAT = [c for c in range(NS) if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+NVEC = []
+NUOK = 0
+for c in NAT:
+    s = set(SOLS[c])
+    rr = frozenset(oi[t] for t in s)
+    if len(rr) == 12 and all(orbs[i][0] in s and orbs[i][1] in s for i in rr):
+        NUOK += 1
+    v = 0
+    for r in rr:
+        v |= (1 << r)
+    NVEC.append(v)
+NSV = set(NVEC)
+NDIFF = [NVEC[0] ^ NVEC[k] for k in range(1, len(NVEC))]
+NPASS = sum(1 for d in NDIFF if set(x ^ d for x in NSV) == NSV)
+
+gate(len(NAT) == 336 and NUOK == 336 and len(NSV) == 336 and len(NDIFF) == 335 and NPASS == 0, "G11",
+     "the sample fold holds {0} of the {1} cuttings, each a union of {2} of its {3} two-orbits; {4} candidates give {5} preserved systems"
+     .format(len(NAT), NS, 12, len(orbs), len(NDIFF), NPASS))
+
+# ================================================================ G12 the forty-eight instances are distinct objects
+
+UNIH = set()
+for h in HELD:
+    UNIH |= set(h)
+INTC = Counter()
+WPAIR = 0
+for g in DIST:
+    fs = [f for f in range(NF) if FOLD[f] == g]
+    for a, b in itertools.combinations(fs, 2):
+        INTC[len(ROWKEY[a][1] & ROWKEY[b][1])] += 1
+        WPAIR += 1
+ICEN = dict(sorted(INTC.items()))
+
+gate(len(set(ROWKEY)) == 48 and len(set(HELD)) == 48 and len(UNIH) == 672 and WPAIR == 168
+     and ICEN == {12: 24, 14: 24, 18: 48, 20: 24, 22: 48}, "G12",
+     "{0} distinct fold and row-set pairs, {1} distinct solution systems, {2} cuttings in the union, {3} within-fold fiber pairs"
+     .format(len(set(ROWKEY)), len(set(HELD)), len(UNIH), WPAIR))
+emit("G12 detail: the within-fold row-set intersection census is {0}, never {1} at any pair".format(dshow(ICEN), NR))
+
+# ================================================================ totals
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with its sixteen corners, the four hundred kept unit-determinant five-corner pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet on the eight interface slots, and the forty-eight transfer-matrix entries at thirty-six — the named wall. The prior cycle refuted, on one sample fiber, every permutation-symmetry carrier of the evenness of fourteen — abstract, geometric, and cell-group — and named the entrance: leave group actions and take the linear structure over the field with two elements. This cycle takes it, at all forty-eight fibers at once.

- **The linearization.** Each fiber's fourteen fold-held cuttings, written over the two-orbits of the four hundred kept pieces under that fiber's own fold, are weight-twelve vectors on exactly forty rows. The six-hundred-twenty-five-point incidence has rank thirty-two and kernel dimension eight at every one of the forty-eight fibers; the kernel is an even-weight code; and the thirteen differences of the solutions from the first span it entirely, so the affine hull of the fourteen is the full two-hundred-fifty-six-element solution coset of the all-ones system.
- **The exact characterization — the headline.** Inside that coset the minimum weight is twelve, the weight-twelve members are exactly the fourteen held cuttings, and the members that are genuine integer-sense exact covers — every one of the six hundred twenty-five sample points in exactly one selected row — are exactly the same fourteen. Since any exact cover must solve the all-ones system and the coset is the complete solution set, each forty-row instance has exactly fourteen exact covers: the count fourteen is a coset minimum-weight count.
- **The universality.** One and the same coset weight census at all forty-eight fibers — one distinct census, total two hundred fifty-six — while the forty-eight instances are pairwise distinct: forty-eight distinct fold-and-row-set pairs, forty-eight distinct solution systems, six hundred seventy-two held cuttings in the union with no cutting held twice, and within-fold row overlaps between twelve and twenty-two of the forty rows, never all forty.
- **The refuted translation.** A nonzero translation preserving a solution set must carry the first solution into the set, so the thirteen differences are the complete candidate list; all thirteen fail at every fiber — zero of six hundred twenty-four tests pass. The same refutation holds natively before any fiber is singled out: of the three hundred thirty-five candidate translations of the sample fold's three-hundred-thirty-six-cutting system, zero pass. With the prior cycle, the parity carrier of the evenness of fourteen is neither a permutation symmetry of the instance nor a translation of its solution set.

The honest boundary: everything here is an exact finite computational identity on the declared object, and nothing wider. The census itself, the rank and kernel dimension, and above all the per-fiber count fourteen stay measured, not derived. What changed is the shape of the wall question: "why is fourteen even" is now exactly "why is the minimum-weight count of this one census even" — one question rather than forty-eight, asked of a linear object of dimension eight rather than of a cover search over four hundred pieces. The named next entrance is whether the forty-eight kernel-and-coset pairs are equivalent under a relabelling of rows — the cell group cannot carry it, since it already fails to move one fiber's solutions — which would descend the parity question to a single kernel and its distinguished coset.

## Verification

- Runner re-run by the orchestrator in a clean shell: exit 0, `TOTAL: PASS=12 FAIL=0`, stdout identical line-for-line to the hand-back, every census recomputed from the rebuilt geometry.
- Full note read plus line-by-line runner review (fabrication hunt; the exact-cover test verified integer-sense point-by-point, not a parity proxy; the kernel verified a real full enumeration with a basis-independence gate; the translation candidate lists verified derived from the solutions with the completeness argument stated in the note; the construction verified rebuilt from the corner list before any gate runs).
- The coset-exhaustiveness inference (exact covers lie in the enumerated coset, so the scan is complete) re-derived independently by the orchestrator before the spec was written, and the universality anchors verified twice by independent probe runs before dispatch.
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags (forbidden-string sweep, numeral containment, link inventory, line-length and stdout budgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
