### PR TITLE
feat: cycle 793 — the wall instance is one: every fiber system is a relabelling of a single coset problem

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_WALL_INSTANCE_UNIQUENESS_CYCLE793_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_WALL_INSTANCE_UNIQUENESS_CYCLE793_NOTE_2026-08-15.md
@@ -1,0 +1,186 @@
+# The wall instance is one: every fiber system is a relabelling of a single coset problem
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: name the action of the canonical instance's single nontrivial symmetry on its 14 held cuttings and read off its cycle structure on the fourteen, since a fixed-point count for an involution on the fourteen has the same parity as the fourteen itself; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, at every wall fiber of the declared finite cell, that the weight census of the fiber's kernel, the column profiles of its kernel and of its coset, and the cover and pairwise-intersection invariants of its fold-held cuttings are single-valued over the fibers; together with a complete backtracking search that exhibits an explicit relabelling of the rows carrying the sample fiber's instance onto every other fiber's instance, verified by explicit image on kernel, blocks and coset; a count of exactly two such relabellings per fiber matching the two symmetries of the sample instance; and an honest rejection of a perturbed control by the same search; no physical or lattice-wide identification`
+- `audit_required_before_effective_retained: true`
+- `bare_retained_allowed: false`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the
+unit four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive
+at the adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into,
+the 192 pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell.
+The pair of tetrahedral letters on the two slots of axis zero, drawn from a 16-letter alphabet,
+gives the interface matrix of trace 2000 with exactly 48 entries equal to 36. Each of those 48
+fibers holds 36 cuttings and is held setwise by exactly 2 of the 384 maps. Its nontrivial holder
+is that fiber's fold; the 48 folds are involutions and collapse to 6 distinct maps with serving
+census `{8: 6}`, and each fold holds 14 of its own fiber's 36 cuttings.
+
+The stem `PHYSICAL_CELL_CUTTING_FIBER_LINEARIZATION_LAW_CYCLE792_NOTE_2026-08-15` is not yet on
+main and is referenced by name only. It put every fiber into linear form: each fold cuts the 400
+kept pieces into 200 two-orbits, each of a fiber's 14 fold-held cuttings is an exact union of 12
+of them, exactly 40 of the 200 occur across the 14, the 625 by 40 point-row incidence over the
+field with two elements has rank 32 and kernel dimension 8 with all 256 kernel vectors of even
+weight, and the 13 differences of the held vectors from the first lie in that kernel and span it,
+so the affine hull of the 14 is the whole 256-element coset of the all-ones system. Everything in
+that list is recomputed here rather than assumed, and regated as G3, with the span statement
+regated in a sharper set-level form as G7. The previous cycle also found the weight census of the
+coset to be the same at all 48 fibers, with its 14 minimum-weight members exactly the 14 held
+cuttings; that census is carried by name here and is not recomputed by this runner.
+
+The question this note asks is whether the 48 per-fiber systems, already known to carry one
+coset weight census while being 48 pairwise-distinct labelled objects, are one instance carried
+in 48 different labellings of its 40 rows. If they are, the parity question the lane is chasing
+stops being a question about 48 systems and becomes a question about one.
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+recomputed by the linked runner from that object alone: it rebuilds the object from the corner
+list before any gate runs, uses the standard library only, performs no file input or output and no
+randomness, and gates each recomputed value against the value stated here.
+
+## The law
+
+- **The further invariants are single-valued.** Beyond the coset weight census, four more
+  invariants take exactly 1 distinct value over the 48 fibers. The weight census of the kernel
+  itself is `{0: 1, 4: 4, 6: 1, 8: 9, 10: 5, 12: 13, 14: 16, 16: 17, 18: 30, 20: 31, 22: 44,
+  24: 40, 26: 24, 28: 12, 30: 7, 32: 1, 34: 1}`, of total 256. Each of the 40 coordinates is 1 on
+  exactly 128 of the 256 kernel vectors and on exactly 128 of the 256 coset members, so both
+  column profiles are `{128: 40}` at every fiber. The 14 held cuttings have per-coordinate cover
+  profile `{1: 6, 2: 10, 3: 2, 4: 7, 6: 9, 8: 3, 10: 3}` of total incidence 168, which is 14
+  times 12, and pairwise support-intersection census `{0: 12, 1: 6, 2: 10, 3: 14, 4: 4, 5: 14,
+  6: 4, 7: 5, 8: 10, 9: 1, 10: 11}` over the 91 pairs.
+
+- **The equivalence is real, not inferred from the invariants.** A complete backtracking search,
+  which can and does return NOT FOUND, finds for the sample fiber against every one of the other
+  47 an explicit bijection of the 40 coordinates. Each is verified not by invariant matching but
+  by explicit image: all 256 kernel vectors of the sample map onto the target's 256 kernel
+  vectors as a set, the 14 held cuttings map onto the target's 14, and all 256 coset members map
+  onto the target's 256. All three set equalities hold at 47 of 47.
+
+- **The count is 2.** Enumerating every equivalence rather than the first gives exactly 2 for
+  each of the 47 targets, and the sample instance has exactly 2 symmetries of its own, the
+  identity and one nontrivial involution. The two match for the expected reason and the reason is
+  checked rather than asserted: composing the nontrivial symmetry with either of a target's two
+  equivalences yields the other, at all 47 targets, so composition acts freely and transitively
+  on the equivalence set.
+
+- **The control is honestly rejected.** A target built from the sample by moving one coordinate
+  out of one block and another coordinate into it — the block staying at weight 12, so the object
+  is still 14 blocks of weight 12 on 40 coordinates — is rejected NOT FOUND by the same search
+  entry point, with the feasibility screening living inside that function so the control
+  exercises the real path.
+
+The search runs at the level of bijections of the 14 blocks, and that is licensed by a lemma
+rather than by convenience. Any bijection of the coordinates carrying kernel onto kernel and
+coset onto coset preserves weight, hence carries minimum-weight coset members to minimum-weight
+coset members, that is, the 14 onto the 14. Conversely any bijection carrying the 14 onto the 14
+carries their affine hull onto the affine hull and their difference span onto the difference
+span; since the 13 differences span the kernel, the affine hull is the coset and the difference
+span is the kernel, so it carries kernel onto kernel and coset onto coset. Instance equivalence
+is therefore exactly equivalence of the 14-block systems, and a search over bijections of the 14
+blocks — with the 40 coordinates classed by their exact membership pattern across the 14 blocks,
+same-pattern coordinates interchangeable, and same-pattern classes required to meet classes of
+equal size — is a complete search, whose images of kernel and of coset depend only on the block
+bijection. The span fact is the previous cycle's; it is gated again here as G7 at all 48 fibers
+in the sharper set-level form, 256 vectors equal to 256 vectors, not an equality of dimension 8
+alone.
+
+## What the wall now asks
+
+The parity question descends to one canonical instance: a single set of 14 vectors of weight 12
+on 40 coordinates, whose difference span is the kernel of dimension 8 in which every vector has
+even weight, and whose affine hull is the distinguished coset. Every one of the 48 fibers carries
+that same instance, differing only in the labelling that gives its own 40 occurring two-orbits,
+drawn from the 200 its fold produces, to the 40 coordinates.
+"Why is 14 even" is now a question about one instance carrying one nontrivial symmetry, not a
+question about 48 systems that happen to agree; and the object in which an answer must be found
+has shrunk from 48 cover problems on 400 pieces to one coset problem on 40 coordinates.
+
+## Boundary and honest reading
+
+Measured, not derived, at the declared finite scope: the weight census of the kernel; both of
+the column profiles at 128 of 256; the cover profile and the
+pairwise support-intersection census of the 14; the count 2 of equivalences and of symmetries;
+and, above all, the count 14 itself, whose evenness remains measured, not derived.
+
+Derived at the declared finite scope: that instance equivalence is exactly equivalence of the
+14-block systems, by the lemma above, whose span input is regated here at all 48 fibers as a set
+equality; that the sample instance is carried onto every one of the other 47 by an explicit
+relabelling of the 40 coordinates, checked by explicit image on all 256 kernel vectors, the 14
+blocks and all 256 coset members; that the number of such relabellings is exactly 2 at each
+target and equals the number of symmetries of the sample, composition acting freely and
+transitively; and that a one-block perturbation is not equivalent to the sample.
+
+The equivalence classes say nothing yet about why the census has an even minimum-weight count.
+Nothing here derives the count 14, its parity, or either census; what is established is that
+there is a single object to ask the question of. All of the above are computational identities of
+the declared unit four-cube object, its 15800 cuttings, and the order-384 symmetry group of the
+cell. No physical, dynamical, or lattice-wide identification is claimed, no continuum limit is
+taken, and nothing here is asserted about cell-cutting systems outside the declared object.
+
+## Next entrance
+
+Name the action of the canonical instance's single nontrivial symmetry on its 14 held cuttings.
+That symmetry is now a distinguished finite object rather than one of 48 accidents, and its cycle
+structure on the fourteen is the next thing to read off: a fixed-point count for an involution on
+the fourteen has the same parity as the fourteen itself, so a cycle structure with a named reason
+for its fixed points would carry the parity of 14 directly. Whether the reason exists is not
+claimed here; what is claimed is that the target is now one involution on one set of 14.
+
+## Review record and boundary
+
+- Rows are the two-orbits of the 400 kept pieces under each fiber's own fold, and blocks are that
+  fiber's fold-held cuttings written as row sets. Both conventions are fixed before any
+  computation runs, and every invariant statement is made for all 48 fibers, not for a chosen one.
+- The search is a real backtracking search over block bijections that returns NOT FOUND when no
+  equivalence exists, and the control at G10 calls the same entry point and does return NOT FOUND.
+  No witness is derived from its target: each witness is constructed from a found block bijection
+  and then verified by explicit image on kernel, blocks and coset.
+- The completeness of the block-level search rests on the lemma stated above, whose span input is
+  regated at G7 as a set equality of 256 with 256 at all 48 fibers rather than carried over.
+- The runner prints censuses, counts and profiles; the incidence matrices, the row lists, the
+  kernel vectors and the coordinate bijections are not printed, so the note quotes censuses and
+  identities instead.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a
+  commit cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.py](../scripts/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.txt](../logs/runner-cache/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, finishes in
+well under a minute on the reference machine, and stays far below one gigabyte. Its final line is
+`TOTAL: PASS=10 FAIL=0`, and it exits nonzero if any gate fails.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13865,6 +13865,10 @@
   "physical_cell_cutting_twelve_frontier_cycle739_note_2026-08-05": {
    "deps_hash": "e85cd6020b67",
    "out_degree": 4
+  },
+  "physical_cell_cutting_wall_instance_uniqueness_cycle793_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_column_family_parity_law_forced_orbits_cycle733_note_2026-08-04": {
    "deps_hash": "34379e6103b0",

--- a/logs/runner-cache/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.py
+runner_sha256: e4c31755f1c42801940f1dc9515fe195e7424b6c5aed870fee69af912e2a36c8
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 19.46
+status: ok
+----- stdout -----
+PASS G1 2672 pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, 16 letters, trace 2000, 48 entries at 36
+PASS G2 each of the 48 fibers is held setwise by exactly 2 of the 384 cell maps; the 48 folds are 6 distinct involutions, census {8: 6}
+PASS G3 at all 48 fibers: 200 two-orbits, 14 held cuttings each a union of 12, 40 rows occur, rank 32, kernel dimension 8
+G3 detail: all 256 kernel vectors have even weight, the 13 differences span dimension 8, and all 256 coset members solve all ones
+G3 detail: each of the 672 held cuttings covers every one of the 625 sample points exactly once, and 0 points lie in no row
+G3 detail: the sample fiber at letter pair (0,4) has rows-per-point census {2: 235, 3: 108, 4: 186, 5: 64, 6: 32}
+PASS G4 the kernel's own weight census takes 1 distinct value over the 48 fibers, of total 256 on 40 coordinates
+G4 detail: that census begins {0: 1, 4: 4, 6: 1, 8: 9, 10: 5, 12: 13, 14: 16, 16: 17, 18: 30,
+G4 detail: and continues 20: 31, 22: 44, 24: 40, 26: 24, 28: 12, 30: 7, 32: 1, 34: 1}
+PASS G5 at every one of the 48 fibers each of the 40 coordinates is one on exactly 128 of the 256 kernel vectors and on 128 coset members
+G5 detail: the kernel column profile is {128: 40} and the coset column profile is {128: 40}, 1 distinct value each
+PASS G6 the block invariants of the 14 held cuttings take 1 distinct value over the 48 fibers: total incidence 168 on 40 coordinates
+G6 detail: the per-coordinate cover profile is {1: 6, 2: 10, 3: 2, 4: 7, 6: 9, 8: 3, 10: 3}, and 168 is 14 times 12
+G6 detail: the pairwise support-intersection census over the 91 pairs is {0: 12, 1: 6, 2: 10, 3: 14, 4: 4, 5: 14, 6: 4, 7: 5, 8: 10, 9: 1, 10: 11}
+PASS G7 at 48 of 48 fibers the span of the 13 differences equals the kernel as a set of 256, and the affine hull of the 14 is the coset
+PASS G8 a relabelling of the 40 coordinates is found at 47 of the 47 other fibers, each verified on kernel, blocks and coset
+G8 detail: explicit images verify 47 kernel sets of 256, 47 block sets of 14, and 47 coset sets of 256
+PASS G9 exactly 2 relabellings at each of the 47 targets, matching the 2 symmetries of the sample instance, the identity and one involution
+G9 detail: composing the nontrivial symmetry with either relabelling gives the other at 47 of 47 targets, freely and transitively
+PASS G10 the control target moves one coordinate out of one block and another in; the same search entry point returns NOT FOUND, 0 found
+G10 detail: coordinate 3 leaves the first block and coordinate 0 enters it, the block staying at weight 12
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.py
+++ b/scripts/physical_cell_cutting_wall_instance_uniqueness_cycle793_2026_08_15.py
@@ -1,0 +1,714 @@
+"""Physical cell cutting: the wall fiber systems are one instance, each fiber carrying it in its own labelling of the rows.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, and the sixteen-letter facet alphabet on the two slots of axis zero. Nothing outside that finite object enters any gate.
+
+The previous cycle linearized every fiber: rows are the two-orbits of the 400 kept pieces under that fiber's fold, the fold-held cuttings
+are weight-twelve vectors on the rows that occur, and the exact cover condition is an all-ones linear system whose solution set is one coset
+of the kernel. This cycle asks whether the 48 systems are one object. It regates that linear form, gates the further invariants that are
+single-valued over the fibers, runs a complete backtracking search for a relabelling of the rows carrying the sample fiber's instance onto
+each of the others, counts every such relabelling, and checks that a one-block perturbation is honestly rejected. The search is complete at
+the block level because the span of the differences is the kernel as a set, so a bijection of the blocks fixes the images of kernel and
+coset. Gates G1 to G10, one line each with a few detail lines, then the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def popc(x):
+    return bin(x).count("1")
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                f = M[r][c]
+                M[r] = [M[r][k] - f * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NK = len(KEPT)
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+GID = ((0, 1, 2, 3), 0)
+
+FACE = {}
+for t in range(NK):
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda f: sorted(sorted(t) for t in f))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def compose(a, b):
+    p, m = a
+    q, n = b
+    r = tuple(q[p[i]] for i in range(4))
+    k = n
+    for j in range(4):
+        if (m >> j) & 1:
+            k ^= (1 << q[j])
+    return (r, k)
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+def rref(rows, ncols):
+    mat = [r for r in rows if r]
+    piv = []
+    r = 0
+    for c in range(ncols):
+        p = -1
+        for i in range(r, len(mat)):
+            if (mat[i] >> c) & 1:
+                p = i
+                break
+        if p < 0:
+            continue
+        mat[r], mat[p] = mat[p], mat[r]
+        for i in range(len(mat)):
+            if i != r and ((mat[i] >> c) & 1):
+                mat[i] ^= mat[r]
+        piv.append(c)
+        r += 1
+    return mat[:r], piv
+
+
+# ================================================================ G1 the declared object, the alphabet and the wall
+
+PAIROF = [(KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS)]
+JC = Counter(PAIROF)
+TRM = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TRM[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TRM[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(PAIROF[i], []).append(i)
+E36 = sorted(kj for kj in FIB if TRM[kj[0]][kj[1]] == 36)
+NF = len(E36)
+FSZ = sorted(set(len(FIB[kj]) for kj in E36))
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NL == 16 and TRC == 2000 and N36 == 48 and NF == 48 and FSZ == [36], "G1",
+     "{0} pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, {7} letters, trace {8}, {9} entries at {10}"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, len(G384), NL, TRC, N36, 36))
+
+# ================================================================ G2 the fold of every fiber
+
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+WALL = sorted(set(c for F in FL for c in F))
+POSW = {c: i for i, c in enumerate(WALL)}
+FOLD = [None] * NF
+STCNT = [0] * NF
+DEFECT = 0
+for g in G384:
+    mp = piecemap(g, USED)
+    if len(set(mp.values())) != NU:
+        DEFECT += 1
+    img = [SIDX[frozenset(mp[t] for t in SOLS[c])] for c in WALL]
+    for f in range(NF):
+        S = FS[f]
+        ok = True
+        for c in FL[f]:
+            if img[POSW[c]] not in S:
+                ok = False
+                break
+        if ok:
+            STCNT[f] += 1
+            if g != GID:
+                FOLD[f] = g
+
+DIST = sorted(set(FOLD))
+FIDX = {g: i for i, g in enumerate(DIST)}
+SERVE = dict(sorted(Counter(Counter(FOLD).values()).items()))
+INVOL = sum(1 for g in DIST if compose(g, g) == GID and g != GID)
+GREP = ((0, 3, 2, 1), 15)
+
+gate(DEFECT == 0 and set(STCNT) == set([2]) and len(WALL) == 1728 and len(DIST) == 6 and SERVE == {8: 6}
+     and INVOL == 6 and GREP in DIST, "G2",
+     "each of the {0} fibers is held setwise by exactly {1} of the {2} cell maps; the {0} folds are {3} distinct involutions, census {4}"
+     .format(NF, sorted(set(STCNT))[0], len(G384), len(DIST), dshow(SERVE)))
+
+# ================================================================ the two-orbit table of each fold
+
+MPKS = []
+ORBS = []
+OIDX = []
+SING = 0
+OVL = 0
+NORB = set()
+for g in DIST:
+    mpk = piecemap(g, range(NK))
+    orbs = []
+    seen = set()
+    for t in range(NK):
+        if t in seen:
+            continue
+        u = mpk[t]
+        seen.add(t)
+        seen.add(u)
+        if u == t:
+            SING += 1
+        if MASK[t] & MASK[u]:
+            OVL += 1
+        orbs.append((t, u))
+    oi = {}
+    for i in range(len(orbs)):
+        oi[orbs[i][0]] = i
+        oi[orbs[i][1]] = i
+    MPKS.append(mpk)
+    ORBS.append(orbs)
+    OIDX.append(oi)
+    NORB.add(len(orbs))
+
+# ================================================================ the per-fiber systems, rebuilt at every fiber
+
+GFIBS = [f for f in range(NF) if FOLD[f] == GREP]
+REPF = GFIBS[0]
+RPAIR = E36[REPF]
+KCEN8 = {0: 1, 4: 4, 6: 1, 8: 9, 10: 5, 12: 13, 14: 16, 16: 17, 18: 30, 20: 31,
+         22: 44, 24: 40, 26: 24, 28: 12, 30: 7, 32: 1, 34: 1}
+COVP8 = {1: 6, 2: 10, 3: 2, 4: 7, 6: 9, 8: 3, 10: 3}
+PAIR8 = {0: 12, 1: 6, 2: 10, 3: 14, 4: 4, 5: 14, 6: 4, 7: 5, 8: 10, 9: 1, 10: 11}
+
+HELD = []
+ROWN = set()
+UNI12 = 0
+CVR = 0
+BARE = 0
+RKS = set()
+KOK = 0
+KEVEN = 0
+SPAN = 0
+COSET1 = 0
+KCENS = set()
+KCOLS = set()
+CCOLS = set()
+COVPS = set()
+PAIRS = set()
+SETK = 0
+SETC = 0
+INST = []
+REPCEN = {}
+
+for f in range(NF):
+    fi = FIDX[FOLD[f]]
+    mpk = MPKS[fi]
+    oi = OIDX[fi]
+    orbs = ORBS[fi]
+    held = [c for c in FL[f] if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+    HELD.append(frozenset(held))
+    raw = []
+    for c in held:
+        s = set(SOLS[c])
+        rr = frozenset(oi[t] for t in s)
+        if len(rr) == 12 and all(orbs[i][0] in s and orbs[i][1] in s for i in rr):
+            UNI12 += 1
+        raw.append(rr)
+    rowg = sorted(set().union(*raw))
+    nr = len(rowg)
+    ROWN.add(nr)
+    rpos = {r: i for i, r in enumerate(rowg)}
+    vecs = []
+    for rr in raw:
+        v = 0
+        for r in rr:
+            v |= (1 << rpos[r])
+        vecs.append(v)
+    sup = [MASK[orbs[rowg[i]][0]] | MASK[orbs[rowg[i]][1]] for i in range(nr)]
+    pat = []
+    for p in range(NPTS):
+        q = 0
+        for i in range(nr):
+            if (sup[i] >> p) & 1:
+                q |= (1 << i)
+        pat.append(q)
+    BARE += sum(1 for q in pat if q == 0)
+    for v in vecs:
+        if all(popc(q & v) == 1 for q in pat):
+            CVR += 1
+    if f == REPF:
+        REPCEN = dict(sorted(Counter(popc(q) for q in pat).items()))
+    red, piv = rref(pat, nr)
+    rk = len(red)
+    RKS.add((nr, rk, nr - rk))
+    pset = set(piv)
+    kb = []
+    for fc in range(nr):
+        if fc in pset:
+            continue
+        v = (1 << fc)
+        for i in range(rk):
+            if (red[i] >> fc) & 1:
+                v |= (1 << piv[i])
+        kb.append(v)
+    if len(kb) == nr - rk and all(all((popc(q & v) & 1) == 0 for q in pat) for v in kb):
+        KOK += 1
+    kern = [0]
+    for b in kb:
+        kern = kern + [x ^ b for x in kern]
+    if len(set(kern)) == 2 ** len(kb) and all((popc(x) & 1) == 0 for x in kern):
+        KEVEN += 1
+    x1 = vecs[0]
+    diffs = [x1 ^ vecs[k] for k in range(1, len(vecs))]
+    dred, dpiv = rref(diffs, nr)
+    if all(all((popc(q & d) & 1) == 0 for q in pat) for d in diffs) and len(dred) == nr - rk:
+        SPAN += 1
+    coset = [x1 ^ x for x in kern]
+    if all(all((popc(q & x) & 1) == 1 for q in pat) for x in coset):
+        COSET1 += 1
+    spanset = set([0])
+    for d in dred:
+        spanset |= set(x ^ d for x in spanset)
+    if spanset == set(kern):
+        SETK += 1
+    if set(x1 ^ s for s in spanset) == set(coset):
+        SETC += 1
+    KCENS.add(tuple(sorted(Counter(popc(x) for x in kern).items())))
+    kc = Counter()
+    cc = Counter()
+    cov = Counter()
+    for i in range(nr):
+        kc[sum(1 for x in kern if (x >> i) & 1)] += 1
+        cc[sum(1 for x in coset if (x >> i) & 1)] += 1
+        cov[sum(1 for v in vecs if (v >> i) & 1)] += 1
+    KCOLS.add(tuple(sorted(kc.items())))
+    CCOLS.add(tuple(sorted(cc.items())))
+    COVPS.add(tuple(sorted(cov.items())))
+    pc = Counter(popc(vecs[a] & vecs[b]) for a, b in itertools.combinations(range(len(vecs)), 2))
+    PAIRS.add(tuple(sorted(pc.items())))
+    INST.append((tuple(vecs), tuple(kern), tuple(coset)))
+
+NH = sorted(set(len(h) for h in HELD))
+NR = sorted(ROWN)[0]
+RKT = sorted(RKS)[0]
+NKV = 2 ** RKT[2]
+
+# ================================================================ G3 the linear form of every fiber, regated here
+
+gate(len(MPKS) == 6 and NORB == set([200]) and SING == 0 and OVL == 0 and NH == [14] and UNI12 == 48 * 14
+     and ROWN == set([40]) and CVR == 48 * 14 and BARE == 0 and len(RKS) == 1 and RKT == (40, 32, 8)
+     and KOK == 48 and KEVEN == 48 and SPAN == 48 and COSET1 == 48, "G3",
+     "at all {0} fibers: {1} two-orbits, {2} held cuttings each a union of {3}, {4} rows occur, rank {5}, kernel dimension {6}"
+     .format(NF, sorted(NORB)[0], NH[0], 12, NR, RKT[1], RKT[2]))
+emit("G3 detail: all {0} kernel vectors have even weight, the {1} differences span dimension {2}, and all {0} coset members solve all ones"
+     .format(NKV, NH[0] - 1, RKT[2]))
+emit("G3 detail: each of the {0} held cuttings covers every one of the {1} sample points exactly once, and {2} points lie in no row"
+     .format(CVR, NPTS, BARE))
+emit("G3 detail: the sample fiber at letter pair ({0},{1}) has rows-per-point census {2}"
+     .format(RPAIR[0], RPAIR[1], dshow(REPCEN)))
+
+# ================================================================ G4 the weight census of the kernel itself
+
+KC1 = dict(sorted(KCENS)[0]) if len(KCENS) == 1 else {}
+KK = sorted(KC1)
+
+gate(len(KCENS) == 1 and KC1 == KCEN8 and sum(KC1.values()) == NKV and min(KC1) == 0 and max(KC1) == 34, "G4",
+     "the kernel's own weight census takes {0} distinct value over the {1} fibers, of total {2} on {3} coordinates"
+     .format(len(KCENS), NF, sum(KC1.values()), NR))
+emit("G4 detail: that census begins " + "{" + ", ".join("{0}: {1}".format(k, KC1[k]) for k in KK[:9]) + ",")
+emit("G4 detail: and continues " + ", ".join("{0}: {1}".format(k, KC1[k]) for k in KK[9:]) + "}")
+
+# ================================================================ G5 the column profiles of kernel and coset
+
+KP1 = dict(sorted(KCOLS)[0]) if len(KCOLS) == 1 else {}
+CP1 = dict(sorted(CCOLS)[0]) if len(CCOLS) == 1 else {}
+
+gate(len(KCOLS) == 1 and len(CCOLS) == 1 and KP1 == {128: 40} and CP1 == {128: 40}, "G5",
+     "at every one of the {0} fibers each of the {1} coordinates is one on exactly {2} of the {3} kernel vectors and on {2} coset members"
+     .format(NF, NR, 128, NKV))
+emit("G5 detail: the kernel column profile is {0} and the coset column profile is {1}, {2} distinct value each"
+     .format(dshow(KP1), dshow(CP1), len(KCOLS)))
+
+# ================================================================ G6 the block invariants of the held cuttings
+
+CV1 = dict(sorted(COVPS)[0]) if len(COVPS) == 1 else {}
+PR1 = dict(sorted(PAIRS)[0]) if len(PAIRS) == 1 else {}
+TOTI = sum(k * CV1[k] for k in CV1)
+NPAIR = sum(PR1.values())
+
+gate(len(COVPS) == 1 and len(PAIRS) == 1 and CV1 == COVP8 and PR1 == PAIR8 and sum(CV1.values()) == NR
+     and TOTI == 168 and TOTI == 14 * 12 and NPAIR == 91, "G6",
+     "the block invariants of the {0} held cuttings take {1} distinct value over the {2} fibers: total incidence {3} on {4} coordinates"
+     .format(NH[0], len(COVPS), NF, TOTI, sum(CV1.values())))
+emit("G6 detail: the per-coordinate cover profile is {0}, and {1} is {2} times {3}".format(dshow(CV1), TOTI, NH[0], 12))
+emit("G6 detail: the pairwise support-intersection census over the {0} pairs is {1}".format(NPAIR, dshow(PR1)))
+
+# ================================================================ G7 the set-level licence for a block-level search
+
+gate(SETK == NF and SETC == NF, "G7",
+     "at {0} of {1} fibers the span of the {2} differences equals the kernel as a set of {3}, and the affine hull of the {4} is the coset"
+     .format(SETK, NF, NH[0] - 1, NKV, NH[0]))
+
+# ================================================================ the complete search over block bijections
+
+
+def patterns(blocks, nc):
+    out = []
+    for c in range(nc):
+        p = 0
+        for i in range(len(blocks)):
+            if (blocks[i] >> c) & 1:
+                p |= (1 << i)
+        out.append(p)
+    return out
+
+
+def shape(blocks, nc):
+    ct = Counter(patterns(blocks, nc))
+    return sorted((popc(p), ct[p]) for p in ct)
+
+
+def eqsearch(ba, bb, nc, findall):
+    """Complete backtracking search for bijections of blocks carrying one instance onto another; empty list means NOT FOUND."""
+    if len(ba) != len(bb) or sorted(popc(x) for x in ba) != sorted(popc(x) for x in bb):
+        return []
+    if shape(ba, nc) != shape(bb, nc):
+        return []
+    m = len(ba)
+    ia = [[popc(ba[i] & ba[j]) for j in range(m)] for i in range(m)]
+    ib = [[popc(bb[i] & bb[j]) for j in range(m)] for i in range(m)]
+    if sorted(sorted(r) for r in ia) != sorted(sorted(r) for r in ib):
+        return []
+    capat = []
+    cur = [0] * nc
+    capat.append(Counter(cur))
+    for k in range(m):
+        for c in range(nc):
+            if (ba[k] >> c) & 1:
+                cur[c] |= (1 << k)
+        capat.append(Counter(cur))
+    asg = [-1] * m
+    used = [False] * m
+    res = []
+
+    def bpat(k):
+        ct = Counter()
+        for c in range(nc):
+            p = 0
+            for i in range(k):
+                if (bb[asg[i]] >> c) & 1:
+                    p |= (1 << i)
+            ct[p] += 1
+        return ct
+
+    def rec(k):
+        if k == m:
+            res.append(tuple(asg))
+            return not findall
+        for j in range(m):
+            if used[j] or popc(ba[k]) != popc(bb[j]):
+                continue
+            good = True
+            for i in range(k):
+                if ia[k][i] != ib[j][asg[i]]:
+                    good = False
+                    break
+            if not good:
+                continue
+            asg[k] = j
+            used[j] = True
+            if bpat(k + 1) == capat[k + 1] and rec(k + 1):
+                used[j] = False
+                asg[k] = -1
+                return True
+            used[j] = False
+            asg[k] = -1
+        return False
+
+    rec(0)
+    return sorted(res)
+
+
+def witness(ba, bb, nc, sig):
+    pa = patterns(ba, nc)
+    pb = patterns(bb, nc)
+    ga = {}
+    gb = {}
+    for c in range(nc):
+        ga.setdefault(pa[c], []).append(c)
+        gb.setdefault(pb[c], []).append(c)
+    pi = [-1] * nc
+    for p in sorted(ga):
+        q = 0
+        for i in range(len(sig)):
+            if (p >> i) & 1:
+                q |= (1 << sig[i])
+        tg = gb.get(q, [])
+        if len(tg) != len(ga[p]):
+            return None
+        for a, b in zip(sorted(ga[p]), sorted(tg)):
+            pi[a] = b
+    return pi if all(x >= 0 for x in pi) else None
+
+
+def image(v, pi):
+    w = 0
+    while v:
+        low = v & (-v)
+        w |= (1 << pi[low.bit_length() - 1])
+        v ^= low
+    return w
+
+
+# ================================================================ G8 the sample instance carries onto every other fiber
+
+SAMP = INST[REPF]
+OTHERS = [f for f in range(NF) if f != REPF]
+FOUND = 0
+VK = 0
+VB = 0
+VC = 0
+for f in OTHERS:
+    tgt = INST[f]
+    sg = eqsearch(SAMP[0], tgt[0], NR, False)
+    if not sg:
+        continue
+    FOUND += 1
+    pi = witness(SAMP[0], tgt[0], NR, sg[0])
+    if pi is None or sorted(pi) != list(range(NR)):
+        continue
+    if set(image(x, pi) for x in SAMP[1]) == set(tgt[1]):
+        VK += 1
+    if set(image(x, pi) for x in SAMP[0]) == set(tgt[0]):
+        VB += 1
+    if set(image(x, pi) for x in SAMP[2]) == set(tgt[2]):
+        VC += 1
+
+gate(FOUND == 47 and VK == 47 and VB == 47 and VC == 47, "G8",
+     "a relabelling of the {0} coordinates is found at {1} of the {2} other fibers, each verified on kernel, blocks and coset"
+     .format(NR, FOUND, len(OTHERS)))
+emit("G8 detail: explicit images verify {0} kernel sets of {1}, {2} block sets of {3}, and {4} coset sets of {1}"
+     .format(VK, NKV, VB, NH[0], VC))
+
+# ================================================================ G9 the count of relabellings and the free action
+
+AUT = eqsearch(SAMP[0], SAMP[0], NR, True)
+IDT = tuple(range(NH[0]))
+NTRIV = [s for s in AUT if s != IDT]
+ALPHA = NTRIV[0] if len(NTRIV) == 1 else IDT
+AUTOK = len(AUT) == 2 and IDT in AUT and len(NTRIV) == 1 and all(ALPHA[ALPHA[i]] == i for i in range(NH[0]))
+CNT2 = 0
+COMPOK = 0
+for f in OTHERS:
+    ss = eqsearch(SAMP[0], INST[f][0], NR, True)
+    if len(ss) != 2:
+        continue
+    CNT2 += 1
+    c0 = tuple(ss[0][ALPHA[i]] for i in range(NH[0]))
+    c1 = tuple(ss[1][ALPHA[i]] for i in range(NH[0]))
+    if c0 == ss[1] and c1 == ss[0]:
+        COMPOK += 1
+
+gate(AUTOK and CNT2 == 47 and COMPOK == 47, "G9",
+     "exactly {0} relabellings at each of the {1} targets, matching the {0} symmetries of the sample instance, the identity and one involution"
+     .format(len(AUT), CNT2))
+emit("G9 detail: composing the nontrivial symmetry with either relabelling gives the other at {0} of {1} targets, freely and transitively"
+     .format(COMPOK, len(OTHERS)))
+
+# ================================================================ G10 the control target, honestly rejected
+
+PATS = patterns(SAMP[0], NR)
+B0 = SAMP[0][0]
+UU = (B0 & (-B0)).bit_length() - 1
+VV = -1
+for c in range(NR):
+    if not ((B0 >> c) & 1) and PATS[c] != PATS[UU]:
+        VV = c
+        break
+FAKE = list(SAMP[0])
+FAKE[0] = (B0 ^ (1 << UU)) | (1 << VV)
+CTRL = eqsearch(SAMP[0], tuple(FAKE), NR, False)
+
+gate(VV >= 0 and PATS[UU] != PATS[VV] and popc(FAKE[0]) == 12 and len(FAKE) == NH[0] and len(CTRL) == 0, "G10",
+     "the control target moves one coordinate out of one block and another in; the same search entry point returns NOT FOUND, {0} found"
+     .format(len(CTRL)))
+emit("G10 detail: coordinate {0} leaves the first block and coordinate {1} enters it, the block staying at weight {2}"
+     .format(UU, VV, popc(FAKE[0])))
+
+# ================================================================ totals
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with its sixteen corners, the four hundred kept unit-determinant five-corner pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet on the eight interface slots, and the forty-eight transfer-matrix entries at thirty-six — the named wall. The prior cycle put every fiber into linear form over the field with two elements and found one coset weight census at all forty-eight fibers, while the forty-eight labelled systems stayed pairwise distinct. This cycle answers the question that left open: the forty-eight systems are not forty-eight objects that happen to agree — they are ONE object in forty-eight labellings.

- **The further invariants are single-valued.** Beyond the coset weight census, four more invariants take exactly one distinct value over all forty-eight fibers: the weight census of the kernel itself (total two hundred fifty-six), both column profiles (every one of the forty coordinates is one on exactly one hundred twenty-eight kernel vectors and one hundred twenty-eight coset members), the per-coordinate cover profile of the fourteen held cuttings (total incidence one hundred sixty-eight, which is fourteen times twelve), and the pairwise support-intersection census over the ninety-one pairs.
- **The equivalence is real, not inferred — the headline.** A complete backtracking search finds, for the sample fiber against every one of the other forty-seven, an explicit bijection of the forty coordinates, each verified by explicit image: all two hundred fifty-six kernel vectors map onto the target's kernel as a set, the fourteen held cuttings onto the target's fourteen, and all two hundred fifty-six coset members onto the target's coset. Completeness is licensed by a lemma proved in the note: instance equivalence is exactly equivalence of the fourteen-block systems, because weight preservation carries the fourteen forward and the difference span (regated set-level at all forty-eight fibers) carries kernel and coset backward.
- **The count is two, for a checked reason.** Enumerating every equivalence gives exactly two per target, matching the sample instance's exactly two symmetries — the identity and one nontrivial involution — and composing that involution with either of a target's two relabellings yields the other at all forty-seven targets, so composition acts freely and transitively.
- **The control is honestly rejected.** A target built from the sample by moving one coordinate out of one block and another in — still fourteen blocks of weight twelve on forty coordinates — is rejected NOT FOUND by the same search entry point, with the feasibility screening living inside that function so the control exercises the real path.

The honest boundary: everything here is an exact finite computational identity on the declared object, and nothing wider. The count fourteen, its evenness, and every census stay measured, not derived. What changed is the shape of the wall question: "why is fourteen even" is now a question about one canonical instance — a single set of fourteen weight-twelve vectors on forty coordinates carrying one nontrivial involution — rather than forty-eight systems that happen to agree. The named next entrance is the cycle structure of that involution on the fourteen: a fixed-point count for an involution on the fourteen has the same parity as the fourteen itself, so a cycle structure with a named reason for its fixed points would carry the parity directly.

## Verification

- Runner re-run by the orchestrator in a clean shell: exit 0, `TOTAL: PASS=10 FAIL=0`, stdout byte-identical to the hand-back, every census recomputed from the rebuilt geometry.
- Full note read plus line-by-line runner review (fabrication hunt; the kernel and coset recomputed at every fiber from the fiber's own incidence, with the parity checks being the field arithmetic itself, not proxies; the exact-cover count verified integer-sense point-by-point; the search's screens verified to live inside the entry point and to prune soundly; witnesses verified constructed from the block bijection and checked against independently computed targets, never derived from them).
- The completeness lemma re-derived independently by the orchestrator before the spec was written; the single-valued invariant anchors verified by independent probe runs before dispatch; the executor additionally ran its own discrimination sweep (positive and negative controls) before hand-back.
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags (forbidden-string sweep, numeral containment, link inventory, line-length and stdout budgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
