### PR TITLE
feat: cycle 794 clean-exchange symmetry and the parity descent to two cuttings

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_CLEAN_EXCHANGE_SYMMETRY_CYCLE794_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_CLEAN_EXCHANGE_SYMMETRY_CYCLE794_NOTE_2026-08-15.md
@@ -1,0 +1,208 @@
+# The clean exchange: four minimal exchanges, one of them the whole symmetry, and the parity of fourteen down to two cuttings
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: read the anatomy of the two held cuttings that the dominant exchange leaves unpaired — what distinguishes them from the twelve it pairs, whether the kernel vector joining them is itself structured, and whether a natively named involution pairs them, since such a pairing would carry the evenness of fourteen outright; none is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, at every wall fiber of the declared finite cell, of the graph of minimal exchanges on the fold-held cuttings, of the equality of its edge differences with the weight-four vectors of the fiber's own kernel, of the closure of the held set under the four toggles those vectors define, of a derived lemma carrying the unique clean toggle to a coordinate-level self-equivalence verified by explicit image on cuttings, kernel and coset, of a complete backtracking search showing that toggle is the instance's entire nontrivial symmetry, and of the parity descent that pairs twelve of the fourteen held cuttings and localises the evenness of fourteen to two of them; the point cardinalities of the equal-union exchanges are fiber-dependent and are anchored as a measured census over the fibers, never as one value; no physical or lattice-wide identification`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the unit
+four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive at the
+adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into, the 192
+pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell. The pair
+of tetrahedral letters on the two slots of axis zero, drawn from a 16-letter alphabet, gives the
+interface matrix of trace 2000 with exactly 48 entries equal to 36. Each of those 48 fibers holds
+36 cuttings and is held setwise by exactly 2 of the 384 maps; its nontrivial holder is that fiber's
+fold, and each fold holds 14 of its own fiber's 36 cuttings.
+
+The stem `PHYSICAL_CELL_CUTTING_WALL_INSTANCE_UNIQUENESS_CYCLE793_NOTE_2026-08-15` is not yet on
+main and is referenced by name only. It put the 48 per-fiber systems into one instance up to
+relabelling of the 40 rows, carrying exactly 2 self-equivalences. Everything that rests on is
+rebuilt here rather than assumed and regated at all 48 fibers: each fold cuts the 400 kept pieces
+into 200 two-orbits, each held cutting is an exact union of 12 of them, exactly 40 of the 200 occur
+across the 14, the 625 by 40 point-row incidence over the field with two elements has rank 32 and
+kernel dimension 8 with all 256 kernel vectors of even weight, every one of the 256 coset members
+solves the all-ones system, each of the 672 held cuttings covers each of the 625 sample points
+exactly once, and the pairwise shared-row census over the 91 pairs is
+`{0: 12, 1: 6, 2: 10, 3: 14, 4: 4, 5: 14, 6: 4, 7: 5, 8: 10, 9: 1, 10: 11}` at every fiber.
+
+The question this note asks is which exchanges of rows carry held cuttings to held cuttings, which
+of those extend to symmetries of the whole instance, and how far the evenness of 14 can be pushed
+down by them. The answer is that there are exactly four such exchanges, that exactly one of them is
+clean, that the clean one is the instance's entire nontrivial symmetry, and that the largest of the
+four pairs 12 of the 14, leaving the parity of 14 carried by exactly two named cuttings.
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+recomputed by the linked runner from that object alone: it rebuilds the object from the corner list
+before any gate runs, uses the standard library only, performs no file input or output and no
+randomness, and gates each recomputed value against the value stated here.
+
+## The law
+
+- **The minimal exchanges are the light kernel vectors.** Call two held cuttings a minimal exchange
+  when they share 10 of their 12 rows. At every fiber there are exactly 11 such pairs; as a graph on
+  the 14 they give degree census `{0: 1, 1: 4, 2: 9}` and five components of sizes 4, 4, 3, 2 and 1,
+  with both components of size 4 being closed cycles of 4 edges. Every difference of two held
+  cuttings lies in the kernel, both being coset members. The 11 edge differences all have weight 4
+  and take exactly 4 distinct values, with multiplicities 6, 2, 2 and 1, and those 4 values are
+  exactly the 4 kernel vectors of weight 4 — the light part of the kernel is not merely where the
+  minimal exchanges live, it is exactly what they are. The unique pair sharing 9 rows differs by the
+  unique kernel vector of weight 6, and over all 91 pairs the multiplicity census of distinct
+  differences is `{1: 25, 2: 30, 6: 1}`, single-valued over the 48 fibers.
+
+- **Each of the four is an equal-union exchange, and the held set is closed under all four toggles.**
+  Search the 40 rows directly for unordered pairs of disjoint two-row halves, each half a pair of
+  rows disjoint as point sets, whose two halves have equal union as point sets. There are exactly 4
+  at every fiber and their four supports are exactly the 4 kernel vectors of weight 4, so the
+  minimal exchanges are found twice over by independent routes: once as differences of held
+  cuttings, once as a bare point-set enumeration on the rows that never looks at the 14. Toggling by
+  such a vector — swapping one half for the other in any held cutting that contains a half in full —
+  lands inside the held set every time, with 0 images outside at every fiber. The moved census over
+  the four is `{2: 1, 4: 2, 12: 1}`, the census of broken cuttings, those meeting a support in a
+  nonempty set that is not a full half, is `{0: 1, 2: 1, 4: 1, 6: 1}`, and for every distinct pair
+  difference the number of held cuttings moved equals 2 times its multiplicity. The
+  multiplicity-6 exchange meets all 14 held cuttings; none is disjoint from its 4 rows.
+
+- **The lemma: a clean exchange extends to a coordinate-level self-equivalence.** Call an exchange
+  clean when its broken count is 0, that is, when every held cutting meeting its support contains a
+  full half. Pair the two halves by either of the two bijections between them. A held cutting
+  containing one half in full maps to the cutting with the other half substituted, which is again
+  held, by closure. Every other held cutting meets no row of the support at all, by cleanliness, so
+  it is fixed row by row. Hence the 14-set is carried onto itself; since the differences of the 14
+  span the kernel and their affine hull is the coset, kernel and coset are carried onto themselves
+  as sets. Both half-pairings therefore give self-equivalences. This is a derivation, not a
+  measurement, and the runner nevertheless verifies both pairings by explicit image: the 14 held
+  cuttings onto the 14, all 256 kernel vectors onto the kernel, all 256 coset members onto the
+  coset, at 48 of 48 fibers.
+
+- **The selector is cleanliness, and it accounts for the whole symmetry.** Exactly 1 of the 4
+  exchanges is clean at every fiber; it has multiplicity 2 and moves 4 cuttings. It is not the
+  exchange of largest multiplicity, which is 6, and it is not picked out by the sizes of its halves,
+  which are 2 and 2 for all four; cleanliness is the selector and nothing else in the census
+  distinguishes it. Running the complete backtracking search for self-equivalences of the instance
+  against itself returns exactly 2 at every fiber, and its nontrivial member is precisely the clean
+  exchange's toggle: the induced permutation of the 40 rows fixes 10 blocks identically as sets and
+  has 2 two-cycles, the same permutation for either half-pairing. So the instance's entire
+  nontrivial symmetry is one clean equal-union exchange of two rows for two rows.
+
+- **The parity descent.** For any nonzero kernel vector the map that adds it is a fixed-point-free
+  involution of the 256-member coset, so the held cuttings it moves are paired two by two and their
+  number is even; over all 255 nonzero kernel vectors the runner confirms that number is even and
+  equals 2 times the multiplicity of the vector. Hence 14 has the same parity as the number of held
+  cuttings the vector leaves unpaired, for every nonzero kernel vector, and the way to make the
+  evenness of 14 small is to make that multiplicity large. The maximum multiplicity over all 255 is
+  6, attained by exactly 1 vector, and 0 vectors attain 7 or more — a multiplicity of 7 would pair
+  all 14 at once and make the instance a translation of itself, and the measured maximum refutes
+  that natively, with no appeal outside the object. So 14 = 6 pairs + 2: the dominant exchange pairs
+  12 of the 14, and the evenness of 14 is now the evenness of the 2 cuttings it strands, which are
+  exactly its 2 broken cuttings and have graph degrees 0 and 1.
+
+## Derived versus measured
+
+Derived at the declared finite scope. Two held cuttings each cover the 625 points exactly once, so
+after deleting their shared rows the two remainders cover the same point set: equal-union
+remainders are forced, not observed, and the equal-union exchanges are the minimal instance of that
+remainder lemma. The clean-exchange lemma above is derived in full, both half-pairings with it. The
+evenness of the number of held cuttings moved by a nonzero kernel vector is derived, from
+fixed-point-freeness of adding a nonzero vector on a coset. And the congruence that 14 has the same
+parity as the count of cuttings left unpaired follows from that evenness for every nonzero kernel
+vector at once.
+
+Measured, not derived, at the declared finite scope: that there are exactly 4 minimal exchanges,
+that exactly 1 of them is clean, that the self-equivalence count is 2, the whole shape of the
+minimal-exchange graph and all of the censuses quoted above, the maximum multiplicity 6 and its
+attainment by exactly 1 vector, and, above all, the count 14 itself, whose evenness remains
+measured, not derived. The descent moves that evenness from 14 cuttings onto 2, and does not
+discharge it.
+
+All of the above are computational identities of the declared unit four-cube object, its 15800
+cuttings, and the order-384 symmetry group of the cell. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+## What the wall now asks
+
+Why does the dominant exchange strand exactly two held cuttings? Everything else about it is now
+named: it is the kernel vector of weight 4 of multiplicity 6, it meets all 14 held cuttings, and it
+pairs 12 of them. The 2 it does not pair are exactly its 2 broken cuttings, they are the vertices of
+degree 0 and degree 1 in the minimal-exchange graph, and they share 8 of their 12 rows, so the
+kernel vector joining them has weight 8, single-valued over the 48 fibers. A natively named pairing
+of those two — any involution of the instance exchanging them, or any reason forcing them to come in
+a pair — would carry the evenness of 14 outright, because the rest of the 14 is already paired by
+the dominant exchange. The wall is no longer "why is 14 even"; it is "why are these two cuttings
+two".
+
+## Next entrance
+
+Read the anatomy of the two exceptional cuttings. They are now distinguished objects rather than
+two of 14: one is the isolated vertex of the minimal-exchange graph, the other an endpoint of a
+path, they share 8 of their 12 rows, and the kernel vector joining them is not one of the 4 light
+ones. What is worth reading next is whether that joining vector has any distinguished place in the
+kernel, whether the two cuttings differ from the other 12 by any invariant of the instance rather
+than of a labelling, and whether any involution of the instance, or of the cell's 384 maps acting on
+the fiber, exchanges them. Whether such a pairing exists is not claimed here; what is claimed is
+that the parity target has shrunk from 14 cuttings to 2.
+
+## Review record
+
+- Rows are the two-orbits of the 400 kept pieces under each fiber's own fold, and blocks are that
+  fiber's fold-held cuttings written as row sets. Both conventions are fixed before any computation
+  runs, and every statement is made for all 48 fibers, not for a chosen one; every census is a
+  multiset, never a list of row labels, and the runner gates that each takes exactly 1 distinct
+  value over the 48 fibers.
+- Equal-union tests compare actual point sets as bitmasks over the 625 sample points, never sizes;
+  cover tests are point-by-point in the integer sense; the kernel is computed by row reduction over
+  the field with two elements of each fiber's own incidence, never carried between fibers.
+- The point cardinalities of the equal-union exchanges are fiber-dependent; the runner's G5 gate is
+  anchored to the full measured census over the 48 fibers, never to a single sample-fiber value.
+  The four union sizes read 50 100 100 100 at 8 fibers, 100 100 100 100 at 32 and 100 100 100 175 at
+  8; the two three-row remainders of the pair sharing 9 rows have equal point union at 48 of 48
+  fibers, of size 120 at 8 fibers, 150 at 32 and 205 at 8. A row's point support depends on which
+  pieces its fiber uses, so these cardinalities are properties of a labelling and not of the
+  instance. What is single-valued and holds at 48 of 48 is the enumeration itself: exactly 4
+  equal-union exchanges, halves disjoint as point sets with equal union, supports exactly the 4
+  kernel vectors of weight 4. Nothing else in this note depends on a point cardinality.
+- No witness is derived from its target: each self-equivalence is built from the clean exchange's
+  half-pairing and then verified by explicit image on the 14 held cuttings, on all 256 kernel
+  vectors and on all 256 coset members, as frozen sets compared for equality.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a commit
+  cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.py](../scripts/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.txt](../logs/runner-cache/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, finishes in
+well under a minute on the reference machine, and stays far below one gigabyte. Its final line is
+`TOTAL: PASS=10 FAIL=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13801,6 +13801,10 @@
   "physical_cell_cutting_charge_space_cycle736_note_2026-08-05": {
    "deps_hash": "4296058e250d",
    "out_degree": 3
+  },
+  "physical_cell_cutting_clean_exchange_symmetry_cycle794_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_crossing_automorphism_cycle777_note_2026-08-11": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.py
+runner_sha256: 0b9f0c43d15762054bac7abea5f4f97d52bb98a5629732db57d0b4e5fb7b5978
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 15.53
+status: ok
+----- stdout -----
+PASS G1 2672 pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, 16 letters, trace 2000, 48 entries at 36
+PASS G2 at all 48 fibers: 200 two-orbits, 14 held cuttings each a union of 12 rows, 40 rows occur, rank 32, kernel dimension 8
+G2 detail: all 256 kernel vectors have even weight, all 256 coset members solve the all ones system, and each of the 672 held
+G2 detail: cuttings covers every one of the 625 sample points exactly once; the fold of each fiber is one of 2 cell maps
+G2 detail: the pairwise shared-row census over the 91 pairs takes 1 distinct value over the 48 fibers, and reads
+G2 detail: {0: 12, 1: 6, 2: 10, 3: 14, 4: 4, 5: 14, 6: 4, 7: 5, 8: 10, 9: 1, 10: 11}
+PASS G3 minimal exchanges, the pairs sharing 10 of their 12 rows, form a graph with 11 edges at every one of the 48 fibers
+G3 detail: degree census {0: 1, 1: 4, 2: 9}, five components of sizes [1, 2, 3, 4, 4], and both components of size 4 are closed cycles of 4 edges
+PASS G4 every pair difference lies in the kernel; the 11 edge differences have weight 4 and take 4 distinct values, census {1: 1, 2: 2, 6: 1}
+G4 detail: those 4 values are exactly the 4 kernel vectors of weight 4, and the unique pair sharing 9 rows differs by
+G4 detail: the unique kernel vector of weight 6; all of this holds at 48 of 48 fibers
+G4 detail: the multiplicity census of all distinct differences over the 91 pairs takes 1 distinct value over the 48 fibers,
+G4 detail: and reads {1: 25, 2: 30, 6: 1}
+PASS G5 over the 40 rows there are exactly 4 equal-union exchanges at 48 of 48 fibers, and the union-size census over the fibers is anchored
+G5 detail: the 4 supports are exactly the 4 kernel vectors of weight 4 and each half is a disjoint pair of rows with equal
+G5 detail: union, at 48 of 48 fibers; the four union sizes read 50 100 100 100 at 8; 100 100 100 100 at 32; 100 100 100 175 at 8
+G5 detail: the two three-row remainders of the pair sharing 9 rows have equal point union at 48 of 48 fibers,
+G5 detail: of sizes 120 at 8; 150 at 32; 205 at 8
+PASS G6 for all 4 exchanges every held cutting meeting a full half toggles to another held cutting, 0 images outside, at 48 fibers
+G6 detail: the moved census is {2: 1, 4: 2, 12: 1} and the broken census is {0: 1, 2: 1, 4: 1, 6: 1}, each 1 distinct value over the 48 fibers
+G6 detail: inside(d) equals 2 times the multiplicity of d for every distinct pair difference, and the multiplicity 6
+G6 detail: exchange meets all 14 held cuttings, none disjoint from its 4 rows
+PASS G7 exactly 1 of the 4 exchanges is clean, with broken count 0; it has multiplicity 2 and moves 4 cuttings, at 48 of 48 fibers
+PASS G8 both half-pairings of the clean exchange carry the 14 held cuttings, the 256 kernel vectors and the 256 coset members onto themselves
+G8 detail: each is a product of two transpositions of the 40 coordinates, and the induced block permutation fixes 10 blocks
+G8 detail: identically as sets and has 2 two-cycles, the same permutation for either pairing, at 48 of 48 fibers
+PASS G9 the complete block-level self-equivalence search returns exactly 2 at 48 of 48 fibers, and the nontrivial one is the clean toggle
+PASS G10 over all 255 nonzero kernel vectors inside(d) is even and equals 2 times the multiplicity of d, at 48 of 48 fibers
+G10 detail: the maximum multiplicity is 6, attained by exactly 1 kernel vector, and 0 vector attains 7 or more
+G10 detail: so the evaders at the maximum number 2, exactly the dominant exchange's broken pair, of graph degrees [0, 1]
+G10 detail: the two exceptional cuttings share 8 rows, 1 distinct value over the 48 fibers; 14 = 6 pairs + 2
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.py
+++ b/scripts/physical_cell_cutting_clean_exchange_symmetry_cycle794_2026_08_15.py
@@ -1,0 +1,842 @@
+"""Physical cell cutting: four minimal exchanges at every wall fiber, exactly one of them clean,
+and the parity of fourteen carried down to two exceptional cuttings.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, and the sixteen-letter facet alphabet on the two slots of axis zero. Nothing outside that finite object enters any gate.
+
+Earlier cycles linearized every wall fiber: rows are the two-orbits of the 400 kept pieces under that fiber's fold, the fold-held cuttings
+are weight-twelve vectors on the rows that occur, the exact cover condition is an all-ones linear system whose solution set is one coset of
+the kernel, and the 48 fiber systems are one instance carried in 48 labellings of the rows. This cycle reads the exchange structure of that
+instance and regates the linear form it stands on. It builds the graph of held pairs sharing ten of their twelve rows, identifies the edge
+differences with the weight-four kernel vectors, enumerates the equal-union splittings of the rows that realize them, checks that the held
+set is closed under all four toggles, isolates the single clean exchange whose toggle is the whole nontrivial symmetry of the instance by a
+complete block-level search, and runs the parity descent over all nonzero kernel vectors. Gates G1 to G10, one line each with a few detail
+lines, then the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    if OUT[0] >= 5800:
+        raise ValueError("output over the character budget")
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def popc(x):
+    return bin(x).count("1")
+
+
+def only(s):
+    return sorted(s)[0] if len(s) == 1 else None
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                fq = M[r][c]
+                M[r] = [M[r][k] - fq * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NK = len(KEPT)
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+GID = ((0, 1, 2, 3), 0)
+
+FACE = {}
+for t in range(NK):
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda fz: sorted(sorted(t) for t in fz))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def compose(a, b):
+    p, m = a
+    q, n = b
+    r = tuple(q[p[i]] for i in range(4))
+    k = n
+    for j in range(4):
+        if (m >> j) & 1:
+            k ^= (1 << q[j])
+    return (r, k)
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+def rref(rows, ncols):
+    mat = [r for r in rows if r]
+    piv = []
+    r = 0
+    for c in range(ncols):
+        p = -1
+        for i in range(r, len(mat)):
+            if (mat[i] >> c) & 1:
+                p = i
+                break
+        if p < 0:
+            continue
+        mat[r], mat[p] = mat[p], mat[r]
+        for i in range(len(mat)):
+            if i != r and ((mat[i] >> c) & 1):
+                mat[i] ^= mat[r]
+        piv.append(c)
+        r += 1
+    return mat[:r], piv
+
+
+def image(v, pi):
+    w = 0
+    while v:
+        low = v & (-v)
+        w |= (1 << pi[low.bit_length() - 1])
+        v ^= low
+    return w
+
+
+# ================================================================ G1 the declared object, the alphabet and the wall
+
+PAIROF = [(KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS)]
+JC = Counter(PAIROF)
+TRM = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TRM[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TRM[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(PAIROF[i], []).append(i)
+E36 = sorted(kj for kj in FIB if TRM[kj[0]][kj[1]] == 36)
+NF = len(E36)
+FSZ = sorted(set(len(FIB[kj]) for kj in E36))
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NL == 16 and TRC == 2000 and N36 == 48 and NF == 48 and FSZ == [36], "G1",
+     "{0} pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, {7} letters, trace {8}, {9} entries at {10}"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, len(G384), NL, TRC, N36, 36))
+
+# ================================================================ the fold of every fiber
+
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+WALL = sorted(set(c for F in FL for c in F))
+POSW = {c: i for i, c in enumerate(WALL)}
+FOLD = [None] * NF
+STCNT = [0] * NF
+DEFECT = 0
+for g in G384:
+    mp = piecemap(g, USED)
+    if len(set(mp.values())) != NU:
+        DEFECT += 1
+    img = [SIDX[frozenset(mp[t] for t in SOLS[c])] for c in WALL]
+    for f in range(NF):
+        S = FS[f]
+        ok = True
+        for c in FL[f]:
+            if img[POSW[c]] not in S:
+                ok = False
+                break
+        if ok:
+            STCNT[f] += 1
+            if g != GID:
+                FOLD[f] = g
+
+DIST = sorted(set(FOLD))
+FIDX = {g: i for i, g in enumerate(DIST)}
+FOLDOK = DEFECT == 0 and set(STCNT) == set([2]) and all(compose(g, g) == GID for g in DIST)
+
+# ================================================================ the two-orbit table of each fold
+
+MPKS = []
+ORBS = []
+OIDX = []
+SING = 0
+OVL = 0
+NORB = set()
+for g in DIST:
+    mpk = piecemap(g, range(NK))
+    orbs = []
+    seen = set()
+    for t in range(NK):
+        if t in seen:
+            continue
+        u = mpk[t]
+        seen.add(t)
+        seen.add(u)
+        if u == t:
+            SING += 1
+        if MASK[t] & MASK[u]:
+            OVL += 1
+        orbs.append((t, u))
+    oi = {}
+    for i in range(len(orbs)):
+        oi[orbs[i][0]] = i
+        oi[orbs[i][1]] = i
+    MPKS.append(mpk)
+    ORBS.append(orbs)
+    OIDX.append(oi)
+    NORB.add(len(orbs))
+
+# ================================================================ the complete search over block bijections
+
+
+def patterns(blocks, nc):
+    out = []
+    for c in range(nc):
+        p = 0
+        for i in range(len(blocks)):
+            if (blocks[i] >> c) & 1:
+                p |= (1 << i)
+        out.append(p)
+    return out
+
+
+def shape(blocks, nc):
+    ct = Counter(patterns(blocks, nc))
+    return sorted((popc(p), ct[p]) for p in ct)
+
+
+def eqsearch(ba, bb, nc, findall):
+    """Complete backtracking search for bijections of blocks carrying one instance onto another; empty list means NOT FOUND."""
+    if len(ba) != len(bb) or sorted(popc(x) for x in ba) != sorted(popc(x) for x in bb):
+        return []
+    if shape(ba, nc) != shape(bb, nc):
+        return []
+    m = len(ba)
+    ia = [[popc(ba[i] & ba[j]) for j in range(m)] for i in range(m)]
+    ib = [[popc(bb[i] & bb[j]) for j in range(m)] for i in range(m)]
+    if sorted(sorted(r) for r in ia) != sorted(sorted(r) for r in ib):
+        return []
+    capat = []
+    cur = [0] * nc
+    capat.append(Counter(cur))
+    for k in range(m):
+        for c in range(nc):
+            if (ba[k] >> c) & 1:
+                cur[c] |= (1 << k)
+        capat.append(Counter(cur))
+    asg = [-1] * m
+    used = [False] * m
+    res = []
+
+    def bpat(k):
+        ct = Counter()
+        for c in range(nc):
+            p = 0
+            for i in range(k):
+                if (bb[asg[i]] >> c) & 1:
+                    p |= (1 << i)
+            ct[p] += 1
+        return ct
+
+    def rec(k):
+        if k == m:
+            res.append(tuple(asg))
+            return not findall
+        for j in range(m):
+            if used[j] or popc(ba[k]) != popc(bb[j]):
+                continue
+            good = True
+            for i in range(k):
+                if ia[k][i] != ib[j][asg[i]]:
+                    good = False
+                    break
+            if not good:
+                continue
+            asg[k] = j
+            used[j] = True
+            if bpat(k + 1) == capat[k + 1] and rec(k + 1):
+                used[j] = False
+                asg[k] = -1
+                return True
+            used[j] = False
+            asg[k] = -1
+        return False
+
+    rec(0)
+    return sorted(res)
+
+
+# ================================================================ the per-fiber work, everything rebuilt at every fiber
+
+PAIR8 = {0: 12, 1: 6, 2: 10, 3: 14, 4: 4, 5: 14, 6: 4, 7: 5, 8: 10, 9: 1, 10: 11}
+DEG3 = {0: 1, 1: 4, 2: 9}
+SIZ3 = [1, 2, 3, 4, 4]
+EDC4 = {1: 1, 2: 2, 6: 1}
+MOV6 = {2: 1, 4: 2, 12: 1}
+BRK6 = {0: 1, 2: 1, 4: 1, 6: 1}
+
+INSOK = 0
+SHAPES = set()
+CVRT = 0
+PAIRSET = set()
+GRAPHS = set()
+CYCOK = 0
+DIFOK = 0
+EDCENS = set()
+ALLCENS = set()
+EUOK = 0
+EUSZ = Counter()
+EUANC = {(50, 100, 100, 100): 8, (100, 100, 100, 100): 32, (100, 100, 100, 175): 8}
+REMEQ = 0
+REMSZ = Counter()
+RMANC = {120: 8, 150: 32, 205: 8}
+TOGOK = 0
+MOVCENS = set()
+BRKCENS = set()
+CLNOK = 0
+LEMOK = 0
+FIXCNT = set()
+SYMOK = 0
+PAROK = 0
+RSHARE = set()
+DEGX = set()
+MAXM = set()
+
+for f in range(NF):
+    fi = FIDX[FOLD[f]]
+    mpk = MPKS[fi]
+    oi = OIDX[fi]
+    orbs = ORBS[fi]
+    held = [c for c in FL[f] if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+    raw = []
+    u12 = 0
+    for c in held:
+        s = set(SOLS[c])
+        rr = frozenset(oi[t] for t in s)
+        if len(rr) == 12 and all(orbs[i][0] in s and orbs[i][1] in s for i in rr):
+            u12 += 1
+        raw.append(rr)
+    nh = len(raw)
+    rowg = sorted(set().union(*raw))
+    nr = len(rowg)
+    rpos = {r: i for i, r in enumerate(rowg)}
+    vecs = [sum(1 << rpos[r] for r in rr) for rr in raw]
+    sup = [MASK[orbs[rowg[i]][0]] | MASK[orbs[rowg[i]][1]] for i in range(nr)]
+    pat = []
+    for p in range(NPTS):
+        q = 0
+        for i in range(nr):
+            if (sup[i] >> p) & 1:
+                q |= (1 << i)
+        pat.append(q)
+    red, piv = rref(pat, nr)
+    rk = len(red)
+    pset = set(piv)
+    kb = []
+    for fc in range(nr):
+        if fc in pset:
+            continue
+        v = (1 << fc)
+        for i in range(rk):
+            if (red[i] >> fc) & 1:
+                v |= (1 << piv[i])
+        kb.append(v)
+    kern = [0]
+    for b in kb:
+        kern = kern + [x ^ b for x in kern]
+    kset = frozenset(kern)
+    coset = [vecs[0] ^ x for x in kern]
+    cset = frozenset(coset)
+    heldset = frozenset(vecs)
+    vidx = {vecs[i]: i for i in range(nh)}
+    cvr = sum(1 for v in vecs if all(popc(q & v) == 1 for q in pat))
+    CVRT += cvr
+    evenk = all((popc(x) & 1) == 0 for x in kern)
+    onec = all(all((popc(q & x) & 1) == 1 for q in pat) for x in coset)
+    SHAPES.add((nh, u12, nr, rk, len(kb), len(kset), len(cset), len(heldset)))
+    if (nh == 14 and u12 == nh and nr == 40 and rk == 32 and len(kb) == 8 and len(kset) == 2 ** len(kb)
+            and len(cset) == len(kset) and evenk and onec and cvr == nh and len(heldset) == nh
+            and set(popc(v) for v in vecs) == set([12])):
+        INSOK += 1
+
+    # ---- pairs, the minimal-exchange graph, and the differences
+    pcen = Counter()
+    dmult = Counter()
+    edges = []
+    nine = None
+    inker = 0
+    for a, b in itertools.combinations(range(nh), 2):
+        it = popc(vecs[a] & vecs[b])
+        pcen[it] += 1
+        dv = vecs[a] ^ vecs[b]
+        dmult[dv] += 1
+        if dv in kset:
+            inker += 1
+        if it == 10:
+            edges.append((a, b))
+        if it == 9:
+            nine = (a, b)
+    PAIRSET.add(tuple(sorted(pcen.items())))
+    adj = [[] for _ in range(nh)]
+    for a, b in edges:
+        adj[a].append(b)
+        adj[b].append(a)
+    deg = Counter(len(adj[i]) for i in range(nh))
+    seenv = set()
+    comps = []
+    for i in range(nh):
+        if i in seenv:
+            continue
+        stack = [i]
+        seenv.add(i)
+        comp = []
+        while stack:
+            u = stack.pop()
+            comp.append(u)
+            for v in adj[u]:
+                if v not in seenv:
+                    seenv.add(v)
+                    stack.append(v)
+        comps.append(set(comp))
+    sizes = sorted(len(c) for c in comps)
+    GRAPHS.add((len(edges), tuple(sorted(deg.items())), tuple(sizes)))
+    big = [c for c in comps if len(c) == 4]
+    if len(big) == 2 and all(sum(1 for a, b in edges if a in c and b in c) == 4
+                             and all(len(adj[u]) == 2 for u in c) for c in big):
+        CYCOK += 1
+    k4 = sorted(x for x in kern if popc(x) == 4)
+    k6 = sorted(x for x in kern if popc(x) == 6)
+    edm = Counter()
+    for a, b in edges:
+        edm[vecs[a] ^ vecs[b]] += 1
+    edc = Counter(edm.values())
+    EDCENS.add(tuple(sorted(edc.items())))
+    ALLCENS.add(tuple(sorted(Counter(dmult.values()).items())))
+    ndf = vecs[nine[0]] ^ vecs[nine[1]] if nine is not None else 0
+    if (inker == nh * (nh - 1) // 2 and len(edges) == 11 and all(popc(d) == 4 for d in edm)
+            and sorted(edm) == k4 and len(k4) == 4 and len(k6) == 1 and popc(ndf) == 6 and ndf == k6[0]):
+        DIFOK += 1
+
+    # ---- equal-union exchanges over the rows, point sets compared as point sets
+    ug = {}
+    for i, j in itertools.combinations(range(nr), 2):
+        if sup[i] & sup[j]:
+            continue
+        ug.setdefault(sup[i] | sup[j], []).append((i, j))
+    eu = []
+    for u in ug:
+        for pa, pb in itertools.combinations(ug[u], 2):
+            if len(set(pa) | set(pb)) == 4:
+                eu.append((pa, pb, popc(u)))
+    spl = {}
+    for pa, pb, usz in eu:
+        ma = (1 << pa[0]) | (1 << pa[1])
+        mb = (1 << pb[0]) | (1 << pb[1])
+        spl[ma | mb] = (ma, mb, usz)
+    r1 = 0
+    r2 = 0
+    if nine is not None:
+        for i in range(nr):
+            if (vecs[nine[0]] >> i) & 1 and not ((vecs[nine[1]] >> i) & 1):
+                r1 |= sup[i]
+            if (vecs[nine[1]] >> i) & 1 and not ((vecs[nine[0]] >> i) & 1):
+                r2 |= sup[i]
+    eqok = True
+    for pa, pb, usz in eu:
+        if sup[pa[0]] & sup[pa[1]]:
+            eqok = False
+        if sup[pb[0]] & sup[pb[1]]:
+            eqok = False
+        if (sup[pa[0]] | sup[pa[1]]) != (sup[pb[0]] | sup[pb[1]]):
+            eqok = False
+    EUSZ[tuple(sorted(v[2] for v in spl.values()))] += 1
+    if len(eu) == 4 and len(spl) == 4 and sorted(spl) == k4 and eqok:
+        EUOK += 1
+    if r1 == r2:
+        REMEQ += 1
+    REMSZ[popc(r1) if r1 == r2 else -1] += 1
+
+    # ---- the four toggles
+    mov = Counter()
+    brk = Counter()
+    dis = Counter()
+    outside = 0
+    for dv in sorted(spl):
+        ma, mb, usz = spl[dv]
+        for w in vecs:
+            x = w & dv
+            if x == ma or x == mb:
+                mov[dv] += 1
+                if (w ^ dv) not in heldset:
+                    outside += 1
+            elif x == 0:
+                dis[dv] += 1
+            else:
+                brk[dv] += 1
+    inside = {}
+    for dv in dmult:
+        inside[dv] = sum(1 for w in vecs if (w ^ dv) in heldset)
+    im2 = all(inside[dv] == 2 * dmult[dv] for dv in dmult)
+    mm = [dv for dv in sorted(spl) if dmult[dv] == 6]
+    MOVCENS.add(tuple(sorted(Counter(mov[dv] for dv in sorted(spl)).items())))
+    BRKCENS.add(tuple(sorted(Counter(brk[dv] for dv in sorted(spl)).items())))
+    if (outside == 0 and im2 and len(mm) == 1 and dis[mm[0]] == 0
+            and all(mov[dv] == 2 * dmult[dv] for dv in sorted(spl))):
+        TOGOK += 1
+
+    # ---- the clean exchange
+    clean = [dv for dv in sorted(spl) if brk[dv] == 0]
+    cok = len(clean) == 1 and dmult[clean[0]] == 2 and mov[clean[0]] == 4
+    if cok:
+        CLNOK += 1
+
+    # ---- the lemma witness: both half-pairings of the clean exchange
+    lem = 0
+    bperm = None
+    if clean:
+        cd = clean[0]
+        ma, mb, usz = spl[cd]
+        aa = [i for i in range(nr) if (ma >> i) & 1]
+        bb = [i for i in range(nr) if (mb >> i) & 1]
+        for tw in (0, 1):
+            pi = list(range(nr))
+            pi[aa[0]] = bb[tw]
+            pi[bb[tw]] = aa[0]
+            pi[aa[1]] = bb[1 - tw]
+            pi[bb[1 - tw]] = aa[1]
+            imb = [image(v, pi) for v in vecs]
+            okb = frozenset(imb) == heldset
+            okk = frozenset(image(x, pi) for x in kern) == kset
+            okc = frozenset(image(x, pi) for x in coset) == cset
+            if okb and okk and okc:
+                pm = tuple(vidx[y] for y in imb)
+                fx = sum(1 for i in range(nh) if pm[i] == i)
+                tc = sum(1 for i in range(nh) if pm[i] != i and pm[pm[i]] == i)
+                if fx == 10 and tc == 4 and all(pm[pm[i]] == i for i in range(nh)):
+                    lem += 1
+                    if bperm is None:
+                        bperm = pm
+                    elif bperm != pm:
+                        bperm = ()
+                    FIXCNT.add((fx, tc // 2))
+    if lem == 2 and bperm:
+        LEMOK += 1
+
+    # ---- the complete self-equivalence search at this fiber
+    aut = eqsearch(tuple(vecs), tuple(vecs), nr, True)
+    idt = tuple(range(nh))
+    ntr = [s for s in aut if s != idt]
+    if len(aut) == 2 and idt in aut and len(ntr) == 1 and bperm and ntr[0] == bperm:
+        SYMOK += 1
+
+    # ---- the parity descent over every nonzero kernel vector
+    ev = 0
+    mx = 0
+    hi = []
+    for x in kern:
+        if x == 0:
+            continue
+        ins = sum(1 for w in vecs if (w ^ x) in heldset)
+        if (ins & 1) == 0 and ins == 2 * dmult.get(x, 0):
+            ev += 1
+        if dmult.get(x, 0) > mx:
+            mx = dmult.get(x, 0)
+        if dmult.get(x, 0) >= 7:
+            hi.append(x)
+    dom = [x for x in kern if x != 0 and dmult.get(x, 0) == mx]
+    MAXM.add((mx, len(dom), len(hi)))
+    exc = []
+    brkset = []
+    rsh = -1
+    dgs = ()
+    if len(dom) == 1 and dom[0] in spl:
+        dv = dom[0]
+        ma, mb, usz = spl[dv]
+        exc = sorted(i for i in range(nh) if (vecs[i] ^ dv) not in heldset)
+        brkset = sorted(i for i in range(nh) if (vecs[i] & dv) not in (0, ma, mb))
+        if len(exc) == 2:
+            rsh = popc(vecs[exc[0]] & vecs[exc[1]])
+            dgs = tuple(sorted(len(adj[i]) for i in exc))
+    RSHARE.add(rsh)
+    DEGX.add(dgs)
+    if (ev == len(kern) - 1 and mx == 6 and len(dom) == 1 and not hi and len(exc) == 2
+            and exc == brkset and dgs == (0, 1) and nh - 2 * mx == 2):
+        PAROK += 1
+
+SH = only(SHAPES) or (0, 0, 0, 0, 0, 0, 0, 0)
+PC = dict(only(PAIRSET)) if len(PAIRSET) == 1 else {}
+GR = only(GRAPHS) or (0, (), ())
+EDC = dict(only(EDCENS)) if len(EDCENS) == 1 else {}
+ALC = dict(only(ALLCENS)) if len(ALLCENS) == 1 else {}
+MOC = dict(only(MOVCENS)) if len(MOVCENS) == 1 else {}
+BRC = dict(only(BRKCENS)) if len(BRKCENS) == 1 else {}
+EUS = "; ".join(" ".join(str(x) for x in k) + " at " + str(EUSZ[k]) for k in sorted(EUSZ))
+RMS = "; ".join(str(k) + " at " + str(REMSZ[k]) for k in sorted(REMSZ))
+MX = only(MAXM) or (0, 0, 0)
+RS = only(RSHARE)
+RS = RS if RS is not None else -1
+DG = only(DEGX) or ()
+FX = only(FIXCNT) or (0, 0)
+
+# ================================================================ G2 the linear instance, regated at every fiber
+
+gate(NORB == set([200]) and SING == 0 and OVL == 0 and FOLDOK and INSOK == NF and SH == (14, 14, 40, 32, 8, 256, 256, 14)
+     and CVRT == NF * 14 and len(PAIRSET) == 1 and PC == PAIR8, "G2",
+     "at all {0} fibers: {1} two-orbits, {2} held cuttings each a union of {3} rows, {4} rows occur, rank {5}, kernel dimension {6}"
+     .format(NF, only(NORB), SH[0], 12, SH[2], SH[3], SH[4]))
+emit("G2 detail: all {0} kernel vectors have even weight, all {0} coset members solve the all ones system, and each of the {1} held"
+     .format(SH[5], CVRT))
+emit("G2 detail: cuttings covers every one of the {0} sample points exactly once; the fold of each fiber is one of {1} cell maps"
+     .format(NPTS, 2))
+emit("G2 detail: the pairwise shared-row census over the {0} pairs takes {1} distinct value over the {2} fibers, and reads"
+     .format(sum(PC.values()), len(PAIRSET), NF))
+emit("G2 detail: " + dshow(PC))
+
+# ================================================================ G3 the minimal-exchange graph
+
+gate(len(GRAPHS) == 1 and GR[0] == 11 and dict(GR[1]) == DEG3 and list(GR[2]) == SIZ3 and CYCOK == NF, "G3",
+     "minimal exchanges, the pairs sharing {0} of their {1} rows, form a graph with {2} edges at every one of the {3} fibers"
+     .format(10, 12, GR[0], NF))
+emit("G3 detail: degree census {0}, five components of sizes {1}, and both components of size {2} are closed cycles of {2} edges"
+     .format(dshow(dict(GR[1])), list(GR[2]), 4))
+
+# ================================================================ G4 the differences are the light kernel vectors
+
+gate(DIFOK == NF and len(EDCENS) == 1 and EDC == EDC4 and len(ALLCENS) == 1, "G4",
+     "every pair difference lies in the kernel; the {0} edge differences have weight {1} and take {2} distinct values, census {3}"
+     .format(GR[0], 4, sum(EDC.values()), dshow(EDC)))
+emit("G4 detail: those {0} values are exactly the {0} kernel vectors of weight {1}, and the unique pair sharing {2} rows differs by"
+     .format(4, 4, 9))
+emit("G4 detail: the unique kernel vector of weight {0}; all of this holds at {1} of {1} fibers".format(6, NF))
+emit("G4 detail: the multiplicity census of all distinct differences over the {0} pairs takes {1} distinct value over the {2} fibers,"
+     .format(sum(PC.values()), len(ALLCENS), NF))
+emit("G4 detail: and reads " + dshow(ALC))
+
+# ================================================================ G5 the equal-union exchanges
+
+gate(EUOK == NF and REMEQ == NF and dict(EUSZ) == EUANC and dict(REMSZ) == RMANC, "G5",
+     "over the {0} rows there are exactly {1} equal-union exchanges at {2} of {3} fibers, and the union-size census over the fibers is anchored"
+     .format(SH[2], 4, EUOK, NF))
+emit("G5 detail: the {0} supports are exactly the {0} kernel vectors of weight {0} and each half is a disjoint pair of rows with equal"
+     .format(4))
+emit("G5 detail: union, at {0} of {1} fibers; the four union sizes read {2}".format(EUOK, NF, EUS))
+emit("G5 detail: the two three-row remainders of the pair sharing {0} rows have equal point union at {1} of {2} fibers,"
+     .format(9, REMEQ, NF))
+emit("G5 detail: of sizes {0}".format(RMS))
+
+# ================================================================ G6 the held set is closed under all four toggles
+
+gate(TOGOK == NF and len(MOVCENS) == 1 and len(BRKCENS) == 1 and MOC == MOV6 and BRC == BRK6, "G6",
+     "for all {0} exchanges every held cutting meeting a full half toggles to another held cutting, {1} images outside, at {2} fibers"
+     .format(4, 0, NF))
+emit("G6 detail: the moved census is {0} and the broken census is {1}, each {2} distinct value over the {3} fibers"
+     .format(dshow(MOC), dshow(BRC), len(MOVCENS), NF))
+emit("G6 detail: inside(d) equals {0} times the multiplicity of d for every distinct pair difference, and the multiplicity {1}"
+     .format(2, 6))
+emit("G6 detail: exchange meets all {0} held cuttings, none disjoint from its {1} rows".format(14, 4))
+
+# ================================================================ G7 exactly one exchange is clean
+
+gate(CLNOK == NF, "G7",
+     "exactly {0} of the {1} exchanges is clean, with broken count {2}; it has multiplicity {3} and moves {4} cuttings, at {5} of {5} fibers"
+     .format(1, 4, 0, 2, 4, NF))
+
+# ================================================================ G8 the clean exchange extends to the coordinates
+
+gate(LEMOK == NF and len(FIXCNT) == 1 and FX == (10, 2), "G8",
+     "both half-pairings of the clean exchange carry the {0} held cuttings, the {1} kernel vectors and the {1} coset members onto themselves"
+     .format(SH[0], SH[5]))
+emit("G8 detail: each is a product of two transpositions of the {0} coordinates, and the induced block permutation fixes {1} blocks"
+     .format(SH[2], FX[0]))
+emit("G8 detail: identically as sets and has {0} two-cycles, the same permutation for either pairing, at {1} of {1} fibers"
+     .format(FX[1], NF))
+
+# ================================================================ G9 that toggle is the whole symmetry
+
+gate(SYMOK == NF, "G9",
+     "the complete block-level self-equivalence search returns exactly {0} at {1} of {1} fibers, and the nontrivial one is the clean toggle"
+     .format(2, NF))
+
+# ================================================================ G10 the parity descent
+
+gate(PAROK == NF and len(MAXM) == 1 and MX == (6, 1, 0) and len(RSHARE) == 1 and RS >= 0 and len(DEGX) == 1 and DG == (0, 1),
+     "G10", "over all {0} nonzero kernel vectors inside(d) is even and equals {1} times the multiplicity of d, at {2} of {2} fibers"
+     .format(SH[5] - 1, 2, NF))
+emit("G10 detail: the maximum multiplicity is {0}, attained by exactly {1} kernel vector, and {2} vector attains {3} or more"
+     .format(MX[0], MX[1], MX[2], 7))
+emit("G10 detail: so the evaders at the maximum number {0}, exactly the dominant exchange's broken pair, of graph degrees {1}"
+     .format(SH[0] - 2 * MX[0], list(DG)))
+emit("G10 detail: the two exceptional cuttings share {0} rows, {1} distinct value over the {2} fibers; {3} = {4} pairs + {5}"
+     .format(RS, len(RSHARE), NF, SH[0], MX[0], SH[0] - 2 * MX[0]))
+
+# ================================================================ totals
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with its sixteen corners, the four hundred kept unit-determinant five-corner pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet on the eight interface slots, and the forty-eight transfer-matrix entries at thirty-six — the named wall. The prior cycle showed the forty-eight fiber systems are ONE instance in forty-eight labellings, carrying exactly one nontrivial involution. This cycle finds where that involution comes from and drives the parity of the fourteen held cuttings down to two of them.

- **The minimal exchanges are the light kernel vectors.** The pairs of held cuttings sharing ten of their twelve rows form an eleven-edge graph at every fiber, and the eleven edge differences take exactly four distinct values — precisely the four weight-four vectors of the fiber's own kernel. The unique pair sharing nine rows differs by the unique weight-six kernel vector.
- **Four equal-union exchanges, found independently of the fourteen.** Over the forty rows there are exactly four two-for-two exchanges — two disjoint row pairs with equal point union — and their supports are exactly the same four weight-four kernel vectors. The held set is closed under all four toggles (zero images land outside), with the inside count equal to twice the pair multiplicity for every difference.
- **One of them is the whole symmetry — the headline.** Exactly one of the four exchanges is clean: it breaks no held cutting it does not move. A lemma proved in the note carries cleanliness to coordinate level — both half-pairings extend to self-equivalences of the instance, verified by explicit image on the fourteen held cuttings, all two hundred fifty-six kernel vectors, and all two hundred fifty-six coset members. A complete backtracking search then returns exactly two self-equivalences — the identity and the clean toggle — so the one clean exchange accounts for the instance's entire symmetry.
- **The parity of fourteen descends to two cuttings.** For every nonzero kernel vector the count of held cuttings it pairs is even — derived, from fixed-point-freeness of adding a nonzero vector on a coset — and equals twice the pair multiplicity, checked over all two hundred fifty-five. The maximum multiplicity six is attained by exactly one vector; that dominant exchange pairs twelve of the fourteen and strands exactly two — the two it breaks, which share eight of their twelve rows. The wall question "why is fourteen even" is now "why are these two cuttings two".

The honest boundary: everything here is an exact finite computational identity on the declared object, and nothing wider; the counts and censuses stay measured, not derived. One designed anchor missed honestly: the spec pinned the exchanges' point-union cardinalities to the sample fiber's values, and the executor's run reported them fiber-dependent — the forty-eight fibers split eight, thirty-two, eight by cardinality class — failing that gate as designed. The orchestrator re-anchored the gate to the full measured census (deterministic across three independent runs, byte-identical stdout) with matching note edits; these cardinalities are labelling properties, and nothing else in the note depends on them. The named next entrance is the anatomy of the two exceptional cuttings: whether their weight-eight joining kernel vector is distinguished in the kernel, and whether any involution pairs them — a pairing with a named reason would carry the evenness of fourteen outright.

## Verification

- Runner re-run by the orchestrator in a clean shell before the re-anchor: stdout byte-identical to the executor's hand-back. After the re-anchor: exit zero, `TOTAL: PASS=10 FAIL=0`, byte-stable across consecutive runs, every census byte-identical to the pre-fix measurement.
- Full note read plus line-by-line runner review (fabrication hunt): every census recomputed from the rebuilt geometry; the kernel row-reduced from each fiber's own incidence; equal-union tests compare point bitmasks, never sizes; the search's feasibility screens live inside the entry point; witnesses built from the half-pairing and checked against independently computed frozen targets, never derived from them.
- The clean-exchange lemma re-derived independently by the orchestrator before the spec was written; the executor ran its own self-check before hand-back.
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags (it caught one over-long docstring line, fixed before landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
