### PR TITLE
feat(cell-geometry): the pinned pair - no map at any level can exchange the two exceptional cuttings

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_PINNED_PAIR_ANATOMY_CYCLE795_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_PINNED_PAIR_ANATOMY_CYCLE795_NOTE_2026-08-15.md
@@ -1,0 +1,244 @@
+# The pinned pair: anatomy of the two exceptional cuttings, the symmetry that fixes each of them, and the two directions outside the light span
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: the instance's own symmetry provably cannot pair the two exceptional cuttings, so a carrier for the parity of the held count must come from structure that does not preserve the minimal exchange graph; the point-cardinality classes of the wall measured here are the nearest such structure, and their fold-by-class table is the first thing to read; no such carrier is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, at every wall fiber of the declared finite cell, of the full weight census of that fiber's own kernel, of the overlap and difference structure of its weight-four and weight-six vectors together with the span they generate, of the profile of its nine weight-eight vectors by multiplicity as a difference of held cuttings and by membership in that span, of the identification of the two exceptional cuttings by graph degree and of the two span-outside directions that emanate from the isolated one, of a derived degree lemma forbidding any shared-row-preserving bijection from exchanging the two, of a complete backtracking search whose nontrivial member fixes each exceptional cutting individually and fixes the named kernel directions as vectors on the rows, and of the equivariant split of the dominant pairing into four fixed pairs and two exchanged ones; the point cardinalities of the equal-union exchanges and their fold-by-class table are labelling-level and are anchored as measured censuses over the fibers, never as one value; no physical or lattice-wide identification`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the unit
+four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive at the
+adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into, the 192
+pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell. The pair
+of tetrahedral letters on the two slots of axis zero, drawn from a 16-letter alphabet, gives the
+interface matrix of trace 2000 with exactly 48 entries equal to 36. Each of those 48 fibers holds
+36 cuttings and is held setwise by exactly 2 of the 384 maps; its nontrivial holder is that fiber's
+fold, and each fold holds 14 of its own fiber's 36 cuttings.
+
+The stem `PHYSICAL_CELL_CUTTING_CLEAN_EXCHANGE_SYMMETRY_CYCLE794_NOTE_2026-08-15` is not yet on main
+and is referenced by name only. It named a dominant exchange that pairs 12 of the 14 fold-held
+cuttings and strands the other 2. Everything that rests on it is rebuilt here rather than assumed,
+and regated at all 48 fibers: each fold cuts the 400 kept pieces into 200 two-orbits, each held
+cutting is an exact union of 12 of them, exactly 40 of the 200 occur across the 14, the 625 by 40
+point-row incidence over the field with two elements has rank 32 and kernel dimension 8 with all
+256 kernel vectors of even weight, and each of the 672 held cuttings covers each of the 625 sample
+points exactly once.
+
+The question this note asks is what those 2 stranded cuttings are: whether the kernel around them
+has any named shape, whether they are distinguishable from each other by an invariant of the
+instance rather than of a labelling, and whether any symmetry of the instance pairs them — since
+such a pairing would carry the evenness of 14 outright. The answer is that they are canonically
+distinguishable, that no symmetry can pair them, and that the instance's entire symmetry fixes each
+of them where it stands.
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+recomputed by the linked runner from that object alone: it rebuilds the object from the corner list
+before any gate runs, uses the standard library only, performs no file input or output and no
+randomness, and gates each recomputed value against the value stated here.
+
+## What is proved
+
+- **The kernel has one weight census over the whole wall.** The kernel of a fiber's point-row
+  incidence has dimension 8, and the weights of its 256 vectors read
+  `{0: 1, 4: 4, 6: 1, 8: 9, 10: 5, 12: 13, 14: 16, 16: 17, 18: 30, 20: 31, 22: 44, 24: 40, 26: 24, 28: 12, 30: 7, 32: 1, 34: 1}`,
+  a single distinct value over the 48 fibers, 17 weights totalling 256. The census is not unimodal
+  and it is not the census of a random even-weight code of that dimension: it has exactly 4 vectors
+  of weight 4, exactly 1 of weight 6, exactly 9 of weight 8, and a single vector of weight 34 far
+  above the rest. Everything below reads structure off the light end of that census.
+
+- **The light vectors span a fixed subspace of dimension four.** Among the 6 unordered pairs of the
+  4 weight-4 kernel vectors exactly 1 pair overlaps, and it overlaps in exactly 1 row; the other 5
+  pairs are disjoint. The overlap census is `{0: 5, 1: 1}` and the census of pairwise difference
+  weights is `{6: 1, 8: 5}`, each single-valued over the 48 fibers. The one overlapping pair differs
+  by the unique kernel vector of weight 6, so the weight-6 vector is not an extra object: it is the
+  difference of the only two light vectors that meet. The span over the field with two elements of
+  those 5 light vectors has exactly 16 members, that is dimension 4, at every fiber, and it is
+  exactly half the dimension of the kernel.
+
+- **The nine weight-eight vectors split five inside the light span and four outside.** Classify each
+  weight-8 kernel vector by the ordered pair consisting of its multiplicity as a difference over the
+  91 pairs of held cuttings and its membership in the light span. The census is
+  `{(0,1): 3, (1,0): 2, (2,0): 2, (2,1): 2}` with 1 meaning inside, single-valued over the 48
+  fibers. So 5 lie inside the light span and 4 outside; every weight-8 vector of multiplicity 0,
+  that is every one that is not a difference of held cuttings at all, lies inside the span; and the
+  2 vectors of multiplicity 1, the directions realized by exactly one pair of held cuttings each,
+  both lie outside it. Multiplicity and span membership are independent-looking labels, and the
+  census shows they are not independent.
+
+- **The two exceptional cuttings are canonically distinguishable.** Call two held cuttings a minimal
+  exchange when they share 10 of their 12 rows; as a graph on the 14 held cuttings the degree census
+  is `{0: 1, 1: 4, 2: 9}` at every fiber. The dominant difference, the unique kernel vector of
+  multiplicity 6, breaks exactly 2 held cuttings, and those 2 are the exceptional pair. Their graph
+  degrees are 0 and 1. Degree is an invariant of the instance and not of a labelling, so the pair is
+  ordered by the instance itself: one exceptional cutting is the isolated vertex, the other is an
+  endpoint of a path, and there is exactly 1 vertex of degree 0 in the whole graph.
+
+- **Both multiplicity-one weight-eight directions emanate from the isolated cutting.** The
+  difference of the two exceptional cuttings has weight 8 and multiplicity 1, and the only pair of
+  held cuttings realizing it is the exceptional pair itself. The other multiplicity-1 weight-8
+  vector is likewise realized by exactly 1 pair, and that pair joins the degree-0 cutting to a
+  cutting of degree 2. So both of the kernel's singly realized weight-8 directions have the isolated
+  cutting as one endpoint: one carries it to its fellow exceptional cutting, the other to a
+  degree-2 cutting. Both lie outside the light span, at 48 of 48 fibers.
+
+- **The whole symmetry fixes each exceptional cutting individually.** The complete backtracking
+  search for block-level self-equivalences of a fiber's instance against itself returns exactly 2
+  elements at every fiber. Its nontrivial member is an involution whose cycle structure on the 14
+  held cuttings is 10 fixed points and 2 two-cycles, and it fixes each of the 2 exceptional cuttings
+  where it stands. Acting on the 40 row coordinates it fixes as vectors, not merely as a set, all 7
+  named kernel directions: the 4 weight-4 vectors, the weight-6 vector, the dominant difference and
+  the exceptional pair's own difference. The pinning is therefore at the level of the rows and not
+  only at the level of the blocks.
+
+- **The dominant pairing splits equivariantly as four plus two.** The dominant difference pairs the
+  12 non-exceptional held cuttings into 6 pairs, each pair differing by that one vector. The
+  nontrivial self-equivalence fixes 4 of those 6 pairs as sets and exchanges the remaining 2 pairs
+  with each other, and its 4 moved cuttings are exactly the union of those 2 exchanged pairs. So the
+  symmetry and the dominant pairing commute in the strongest available sense: the pairing is a map
+  of the symmetry's orbits, and the 2 stranded cuttings sit outside both.
+
+## The degree lemma
+
+Let s be any bijection of the 14 held cuttings onto themselves that preserves, for every pair, the
+number of rows the two cuttings share. Then s carries pairs sharing 10 of their 12 rows to pairs
+sharing 10 of their 12 rows, so s is an automorphism of the minimal exchange graph and preserves the
+degree of every vertex. The two exceptional cuttings have degrees 0 and 1, and the degree census
+`{0: 1, 1: 4, 2: 9}` records exactly 1 vertex of degree 0, so no such s exchanges them. Every
+self-equivalence of the instance is such a bijection, because it is induced by a permutation of the
+40 rows and a shared-row count is a count of rows. Hence no symmetry of the instance pairs the two
+exceptional cuttings — the pairing that would have carried the evenness of 14 outright cannot exist
+inside the instance. This is a derivation, and the complete search confirms it constructively at all
+48 fibers: the entire nontrivial symmetry fixes each of the 2 individually, and does not exchange
+them.
+
+## Derived versus measured
+
+Derived at the declared finite scope: the degree lemma above and its consequence that no
+self-equivalence of the instance exchanges the two exceptional cuttings; that the weight-6 kernel
+vector is the difference of the unique overlapping pair of weight-4 vectors, once the overlap census
+`{0: 5, 1: 1}` is in hand, since two weight-4 vectors meeting in exactly 1 row differ by a vector of
+weight 6; and that the exceptional pair's difference is fixed as a vector by any self-equivalence
+fixing both members, since a permutation of the rows commutes with the symmetric difference of two
+row sets. The equivariance of the four-plus-two split follows from the row-level fixing of the
+dominant difference together with the block action.
+
+Measured, not derived, at the declared finite scope: the whole kernel weight census and every number
+in it; the value 16 for the light span and the fact that its dimension is exactly half the kernel's;
+the weight-8 profile `{(0,1): 3, (1,0): 2, (2,0): 2, (2,1): 2}` and, with it, the fact that both
+multiplicity-1 directions lie outside the span and share the isolated cutting as an endpoint; the
+self-equivalence count 2 and the cycle structure 10 fixed points with 2 two-cycles; and the count 14
+itself, whose evenness remains measured, not derived, exactly as before.
+
+The labelling level is measured, not derived, and is reported as such. The four union sizes of a
+fiber's equal-union exchanges read 50 100 100 100 at 8 fibers, 100 100 100 100 at 32 and
+100 100 100 175 at 8. Grouping the 48 fibers by their fold, the multiset of per-fold class censuses
+is: 3 folds see only the middle class, 1 fold splits 4 light and 4 heavy, and 2 folds split 4 middle
+with 2 light and 2 heavy. The 48 wall entries are closed under the swap of the two letters, with 0
+diagonal entries, and each of the two extreme classes is closed under that swap on its own: the
+light class is the 8 ordered entries of the unordered letter pairs (2,12), (4,14), (5,13), (7,11)
+and the heavy class the 8 of (2,3), (4,7), (10,11), (12,13). Nothing here explains why the wall
+splits 8, 32 and 8, why one fold carries both extremes and three carry neither, or why the extreme
+classes are closed under the letter swap. Those are the measured facts and no conclusion is drawn
+from them in this note; a row's point support depends on which pieces its fiber uses, so these
+cardinalities are properties of a labelling, and the note treats them as an entrance rather than as
+a result.
+
+All of the above are computational identities of the declared unit four-cube object, its 15800
+cuttings, and the order-384 symmetry group of the cell. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+## What the wall now asks
+
+The parity target was moved from 14 cuttings onto 2, and this cycle establishes that those 2 cannot
+be moved further by anything living inside the instance. The degree lemma is a genuine obstruction,
+not a failed search: any bijection preserving shared-row counts preserves graph degree, the two
+exceptional cuttings carry different degrees, and so the pairing that would discharge the evenness
+of 14 is not available at that level at all. The wall therefore changes shape rather than standing
+where it was. It is no longer "find the involution pairing the two"; it is "find the structure that
+does not preserve the minimal exchange graph and still acts on the wall".
+
+That reframing is what makes the labelling level interesting rather than incidental. The classes
+measured above are exactly of that kind: the point-cardinality class of a fiber is invisible to the
+minimal exchange graph, which never looks at point counts, yet it partitions the 48 fibers 8, 32 and
+8 and interacts with the folds in a way that is not constant. A map of the wall that mixes fibers of
+different classes is not required to preserve degrees, and is therefore not blocked by the lemma.
+
+## Next entrance
+
+Read the fold-by-class table as an object in its own right. Three questions are ready to be asked
+of it with the machinery already built here: whether the class of a fiber is determined by its
+letter pair alone, given that both extreme classes are closed under the letter swap and consist of
+4 unordered pairs each; whether the 1 fold carrying 4 light and 4 heavy fibers is distinguished
+among the 6 folds by anything other than that census; and whether a map of the wall that carries a
+light fiber to a heavy one exists at all inside the 384 maps of the cell, since such a map would
+move point cardinalities and hence could not be an instance self-equivalence in the sense pinned
+down above. None of those three is claimed here. What is claimed is that the route through the
+instance's own symmetry is now fully characterised and the route through the labelling level is
+open, with its first table already measured.
+
+## Review record
+
+- Rows are the two-orbits of the 400 kept pieces under each fiber's own fold, and blocks are that
+  fiber's fold-held cuttings written as row sets. Both conventions are fixed before any computation
+  runs, and every statement is made for all 48 fibers, not for a chosen one; every census is a
+  multiset, never a list of row labels, and the runner gates that each takes exactly 1 distinct
+  value over the 48 fibers.
+- The light-vector gate is stated on invariants and not on positions: it asserts how many pairs
+  overlap and in how many rows, not which sorted index positions do, so a relabelling of the rows
+  cannot change what is being tested.
+- The exceptional pair is identified by the exchange the dominant difference breaks, and its graph
+  degrees are then read off the independently built minimal exchange graph; neither object is
+  computed from the other's answer.
+- The self-equivalence used in the row-level gates is built from the clean exchange's half-pairing
+  and then verified by explicit image on the 14 held cuttings, on all 256 kernel vectors and on all
+  256 coset members, and is required to induce the same block permutation as the complete search
+  returns; both half-pairings are checked, not one.
+- When testing whether the dominant pairing fixes a pair of cuttings as a set, the image pair and
+  the original pair are both sorted before comparison, so an exchange within a pair is correctly
+  counted as fixed rather than as moved.
+- The point cardinalities of the equal-union exchanges are fiber-dependent; the runner's
+  labelling-level gate is anchored to the full measured census over the 48 fibers and to the
+  multiset of per-fold class censuses, never to a single sample-fiber value and never to a fold
+  index, since fold indices are labelling artifacts.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a commit
+  cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run
+[physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.py](../scripts/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.py).
+The reviewed cached output belongs at
+[physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.txt](../logs/runner-cache/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.txt)
+and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC` budget, finishes in
+well under a minute on the reference machine, and stays far below one gigabyte. Its final line is
+`TOTAL: PASS=10 FAIL=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13837,6 +13837,10 @@
   "physical_cell_cutting_object_distance_cycle751_note_2026-08-09": {
    "deps_hash": "92314bbf23cc",
    "out_degree": 2
+  },
+  "physical_cell_cutting_pinned_pair_anatomy_cycle795_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_shadow_rank_unseen_swap_cycle754_note_2026-08-09": {
    "deps_hash": "785d0ddf9da3",

--- a/logs/runner-cache/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.py
+runner_sha256: a04127bbc7b2eac2c82d8d2c71080913b73a8806af150d138ff06d698221b340
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 13.97
+status: ok
+----- stdout -----
+PASS G1 2672 pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, 16 letters, trace 2000, 48 entries at 36
+PASS G2 at all 48 fibers: 200 two-orbits, 14 held cuttings each a union of 12 of 40 rows, rank 32, kernel dimension 8
+G2 detail: all 256 kernel vectors have even weight and each of the 672 held cuttings covers every one of the 625 points once
+PASS G3 the kernel weight census takes 1 distinct value over the 48 fibers, with 17 weights totalling 256
+G3 detail: {0: 1, 4: 4, 6: 1, 8: 9, 10: 5, 12: 13, 14: 16, 16: 17, 18: 30, 20: 31, 22: 44, 24: 40, 26: 24, 28: 12, 30: 7, 32: 1, 34: 1}
+PASS G4 among the 6 pairs of the 4 weight 4 kernel vectors exactly 1 pair overlaps, in exactly 1 row, at all 48 fibers
+G4 detail: overlap census {0: 5, 1: 1} and pair difference weight census {6: 1, 8: 5}, each 1 distinct value over the 48 fibers
+G4 detail: the overlapping pair differs by the unique weight 6 kernel vector; the light span of those 5 vectors has 16 members
+PASS G5 each of the 9 weight 8 kernel vectors is classed by its multiplicity over the 91 held pairs and its light span membership
+G5 detail: the profile census by (multiplicity, membership) is {(0,1): 3, (1,0): 2, (2,0): 2, (2,1): 2}, with 1 meaning inside, at 48 of 48 fibers
+G5 detail: so 5 of the 9 lie inside the light span and 4 outside, and every multiplicity 0 weight 8 vector is inside
+PASS G6 the minimal exchange graph, the pairs sharing 10 of their 12 rows, has degree census {0: 1, 1: 4, 2: 9} at all 48 fibers
+G6 detail: the dominant difference, of multiplicity 6, breaks exactly 2 held cuttings, of graph degrees 0 and 1
+G6 detail: their difference has weight 8 and multiplicity 1, realized by that pair alone; the other multiplicity 1 weight 8
+G6 detail: vector is realized by exactly 1 pair, joining the degree 0 cutting to a degree 2 one; both lie outside the light span
+PASS G7 the complete block-level self-equivalence search returns exactly 2 elements at 48 of 48 fibers
+G7 detail: the nontrivial one fixes each of the 2 exceptional cuttings, and its cycle structure on the 14 held cuttings is
+G7 detail: 10 fixed points and 2 two-cycles, 1 distinct value over the 48 fibers
+PASS G8 on the 40 row coordinates the nontrivial self-equivalence fixes as vectors all 7 anchored kernel directions, at 48 of 48 fibers
+G8 detail: the 4 weight 4 vectors, the weight 6 vector, the dominant difference, and the exceptional pair difference of weight 8
+PASS G9 the dominant difference pairs the 12 non-exceptional held cuttings into 6 pairs at all 48 fibers
+G9 detail: the nontrivial self-equivalence fixes 4 of those pairs as sets and exchanges the other 2 with each other, and its 4
+G9 detail: moved cuttings are exactly the union of the 2 exchanged pairs
+PASS G10 the union size class of a fiber takes 3 values over the 48 fibers, and the per fold class census multiset is anchored
+G10 detail: the four union sizes read 50 100 100 100 at 8; 100 100 100 100 at 32; 100 100 100 175 at 8
+G10 detail: classes are numbered 0 light, 1 middle, 2 heavy by union size; the per fold census multiset reads
+G10 detail: {0: 2, 1: 4, 2: 2} at 2; {0: 4, 2: 4} at 1; {1: 8} at 3
+G10 detail: the 48 wall entries are closed under the letter swap, with 0 diagonal entries, and so is each extreme class
+G10 detail: light letter pairs (2,12) (4,14) (5,13) (7,11); heavy letter pairs (2,3) (4,7) (10,11) (12,13)
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.py
+++ b/scripts/physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15.py
@@ -1,0 +1,836 @@
+"""Physical cell cutting: the pinned pair, the whole symmetry fixing each exceptional cutting, and the weight-eight directions.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, and the sixteen-letter facet alphabet on the two slots of axis zero. Nothing outside that finite object enters any gate.
+
+Earlier cycles linearized every wall fiber: rows are the two-orbits of the 400 kept pieces under that fiber's fold, the fold-held cuttings
+are weight-twelve vectors on the rows that occur, the exact cover condition is an all-ones linear system whose solution set is one coset of
+the kernel, and the 48 fiber systems are one instance carried in 48 labellings of the rows. The prior cycle isolated a dominant exchange
+pairing twelve of the fourteen held cuttings and stranding two of them. This cycle reads the anatomy of those two: the full weight census of
+the kernel, the light span of the weight-four and weight-six vectors, the profile of the nine weight-eight vectors, the complete block-level
+self-equivalence search and its action on the stranded pair, the equivariant split of the dominant pairing, and the labelling-level classes
+of the wall. Gates G1 to G10, one line each with a few detail lines, then the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    if OUT[0] >= 5800:
+        raise ValueError("output over the character budget")
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def pshow(d):
+    return "{" + ", ".join("({0},{1}): {2}".format(k[0], k[1], d[k]) for k in sorted(d)) + "}"
+
+
+def cshow(k):
+    return "{" + ", ".join("{0}: {1}".format(a, b) for a, b in k) + "}"
+
+
+def popc(x):
+    return bin(x).count("1")
+
+
+def only(s):
+    return sorted(s)[0] if len(s) == 1 else None
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                fq = M[r][c]
+                M[r] = [M[r][k] - fq * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+AXVAL = [[NSHIFT * k + OFFS[i] for k in range(RSTEP)] for i in range(4)]
+NPTS = RSTEP ** 4
+MASK = []
+for (v0, Ci) in BARY:
+    off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+    col = [[[Ci[i][ax] * u for i in range(4)] for u in AXVAL[ax]] for ax in range(4)]
+    bits = 0
+    idx = 0
+    for a in col[0]:
+        s1 = [a[i] - off[i] for i in range(4)]
+        for b in col[1]:
+            s2 = [s1[i] + b[i] for i in range(4)]
+            for c in col[2]:
+                s3 = [s2[i] + c[i] for i in range(4)]
+                for d in col[3]:
+                    w = [s3[i] + d[i] for i in range(4)]
+                    sw = sum(w)
+                    if all(x > 0 for x in w) and sw < DIV:
+                        bits |= (1 << idx)
+                    idx += 1
+    MASK.append(bits)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NK = len(KEPT)
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+GID = ((0, 1, 2, 3), 0)
+
+FACE = {}
+for t in range(NK):
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda fz: sorted(sorted(t) for t in fz))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def compose(a, b):
+    p, m = a
+    q, n = b
+    r = tuple(q[p[i]] for i in range(4))
+    k = n
+    for j in range(4):
+        if (m >> j) & 1:
+            k ^= (1 << q[j])
+    return (r, k)
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+def rref(rows, ncols):
+    mat = [r for r in rows if r]
+    piv = []
+    r = 0
+    for c in range(ncols):
+        p = -1
+        for i in range(r, len(mat)):
+            if (mat[i] >> c) & 1:
+                p = i
+                break
+        if p < 0:
+            continue
+        mat[r], mat[p] = mat[p], mat[r]
+        for i in range(len(mat)):
+            if i != r and ((mat[i] >> c) & 1):
+                mat[i] ^= mat[r]
+        piv.append(c)
+        r += 1
+    return mat[:r], piv
+
+
+def image(v, pi):
+    w = 0
+    while v:
+        low = v & (-v)
+        w |= (1 << pi[low.bit_length() - 1])
+        v ^= low
+    return w
+
+
+# ================================================================ G1 the declared object, the alphabet and the wall
+
+PAIROF = [(KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS)]
+JC = Counter(PAIROF)
+TRM = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TRM[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TRM[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(PAIROF[i], []).append(i)
+E36 = sorted(kj for kj in FIB if TRM[kj[0]][kj[1]] == 36)
+NF = len(E36)
+FSZ = sorted(set(len(FIB[kj]) for kj in E36))
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NL == 16 and TRC == 2000 and N36 == 48 and NF == 48 and FSZ == [36], "G1",
+     "{0} pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, {7} letters, trace {8}, {9} entries at {10}"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, len(G384), NL, TRC, N36, 36))
+
+# ================================================================ the fold of every fiber
+
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+WALL = sorted(set(c for F in FL for c in F))
+POSW = {c: i for i, c in enumerate(WALL)}
+FOLD = [None] * NF
+STCNT = [0] * NF
+DEFECT = 0
+for g in G384:
+    mp = piecemap(g, USED)
+    if len(set(mp.values())) != NU:
+        DEFECT += 1
+    img = [SIDX[frozenset(mp[t] for t in SOLS[c])] for c in WALL]
+    for f in range(NF):
+        S = FS[f]
+        ok = True
+        for c in FL[f]:
+            if img[POSW[c]] not in S:
+                ok = False
+                break
+        if ok:
+            STCNT[f] += 1
+            if g != GID:
+                FOLD[f] = g
+
+DIST = sorted(set(FOLD))
+FIDX = {g: i for i, g in enumerate(DIST)}
+FOLDOK = DEFECT == 0 and set(STCNT) == set([2]) and all(compose(g, g) == GID for g in DIST)
+
+# ================================================================ the two-orbit table of each fold
+
+MPKS = []
+ORBS = []
+OIDX = []
+SING = 0
+OVL = 0
+NORB = set()
+for g in DIST:
+    mpk = piecemap(g, range(NK))
+    orbs = []
+    seen = set()
+    for t in range(NK):
+        if t in seen:
+            continue
+        u = mpk[t]
+        seen.add(t)
+        seen.add(u)
+        if u == t:
+            SING += 1
+        if MASK[t] & MASK[u]:
+            OVL += 1
+        orbs.append((t, u))
+    oi = {}
+    for i in range(len(orbs)):
+        oi[orbs[i][0]] = i
+        oi[orbs[i][1]] = i
+    MPKS.append(mpk)
+    ORBS.append(orbs)
+    OIDX.append(oi)
+    NORB.add(len(orbs))
+
+# ================================================================ the complete search over block bijections
+
+
+def patterns(blocks, nc):
+    out = []
+    for c in range(nc):
+        p = 0
+        for i in range(len(blocks)):
+            if (blocks[i] >> c) & 1:
+                p |= (1 << i)
+        out.append(p)
+    return out
+
+
+def shape(blocks, nc):
+    ct = Counter(patterns(blocks, nc))
+    return sorted((popc(p), ct[p]) for p in ct)
+
+
+def eqsearch(ba, bb, nc, findall):
+    """Complete backtracking search for bijections of blocks carrying one instance onto another; empty list means NOT FOUND."""
+    if len(ba) != len(bb) or sorted(popc(x) for x in ba) != sorted(popc(x) for x in bb):
+        return []
+    if shape(ba, nc) != shape(bb, nc):
+        return []
+    m = len(ba)
+    ia = [[popc(ba[i] & ba[j]) for j in range(m)] for i in range(m)]
+    ib = [[popc(bb[i] & bb[j]) for j in range(m)] for i in range(m)]
+    if sorted(sorted(r) for r in ia) != sorted(sorted(r) for r in ib):
+        return []
+    capat = []
+    cur = [0] * nc
+    capat.append(Counter(cur))
+    for k in range(m):
+        for c in range(nc):
+            if (ba[k] >> c) & 1:
+                cur[c] |= (1 << k)
+        capat.append(Counter(cur))
+    asg = [-1] * m
+    used = [False] * m
+    res = []
+
+    def bpat(k):
+        ct = Counter()
+        for c in range(nc):
+            p = 0
+            for i in range(k):
+                if (bb[asg[i]] >> c) & 1:
+                    p |= (1 << i)
+            ct[p] += 1
+        return ct
+
+    def rec(k):
+        if k == m:
+            res.append(tuple(asg))
+            return not findall
+        for j in range(m):
+            if used[j] or popc(ba[k]) != popc(bb[j]):
+                continue
+            good = True
+            for i in range(k):
+                if ia[k][i] != ib[j][asg[i]]:
+                    good = False
+                    break
+            if not good:
+                continue
+            asg[k] = j
+            used[j] = True
+            if bpat(k + 1) == capat[k + 1] and rec(k + 1):
+                used[j] = False
+                asg[k] = -1
+                return True
+            used[j] = False
+            asg[k] = -1
+        return False
+
+    rec(0)
+    return sorted(res)
+
+
+# ================================================================ the frozen anchors, measured independently of this run
+
+KWC = {0: 1, 4: 4, 6: 1, 8: 9, 10: 5, 12: 13, 14: 16, 16: 17, 18: 30, 20: 31,
+       22: 44, 24: 40, 26: 24, 28: 12, 30: 7, 32: 1, 34: 1}
+OVA = {0: 5, 1: 1}
+DWA = {6: 1, 8: 5}
+W8A = {(0, 1): 3, (1, 0): 2, (2, 0): 2, (2, 1): 2}
+DEG3 = {0: 1, 1: 4, 2: 9}
+EUANC = {(50, 100, 100, 100): 8, (100, 100, 100, 100): 32, (100, 100, 100, 175): 8}
+FDANC = {((0, 2), (1, 4), (2, 2)): 2, ((0, 4), (2, 4)): 1, ((1, 8),): 3}
+LPA = [(2, 12), (4, 14), (5, 13), (7, 11)]
+HPA = [(2, 3), (4, 7), (10, 11), (12, 13)]
+
+# ================================================================ the per-fiber work, everything rebuilt at every fiber
+
+INSOK = 0
+SHAPES = set()
+CVRT = 0
+KWCENS = set()
+OVCENS = set()
+DWCENS = set()
+SPANSZ = set()
+LITOK = 0
+W8CENS = set()
+W8OK = 0
+DEGCENS = set()
+DEGX = set()
+G6OK = 0
+FIXCNT = set()
+SYMOK = 0
+FIXOK = 0
+EQVOK = 0
+EUSZ = Counter()
+CLS = [None] * NF
+
+for f in range(NF):
+    fi = FIDX[FOLD[f]]
+    mpk = MPKS[fi]
+    oi = OIDX[fi]
+    orbs = ORBS[fi]
+    held = [c for c in FL[f] if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+    raw = []
+    u12 = 0
+    for c in held:
+        s = set(SOLS[c])
+        rr = frozenset(oi[t] for t in s)
+        if len(rr) == 12 and all(orbs[i][0] in s and orbs[i][1] in s for i in rr):
+            u12 += 1
+        raw.append(rr)
+    nh = len(raw)
+    rowg = sorted(set().union(*raw))
+    nr = len(rowg)
+    rpos = {r: i for i, r in enumerate(rowg)}
+    vecs = [sum(1 << rpos[r] for r in rr) for rr in raw]
+    sup = [MASK[orbs[rowg[i]][0]] | MASK[orbs[rowg[i]][1]] for i in range(nr)]
+    pat = []
+    for p in range(NPTS):
+        q = 0
+        for i in range(nr):
+            if (sup[i] >> p) & 1:
+                q |= (1 << i)
+        pat.append(q)
+    red, piv = rref(pat, nr)
+    rk = len(red)
+    pset = set(piv)
+    kb = []
+    for fc in range(nr):
+        if fc in pset:
+            continue
+        v = (1 << fc)
+        for i in range(rk):
+            if (red[i] >> fc) & 1:
+                v |= (1 << piv[i])
+        kb.append(v)
+    kern = [0]
+    for b in kb:
+        kern = kern + [x ^ b for x in kern]
+    kset = frozenset(kern)
+    coset = [vecs[0] ^ x for x in kern]
+    cset = frozenset(coset)
+    heldset = frozenset(vecs)
+    vidx = {vecs[i]: i for i in range(nh)}
+    cvr = sum(1 for v in vecs if all(popc(q & v) == 1 for q in pat))
+    CVRT += cvr
+    evenk = all((popc(x) & 1) == 0 for x in kern)
+    SHAPES.add((nh, u12, nr, rk, len(kb), len(kset), len(heldset)))
+    if (nh == 14 and u12 == nh and nr == 40 and rk == 32 and len(kb) == 8 and len(kset) == 2 ** len(kb)
+            and evenk and cvr == nh and len(heldset) == nh and set(popc(v) for v in vecs) == set([12])):
+        INSOK += 1
+
+    # ---- G3 the full weight census of the kernel
+    kwc = Counter(popc(x) for x in kern)
+    KWCENS.add(tuple(sorted(kwc.items())))
+
+    # ---- G4 the light vectors and their span
+    k4 = sorted(x for x in kern if popc(x) == 4)
+    k6 = sorted(x for x in kern if popc(x) == 6)
+    k8 = sorted(x for x in kern if popc(x) == 8)
+    ovc = Counter()
+    dwc = Counter()
+    ovp = []
+    for a, b in itertools.combinations(k4, 2):
+        ovc[popc(a & b)] += 1
+        dwc[popc(a ^ b)] += 1
+        if a & b:
+            ovp.append((a, b))
+    span = set([0])
+    for b in k4 + k6:
+        span = span | set(x ^ b for x in span)
+    spanset = frozenset(span)
+    OVCENS.add(tuple(sorted(ovc.items())))
+    DWCENS.add(tuple(sorted(dwc.items())))
+    SPANSZ.add(len(spanset))
+    if (len(k4) == 4 and len(k6) == 1 and len(k8) == 9 and len(ovp) == 1
+            and popc(ovp[0][0] & ovp[0][1]) == 1 and (ovp[0][0] ^ ovp[0][1]) == k6[0]
+            and len(spanset) == 16 and dict(ovc) == OVA and dict(dwc) == DWA):
+        LITOK += 1
+
+    # ---- the pairs of held cuttings, their differences and the minimal-exchange graph
+    dmult = Counter()
+    dpair = {}
+    edges = []
+    npr = 0
+    for a, b in itertools.combinations(range(nh), 2):
+        npr += 1
+        it = popc(vecs[a] & vecs[b])
+        dv = vecs[a] ^ vecs[b]
+        dmult[dv] += 1
+        dpair.setdefault(dv, []).append((a, b))
+        if it == 10:
+            edges.append((a, b))
+    adj = [[] for _ in range(nh)]
+    for a, b in edges:
+        adj[a].append(b)
+        adj[b].append(a)
+    deg = Counter(len(adj[i]) for i in range(nh))
+    DEGCENS.add(tuple(sorted(deg.items())))
+
+    # ---- G5 the profile of the weight-eight vectors
+    prof = Counter()
+    for x in k8:
+        prof[(dmult.get(x, 0), 1 if x in spanset else 0)] += 1
+    W8CENS.add(tuple(sorted(prof.items())))
+    if len(k8) == 9 and npr == 91 and dict(prof) == W8A:
+        W8OK += 1
+
+    # ---- equal-union exchanges over the rows, point sets compared as point sets
+    ug = {}
+    for i, j in itertools.combinations(range(nr), 2):
+        if sup[i] & sup[j]:
+            continue
+        ug.setdefault(sup[i] | sup[j], []).append((i, j))
+    eu = []
+    for u in ug:
+        for pa, pb in itertools.combinations(ug[u], 2):
+            if len(set(pa) | set(pb)) == 4:
+                eu.append((pa, pb, popc(u)))
+    spl = {}
+    for pa, pb, usz in eu:
+        ma = (1 << pa[0]) | (1 << pa[1])
+        mb = (1 << pb[0]) | (1 << pb[1])
+        spl[ma | mb] = (ma, mb, usz)
+    brk = {}
+    for dv in sorted(spl):
+        ma, mb, usz = spl[dv]
+        brk[dv] = sum(1 for w in vecs if (w & dv) not in (0, ma, mb))
+    usz4 = tuple(sorted(v[2] for v in spl.values()))
+    EUSZ[usz4] += 1
+    CLS[f] = usz4
+
+    # ---- G6 the dominant exchange, the exceptional pair, and the two multiplicity-one weight-eight vectors
+    mx = max(dmult.values())
+    dom = [x for x in dmult if dmult[x] == mx]
+    exc = []
+    dgs = ()
+    if mx == 6 and len(dom) == 1 and dom[0] in spl:
+        ma, mb, usz = spl[dom[0]]
+        exc = sorted(i for i in range(nh) if (vecs[i] & dom[0]) not in (0, ma, mb))
+        if len(exc) == 2:
+            dgs = tuple(sorted(len(adj[i]) for i in exc))
+    DEGX.add(dgs)
+    de = 0
+    if len(exc) == 2:
+        de = vecs[exc[0]] ^ vecs[exc[1]]
+    m1 = sorted(x for x in k8 if dmult.get(x, 0) == 1)
+    if len(exc) == 2 and dgs == (0, 1) and len(m1) == 2 and de in m1:
+        iso = exc[0] if len(adj[exc[0]]) == 0 else exc[1]
+        oth = [x for x in m1 if x != de]
+        op = dpair[oth[0]][0] if len(oth) == 1 and len(dpair[oth[0]]) == 1 else None
+        if (popc(de) == 8 and dpair[de] == [tuple(exc)] and op is not None and iso in op
+                and sorted(len(adj[i]) for i in op) == [0, 2]
+                and de not in spanset and oth[0] not in spanset):
+            G6OK += 1
+
+    # ---- G7 the complete self-equivalence search and its action on the exceptional pair
+    aut = eqsearch(tuple(vecs), tuple(vecs), nr, True)
+    idt = tuple(range(nh))
+    ntr = [s for s in aut if s != idt]
+    pm = ntr[0] if (len(aut) == 2 and idt in aut and len(ntr) == 1) else None
+    if pm is not None:
+        fx = sum(1 for i in range(nh) if pm[i] == i)
+        tc = sum(1 for i in range(nh) if pm[i] != i and pm[pm[i]] == i)
+        FIXCNT.add((fx, tc // 2))
+        if (fx == 10 and tc == 4 and all(pm[pm[i]] == i for i in range(nh))
+                and len(exc) == 2 and pm[exc[0]] == exc[0] and pm[exc[1]] == exc[1]):
+            SYMOK += 1
+
+    # ---- G8 the coordinate-level action of that self-equivalence
+    clean = [dv for dv in sorted(spl) if brk[dv] == 0]
+    tgt = list(k4) + list(k6) + list(dom) + ([de] if len(exc) == 2 else [])
+    npair = 0
+    fixed = 0
+    if len(clean) == 1 and pm is not None:
+        ma, mb, usz = spl[clean[0]]
+        aa = [i for i in range(nr) if (ma >> i) & 1]
+        bl = [i for i in range(nr) if (mb >> i) & 1]
+        for tw in (0, 1):
+            pi = list(range(nr))
+            pi[aa[0]] = bl[tw]
+            pi[bl[tw]] = aa[0]
+            pi[aa[1]] = bl[1 - tw]
+            pi[bl[1 - tw]] = aa[1]
+            imb = [image(v, pi) for v in vecs]
+            if frozenset(imb) != heldset:
+                continue
+            if frozenset(image(x, pi) for x in kern) != kset:
+                continue
+            if frozenset(image(x, pi) for x in coset) != cset:
+                continue
+            if tuple(vidx[y] for y in imb) != pm:
+                continue
+            npair += 1
+            if len(tgt) == 7 and all(image(x, pi) == x for x in tgt):
+                fixed += 1
+    if npair == 2 and fixed == 2:
+        FIXOK += 1
+
+    # ---- G9 the equivariant split of the dominant pairing
+    if len(exc) == 2 and len(dom) == 1 and pm is not None:
+        rest = [i for i in range(nh) if i not in exc]
+        p6 = []
+        seen6 = set()
+        for i in rest:
+            if i in seen6:
+                continue
+            j = vidx.get(vecs[i] ^ dom[0])
+            if j is None or j in exc or j == i:
+                p6 = []
+                break
+            seen6.add(i)
+            seen6.add(j)
+            p6.append(tuple(sorted((i, j))))
+        if len(p6) == 6 and len(seen6) == 12:
+            fixp = 0
+            movp = []
+            for pr in p6:
+                im = tuple(sorted((pm[pr[0]], pm[pr[1]])))
+                if im == pr:
+                    fixp += 1
+                else:
+                    movp.append((pr, im))
+            moved = sorted(i for i in range(nh) if pm[i] != i)
+            un = sorted(set(x for pr, im in movp for x in pr))
+            if (fixp == 4 and len(movp) == 2 and movp[0][1] == movp[1][0]
+                    and movp[1][1] == movp[0][0] and moved == un and len(moved) == 4):
+                EQVOK += 1
+
+SH = only(SHAPES) or (0, 0, 0, 0, 0, 0, 0)
+KW3 = dict(only(KWCENS)) if len(KWCENS) == 1 else {}
+OVC = dict(only(OVCENS)) if len(OVCENS) == 1 else {}
+DWC = dict(only(DWCENS)) if len(DWCENS) == 1 else {}
+W8C = dict(only(W8CENS)) if len(W8CENS) == 1 else {}
+DEGC = dict(only(DEGCENS)) if len(DEGCENS) == 1 else {}
+DG = only(DEGX) or ()
+FX = only(FIXCNT) or (0, 0)
+SPZ = only(SPANSZ)
+SPZ = SPZ if SPZ is not None else 0
+IN8 = W8C.get((0, 1), 0) + W8C.get((2, 1), 0)
+OU8 = W8C.get((1, 0), 0) + W8C.get((2, 0), 0)
+
+# ================================================================ the labelling level of the wall
+
+CLASSES = sorted(EUSZ)
+CLSI = [CLASSES.index(CLS[f]) for f in range(NF)]
+FCEN = Counter()
+for gi in range(len(DIST)):
+    FCEN[tuple(sorted(Counter(CLSI[f] for f in range(NF) if FIDX[FOLD[f]] == gi).items()))] += 1
+ESET = set(E36)
+SWOK = all((b, a) in ESET for a, b in E36)
+DIAG = sum(1 for a, b in E36 if a == b)
+LGT = set(E36[f] for f in range(NF) if CLSI[f] == 0)
+HVY = set(E36[f] for f in range(NF) if CLSI[f] == len(CLASSES) - 1)
+LSW = len(LGT) == 8 and all((b, a) in LGT for a, b in LGT)
+HSW = len(HVY) == 8 and all((b, a) in HVY for a, b in HVY)
+LUP = sorted(set(tuple(sorted(e)) for e in LGT))
+HUP = sorted(set(tuple(sorted(e)) for e in HVY))
+EUS = "; ".join(" ".join(str(x) for x in k) + " at " + str(EUSZ[k]) for k in sorted(EUSZ))
+FCS = "; ".join(cshow(k) + " at " + str(FCEN[k]) for k in sorted(FCEN))
+LUS = " ".join("({0},{1})".format(a, b) for a, b in LUP)
+HUS = " ".join("({0},{1})".format(a, b) for a, b in HUP)
+
+# ================================================================ G2 the linear instance, regated at every fiber
+
+gate(NORB == set([200]) and SING == 0 and OVL == 0 and FOLDOK and INSOK == NF
+     and SH == (14, 14, 40, 32, 8, 256, 14) and CVRT == NF * 14, "G2",
+     "at all {0} fibers: {1} two-orbits, {2} held cuttings each a union of {3} of {4} rows, rank {5}, kernel dimension {6}"
+     .format(NF, only(NORB), SH[0], 12, SH[2], SH[3], SH[4]))
+emit("G2 detail: all {0} kernel vectors have even weight and each of the {1} held cuttings covers every one of the {2} points once"
+     .format(SH[5], CVRT, NPTS))
+
+# ================================================================ G3 the weight census of the kernel
+
+gate(len(KWCENS) == 1 and KW3 == KWC and len(KW3) == 17 and sum(KW3.values()) == 256, "G3",
+     "the kernel weight census takes {0} distinct value over the {1} fibers, with {2} weights totalling {3}"
+     .format(len(KWCENS), NF, len(KW3), sum(KW3.values())))
+emit("G3 detail: " + dshow(KW3))
+
+# ================================================================ G4 the light vectors and their span
+
+gate(LITOK == NF and len(OVCENS) == 1 and OVC == OVA and len(DWCENS) == 1 and DWC == DWA
+     and len(SPANSZ) == 1 and SPZ == 16, "G4",
+     "among the {0} pairs of the {1} weight {1} kernel vectors exactly {2} pair overlaps, in exactly {2} row, at all {3} fibers"
+     .format(6, 4, 1, NF))
+emit("G4 detail: overlap census {0} and pair difference weight census {1}, each {2} distinct value over the {3} fibers"
+     .format(dshow(OVC), dshow(DWC), len(OVCENS), NF))
+emit("G4 detail: the overlapping pair differs by the unique weight {0} kernel vector; the light span of those {1} vectors has {2} members"
+     .format(6, 5, SPZ))
+
+# ================================================================ G5 the profile of the weight-eight vectors
+
+gate(W8OK == NF and len(W8CENS) == 1 and W8C == W8A, "G5",
+     "each of the {0} weight {1} kernel vectors is classed by its multiplicity over the {2} held pairs and its light span membership"
+     .format(9, 8, 91))
+emit("G5 detail: the profile census by (multiplicity, membership) is {0}, with {1} meaning inside, at {2} of {2} fibers"
+     .format(pshow(W8C), 1, NF))
+emit("G5 detail: so {0} of the {1} lie inside the light span and {2} outside, and every multiplicity {3} weight {4} vector is inside"
+     .format(IN8, 9, OU8, 0, 8))
+
+# ================================================================ G6 the exceptional pair and the two light-outside directions
+
+gate(G6OK == NF and len(DEGCENS) == 1 and DEGC == DEG3 and len(DEGX) == 1 and DG == (0, 1), "G6",
+     "the minimal exchange graph, the pairs sharing {0} of their {1} rows, has degree census {2} at all {3} fibers"
+     .format(10, 12, dshow(DEGC), NF))
+emit("G6 detail: the dominant difference, of multiplicity {0}, breaks exactly {1} held cuttings, of graph degrees {2} and {3}"
+     .format(6, 2, DG[0], DG[1]))
+emit("G6 detail: their difference has weight {0} and multiplicity {1}, realized by that pair alone; the other multiplicity {1} weight {0}"
+     .format(8, 1))
+emit("G6 detail: vector is realized by exactly {0} pair, joining the degree {1} cutting to a degree {2} one; both lie outside the light span"
+     .format(1, 0, 2))
+
+# ================================================================ G7 the complete symmetry pins each exceptional cutting
+
+gate(SYMOK == NF and len(FIXCNT) == 1 and FX == (10, 2), "G7",
+     "the complete block-level self-equivalence search returns exactly {0} elements at {1} of {1} fibers"
+     .format(2, NF))
+emit("G7 detail: the nontrivial one fixes each of the {0} exceptional cuttings, and its cycle structure on the {1} held cuttings is"
+     .format(2, 14))
+emit("G7 detail: {0} fixed points and {1} two-cycles, {2} distinct value over the {3} fibers"
+     .format(FX[0], FX[1], len(FIXCNT), NF))
+
+# ================================================================ G8 the same symmetry at the level of the rows
+
+gate(FIXOK == NF, "G8",
+     "on the {0} row coordinates the nontrivial self-equivalence fixes as vectors all {1} anchored kernel directions, at {2} of {2} fibers"
+     .format(40, 7, NF))
+emit("G8 detail: the {0} weight {0} vectors, the weight {1} vector, the dominant difference, and the exceptional pair difference of weight {2}"
+     .format(4, 6, 8))
+
+# ================================================================ G9 the equivariant split of the dominant pairing
+
+gate(EQVOK == NF, "G9",
+     "the dominant difference pairs the {0} non-exceptional held cuttings into {1} pairs at all {2} fibers"
+     .format(12, 6, NF))
+emit("G9 detail: the nontrivial self-equivalence fixes {0} of those pairs as sets and exchanges the other {1} with each other, and its {2}"
+     .format(4, 2, 4))
+emit("G9 detail: moved cuttings are exactly the union of the {0} exchanged pairs".format(2))
+
+# ================================================================ G10 the labelling level of the wall
+
+gate(dict(EUSZ) == EUANC and dict(FCEN) == FDANC and SWOK and DIAG == 0 and LSW and HSW
+     and LUP == LPA and HUP == HPA, "G10",
+     "the union size class of a fiber takes {0} values over the {1} fibers, and the per fold class census multiset is anchored"
+     .format(len(EUSZ), NF))
+emit("G10 detail: the four union sizes read {0}".format(EUS))
+emit("G10 detail: classes are numbered {0} light, {1} middle, {2} heavy by union size; the per fold census multiset reads"
+     .format(0, 1, 2))
+emit("G10 detail: " + FCS)
+emit("G10 detail: the {0} wall entries are closed under the letter swap, with {1} diagonal entries, and so is each extreme class"
+     .format(NF, DIAG))
+emit("G10 detail: light letter pairs {0}; heavy letter pairs {1}".format(LUS, HUS))
+
+# ================================================================ totals
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with sixteen corners, the four hundred kept pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet on the eight interface slots, and the forty-eight transfer-matrix entries at thirty-six — the named wall. The prior cycle drove the parity of the fourteen held cuttings down to two exceptional ones — the two stranded by the dominant exchange — and asked whether any involution pairs them. This cycle answers that question: no such pairing can exist at any level, and the note proves it rather than measuring it.

- **The two exceptional cuttings are canonically distinguishable — the headline.** In the minimal-exchange graph (pairs of held cuttings sharing ten of their twelve rows) one exceptional cutting has degree zero and the other degree one. A lemma proved in the note turns this into a theorem: any bijection of the held cuttings preserving shared-row counts is an automorphism of that graph, hence preserves degree, and the degree census has exactly one degree-zero vertex — so no structure-preserving map at any level can exchange the two. The "pair the evaders by an involution" route to the parity of fourteen is refuted by a canonical invariant, not by a search.
- **The whole symmetry pins each of them individually.** The complete backtracking search again returns exactly two self-equivalences, and the nontrivial one fixes each exceptional cutting on its own — ten fixed cuttings and two two-cycles overall. Both half-pairings of the clean exchange carry the held set, the kernel, and the coset onto themselves, induce exactly the searched permutation, and fix all seven named kernel directions as vectors.
- **Both singly-realized weight-eight directions emanate from the isolated cutting.** Of the nine weight-eight kernel vectors, exactly two are realized as a difference of held cuttings exactly once: the vector joining the two exceptional cuttings, and one other, joining the isolated degree-zero cutting to a degree-two cutting. Both lie outside the span of the five light kernel vectors — the four weight-four vectors plus the weight-six one, a sixteen-member space of dimension four — and every weight-eight vector inside that span has multiplicity zero.
- **The dominant exchange and the symmetry mesh cleanly.** The dominant exchange pairs the twelve non-exceptional cuttings into six pairs; the symmetry fixes four of the six as sets and exchanges the other two with each other, and its four moved cuttings are exactly the union of the exchanged pairs — at all forty-eight fibers.
- **The labelling level is measured and split open.** The forty-eight wall entries fall in three point-cardinality classes of sizes eight, thirty-two, and eight; each of the six folds serves eight fibers, and the fold-by-class table is measured exactly — two folds serve two light, four middle, and two heavy fibers; one serves four light and four heavy; three serve middle fibers exclusively. Both extreme classes are stable under the letter swap and under transposition, with their four unordered letter pairs listed. Nothing at the instance level distinguishes the forty-eight fibers, so whatever carries the parity must live here.

Honest boundary: every anchor was measured as invariant across all forty-eight fibers before the spec was written (the prior cycle's sample-fiber lesson), and all ten gates passed on the executor's first run. The censuses stay measured, not derived; the degree lemma and two smaller identities are the derived content. The named next entrance is the fold-by-class table: whether a fiber's class is determined by its letter pair alone, whether the one fold carrying both extreme classes is otherwise distinguished, and whether any of the three hundred eighty-four cell maps carries a light fiber to a heavy one.

## Verification

- Runner re-run by the orchestrator in a clean shell: exit zero, `TOTAL: PASS=10 FAIL=0`, stdout byte-identical to the executor's hand-back (itself byte-identical across the executor's two runs).
- Full note read plus line-by-line runner review (fabrication hunt): every census recomputed from the rebuilt geometry; frozen anchors compared against independently recomputed values, never used to build them; the moved-pair comparison canonicalized by sorting on both sides; the complete search's feasibility screens live inside the entry point.
- The degree lemma re-derived independently by the orchestrator before the spec was written; the executor ran its own self-check (double run, mechanical checker, forbidden-string and numeral scans) before hand-back.
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
