### PR TITLE
feat: cycle 796 wall homogeneity and the fold as entry stabilizer

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_WALL_HOMOGENEITY_CYCLE796_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_WALL_HOMOGENEITY_CYCLE796_NOTE_2026-08-15.md
@@ -1,0 +1,193 @@
+# Physical cell cutting: wall homogeneity, the fold as entry stabilizer, and the frame-stable class split
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: read the letter level of the interface matrix directly — why the 48 entries of value 36 are the letter pairs they are, why the acting maps move an entry between the light, middle and heavy classes of union size while the class sizes stay put, and where the union values 50, 100 and 175 come from as multiples of 25; none of that is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, on the declared finite cell, of which of its 384 signed coordinate maps carry the wall of the interface matrix to itself — exactly the 96 that fix the first axis, with all 288 others failing — of the transitivity of that action on the 48 wall entries, of the counting identity that forces every entry stabilizer to have order 2, of the identification of that stabilizer with the entry's own fold as computed by an independent per-fiber search, of the conjugation law carrying folds along the action at all 4608 map-entry pairs, of the single conjugacy class of 6 folds each serving 8 fibers, and of the split of the 48 entries into 8 light, 32 middle and 8 heavy by the union sizes of their equal-union exchanges, together with the measured fact that this split is stable across a second generic point frame yet is not preserved by the action itself; which letter pairs carry which class is anchored as a measured list, and no physical or lattice-wide identification is made`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the unit
+four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive at the
+adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into, the 192
+pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell. The pair
+of tetrahedral letters on the two slots of the first axis, drawn from a 16-letter alphabet, gives
+the interface matrix of trace 2000 with exactly 48 entries equal to 36. Each of those 48 fibers
+holds 36 cuttings and is held setwise by exactly 2 of the 384 maps; its nontrivial holder is that
+fiber's fold, and each fold holds 14 of its own fiber's 36 cuttings, each an exact union of 12 of
+the 40 rows that the fold's 200 two-orbits contribute, with incidence kernel dimension 8 and
+exactly 4 equal-union exchanges.
+
+Earlier cycles of this lane established that per-fiber anatomy and put the 48 systems into a single
+instance up to relabelling of the 40 rows; the immediately preceding stem
+`physical_cell_cutting_pinned_pair_anatomy_cycle795_2026_08_15` is not yet on main and is referred
+to by name only. Nothing from it is assumed here: the object, the fold table, the rows, the held
+cuttings, the kernels and the exchanges are all rebuilt by the linked runner before any gate runs.
+
+The question this note asks is a level up from the fiber. The wall — the 48 entries of value 36 —
+has until now been a list of 48 separate instances that happen to look alike. Does the cell's own
+symmetry group act on that list, and if so, what does the action say about the fold, which so far
+has only been found by search, one fiber at a time?
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+recomputed by the linked runner from the corner list alone: it uses the standard library only,
+performs no file input or output and no randomness, and gates each recomputed value against the
+value stated here.
+
+## The law
+
+- **Exactly 96 of the 384 maps act on the wall, and they are exactly the maps fixing the first
+  axis.** For a map to act on the wall it must send each entry's 36 cuttings into the cuttings of a
+  single entry of the same value. Testing all 384 maps, exactly 96 do: every one of the 96 that fix
+  the first axis succeeds, and all 288 that move it fail. The identity induces the identity, and on
+  all 9216 ordered pairs of acting maps the induced maps compose in the order in which the maps are
+  applied. This is what makes the wall an object with a symmetry rather than a list: the acting set
+  is a subgroup, and it is named intrinsically, by the axis that carries the letters, not by hand.
+
+- **The action is transitive: the wall is homogeneous.** The 48 entries form one orbit of size 48.
+  Every wall entry can be carried to every other by a symmetry of the cell, so the 48 per-fiber
+  systems are not merely isomorphic as abstract incidence data — they are literally the same object
+  seen from 48 positions of the cell. Everything proved at one fiber now transports to all of them
+  by construction rather than by regating fiber by fiber.
+
+- **The counting identity forces stabilizer order 2, and the stabilizer is the fold.** With 96
+  acting maps and one orbit of size 48, the stabilizer of each entry has order 96 divided by 48,
+  that is exactly 2, and the measured census confirms order 2 at all 48 entries. The nontrivial
+  element of that stabilizer is exactly the entry's fold, at 48 of 48 entries, where the fold table
+  is built by a completely separate computation: for each fiber, search all 384 maps for those
+  holding the fiber setwise, which returns exactly 2 of them and their nontrivial member. What an
+  earlier cycle could only measure — that each fiber is held by exactly 2 maps — this cycle derives
+  from the orbit count, and the two computations agree entry by entry.
+
+- **Folds transport by conjugation.** For every acting map and every entry, the fold of the image
+  entry is the conjugate of the fold of the source entry by that map: 4608 checks, that is 96 maps
+  by 48 entries, all passing, in either ordering of the map and its inverse, with each inverse found
+  by search over the 384 maps rather than assumed. The fold is therefore not 48 unrelated accidents
+  but a single equivariant assignment.
+
+- **The 6 folds are one conjugacy class, each serving 8 fibers.** Only 6 distinct maps occur as
+  folds, all involutions. Inside the acting 96 they form exactly one conjugacy class, and the number
+  of fibers each one serves is 8 for every one of them: 48 = 6 x 8. The fold is thus a class
+  function of the wall, and the wall is a homogeneous space carrying it.
+
+- **The class split by union size is frame-stable but is moved by the action.** Each entry's 4
+  equal-union exchanges have point union sizes forming a sorted four-tuple. Exactly three tuples
+  occur: 8 entries are light, with sizes 50, 100, 100, 100; 32 are middle, with 100, 100, 100, 100;
+  and 8 are heavy, with 100, 100, 100, 175. Within each class the full table of broken count against
+  union size is single-valued, and the difference lives entirely in the exchange of broken count 2,
+  whose union is 50, 100 or 175 while the other three are 100 throughout. Every union size is a
+  multiple of 25. Recomputing the entire per-fiber anatomy on a second generic point frame, with
+  per-axis offsets 3, 5, 6, 7 in place of 1, 2, 4, 8, reproduces the same kernel dimension 8, the
+  same 4 exchanges with the same supports and the same half-splits at 48 of 48 fibers, the same
+  broken-count and union-size table, and the same 8 / 32 / 8 split with the same members. Yet the
+  split is not invariant under the action: a searched map carries the light entry with letter pair
+  2, 12 to a middle entry, and another searched map carries the same light entry to a heavy one, in
+  both cases mapping the 14 held cuttings exactly onto the 14 held cuttings of the target and
+  matching exchange to exchange, with the broken-2 union going 50 to 100 in the first case and 50 to
+  175 in the second while the other three stay at 100.
+
+## Derived versus measured
+
+Derived at the declared finite scope. The stabilizer order 2 is derived, from the acting count 96
+and the single orbit of size 48, and no longer needs the per-fiber holder search; the agreement of
+the derived stabilizer with the independently searched fold is a check between two computations,
+neither of which reads the other's result. The conjugation law is derived in the sense that it is verified on every one of
+the 4608 map-entry pairs, not sampled. The single conjugacy class and the equal service count 8
+follow from transitivity together with the conjugation law, and are also measured directly. That the
+class split cannot be an invariant of the abstract instance follows immediately from transitivity
+plus the observed movement between classes: since all 48 entries lie in one orbit, any quantity
+genuinely intrinsic to the instance must be constant across the wall, so a quantity that takes three
+values is a property of how the instance sits relative to the point frame and the letter labels, not
+of the instance.
+
+What is measured, not derived, at the declared finite scope: that exactly the 96 first-axis maps act, with
+288 failures — the failure of the other 288 is checked map by map, not argued; the class sizes 8, 32
+and 8; which letter pairs carry which class, anchored as measured lists, the light pairs being
+2 and 12, 4 and 14, 5 and 13, 7 and 11, and the heavy pairs 2 and 3, 4 and 7, 10 and 11, 12 and 13,
+each pair occurring on 2 entries, once for each order of its two letters; the union values 50, 100
+and 175 themselves and their common divisor 25; and the frame stability, which is established at one
+additional generic frame and not proven for all frames.
+
+All of the above are computational identities of the declared unit four-cube object, its 15800
+cuttings, and the order-384 symmetry group of the cell. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+## What the wall now asks
+
+What opened is a letter-level question that could not even be posed before. The wall is homogeneous,
+so no fiber is special; the fold is equivariant, so no fold is special; and yet the letters split the
+48 entries into 8, 32 and 8 in a way that survives a change of point frame while being scrambled by
+the cell's own symmetry. That is exactly the signature of a quantity attached to the interface
+matrix rather than to the fiber: the 48 entries of value 36 sit inside a 16-letter alphabet whose
+matrix has trace 2000, and the split must be readable from that matrix. The wall now asks what the
+light, middle and heavy classes are as sets of letter pairs, and why the exchange of broken count 2
+is the one that carries the whole distinction.
+
+## Next entrance
+
+Read the interface matrix at letter level. The concrete entrance is the union values themselves:
+50, 100 and 175 are 2, 4 and 7 times 25, the light and heavy classes have 8 members each against 32
+in the middle, and the entire distinction is carried by a single exchange, the one with broken count
+2. Worth reading next is whether the 16 letters carry a natural pairing under which the 48 entries
+of value 36 are described directly, whether the light and heavy pairs are the two ends of one
+letter-level statistic, and whether the factor 25 is the point frame speaking or the object. Because
+the action moves entries between classes, any answer must be stated relative to the frame; because
+the wall is homogeneous, any answer will hold at all 48 entries at once.
+
+## Review record
+
+- Rows are the two-orbits of the 400 kept pieces under each fiber's own fold, and blocks are that
+  fiber's fold-held cuttings written as row sets. Both conventions are fixed before any computation
+  runs, and every statement is made for all 48 fibers, not for a chosen one.
+- The fold table and the wall action are computed independently. The fold table comes from a search
+  over all 384 maps for those holding each fiber setwise; the stabilizers come from the induced maps
+  on the 48 entries. Neither is derived from the other, so their agreement at 48 of 48 entries is a
+  genuine cross-check and not a restatement.
+- Inverses of acting maps are found by search over the 384 maps, and both orderings of the
+  conjugation are tested, so the composition convention cannot silently carry the result.
+- The transport statement is searched, not planted: the runner walks the acting maps in construction
+  order and reports the first one reaching each of the other two classes out of the named light
+  entry, then verifies that map by explicit image of the 14 held cuttings and of all 4 exchanges as
+  frozen sets.
+- The point cardinalities of the equal-union exchanges are properties of a labelling relative to the
+  point frame; the runner anchors them as the full measured table over the 48 entries and repeats
+  the entire per-fiber computation on a second generic frame, gating the two against each other.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a commit
+  cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run the [runner](../scripts/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.py). The
+reviewed [cache](../logs/runner-cache/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.txt)
+belongs beside it and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC`
+budget, finishes in well under a minute on the reference machine, and stays far below one gigabyte.
+Its final line is `TOTAL: PASS=10 FAIL=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13865,6 +13865,10 @@
   "physical_cell_cutting_twelve_frontier_cycle739_note_2026-08-05": {
    "deps_hash": "e85cd6020b67",
    "out_degree": 4
+  },
+  "physical_cell_cutting_wall_homogeneity_cycle796_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_column_family_parity_law_forced_orbits_cycle733_note_2026-08-04": {
    "deps_hash": "34379e6103b0",

--- a/logs/runner-cache/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.py
+runner_sha256: 2959e15c50fcc82cbcd8dd61e98b3a42ef30f59367e70db3c7a5b1defe903483
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 14.93
+status: ok
+----- stdout -----
+PASS G1 2672 pieces, floor 6, 400 kept, 15800 cuttings of 24, 192 used, cell group 384, 16 letters, trace 2000, 48 entries at 36
+PASS G2 exactly 96 of the 384 cell maps induce a well-defined map on the 48 wall entries: every map fixing the first axis acts, 288 fail
+G2 detail: 0 first-axis maps fail and 0 maps moving the first axis act; the identity induces the identity
+G2 detail: one ordering holds, em[g after h] = em[g] after em[h], at 9216 of 9216 pairs, all of them acting maps; the other ordering holds at 1920
+PASS G3 the acting maps carry the 48 wall entries in one orbit of size 48: every entry is carried to every other entry
+PASS G4 within the acting 96 every entry has a stabilizer of order exactly 2, census {2: 48}, so 48 x 2 = 96
+PASS G5 at 48 of 48 entries the unique nontrivial stabilizer element equals that entry's fold from the separate per-fiber search
+G5 detail: that search holds each fiber setwise under exactly 2 of the 384 cell maps and returns 6 distinct folds, all involutions
+G5 detail: each entry carries 36 cuttings, 14 of them held by its fold, each a union of 12 of the 40 rows over 200 two-orbits
+PASS G6 fold transport holds at 4608 of 4608 pairs: the fold of the image entry is the conjugate of the fold by the acting map, over 96 x 48
+G6 detail: each acting map's inverse is found by search over the 384 cell maps, never assumed
+PASS G7 the 6 distinct folds are one conjugacy class inside the acting 96, and each serves 8 fibers: census [8, 8, 8, 8, 8, 8], 48 = 6 x 8
+PASS G8 searched transport out of the light entry with letter pair (2, 12): the first acting map reaching each of the other two classes carries
+G8 detail: ((0, 1, 2, 3), 2) takes the 14 held cuttings onto those of entry (0, 4), broken 2 union 50 -> 100, broken (0, 4, 6) 100 -> 100
+G8 detail: ((0, 1, 2, 3), 6) takes the 14 held cuttings onto those of entry (12, 13), broken 2 union 50 -> 175, broken (0, 4, 6) 100 -> 100
+G8 detail: for both maps the conjugate of the source fold is the target fold, in either ordering of the acting map and its inverse
+PASS G9 the 48 entries split by the sorted four-tuple of exchange union sizes into 8 light, 32 middle and 8 heavy
+G9 detail: light letter pairs [(2, 12), (4, 14), (5, 13), (7, 11)]; heavy letter pairs [(2, 3), (4, 7), (10, 11), (12, 13)], each on 2 entries
+G9 detail: the broken 0, 4 and 6 exchanges have union 100 at all 48 entries; the broken 2 exchange has union 50, 100, 175
+G9 detail: every union size is a multiple of 25: 50 = 2 x 25, 100 = 4 x 25, 175 = 7 x 25
+PASS G10 second generic frame, per-axis offsets (3, 5, 6, 7) in place of (1, 2, 4, 8): 0 of the 15800 cuttings fail to cover the 625 points once
+G10 detail: at all 48 fibers the kernel dimension is 8 and there are exactly 4 equal-union exchanges, and the exchange supports
+G10 detail: and their half-splits are identical to the first frame at 48 of 48 fibers; the class split is identical, 8 / 32 / 8
+G10 detail: and the broken-count and union-size table matches the first frame at 48 of 48 fibers, class by class
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.py
+++ b/scripts/physical_cell_cutting_wall_homogeneity_cycle796_2026_08_15.py
@@ -1,0 +1,665 @@
+"""Physical cell cutting: the wall action is exactly the first-axis cell maps, the fold is the entry stabilizer, the split is frame stable.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, and the sixteen-letter facet alphabet on the two slots of axis zero. Nothing outside that finite object enters any gate.
+
+Earlier cycles built the wall of 48 interface entries of value 36, gave every entry a fold that holds its fiber setwise, and linearized each
+fiber: rows are the two-orbits of the 400 kept pieces under that fold, the fold-held cuttings are weight-twelve vectors on the rows that
+occur, and the exact cover condition is an all-ones linear system. This cycle asks which cell maps move the wall itself. It tests every one
+of the 384 maps for a well-defined induced map on the 48 entries, reads the orbit and the stabilizers of the acting set, identifies each
+stabilizer with that fiber's own fold as computed by the separate per-fiber search, transports folds by conjugation, and rebuilds every
+fiber instance on a second generic sample frame to separate a property of the instance from a property of how it is embedded relative to
+the transfer frame. Gates G1 to G10, one line each with a few detail lines, then the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    if OUT[0] >= 5800:
+        raise ValueError("output over the character budget")
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def popc(x):
+    return bin(x).count("1")
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                fq = M[r][c]
+                M[r] = [M[r][k] - fq * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+OFFS2 = (3, 5, 6, 7)
+DIV = NSHIFT * RSTEP
+NPTS = RSTEP ** 4
+
+
+def buildmask(offs):
+    """Membership bitmasks of every kept piece on the sample points of one per-axis offset table, by exact integer barycentric tests."""
+    axval = [[NSHIFT * k + offs[i] for k in range(RSTEP)] for i in range(4)]
+    out = []
+    for (v0, Ci) in BARY:
+        off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+        col = [[[Ci[i][ax] * u for i in range(4)] for u in axval[ax]] for ax in range(4)]
+        bits = 0
+        idx = 0
+        for a in col[0]:
+            s1 = [a[i] - off[i] for i in range(4)]
+            for b in col[1]:
+                s2 = [s1[i] + b[i] for i in range(4)]
+                for c in col[2]:
+                    s3 = [s2[i] + c[i] for i in range(4)]
+                    for d in col[3]:
+                        w = [s3[i] + d[i] for i in range(4)]
+                        sw = sum(w)
+                        if all(x > 0 for x in w) and sw < DIV:
+                            bits |= (1 << idx)
+                        idx += 1
+        out.append(bits)
+    return out
+
+
+MASK = buildmask(OFFS)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NK = len(KEPT)
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+GID = ((0, 1, 2, 3), 0)
+
+FACE = {}
+for t in range(NK):
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda fz: sorted(sorted(t) for t in fz))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def compose(a, b):
+    p, m = a
+    q, n = b
+    r = tuple(q[p[i]] for i in range(4))
+    k = n
+    for j in range(4):
+        if (m >> j) & 1:
+            k ^= (1 << q[j])
+    return (r, k)
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+def rref(rows, ncols):
+    mat = [r for r in rows if r]
+    piv = []
+    r = 0
+    for c in range(ncols):
+        p = -1
+        for i in range(r, len(mat)):
+            if (mat[i] >> c) & 1:
+                p = i
+                break
+        if p < 0:
+            continue
+        mat[r], mat[p] = mat[p], mat[r]
+        for i in range(len(mat)):
+            if i != r and ((mat[i] >> c) & 1):
+                mat[i] ^= mat[r]
+        piv.append(c)
+        r += 1
+    return mat[:r], piv
+
+
+# ================================================================ G1 the declared object, the alphabet and the wall
+
+PAIROF = [(KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS)]
+JC = Counter(PAIROF)
+TRM = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TRM[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TRM[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(PAIROF[i], []).append(i)
+E36 = sorted(kj for kj in FIB if TRM[kj[0]][kj[1]] == 36)
+NF = len(E36)
+FSZ = sorted(set(len(FIB[kj]) for kj in E36))
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NL == 16 and TRC == 2000 and N36 == 48 and NF == 48 and FSZ == [36], "G1",
+     "{0} pieces, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, cell group {6}, {7} letters, trace {8}, {9} entries at {10}"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, len(G384), NL, TRC, N36, 36))
+
+# ================================================================ the fold of every fiber, by the independent per-fiber search
+
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+WALL = sorted(set(c for F in FL for c in F))
+POSW = {c: i for i, c in enumerate(WALL)}
+FOLD = [None] * NF
+STCNT = [0] * NF
+DEFECT = 0
+for g in G384:
+    mp = piecemap(g, USED)
+    if len(set(mp.values())) != NU:
+        DEFECT += 1
+    img = [SIDX[frozenset(mp[t] for t in SOLS[c])] for c in WALL]
+    for f in range(NF):
+        S = FS[f]
+        ok = True
+        for c in FL[f]:
+            if img[POSW[c]] not in S:
+                ok = False
+                break
+        if ok:
+            STCNT[f] += 1
+            if g != GID:
+                FOLD[f] = g
+
+DIST = sorted(set(FOLD))
+FIDX = {g: i for i, g in enumerate(DIST)}
+FOLDOK = DEFECT == 0 and set(STCNT) == set([2]) and all(compose(g, g) == GID for g in DIST)
+
+# ================================================================ the two-orbit table of each fold
+
+MPKS = []
+ORBS = []
+OIDX = []
+NORB = set()
+for g in DIST:
+    mpk = piecemap(g, range(NK))
+    orbs = []
+    seen = set()
+    for t in range(NK):
+        if t in seen:
+            continue
+        u = mpk[t]
+        seen.add(t)
+        seen.add(u)
+        orbs.append((t, u))
+    oi = {}
+    for i in range(len(orbs)):
+        oi[orbs[i][0]] = i
+        oi[orbs[i][1]] = i
+    MPKS.append(mpk)
+    ORBS.append(orbs)
+    OIDX.append(oi)
+    NORB.add(len(orbs))
+
+# ================================================================ the fiber instance, rebuilt on any sample frame
+
+MEMB = [len(o) for o in ORBS]
+
+
+def instance(f, MX):
+    """Rebuild fiber f from the two-orbits of its fold: held cuttings as row vectors, point supports of the rows on the given frame,
+    the kernel dimension of the incidence system, the equal-union exchanges of the rows, and the broken count of each exchange."""
+    fi = FIDX[FOLD[f]]
+    mpk = MPKS[fi]
+    oi = OIDX[fi]
+    orbs = ORBS[fi]
+    held = [c for c in FL[f] if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+    raw = [frozenset(oi[t] for t in SOLS[c]) for c in held]
+    rowg = sorted(set().union(*raw))
+    nr = len(rowg)
+    rpos = {r: i for i, r in enumerate(rowg)}
+    vecs = [sum(1 << rpos[r] for r in rr) for rr in raw]
+    sup = [MX[orbs[rowg[i]][0]] | MX[orbs[rowg[i]][1]] for i in range(nr)]
+    pat = []
+    for p in range(NPTS):
+        q = 0
+        for i in range(nr):
+            if (sup[i] >> p) & 1:
+                q |= (1 << i)
+        pat.append(q)
+    red, piv = rref(pat, nr)
+    ug = {}
+    for i, j in itertools.combinations(range(nr), 2):
+        if sup[i] & sup[j]:
+            continue
+        ug.setdefault(sup[i] | sup[j], []).append((i, j))
+    spl = {}
+    for u in ug:
+        for pa, pb in itertools.combinations(ug[u], 2):
+            if len(set(pa) | set(pb)) == 4:
+                ma = (1 << pa[0]) | (1 << pa[1])
+                mb = (1 << pb[0]) | (1 << pb[1])
+                spl[ma | mb] = (ma, mb, popc(u))
+    brk = Counter()
+    for dv in spl:
+        ma, mb, usz = spl[dv]
+        for w in vecs:
+            x = w & dv
+            if x != 0 and x != ma and x != mb:
+                brk[dv] += 1
+    tab = tuple(sorted((brk[dv], spl[dv][2]) for dv in spl))
+    return {"held": held, "rowg": rowg, "nr": nr, "orbs": orbs, "vecs": vecs,
+            "kdim": nr - len(piv), "spl": spl, "brk": brk, "tab": tab}
+
+
+def dvpieces(d, dv):
+    ps = set()
+    for i in range(d["nr"]):
+        if (dv >> i) & 1:
+            ps |= set(d["orbs"][d["rowg"][i]])
+    return frozenset(ps)
+
+
+# ================================================================ G2 which cell maps act on the wall at all
+
+EIDX = dict((e, i) for i, e in enumerate(E36))
+ACT = []
+FAIL0 = 0
+FAILR = 0
+ACTR = 0
+for g in G384:
+    pmp = piecemap(g, USED)
+    em = [-1] * NF
+    okg = True
+    for f in range(NF):
+        tgt = set()
+        for c in FL[f]:
+            j = SIDX.get(frozenset(pmp[t] for t in SOLS[c]))
+            if j is None:
+                okg = False
+                break
+            tgt.add(PAIROF[j])
+        if not okg or len(tgt) != 1:
+            okg = False
+            break
+        te = sorted(tgt)[0]
+        if te not in EIDX:
+            okg = False
+            break
+        em[f] = EIDX[te]
+    if okg:
+        ACT.append((g, tuple(em)))
+        if g[0][0] != 0:
+            ACTR += 1
+    elif g[0][0] == 0:
+        FAIL0 += 1
+    else:
+        FAILR += 1
+
+NA = len(ACT)
+EMOF = dict(ACT)
+IDEM = tuple(range(NF))
+NPAIR = NA * NA
+CLOSN = 0
+FWD = 0
+REV = 0
+for g, eg in ACT:
+    for h, eh in ACT:
+        ec = EMOF.get(compose(g, h))
+        if ec is None:
+            continue
+        CLOSN += 1
+        if ec == tuple(eg[eh[f]] for f in range(NF)):
+            FWD += 1
+        if ec == tuple(eh[eg[f]] for f in range(NF)):
+            REV += 1
+IDOK = EMOF.get(GID) == IDEM
+ONEOR = (FWD == NPAIR) != (REV == NPAIR)
+ORIENT = "em[g after h] = em[g] after em[h]" if FWD == NPAIR else "em[g after h] = em[h] after em[g]"
+
+gate(NA == 96 and FAIL0 == 0 and FAILR == 288 and ACTR == 0 and CLOSN == NPAIR and NPAIR == 9216 and IDOK and ONEOR, "G2",
+     "exactly {0} of the {1} cell maps induce a well-defined map on the {2} wall entries: every map fixing the first axis acts, {3} fail"
+     .format(NA, len(G384), NF, FAILR))
+emit("G2 detail: {0} first-axis maps fail and {1} maps moving the first axis act; the identity induces the identity"
+     .format(FAIL0, ACTR))
+emit("G2 detail: one ordering holds, {0}, at {1} of {2} pairs, all of them acting maps; the other ordering holds at {3}"
+     .format(ORIENT, FWD if FWD == NPAIR else REV, NPAIR, REV if FWD == NPAIR else FWD))
+
+# ================================================================ G3 one orbit
+
+par = list(range(NF))
+
+
+def findp(a):
+    while par[a] != a:
+        par[a] = par[par[a]]
+        a = par[a]
+    return a
+
+
+for g, em in ACT:
+    for f in range(NF):
+        a, b = findp(f), findp(em[f])
+        if a != b:
+            par[a] = b
+OSZ = sorted(Counter(findp(f) for f in range(NF)).values())
+
+gate(OSZ == [NF] and NF == 48, "G3",
+     "the acting maps carry the {0} wall entries in one orbit of size {1}: every entry is carried to every other entry"
+     .format(NF, OSZ[0]))
+
+# ================================================================ G4 and G5 stabilizers, and the fold
+
+STORD = Counter()
+STFOLD = 0
+for f in range(NF):
+    els = [g for g, em in ACT if em[f] == f]
+    STORD[len(els)] += 1
+    nt = [g for g in els if g != GID]
+    if len(nt) == 1 and nt[0] == FOLD[f]:
+        STFOLD += 1
+
+gate(dict(STORD) == {2: 48} and NF * 2 == NA, "G4",
+     "within the acting {0} every entry has a stabilizer of order exactly 2, census {1}, so {2} x 2 = {3}"
+     .format(NA, dshow(STORD), NF, NF * 2))
+
+D1 = [instance(f, MASK) for f in range(NF)]
+NHELD = sorted(set(len(d["held"]) for d in D1))
+NROW = sorted(set(d["nr"] for d in D1))
+NWT = sorted(set(popc(v) for d in D1 for v in d["vecs"]))
+KD1 = sorted(set(d["kdim"] for d in D1))
+
+gate(STFOLD == NF and NF == 48 and FOLDOK and len(DIST) == 6 and NHELD == [14] and NROW == [40]
+     and NWT == [12] and sorted(NORB) == [200] and KD1 == [8], "G5",
+     "at {0} of {1} entries the unique nontrivial stabilizer element equals that entry's fold from the separate per-fiber search"
+     .format(STFOLD, NF))
+emit("G5 detail: that search holds each fiber setwise under exactly {0} of the {1} cell maps and returns {2} distinct folds, all involutions"
+     .format(sorted(set(STCNT))[0], len(G384), len(DIST)))
+emit("G5 detail: each entry carries {0} cuttings, {1} of them held by its fold, each a union of {2} of the {3} rows over {4} two-orbits"
+     .format(36, NHELD[0], NWT[0], NROW[0], sorted(NORB)[0]))
+
+# ================================================================ G6 fold transport
+
+INV = {}
+for g, em in ACT:
+    for k in G384:
+        if compose(g, k) == GID and compose(k, g) == GID:
+            INV[g] = k
+            break
+TRT = 0
+TRN = 0
+for g, em in ACT:
+    for f in range(NF):
+        TRT += 1
+        if FOLD[em[f]] == compose(compose(g, FOLD[f]), INV[g]):
+            TRN += 1
+
+gate(TRN == TRT and TRT == 4608 and len(INV) == NA, "G6",
+     "fold transport holds at {0} of {1} pairs: the fold of the image entry is the conjugate of the fold by the acting map, over {2} x {3}"
+     .format(TRN, TRT, NA, NF))
+emit("G6 detail: each acting map's inverse is found by search over the {0} cell maps, never assumed".format(len(G384)))
+
+# ================================================================ G7 the six folds are one class
+
+CJ = set(compose(compose(g, DIST[0]), INV[g]) for g, em in ACT)
+SERVE = sorted(Counter(FOLD).values())
+
+gate(CJ == set(DIST) and len(CJ) == 6 and SERVE == [8] * 6 and 6 * 8 == NF, "G7",
+     "the {0} distinct folds are one conjugacy class inside the acting {1}, and each serves {2} fibers: census {3}, {4} = {0} x {2}"
+     .format(len(DIST), NA, SERVE[0], SERVE, NF))
+
+# ================================================================ G9 the intrinsic classes on the first frame (computed before G8)
+
+KEY1 = [tuple(sorted(v[2] for v in D1[f]["spl"].values())) for f in range(NF)]
+PART = {}
+for f in range(NF):
+    PART.setdefault(KEY1[f], []).append(f)
+ORD = sorted(PART)
+CLS = [ORD.index(KEY1[f]) for f in range(NF)]
+SIZES = [len(PART[k]) for k in ORD]
+LETT = [sorted(set(tuple(sorted(E36[f])) for f in PART[k])) for k in ORD]
+LCEN = [sorted(Counter(tuple(sorted(E36[f])) for f in PART[k]).values()) for k in ORD]
+TABS = [sorted(set(D1[f]["tab"] for f in PART[k])) for k in ORD]
+MUL25 = all(divmod(u, 25)[1] == 0 for k in ORD for u in k)
+ANCT = [[((0, 100), (2, 50), (4, 100), (6, 100))],
+        [((0, 100), (2, 100), (4, 100), (6, 100))],
+        [((0, 100), (2, 175), (4, 100), (6, 100))]]
+LANC = [(2, 12), (4, 14), (5, 13), (7, 11)]
+HANC = [(2, 3), (4, 7), (10, 11), (12, 13)]
+
+# ================================================================ G8 explicit transport across the classes, searched
+
+SRC = [f for f in range(NF) if E36[f] == (2, 12)]
+SRC = SRC[0] if len(SRC) == 1 else -1
+HIT = [None, None, None]
+for g, em in ACT:
+    c = CLS[em[SRC]]
+    if HIT[c] is None:
+        HIT[c] = (g, em[SRC])
+REP = []
+for c in (1, 2):
+    g, tf = HIT[c]
+    pmp = piecemap(g, USED)
+    d0 = D1[SRC]
+    d1 = D1[tf]
+    him = set(SIDX.get(frozenset(pmp[t] for t in SOLS[cc])) for cc in d0["held"])
+    hok = him == set(d1["held"])
+    p2d = dict((dvpieces(d1, dv), dv) for dv in d1["spl"])
+    mt = []
+    for dv in d0["spl"]:
+        w = p2d.get(frozenset(pmp[t] for t in dvpieces(d0, dv)))
+        if w is None:
+            mt = None
+            break
+        mt.append((d0["brk"][dv], d1["brk"][w], d0["spl"][dv][2], d1["spl"][w][2]))
+    cj1 = compose(compose(g, FOLD[SRC]), INV[g]) == FOLD[tf]
+    cj2 = compose(compose(INV[g], FOLD[SRC]), g) == FOLD[tf]
+    REP.append((g, tf, hok, sorted(mt) if mt is not None else None, cj1, cj2))
+
+BR0 = sorted([(0, 0, 100, 100), (2, 2, 50, 100), (4, 4, 100, 100), (6, 6, 100, 100)])
+BR2 = sorted([(0, 0, 100, 100), (2, 2, 50, 175), (4, 4, 100, 100), (6, 6, 100, 100)])
+G8OK = (SRC >= 0 and CLS[SRC] == 0 and len(REP) == 2
+        and all(r[2] and r[4] and r[5] for r in REP)
+        and REP[0][3] == BR0 and REP[1][3] == BR2)
+
+gate(G8OK, "G8",
+     "searched transport out of the light entry with letter pair {0}: the first acting map reaching each of the other two classes carries"
+     .format(tuple(sorted(E36[SRC]))))
+for i in (0, 1):
+    g, tf, hok, mt, cj1, cj2 = REP[i]
+    emit("G8 detail: {0} takes the {1} held cuttings onto those of entry {2}, broken {3} union {4} -> {5}, broken {6} {7} -> {7}"
+         .format(g, len(D1[SRC]["held"]), tuple(sorted(E36[tf])), mt[1][0], mt[1][2], mt[1][3],
+                 tuple(x[0] for x in mt if x[0] != mt[1][0]), mt[0][2]))
+emit("G8 detail: for both maps the conjugate of the source fold is the target fold, in either ordering of the acting map and its inverse")
+
+# ================================================================ G9 headline
+
+gate(SIZES == [8, 32, 8] and len(ORD) == 3 and set(LETT[0]) == set(LANC) and set(LETT[2]) == set(HANC)
+     and LCEN[0] == [2] * 4 and LCEN[2] == [2] * 4 and TABS == ANCT and MUL25, "G9",
+     "the {0} entries split by the sorted four-tuple of exchange union sizes into {1} light, {2} middle and {3} heavy"
+     .format(NF, SIZES[0], SIZES[1], SIZES[2]))
+emit("G9 detail: light letter pairs {0}; heavy letter pairs {1}, each on {2} entries"
+     .format(LETT[0], LETT[2], 2))
+emit("G9 detail: the broken {0}, {1} and {2} exchanges have union {3} at all {4} entries; the broken {5} exchange has union {6}, {3}, {7}"
+     .format(0, 4, 6, 100, NF, 2, 50, 175))
+emit("G9 detail: every union size is a multiple of {0}: {1} = {2} x {0}, {3} = {4} x {0}, {5} = {6} x {0}"
+     .format(25, 50, 2, 100, 4, 175, 7))
+
+# ================================================================ G10 the second generic frame
+
+MASK2 = buildmask(OFFS2)
+PC2 = [popc(m) for m in MASK2]
+BADC = 0
+for s in SOLS:
+    m = 0
+    tot = 0
+    for t in s:
+        m |= MASK2[t]
+        tot += PC2[t]
+    if m != UNIV or tot != NPTS:
+        BADC += 1
+D2 = [instance(f, MASK2) for f in range(NF)]
+KD2 = sorted(set(d["kdim"] for d in D2))
+NEX2 = sorted(set(len(d["spl"]) for d in D2))
+SUPOK = sum(1 for f in range(NF) if sorted(D2[f]["spl"]) == sorted(D1[f]["spl"]))
+HALFOK = sum(1 for f in range(NF)
+             if all(set(D2[f]["spl"][dv][:2]) == set(D1[f]["spl"][dv][:2]) for dv in D1[f]["spl"]))
+KEY2 = [tuple(sorted(v[2] for v in D2[f]["spl"].values())) for f in range(NF)]
+TABOK = sum(1 for f in range(NF) if D2[f]["tab"] == D1[f]["tab"])
+PART2 = {}
+for f in range(NF):
+    PART2.setdefault(KEY2[f], []).append(f)
+SIZ2 = [len(PART2[k]) for k in sorted(PART2)]
+
+gate(BADC == 0 and KD2 == [8] and NEX2 == [4] and SUPOK == NF and HALFOK == NF and KEY2 == KEY1
+     and TABOK == NF and SIZ2 == SIZES and sorted(PART2) == ORD, "G10",
+     "second generic frame, per-axis offsets {0} in place of {1}: {2} of the {3} cuttings fail to cover the {4} points once"
+     .format(OFFS2, OFFS, BADC, NS, NPTS))
+emit("G10 detail: at all {0} fibers the kernel dimension is {1} and there are exactly {2} equal-union exchanges, and the exchange supports"
+     .format(NF, KD2[0], NEX2[0]))
+emit("G10 detail: and their half-splits are identical to the first frame at {0} of {0} fibers; the class split is identical, {1} / {2} / {3}"
+     .format(NF, SIZ2[0], SIZ2[1], SIZ2[2]))
+emit("G10 detail: and the broken-count and union-size table matches the first frame at {0} of {0} fibers, class by class".format(NF))
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with sixteen corners, the four hundred kept pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet, and the forty-eight transfer-matrix entries at thirty-six — the named wall. Until now the wall has been a list of forty-eight per-fiber systems that happen to look alike, each with a fold found by search one fiber at a time. This cycle asks whether the cell's own symmetry group acts on the wall itself, and the answer reorganizes the whole picture.

- **Exactly ninety-six of the three hundred eighty-four cell maps act on the wall — precisely those fixing the first axis.** Tested map by map: every one of the ninety-six maps fixing the letter-carrying axis induces a well-defined map on the forty-eight entries, and all two hundred eighty-eight others fail. The induced maps compose in the order the maps are applied at all nine thousand two hundred sixteen ordered pairs; the reverse ordering holds at only one thousand nine hundred twenty, so the orientation is measured, not assumed.
- **The wall is homogeneous.** The action is transitive: the forty-eight entries form a single orbit, so every wall entry is carried to every other by a symmetry of the cell. The forty-eight per-fiber systems are not merely isomorphic — they are one object seen from forty-eight positions of the cell.
- **The fold is derived, no longer searched.** Ninety-six acting maps over a single orbit of forty-eight forces every entry stabilizer to have order exactly two, and the nontrivial stabilizer element equals the fold from the independent per-fiber search at all forty-eight entries. What an earlier cycle could only measure — each fiber held setwise by exactly two maps — now follows from the orbit count.
- **The six folds are a single conjugacy class, transported by the action.** The fold of an image entry is the conjugate of the source fold by the acting map at all four thousand six hundred eight map-entry pairs, with every inverse found by search rather than assumed; the six distinct folds form one conjugacy class inside the acting ninety-six, each serving exactly eight fibers.
- **The light, middle and heavy split is frame-stable yet moved by the action.** The eight, thirty-two, eight split of the entries by exchange union sizes (fifty, one hundred, one hundred seventy-five — all multiples of twenty-five) reproduces exactly, member for member, on a second generic point frame; yet searched maps carry a light entry to a middle one and to a heavy one. Since the wall is homogeneous, any quantity intrinsic to the abstract instance must be constant across it, so the split is a property of how the instance sits relative to the point frame and the letter labels — and the note names the letter level of the interface matrix as the next entrance.

Honest boundary: the exactly-ninety-six count, the class sizes, the letter-pair lists, and the union values stay measured, not derived; the derived content is the stabilizer order from the counting identity, the conjugation law verified on every pair rather than sampled, and the embedding-relativity argument from transitivity. Frame stability is established at one additional generic frame, not proven for all frames. The executor caught two of its own mistakes before hand-back: the source entry for the transport search must be selected as an ordered letter pair (each unordered pair occupies two wall entries), and an anchor table first written in the wrong representation produced a legitimate gate failure that was fixed as representation only. Transporters are reported as the first found in construction order, not as canonical choices.

## Verification

- Runner re-run by the orchestrator in a clean shell: exit zero, `TOTAL: PASS=10 FAIL=0`, stdout byte-identical to the executor's hand-back (itself byte-identical across the executor's two runs), and byte-identical again after the orchestrator strengthened one gate in review.
- Full note read plus line-by-line runner review (fabrication hunt): the fold table and the wall action are computed by separate identification logic, neither reading the other's result; the composition-orientation gate is discriminating rather than tautological; anchors are compared against recomputed values, never used to build them; the second-frame masks are genuinely rebuilt from the new offsets.
- Review edits by the orchestrator: one note sentence tightened, and the per-fiber anatomy values printed in the fold gate's detail lines are now pinned by that gate as well.
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
