### PR TITLE
feat: letter action, interface orbit census, and piece-size quantum (cycle 797)

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_LETTER_ACTION_ORBIT_CENSUS_CYCLE797_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_LETTER_ACTION_ORBIT_CENSUS_CYCLE797_NOTE_2026-08-15.md
@@ -1,0 +1,237 @@
+# Physical cell cutting: the letter action, the orbit census of the interface matrix, and the piece-size quantum
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: derive, from the piece geometry and the adjacency cost floor alone, why the unit spectrum of the kept pieces is 1, 3, 7, 14 and why every one of the 15800 cuttings realizes the single profile of one lightest piece, eleven of each middle size and one heaviest; and find what separates the two orbits that share the smallest off-diagonal value 18, the one degeneracy the matrix value cannot see while the action can; none of that is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, on the declared finite cell, that each of the 96 signed coordinate maps fixing the first axis induces exactly one pair consisting of a permutation of the 16 facet letters and a slot-swap flag while all 288 other maps induce none for either flag value, that the flag is bit zero of the map's flip mask, that the assignment is a faithful homomorphism at all 9216 ordered pairs whose permutation part has kernel of size 2 and image of order 48, that the interface matrix is symmetric and equivariant so that its 256 ordered letter pairs fall into exactly 10 orbits on which the matrix is constant, carrying the 9 distinct values 18, 36, 50, 52, 90, 92, 100, 104 and 200 with a single degeneracy at 18 where two orbits of size 12 share one value, that the 48 wall entries of value 36 are exactly one of those orbits and unordered form a 4-regular graph of 24 edges on the 12 wall letters, that every one of the 400 kept pieces has a point count of exactly 5 times a unit drawn from the spectrum 1, 3, 7, 14 whose sum is 25 and that all 15800 cuttings carry one and the same unit profile totalling 125 units, and that the light, middle and heavy classes of the previous cycle are exactly the piece-size composition of the distinguished exchange, with the product-structure hypothesis for the union sizes 50, 100 and 175 refuted at every exchange of every fiber over all 6 axis pairs; the letter lists, the edge lists and the censuses are anchored as measured, and no physical or lattice-wide identification is made`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the unit
+four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive at the
+adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into, the 192
+pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell. Points are
+counted on the generic sample grid with per-axis offsets 1, 2, 4, 8, that is 5 values on each of the
+four axes and 625 points in all. The pair of facet letters on the two slots of the first axis, drawn
+from a 16-letter alphabet, gives the interface matrix of trace 2000, whose 48 entries of value 36 are
+the wall.
+
+The previous cycle showed that exactly the 96 maps fixing the first axis act on the wall, that they
+act transitively, that each entry stabilizer has order 2 and is that entry's own fold, and that the
+light, middle and heavy split of 8, 32 and 8 is stable across a second generic point frame yet is
+moved by the action itself. It left three questions at the letter level: which letter pairs carry the
+wall and why; what the light and heavy classes are as letter-level objects; and where the union
+values 50, 100 and 175, all multiples of 25, come from. Those are the questions this note answers.
+Nothing from the previous cycle is assumed: the object, the alphabet, the matrix, the folds, the rows
+and the exchanges are all rebuilt by the linked runner before any gate runs, and the previous cycle's
+class lists enter only as anchors to compare a freshly recomputed classification against.
+
+These are finite-scope object choices, not imported physical primitives. Every integer below is
+recomputed by the linked runner from the corner list alone: it uses the standard library only,
+performs no file input or output and no randomness, and gates each recomputed value against the value
+stated here.
+
+## The letter representation
+
+- **Every acting map induces exactly one letter permutation together with a slot-swap flag, and no
+  other map induces any.** A cell map permutes the 15800 cuttings, hence carries each cutting's pair
+  of first-axis letters to the letter pair of the image cutting. Whether that induced pair map comes
+  from a single permutation of the 16 letters, with the two slots either kept or swapped, is a
+  well-posed question, and both flag values are tested for every one of the 384 maps. Exactly the 96
+  maps that fix the first axis answer yes, each with exactly one valid pair of permutation and flag;
+  the other 288 answer no for both flags. The complement is counted, not assumed. The flag is not
+  free either: it is bit zero of the map's flip mask at all 96 acting maps, so the slot swap is
+  precisely the reversal of the first axis.
+
+- **The assignment is a faithful homomorphism.** At all 9216 ordered pairs of acting maps the letter
+  permutation composes in the order in which the maps are applied and the flags add modulo two. The
+  96 pairs of permutation and flag are pairwise distinct, so the action of the acting maps on the
+  letters together with the flag is faithful. The permutation alone is not: exactly 2 maps give the
+  identity permutation, namely the identity map with flag 0 and the pure first-axis flip with flag 1,
+  so the permutations form an image of order 48. The wall action of the previous cycle is therefore
+  not merely a symmetry of a list of 48 entries; it is a representation of the acting maps by letters.
+
+- **The letters themselves fall into two orbits, and one of them is the wall alphabet.** Under the 96
+  permutations the 16 letters split into exactly 2 orbits, of sizes 12 and 4. The size-12 orbit is
+  exactly the set of letters that occur in wall entries, namely 0, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13
+  and 14; the size-4 orbit is its complement, 1, 6, 8 and 15. Row sums are constant on each orbit,
+  862 on the wall letters and 1364 on the others, and diagonal entries are constant too, 100 on the
+  wall letters and 200 on the others, with the trace 2000 recovered.
+
+- **The interface matrix collapses to ten orbit constants.** The matrix is symmetric at all 256
+  entries and equivariant under all 96 acting maps, with the slots swapped when the flag is set. The
+  induced action on the 256 ordered letter pairs has exactly 10 orbits, of sizes 4, 12, 12, 12, 12,
+  12, 48, 48, 48 and 48, and the matrix is constant on each of them. The orbit values are the 9
+  distinct entries 18, 36, 50, 52, 90, 92, 100, 104 and 200, so the value determines the orbit
+  everywhere except at the smallest off-diagonal value 18, which is carried by two different orbits of
+  size 12 each. That is the single degeneracy of the whole matrix: the numeric entry cannot separate
+  those two orbits, but the action can. Each of the two is held by the transpose and so consists of 6
+  unordered pairs; the first is 0 and 7, 2 and 13, 3 and 5, 4 and 11, 9 and 12, 10 and 14, and the
+  second is 0 and 12, 2 and 11, 3 and 10, 4 and 13, 5 and 14, 7 and 9. The two edge sets are disjoint
+  and together give all 12 unordered pairs at that value. The value census over the 256 entries is 24
+  entries at 18, 48 at 36, 48 at 50, 48 at 52, 12 at 90, 48 at 92, 12 at 100, 12 at 104 and 4 at 200;
+  the weighted sum recovers the cutting count 15800 and the diagonal recovers the trace 2000.
+
+## The wall as an orbit and a graph
+
+The wall is not a pairing, and it is not a coincidence of value: the 48 entries of value 36 are
+exactly one of the 10 pair orbits. The previous cycle established transitivity by moving cuttings; it
+is now visible one level up, as the statement that the wall is a single orbit of ordered letter
+pairs. The action on a wall entry is given by the letter formula, that is the image entry is obtained
+by applying the permutation to both letters and swapping the slots when the flag is set, and this is
+verified at all 4608 pairs of an acting map with a wall entry.
+
+At the unordered level the wall is a graph: 24 edges on the 12 wall letters, and every one of those
+letters has degree exactly 4. So the answer to the first entrance question of the previous cycle is
+that the wall letters carry a 4-regular graph, which is why no letter of the wall alphabet is special
+and why 24 doubles to 48 under the two orders of a pair.
+
+## The size quantum and the constant profile
+
+Every one of the 400 kept pieces has a point count that is exactly 5 times an integer unit, and the
+unit takes only the four values 1, 3, 7 and 14. The census over the kept pieces is 24 pieces of unit
+1, 176 of unit 3, 176 of unit 7 and 24 of unit 14; over the 192 used pieces it is 8, 88, 88 and 8.
+The four distinct units sum to 25.
+
+The profile is not merely available, it is forced: every one of the 15800 cuttings has the same unit
+profile, one piece of unit 1, 11 pieces of unit 3, 11 pieces of unit 7 and one piece of unit 14. That
+is 125 units, that is 625 points, the whole sample grid, and the 24 pieces of a cutting are accounted
+for as 1 plus 11 plus 11 plus 1. No cutting deviates. The size quantum is therefore a property of the
+object and not of any particular cutting, and the multiples of 25 that the previous cycle asked about
+are already present in the piece sizes before any exchange is looked at.
+
+## Class as composition
+
+In each of the 48 wall fibers the fold-held cuttings decompose over 40 rows, and among those rows the
+equal-union exchanges are the pairs of disjoint row pairs sharing a point union. Over every exchange
+of every fiber, that is all 192 of them, the sorted pair of half unit-profiles is a function of the
+union point-size and of nothing else: union 50 gives halves of units 1, 3, 3, 3; union 100 gives 3,
+3, 7, 7; union 175 gives 7, 7, 7, 14. There are 0 exceptions.
+
+Each fiber carries exactly one exchange of broken count 2, the one the previous cycle identified as
+carrying the whole distinction, and its union size is 50 at 8 fibers, 100 at 32 and 175 at 8. That
+census agrees with the light, middle and heavy letter-pair lists of the previous cycle at 48 of 48
+fibers. So the trichotomy is read off directly: light means the distinguished exchange carries a
+piece of the smallest unit 1 in each half, heavy means it carries a piece of the largest unit 14, and
+middle means neither end appears. The light and heavy classes are the two ends of the piece-size
+spectrum, which answers the second entrance question, and it explains without difficulty why the
+classification is not invariant under the action: the composition is stated relative to the point
+frame that gives pieces their point counts, exactly the relativity the previous cycle measured.
+
+## A refuted product hypothesis
+
+The obvious reading of the union values 50, 100 and 175 as 2, 4 and 7 times 25 is that an exchange
+union is a base set on two axes times the full square of 25 points on the complementary two axes.
+That hypothesis is refuted here. Grouping each union's points by their coordinates on a chosen axis
+pair and asking whether every nonempty group has exactly 25 points returns 0 factorizations out of
+the 1152 tests, that is every exchange union of every fiber against each of the 6 unordered axis
+pairs, and the same test on single row supports returns 0 out of 11520. The test is not vacuous: run
+on the whole sample grid it reports a factorization on all 6 of the 6 axis pairs, so a positive
+answer is reachable and the object simply does not give one.
+
+The factor 25 therefore belongs to the object through its piece sizes, not through a product
+structure of the unions. That answers the third entrance question, in the negative for the shape the
+previous cycle proposed and in the affirmative for the quantity it was chasing.
+
+## Derived versus measured
+
+Derived at the declared finite scope. The uniqueness of the flag is derived, in the sense that both
+flag values are tested at every one of the 384 maps and exactly one survives at each of the 96 acting
+maps while neither survives at the other 288. The homomorphism and the faithfulness are derived by
+verification at all 9216 ordered pairs, not sampled. The orbit decompositions of the 16 letters and
+of the 256 ordered pairs are derived by closure under the full set of 96 actions, and the constancy
+of the matrix on each orbit follows from the equivariance, which is itself checked entry by entry.
+That the wall is one orbit, and hence that its unordered graph is regular, is derived rather than
+observed. The half-profile law is derived in the same sense: it is verified as a function of union
+size with 0 exceptions over every exchange of every fiber, and its failure at a single exchange would
+have been reported.
+
+What is measured, not derived, at the declared finite scope: the value census of the matrix and the 9
+distinct values themselves; which letters are wall letters, anchored as the measured list 0, 2, 3, 4,
+5, 7, 9, 10, 11, 12, 13, 14 with complement 1, 6, 8, 15; the two edge lists at value 18 and the 24
+edges of the wall graph, all of which are frame-anchored labels; the row sums 862 and 1364; the unit
+spectrum 1, 3, 7, 14 and its censuses; the constant profile of one, eleven, eleven and one; and the
+broken-count-2 census 8, 32 and 8. Above all, why the unit spectrum is 1, 3, 7, 14 and why every one
+of the 15800 cuttings carries the same profile are measured facts here, not consequences of anything
+proved in this note.
+
+## Boundary and the honest auditor read
+
+All of the above are computational identities of the declared unit four-cube object, its 400 kept
+pieces, its 15800 cuttings, its 16-letter alphabet and the order-384 symmetry group of the cell. The
+letter graph and the two edge lists at value 18 are stated in the labels of the declared alphabet and
+the declared point frame, and are not claimed to be frame-independent. The refutation is a refutation
+of one named product hypothesis on this object, tested over all 6 axis pairs, and says nothing about
+other factorization shapes. No physical, dynamical, or lattice-wide identification is claimed, no
+continuum limit is taken, and nothing here is asserted about cell-cutting systems outside the
+declared object.
+
+## Next entrance
+
+Two questions are now sharp. The first is the size quantum: the units 1, 3, 7 and 14 sum to 25, they
+appear in the fixed multiplicities 1, 11, 11 and 1 in every cutting, and both the spectrum and the
+multiplicities are so far only counted. Deriving them from the corner geometry and the adjacency cost
+floor would explain the multiples of 25 at their source and would make the class composition a
+theorem rather than a table. The second is the degeneracy at value 18: it is the only place where the
+interface matrix fails to separate its own orbits, so whatever function does separate them is a
+strictly finer invariant of the object than the matrix, and finding it is the natural next reading of
+the letter level.
+
+## Review record
+
+- Rows are the two-orbits of the 400 kept pieces under each fiber's own fold, and blocks are that
+  fiber's fold-held cuttings written as row sets. Both conventions are fixed before any computation
+  runs, and every statement is made for all 48 fibers, not for a chosen one.
+- The letter maps are found by search, not by construction from the coordinate action: for each of
+  the 384 maps and each of the two flag values the runner attempts to build a bijection from the
+  cutting images and rejects it on the first inconsistency, so the 288 failures are genuine failures
+  and the 96 successes are genuine solutions.
+- The composition convention is the base convention, apply the second map first, and the
+  homomorphism is tested in that order at every one of the 9216 ordered pairs.
+- The orbit decompositions are computed by closure under the recomputed actions and are compared
+  against the anchors of size and value only after being formed, so an anchor cannot seed an orbit.
+- The class comparison runs in the honest direction: the runner recomputes each fiber's distinguished
+  exchange and its union size, then compares the resulting classification against the previous
+  cycle's letter-pair lists. The lists are never used to decide a class.
+- The refutation gate carries a positive control on the same code path, the whole sample grid, which
+  must and does report a factorization on all 6 axis pairs, so the two zeros cannot be an artifact of
+  a broken test.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a commit
+  cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run the [runner](../scripts/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.py).
+The reviewed
+[cache](../logs/runner-cache/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.txt)
+belongs beside it and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC`
+budget, finishes in well under a minute on the reference machine, and stays far below one gigabyte.
+Its final line is `TOTAL: PASS=10 FAIL=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13833,6 +13833,10 @@
   "physical_cell_cutting_least_computing_sets_cycle737_note_2026-08-05": {
    "deps_hash": "ba0326da985f",
    "out_degree": 3
+  },
+  "physical_cell_cutting_letter_action_orbit_census_cycle797_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_object_distance_cycle751_note_2026-08-09": {
    "deps_hash": "92314bbf23cc",

--- a/logs/runner-cache/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.py
+runner_sha256: 81b68b8b92f0b50237c6b83e3d39ca708e6e978f2147460ca2084dbcd9f0e822
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 16.43
+status: ok
+----- stdout -----
+PASS G1 of the 384 cell maps exactly 96 induce a letter map, each with one flag value, and the other 288 induce none for either flag
+G1 detail: declared cell: 2672 candidates, floor 6, 400 kept, 15800 cuttings of 24, 192 used, 16 letters, trace 2000
+PASS G2 the flag is bit zero of the flip mask at all 96 acting maps, the 96 letter maps are pairwise distinct, and the kernel has size 2
+G2 detail: the kernel is the identity with flag 0 and the pure first-axis flip with flag 1, so the permutation image has order 48
+PASS G3 at all 9216 ordered pairs of acting maps the letter permutation composes in the order the maps are applied and the flags add
+PASS G4 the interface matrix is symmetric at all 256 entries and equivariant under all 96 acting maps, with slots swapped when the flag is set
+PASS G5 the 16 letters fall into exactly 2 orbits of sizes 12 and 4, and the size 12 orbit is exactly the set of letters of the wall
+G5 detail: row sums are 862 on the 12 wall letters [0, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13, 14] and 1364 on the others [1, 6, 8, 15]
+G5 detail: diagonal entries are 100 on the wall letters and 200 on the others, and the trace is 2000
+PASS G6 the 256 ordered letter pairs fall into exactly 10 orbits, the matrix is constant on each, and its 256 entries sum to 15800
+G6 detail: orbit sizes with their values [(4, 200), (12, 18), (12, 18), (12, 90), (12, 100), (12, 104), (48, 36), (48, 50), (48, 52), (48, 92)]
+G6 detail: the value 18 alone carries 2 orbits, each held by the transpose, giving 6 unordered pairs each
+G6 detail: the first orbit at that value is [(0, 7), (2, 13), (3, 5), (4, 11), (9, 12), (10, 14)]
+G6 detail: the second orbit at that value is [(0, 12), (2, 11), (3, 10), (4, 13), (5, 14), (7, 9)]
+G6 detail: the value census over the 256 entries is {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}
+PASS G7 the 48 wall entries at value 36 are exactly one orbit, and the letter pair formula gives the induced entry map at all 4608 pairs
+G7 detail: unordered the wall is 24 edges on the 12 wall letters, and every one of those letters has degree exactly 4
+PASS G8 every one of the 400 kept pieces has a point count of exactly 5 times its unit, and the unit spectrum [1, 3, 7, 14] sums to 25
+G8 detail: the unit census over the kept pieces is {1: 24, 3: 176, 7: 176, 14: 24} and over the 192 used pieces is {1: 8, 3: 88, 7: 88, 14: 8}
+G8 detail: all 15800 cuttings carry one and the same profile, 1 piece of unit 1, 11 of unit 3, 11 of unit 7, 1 of unit 14
+G8 detail: that profile totals 125 units, that is 625 points, the whole sample grid
+PASS G9 over the 40 rows of every one of the 48 fibers, the half unit profiles of all 192 equal-union exchanges follow the union size
+G9 detail: union 50 gives halves (1, 3, 3, 3), union 100 gives (3, 3, 7, 7), union 175 gives (7, 7, 7, 14), with 0 exceptions
+G9 detail: each fiber has exactly 1 exchange of broken count 2, and its union size census over the 48 fibers is {50: 8, 100: 32, 175: 8}
+G9 detail: that census matches the light, middle and heavy letter pair lists of the previous cycle at 48 of 48 fibers
+PASS G10 over all 6 axis pairs no exchange union factorizes as a base times the full 25 point square: 0 of 1152 unions factorize
+G10 detail: and no single row support factorizes either, 0 of 11520 tested, so the union sizes are piece-size accounting
+G10 detail: the same test on the whole sample grid returns a factorization on all 6 of 6 axis pairs, so the test can succeed
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.py
+++ b/scripts/physical_cell_cutting_letter_action_orbit_census_cycle797_2026_08_15.py
@@ -1,0 +1,727 @@
+"""Physical cell cutting: the letter action, the orbit census of the interface matrix, the piece-size quantum, and class as composition.
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, the order-384 group of signed coordinate
+maps of the cell, and the sixteen-letter facet alphabet on the two slots of axis zero. Nothing outside that finite object enters any gate.
+
+The previous cycle showed that exactly the 96 cell maps fixing the first axis carry the wall of 48 interface entries of value 36 to itself,
+transitively, with each entry stabilizer of order 2 equal to that fiber's fold. This cycle reads the letter level. Every cell map is tested
+for an induced letter map: a permutation of the 16 letters together with a slot-swap flag, with both flag values tried. The assignment is
+tested for uniqueness, for the flag law, for faithfulness, for its kernel, and for the homomorphism property at every ordered pair of acting
+maps. The induced action on the 256 ordered letter pairs is decomposed into orbits, the interface matrix is tested for constancy on each,
+the wall is identified with a single orbit and drawn as a graph, every kept piece is tested for a point count that is a multiple of five,
+every cutting for one and the same unit profile, and the light, middle and heavy classes of the previous cycle are matched against the
+piece-size composition of the distinguished exchange. A product-structure hypothesis for the union sizes is tested and refuted.
+Gates G1 to G10, one line each with a few detail lines, then the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    if OUT[0] >= 5800:
+        raise ValueError("output over the character budget")
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def popc(x):
+    return bin(x).count("1")
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                fq = M[r][c]
+                M[r] = [M[r][k] - fq * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+NPTS = RSTEP ** 4
+
+
+def buildmask(offs):
+    """Membership bitmasks of every kept piece on the sample points of one per-axis offset table, by exact integer barycentric tests."""
+    axval = [[NSHIFT * k + offs[i] for k in range(RSTEP)] for i in range(4)]
+    out = []
+    for (v0, Ci) in BARY:
+        off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+        col = [[[Ci[i][ax] * u for i in range(4)] for u in axval[ax]] for ax in range(4)]
+        bits = 0
+        idx = 0
+        for a in col[0]:
+            s1 = [a[i] - off[i] for i in range(4)]
+            for b in col[1]:
+                s2 = [s1[i] + b[i] for i in range(4)]
+                for c in col[2]:
+                    s3 = [s2[i] + c[i] for i in range(4)]
+                    for d in col[3]:
+                        w = [s3[i] + d[i] for i in range(4)]
+                        sw = sum(w)
+                        if all(x > 0 for x in w) and sw < DIV:
+                            bits |= (1 << idx)
+                        idx += 1
+        out.append(bits)
+    return out
+
+
+MASK = buildmask(OFFS)
+UNIV = (1 << NPTS) - 1
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(len(KEPT)):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+SIDX = {frozenset(s): i for i, s in enumerate(SOLS)}
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+CSET = [frozenset(s) for s in SOLS]
+PSIZE = len(set(len(s) for s in SOLS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+NK = len(KEPT)
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+GID = ((0, 1, 2, 3), 0)
+FLIP1 = ((0, 1, 2, 3), 1)
+
+FACE = {}
+for t in range(NK):
+    S = KEPT[t]
+    for a in range(4):
+        for c in (0, 1):
+            F = [v for v in S if CORN[v][a] == c]
+            if len(F) == 4:
+                FACE[(t, a, c)] = frozenset(tuple(CORN[v][r] for r in range(4) if r != a) for v in F)
+
+KEYF = []
+for s in SOLS:
+    d = {}
+    for a in range(4):
+        for c in (0, 1):
+            d[(a, c)] = frozenset(FACE[(t, a, c)] for t in s if (t, a, c) in FACE)
+    KEYF.append(d)
+
+ALLK = sorted({d[k] for d in KEYF for k in d}, key=lambda fz: sorted(sorted(t) for t in fz))
+KN = {k: i for i, k in enumerate(ALLK)}
+KEY = [{k: KN[v] for k, v in d.items()} for d in KEYF]
+NL = len(ALLK)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def compose(a, b):
+    p, m = a
+    q, n = b
+    r = tuple(q[p[i]] for i in range(4))
+    k = n
+    for j in range(4):
+        if (m >> j) & 1:
+            k ^= (1 << q[j])
+    return (r, k)
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+def imgof(pmp, IMG, i):
+    """Image cutting index of cutting i under the piece map pmp, cached in IMG so no cutting image is ever recomputed for one cell map."""
+    j = IMG[i]
+    if j < 0:
+        j = SIDX[frozenset(pmp[t] for t in SOLS[i])]
+        IMG[i] = j
+    return j
+
+
+# ---------------------------------------------- the alphabet, the interface matrix and the wall
+
+PAIROF = [(KEY[i][(0, 0)], KEY[i][(0, 1)]) for i in range(NS)]
+JC = Counter(PAIROF)
+TRM = [[JC[(x, y)] for y in range(NL)] for x in range(NL)]
+TRC = sum(TRM[x][x] for x in range(NL))
+N36 = sum(1 for x in range(NL) for y in range(NL) if TRM[x][y] == 36)
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(PAIROF[i], []).append(i)
+E36 = sorted(kj for kj in FIB if TRM[kj[0]][kj[1]] == 36)
+NF = len(E36)
+FL = [FIB[kj] for kj in E36]
+FS = [set(F) for F in FL]
+EIDX = dict((e, i) for i, e in enumerate(E36))
+IDS = tuple(range(NL))
+
+# ============================================== G1 the induced letter map of every cell map, both flag values tried
+
+FOLD = [None] * NF
+STCNT = [0] * NF
+DEFECT = 0
+EMAP = {}
+LMAP = {}
+NSOLC = Counter()
+for g in G384:
+    pmp = piecemap(g, USED)
+    IMGB = [-1] * NS
+    if len(set(pmp.values())) != NU:
+        DEFECT += 1
+    em = [-1] * NF
+    for f in range(NF):
+        tg = set()
+        hold = True
+        for c in FL[f]:
+            j = imgof(pmp, IMGB, c)
+            if j not in FS[f]:
+                hold = False
+            tg.add(PAIROF[j])
+        if hold:
+            STCNT[f] += 1
+            if g != GID:
+                FOLD[f] = g
+        if len(tg) == 1:
+            e = sorted(tg)[0]
+            if e in EIDX:
+                em[f] = EIDX[e]
+    EMAP[g] = tuple(em)
+    good = []
+    for sw in (0, 1):
+        sig = [-1] * NL
+        bak = [-1] * NL
+        ok = True
+        for i in range(NS):
+            a, b = PAIROF[i]
+            u, v = PAIROF[imgof(pmp, IMGB, i)]
+            if sw:
+                u, v = v, u
+            if sig[a] < 0 and bak[u] < 0:
+                sig[a] = u
+                bak[u] = a
+            elif sig[a] != u:
+                ok = False
+                break
+            if sig[b] < 0 and bak[v] < 0:
+                sig[b] = v
+                bak[v] = b
+            elif sig[b] != v:
+                ok = False
+                break
+        if ok and min(sig) >= 0:
+            good.append((tuple(sig), sw))
+    NSOLC[(g[0][0] == 0, len(good))] += 1
+    if len(good) == 1:
+        LMAP[g] = good[0]
+
+FIXONE = NSOLC[(True, 1)]
+FIXBAD = sum(NSOLC[k] for k in NSOLC if k[0] and k[1] != 1)
+OTHNIL = NSOLC[(False, 0)]
+OTHBAD = sum(NSOLC[k] for k in NSOLC if (not k[0]) and k[1] != 0)
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NL == 16 and TRC == 2000 and N36 == 48 and NF == 48 and DEFECT == 0
+     and FIXONE == 96 and FIXBAD == 0 and OTHNIL == 288 and OTHBAD == 0, "G1",
+     "of the {0} cell maps exactly {1} induce a letter map, each with one flag value, and the other {2} induce none for either flag"
+     .format(len(G384), FIXONE, OTHNIL))
+emit("G1 detail: declared cell: {0} candidates, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, {6} letters, trace {7}"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, NL, TRC))
+
+# ============================================== G2 the flag law, faithfulness, the kernel of the letter permutation
+
+ACTG = [g for g in G384 if g[0][0] == 0]
+SWOK = sum(1 for g in ACTG if g in LMAP and LMAP[g][1] == (g[1] & 1))
+DISTP = len(set(LMAP[g] for g in ACTG if g in LMAP))
+KER = sorted(g for g in ACTG if g in LMAP and LMAP[g][0] == IDS)
+SIGIM = len(set(LMAP[g][0] for g in ACTG if g in LMAP))
+KEROK = KER == [GID, FLIP1] and LMAP[GID][1] == 0 and LMAP[FLIP1][1] == 1
+
+gate(len(ACTG) == 96 and SWOK == 96 and DISTP == 96 and len(KER) == 2 and KEROK and SIGIM == 48, "G2",
+     "the flag is bit zero of the flip mask at all {0} acting maps, the {0} letter maps are pairwise distinct, and the kernel has size {1}"
+     .format(len(ACTG), len(KER)))
+emit("G2 detail: the kernel is the identity with flag {0} and the pure first-axis flip with flag {1}, so the permutation image has order {2}"
+     .format(LMAP[GID][1], LMAP[FLIP1][1], SIGIM))
+
+# ============================================== G3 the assignment is a homomorphism at every ordered pair
+
+HOM = 0
+for g in ACTG:
+    sg, wg = LMAP[g]
+    for h in ACTG:
+        sh, wh = LMAP[h]
+        e = LMAP.get(compose(g, h))
+        if e is None:
+            continue
+        if e[0] == tuple(sg[sh[x]] for x in range(NL)) and e[1] == (wg ^ wh):
+            HOM += 1
+
+gate(HOM == 9216 and len(ACTG) * len(ACTG) == 9216, "G3",
+     "at all {0} ordered pairs of acting maps the letter permutation composes in the order the maps are applied and the flags add"
+     .format(HOM))
+
+# ============================================== G4 the interface matrix is symmetric and equivariant
+
+SYM = sum(1 for a in range(NL) for b in range(NL) if TRM[a][b] == TRM[b][a])
+EQV = 0
+for g in ACTG:
+    sg, wg = LMAP[g]
+    cc = 0
+    for a in range(NL):
+        for b in range(NL):
+            ia, ib = (sg[b], sg[a]) if wg else (sg[a], sg[b])
+            if TRM[ia][ib] == TRM[a][b]:
+                cc += 1
+    if cc == NL * NL:
+        EQV += 1
+
+gate(SYM == 256 and NL * NL == 256 and EQV == 96, "G4",
+     "the interface matrix is symmetric at all {0} entries and equivariant under all {1} acting maps, with slots swapped when the flag is set"
+     .format(SYM, EQV))
+
+# ============================================== G5 the letters fall into two orbits
+
+LPAR = list(range(NL))
+
+
+def findl(a):
+    while LPAR[a] != a:
+        LPAR[a] = LPAR[LPAR[a]]
+        a = LPAR[a]
+    return a
+
+
+for g in ACTG:
+    sg = LMAP[g][0]
+    for a in range(NL):
+        ra, rb = findl(a), findl(sg[a])
+        if ra != rb:
+            LPAR[ra] = rb
+LORB = {}
+for a in range(NL):
+    LORB.setdefault(findl(a), []).append(a)
+LOS = sorted(LORB.values(), key=len, reverse=True)
+BIG = sorted(LOS[0])
+SML = sorted(LOS[1]) if len(LOS) > 1 else []
+WLET = sorted(set(x for e in E36 for x in e))
+NWLET = [a for a in range(NL) if a not in WLET]
+RS = [sum(TRM[a]) for a in range(NL)]
+RSB = sorted(set(RS[a] for a in BIG))
+RSS = sorted(set(RS[a] for a in SML))
+DGB = sorted(set(TRM[a][a] for a in BIG))
+DGS = sorted(set(TRM[a][a] for a in SML))
+
+gate(len(LOS) == 2 and len(BIG) == 12 and len(SML) == 4 and BIG == WLET and SML == NWLET
+     and BIG == [0, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13, 14] and SML == [1, 6, 8, 15]
+     and RSB == [862] and RSS == [1364] and DGB == [100] and DGS == [200] and TRC == 2000 and NL == 16, "G5",
+     "the {0} letters fall into exactly {1} orbits of sizes {2} and {3}, and the size {2} orbit is exactly the set of letters of the wall"
+     .format(NL, len(LOS), len(BIG), len(SML)))
+emit("G5 detail: row sums are {0} on the {1} wall letters {2} and {3} on the others {4}"
+     .format(RSB[0], len(BIG), BIG, RSS[0], SML))
+emit("G5 detail: diagonal entries are {0} on the wall letters and {1} on the others, and the trace is {2}"
+     .format(DGB[0], DGS[0], TRC))
+
+# ============================================== G6 the orbit census of the 256 ordered letter pairs
+
+NP2 = NL * NL
+PPAR = list(range(NP2))
+
+
+def findp(a):
+    while PPAR[a] != a:
+        PPAR[a] = PPAR[PPAR[a]]
+        a = PPAR[a]
+    return a
+
+
+for g in ACTG:
+    sg, wg = LMAP[g]
+    for a in range(NL):
+        for b in range(NL):
+            ia, ib = (sg[b], sg[a]) if wg else (sg[a], sg[b])
+            ra, rb = findp(a * NL + b), findp(ia * NL + ib)
+            if ra != rb:
+                PPAR[ra] = rb
+POR = {}
+for k in range(NP2):
+    POR.setdefault(findp(k), []).append(k)
+ORBL = []
+CONST = 0
+for r in sorted(POR):
+    mem = POR[r]
+    vs = set(TRM[divmod(k, NL)[0]][divmod(k, NL)[1]] for k in mem)
+    if len(vs) == 1:
+        CONST += 1
+    ORBL.append((len(mem), sorted(vs)[0], mem))
+OV = sorted((s, v) for s, v, mem in ORBL)
+VALS = sorted(set(v for s, v in OV))
+OPV = Counter(v for s, v in OV)
+ECEN = Counter(TRM[a][b] for a in range(NL) for b in range(NL))
+WSUM = sum(v * ECEN[v] for v in ECEN)
+ANCOV = [(4, 200), (12, 18), (12, 18), (12, 90), (12, 100), (12, 104), (48, 36), (48, 50), (48, 52), (48, 92)]
+ANCEC = {18: 24, 36: 48, 50: 48, 52: 48, 90: 12, 92: 48, 100: 12, 104: 12, 200: 4}
+O18 = [mem for s, v, mem in ORBL if v == 18]
+TR18 = all(set(divmod(k, NL)[1] * NL + divmod(k, NL)[0] for k in mem) == set(mem) for mem in O18)
+ED = sorted(sorted(set(tuple(sorted(divmod(k, NL))) for k in mem)) for mem in O18)
+A18 = sorted(set(tuple(sorted((a, b))) for a in range(NL) for b in range(NL) if TRM[a][b] == 18))
+E18OK = (len(O18) == 2 and TR18 and [len(e) for e in ED] == [6, 6] and not set(ED[0]) & set(ED[1])
+         and sorted(set(ED[0]) | set(ED[1])) == A18 and len(A18) == 12)
+
+gate(len(OV) == 10 and OV == ANCOV and CONST == 10 and len(VALS) == 9 and OPV[18] == 2
+     and sorted(OPV[v] for v in VALS if v != 18) == [1] * 8 and dict(ECEN) == ANCEC and WSUM == 15800
+     and sum(ECEN[v] for v in ECEN) == 256 and E18OK, "G6",
+     "the {0} ordered letter pairs fall into exactly {1} orbits, the matrix is constant on each, and its {0} entries sum to {2}"
+     .format(NP2, len(OV), WSUM))
+emit("G6 detail: orbit sizes with their values {0}".format(OV))
+emit("G6 detail: the value {0} alone carries {1} orbits, each held by the transpose, giving {2} unordered pairs each"
+     .format(18, OPV[18], len(ED[0])))
+emit("G6 detail: the first orbit at that value is {0}".format(ED[0]))
+emit("G6 detail: the second orbit at that value is {0}".format(ED[1]))
+emit("G6 detail: the value census over the {0} entries is {1}".format(NP2, dshow(ECEN)))
+
+# ============================================== G7 the wall is the orbit at value 36, and a graph
+
+W36 = set(a * NL + b for (a, b) in E36)
+O36 = [set(mem) for s, v, mem in ORBL if v == 36]
+PF = 0
+for g in ACTG:
+    sg, wg = LMAP[g]
+    for f in range(NF):
+        a, b = E36[f]
+        ia, ib = (sg[b], sg[a]) if wg else (sg[a], sg[b])
+        if EMAP[g][f] >= 0 and E36[EMAP[g][f]] == (ia, ib):
+            PF += 1
+UNW = sorted(set(tuple(sorted(e)) for e in E36))
+DEG = Counter()
+for (a, b) in UNW:
+    DEG[a] += 1
+    DEG[b] += 1
+DEGV = sorted(set(DEG.values()))
+
+gate(len(O36) == 1 and O36[0] == W36 and len(W36) == 48 and PF == 4608 and PF == len(ACTG) * NF
+     and len(UNW) == 24 and sorted(DEG) == WLET and DEGV == [4], "G7",
+     "the {0} wall entries at value {1} are exactly one orbit, and the letter pair formula gives the induced entry map at all {2} pairs"
+     .format(len(W36), 36, PF))
+emit("G7 detail: unordered the wall is {0} edges on the {1} wall letters, and every one of those letters has degree exactly {2}"
+     .format(len(UNW), len(WLET), DEGV[0]))
+
+# ============================================== G8 the piece-size quantum and the constant profile
+
+PSZ = [popc(MASK[t]) for t in range(NK)]
+UNIT = [0] * NK
+DIVOK = 0
+for t in range(NK):
+    q, r = divmod(PSZ[t], 5)
+    UNIT[t] = q
+    if r == 0 and q * 5 == PSZ[t]:
+        DIVOK += 1
+CKEPT = Counter(UNIT)
+CUSED = Counter(UNIT[t] for t in USED)
+SPEC = sorted(CKEPT)
+PROF = set(tuple(sorted(Counter(UNIT[t] for t in s).items())) for s in SOLS)
+ONEP = sorted(PROF)[0]
+TUNIT = sum(k * n for k, n in ONEP)
+
+gate(DIVOK == NK and NK == 400 and SPEC == [1, 3, 7, 14] and sum(SPEC) == 25
+     and dict(CKEPT) == {1: 24, 3: 176, 7: 176, 14: 24} and dict(CUSED) == {1: 8, 3: 88, 7: 88, 14: 8}
+     and len(PROF) == 1 and ONEP == ((1, 1), (3, 11), (7, 11), (14, 1)) and TUNIT == 125
+     and TUNIT * 5 == NPTS and NPTS == 625 and NS == 15800 and NU == 192, "G8",
+     "every one of the {0} kept pieces has a point count of exactly {1} times its unit, and the unit spectrum {2} sums to {3}"
+     .format(NK, 5, SPEC, sum(SPEC)))
+emit("G8 detail: the unit census over the kept pieces is {0} and over the {1} used pieces is {2}"
+     .format(dshow(CKEPT), NU, dshow(CUSED)))
+emit("G8 detail: all {0} cuttings carry one and the same profile, {1} piece of unit {2}, {3} of unit {4}, {3} of unit {5}, {1} of unit {6}"
+     .format(NS, 1, 1, 11, 3, 7, 14))
+emit("G8 detail: that profile totals {0} units, that is {1} points, the whole sample grid".format(TUNIT, TUNIT * 5))
+
+# ============================================== the fold two-orbit tables and the fiber instances
+
+DIST = sorted(set(FOLD))
+FIDX = {g: i for i, g in enumerate(DIST)}
+MPKS = []
+ORBS = []
+OIDX = []
+NORB = set()
+for g in DIST:
+    mpk = piecemap(g, range(NK))
+    orbs = []
+    seen = set()
+    for t in range(NK):
+        if t in seen:
+            continue
+        u = mpk[t]
+        seen.add(t)
+        seen.add(u)
+        orbs.append((t, u))
+    oi = {}
+    for i in range(len(orbs)):
+        oi[orbs[i][0]] = i
+        oi[orbs[i][1]] = i
+    MPKS.append(mpk)
+    ORBS.append(orbs)
+    OIDX.append(oi)
+    NORB.add(len(orbs))
+
+
+def instance(f, MX):
+    """Rebuild fiber f from the two-orbits of its fold: the held cuttings as row vectors, the point supports of the rows on the given
+    frame, the equal-union exchanges of the rows with their unions, and the broken count of each exchange."""
+    fi = FIDX[FOLD[f]]
+    mpk = MPKS[fi]
+    oi = OIDX[fi]
+    orbs = ORBS[fi]
+    held = [c for c in FL[f] if frozenset(mpk[t] for t in SOLS[c]) == CSET[c]]
+    raw = [frozenset(oi[t] for t in SOLS[c]) for c in held]
+    rowg = sorted(set().union(*raw))
+    nr = len(rowg)
+    rpos = {r: i for i, r in enumerate(rowg)}
+    vecs = [sum(1 << rpos[r] for r in rr) for rr in raw]
+    sup = [MX[orbs[rowg[i]][0]] | MX[orbs[rowg[i]][1]] for i in range(nr)]
+    ug = {}
+    for i, j in itertools.combinations(range(nr), 2):
+        if sup[i] & sup[j]:
+            continue
+        ug.setdefault(sup[i] | sup[j], []).append((i, j))
+    spl = {}
+    for u in ug:
+        for pa, pb in itertools.combinations(ug[u], 2):
+            if len(set(pa) | set(pb)) == 4:
+                ma = (1 << pa[0]) | (1 << pa[1])
+                mb = (1 << pb[0]) | (1 << pb[1])
+                spl[ma | mb] = (ma, mb, popc(u), u)
+    brk = Counter()
+    for dv in spl:
+        ma, mb, usz, uu = spl[dv]
+        for w in vecs:
+            x = w & dv
+            if x != 0 and x != ma and x != mb:
+                brk[dv] += 1
+    return {"held": held, "rowg": rowg, "nr": nr, "orbs": orbs, "vecs": vecs, "spl": spl, "brk": brk, "sup": sup}
+
+
+def halfprof(d, m):
+    """The sorted unit profile of the four kept pieces carried by the two rows of one half of an equal-union exchange."""
+    ps = []
+    for i in range(d["nr"]):
+        if (m >> i) & 1:
+            ps.extend(UNIT[t] for t in d["orbs"][d["rowg"][i]])
+    return tuple(sorted(ps))
+
+
+D1 = [instance(f, MASK) for f in range(NF)]
+
+# ============================================== G9 the class of a fiber is the piece-size composition of its distinguished exchange
+
+NROW = sorted(set(d["nr"] for d in D1))
+NEXC = sorted(set(len(d["spl"]) for d in D1))
+EXPP = {50: ((1, 3, 3, 3), (1, 3, 3, 3)), 100: ((3, 3, 7, 7), (3, 3, 7, 7)), 175: ((7, 7, 7, 14), (7, 7, 7, 14))}
+BADP = 0
+NCHK = 0
+B2 = {}
+B2N = Counter()
+for f in range(NF):
+    d = D1[f]
+    for dv in d["spl"]:
+        ma, mb, usz, uu = d["spl"][dv]
+        NCHK += 1
+        if tuple(sorted((halfprof(d, ma), halfprof(d, mb)))) != EXPP.get(usz):
+            BADP += 1
+    two = sorted(dv for dv in d["spl"] if d["brk"][dv] == 2)
+    B2N[len(two)] += 1
+    if len(two) == 1:
+        B2[f] = d["spl"][two[0]][2]
+LANC = [(2, 12), (4, 14), (5, 13), (7, 11)]
+HANC = [(2, 3), (4, 7), (10, 11), (12, 13)]
+ANCU = {}
+for f in range(NF):
+    e = tuple(sorted(E36[f]))
+    ANCU[f] = 50 if e in LANC else (175 if e in HANC else 100)
+AGREE = sum(1 for f in range(NF) if f in B2 and B2[f] == ANCU[f])
+CEN = Counter(B2[f] for f in B2)
+
+gate(NROW == [40] and NEXC == [4] and BADP == 0 and NCHK == NF * 4 and dict(B2N) == {1: NF}
+     and AGREE == NF and NF == 48 and dict(CEN) == {50: 8, 100: 32, 175: 8}
+     and sorted(NORB) == [200] and sorted(set(len(d["held"]) for d in D1)) == [14], "G9",
+     "over the {0} rows of every one of the {1} fibers, the half unit profiles of all {2} equal-union exchanges follow the union size"
+     .format(NROW[0], NF, NCHK))
+emit("G9 detail: union {0} gives halves {1}, union {2} gives {3}, union {4} gives {5}, with {6} exceptions"
+     .format(50, EXPP[50][0], 100, EXPP[100][0], 175, EXPP[175][0], BADP))
+emit("G9 detail: each fiber has exactly {0} exchange of broken count {1}, and its union size census over the {2} fibers is {3}"
+     .format(1, 2, NF, dshow(CEN)))
+emit("G9 detail: that census matches the light, middle and heavy letter pair lists of the previous cycle at {0} of {0} fibers".format(NF))
+
+# ============================================== G10 the product-structure hypothesis, tested and refuted
+
+AXP = sorted(itertools.combinations(range(4), 2))
+CP = []
+for (i, j) in AXP:
+    tab = [0] * NPTS
+    for p in range(NPTS):
+        q, c3 = divmod(p, RSTEP)
+        q, c2 = divmod(q, RSTEP)
+        c0, c1 = divmod(q, RSTEP)
+        cs = (c0, c1, c2, c3)
+        tab[p] = cs[i] * RSTEP + cs[j]
+    CP.append(tab)
+
+
+def factorizes(supm, ap):
+    """True when the point set factorizes as a base on the given axis pair times the full five by five square on the other two axes."""
+    cnt = {}
+    m = supm
+    while m:
+        low = m & (-m)
+        k = CP[ap][low.bit_length() - 1]
+        cnt[k] = cnt.get(k, 0) + 1
+        m ^= low
+    return len(cnt) > 0 and all(v == RSTEP * RSTEP for v in cnt.values())
+
+
+FACU = 0
+FACR = 0
+NUT = 0
+NRT = 0
+for f in range(NF):
+    d = D1[f]
+    for dv in d["spl"]:
+        uu = d["spl"][dv][3]
+        for ap in range(len(AXP)):
+            NUT += 1
+            if factorizes(uu, ap):
+                FACU += 1
+    for i in range(d["nr"]):
+        for ap in range(len(AXP)):
+            NRT += 1
+            if factorizes(d["sup"][i], ap):
+                FACR += 1
+
+CTRL = sum(1 for ap in range(len(AXP)) if factorizes(UNIV, ap))
+
+gate(len(AXP) == 6 and RSTEP * RSTEP == 25 and FACU == 0 and FACR == 0 and NUT == NF * 4 * 6 and NRT == NF * 40 * 6
+     and CTRL == len(AXP), "G10",
+     "over all {0} axis pairs no exchange union factorizes as a base times the full {1} point square: {2} of {3} unions factorize"
+     .format(len(AXP), RSTEP * RSTEP, FACU, NUT))
+emit("G10 detail: and no single row support factorizes either, {0} of {1} tested, so the union sizes are piece-size accounting"
+     .format(FACR, NRT))
+emit("G10 detail: the same test on the whole sample grid returns a factorization on all {0} of {0} axis pairs, so the test can succeed"
+     .format(CTRL))
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note, one paired runner, one runner cache (source-only triple), plus the separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The object is the landed finite cell: the unit four-cube with sixteen corners, the four hundred kept pieces at adjacency-cost floor six, the fifteen thousand eight hundred exact twenty-four-piece cuttings, the sixteen-letter facet alphabet, and the sixteen-by-sixteen interface matrix whose forty-eight entries at thirty-six are the named wall. The previous cycle showed that exactly the ninety-six first-axis-fixing cell maps act on the wall and act transitively. This cycle pushes that action down to the letters themselves and up to the piece sizes, and both directions collapse.

- **The acting maps induce a faithful letter representation.** Every one of the ninety-six acting maps induces a unique permutation-with-flag on the sixteen letters, tested against both flag values, and every one of the other two hundred eighty-eight cell maps induces none for either flag. The flag is bit zero of the flip mask; composition holds at all nine thousand two hundred sixteen ordered pairs with flags adding; the kernel of the permutation part is the identity and the pure first-axis flip, so the permutation image has order forty-eight.
- **The interface matrix collapses to ten orbit constants.** The matrix is symmetric and equivariant under the whole representation, and the two hundred fifty-six ordered letter pairs fall into exactly ten orbits with the matrix constant on each. There are nine distinct values, and the value eighteen alone carries two orbits — two transpose-closed families of six unordered pairs each that the matrix value cannot separate but the action can. The two hundred fifty-six entries sum to fifteen thousand eight hundred, which is the cutting count.
- **The letters split into two orbits and the wall is a single pair-orbit.** The twelve wall letters form one letter orbit and the remaining four the other, with row sums, diagonal entries, and the trace of two thousand constant per orbit. The forty-eight wall entries are exactly the single pair-orbit at value thirty-six — unordered, a four-regular graph of twenty-four edges on the twelve wall letters — and the letter-pair formula reproduces the independently computed induced entry map at all four thousand six hundred eight map-entry pairs.
- **Piece sizes are quantized and every cutting has the same shape.** Every one of the four hundred kept pieces has point count exactly five times a unit drawn from the spectrum one, three, seven, fourteen — a spectrum that itself sums to twenty-five. All fifteen thousand eight hundred cuttings carry one and the same unit profile: one piece of unit one, eleven of unit three, eleven of unit seven, one of unit fourteen, totaling the whole sample grid.
- **Light, middle and heavy is the piece-size composition.** Over all one hundred ninety-two equal-union exchanges across the forty-eight fibers, the half unit profiles are a function of the union size alone, with zero exceptions: union fifty gives halves of units one, three, three, three; union one hundred gives three, three, seven, seven; union one hundred seventy-five gives seven, seven, seven, fourteen. Each fiber's distinguished broken-count-two exchange reproduces the previous cycle's light, middle and heavy letter-pair lists at all forty-eight fibers.
- **A product hypothesis is refuted, with a positive control.** No exchange union and no single row support factorizes as a two-axis base times the full twenty-five-point square over any of the six axis pairs — zero of one thousand one hundred fifty-two unions and zero of eleven thousand five hundred twenty row supports — while the same test applied to the whole sample grid factorizes on all six axis pairs, so the test can succeed. The multiples-of-twenty-five union sizes are piece-size accounting, not a hidden product structure.

Honest boundary: the orbit lists, the matrix values, the unit spectrum, and every census stay measured, not derived; the derived content is the homomorphism law verified at every ordered pair, the two-route agreement between the induced entry map and the letter-pair formula, and the refutation with its control. The orchestrator's own pre-dispatch probing corrected the orchestrator's prediction of nine pair-orbits to the measured ten — the double orbit at eighteen was discovered, not predicted. In review the orchestrator corrected one runner print line that misdescribed a correctly computed total (it is the sum of all matrix entries, not of the distinct values); the computation itself was untouched. The note names the open questions this creates: why the unit spectrum takes those four values, why the cutting profile is constant, and what separates the two orbits that share the value eighteen.

## Verification

- Runner re-run by the orchestrator in a clean shell: exit zero, `TOTAL: PASS=10 FAIL=0`, stdout byte-identical across two consecutive orchestrator runs; it differs from the executor's hand-back only on the one corrected print line.
- Full note read plus line-by-line review of the entire runner (fabrication hunt): the induced entry map and the letter-pair formula are computed by separate logic, neither reading the other's result; orbit anchors are compared after the orbits are formed, never used to build them; the class-follows-size gate runs in the honest direction against the previous cycle's landed lists; the factorization refutation runs its positive control through the same code path as the refuted cases.
- Mechanical pre-review checker over note, runner source, and fresh stdout: zero flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
