### PR TITLE
feat(formclass): count cube-covariant formation predicates

### DIFF
--- a/docs/CUBE_COVARIANT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CUBE_COVARIANT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,239 @@
+---
+claim_id: cube_covariant_formation_predicate_class_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the 64 occupancy 6-tuples, the cube-covariant boolean formation predicates form a set of size 2^{10}=1024. L1's n≠0 rule is one element. No physical law is adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cube_covariant_formation_predicate_class_2026_08_15.py
+---
+
+# Cube-Covariant Formation Predicate Class
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the finite set of boolean maps on occupancy 6-tuples that are
+constant on proper-cube-rotation orbits. No member of the set is selected as
+a physical formation rule.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cube_covariant_formation_predicate_class_2026_08_15.py`](../scripts/cube_covariant_formation_predicate_class_2026_08_15.py)
+
+## Result up front
+
+Let `C = {0,1}^6` be occupancy on the six directed nearest-neighbor slots
+`(+x,-x,+y,-y,+z,-z)`. Let `G` be the 24 proper cube rotations, acting by
+permuting those six slots. A formation predicate is a map `f: C → {0,1}`. It
+is cube-covariant when `f(R·c) = f(c)` for every `R ∈ G` and every `c ∈ C`.
+
+`G` partitions `C` into orbits. Cube-covariant predicates are exactly the
+boolean functions constant on those orbits, so the class `F_G` has cardinality
+`2^{N_orb}`. Enumerating the 64 cells and the 24 rotations in exact integer
+arithmetic gives
+
+```text
+N_orb = 10
+|F_G| = 1024
+```
+
+L1's predicate `form` iff `n ≠ 0`, written `f_L1(c) = 0` exactly when
+`c_{+μ} = c_{-μ}` on all three axes, is one element of `F_G`. It is not the
+only element. The four maps `f_empty`, `f_any`, `f_full`, and `f_two` defined
+below are cube-covariant and pairwise distinct from `f_L1`. The class split
+between `f_L1` and `f_two` is the 24 cells with exactly one unbalanced axis.
+
+This note counts a finite function class. It does not adopt a member. It is
+not leftover-character of L1, not a new spatial patch, and not Aut-pick.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 10-orbit partition of the 64 occupancy 6-tuples and the resulting 1024 cube-covariant boolean maps are finite exact counts; no physical formation rule is selected."
+trace_class: negative_route_pruning
+target_claim_id: unique_cube_covariant_formation_predicate
+target_blocker_text: "uniqueness of L1's n≠0 formation predicate among cube-covariant boolean maps on the six-neighbor occupancy 6-tuple"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "a physical formation rule, if claimed, must be selected by further structure beyond cube covariance on occupancy 6-tuples"
+conditional_surface_status: "exact for boolean maps on the 64 occupancy 6-tuples; no physical law, rate, or site selector"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+The current Lattice and Admissibility wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is:
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility names one fixed covariant rule and leaves form open: read with
+Record, the distribution is conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+Record states:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+Those sentences identify the covariance group and the open formation slot.
+They do not name a boolean formation predicate on occupancy 6-tuples. The
+occupancy alphabet `{0,1}` on the six slots is a declared finite test object
+for the class count, not a replacement of the one-site possibility domain
+`M_2(C)`.
+
+## Exact objects
+
+Write slots in the order `(+x,-x,+y,-y,+z,-z)`. A cell is a 6-tuple
+`c ∈ C = {0,1}^6`. The proper cube rotation group `G` is the set of
+`3×3` signed permutation matrices of determinant `+1`. Each `R ∈ G` sends
+slot `v` to `R v` and acts on cells by
+
+```text
+(R·c)_{R v} = c_v.
+```
+
+The three axis pairs are `(+x,-x)`, `(+y,-y)`, `(+z,-z)`. Define
+
+```text
+n(c) = |{ μ : c_{+μ} ≠ c_{-μ} }|.
+```
+
+Then `n(c) = 0` if and only if `c_{+μ} = c_{-μ}` for all three axes.
+
+A formation predicate is any boolean map `f: C → {0,1}`. The cube-covariant
+class is
+
+```text
+F_G = { f : C → {0,1} : f(R·c) = f(c) for all R ∈ G, c ∈ C }.
+```
+
+L1's predicate on this test object is
+
+```text
+f_L1(c) = 0  if n(c) = 0,
+f_L1(c) = 1  otherwise.
+```
+
+Equivalently, `f_L1(c) = 0` iff `c_{+μ} = c_{-μ}` for all three axes. Four
+further maps on the same domain are
+
+```text
+f_empty(c) = [c = 000000],
+f_any(c)   = [sum(c) ≥ 1],
+f_full(c)  = [c = 111111],
+f_two(c)   = [n(c) ≥ 2].
+```
+
+None of these five maps is adopted as a physical law.
+
+## Theorem 1 — orbit count and class cardinality
+
+`G` has 24 elements: six images for the first axis, four remaining images
+for the second, and the third axis then fixed by orientation. Inversion is
+absent. The induced action on the six slots is 24 distinct permutations.
+
+Direct enumeration of the 64 cells under those 24 permutations yields
+`N_orb = 10` orbits. The orbit sizes, sorted, are
+
+```text
+[1, 1, 3, 3, 6, 6, 8, 12, 12, 12].
+```
+
+They sum to 64. Burnside's lemma in exact integer arithmetic gives the same
+count: if `cyc(R)` is the number of cycles of the slot permutation of `R`,
+
+```text
+(1/24) ∑_{R ∈ G} 2^{cyc(R)} = 10.
+```
+
+A boolean map is cube-covariant if and only if it is constant on each orbit.
+Choosing a value in `{0,1}` independently on each orbit therefore gives
+
+```text
+|F_G| = 2^{N_orb} = 1024.
+```
+
+## Theorem 2 — L1 is one point of the class, not the only point
+
+The function `n` is constant on each `G`-orbit, because a proper cube rotation
+permutes the three axis pairs and may swap the two slots of a pair, but cannot
+change whether a pair is balanced. Hence `f_L1` is constant on orbits, so
+`f_L1 ∈ F_G`.
+
+The same invariance shows `f_empty`, `f_any`, `f_full`, and `f_two` lie in
+`F_G`. They are pairwise distinct from `f_L1` on `C`:
+
+- `f_empty(000000) = 1` while `f_L1(000000) = 0`;
+- `f_any(111111) = 1` while `f_L1(111111) = 0`;
+- `f_full(111111) = 1` while `f_L1(111111) = 0`;
+- `f_two` vanishes on every cell with `n = 1`, while `f_L1` equals `1` there.
+
+So uniqueness of `f_L1` inside `F_G` fails by explicit counterexamples. The
+count `|F_G| = 1024` already implies the same conclusion. Cube covariance on
+occupancy 6-tuples does not select a formation rule.
+
+## Theorem 3 — class split between `f_L1` and `f_two`
+
+The predicates `f_L1` and `f_two` agree on cells with `n = 0` (both vanish)
+and on cells with `n ≥ 2` (both equal `1`). They disagree exactly on the cells
+with `n = 1`.
+
+There are three choices of the unbalanced axis, two occupancy patterns on that
+axis, and two balanced patterns on each of the other two axes, hence
+
+```text
+3 × 2 × 2 × 2 = 24
+```
+
+such cells. Direct listing of all 64 cells confirms that `f_L1` and `f_two`
+disagree on exactly 24 cells. That disagreement is the class split
+at-least-one unbalanced axis versus at-least-two.
+
+## Obligation graph
+
+| obligation | exact disposition |
+|---|---|
+| `|C| = 64` | enumerated binary 6-tuples |
+| `|G| = 24`, orientation-preserving | signed permutations of determinant `+1` |
+| compute `N_orb` | enumeration plus Burnside; `N_orb = 10` |
+| compute `|F_G|` | `2^{N_orb} = 1024` |
+| `f_L1 ∈ F_G` | `n` is an orbit invariant |
+| four further points of `F_G` distinct from `f_L1` | explicit evaluation on `C` |
+| `f_L1` versus `f_two` split | 24 cells with `n = 1` |
+| adopt a member of `F_G` as physical law | not claimed |
+| leftover-character of L1 | outside the object; not claimed |
+| formation site, probability, or rate | open; not supplied |
+
+## Imports and non-claims
+
+The only scientific dependency is the current four-axiom authority linked
+above, used only to pin the proper-cube covariance group and the open
+formation slot. No observational comparator is admitted. No dynamics,
+Hamiltonian, or record-production process is constructed. The five named
+maps are witnesses inside a finite function class; the note does not adopt
+any of them.
+
+This is not a leftover-character theorem for L1, not a spatial-patch
+construction, and not an Aut-pick of a preferred representative.
+
+## Value and no-go boundary
+
+The positive content is the exact integer pair `(N_orb, |F_G|)` and the
+explicit witnesses that `f_L1` is not the unique point of `F_G`. The negative
+content is only uniqueness of that one predicate from cube covariance on
+occupancy 6-tuples. Further structure could still select a member. No global
+impossibility of a formation rule is claimed.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2813,6 +2813,10 @@
   "cte_rconn_spatial_tensor_color_bridge_is_a_cross_domain_coincidence_narrow_no_go_note_2026-06-08": {
    "deps_hash": "825a4024d61b",
    "out_degree": 4
+  },
+  "cube_covariant_formation_predicate_class_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
    "deps_hash": "04fc7d8812c4",

--- a/logs/runner-cache/cube_covariant_formation_predicate_class_2026_08_15.txt
+++ b/logs/runner-cache/cube_covariant_formation_predicate_class_2026_08_15.txt
@@ -1,0 +1,65 @@
+===== runner cache v1 =====
+runner: scripts/cube_covariant_formation_predicate_class_2026_08_15.py
+runner_sha256: 9a3c04d674419d7e3d7830caf226bf16b82f603d186d2e108afc9eee4588e093
+input_fingerprint_sha256: b975b5fc76eb52b3ad8a5245f7f63579c1ff050b9d948e2e09a92c738918dd61
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+Cube-covariant formation predicate class on occupancy 6-tuples
+AUDIT_INPUT_PATHS:
+  docs/CUBE_COVARIANT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: boolean maps on the 64 occupancy 6-tuples; no member adopted
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-normalized
+PASS: audit-timeout-declared
+PASS: source-lattice-current
+PASS: source-one-fixed-covariant-rule-current
+PASS: source-formation-open-current
+PASS: source-records-form-current
+PASS: note-no-axiom-edit
+PASS: cell-count-64
+PASS: cells-are-binary-6-tuples
+PASS: rotation-count-24
+PASS: rotations-include-identity
+PASS: rotations-exclude-inversion
+PASS: rotation-group-closed
+PASS: rotation-inverses-present
+PASS: rotation-determinants-plus-one
+PASS: slot-permutations-24-distinct
+PASS: slot-permutations-are-bijections
+N_orb=10
+|F_G|=1024
+orbit_sizes=[1, 1, 3, 3, 6, 6, 8, 12, 12, 12]
+burnside_orbits=10
+PASS: orbits-partition-C
+PASS: orbit-count-is-positive-int
+PASS: burnside-agrees-exact-int  (sum=240)
+PASS: class-size-is-two-to-N_orb
+PASS: covariant-maps-are-orbit-constant
+PASS: f_L1-cube-covariant
+PASS: f_empty-cube-covariant
+PASS: f_any-cube-covariant
+PASS: f_full-cube-covariant
+PASS: f_two-cube-covariant
+PASS: f_L1-is-n-nonzero
+PASS: named-predicates-distinct-from-f_L1
+PASS: named-predicates-pairwise-distinct
+f_L1_f_two_disagree=24
+PASS: class-split-is-exactly-one-unbalanced-axis  (disagree=24)
+PASS: split-cells-are-L1-form-and-f_two-absent
+PASS: note-reports-N_orb
+PASS: note-reports-class-size
+PASS: note-reports-disagreement
+PASS: note-claim-scope-class-not-law
+PASS: note-does-not-adopt-a-member
+PASS: forbidden-phrase-hygiene
+PASS: no-runner-cache-or-citation-manifest
+TOTAL: PASS=40 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cube_covariant_formation_predicate_class_2026_08_15.py
+++ b/scripts/cube_covariant_formation_predicate_class_2026_08_15.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Enumerate the cube-covariant boolean formation predicates on {0,1}^6.
+
+The paired note is
+docs/CUBE_COVARIANT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+The objects are occupancy 6-tuples on the six directed nearest-neighbor slots
+and the 24 proper cube rotations acting by slot permutation. No formation
+member is selected. No axiom sentence is written. No cache is written.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/CUBE_COVARIANT_FORMATION_PREDICATE_CLASS_BOUNDED_"
+    "THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CUBE_COVARIANT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+SLOTS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SLOT_INDEX = {slot: i for i, slot in enumerate(SLOTS)}
+AXIS_PAIRS = ((0, 1), (2, 3), (4, 5))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def permutation_sign(perm: tuple[int, ...]) -> int:
+    inversions = sum(
+        perm[i] > perm[j] for i in range(len(perm)) for j in range(i + 1, len(perm))
+    )
+    return -1 if inversions % 2 else 1
+
+
+def proper_rotation_matrices() -> tuple[tuple[tuple[int, int, int], ...], ...]:
+    mats: list[tuple[tuple[int, int, int], ...]] = []
+    for perm in permutations(range(3)):
+        axis_sign = permutation_sign(perm)
+        for signs in product((-1, 1), repeat=3):
+            det = axis_sign * signs[0] * signs[1] * signs[2]
+            if det != 1:
+                continue
+            rows = [[0, 0, 0] for _ in range(3)]
+            for col, row in enumerate(perm):
+                rows[row][col] = signs[col]
+            mats.append(tuple(tuple(row) for row in rows))
+    unique = tuple(sorted(set(mats)))
+    return unique
+
+
+def matvec(matrix: tuple[tuple[int, int, int], ...], vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(sum(matrix[i][j] * vector[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def matmul(
+    left: tuple[tuple[int, int, int], ...],
+    right: tuple[tuple[int, int, int], ...],
+) -> tuple[tuple[int, int, int], ...]:
+    return tuple(
+        tuple(sum(left[i][k] * right[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )
+
+
+def transpose(matrix: tuple[tuple[int, int, int], ...]) -> tuple[tuple[int, int, int], ...]:
+    return tuple(tuple(matrix[j][i] for j in range(3)) for i in range(3))
+
+
+def slot_permutation(matrix: tuple[tuple[int, int, int], ...]) -> tuple[int, ...]:
+    return tuple(SLOT_INDEX[matvec(matrix, slot)] for slot in SLOTS)
+
+
+def apply_perm(cell: tuple[int, ...], perm: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * 6
+    for source, dest in enumerate(perm):
+        out[dest] = cell[source]
+    return tuple(out)
+
+
+def all_cells() -> tuple[tuple[int, ...], ...]:
+    return tuple(product((0, 1), repeat=6))
+
+
+def cycle_count(perm: tuple[int, ...]) -> int:
+    seen = [False] * len(perm)
+    cycles = 0
+    for start in range(len(perm)):
+        if seen[start]:
+            continue
+        cycles += 1
+        here = start
+        while not seen[here]:
+            seen[here] = True
+            here = perm[here]
+    return cycles
+
+
+def orbit_partition(perms: tuple[tuple[int, ...], ...]) -> tuple[frozenset[tuple[int, ...]], ...]:
+    remaining = set(all_cells())
+    orbits: list[frozenset[tuple[int, ...]]] = []
+    while remaining:
+        seed = remaining.pop()
+        orbit = {seed}
+        stack = [seed]
+        while stack:
+            cell = stack.pop()
+            for perm in perms:
+                image = apply_perm(cell, perm)
+                if image not in orbit:
+                    orbit.add(image)
+                    stack.append(image)
+        remaining -= orbit
+        orbits.append(frozenset(orbit))
+    return tuple(sorted(orbits, key=lambda orbit: (len(orbit), min(orbit))))
+
+
+def unbalanced_axis_count(cell: tuple[int, ...]) -> int:
+    return sum(cell[plus] != cell[minus] for plus, minus in AXIS_PAIRS)
+
+
+def f_l1(cell: tuple[int, ...]) -> int:
+    return 0 if all(cell[plus] == cell[minus] for plus, minus in AXIS_PAIRS) else 1
+
+
+def f_empty(cell: tuple[int, ...]) -> int:
+    return int(cell == (0, 0, 0, 0, 0, 0))
+
+
+def f_any(cell: tuple[int, ...]) -> int:
+    return int(sum(cell) >= 1)
+
+
+def f_full(cell: tuple[int, ...]) -> int:
+    return int(cell == (1, 1, 1, 1, 1, 1))
+
+
+def f_two(cell: tuple[int, ...]) -> int:
+    return int(unbalanced_axis_count(cell) >= 2)
+
+
+def table_of(func) -> tuple[int, ...]:
+    return tuple(func(cell) for cell in all_cells())
+
+
+def is_covariant(func, perms: tuple[tuple[int, ...], ...]) -> bool:
+    for cell in all_cells():
+        value = func(cell)
+        for perm in perms:
+            if func(apply_perm(cell, perm)) != value:
+                return False
+    return True
+
+
+def constant_on_orbits(func, orbits: tuple[frozenset[tuple[int, ...]], ...]) -> bool:
+    for orbit in orbits:
+        values = {func(cell) for cell in orbit}
+        if len(values) != 1:
+            return False
+    return True
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("Cube-covariant formation predicate class on occupancy 6-tuples")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: boolean maps on the 64 occupancy 6-tuples; no member adopted")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-paths-unique-normalized",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(
+            not Path(path).is_absolute() and ".." not in Path(path).parts
+            for path in AUDIT_INPUT_PATHS
+        ),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    covariant_rule_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice "
+        "translations and proper cubic rotations."
+    )
+    formation_boundary = "it does not supply the formation site, probability, or rate"
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-current",
+        lattice_sentence in normalized_axiom and lattice_sentence in normalized_note,
+    )
+    checks.check(
+        "source-one-fixed-covariant-rule-current",
+        covariant_rule_sentence in normalized_axiom
+        and covariant_rule_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-open-current",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-records-form-current",
+        records_form in axiom and records_form in note,
+    )
+    checks.check(
+        "note-no-axiom-edit",
+        "hypothetical_axiom_status: no edit" in note
+        or 'hypothetical_axiom_status: "no edit"' in note,
+    )
+
+    cells = all_cells()
+    checks.check("cell-count-64", len(cells) == 64 and len(set(cells)) == 64)
+    checks.check("cells-are-binary-6-tuples", all(len(cell) == 6 and set(cell) <= {0, 1} for cell in cells))
+
+    rotations = proper_rotation_matrices()
+    identity = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    inversion = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    rotation_set = set(rotations)
+    checks.check("rotation-count-24", len(rotations) == 24)
+    checks.check("rotations-include-identity", identity in rotation_set)
+    checks.check("rotations-exclude-inversion", inversion not in rotation_set)
+    checks.check(
+        "rotation-group-closed",
+        all(matmul(left, right) in rotation_set for left in rotations for right in rotations),
+    )
+    checks.check(
+        "rotation-inverses-present",
+        all(transpose(matrix) in rotation_set and matmul(matrix, transpose(matrix)) == identity for matrix in rotations),
+    )
+    checks.check(
+        "rotation-determinants-plus-one",
+        all(
+            matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+            - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+            + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+            == 1
+            for matrix in rotations
+        ),
+    )
+
+    perms = tuple(slot_permutation(matrix) for matrix in rotations)
+    checks.check("slot-permutations-24-distinct", len(set(perms)) == 24)
+    checks.check("slot-permutations-are-bijections", all(sorted(perm) == list(range(6)) for perm in perms))
+
+    orbits = orbit_partition(perms)
+    n_orb = len(orbits)
+    covered = set().union(*orbits)
+    class_size = 1 << n_orb
+    burnside_fixed = sum(1 << cycle_count(perm) for perm in perms)
+    burnside_orbits, burnside_rem = divmod(burnside_fixed, 24)
+
+    print(f"N_orb={n_orb}")
+    print(f"|F_G|={class_size}")
+    print(f"orbit_sizes={sorted(len(orbit) for orbit in orbits)}")
+    print(f"burnside_orbits={burnside_orbits}")
+
+    checks.check("orbits-partition-C", covered == set(cells) and sum(len(orbit) for orbit in orbits) == 64)
+    checks.check("orbit-count-is-positive-int", isinstance(n_orb, int) and n_orb > 0)
+    checks.check(
+        "burnside-agrees-exact-int",
+        burnside_rem == 0 and burnside_orbits == n_orb and isinstance(burnside_fixed, int),
+        f"sum={burnside_fixed}",
+    )
+    checks.check("class-size-is-two-to-N_orb", class_size == 2**n_orb)
+    checks.check(
+        "covariant-maps-are-orbit-constant",
+        all(constant_on_orbits(lambda cell, orbit=orbit: int(cell in orbit), orbits) for orbit in orbits)
+        and is_covariant(lambda cell: int(cell in next(iter(orbits))), perms),
+    )
+
+    named = {
+        "f_L1": f_l1,
+        "f_empty": f_empty,
+        "f_any": f_any,
+        "f_full": f_full,
+        "f_two": f_two,
+    }
+    tables = {name: table_of(func) for name, func in named.items()}
+    for name, func in named.items():
+        checks.check(
+            f"{name}-cube-covariant",
+            is_covariant(func, perms) and constant_on_orbits(func, orbits),
+        )
+
+    checks.check(
+        "f_L1-is-n-nonzero",
+        all(f_l1(cell) == int(unbalanced_axis_count(cell) != 0) for cell in cells),
+    )
+    checks.check(
+        "named-predicates-distinct-from-f_L1",
+        all(tables[name] != tables["f_L1"] for name in ("f_empty", "f_any", "f_full", "f_two")),
+    )
+    checks.check(
+        "named-predicates-pairwise-distinct",
+        len({tables[name] for name in named}) == len(named),
+    )
+
+    disagree = sum(f_l1(cell) != f_two(cell) for cell in cells)
+    one_unbalanced = sum(unbalanced_axis_count(cell) == 1 for cell in cells)
+    print(f"f_L1_f_two_disagree={disagree}")
+    checks.check(
+        "class-split-is-exactly-one-unbalanced-axis",
+        disagree == one_unbalanced and disagree > 0,
+        f"disagree={disagree}",
+    )
+    checks.check(
+        "split-cells-are-L1-form-and-f_two-absent",
+        all(
+            (f_l1(cell) == 1 and f_two(cell) == 0) if unbalanced_axis_count(cell) == 1 else True
+            for cell in cells
+        ),
+    )
+
+    checks.check("note-reports-N_orb", f"N_orb = {n_orb}" in note)
+    checks.check("note-reports-class-size", f"|F_G| = {class_size}" in note)
+    checks.check("note-reports-disagreement", f"disagree on exactly {disagree} cells" in note)
+    checks.check(
+        "note-claim-scope-class-not-law",
+        "cube-covariant boolean formation predicates form a set of size" in normalized_note
+        and "No physical law is adopted" in note,
+    )
+    checks.check(
+        "note-does-not-adopt-a-member",
+        "does not adopt" in normalized_note and "one element" in normalized_note,
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE", "new axiom")
+    checks.check(
+        "forbidden-phrase-hygiene",
+        all(phrase not in note for phrase in forbidden),
+        ",".join(phrase for phrase in forbidden if phrase in note),
+    )
+    checks.check(
+        "no-runner-cache-or-citation-manifest",
+        "runner-cache" not in note and "citation_manifest" not in note and "CITATION_MANIFEST" not in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the 64 occupancy 6-tuples the 24 proper cube rotations split cells into 10 orbits, so there are 1024 cube-covariant boolean formation predicates. L1 n\neq0 is one element. f_L1 and f_two disagree on 24 cells. Displayed class count, not adopted.

## Runner

`scripts/cube_covariant_formation_predicate_class_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.