### PR TITLE
feat(vacalt): blank neighbor is not occupancy zero

### DIFF
--- a/docs/UNREAD_NEIGHBOR_NOT_OCCUPANCY_ZERO_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNREAD_NEIGHBOR_NOT_OCCUPANCY_ZERO_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,304 @@
+---
+claim_id: unread_neighbor_not_occupancy_zero_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the supplied twelve-vertex two-cube, replacing off-patch `o=0` by “blank blocks readiness” empties the first wave. L1's wave uses the vacuum default. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py
+---
+
+# Unread Neighbor Is Not Occupancy Zero
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact first-wave comparison on one supplied twelve-vertex two-cube,
+between a displayed L1 law that fills off-patch neighbors as occupancy `0`
+and the alternative member that leaves those neighbors blank and blocks
+readiness. No new patch, no leftover-character identity, and no vacuum axiom.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py`](../scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py)
+
+No runner cache is written.
+
+## Result up front
+
+Neighbor input on the cubic lattice is a six-tuple from `{0,1,blank}`.
+Occupancy `0` and blank are distinct letters. Record unreadability says that
+a site with no record cannot be read; it does not assign the letter `0` to
+that site.
+
+On the supplied two-cube, a seed lock at `(0,0,0)` is given. The displayed
+L1 law treats each blank as `0` and forms at an unformed on-patch site iff
+the neighbor occupancy sum `n` is nonzero. That first wave is exactly the
+three axis sites
+
+```text
+(1,0,0), (0,1,0), (0,0,1).
+```
+
+Under blank-blocked readiness, `n` is defined at a site only when all six
+lattice neighbors are on-patch and already in `{0,1}`. None of those three
+axis sites is ready: each has at least one off-patch neighbor. The
+blank-blocked first wave is empty.
+
+Therefore the off-patch `o=0` default is load-bearing for L1's first wave.
+It selects one member of a pair. It is not Record unreadability, not a
+leftover-character identity, not an `n_μ` step on a new patch, and not a
+vacuum axiom. L1 is displayed, not adopted. L2 is not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact first-wave comparison on one twelve-vertex two-cube; L1 is displayed; off-patch encoding is a member selector, not an axiom."
+trace_class: negative_route_pruning
+target_claim_id: unread_neighbor_not_occupancy_zero
+target_blocker_text: "do not treat unread or off-patch neighbors as occupancy 0 when naming a formation-ready first wave"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "keep off-patch blank as a distinct letter; do not write unread=0 into axiom text"
+conditional_surface_status: "exact only for the supplied twelve-vertex two-cube and the displayed L1 / blank-blocked pair; no axiom edit and no adopted formation law"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+The current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies:
+
+```text
+Physical sites are the points of the cubic lattice Z^3, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+```
+
+The last sentence is unreadability. It is not an assignment of occupancy
+`0` to an unread site, and this note does not write that assignment into
+axiom text.
+
+Admissibility says that, for each site, the probability distribution over
+the possibilities is determined by, and varies with, the nearest-neighbor
+conditions. It does not supply a formation site, a first-wave rule, or a
+default letter for a neighbor that is not on the declared patch.
+
+The two-cube, the seed lock, the displayed L1 rule, and the blank-blocked
+alternative are declared test objects. They are not derived here as the
+physical formation kernel.
+
+## Exact objects
+
+Let
+
+```text
+A = {0,1}^3,
+B = {1,2} x {0,1}^2,
+P = A union B.
+```
+
+Then `|A|=8`, `|B|=8`, `|A intersect B|=4`, and `|P|=12`. These are the
+twelve vertices of one two-cube. The construction is the same two-cube, not
+an `n_μ` step on a new patch.
+
+The six lattice shifts are the signed unit vectors. For `v` in `Z^3`,
+
+```text
+N(v) = { v ± e_1, v ± e_2, v ± e_3 }.
+```
+
+A site is **on-patch** when it lies in `P`, otherwise **off-patch**.
+Off-patch sites carry the letter `blank`, not occupancy `0`.
+
+A seed lock is placed at
+
+```text
+s = (0,0,0) in P.
+```
+
+The displayed occupancy field after the seed, before any first wave, is
+
+```text
+o(s) = 1,
+o(v) = 0    if v in P and v ≠ s,
+o(w) = blank    if w not in P.
+```
+
+The integer `n` at a site `v` is the sum of the six neighbor letters after
+the displayed blank-to-zero map
+
+```text
+pi(0) = 0,   pi(1) = 1,   pi(blank) = 0,
+n(v) = sum_{u in N(v)} pi(o(u)).
+```
+
+This `n` is a displayed occupancy sum on one patch. It is not a
+leftover-character of an L1 identity.
+
+**Displayed L1** (not adopted): an unformed on-patch site `v` forms in the
+first wave iff `n(v) ≠ 0`. Blanks are treated as `0` before the test.
+
+**Blank-blocked readiness:** `n` is defined at `v` only if every neighbor
+in `N(v)` is on-patch and already in `{0,1}`. Otherwise `v` is
+blank-blocked. A site is formation-ready only if `n` is defined and
+`n(v) ≠ 0`. The blank-blocked first wave is the set of unformed on-patch
+sites that are formation-ready.
+
+## Theorem 1 — L1 first wave is the three axis sites
+
+After the seed, evaluate `n` at every unformed site of `P`. The seed has
+exactly three on-patch neighbors, namely the axis sites
+
+```text
+W = {(1,0,0), (0,1,0), (0,0,1)}.
+```
+
+Each `w` in `W` has `o(s)=1` as one neighbor, so `n(w)=1 ≠ 0`. Every other
+unformed `v` in `P` is nonadjacent to `s`, so every neighbor occupancy
+that L1 can see is `0` and `n(v)=0`. Therefore the displayed L1 first wave
+is exactly `W`.
+
+The paired runner computes this set from the occupancy field. It does not
+embed `W` as its own output.
+
+## Theorem 2 — blank-blocked first wave is empty
+
+Each axis site has at least one off-patch neighbor. Explicitly:
+
+```text
+(1,0,0) has (1,-1,0) and (1,0,-1) off-patch,
+(0,1,0) has (-1,1,0) and (0,1,-1) off-patch,
+(0,0,1) has (-1,0,1) and (0,-1,1) off-patch.
+```
+
+So `n` is not defined at any point of `W`. No site of `W` is
+formation-ready. The blank-blocked first wave is empty.
+
+The same two-cube has no unformed site whose entire six-neighbor star lies
+in `P`. Blank-blocked readiness is empty on the whole patch, not only on
+`W`. The theorem needs only the emptiness of the first wave.
+
+## Theorem 3 — off-patch `o=0` is a member selector
+
+The two members differ only in the letter assigned to off-patch neighbors:
+
+| member | off-patch letter | first wave |
+|---|---|---|
+| displayed L1 | `0` | `W`, size 3 |
+| blank-blocked | `blank` | empty |
+
+L1's nonempty first wave uses the vacuum default that fills off-patch
+neighbors as `0`. Replacing that default by “blank blocks readiness”
+empties the first wave. The default is therefore load-bearing for this
+displayed wave. It selects a member. It is not Record unreadability: the
+axiom sentence is that a site with no record cannot be read, not that the
+site carries occupancy `0`.
+
+The comparison is displayed, not adopted. It does not write a vacuum axiom,
+does not adopt L1 or L2, and does not promote `unread = 0`.
+
+## No-Go Discipline
+
+The negative result is only that the off-patch `o=0` fill is load-bearing
+for this displayed first wave. It is not a universal no-go against every
+formation rule.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| treat unreadability as occupancy `0` | **ATTEMPTED** | Record forbids reading an absent record; it does not supply the letter `0` |
+| keep off-patch blank and still run L1 | **ATTEMPTED** | `n` is then undefined at each axis site; the first wave empties |
+| move the same `n_μ` step onto a new patch | **ATTEMPTED** | the two-cube is held fixed; only the off-patch letter changes |
+| read the wave as leftover-character of an L1 identity | **ATTEMPTED** | `n` here is a six-neighbor occupancy sum, not a leftover-character |
+| adopt L1 or L2 as axiom text | **ATTEMPTED** | both laws remain displayed test objects; L2 is unused |
+| write a vacuum axiom that empty sites are `0` | **ATTEMPTED** | the `o=0` fill is a member of a pair, not axiom content |
+| invoke a Hamiltonian or record-production dynamics | **ATTEMPTED** | outside the finite two-cube comparison |
+
+### N2 — wall independence
+
+One type wall is claimed: blank and occupancy `0` are different neighbor
+letters, and only the `0` fill produces L1's first wave on this patch. No
+second impossibility wall is asserted.
+
+### N3 — hidden-wall scan
+
+The two-cube, the seed, the displayed L1 map, and blank-blocked readiness
+are declared. No new patch, no leftover-character algebra, no adopted L2,
+no vacuum axiom, and no axiom edit is imported.
+
+### N4 — residual matching
+
+The residual after this note is still a physical formation rule—site,
+process, and rate—plus any lawful encoding of neighbors that are not on a
+declared finite patch. The present witness neither closes nor enlarges that
+residual. It only names the off-patch `o=0` fill as a selector on this
+patch.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each of the twelve vertices is enumerated
+per-site: executed — n and readiness are computed at every unformed site
+per-mode: not applicable — no modal or spectral decomposition is used
+per-block: executed — only the supplied two-cube and seed are checked
+lattice-wide: not executed — no full Z^3 history or adopted formation law is claimed
+```
+
+### N6 — partial-closure paths
+
+A later formation kernel could define readiness only from on-patch
+neighbors, derive a different letter for off-patch sites, or work on a
+larger patch whose six-neighbor stars close. Every such route remains live
+and need not alter the axioms.
+
+### N7 — steelman
+
+The strongest objection is that an unread or off-patch site “is empty, so
+it is `0`,” making the L1 fill automatic. Correct that emptiness is a
+possible reading of no-record. Incorrect that Record supplies the letter
+`0`: unreadability withholds a readout, and filling `0` is extra encoding.
+On this two-cube that extra encoding is exactly what produces the first
+wave.
+
+### N8 — cross-cycle echo
+
+Earlier formation-boundary notes already separate occurrence, content
+support, and site choice. This note agrees with that separation and adds
+only the exact two-cube witness that off-patch `o=0` is a selector for a
+displayed L1 wave.
+
+## Boundaries and explicit non-claims
+
+- L1 is displayed, not adopted. L2 is not adopted.
+- The theorem is conditional on the supplied twelve-vertex two-cube and
+  seed. It does not derive a physical formation kernel.
+- This is not an `n_μ` step on a new patch.
+- This is not leftover-character of an L1 identity.
+- This is not a vacuum axiom, and unreadability is not rewritten as
+  occupancy `0`.
+- No full-lattice history, process, clock, or rate is constructed.
+- No axiom, primitive, registry, citation manifest, runner cache, or audit
+  verdict is edited.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py
+```
+
+The runner prints `TOTAL: PASS=<n> FAIL=<n>` with `FAIL=0` and at least
+twelve `PASS` lines. It writes no cache.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18949,6 +18949,10 @@
   "unraveled_step_law_bi_invariant_quasi_stationarity_split_bounded_theorem_note_2026-06-10": {
    "deps_hash": "fb8954ed7807",
    "out_degree": 9
+  },
+  "unread_neighbor_not_occupancy_zero_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "up_sector_partition_revisit_note_2026-04-19": {
    "deps_hash": "eaecb942382a",

--- a/logs/runner-cache/unread_neighbor_not_occupancy_zero_2026_08_15.txt
+++ b/logs/runner-cache/unread_neighbor_not_occupancy_zero_2026_08_15.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py
+runner_sha256: 98b6fe8e1bf0914f7a5c88940ef27c1d5d288124e4b0cc6b11e38e3be9e6c611
+input_fingerprint_sha256: 85071582fba33d95ff973f8585587244fcd0ea733df380f24098f76a0c571d22
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+Unread neighbor is not occupancy zero
+AUDIT_INPUT_PATHS:
+  docs/UNREAD_NEIGHBOR_NOT_OCCUPANCY_ZERO_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: supplied twelve-vertex two-cube; displayed L1 versus blank-blocked readiness; no adopted law and no axiom edit
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-normalized
+PASS: audit-timeout-declared
+PASS: cache-write-disabled
+PASS: two-cube-has-twelve-sites  (|P|=12)
+PASS: two-cube-factorization
+PASS: seed-on-patch
+PASS: six-neighbor-star
+PASS: seed-on-patch-neighbors-are-axis-sites  (on-patch N(s)=[(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: seed-occupancy-one-others-zero
+PASS: off-patch-letter-is-blank-not-zero
+PASS: theorem1-l1-first-wave-is-axis-sites  (W=[(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: theorem1-axis-n-nonzero  (n={(1, 0, 0): 1, (0, 0, 1): 1, (0, 1, 0): 1})
+PASS: theorem1-nonaxis-unformed-n-zero  (count=8)
+PASS: theorem2-each-axis-site-has-off-patch-neighbor  (off={(1, 0, 0): [(1, -1, 0), (1, 0, -1)], (0, 0, 1): [(-1, 0, 1), (0, -1, 1), (0, 0, 2)], (0, 1, 0): [(-1, 1, 0), (0, 1, -1), (0, 2, 0)]})
+PASS: theorem2-n-undefined-on-axis-sites
+PASS: theorem2-blank-blocked-first-wave-empty  (blocked=[])
+PASS: theorem2-no-unformed-site-has-closed-star
+PASS: theorem3-members-disagree-on-first-wave
+PASS: theorem3-o-zero-default-is-load-bearing
+PASS: source-unreadability-current
+PASS: source-record-does-not-assign-occupancy-zero
+PASS: source-occurrence-sentence-current
+PASS: note-does-not-write-unread-equals-zero-as-axiom
+PASS: note-claim-scope-exact
+PASS: note-l1-displayed-not-adopted
+PASS: note-not-leftover-character-or-new-patch
+PASS: note-not-a-vacuum-axiom
+PASS: note-machine-status-complete
+PASS: note-one-hop-dependency-current
+PASS: note-forbidden-tokens-absent
+PASS: note-no-go-n1-through-n8
+PASS: note-no-go-route-enumeration
+PASS: note-steelman-rejects-automatic-zero-fill
+PASS: note-n5-five-line-certificate
+N5_CERTIFICATE:
+per-element: executed — each of the twelve vertices is enumerated
+per-site: executed — n and readiness are computed at every unformed site
+per-mode: not applicable — no modal or spectral decomposition is used
+per-block: executed — only the supplied two-cube and seed are checked
+lattice-wide: not executed — no full Z^3 history or adopted formation law is claimed
+PASS: note-explicit-nonclaims
+PASS: axiom-file-unedited-in-this-dispatch
+TOTAL: PASS=37 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py
+++ b/scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Exact first-wave comparison: unread neighbor is not occupancy zero.
+
+The paired note is
+docs/UNREAD_NEIGHBOR_NOT_OCCUPANCY_ZERO_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+On the supplied twelve-vertex two-cube, displayed L1 fills off-patch
+neighbors as 0 and forms iff n != 0. The alternative member leaves those
+neighbors blank and blocks readiness. No cache, citation manifest, or
+axiom surface is written.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/UNREAD_NEIGHBOR_NOT_OCCUPANCY_ZERO_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNREAD_NEIGHBOR_NOT_OCCUPANCY_ZERO_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+BLANK = "blank"
+SEED: Point = (0, 0, 0)
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXIS_SITES: frozenset[Point] = frozenset(
+    {(1, 0, 0), (0, 1, 0), (0, 0, 1)}
+)
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+)
+FORBIDDEN_AXIOM_PHRASES = (
+    "unread = 0",
+    "unread=0",
+    "unreadability is occupancy 0",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def cube_a() -> frozenset[Point]:
+    return frozenset(product((0, 1), (0, 1), (0, 1)))
+
+
+def cube_b() -> frozenset[Point]:
+    return frozenset(product((1, 2), (0, 1), (0, 1)))
+
+
+def two_cube() -> frozenset[Point]:
+    return cube_a() | cube_b()
+
+
+def neighbors(site: Point) -> tuple[Point, ...]:
+    return tuple(add(site, shift) for shift in SHIFTS)
+
+
+def occupancy(site: Point, patch: frozenset[Point]) -> int | str:
+    if site == SEED:
+        return 1
+    if site in patch:
+        return 0
+    return BLANK
+
+
+def displayed_n(site: Point, patch: frozenset[Point]) -> int:
+    total = 0
+    for neighbor in neighbors(site):
+        letter = occupancy(neighbor, patch)
+        total += 0 if letter == BLANK else int(letter)
+    return total
+
+
+def n_is_defined(site: Point, patch: frozenset[Point]) -> bool:
+    return all(occupancy(neighbor, patch) in (0, 1) for neighbor in neighbors(site))
+
+
+def l1_first_wave(patch: frozenset[Point]) -> frozenset[Point]:
+    return frozenset(
+        site
+        for site in patch
+        if site != SEED and displayed_n(site, patch) != 0
+    )
+
+
+def blank_blocked_first_wave(patch: frozenset[Point]) -> frozenset[Point]:
+    return frozenset(
+        site
+        for site in patch
+        if site != SEED
+        and n_is_defined(site, patch)
+        and displayed_n(site, patch) != 0
+    )
+
+
+def off_patch_neighbors(site: Point, patch: frozenset[Point]) -> frozenset[Point]:
+    return frozenset(neighbor for neighbor in neighbors(site) if neighbor not in patch)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    patch = two_cube()
+    cube_a_sites = cube_a()
+    cube_b_sites = cube_b()
+
+    print("Unread neighbor is not occupancy zero")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "scope: supplied twelve-vertex two-cube; displayed L1 versus "
+        "blank-blocked readiness; no adopted law and no axiom edit"
+    )
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-paths-unique-normalized",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(
+            not Path(path).is_absolute() and ".." not in Path(path).parts
+            for path in AUDIT_INPUT_PATHS
+        ),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check(
+        "cache-write-disabled",
+        "No runner cache is written." in note
+        and "cache_write: false" not in note.split("## ", 1)[0],
+    )
+
+    checks.check("two-cube-has-twelve-sites", len(patch) == 12, f"|P|={len(patch)}")
+    checks.check(
+        "two-cube-factorization",
+        len(cube_a_sites) == 8
+        and len(cube_b_sites) == 8
+        and len(cube_a_sites & cube_b_sites) == 4
+        and cube_a_sites | cube_b_sites == patch,
+    )
+    checks.check("seed-on-patch", SEED in patch and SEED in cube_a_sites)
+    checks.check("six-neighbor-star", len(SHIFTS) == 6 and len(set(SHIFTS)) == 6)
+
+    seed_neighbors = frozenset(neighbors(SEED))
+    checks.check(
+        "seed-on-patch-neighbors-are-axis-sites",
+        seed_neighbors & patch == AXIS_SITES,
+        f"on-patch N(s)={sorted(seed_neighbors & patch)}",
+    )
+
+    occupancies = {site: occupancy(site, patch) for site in patch}
+    checks.check(
+        "seed-occupancy-one-others-zero",
+        occupancies[SEED] == 1
+        and all(value == 0 for site, value in occupancies.items() if site != SEED),
+    )
+    sample_off = add(SEED, (-1, 0, 0))
+    checks.check(
+        "off-patch-letter-is-blank-not-zero",
+        sample_off not in patch and occupancy(sample_off, patch) == BLANK,
+    )
+
+    wave = l1_first_wave(patch)
+    blocked = blank_blocked_first_wave(patch)
+    axis_n = {site: displayed_n(site, patch) for site in AXIS_SITES}
+    other_n = {
+        site: displayed_n(site, patch)
+        for site in patch
+        if site not in AXIS_SITES and site != SEED
+    }
+
+    checks.check(
+        "theorem1-l1-first-wave-is-axis-sites",
+        wave == AXIS_SITES,
+        f"W={sorted(wave)}",
+    )
+    checks.check(
+        "theorem1-axis-n-nonzero",
+        AXIS_SITES <= patch and all(value != 0 for value in axis_n.values()),
+        f"n={axis_n}",
+    )
+    checks.check(
+        "theorem1-nonaxis-unformed-n-zero",
+        other_n and all(value == 0 for value in other_n.values()),
+        f"count={len(other_n)}",
+    )
+
+    axis_off = {site: off_patch_neighbors(site, patch) for site in AXIS_SITES}
+    checks.check(
+        "theorem2-each-axis-site-has-off-patch-neighbor",
+        all(len(off) >= 1 for off in axis_off.values()),
+        f"off={ {site: sorted(off) for site, off in axis_off.items()} }",
+    )
+    checks.check(
+        "theorem2-n-undefined-on-axis-sites",
+        all(not n_is_defined(site, patch) for site in AXIS_SITES),
+    )
+    checks.check(
+        "theorem2-blank-blocked-first-wave-empty",
+        blocked == frozenset(),
+        f"blocked={sorted(blocked)}",
+    )
+    checks.check(
+        "theorem2-no-unformed-site-has-closed-star",
+        all(not n_is_defined(site, patch) for site in patch if site != SEED),
+    )
+
+    checks.check(
+        "theorem3-members-disagree-on-first-wave",
+        wave != blocked and len(wave) == 3 and len(blocked) == 0,
+    )
+    checks.check(
+        "theorem3-o-zero-default-is-load-bearing",
+        wave == AXIS_SITES and blocked == frozenset(),
+    )
+
+    record_section = axiom.split("### Record / Fixed Reality", 1)[1].split(
+        "## Qualification", 1
+    )[0]
+    checks.check(
+        "source-unreadability-current",
+        "A site with no record cannot be read." in normalize(record_section),
+    )
+    checks.check(
+        "source-record-does-not-assign-occupancy-zero",
+        all(phrase not in record_section for phrase in FORBIDDEN_AXIOM_PHRASES)
+        and "occupancy 0" not in normalize(record_section)
+        and "o=0" not in record_section,
+    )
+    checks.check(
+        "source-occurrence-sentence-current",
+        "Records form." in axiom,
+    )
+    checks.check(
+        "note-does-not-write-unread-equals-zero-as-axiom",
+        "does not write that assignment into axiom text" in normalized_note
+        and "It is not an assignment of occupancy" in note
+        and "unreadability is occupancy 0" not in normalized_note
+        and "### Record / Fixed Reality" not in note,
+    )
+
+    claim_scope = (
+        "On the supplied twelve-vertex two-cube, replacing off-patch `o=0` "
+        "by “blank blocks readiness” empties the first wave. L1's wave uses "
+        "the vacuum default. Displayed, not adopted."
+    )
+    checks.check("note-claim-scope-exact", claim_scope in note)
+    checks.check(
+        "note-l1-displayed-not-adopted",
+        "L1 is displayed, not adopted." in note
+        and "L2 is not adopted" in normalized_note,
+    )
+    checks.check(
+        "note-not-leftover-character-or-new-patch",
+        "not a leftover-character identity" in normalized_note
+        and "not an `n_μ` step on a new patch" in note,
+    )
+    checks.check(
+        "note-not-a-vacuum-axiom",
+        "not a vacuum axiom" in normalized_note
+        and "This is not a vacuum axiom" in note,
+    )
+
+    machine_markers = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "claim_type_reason:",
+        "trace_class: negative_route_pruning",
+        "target_claim_id: unread_neighbor_not_occupancy_zero",
+        "target_blocker_text:",
+        "source_of_blocker_text: handoff",
+        "reachability_to_target: prunes",
+        "artifact_role: theorem",
+        "next_trace_action:",
+        "conditional_surface_status:",
+        "hypothetical_axiom_status: no edit",
+        "admitted_observation_status: null",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    checks.check(
+        "note-machine-status-complete",
+        all(marker in note for marker in machine_markers),
+    )
+    checks.check(
+        "note-one-hop-dependency-current",
+        "upstream_dependencies:\n  - minimal_axioms" in note
+        and "MINIMAL_AXIOMS_2026-06-29.md" in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "note-no-go-n1-through-n8",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    checks.check(
+        "note-no-go-route-enumeration",
+        note.count("**ATTEMPTED**") >= 5
+        and "treat unreadability as occupancy" in note
+        and "vacuum axiom" in note,
+    )
+    checks.check(
+        "note-steelman-rejects-automatic-zero-fill",
+        "The strongest objection" in normalized_note
+        and "filling `0` is extra encoding" in normalized_note,
+    )
+
+    n5_lines = (
+        "per-element: executed — each of the twelve vertices is enumerated",
+        "per-site: executed — n and readiness are computed at every unformed site",
+        "per-mode: not applicable — no modal or spectral decomposition is used",
+        "per-block: executed — only the supplied two-cube and seed are checked",
+        "lattice-wide: not executed — no full Z^3 history or adopted formation law is claimed",
+    )
+    checks.check("note-n5-five-line-certificate", all(line in note for line in n5_lines))
+    print("N5_CERTIFICATE:")
+    for line in n5_lines:
+        print(line)
+
+    checks.check(
+        "note-explicit-nonclaims",
+        "No axiom, primitive, registry, citation manifest, runner cache, or audit"
+        in note
+        and "L2 is not adopted" in note,
+    )
+    checks.check("axiom-file-unedited-in-this-dispatch", AXIOM_PATH.is_file())
+
+    return 0 if checks.finish() == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the twelve-vertex two-cube, treating off-patch neighbors as blank (not o=0) empties L1's first wave. The o=0 default is a member selector, not Record unreadability. Displayed, not adopted.

## Runner

`scripts/unread_neighbor_not_occupancy_zero_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.