### PR TITLE
feat(nonlin1): two-axis unbalanced formation member

### DIFF
--- a/docs/TWO_AXIS_UNBALANCED_FORMATION_MEMBER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_UNBALANCED_FORMATION_MEMBER_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,250 @@
+---
+claim_id: two_axis_unbalanced_formation_member_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "f_two is a cube-covariant formation predicate inequivalent to L1's n≠0 on the 64 cells and on the two-cube first wave. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_unbalanced_formation_member_2026_08_15.py
+---
+
+# Two-Axis Unbalanced Formation Member
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one cube-covariant boolean formation predicate on occupancy
+6-tuples, compared with L1's `n ≠ 0` rule on the same 64 cells and on the
+displayed two-cube first wave. The member is displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_unbalanced_formation_member_2026_08_15.py`](../scripts/two_axis_unbalanced_formation_member_2026_08_15.py)
+
+## Result up front
+
+Let `C = {0,1}^6` be occupancy on the six directed nearest-neighbor slots
+`(+x,-x,+y,-y,+z,-z)`. For `c ∈ C` write
+
+```text
+u(c) = |{ μ : c_{+μ} ≠ c_{-μ} }| ∈ {0,1,2,3}.
+```
+
+L1's displayed predicate on this test object is `f_L1(c) = 1` iff `u(c) ≥ 1`,
+equivalently `n ≠ 0` for the linear imbalance `n_μ = c_{+μ} − c_{-μ}`. The
+two-axis member is
+
+```text
+f_two(c) = 1  iff  u(c) ≥ 2.
+```
+
+The 24 proper cube rotations permute the six slots and therefore permute the
+three axes. They leave `u` invariant, so `f_two` is cube-covariant. It is not
+linear in `c` and it is not the predicate `n ≠ 0`. The two maps disagree on
+the 24 cells with exactly one unbalanced axis.
+
+On the displayed twelve-vertex two-cube of construction `#6320`, with seed
+lock at `(0,0,0)` and off-patch occupancy `o = 0` (L1's displayed vacuum
+default, not adopted here), L1's first wave is the three axis sites
+`(1,0,0)`, `(0,1,0)`, `(0,0,1)`, each with `u = 1`. The first wave of
+`f_two` is empty. The members are therefore inequivalent as occupancy-to-lock
+steps on the same patch type.
+
+The Admissibility formation slot therefore has more than one displayed
+cube-covariant point. This note does not adopt `f_two`.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Cube covariance of f_two, the exact 24-cell disagreement with f_L1, and the empty versus three-site first-wave split on the displayed two-cube are finite exact identities; no physical formation rule is selected."
+trace_class: negative_route_pruning
+target_claim_id: unique_displayed_l1_formation_member
+target_blocker_text: "L1's n≠0 occupancy-to-lock step is the only displayed cube-covariant formation member on the 64 occupancy cells"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "further structure beyond cube covariance is required before any displayed occupancy-to-lock predicate can be adopted"
+conditional_surface_status: "exact on the 64 occupancy 6-tuples and the displayed twelve-vertex two-cube; no physical law, rate, or site selector"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+The current Lattice and Admissibility wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is:
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility names one fixed covariant rule and leaves form open: read with
+Record, the distribution is conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+Record states:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+Those sentences identify the covariance group and the open formation slot.
+They do not name a boolean formation predicate on occupancy 6-tuples. The
+alphabet `{0,1}` on the six slots is a declared finite test object, not a
+replacement of the one-site possibility domain `M_2(C)`. The two-cube, the
+seed lock, and the off-patch default `o = 0` are displayed construction data
+from `#6320`, not axiom text.
+
+## Exact objects
+
+Write slots in the order `(+x,-x,+y,-y,+z,-z)`. A cell is a 6-tuple
+`c ∈ C = {0,1}^6`. The proper cube rotation group `G` is the set of
+`3×3` signed permutation matrices of determinant `+1`. Each `R ∈ G` sends
+slot `v` to `R v` and acts on cells by
+
+```text
+(R·c)_{R v} = c_v.
+```
+
+The three axis pairs are `(+x,-x)`, `(+y,-y)`, `(+z,-z)`. The imbalance
+vector and its support count are
+
+```text
+n_μ(c) = c_{+μ} − c_{-μ},
+u(c)   = |{ μ : n_μ(c) ≠ 0 }| = |{ μ : c_{+μ} ≠ c_{-μ} }|.
+```
+
+Then `u(c) ∈ {0,1,2,3}` and `n(c) = 0` if and only if `u(c) = 0`.
+
+```text
+f_L1(c)  = 1  iff  u(c) ≥ 1,
+f_two(c) = 1  iff  u(c) ≥ 2.
+```
+
+The displayed two-cube of `#6320` has vertices
+
+```text
+A = {0,1}^3,
+B = {1,2} × {0,1}^2,
+P = A ∪ B
+```
+
+(`|P| = 12`). The seed lock is `(0,0,0)`. Occupancy of a locked site is `1`.
+Occupancy of an unlocked on-patch site is `0`. Occupancy of an off-patch
+site is the displayed default `o = 0`. The occupancy 6-tuple at an on-patch
+site is the six neighbor occupancies. The first wave of a predicate `f` is
+the set of unlocked sites in `P` at which `f` equals `1` after the seed.
+
+Neither `f_L1` nor `f_two` is adopted as a physical law.
+
+## Theorem 1 — `f_two` is cube-covariant
+
+`G` has 24 elements: six images for the first axis, four remaining images
+for the second, and the third axis then fixed by orientation. Inversion is
+absent. The induced action on the six slots is 24 distinct permutations.
+
+A proper cube rotation permutes the three axis pairs and may swap the two
+slots of a pair. It cannot change whether a pair is balanced. Therefore
+`u(R·c) = u(c)` for every `R ∈ G` and every `c ∈ C`, and
+
+```text
+f_two(R·c) = f_two(c).
+```
+
+The same invariance holds for `f_L1`. Direct evaluation on all 64 cells and
+all 24 slot permutations confirms both identities.
+
+## Theorem 2 — the predicates disagree on a nonempty set
+
+The maps `f_L1` and `f_two` agree on cells with `u = 0` (both vanish) and on
+cells with `u ≥ 2` (both equal `1`). They disagree exactly on the cells with
+`u = 1`: there `f_L1 = 1` and `f_two = 0`.
+
+There are three choices of the unbalanced axis, two occupancy patterns on
+that axis, and two balanced patterns on each of the other two axes, hence
+
+```text
+3 × 2 × 2 × 2 = 24
+```
+
+such cells. Direct listing of all 64 cells confirms that `f_L1` and `f_two`
+disagree on exactly 24 cells. In particular the disagreement set is nonempty
+(cardinality `24 ≥ 1`).
+
+The predicate `f_two` is not `n ≠ 0`, because those 24 cells have `n ≠ 0`
+and `f_two = 0`. It is not linear in `c`: over `GF(2)`, the two one-axis
+cells with support on distinct axes sum to a two-axis cell, so
+
+```text
+f_two(c) = 0,   f_two(c') = 0,   f_two(c + c') = 1,
+```
+
+which forbids additivity. The zero set of `f_two` is therefore not the kernel
+of a linear form on `C`.
+
+## Theorem 3 — inequivalent first waves on the displayed two-cube
+
+After the seed lock at `(0,0,0)`, the only on-patch sites whose neighbor
+6-tuple has `u ≥ 1` are the three axis neighbors of the seed,
+
+```text
+(1,0,0), (0,1,0), (0,0,1).
+```
+
+Each of those sites has the seed in one directed slot and `0` in the other
+five slots, so `u = 1` there. L1 therefore forms exactly those three sites
+as its first wave.
+
+Because those sites have `u = 1`, `f_two` vanishes on them. No other
+unlocked site in `P` has `u ≥ 2`. The first wave of `f_two` is empty.
+
+The two predicates therefore induce distinct occupancy-to-lock steps on the
+same twelve-vertex patch. The two-axis member is not an occupancy-step clone
+of L1: the patch type is unchanged and the formation predicate is different.
+
+The off-patch default `o = 0` is L1's displayed vacuum assignment, used here
+only to hold the two-cube data fixed. It is not adopted.
+
+## Obligation graph
+
+| obligation | exact disposition |
+|---|---|
+| `|C| = 64` | enumerated binary 6-tuples |
+| `|G| = 24`, orientation-preserving | signed permutations of determinant `+1` |
+| `u` invariant under `G` | axis pairs are permuted |
+| `f_two` cube-covariant | Theorem 1 |
+| `f_two` not `n ≠ 0` | 24 cells with `u = 1` |
+| `f_two` not linear in `c` | `GF(2)` additivity fails |
+| disagreement set | exactly the 24 cells with `u = 1` |
+| disagreement nonempty | `24 ≥ 1` |
+| L1 first wave on `#6320` two-cube | three axis sites |
+| `f_two` first wave on the same patch | empty |
+| adopt `f_two` | not claimed |
+
+## Imports and non-claims
+
+The only scientific dependency is the current four-axiom authority linked
+above, used only to pin the proper-cube covariance group and the open
+formation slot. The two-cube, seed, and `o = 0` default are displayed
+construction data. No observational comparator is admitted. No dynamics,
+Hamiltonian, or record-production process is constructed.
+
+This note displays one additional cube-covariant point of the Admissibility
+formation class. It does not adopt that point. It does not write axiom
+sentences. It is not leftover-character of L1 and not a new spatial patch.
+
+## Value and no-go boundary
+
+The positive content is the exact covariance of `f_two`, the exact 24-cell
+disagreement with `f_L1`, and the empty-versus-three first-wave split on the
+displayed two-cube. The negative content is only uniqueness of L1 as a
+displayed cube-covariant occupancy-to-lock step on this test object. Further
+structure could still select a member. No global impossibility of a formation
+rule is claimed.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18525,6 +18525,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_axis_unbalanced_formation_member_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_axis_unbalanced_formation_member_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_unbalanced_formation_member_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_unbalanced_formation_member_2026_08_15.py
+runner_sha256: e308740d2c5944123520b5cf70a6d2ee9a1e12d321fe4700016da13d1b4e67f3
+input_fingerprint_sha256: 1f412c4ebb820d739438d0ef3778a76e016c6d5d2a2066638e8351e0dfd9e763
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+Two-axis unbalanced formation member versus L1
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_UNBALANCED_FORMATION_MEMBER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: displayed f_two on 64 cells and the two-cube first wave; not adopted
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-normalized
+PASS: audit-timeout-declared
+PASS: source-lattice-current
+PASS: source-one-fixed-covariant-rule-current
+PASS: source-formation-open-current
+PASS: source-records-form-current
+PASS: note-no-axiom-edit
+PASS: cell-count-64
+PASS: cells-are-binary-6-tuples
+PASS: rotation-count-24
+PASS: rotations-include-identity
+PASS: rotations-exclude-inversion
+PASS: rotation-determinants-plus-one
+PASS: slot-permutations-24-distinct
+PASS: slot-permutations-are-bijections
+PASS: u-range-is-0-to-3
+PASS: u-invariant-under-rotations
+PASS: f_two-cube-covariant
+PASS: f_L1-cube-covariant
+PASS: f_L1-is-n-nonzero
+PASS: f_two-is-not-n-nonzero
+disagree_count=24
+one_unbalanced_count=24
+combo_count=24
+PASS: disagreement-is-exactly-one-unbalanced-axis  (disagree=24)
+PASS: disagreement-count-matches-axis-combo  (count=24)
+PASS: disagreement-at-least-one
+PASS: split-cells-are-L1-form-and-f_two-absent
+PASS: f_two-not-linear-over-GF2
+two_cube_sites=12
+L1_first_wave=[(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+f_two_first_wave=[]
+axis_u={(1, 0, 0): 1, (0, 0, 1): 1, (0, 1, 0): 1}
+PASS: two-cube-has-twelve-sites
+PASS: seed-is-on-patch
+PASS: L1-first-wave-is-three-axis-sites
+PASS: axis-sites-have-u-one
+PASS: f_two-first-wave-empty
+PASS: members-inequivalent-as-occupancy-lock-steps
+PASS: note-reports-disagreement-count
+PASS: note-reports-combo-identity
+PASS: note-claim-scope-displayed-not-adopted
+PASS: note-does-not-adopt-the-member
+PASS: forbidden-phrase-hygiene
+PASS: no-runner-cache-or-citation-manifest
+TOTAL: PASS=39 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_unbalanced_formation_member_2026_08_15.py
+++ b/scripts/two_axis_unbalanced_formation_member_2026_08_15.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Display one cube-covariant formation member inequivalent to L1.
+
+The paired note is
+docs/TWO_AXIS_UNBALANCED_FORMATION_MEMBER_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+Objects: occupancy 6-tuples on the six directed nearest-neighbor slots,
+the 24 proper cube rotations, and the displayed twelve-vertex two-cube
+with seed (0,0,0) and off-patch occupancy 0. The two-axis predicate is
+displayed, not adopted. No axiom sentence is written. No cache is written.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_UNBALANCED_FORMATION_MEMBER_BOUNDED_"
+    "THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_UNBALANCED_FORMATION_MEMBER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+SLOTS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SLOT_INDEX = {slot: i for i, slot in enumerate(SLOTS)}
+AXIS_PAIRS = ((0, 1), (2, 3), (4, 5))
+SEED = (0, 0, 0)
+OFF_PATCH = 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def permutation_sign(perm: tuple[int, ...]) -> int:
+    inversions = sum(
+        perm[i] > perm[j] for i in range(len(perm)) for j in range(i + 1, len(perm))
+    )
+    return -1 if inversions % 2 else 1
+
+
+def proper_rotation_matrices() -> tuple[tuple[tuple[int, int, int], ...], ...]:
+    mats: list[tuple[tuple[int, int, int], ...]] = []
+    for perm in permutations(range(3)):
+        axis_sign = permutation_sign(perm)
+        for signs in product((-1, 1), repeat=3):
+            det = axis_sign * signs[0] * signs[1] * signs[2]
+            if det != 1:
+                continue
+            rows = [[0, 0, 0] for _ in range(3)]
+            for col, row in enumerate(perm):
+                rows[row][col] = signs[col]
+            mats.append(tuple(tuple(row) for row in rows))
+    return tuple(sorted(set(mats)))
+
+
+def matvec(
+    matrix: tuple[tuple[int, int, int], ...], vector: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return tuple(sum(matrix[i][j] * vector[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def slot_permutation(matrix: tuple[tuple[int, int, int], ...]) -> tuple[int, ...]:
+    return tuple(SLOT_INDEX[matvec(matrix, slot)] for slot in SLOTS)
+
+
+def apply_perm(cell: tuple[int, ...], perm: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * 6
+    for source, dest in enumerate(perm):
+        out[dest] = cell[source]
+    return tuple(out)
+
+
+def all_cells() -> tuple[tuple[int, ...], ...]:
+    return tuple(product((0, 1), repeat=6))
+
+
+def unbalanced_axis_count(cell: tuple[int, ...]) -> int:
+    return sum(cell[plus] != cell[minus] for plus, minus in AXIS_PAIRS)
+
+
+def imbalance(cell: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(cell[plus] - cell[minus] for plus, minus in AXIS_PAIRS)
+
+
+def f_l1(cell: tuple[int, ...]) -> int:
+    return int(unbalanced_axis_count(cell) >= 1)
+
+
+def f_two(cell: tuple[int, ...]) -> int:
+    return int(unbalanced_axis_count(cell) >= 2)
+
+
+def is_covariant(func, perms: tuple[tuple[int, ...], ...]) -> bool:
+    for cell in all_cells():
+        value = func(cell)
+        for perm in perms:
+            if func(apply_perm(cell, perm)) != value:
+                return False
+    return True
+
+
+def gf2_add(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple((a + b) % 2 for a, b in zip(left, right, strict=True))
+
+
+def two_cube_patch() -> frozenset[tuple[int, int, int]]:
+    cube_a = product((0, 1), (0, 1), (0, 1))
+    cube_b = product((1, 2), (0, 1), (0, 1))
+    return frozenset(cube_a) | frozenset(cube_b)
+
+
+def occupancy(
+    site: tuple[int, int, int],
+    locked: frozenset[tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> int:
+    if site in locked:
+        return 1
+    if site not in patch:
+        return OFF_PATCH
+    return 0
+
+
+def neighbor_cell(
+    site: tuple[int, int, int],
+    locked: frozenset[tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> tuple[int, ...]:
+    return tuple(
+        occupancy(
+            (site[0] + slot[0], site[1] + slot[1], site[2] + slot[2]),
+            locked,
+            patch,
+        )
+        for slot in SLOTS
+    )
+
+
+def first_wave(
+    func,
+    locked: frozenset[tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> frozenset[tuple[int, int, int]]:
+    return frozenset(
+        site
+        for site in patch
+        if site not in locked and func(neighbor_cell(site, locked, patch)) == 1
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("Two-axis unbalanced formation member versus L1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: displayed f_two on 64 cells and the two-cube first wave; not adopted")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-paths-unique-normalized",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(
+            not Path(path).is_absolute() and ".." not in Path(path).parts
+            for path in AUDIT_INPUT_PATHS
+        ),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    covariant_rule_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice "
+        "translations and proper cubic rotations."
+    )
+    formation_boundary = "it does not supply the formation site, probability, or rate"
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-current",
+        lattice_sentence in normalized_axiom and lattice_sentence in normalized_note,
+    )
+    checks.check(
+        "source-one-fixed-covariant-rule-current",
+        covariant_rule_sentence in normalized_axiom
+        and covariant_rule_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-open-current",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-records-form-current",
+        records_form in axiom and records_form in note,
+    )
+    checks.check(
+        "note-no-axiom-edit",
+        "hypothetical_axiom_status: no edit" in note
+        or 'hypothetical_axiom_status: "no edit"' in note,
+    )
+
+    cells = all_cells()
+    checks.check("cell-count-64", len(cells) == 64 and len(set(cells)) == 64)
+    checks.check(
+        "cells-are-binary-6-tuples",
+        all(len(cell) == 6 and set(cell) <= {0, 1} for cell in cells),
+    )
+
+    rotations = proper_rotation_matrices()
+    identity = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    inversion = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    rotation_set = set(rotations)
+    checks.check("rotation-count-24", len(rotations) == 24)
+    checks.check("rotations-include-identity", identity in rotation_set)
+    checks.check("rotations-exclude-inversion", inversion not in rotation_set)
+    checks.check(
+        "rotation-determinants-plus-one",
+        all(
+            matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+            - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+            + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+            == 1
+            for matrix in rotations
+        ),
+    )
+
+    perms = tuple(slot_permutation(matrix) for matrix in rotations)
+    checks.check("slot-permutations-24-distinct", len(set(perms)) == 24)
+    checks.check(
+        "slot-permutations-are-bijections",
+        all(sorted(perm) == list(range(6)) for perm in perms),
+    )
+
+    u_values = tuple(unbalanced_axis_count(cell) for cell in cells)
+    checks.check("u-range-is-0-to-3", set(u_values) == {0, 1, 2, 3})
+    checks.check(
+        "u-invariant-under-rotations",
+        all(
+            unbalanced_axis_count(apply_perm(cell, perm)) == unbalanced_axis_count(cell)
+            for cell in cells
+            for perm in perms
+        ),
+    )
+    checks.check("f_two-cube-covariant", is_covariant(f_two, perms))
+    checks.check("f_L1-cube-covariant", is_covariant(f_l1, perms))
+    checks.check(
+        "f_L1-is-n-nonzero",
+        all(f_l1(cell) == int(any(component != 0 for component in imbalance(cell))) for cell in cells),
+    )
+    checks.check(
+        "f_two-is-not-n-nonzero",
+        any(f_two(cell) != int(any(component != 0 for component in imbalance(cell))) for cell in cells),
+    )
+
+    disagree_cells = tuple(cell for cell in cells if f_l1(cell) != f_two(cell))
+    one_unbalanced = tuple(cell for cell in cells if unbalanced_axis_count(cell) == 1)
+    combo_count = 3 * 2 * 2 * 2
+    print(f"disagree_count={len(disagree_cells)}")
+    print(f"one_unbalanced_count={len(one_unbalanced)}")
+    print(f"combo_count={combo_count}")
+    checks.check(
+        "disagreement-is-exactly-one-unbalanced-axis",
+        set(disagree_cells) == set(one_unbalanced),
+        f"disagree={len(disagree_cells)}",
+    )
+    checks.check(
+        "disagreement-count-matches-axis-combo",
+        len(disagree_cells) == combo_count == len(one_unbalanced),
+        f"count={len(disagree_cells)}",
+    )
+    checks.check("disagreement-at-least-one", len(disagree_cells) >= 1)
+    checks.check(
+        "split-cells-are-L1-form-and-f_two-absent",
+        all(f_l1(cell) == 1 and f_two(cell) == 0 for cell in one_unbalanced),
+    )
+
+    axis_unit = []
+    for plus, _minus in AXIS_PAIRS:
+        unit = [0] * 6
+        unit[plus] = 1
+        axis_unit.append(tuple(unit))
+    gf2_additivity_fails = any(
+        f_two(left) == 0
+        and f_two(right) == 0
+        and f_two(gf2_add(left, right)) == 1
+        for left, right in zip(axis_unit, axis_unit[1:], strict=False)
+    )
+    checks.check("f_two-not-linear-over-GF2", gf2_additivity_fails)
+
+    patch = two_cube_patch()
+    locked = frozenset({SEED})
+    axis_sites = frozenset(
+        (SEED[0] + slot[0], SEED[1] + slot[1], SEED[2] + slot[2])
+        for slot in SLOTS
+        if (SEED[0] + slot[0], SEED[1] + slot[1], SEED[2] + slot[2]) in patch
+    )
+    l1_wave = first_wave(f_l1, locked, patch)
+    two_wave = first_wave(f_two, locked, patch)
+    axis_u = {site: unbalanced_axis_count(neighbor_cell(site, locked, patch)) for site in axis_sites}
+    print(f"two_cube_sites={len(patch)}")
+    print(f"L1_first_wave={sorted(l1_wave)}")
+    print(f"f_two_first_wave={sorted(two_wave)}")
+    print(f"axis_u={axis_u}")
+
+    checks.check("two-cube-has-twelve-sites", len(patch) == 12)
+    checks.check("seed-is-on-patch", SEED in patch)
+    checks.check("L1-first-wave-is-three-axis-sites", l1_wave == axis_sites and len(axis_sites) == 3)
+    checks.check("axis-sites-have-u-one", set(axis_u.values()) == {1})
+    checks.check("f_two-first-wave-empty", two_wave == frozenset())
+    checks.check("members-inequivalent-as-occupancy-lock-steps", l1_wave != two_wave)
+
+    checks.check(
+        "note-reports-disagreement-count",
+        f"disagree on exactly {len(disagree_cells)} cells" in note,
+    )
+    checks.check(
+        "note-reports-combo-identity",
+        f"3 × 2 × 2 × 2 = {combo_count}" in note,
+    )
+    checks.check(
+        "note-claim-scope-displayed-not-adopted",
+        "inequivalent to L1" in normalized_note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "note-does-not-adopt-the-member",
+        "does not adopt" in normalized_note and "not adopted" in normalized_note,
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE", "new axiom")
+    checks.check(
+        "forbidden-phrase-hygiene",
+        all(phrase not in note for phrase in forbidden),
+        ",".join(phrase for phrase in forbidden if phrase in note),
+    )
+    checks.check(
+        "no-runner-cache-or-citation-manifest",
+        "runner-cache" not in note
+        and "citation_manifest" not in note
+        and "CITATION_MANIFEST" not in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

f_two (form iff at least two axes unbalanced) is cube-covariant and disagrees with L1 n\neq0 on 24 cells and on the two-cube first wave. Inequivalent displayed member, not adopted.

## Runner

`scripts/two_axis_unbalanced_formation_member_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.