### PR TITLE
feat(ftwofill): f_two three-site seed halt census

### DIFF
--- a/docs/F_TWO_THREE_SITE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_TWO_THREE_SITE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,167 @@
+---
+claim_id: f_two_three_site_seed_fill_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the twelve-vertex two-cube with off-patch o=0 and a displayed 3-site seed, f_two occupancy ticks reach a fixed point with a reported (T, |locks|). Displayed, not adopted. No clock/source identities."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_two_three_site_seed_fill_2026_08_15.py
+---
+
+# f_two Three-Site Seed Fill On The Two-Cube
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-lock ticks of the displayed f_two ready rule
+(form iff `u >= 2`) on one twelve-site two-cube carrier, from one
+displayed 3-site seed. The pair `(T, |locks_T|)` is a finite halt
+census. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_two_three_site_seed_fill_2026_08_15.py`](../scripts/f_two_three_site_seed_fill_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The two-cube patch has twelve vertices. Off-patch occupancy is `o = 0`.
+The displayed seed is the axis triple of the origin corner,
+
+```text
+S0 = {(1,0,0), (0,1,0), (0,0,1)}.
+```
+
+That triple has a nonempty first wave, so it is the working seed (the
+same algebra as the f_two minimal-seed census). Each tick locks every
+unlocked ready site at once. Ready means `u(v) >= 2` with `v` unlocked,
+where `u(v)` is the number of axes at `v` with `o_{+μ} ≠ o_{-μ}`.
+
+The process reaches a fixed point at halt tick `T = 2` with
+`|locks_2| = 8`. The twelve-vertex patch does not fill.
+
+Displayed contrast only (not a clone table): L1 from a 1-site seed
+halts at diameter 4 with 12 locks. That is a different member. Here
+f_two from this 3-site seed stops short of the patch.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact occupancy-lock halt census of displayed f_two on one twelve-site two-cube carrier from one 3-site seed."
+trace_class: frontier_discovery
+target_claim_id: f_two_three_site_seed_fill
+target_blocker_text: "whether displayed f_two from the axis-triple seed fills the twelve-site two-cube"
+source_of_blocker_text: handoff
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded halt census"
+conditional_surface_status: "exact on the supplied two-cube f_two patch and seed; other members and complexes remain separate"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+`cache_write: false`
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** live Lattice and Record sentences, quoted without rewrite.
+- **Explicit theorem-domain condition:** displayed f_two ready rule
+  `u >= 2`, two-cube patch, off-patch occupancy zero, axis-triple seed,
+  simultaneous lock of every unlocked ready site.
+- **External empirical or literature inputs:** none.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> Records form.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone.
+
+Their dependency role is limited to the cubic site set, lock permanence, and
+the unreadability of absence. The occupancy kernel, the two-cube patch, the
+seed, and the tick index are separately supplied.
+
+## Exact Objects
+
+All runner values are exact integers. No float is used.
+
+Cubes `A = {0,1} × {0,1} × {0,1}` and `B = {1,2} × {0,1} × {0,1}`.
+Patch `V = A ∪ B`, so `|V| = 12`. Occupancy of a site is `1` if the
+site is locked and `0` otherwise, including every off-patch neighbor.
+
+For each site `v` and axis `μ ∈ {x,y,z}`,
+
+```text
+u(v) = |{ μ : o(v+e_μ) ≠ o(v−e_μ) }|.
+```
+
+A site is ready iff it is unlocked and `u(v) >= 2`. One tick replaces
+the lock set `L` by `L ∪ { v ∈ V \ L : u(v) >= 2 }`. Locked sites stay
+locked.
+
+Seed locks `S0`. First wave is the ready set at `L = S0`.
+
+## Exact Target And Proof Obligations
+
+Check that the first wave is nonempty, that the iteration reaches a
+fixed point in at most 12 ticks, and report the exact pair
+`(T, |locks_T|)` together with whether `|locks_T| = 12`.
+
+## Theorems
+
+### Theorem 1 — first wave is nonempty
+
+At `L = S0` the origin `(0,0,0)` has all three axes unbalanced, so
+`u = 3`. The sites `(0,1,1)`, `(1,0,1)`, and `(1,1,0)` each have
+`u = 2`. The first wave is
+
+```text
+{(0,0,0), (0,1,1), (1,0,1), (1,1,0)}.
+```
+
+It is nonempty.
+
+### Theorem 2 — a fixed point in at most 12 ticks
+
+The site set is finite of size 12, locks are permanent, and each
+non-halt tick adds at least one lock. The iteration therefore reaches
+a fixed point in at most 12 ticks.
+
+### Theorem 3 — halt pair and fill boolean
+
+After two ticks the lock set equals cube `A`:
+
+```text
+T = 2,   |locks_2| = 8,   locks_2 = A ≠ V.
+```
+
+The four `x = 2` sites remain unlocked, each with `u = 1`. The
+twelve-vertex patch does not fill. That boolean is the member
+difference versus L1 from a 1-site seed, which is displayed only as
+halting at diameter 4 with 12 locks.
+
+## What Is Not Claimed
+
+- No unique member of the axiom class, and no adoption of f_two.
+- No clock identity, no source identity, and no formation-count table.
+- No leftover-character classification.
+- No 4x4x4, torus, or line complex.
+- No axiom edit and no replacement of the live Record sentences.
+- Qubit remains `M_2(C)`.
+- No inverse-square law and no Newtonian identification.
+
+## Runner Contract
+
+The companion runner reconstructs the occupancy-lock ticks on the
+displayed patch and checks the theorems with exact integer arithmetic.
+It prints `TOTAL: PASS=... FAIL=...` and writes no cache. Declared
+review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_two_three_site_seed_fill_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_two_three_site_seed_fill_2026_08_15.txt
+++ b/logs/runner-cache/f_two_three_site_seed_fill_2026_08_15.txt
@@ -1,0 +1,67 @@
+===== runner cache v1 =====
+runner: scripts/f_two_three_site_seed_fill_2026_08_15.py
+runner_sha256: 3daf33bca0c156dd64417c7ec8ff33f53f814873ad5c2a877c21a0c798090a48
+input_fingerprint_sha256: 5cf0be0a5aa364b9436800d631d60baf0a57de6e0d2784df407e00ea4287e605
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+f_two three-site seed fill on the two-cube
+AUDIT_INPUT_PATHS:
+  docs/F_TWO_THREE_SITE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: supplied two-cube f_two patch; 3-site seed halt census
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-relative
+PASS: audit-timeout-declared
+PASS: lattice-quote-present
+PASS: record-form-quote-present
+PASS: hygiene-avoids-'G_N'
+PASS: hygiene-avoids-'1/r'
+PASS: hygiene-avoids-'1/r^2'
+PASS: hygiene-avoids-'Lattice-named'
+PASS: hygiene-avoids-'not a TOE'
+PASS: hygiene-avoids-'exhausted'
+PASS: hygiene-avoids-'only route'
+PASS: hygiene-avoids-'we adopt'
+PASS: hygiene-avoids-'Codex'
+PASS: hygiene-avoids-'L_phys'
+PASS: hygiene-avoids-'PVM'
+PASS: note-has-no-runner-cache-path
+PASS: note-has-no-citation-manifest
+PASS: patch-has-twelve-sites
+PASS: seed-is-axis-triple
+PASS: seed-sites-on-patch
+PASS: off-patch-occupancy-is-zero
+PASS: theorem-1-first-wave-nonempty
+PASS: origin-ready-at-seed
+PASS: first-wave-computed-set
+PASS: theorem-2-halt-within-twelve
+PASS: theorem-2-halt-is-fixed-point
+PASS: seed-permanent-in-halt
+PASS: locks-monotone
+PASS: halt-tick-is-first-fixed-point
+PASS: theorem-3-halt-tick  (T=2)
+PASS: theorem-3-lock-count  (|locks|=8)
+PASS: theorem-3-patch-does-not-fill
+PASS: halt-locks-equal-cube-a
+PASS: x-equals-two-sites-unlocked
+PASS: unlocked-sites-have-u-less-than-two
+PASS: note-reports-halt-tick-two
+PASS: note-reports-eight-locks
+PASS: note-reports-does-not-fill
+halt_tick: 2
+lock_count: 8
+fills_patch: False
+per_element: 12 vertices
+per_site: occupancy lock
+per_mode: f_two u>=2
+per_block: halt census
+lattice_wide: checked and not executed
+TOTAL: PASS=39 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_two_three_site_seed_fill_2026_08_15.py
+++ b/scripts/f_two_three_site_seed_fill_2026_08_15.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Exact checks for f_two three-site seed fill on the two-cube.
+
+Reconstructs the displayed f_two occupancy-lock ticks (form iff u>=2)
+on the twelve-site two-cube patch from the axis-triple seed. Writes no
+cache and no governance surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/F_TWO_THREE_SITE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Vec = tuple[int, int, int]
+AXES: tuple[Vec, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+CUBE_A = frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+CUBE_B = frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+PATCH = CUBE_A | CUBE_B
+SEED: frozenset[Vec] = frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)})
+
+FORBIDDEN_NOTE_SUBSTRINGS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "exhausted",
+    "only route",
+    "we adopt",
+    "Codex",
+    "L_phys",
+    "PVM",
+)
+
+
+def plus(site: Vec, step: Vec) -> Vec:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def minus(site: Vec, step: Vec) -> Vec:
+    return (site[0] - step[0], site[1] - step[1], site[2] - step[2])
+
+
+def occupancy(site: Vec, locks: frozenset[Vec]) -> int:
+    return 1 if site in locks else 0
+
+
+def unbalanced_axes(site: Vec, locks: frozenset[Vec]) -> int:
+    return sum(
+        occupancy(plus(site, axis), locks) != occupancy(minus(site, axis), locks)
+        for axis in AXES
+    )
+
+
+def ready_sites(locks: frozenset[Vec]) -> frozenset[Vec]:
+    return frozenset(
+        site
+        for site in PATCH
+        if site not in locks and unbalanced_axes(site, locks) >= 2
+    )
+
+
+def step(locks: frozenset[Vec]) -> frozenset[Vec]:
+    return locks | ready_sites(locks)
+
+
+def evolve_until_halt(max_ticks: int = 12) -> tuple[int, frozenset[Vec], list[frozenset[Vec]]]:
+    hist = [SEED]
+    locks = SEED
+    for tick in range(1, max_ticks + 1):
+        nxt = step(locks)
+        if nxt == locks:
+            return tick - 1, locks, hist
+        locks = nxt
+        hist.append(locks)
+    return max_ticks, locks, hist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def hygiene(checks: Checks, note: str, axiom: str) -> None:
+    checks.check("audit-input-paths-exist", all((ROOT / p).is_file() for p in AUDIT_INPUT_PATHS))
+    checks.check(
+        "audit-input-paths-unique-relative",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(not Path(p).is_absolute() and ".." not in Path(p).parts for p in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check("lattice-quote-present", "proper cubic rotations" in axiom)
+    checks.check("record-form-quote-present", "Records form" in axiom)
+    for token in FORBIDDEN_NOTE_SUBSTRINGS:
+        checks.check(f"hygiene-avoids-{token!r}", token not in note)
+    checks.check("note-has-no-runner-cache-path", "runner-cache" not in note)
+    checks.check("note-has-no-citation-manifest", "citation_manifest" not in note)
+    checks.check("patch-has-twelve-sites", len(PATCH) == 12)
+    checks.check("seed-is-axis-triple", SEED == frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)}))
+    checks.check("seed-sites-on-patch", SEED <= PATCH)
+    checks.check("off-patch-occupancy-is-zero", occupancy((3, 0, 0), SEED) == 0)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    print("f_two three-site seed fill on the two-cube")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: supplied two-cube f_two patch; 3-site seed halt census")
+    hygiene(checks, note, axiom)
+
+    first_wave = ready_sites(SEED)
+    halt_tick, locks, hist = evolve_until_halt(12)
+    post_halt = step(locks)
+    unlocked = PATCH - locks
+
+    checks.check("theorem-1-first-wave-nonempty", len(first_wave) > 0)
+    checks.check("origin-ready-at-seed", (0, 0, 0) in first_wave)
+    checks.check(
+        "first-wave-computed-set",
+        first_wave == frozenset({(0, 0, 0), (0, 1, 1), (1, 0, 1), (1, 1, 0)}),
+    )
+    checks.check("theorem-2-halt-within-twelve", halt_tick <= 12)
+    checks.check("theorem-2-halt-is-fixed-point", post_halt == locks)
+    checks.check("seed-permanent-in-halt", SEED <= locks)
+    checks.check("locks-monotone", all(hist[i] <= hist[i + 1] for i in range(len(hist) - 1)))
+    if halt_tick > 0:
+        checks.check("halt-tick-is-first-fixed-point", step(hist[halt_tick - 1]) != hist[halt_tick - 1])
+    checks.check("theorem-3-halt-tick", halt_tick == 2, f"T={halt_tick}")
+    checks.check("theorem-3-lock-count", len(locks) == 8, f"|locks|={len(locks)}")
+    checks.check("theorem-3-patch-does-not-fill", locks != PATCH and len(locks) != 12)
+    checks.check("halt-locks-equal-cube-a", locks == CUBE_A)
+    checks.check(
+        "x-equals-two-sites-unlocked",
+        unlocked == frozenset({(2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1)}),
+    )
+    checks.check(
+        "unlocked-sites-have-u-less-than-two",
+        all(unbalanced_axes(site, locks) < 2 for site in unlocked),
+    )
+    checks.check("note-reports-halt-tick-two", "T = 2" in note)
+    checks.check("note-reports-eight-locks", "|locks_2| = 8" in note)
+    checks.check("note-reports-does-not-fill", "does not fill" in note)
+
+    print(f"halt_tick: {halt_tick}")
+    print(f"lock_count: {len(locks)}")
+    print(f"fills_patch: {locks == PATCH}")
+    print("per_element: 12 vertices")
+    print("per_site: occupancy lock")
+    print("per_mode: f_two u>=2")
+    print("per_block: halt census")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the twelve-vertex two-cube, displayed f_two from the axis-triple seed reaches a fixed point at T=2 with 8 locks and does not fill. Member difference vs L1. Displayed, not adopted.

## Runner

`scripts/f_two_three_site_seed_fill_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.