### PR TITLE
feat(koname): occupancy lock labels are the pairs (S,k)

### DIFF
--- a/docs/OCCUPANCY_LOCK_LABEL_PAIRS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OCCUPANCY_LOCK_LABEL_PAIRS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,272 @@
+---
+claim_id: occupancy_lock_label_pairs_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Occupancy-only lock labels are the 8 pairs (S,k) for S⊆{x,y,z}. This is not a PVM and does not use Aut(M_2). Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/occupancy_lock_label_pairs_2026_08_15.py
+---
+
+# Occupancy Lock Labels Are The Pairs (S,k)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact census of occupancy-only labels on the 64 binary six-tuples.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/occupancy_lock_label_pairs_2026_08_15.py`](../scripts/occupancy_lock_label_pairs_2026_08_15.py)
+
+## Result up front
+
+A nearest-neighbor occupancy cell is a binary 6-tuple, one bit for each
+directed neighbor of a cubic site. Occupancy-only content forgets every
+further pairing and keeps only which axes fail to match on the two opposite
+rays. The displayed label is the pair `(S,k)` with `S` the set of unmatched
+axes and `k=|S|`. Enumerating all 64 cells yields exactly eight labels: the
+empty set and the seven nonempty subsets of `{x,y,z}`. Cells sharing a label
+are indistinguishable by occupancy-only content.
+
+This is a new content object. It is not the leftover Aut yes/no character of
+claim `#6383`. It is not a rank-1 projector: those require an axis–Pauli
+pairing that is not supplied here. The pairs are displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The image of the occupancy label map on the 64 binary six-tuples is the eight pairs (S,k); projector and Aut identifications are refused. Formation, readout, and any operator pairing remain unsupplied."
+trace_class: negative_route_pruning
+target_claim_id: occupancy_lock_rank_one_projector_from_occupancy_bits
+target_blocker_text: "identify occupancy-only six-tuple content with a rank-1 projector or leftover Aut character"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "keep occupancy labels as displayed (S,k) pairs; do not identify them with Aut leftover or with an axis–Pauli projector pairing"
+conditional_surface_status: "exact on the declared 64-cell occupancy carrier; not adopted as a physical lock menu"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+The current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+nearest-neighbor adjacency on the cubic lattice, a nearest-neighbor
+admissibility rule, and the Record sentences
+
+```text
+When present, a record locks exactly one admissible local possibility.
+A readout value is determined by record content alone.
+```
+
+Those sentences identify lock and content-only readout. They do not name a
+binary occupancy alphabet, do not enumerate six-tuples, and do not pair an
+axis with a Pauli generator. The 64-cell carrier and the map `λ` below are
+declared finite test objects. No axiom is edited. `Aut(M_2)` is not used.
+
+## Exact objects
+
+Write the directed axes in the fixed order
+
+```text
+(+x, -x, +y, -y, +z, -z).
+```
+
+A cell is a 6-tuple
+
+```text
+c ∈ {0,1}^6,
+c = (c_{+x}, c_{-x}, c_{+y}, c_{-y}, c_{+z}, c_{-z}).
+```
+
+There are `2^6 = 64` cells. For each axis `μ ∈ {x,y,z}` the two opposite bits
+are `c_{+μ}` and `c_{-μ}`. Define
+
+```text
+S(c) = { μ ∈ {x,y,z} : c_{+μ} ≠ c_{-μ} },
+k(c) = |S(c)|,
+λ(c) = (S(c), k(c)).
+```
+
+The integer `k` is determined by `S`. It is displayed so that the label is
+the pair `(S,k)` rather than the set `S` alone. An axis in `S` is
+unbalanced; an axis outside `S` is balanced (`c_{+μ} = c_{-μ}`).
+
+## Theorem 1 — the image of λ has size 8
+
+Every value of `λ` is a pair `(S, |S|)` for some `S ⊆ {x,y,z}`. There are
+`2^3 = 8` subsets of a three-element set: the empty set and seven nonempty
+subsets. Grouped by cardinality they are
+
+```text
+k=0:  ∅
+k=1:  {x}, {y}, {z}
+k=2:  {x,y}, {x,z}, {y,z}
+k=3:  {x,y,z}.
+```
+
+That is the split `1+3+3+1 = 8`. Each subset occurs: for any prescribed `S`,
+set the two bits of every `μ ∈ S` to `(1,0)` and the two bits of every
+balanced axis to `(0,0)`. Then `S(c)=S` and `k(c)=|S|`. Hence
+
+```text
+im(λ) = { (S, |S|) : S ⊆ {x,y,z} },
+|im(λ)| = 8.
+```
+
+## Theorem 2 — balanced cells and nonempty fibers
+
+The cells with `k=0` are exactly the axis-balanced 6-tuples: `c_{+μ}=c_{-μ}`
+on every axis. Each axis then has two choices, `(0,0)` or `(1,1)`, so there
+are `2^3 = 8` such cells.
+
+For a fixed subset `S`, each axis still has two occupancy choices: a
+balanced axis may be `(0,0)` or `(1,1)`, and an unbalanced axis may be
+`(1,0)` or `(0,1)`. Thus every fiber of `λ` has exactly eight cells. In
+particular every nonempty `S` is realized, and any two distinct cells in the
+same fiber are indistinguishable by occupancy-only content.
+
+The k-census on the 64 cells is therefore
+
+```text
+k=0: 8,   k=1: 24,   k=2: 24,   k=3: 8.
+```
+
+## Theorem 3 — displayed invariances; not a rank-1 projector
+
+The map `λ` depends only on which axes have unequal opposite bits.
+
+- Swapping the two bits on a balanced axis leaves those bits equal, so the
+  swap is the identity on that axis and `S` is unchanged.
+- Swapping the two bits on an unbalanced axis together means flipping both
+  bits. The pair `(1,0)` becomes `(0,1)` and conversely; the bits remain
+  unequal, so `S` is unchanged.
+
+Both operations therefore fix `λ(c)`. They do not mix distinct labels.
+
+The same occupancy pair is not a rank-1 projector. A rank-1 projector on the
+one-site algebra would require an axis–Pauli pairing, which is the extra
+content of `#6383` and is not supplied by occupancy bits. The present object
+is a function from `{0,1}^6` to eight discrete pairs. It does not assign an
+operator, does not use `Aut(M_2)`, and is not the leftover Aut yes/no
+character of `#6383`.
+
+## Negative check — not a projector-valued measure
+
+This paragraph is a negative check, not a theorem statement. The eight labels
+do not form a projector-valued measure: there is no supplied family of
+operators summing to the identity, and no axis–Pauli pairing with which to
+build one. Occupancy-only indistinguishability is equality of `(S,k)`, not
+equality of spectral projections.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| 64-cell binary six-tuple carrier | declared; enumerated |
+| definition of `S`, `k`, and `λ` | declared |
+| `|im(λ)|=8` with split `1+3+3+1` | proved by listing subsets and exhibiting a preimage |
+| `k=0` cells are the 8 axis-balanced 6-tuples | proved by independent bit choices |
+| every nonempty `S` has a nonempty fiber | proved; each fiber has 8 cells |
+| swap on a balanced axis and joint flip on an unbalanced axis fix `λ` | proved |
+| not a rank-1 projector and not Aut leftover | negative check; pairing unsupplied |
+| formation site, process, or rate | open; not used |
+| axiom edit | none |
+
+## No-go discipline
+
+The only wall is the identification of occupancy-only labels with a rank-1
+projector or with the Aut leftover of `#6383`. The positive census of eight
+pairs is not itself an impossibility claim.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| count distinct occupancy pairs `(S,k)` on 64 cells | **USED** | image size 8 |
+| treat leftover Aut yes/no as the occupancy label | **ATTEMPTED** | that character is `#6383`, a different object |
+| identify each `(S,k)` with a rank-1 projector | **ATTEMPTED** | requires an unsupplied axis–Pauli pairing |
+| use `Aut(M_2)` to reduce cells | **ATTEMPTED** | `Aut(M_2)` is not used |
+| derive formation site or rate from `S` | **ATTEMPTED** | `S` is occupancy content, not a formation rule |
+| adopt the eight pairs as a physical menu | **ATTEMPTED** | displayed, not adopted |
+
+### N2 — wall independence
+
+One identification wall is claimed: occupancy pairs are not projectors and
+not Aut leftover. The image-size count is a positive finite census, not a
+second wall.
+
+### N3 — hidden-wall scan
+
+The carrier, bit order, and label map are declared. No formation process,
+clock, operator pairing, leftover Aut character, or adopted physical menu is
+imported.
+
+### N4 — residual matching
+
+The residual after this census is any later pairing of occupancy bits with
+operators, formation, or Aut data. The residual is not closed and is not
+enlarged.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — every one of the 64 cells is labeled
+per-site: executed — the three axes x,y,z are the only site directions used
+per-mode: not applicable — no modal or spectral decomposition is used
+per-block: executed — image, fibers, invariances, and the projector refusal
+lattice-wide: not executed — no global history or formation law is claimed
+```
+
+### N6 — partial-closure paths
+
+A separately supplied axis–Pauli pairing could still define projectors. A
+separately supplied formation rule could still lock one admissible
+possibility. Those routes remain live and are outside the occupancy census.
+
+### N7 — steelman
+
+The strongest objection is that `k` is redundant because `k=|S|`, so the
+true label is just `S`. Correct that `k` is determined by `S`. The displayed
+object is nevertheless the pair `(S,k)`, as required by the occupancy-lock
+split against projectors. Redundancy of the integer does not identify the
+pair with a projector.
+
+### N8 — cross-cycle echo
+
+Claim `#6383` split Aut yes/no leftover character from other content. This
+note does not replay that split. It pins only the occupancy-only label set
+`(S,k)` and refuses the projector reading.
+
+## Boundaries and explicit non-claims
+
+- The eight pairs are displayed, not adopted.
+- Occupancy bits are a declared finite alphabet, not a derived local
+  possibility domain.
+- The theorem does not construct `Aut(M_2)` and does not consume leftover
+  Aut character.
+- The theorem does not supply formation site, process, rate, or readout
+  values beyond occupancy equality.
+- No axiom, primitive, registry, or audit verdict is edited.
+
+FAIL / DO NOT SHIP for “occupancy labels are rank-1 projectors”, “this is the
+Aut leftover of `#6383`”, or “the eight pairs are adopted physical content”.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/occupancy_lock_label_pairs_2026_08_15.py
+```
+
+The runner enumerates the 64 cells, checks the image, fibers, invariances,
+and the projector/Aut refusal, and pins the declared source paths. Expected
+summary:
+
+```text
+TOTAL: PASS>=14 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13413,6 +13413,10 @@
   "occupancy_atom_is_the_outcome_dictionary_flow_selects_equipartition_bounded_note_2026-06-12": {
    "deps_hash": "61b6add32af6",
    "out_degree": 3
+  },
+  "occupancy_lock_label_pairs_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "occupancy_nonexclusivity_mixture_bound_note_2026-06-09": {
    "deps_hash": "188680808cab",

--- a/logs/runner-cache/occupancy_lock_label_pairs_2026_08_15.txt
+++ b/logs/runner-cache/occupancy_lock_label_pairs_2026_08_15.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/occupancy_lock_label_pairs_2026_08_15.py
+runner_sha256: f55d6b584cc0b597352fe168ad874d901259636d084b668467959764e05b8f44
+input_fingerprint_sha256: 2a4e31f6f4612fbc535ccc0b42501ba2991ab9c86294b307639614009212e4d2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/OCCUPANCY_LOCK_LABEL_PAIRS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: occupancy-only labels on the declared 64-cell carrier; displayed, not adopted; no Aut(M_2) and no projector pairing
+PASS: audit-input-paths declared inputs are exactly the note and the current axiom memo
+PASS: audit-timeout-declared audit timeout is the standing 120-second bound
+PASS: source-lock-sentence current Record locks exactly one admissible local possibility
+PASS: source-content-readout current Record determines a readout by record content alone
+PASS: cell-count-64 the occupancy carrier is exactly the 64 binary six-tuples
+PASS: k-determined-by-S the displayed integer k equals |S| on every cell
+PASS: theorem-1-image-size-8 the image of lambda has size 8
+PASS: theorem-1-binomial-split the eight labels split as 1+3+3+1 empty and nonempty subsets
+PASS: theorem-2-k0-axis-balanced cells with k=0 are exactly the 8 axis-balanced 6-tuples
+PASS: theorem-2-nonempty-S-realized every nonempty S occurs as an occupancy label
+PASS: theorem-2-eight-cells-per-label every occupancy label has exactly eight indistinguishable cells
+PASS: theorem-2-k-census the occupancy census is 8,24,24,8 by k
+PASS: theorem-3-balanced-swap swapping the two bits on any balanced axis leaves lambda fixed
+PASS: theorem-3-unbalanced-joint-flip flipping both bits on an unbalanced axis leaves S unchanged
+PASS: occupancy-only-indistinguishability two distinct cells can share a label and are then occupancy-indistinguishable
+PASS: not-rank-1-projector lambda is a discrete pair-valued map, not a rank-1 projector
+PASS: note-contract claim scope, machine fields, and displayed-not-adopted wording hold
+PASS: forbidden-hygiene the note avoids the standing forbidden tokens
+PASS: theorem-statement-hygiene the theorem block names no Bloch sphere, no PVM, and no generator symbol
+PASS: negative-check-may-name-pvm the negative check may refuse a projector-valued reading
+per_element: every one of the 64 occupancy cells is labeled
+per_site: only the three cubic axes enter S
+per_mode: checked and not executed — no spectral pairing is claimed
+per_block: image, fibers, invariances, and projector refusal are executed
+lattice_wide: checked and not executed — no formation law is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/occupancy_lock_label_pairs_2026_08_15.py
+++ b/scripts/occupancy_lock_label_pairs_2026_08_15.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Exact census of occupancy-only lock labels (S,k) on 64 binary six-tuples.
+
+The paired note is
+docs/OCCUPANCY_LOCK_LABEL_PAIRS_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+The 64-cell carrier and the map lambda are declared finite test objects.
+No Aut(M_2) reduction, projector pairing, formation process, cache write,
+or axiom edit is performed.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/OCCUPANCY_LOCK_LABEL_PAIRS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+AXES = ("x", "y", "z")
+ALL_SUBSETS = tuple(
+    frozenset(bits)
+    for bits in (
+        (),
+        ("x",),
+        ("y",),
+        ("z",),
+        ("x", "y"),
+        ("x", "z"),
+        ("y", "z"),
+        ("x", "y", "z"),
+    )
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_bits(cell: tuple[int, ...], axis: str) -> tuple[int, int]:
+    index = AXES.index(axis)
+    return cell[2 * index], cell[2 * index + 1]
+
+
+def unbalanced_axes(cell: tuple[int, ...]) -> frozenset[str]:
+    return frozenset(axis for axis in AXES if axis_bits(cell, axis)[0] != axis_bits(cell, axis)[1])
+
+
+def label_of(cell: tuple[int, ...]) -> tuple[frozenset[str], int]:
+    axes = unbalanced_axes(cell)
+    return axes, len(axes)
+
+
+def swap_axis(cell: tuple[int, ...], axis: str) -> tuple[int, ...]:
+    index = AXES.index(axis)
+    values = list(cell)
+    values[2 * index], values[2 * index + 1] = values[2 * index + 1], values[2 * index]
+    return tuple(values)
+
+
+def flip_both(cell: tuple[int, ...], axis: str) -> tuple[int, ...]:
+    index = AXES.index(axis)
+    values = list(cell)
+    values[2 * index] = 1 - values[2 * index]
+    values[2 * index + 1] = 1 - values[2 * index + 1]
+    return tuple(values)
+
+
+def exhibit(subset: frozenset[str]) -> tuple[int, ...]:
+    values: list[int] = []
+    for axis in AXES:
+        if axis in subset:
+            values.extend((1, 0))
+        else:
+            values.extend((0, 0))
+    return tuple(values)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    cells = tuple(product((0, 1), repeat=6))
+    labels = tuple(label_of(cell) for cell in cells)
+    image = frozenset(labels)
+    fibers: dict[tuple[frozenset[str], int], list[tuple[int, ...]]] = {}
+    for cell, pair in zip(cells, labels, strict=True):
+        fibers.setdefault(pair, []).append(cell)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "scope: occupancy-only labels on the declared 64-cell carrier; "
+        "displayed, not adopted; no Aut(M_2) and no projector pairing"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the note and the current axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/OCCUPANCY_LOCK_LABEL_PAIRS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+        AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "audit-timeout-declared",
+        "audit timeout is the standing 120-second bound",
+        AUDIT_TIMEOUT_SEC == 120,
+        AUDIT_TIMEOUT_SEC,
+    )
+    checks.check(
+        "source-lock-sentence",
+        "current Record locks exactly one admissible local possibility",
+        "When present, a record locks exactly one admissible local possibility." in axiom,
+    )
+    checks.check(
+        "source-content-readout",
+        "current Record determines a readout by record content alone",
+        "A readout value is determined by record content alone." in normalized_axiom,
+    )
+    checks.check(
+        "cell-count-64",
+        "the occupancy carrier is exactly the 64 binary six-tuples",
+        len(cells) == 64 and len(set(cells)) == 64,
+        len(cells),
+    )
+    checks.check(
+        "k-determined-by-S",
+        "the displayed integer k equals |S| on every cell",
+        all(pair[1] == len(pair[0]) for pair in labels),
+    )
+    expected_image = frozenset((subset, len(subset)) for subset in ALL_SUBSETS)
+    checks.check(
+        "theorem-1-image-size-8",
+        "the image of lambda has size 8",
+        len(image) == 8 and image == expected_image,
+        sorted((sorted(subset), k) for subset, k in image),
+    )
+    split = (
+        sum(1 for subset, _ in image if len(subset) == 0),
+        sum(1 for subset, _ in image if len(subset) == 1),
+        sum(1 for subset, _ in image if len(subset) == 2),
+        sum(1 for subset, _ in image if len(subset) == 3),
+    )
+    checks.check(
+        "theorem-1-binomial-split",
+        "the eight labels split as 1+3+3+1 empty and nonempty subsets",
+        split == (1, 3, 3, 1) and 1 + 3 + 3 + 1 == 8,
+        split,
+    )
+    balanced = tuple(cell for cell in cells if label_of(cell)[1] == 0)
+    axis_balanced = tuple(
+        cell for cell in cells if all(axis_bits(cell, axis)[0] == axis_bits(cell, axis)[1] for axis in AXES)
+    )
+    checks.check(
+        "theorem-2-k0-axis-balanced",
+        "cells with k=0 are exactly the 8 axis-balanced 6-tuples",
+        balanced == axis_balanced and len(balanced) == 8,
+        len(balanced),
+    )
+    nonempty_realized = all(
+        fibers[(subset, len(subset))] and label_of(exhibit(subset)) == (subset, len(subset))
+        for subset in ALL_SUBSETS
+        if subset
+    )
+    checks.check(
+        "theorem-2-nonempty-S-realized",
+        "every nonempty S occurs as an occupancy label",
+        nonempty_realized,
+    )
+    fiber_sizes = {pair: len(members) for pair, members in fibers.items()}
+    checks.check(
+        "theorem-2-eight-cells-per-label",
+        "every occupancy label has exactly eight indistinguishable cells",
+        all(size == 8 for size in fiber_sizes.values()) and sum(fiber_sizes.values()) == 64,
+        fiber_sizes,
+    )
+    k_census = tuple(sum(1 for cell in cells if label_of(cell)[1] == k) for k in range(4))
+    checks.check(
+        "theorem-2-k-census",
+        "the occupancy census is 8,24,24,8 by k",
+        k_census == (8, 24, 24, 8),
+        k_census,
+    )
+    swap_ok = all(
+        label_of(swap_axis(cell, axis)) == label_of(cell)
+        for cell in cells
+        for axis in AXES
+        if axis not in unbalanced_axes(cell)
+    )
+    checks.check(
+        "theorem-3-balanced-swap",
+        "swapping the two bits on any balanced axis leaves lambda fixed",
+        swap_ok,
+    )
+    flip_ok = all(
+        label_of(flip_both(cell, axis)) == label_of(cell)
+        for cell in cells
+        for axis in AXES
+        if axis in unbalanced_axes(cell)
+    )
+    checks.check(
+        "theorem-3-unbalanced-joint-flip",
+        "flipping both bits on an unbalanced axis leaves S unchanged",
+        flip_ok,
+    )
+    same_label_pairs = all(len(members) >= 2 for members in fibers.values())
+    checks.check(
+        "occupancy-only-indistinguishability",
+        "two distinct cells can share a label and are then occupancy-indistinguishable",
+        same_label_pairs
+        and label_of((0, 0, 0, 0, 0, 0)) == label_of((1, 1, 1, 1, 1, 1)) == (frozenset(), 0),
+    )
+    checks.check(
+        "not-rank-1-projector",
+        "lambda is a discrete pair-valued map, not a rank-1 projector",
+        all(isinstance(pair[0], frozenset) and isinstance(pair[1], int) for pair in image)
+        and "not a rank-1 projector" in note
+        and "axis–Pauli pairing" in note
+        and "Aut(M_2)" in note
+        and "does not use Aut(M_2)" in note,
+    )
+    required = (
+        'claim_scope: "Occupancy-only lock labels are the 8 pairs (S,k) for S⊆{x,y,z}. This is not a PVM and does not use Aut(M_2). Displayed, not adopted."',
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: negative_route_pruning",
+        'hypothetical_axiom_status: "no edit"',
+        "Displayed, not adopted",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+    )
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+    )
+    theorem_block = note.split("## Theorem 1", 1)[1].split("## Negative check", 1)[0]
+    checks.check(
+        "note-contract",
+        "claim scope, machine fields, and displayed-not-adopted wording hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9)),
+        [phrase for phrase in required if phrase not in note],
+    )
+    checks.check(
+        "forbidden-hygiene",
+        "the note avoids the standing forbidden tokens",
+        all(token not in note for token in forbidden),
+        [token for token in forbidden if token in note],
+    )
+    checks.check(
+        "theorem-statement-hygiene",
+        "the theorem block names no Bloch sphere, no PVM, and no generator symbol",
+        "Bloch" not in theorem_block
+        and "PVM" not in theorem_block
+        and "σ" not in theorem_block
+        and "sigma" not in theorem_block.lower(),
+    )
+    checks.check(
+        "negative-check-may-name-pvm",
+        "the negative check may refuse a projector-valued reading",
+        "not a projector-valued measure" in note and "This is not a PVM" in note,
+    )
+
+    print("per_element: every one of the 64 occupancy cells is labeled")
+    print("per_site: only the three cubic axes enter S")
+    print("per_mode: checked and not executed — no spectral pairing is claimed")
+    print("per_block: image, fibers, invariances, and projector refusal are executed")
+    print("lattice_wide: checked and not executed — no formation law is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Occupancy-only labels on 64 binary six-tuples are the 8 pairs (S,k). Not a PVM and not Aut leftover of #6383. Displayed, not adopted.

## Runner

`scripts/occupancy_lock_label_pairs_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.