### PR TITLE
feat(ftwoseed): f_two first wave exists from a 2-site face-diagonal seed

### DIFF
--- a/docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,241 @@
+---
+claim_id: f_two_minimal_seed_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the twelve-vertex two-cube with off-patch o=0, f_two has no first wave from 1-site seeds, has a first wave from an explicit 2-site face-diagonal seed (22 of 66 pairs), and has a first wave from an explicit 3-site seed. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_two_minimal_seed_2026_08_15.py
+---
+
+# Minimal Occupancy Seed For An `f_two` First Wave
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** first-wave occupancy of the displayed two-axis predicate
+`f_two` (`u ≥ 2`) on the twelve-vertex two-cube of construction `#6320`
+with off-patch occupancy `o = 0`. The member is displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_two_minimal_seed_2026_08_15.py`](../scripts/f_two_minimal_seed_2026_08_15.py)
+
+## Result up front
+
+The displayed two-cube has twelve vertices
+
+```text
+A = {0,1}^3,
+B = {1,2} × {0,1}^2,
+P = A ∪ B.
+```
+
+A seed `S ⊂ P` locks exactly the sites in `S`. Off-patch occupancy is the
+displayed L1 vacuum default `o = 0`, used here only to hold the patch data
+fixed and not adopted. At an unlocked site `v ∈ P \ S` write `c_{±μ}` for
+the occupancy of the neighbor `v ± e_μ` and
+
+```text
+u(v) = |{ μ : c_{+μ} ≠ c_{-μ} }|.
+```
+
+The site is ready for `f_two` iff `u(v) ≥ 2`. The first wave of `S` is the
+set of unlocked ready sites.
+
+Every one-site seed has empty first wave: each neighbor of a single lock
+has `u ≤ 1`. That is the leftover one-seed emptiness of `#6384`, now
+checked on all twelve vertices rather than only `(0,0,0)`.
+
+Not every two-site seed is empty. A pair has a nonempty first wave if and
+only if the two sites are opposite corners of an on-patch square (a face
+diagonal). There are `C(12,2) = 66` pairs and exactly 22 face diagonals
+(six faces on cube `A`, six on cube `B`, two diagonals each, minus the two
+diagonals of the shared face counted twice). One explicit pair is
+
+```text
+S2 = {(0,0,0), (1,1,0)},
+first wave = {(1,0,0), (0,1,0)}.
+```
+
+The three axis neighbors of the corner `(0,0,0)` also work:
+
+```text
+S3 = {(1,0,0), (0,1,0), (0,0,1)},
+first wave = {(0,0,0), (1,0,1), (1,1,0), (0,1,1)}.
+```
+
+So the minimal occupancy-seed cardinality that makes the first wave of
+`f_two` nonempty on this patch is 2. L1's displayed one-site seed already
+has a three-site first wave; that is a member difference, not an
+L1-identity clone. This note does not adopt `f_two`.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The one-site emptiness, the 22-of-66 face-diagonal pair census, and the explicit 2-site and 3-site first waves are finite exact listings on twelve vertices; no physical formation rule is selected."
+trace_class: frontier_discovery
+target_claim_id: f_two_minimal_occupancy_seed_cardinality
+target_blocker_text: "smallest occupancy seed on the displayed two-cube that makes the first wave of f_two nonempty"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "further structure beyond a nonempty first wave is required before any displayed occupancy-to-lock predicate can be adopted"
+conditional_surface_status: "exact on the displayed twelve-vertex two-cube with o=0; no physical law, rate, or site selector"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+The current Lattice and Admissibility wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is:
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility names one fixed covariant rule and leaves form open: read with
+Record, the distribution is conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+Record states:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+Those sentences identify the covariance group, the lock operation, and the
+open formation slot. They do not name `f_two`, a seed cardinality, or a
+two-cube. The alphabet `{0,1}` on occupancy, the patch `P`, and `o = 0`
+are displayed construction data from `#6320` and `#6384`, not axiom text.
+
+## Exact objects
+
+Slots are ordered `(+x,-x,+y,-y,+z,-z)`. Occupancy of a locked site is `1`.
+Occupancy of an unlocked on-patch site is `0`. Occupancy of an off-patch
+site is `o = 0`. The occupancy 6-tuple at `v ∈ P` is the six neighbor
+occupancies. Then
+
+```text
+f_two(c) = 1  iff  u(c) ≥ 2,
+f_L1(c)  = 1  iff  u(c) ≥ 1.
+```
+
+`f_L1` is displayed only as a contrast on one-site seeds. Neither predicate
+is adopted.
+
+A pair `{p,q} ⊂ P` is a face diagonal when the taxicab distance is 2, the
+coordinatewise max-gap is 1, and `p` and `q` have exactly two common
+on-patch neighbors. Those two neighbors are the other corners of the unique
+on-patch square they span.
+
+## Theorem 1 — every one-site seed has empty first wave
+
+Let `S = {s}` with `s ∈ P`. For an unlocked site `v`, an axis `μ` is
+unbalanced only if exactly one of `v ± e_μ` equals `s`. A site has at most
+one neighbor equal to `s`, so `u(v) ≤ 1`. Ready for `f_two` requires
+`u(v) ≥ 2`. The first wave is empty.
+
+Direct evaluation on all twelve seeds confirms emptiness. In particular the
+three axis neighbors of `(0,0,0)` each have `u = 1`, which is the `#6384`
+one-seed fact, now the full one-site census rather than leftover character
+of that single seed.
+
+## Theorem 2 — two-site first waves are exactly the face diagonals
+
+There are `C(12,2) = 66` two-site seeds.
+
+If `{p,q}` is an on-patch face diagonal, the other two corners `v,w` of
+that square are each adjacent to both locks along two distinct axes. At
+each of `v` and `w` those two axes are unbalanced and the third is
+balanced, so `u = 2`. Both corners are unlocked. The first wave is
+`{v,w}`.
+
+If `{p,q}` is not a face diagonal, no unlocked site is adjacent to both
+locks along two distinct axes. A site adjacent to only one lock has
+`u ≤ 1`. A site adjacent to both locks along the same axis (the midpoint
+of an axis segment of length 2) has that axis balanced (`1 = 1`) and the
+other axes empty, so `u = 0`. The first wave is empty.
+
+The two-cube has six faces on `A` and six on `B`. Each face contributes two
+diagonals. The shared face `x = 1` is counted in both cubes, so the number
+of distinct face diagonals is
+
+```text
+6·2 + 6·2 − 2 = 22.
+```
+
+Direct listing confirms: 22 pairs have nonempty first wave, 44 have empty
+first wave, and the nonempty set is exactly the face-diagonal set. One
+explicit witness is `S2` above.
+
+The statement “every two-site seed has empty first wave” is therefore
+false. It is recorded here as a failed mutation, not as a theorem.
+
+## Theorem 3 — an explicit three-site seed has a nonempty first wave
+
+Let `S3` be the three axis neighbors of the corner `(0,0,0)`,
+
+```text
+S3 = {(1,0,0), (0,1,0), (0,0,1)}.
+```
+
+The corner itself has the three locks on its three on-patch axes and
+off-patch `0` on the opposite slots, so `u((0,0,0)) = 3`. It is unlocked,
+hence ready. Direct evaluation gives the full first wave
+
+```text
+{(0,0,0), (1,0,1), (1,1,0), (0,1,1)}.
+```
+
+The last three sites are the face-diagonal partners of pairs inside `S3`.
+The first wave is nonempty. Combined with Theorem 1 and Theorem 2, the
+minimal seed cardinality for a nonempty `f_two` first wave on this patch
+is 2, not 3.
+
+## Obligation graph
+
+| obligation | exact disposition |
+|---|---|
+| `\|P\| = 12` | `A ∪ B` listed |
+| off-patch default | displayed `o = 0`, not adopted |
+| ready | `u ≥ 2` and unlocked |
+| one-site first wave | empty on all 12 seeds (Theorem 1) |
+| pair count | `C(12,2) = 66` |
+| face-diagonal count | `22` |
+| two-site first wave | nonempty iff face diagonal (Theorem 2) |
+| explicit pair | `S2` with wave `{(1,0,0),(0,1,0)}` |
+| explicit triple | `S3` with four-site wave (Theorem 3) |
+| minimal cardinality | `2` |
+| L1 one-site contrast | first wave of `{(0,0,0)}` has three sites |
+| adopt `f_two` | not claimed |
+
+## Imports and non-claims
+
+The only scientific dependency is the current four-axiom authority linked
+above, used only to pin the lattice adjacency, the lock operation, and the
+open formation slot. The two-cube, the off-patch default, and `f_two` are
+displayed construction data. No observational comparator is admitted. No
+dynamics, Hamiltonian, or record-production process is constructed.
+
+This note is a seed-cardinality census for one displayed predicate. It is
+not leftover-character of the `#6384` one-seed emptiness and not an
+L1-identity replay. It does not adopt `f_two`. It does not write axiom
+sentences.
+
+## Value and no-go boundary
+
+The positive content is the exact one-site emptiness, the exact 22-of-66
+face-diagonal pair census, and the explicit 2-site and 3-site first waves.
+The negative content is only that one-site seeds do not start `f_two` on
+this patch, and that “every pair is empty” fails. Further structure could
+still select or reject the member. No global impossibility of a formation
+rule is claimed.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_two_minimal_seed_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_two_minimal_seed_2026_08_15.txt
+++ b/logs/runner-cache/f_two_minimal_seed_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/f_two_minimal_seed_2026_08_15.py
+runner_sha256: 6ad88d3ee0edf76fc5a65af238965ad19824611a705750589b4acf287e555dee
+input_fingerprint_sha256: 75a1de073e1ff1f7d1f2af9204009e5b74de56c6dfe1159fd2cfbdfeeb365664
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+Minimal occupancy seed for an f_two first wave
+AUDIT_INPUT_PATHS:
+  docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: displayed f_two first-wave seed census on the two-cube; not adopted
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-literal
+PASS: audit-timeout-declared
+PASS: source-lattice-current
+PASS: source-one-fixed-covariant-rule-current
+PASS: source-formation-open-current
+PASS: source-records-form-current
+PASS: note-no-axiom-edit
+PASS: two-cube-has-twelve-sites
+PASS: off-patch-default-is-zero
+PASS: thm1-all-one-site-empty  (n=12)
+PASS: thm1-neighbors-u-leq-1  (max_u=1)
+pair_count=66
+nonempty_pair_count=22
+face_diagonal_count=22
+PASS: pair-count-66
+PASS: thm2-face-diagonal-count-22  (count=22)
+PASS: thm2-nonempty-equals-face-diagonals  (nonempty=22)
+PASS: thm2-non-face-diagonals-empty
+PASS: mutation-all-pairs-empty-fails
+explicit_pair=((0, 0, 0), (1, 1, 0))
+explicit_pair_wave=[(0, 1, 0), (1, 0, 0)]
+PASS: thm2-explicit-pair-wave
+explicit_triple=((1, 0, 0), (0, 1, 0), (0, 0, 1))
+explicit_triple_wave=[(0, 0, 0), (0, 1, 1), (1, 0, 1), (1, 1, 0)]
+PASS: thm3-explicit-triple-nonempty
+PASS: thm3-triple-is-axis-neighbors-of-corner
+PASS: minimal-cardinality-is-2
+PASS: l1-one-site-contrast-nonempty
+PASS: not-l1-identity
+PASS: note-reports-pair-census
+PASS: note-reports-explicit-triple
+PASS: note-claim-scope-displayed-not-adopted
+PASS: note-does-not-claim-all-pairs-empty
+PASS: note-records-failed-all-pairs-empty
+PASS: forbidden-phrase-hygiene
+PASS: no-runner-cache-or-citation-manifest
+per_element: checked exactly — u and readiness at each unlocked site
+per_site: checked exactly — all twelve vertices as one-site seeds
+per_mode: checked exactly — all 66 pairs and the explicit triple
+per_block: checked exactly — face-diagonal census versus first-wave emptiness
+lattice_wide: checked and not executed — no physical formation law is selected
+TOTAL: PASS=30 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_two_minimal_seed_2026_08_15.py
+++ b/scripts/f_two_minimal_seed_2026_08_15.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Minimal occupancy seed for a nonempty f_two first wave.
+
+The paired note is
+docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+Objects: the displayed twelve-vertex two-cube with off-patch occupancy 0,
+seeds as lock sets, and f_two (form iff at least two axes unbalanced).
+The predicate is displayed, not adopted. No axiom sentence is written.
+No cache is written.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+SLOTS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXIS_PAIRS = ((0, 1), (2, 3), (4, 5))
+OFF_PATCH = 0
+SEED3 = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SEED2 = ((0, 0, 0), (1, 1, 0))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def two_cube_patch() -> frozenset[tuple[int, int, int]]:
+    cube_a = product((0, 1), (0, 1), (0, 1))
+    cube_b = product((1, 2), (0, 1), (0, 1))
+    return frozenset(cube_a) | frozenset(cube_b)
+
+
+def occupancy(
+    site: tuple[int, int, int],
+    locked: frozenset[tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> int:
+    if site in locked:
+        return 1
+    if site not in patch:
+        return OFF_PATCH
+    return 0
+
+
+def neighbor_cell(
+    site: tuple[int, int, int],
+    locked: frozenset[tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> tuple[int, ...]:
+    return tuple(
+        occupancy(
+            (site[0] + slot[0], site[1] + slot[1], site[2] + slot[2]),
+            locked,
+            patch,
+        )
+        for slot in SLOTS
+    )
+
+
+def unbalanced_axis_count(cell: tuple[int, ...]) -> int:
+    return sum(cell[plus] != cell[minus] for plus, minus in AXIS_PAIRS)
+
+
+def f_two(cell: tuple[int, ...]) -> int:
+    return int(unbalanced_axis_count(cell) >= 2)
+
+
+def f_l1(cell: tuple[int, ...]) -> int:
+    return int(unbalanced_axis_count(cell) >= 1)
+
+
+def first_wave(
+    func,
+    locked: frozenset[tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> frozenset[tuple[int, int, int]]:
+    return frozenset(
+        site
+        for site in patch
+        if site not in locked and func(neighbor_cell(site, locked, patch)) == 1
+    )
+
+
+def on_patch_neighbors(
+    site: tuple[int, int, int],
+    patch: frozenset[tuple[int, int, int]],
+) -> frozenset[tuple[int, int, int]]:
+    return frozenset(
+        (site[0] + slot[0], site[1] + slot[1], site[2] + slot[2])
+        for slot in SLOTS
+        if (site[0] + slot[0], site[1] + slot[1], site[2] + slot[2]) in patch
+    )
+
+
+def taxicab(left: tuple[int, int, int], right: tuple[int, int, int]) -> int:
+    return sum(abs(left[i] - right[i]) for i in range(3))
+
+
+def max_gap(left: tuple[int, int, int], right: tuple[int, int, int]) -> int:
+    return max(abs(left[i] - right[i]) for i in range(3))
+
+
+def is_face_diagonal(
+    pair: tuple[tuple[int, int, int], tuple[int, int, int]],
+    patch: frozenset[tuple[int, int, int]],
+) -> bool:
+    left, right = pair
+    shared = on_patch_neighbors(left, patch) & on_patch_neighbors(right, patch)
+    return taxicab(left, right) == 2 and max_gap(left, right) == 1 and len(shared) == 2
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("Minimal occupancy seed for an f_two first wave")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: displayed f_two first-wave seed census on the two-cube; not adopted")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-paths-literal",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_TWO_MINIMAL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(
+            not Path(path).is_absolute() and ".." not in Path(path).parts
+            for path in AUDIT_INPUT_PATHS
+        ),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    covariant_rule_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice "
+        "translations and proper cubic rotations."
+    )
+    formation_boundary = "it does not supply the formation site, probability, or rate"
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-current",
+        lattice_sentence in normalized_axiom and lattice_sentence in normalized_note,
+    )
+    checks.check(
+        "source-one-fixed-covariant-rule-current",
+        covariant_rule_sentence in normalized_axiom
+        and covariant_rule_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-open-current",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-records-form-current",
+        records_form in axiom and records_form in note,
+    )
+    checks.check(
+        "note-no-axiom-edit",
+        "hypothetical_axiom_status: no edit" in note
+        or 'hypothetical_axiom_status: "no edit"' in note,
+    )
+
+    patch = two_cube_patch()
+    sites = tuple(sorted(patch))
+    checks.check("two-cube-has-twelve-sites", len(patch) == 12 and len(sites) == 12)
+    checks.check("off-patch-default-is-zero", OFF_PATCH == 0)
+
+    one_site_waves = {
+        seed: first_wave(f_two, frozenset({seed}), patch) for seed in sites
+    }
+    one_site_max_u = []
+    for seed in sites:
+        locked = frozenset({seed})
+        for site in patch:
+            if site == seed:
+                continue
+            one_site_max_u.append(unbalanced_axis_count(neighbor_cell(site, locked, patch)))
+    checks.check(
+        "thm1-all-one-site-empty",
+        all(wave == frozenset() for wave in one_site_waves.values()),
+        f"n={len(one_site_waves)}",
+    )
+    checks.check(
+        "thm1-neighbors-u-leq-1",
+        one_site_max_u and max(one_site_max_u) <= 1,
+        f"max_u={max(one_site_max_u) if one_site_max_u else None}",
+    )
+
+    pairs = tuple(combinations(sites, 2))
+    pair_waves = {
+        pair: first_wave(f_two, frozenset(pair), patch) for pair in pairs
+    }
+    nonempty_pairs = tuple(pair for pair, wave in pair_waves.items() if wave)
+    empty_pairs = tuple(pair for pair, wave in pair_waves.items() if not wave)
+    face_diags = tuple(pair for pair in pairs if is_face_diagonal(pair, patch))
+    face_diag_set = set(face_diags)
+    nonempty_set = set(nonempty_pairs)
+    print(f"pair_count={len(pairs)}")
+    print(f"nonempty_pair_count={len(nonempty_pairs)}")
+    print(f"face_diagonal_count={len(face_diags)}")
+
+    checks.check("pair-count-66", len(pairs) == 66)
+    checks.check(
+        "thm2-face-diagonal-count-22",
+        len(face_diags) == 6 * 2 + 6 * 2 - 2 == 22,
+        f"count={len(face_diags)}",
+    )
+    checks.check(
+        "thm2-nonempty-equals-face-diagonals",
+        nonempty_set == face_diag_set,
+        f"nonempty={len(nonempty_pairs)}",
+    )
+    checks.check(
+        "thm2-non-face-diagonals-empty",
+        len(empty_pairs) == 66 - 22
+        and all(not is_face_diagonal(pair, patch) for pair in empty_pairs),
+    )
+    checks.check(
+        "mutation-all-pairs-empty-fails",
+        len(nonempty_pairs) != 0,
+    )
+
+    wave2 = pair_waves[SEED2]
+    expected2 = frozenset({(1, 0, 0), (0, 1, 0)})
+    print(f"explicit_pair={SEED2}")
+    print(f"explicit_pair_wave={sorted(wave2)}")
+    checks.check(
+        "thm2-explicit-pair-wave",
+        SEED2 in face_diag_set and wave2 == expected2,
+    )
+
+    locked3 = frozenset(SEED3)
+    wave3 = first_wave(f_two, locked3, patch)
+    expected3 = frozenset({(0, 0, 0), (1, 0, 1), (1, 1, 0), (0, 1, 1)})
+    print(f"explicit_triple={SEED3}")
+    print(f"explicit_triple_wave={sorted(wave3)}")
+    checks.check("thm3-explicit-triple-nonempty", wave3 == expected3 and len(wave3) >= 1)
+    checks.check(
+        "thm3-triple-is-axis-neighbors-of-corner",
+        locked3 == on_patch_neighbors((0, 0, 0), patch) and (0, 0, 0) in wave3,
+    )
+    checks.check(
+        "minimal-cardinality-is-2",
+        all(wave == frozenset() for wave in one_site_waves.values())
+        and len(nonempty_pairs) >= 1
+        and len(wave3) >= 1,
+    )
+
+    l1_wave = first_wave(f_l1, frozenset({(0, 0, 0)}), patch)
+    checks.check(
+        "l1-one-site-contrast-nonempty",
+        l1_wave == on_patch_neighbors((0, 0, 0), patch) and len(l1_wave) == 3,
+    )
+    checks.check(
+        "not-l1-identity",
+        first_wave(f_two, frozenset({(0, 0, 0)}), patch) != l1_wave,
+    )
+
+    checks.check(
+        "note-reports-pair-census",
+        "22 of 66" in note and "S2 = {(0,0,0), (1,1,0)}" in note,
+    )
+    checks.check(
+        "note-reports-explicit-triple",
+        "S3 = {(1,0,0), (0,1,0), (0,0,1)}" in note
+        and "(0,0,0), (1,0,1), (1,1,0), (0,1,1)" in note,
+    )
+    checks.check(
+        "note-claim-scope-displayed-not-adopted",
+        "Displayed, not adopted" in note and "does not adopt `f_two`" in note,
+    )
+    checks.check(
+        "note-does-not-claim-all-pairs-empty",
+        "every two-site seed has empty first wave” is therefore" in note
+        or 'every two-site seed has empty first wave" is therefore' in note
+        or "every two-site seed has empty first wave` is therefore" in note,
+    )
+    # The previous check is fragile. Also require the failed-mutation sentence.
+    checks.check(
+        "note-records-failed-all-pairs-empty",
+        "failed mutation" in note and "minimal occupancy-seed cardinality" in note,
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE", "new axiom")
+    checks.check(
+        "forbidden-phrase-hygiene",
+        all(phrase not in note for phrase in forbidden),
+        ",".join(phrase for phrase in forbidden if phrase in note),
+    )
+    checks.check(
+        "no-runner-cache-or-citation-manifest",
+        "runner-cache" not in note
+        and "citation_manifest" not in note
+        and "CITATION_MANIFEST" not in note,
+    )
+
+    print("per_element: checked exactly — u and readiness at each unlocked site")
+    print("per_site: checked exactly — all twelve vertices as one-site seeds")
+    print("per_mode: checked exactly — all 66 pairs and the explicit triple")
+    print("per_block: checked exactly — face-diagonal census versus first-wave emptiness")
+    print("lattice_wide: checked and not executed — no physical formation law is selected")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the twelve-vertex two-cube with off-patch o=0, every 1-site seed of displayed f_two has empty first wave. Exactly 22 of 66 two-site seeds (the face diagonals) have a nonempty first wave. An explicit 3-site axis triple also works. The spec's "all pairs empty" guess fails; minimal seed cardinality is 2. Displayed, not adopted.

## Runner

`scripts/f_two_minimal_seed_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.