### PR TITLE
feat(blankclass): blank-slot covariant formation class is larger than F_G

### DIFF
--- a/docs/BLANK_SLOT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/BLANK_SLOT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,347 @@
+---
+claim_id: blank_slot_formation_predicate_class_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Cube-covariant boolean predicates on {0,1,blank}^6 form a set of size 2^{N_orb_⊥} with N_orb_⊥ > 10. Restriction to {0,1}^6 is onto F_G. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/blank_slot_formation_predicate_class_2026_08_15.py
+---
+
+# Blank-Slot Formation-Predicate Class
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact orbit count of cube-covariant boolean predicates on the
+six nearest-neighbor slots with alphabet `{0,1,blank}`. The class is
+displayed, not adopted as a physical formation law.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/blank_slot_formation_predicate_class_2026_08_15.py`](../scripts/blank_slot_formation_predicate_class_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The six nearest-neighbor slots at one site carry letters from the three-letter
+alphabet `A = {0,1,blank}`. The configuration space is `A^6` and has 729
+cells. The group `G` of 24 proper cube rotations permutes those slots and
+fixes the letter `blank`: a rotation never turns `blank` into `0` or `1`.
+
+A boolean ready-predicate is a map `f: A^6 → {0,1}`. It is cube-covariant
+when `f(g·x) = f(x)` for every `g ∈ G`. Such maps are exactly the
+assignments of a bit to each `G`-orbit, so if `N_orb_perp` is the number of
+orbits then
+
+`|F_perp| = 2^{N_orb_perp}`.
+
+Theorem 1 enumerates all 729 cells under the 24 rotations and obtains
+
+`N_orb_perp = 57`, `|F_perp| = 2^{57} = 144115188075855872`.
+
+The same count is recovered from Burnside's lemma. The binary subset
+`{0,1}^6` is `G`-invariant and splits into 10 orbits, so the previously
+counted covariant class `F_G` on `{0,1}^6` has size `2^{10} = 1024`.
+Restriction `F_perp → F_G` is a surjective homomorphism of Boolean cubes:
+every covariant binary predicate extends by the constant `0` on any cell
+that contains a `blank`. Because `N_orb_perp > 10`, one has the strict
+enlargement `|F_perp| > |F_G|`. Blank is new orbit content, not a
+relabeling of `0`.
+
+No member of `F_perp` is selected as a formation site, formation
+probability, formation rate, or Record compiler. The class is displayed,
+not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The only use of those sentences is to name the six nearest-neighbor slots
+and the 24 proper rotations that permute them. The axiom does not name the
+three-letter alphabet, a ready-predicate, or a formation selector.
+
+The current Record wording is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility, read with Record, concerns which possibility a forming record
+locks, conditional on formation at that site; it does not supply the formation
+site, probability, or rate. Counting `F_perp` does not close that gap.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 729-cell enumeration, the 24-element rotation group, the orbit count N_orb_perp=57, the identification |F_perp|=2^{N_orb_perp}, the surjective restriction onto F_G, and the strict inequality N_orb_perp>10 are finite exact identities. No physical ready-predicate is selected."
+trace_class: negative_route_pruning
+target_claim_id: blank_slot_formation_predicate_class
+target_blocker_text: "count the cube-covariant boolean ready-predicates on {0,1,blank}^6 and compare the class to F_G"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Do not adopt a member of F_perp as a formation law. Any physical use must separately derive a selector, a Record content map, and a formation site."
+conditional_surface_status: "exact for boolean G-covariant maps on the displayed three-letter six-slot cube; ternary ready/blocked/no maps and physical adoption remain unclaimed"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Label the six nearest-neighbor directions at the origin by
+
+`(+x,-x,+y,-y,+z,-z)`.
+
+A configuration is a 6-tuple with values in `A = {0,1,blank}`. The letter
+`blank` is a third alphabet symbol, not a synonym for `0`. The group `G` is
+the group of `3×3` signed permutation matrices of determinant `+1`. Each
+matrix sends face normals to face normals and therefore induces a permutation
+of the six slots. There are 24 such matrices, they form a group, and the
+induced slot permutations are 24 distinct elements of `S_6`.
+
+The action on configurations is the ordinary left action
+
+`(g·x)_i = x_{g^{-1}i}`.
+
+Because `g` only permutes coordinates, the letter-count triple
+
+`(n_0, n_1, n_blank)`
+
+is a `G`-invariant. In particular `blank` remains `blank`.
+
+Write `F_perp` for the set of functions `f: A^6 → {0,1}` satisfying
+`f(g·x)=f(x)` for all `g∈G`. Write `F_G` for the same class on the
+`G`-invariant subset `{0,1}^6`.
+
+## Theorem 1 — Orbit Count
+
+Enumerate the 729 cells. For each cell form the 24 images under `G` and
+retain the lexicographic minimum as the orbit representative. The distinct
+representatives number
+
+`N_orb_perp = 57`.
+
+Independently, Burnside's lemma applied to the same 24 permutations gives
+
+```text
+(1 · 3^6 + 6 · 3^3 + 3 · 3^4 + 8 · 3^2 + 6 · 3^3) / 24
+  = (729 + 162 + 243 + 72 + 162) / 24
+  = 1368 / 24
+  = 57.
+```
+
+The five summands are the identity, the six 90°/270° face rotations (cycle
+type `4,1,1`), the three 180° face rotations (cycle type `2,2,1,1`), the
+eight 120°/240° vertex rotations (cycle type `3,3`), and the six 180°
+edge rotations (cycle type `2,2,2`). A coloring is fixed only when it is
+constant on cycles, so the displayed powers of 3 are exact.
+
+Covariant boolean predicates assign one bit per orbit, therefore
+
+`|F_perp| = 2^{57} = 144115188075855872`.
+
+This is a new alphabet, not a leftover character of the binary count on
+`{0,1}^6`.
+
+## Theorem 2 — Restriction Onto `F_G`
+
+The subset `{0,1}^6` is `G`-invariant: a rotation never manufactures a
+`blank`. The same enumeration, now restricted to the 64 binary cells, yields
+exactly 10 orbits. Burnside with two letters recovers the same 10. Hence
+`|F_G| = 2^{10} = 1024`.
+
+Restriction of a covariant `f ∈ F_perp` to `{0,1}^6` is a covariant
+predicate on `{0,1}^6`, so there is a well-defined map `F_perp → F_G`.
+It is surjective: given `h ∈ F_G`, set
+
+`f(x) = h(x)` if `x ∈ {0,1}^6`, and `f(x) = 0` if `x` contains a `blank`.
+
+The blank-bearing set is itself `G`-invariant, so `f` is covariant, and
+`f` restricts to `h`. The runner checks this extension on all 1024 members
+of `F_G`.
+
+## Theorem 3 — Strict Enlargement
+
+Of the 57 orbits, exactly 10 are binary and 47 contain at least one
+`blank`. Therefore `N_orb_perp > 10` and
+
+`|F_perp| = 2^{57} > 2^{10} = |F_G|`.
+
+Letter counts distinguish the new orbits from any relabeling of `0`. The
+all-zero cell `(0,0,0,0,0,0)` and the all-blank cell
+`(blank,blank,blank,blank,blank,blank)` lie in different orbits. The cell
+with a single `blank` and five zeros has letter count `(5,0,1)` and cannot
+be rotated onto any binary cell.
+
+The 10 binary orbits are the classical two-color face colorings of the
+cube. The 47 blank-bearing orbits are additional content. Treating `blank`
+as `0` would collapse those 47 orbits into the 10 binary ones and would
+erase the inequality.
+
+## Mutations
+
+1. Replace `blank` by `0` before counting: the letter-count invariant is
+   destroyed and the orbit count collapses to 10.
+2. Count all boolean maps on `A^6` without covariance: the class has size
+   `2^{729}`, not `2^{57}`.
+3. Replace `G` by the 48-element group that includes reflections: that is
+   a different group and a different class.
+4. Count maps to `{ready, blocked, no}`: that class has size `3^{57}`,
+   which this note does not claim.
+5. Adopt one displayed member of `F_perp` as the formation law: no such
+   selection is performed or licensed.
+6. Claim that restriction `F_perp → F_G` misses some binary predicate:
+   the zero-on-blank extension hits every member of `F_G`.
+
+## What This Does Not Claim
+
+- No physical formation site, probability, or rate.
+- No member of `F_perp` is selected as the Admissibility rule.
+- No ternary ready/blocked/no classification is counted.
+- No Record content map, readout compiler, or occurrence law.
+- No leftover-character reading of the binary class `F_G`.
+- No axiom edit and no approved-primitive registration.
+
+## No-Go Discipline Gate
+
+The negative claim is only that the three-letter covariant class is
+strictly larger than `F_G` and is not a relabeling of the binary alphabet.
+It is not a claim that a physical ready-predicate is impossible, and it is
+not a claim that any particular member of `F_perp` is the formation law.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| leftover-character collapse | Identify `blank` with `0` and reuse the 10 binary orbits. | Theorem 3: letter counts are `G`-invariants; 47 orbits carry a `blank`. | **ATTEMPTED** |
+| unconstrained function count | Count all maps `A^6 → {0,1}` without covariance. | Theorem 1: covariance forces constancy on orbits, so `2^{57}` not `2^{729}`. | **ATTEMPTED** |
+| full octahedral group | Replace the 24 proper rotations by the 48-element group with reflections. | Theorem 1 constructs `G` as determinant-`+1` signed permutation matrices only. | **ATTEMPTED** |
+| ternary ready/blocked/no class | Count maps to a three-value codomain. | The displayed class is boolean; a ternary count would be `3^{57}` and is unclaimed. | **ATTEMPTED** |
+| physical adoption | Treat the existence of `F_perp` as a selected formation predicate. | The class is displayed, not adopted; Admissibility still withholds formation. | **ATTEMPTED** |
+| restriction failure | Claim some covariant binary predicate has no covariant three-letter extension. | Theorem 2: zero-on-blank extension is covariant and hits every member of `F_G`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one counting theorem and one comparison. The Burnside evaluation
+and the 729-cell enumeration are two certificates of the same orbit count;
+they collapse rather than count as independent walls. The surjective
+restriction and the strict inequality are separate conclusions: one compares
+domains, the other compares cardinalities.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| enumeration / Burnside | yes, both compute `N_orb_perp` | yes | collapse into Theorem 1 |
+| restriction onto `F_G` / `|F_perp| > |F_G|` | no: surjectivity does not force extra orbits | no: extra orbits do not by themselves construct the extension | independent conclusions |
+| letter-count invariant / leftover-character collapse | yes, for the relabeling route | yes, as the explicit invariant | collapse into Theorem 3 |
+
+Physical formation, ternary maps, and axiom edits are not walls: this note
+makes no negative theorem that they are impossible and simply does not
+claim them.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| six nearest-neighbor slots | cited Lattice adjacency; grants only the geometric domain |
+| 24 proper cube rotations | cited Lattice/Admissibility covariance group; constructed as det `+1` signed permutation matrices |
+| alphabet `{0,1,blank}` | explicit theorem hypothesis; not supplied by the axioms |
+| boolean ready-predicate | explicit codomain `{0,1}`; ternary maps excluded |
+| “displayed, not adopted” | status of the counted class; not a selected law |
+| Record lock/content/absence | cited only to keep formation and readout unclaimed |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | geometric six-slot domain | cubic nearest-neighbor sites and proper rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:56` | covariance group | one admissibility rule, covariant under proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:68` | formation gap | formation site, probability, and rate remain unsupplied | yes; boundary stays open |
+| `scripts/blank_slot_formation_predicate_class_2026_08_15.py:129` | orbit enumeration | 729 cells under 24 rotations | yes |
+| `scripts/blank_slot_formation_predicate_class_2026_08_15.py:296` | Burnside cross-check | same `N_orb_perp` from cycle index | yes |
+| `scripts/blank_slot_formation_predicate_class_2026_08_15.py:365` | restriction onto `F_G` | zero-on-blank extension hits all 1024 binary predicates | yes |
+| `scripts/blank_slot_formation_predicate_class_2026_08_15.py:380` | strict enlargement | `N_orb_perp > 10` | yes |
+
+No evidence citation is used to claim that a physical ready-predicate,
+formation site, or Record compiler has been selected.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 729 cells | each cell is assigned its orbit representative |
+| per site | yes: six slots at one displayed site | no other site or composite is classified |
+| per mode | yes: boolean `G`-covariant predicates | ternary ready/blocked/no maps are uncounted |
+| per block | yes: restriction `F_perp → F_G` | zero extension is onto; no physical selector is inferred |
+| lattice wide | no | no lattice-wide ready law or formation process is asserted |
+
+### N6 — partial closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies the three-letter alphabet or a ready-predicate.
+None is reclassified as an import or wall.
+
+Two partial-closure mechanisms were tested rather than suppressed. Burnside
+reproduces the enumeration, and zero-on-blank extension reproduces every
+binary covariant predicate. Neither mechanism selects a physical member of
+`F_perp` or supplies formation. Those remaining choices stay explicit and
+do not require an axiom edit to state honestly.
+
+### N7 — hostile steelman
+
+The strongest objection is that `blank` is only an unread site, already
+typed by Record as “a site with no record cannot be read,” so identifying
+`blank` with `0` should not change the covariant class. That objection
+names a reading of absence, not an alphabet identification. The theorem
+treats `blank` as a third letter on the six condition slots. The
+letter-count invariant then produces 47 orbits that no rotation can carry
+onto `{0,1}^6`. To overturn the strict enlargement one would have to
+exhibit a `G`-equivariant bijection between `A^6` and `{0,1}^6`, which
+these sets do not admit, or change the group, or change the alphabet.
+
+### N8 — cross-cycle echo
+
+This note does not load a parent counting surface. The binary count
+`|F_G|=2^{10}` is recomputed here by the same 24 rotations acting on the
+64 binary cells. No earlier mechanism retires the three-letter enlargement.
+A leftover-character reading of the binary class is exactly the mutation
+ruled out by Theorem 3.
+
+No-Go Discipline disposition: **PASS** for the algebraic class-count and
+the display-only status stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A readout value is determined by record content alone.
+
+> A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner constructs the 24 proper rotations, enumerates the 729
+cells, matches Burnside, counts the 10 binary orbits, checks that
+zero-on-blank extension hits every member of `F_G`, verifies
+`N_orb_perp > 10`, and pins the quoted axiom boundary. Declared audit
+inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1421,6 +1421,10 @@
   "bksf_holonomy_compression_cycle728_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2bdda41c6188",
    "out_degree": 3
+  },
+  "blank_slot_formation_predicate_class_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "block_gaussian_schur_marginalization_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/blank_slot_formation_predicate_class_2026_08_15.txt
+++ b/logs/runner-cache/blank_slot_formation_predicate_class_2026_08_15.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/blank_slot_formation_predicate_class_2026_08_15.py
+runner_sha256: 74a41c5b3f8a4a54e33b748d7fa27c77abf9d119a9f97555caffd4c5be545faf
+input_fingerprint_sha256: f3f2016a763db9d72be78007c4ad3e8818276d7bcaeeaff8c88c83a342a2ce6a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.23
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries are source-bound; no observation or fit
+integrity_reads: this runner, its note, and the current axiom memo; no other scientific inputs
+construction: 24 proper cube rotations acting on six nearest-neighbor slots; alphabet {0,1,blank}; boolean G-covariant predicates
+negative_scope: the counted class is displayed, not adopted as a formation law, site selector, or Record compiler
+PASS: audit-inputs declared source-bound inputs exist as the required two-path literal
+PASS: source-lattice current cubic nearest-neighbor and proper-rotation wording is pinned
+PASS: source-admissibility current covariant nearest-neighbor wording is pinned
+PASS: source-record-boundary current lock, content-only readout, and unreadable absence are pinned
+PASS: source-formation-boundary Admissibility still withholds formation site, probability, and rate
+PASS: thm1-group-order |G|=24 distinct proper rotations of the six slots
+PASS: thm1-domain-size |A|=3 and |A^6|=729
+N_orb_perp=57
+N_orb_binary=10
+|F_perp|=2^57=144115188075855872
+|F_G|=2^10=1024
+blank_bearing_orbits=47
+PASS: thm1-orbit-enumeration N_orb_perp from 729 cells and 24 rotations equals the Burnside count
+PASS: thm1-boolean-class-size |F_perp| equals 2 to the orbit count
+PASS: thm1-note-reports-count note displays the computed orbit count and boolean class size
+PASS: thm1-blank-stays-blank rotations permute slots and send blank only to blank
+PASS: thm2-binary-orbits {0,1}^6 has exactly 10 G-orbits by the same enumeration
+PASS: thm2-binary-invariant {0,1}^6 is G-invariant, and so is the blank-bearing complement
+PASS: thm2-restriction-surjective zero-on-blank extension realizes every covariant predicate on {0,1}^6
+PASS: thm2-restriction-map restriction F_perp -> F_G is well-defined because {0,1}^6 is G-invariant
+PASS: thm3-strict-enlargement N_orb_perp > 10 so |F_perp| > |F_G|
+PASS: thm3-blank-not-relabel blank is new orbit content: letter counts are G-invariants
+PASS: claim-scope-displayed claim_scope states the counted class, the inequality, onto restriction, and display-only status
+PASS: displayed-not-adopted note refuses to adopt a member of the class as a formation law
+PASS: forbidden-phrases-absent note and runner avoid the dispatch-forbidden phrases
+PASS: machine-status-contract note carries bounded-support status and the N1-N8 gate
+per_element: checked exactly — each of the 729 cells is assigned its G-orbit representative
+per_site: checked exactly — six nearest-neighbor slots at one displayed site
+per_mode: checked exactly — boolean G-covariant predicates; ternary ready/blocked/no maps are uncounted
+per_block: checked exactly — restriction onto the 10-orbit binary class by zero extension
+lattice_wide: checked and not executed — no physical formation predicate or lattice-wide ready law is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/blank_slot_formation_predicate_class_2026_08_15.py
+++ b/scripts/blank_slot_formation_predicate_class_2026_08_15.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Exact orbit count of cube-covariant boolean predicates on {0,1,blank}^6.
+
+Enumerates the 729 cells and the 24 proper cube rotations. No cache write,
+no network, no axiom edit.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "BLANK_SLOT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/BLANK_SLOT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+ZERO = 0
+ONE = 1
+BLANK = 2
+ALPHABET: tuple[int, ...] = (ZERO, ONE, BLANK)
+BINARY: tuple[int, ...] = (ZERO, ONE)
+SLOT_COUNT = 6
+FACES: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+Cell = tuple[int, ...]
+Perm = tuple[int, ...]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def det3(matrix: tuple[tuple[int, int, int], ...]) -> int:
+    a, b, c = matrix
+    return (
+        a[0] * (b[1] * c[2] - b[2] * c[1])
+        - a[1] * (b[0] * c[2] - b[2] * c[0])
+        + a[2] * (b[0] * c[1] - b[1] * c[0])
+    )
+
+
+def apply_matrix(
+    matrix: tuple[tuple[int, int, int], ...], vector: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )
+
+
+def proper_rotation_matrices() -> tuple[tuple[tuple[int, int, int], ...], ...]:
+    matrices = []
+    for axis_perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for row, axis in enumerate(axis_perm):
+                rows[row][axis] = signs[row]
+            matrix = tuple(tuple(row) for row in rows)
+            if det3(matrix) == 1:
+                matrices.append(matrix)
+    return tuple(matrices)
+
+
+def face_permutations() -> tuple[Perm, ...]:
+    face_index = {face: index for index, face in enumerate(FACES)}
+    perms = []
+    for matrix in proper_rotation_matrices():
+        perm = tuple(face_index[apply_matrix(matrix, face)] for face in FACES)
+        perms.append(perm)
+    return tuple(perms)
+
+
+def compose(left: Perm, right: Perm) -> Perm:
+    return tuple(left[right[index]] for index in range(SLOT_COUNT))
+
+
+def inverse(perm: Perm) -> Perm:
+    out = [0] * SLOT_COUNT
+    for source, dest in enumerate(perm):
+        out[dest] = source
+    return tuple(out)
+
+
+def act(perm: Perm, cell: Cell) -> Cell:
+    inv = inverse(perm)
+    return tuple(cell[inv[index]] for index in range(SLOT_COUNT))
+
+
+def cycle_lengths(perm: Perm) -> tuple[int, ...]:
+    seen = [False] * SLOT_COUNT
+    lengths: list[int] = []
+    for start in range(SLOT_COUNT):
+        if seen[start]:
+            continue
+        length = 0
+        cursor = start
+        while not seen[cursor]:
+            seen[cursor] = True
+            cursor = perm[cursor]
+            length += 1
+        lengths.append(length)
+    return tuple(sorted(lengths, reverse=True))
+
+
+def burnside_orbit_count(perms: tuple[Perm, ...], alphabet_size: int) -> int:
+    total = 0
+    for perm in perms:
+        total += alphabet_size ** len(cycle_lengths(perm))
+    if total % len(perms) != 0:
+        raise ArithmeticError("Burnside sum is not divisible by |G|")
+    return total // len(perms)
+
+
+def enumerate_orbits(
+    perms: tuple[Perm, ...], alphabet: tuple[int, ...]
+) -> tuple[int, frozenset[Cell], dict[Cell, Cell]]:
+    representatives: set[Cell] = set()
+    to_rep: dict[Cell, Cell] = {}
+    for cell in product(alphabet, repeat=SLOT_COUNT):
+        if cell in to_rep:
+            continue
+        orbit = tuple(act(perm, cell) for perm in perms)
+        representative = min(orbit)
+        representatives.add(representative)
+        for image in orbit:
+            to_rep[image] = representative
+    return len(representatives), frozenset(representatives), to_rep
+
+
+def letter_count(cell: Cell) -> tuple[int, int, int]:
+    return (cell.count(ZERO), cell.count(ONE), cell.count(BLANK))
+
+
+def has_blank(cell: Cell) -> bool:
+    return BLANK in cell
+
+
+def is_binary(cell: Cell) -> bool:
+    return all(letter in BINARY for letter in cell)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current Lattice, Admissibility, and Record "
+        "boundaries are source-bound; no observation or fit"
+    )
+    print(
+        "integrity_reads: this runner, its note, and the current axiom memo; "
+        "no other scientific inputs"
+    )
+    print(
+        "construction: 24 proper cube rotations acting on six nearest-neighbor "
+        "slots; alphabet {0,1,blank}; boolean G-covariant predicates"
+    )
+    print(
+        "negative_scope: the counted class is displayed, not adopted as a "
+        "formation law, site selector, or Record compiler"
+    )
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as the required two-path literal",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/BLANK_SLOT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == 2
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n    "docs/BLANK_SLOT_FORMATION_PREDICATE_CLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in self_source,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_cov = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor and proper-rotation wording is pinned",
+        lattice_sentence in normalize(axiom)
+        and "proper cubic rotations about each site" in axiom
+        and lattice_sentence in note
+        and "proper cubic rotations" in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current covariant nearest-neighbor wording is pinned",
+        admissibility_cov in normalize(axiom) and admissibility_cov in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock, content-only readout, and unreadable absence are pinned",
+        all(
+            phrase in normalized_axiom
+            for phrase in (record_lock, record_content, record_absence)
+        )
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "Admissibility still withholds formation site, probability, and rate",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    matrices = proper_rotation_matrices()
+    perms = face_permutations()
+    identity = tuple(range(SLOT_COUNT))
+    perm_set = set(perms)
+    closed = all(compose(left, right) in perm_set for left in perms for right in perms)
+    inverses = all(inverse(perm) in perm_set for perm in perms)
+    unique_slots = all(len(set(perm)) == SLOT_COUNT for perm in perms)
+
+    checks.check(
+        "thm1-group-order",
+        "|G|=24 distinct proper rotations of the six slots",
+        len(matrices) == 24
+        and len(set(matrices)) == 24
+        and len(perms) == 24
+        and len(perm_set) == 24
+        and identity in perm_set
+        and closed
+        and inverses
+        and unique_slots,
+        residual=(len(matrices), len(perm_set)),
+    )
+    checks.check(
+        "thm1-domain-size",
+        "|A|=3 and |A^6|=729",
+        len(ALPHABET) == 3 and 3**SLOT_COUNT == 729 and len(list(product(ALPHABET, repeat=SLOT_COUNT))) == 729,
+    )
+
+    n_orb, representatives, to_rep = enumerate_orbits(perms, ALPHABET)
+    n_orb_burnside = burnside_orbit_count(perms, 3)
+    n_orb_binary, binary_reps, binary_to_rep = enumerate_orbits(perms, BINARY)
+    n_orb_binary_burnside = burnside_orbit_count(perms, 2)
+    blank_reps = frozenset(rep for rep in representatives if has_blank(rep))
+    type_hist = Counter(letter_count(rep) for rep in representatives)
+
+    print(f"N_orb_perp={n_orb}")
+    print(f"N_orb_binary={n_orb_binary}")
+    print(f"|F_perp|=2^{n_orb}={2**n_orb}")
+    print(f"|F_G|=2^{n_orb_binary}={2**n_orb_binary}")
+    print(f"blank_bearing_orbits={len(blank_reps)}")
+
+    checks.check(
+        "thm1-orbit-enumeration",
+        "N_orb_perp from 729 cells and 24 rotations equals the Burnside count",
+        n_orb == n_orb_burnside and n_orb > 10 and len(representatives) == n_orb,
+        residual=(n_orb, n_orb_burnside),
+    )
+    checks.check(
+        "thm1-boolean-class-size",
+        "|F_perp| equals 2 to the orbit count",
+        2**n_orb == pow(2, n_orb) and n_orb == len(representatives),
+    )
+    checks.check(
+        "thm1-note-reports-count",
+        "note displays the computed orbit count and boolean class size",
+        f"N_orb_perp = {n_orb}" in note
+        and f"2^{{{n_orb}}}" in note
+        and str(2**n_orb) in note,
+    )
+    checks.check(
+        "thm1-blank-stays-blank",
+        "rotations permute slots and send blank only to blank",
+        all(
+            act(perm, cell).count(BLANK) == cell.count(BLANK)
+            for perm in perms
+            for cell in (
+                (BLANK, ZERO, ZERO, ZERO, ZERO, ZERO),
+                (BLANK, ONE, ZERO, ZERO, ZERO, ZERO),
+                (BLANK, BLANK, ONE, ZERO, ZERO, ZERO),
+            )
+        )
+        and all(letter_count(act(perm, cell)) == letter_count(cell) for perm in perms for cell in representatives),
+    )
+
+    checks.check(
+        "thm2-binary-orbits",
+        "{0,1}^6 has exactly 10 G-orbits by the same enumeration",
+        n_orb_binary == 10
+        and n_orb_binary_burnside == 10
+        and len(binary_reps) == 10
+        and all(is_binary(rep) for rep in binary_reps),
+        residual=(n_orb_binary, n_orb_binary_burnside),
+    )
+    checks.check(
+        "thm2-binary-invariant",
+        "{0,1}^6 is G-invariant, and so is the blank-bearing complement",
+        all(is_binary(act(perm, cell)) for perm in perms for cell in binary_reps)
+        and all(has_blank(act(perm, cell)) for perm in perms for cell in blank_reps)
+        and len(binary_reps) + len(blank_reps) == n_orb,
+    )
+
+    restriction_ok = True
+    for assignment in product((0, 1), repeat=n_orb_binary):
+        value_of = {rep: bit for rep, bit in zip(sorted(binary_reps), assignment, strict=True)}
+
+        def extended(cell: Cell) -> int:
+            if has_blank(cell):
+                return 0
+            return value_of[binary_to_rep[cell]]
+
+        for perm in perms:
+            for rep in binary_reps:
+                if extended(act(perm, rep)) != extended(rep):
+                    restriction_ok = False
+            for rep in blank_reps:
+                if extended(act(perm, rep)) != 0:
+                    restriction_ok = False
+        if not restriction_ok:
+            break
+
+    checks.check(
+        "thm2-restriction-surjective",
+        "zero-on-blank extension realizes every covariant predicate on {0,1}^6",
+        restriction_ok and 2**n_orb_binary == 1024,
+    )
+    checks.check(
+        "thm2-restriction-map",
+        "restriction F_perp -> F_G is well-defined because {0,1}^6 is G-invariant",
+        all(to_rep[cell] in binary_reps for cell in binary_to_rep)
+        and all(not has_blank(cell) for cell in binary_to_rep),
+    )
+
+    all_zero = (ZERO,) * SLOT_COUNT
+    all_blank = (BLANK,) * SLOT_COUNT
+    one_blank = (BLANK, ZERO, ZERO, ZERO, ZERO, ZERO)
+    checks.check(
+        "thm3-strict-enlargement",
+        "N_orb_perp > 10 so |F_perp| > |F_G|",
+        n_orb > 10 and 2**n_orb > 2**n_orb_binary and len(blank_reps) == n_orb - 10,
+        residual=(n_orb, n_orb_binary),
+    )
+    checks.check(
+        "thm3-blank-not-relabel",
+        "blank is new orbit content: letter counts are G-invariants",
+        to_rep[all_blank] != to_rep[all_zero]
+        and has_blank(one_blank)
+        and not is_binary(one_blank)
+        and letter_count(one_blank) != letter_count(all_zero)
+        and type_hist[(6, 0, 0)] == 1
+        and type_hist[(0, 0, 6)] == 1
+        and type_hist[(5, 0, 1)] == 1
+        and sum(count for key, count in type_hist.items() if key[2] == 0) == 10
+        and sum(count for key, count in type_hist.items() if key[2] > 0) == n_orb - 10,
+    )
+    checks.check(
+        "claim-scope-displayed",
+        "claim_scope states the counted class, the inequality, onto restriction, and display-only status",
+        'claim_scope: "Cube-covariant boolean predicates on {0,1,blank}^6 form a set of size 2^{N_orb_⊥} with'
+        in note
+        and "N_orb_⊥ > 10" in note
+        and "Restriction to {0,1}^6 is onto F_G" in note
+        and "Displayed, not adopted." in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "note refuses to adopt a member of the class as a formation law",
+        "displayed, not adopted" in normalized_note
+        and "No member of `F_perp` is selected" in note
+        and "hypothetical_axiom_status: \"not proposed; no axiom or approved primitive is added\""
+        in note,
+    )
+    forbidden = (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-phrases-absent",
+        "note and runner avoid the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+        residual=[phrase for phrase in forbidden if phrase in note or phrase in self_source],
+    )
+    checks.check(
+        "machine-status-contract",
+        "note carries bounded-support status and the N1-N8 gate",
+        "actual_current_surface_status: bounded-support" in note
+        and "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and "runner-cache" not in note
+        and "citation_manifest" not in note
+        and "citation-manifest" not in note,
+    )
+
+    print("per_element: checked exactly — each of the 729 cells is assigned its G-orbit representative")
+    print("per_site: checked exactly — six nearest-neighbor slots at one displayed site")
+    print("per_mode: checked exactly — boolean G-covariant predicates; ternary ready/blocked/no maps are uncounted")
+    print("per_block: checked exactly — restriction onto the 10-orbit binary class by zero extension")
+    print("lattice_wide: checked and not executed — no physical formation predicate or lattice-wide ready law is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Cube-covariant boolean predicates on {0,1,blank}^6 have 57 orbits so |F_perp|=2^57. Restriction to {0,1}^6 is onto F_G. Blank is new orbit content, not a relabeling of 0. Displayed, not adopted.

## Runner

`scripts/blank_slot_formation_predicate_class_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.