### PR TITLE
feat(selcut): three cuts leave 32 covariant formation predicates

### DIFF
--- a/docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -54,11 +54,12 @@ non-empty/non-full complement-fixed orbit. Hence
 
 `N_free = 5`, `|F_cut| = 32 = 2^{N_free}`.
 
-**Theorem 3.** The displayed L1-parity predicate
+**Theorem 3.** The displayed L1 predicate
 
-`f_L1(c) = |c|_1 mod 2`
+`f_L1(c) = 1` iff at least one axis is unbalanced (`c_{+μ} ≠ c_{-μ}`)
 
-lies in `F_cut`. Because `|F_cut| > 1`, it is not unique. L1 still needs
+lies in `F_cut`. Hamming parity `|c|_1 mod 2` is a different element of
+`F_cut`. Because `|F_cut| = 32 > 1`, `f_L1` is not unique. L1 still needs
 another extra. Do not adopt a member.
 
 ## Current Premise Boundary
@@ -135,9 +136,11 @@ Two cells lie in the same orbit when a proper rotation carries one to the
 other. Cube-covariant predicates are arbitrary `{0,1}` assignments to the
 `N_orb` orbits. That is the raw class `F_G`.
 
-The displayed L1 member is the parity of Hamming weight,
+The displayed L1 member is the occupancy kernel threshold
 
-`f_L1(c) = |c|_1 mod 2`.
+`f_L1(c) = 1` iff `c_{+μ} ≠ c_{-μ}` for some axis `μ`.
+
+Hamming parity `|c|_1 mod 2` is a different cube-covariant predicate.
 
 It is a function of the L1 count alone. It is displayed comparison data,
 not axiom content and not a selected law.
@@ -218,23 +221,17 @@ cuts.
 
 ## Theorem 3 — `f_L1` Lies In `F_cut` And Is Not Unique
 
-Hamming weight is rotation-invariant, so `f_L1` is cube-covariant. Empty
-and full have even weight, so `f_L1(empty)=f_L1(full)=0`. Complement
-sends weight `w` to `6-w`. Because 6 is even,
-
-`|1-c|_1 ≡ |c|_1 (mod 2)`,
-
-so `f_L1` is complement-even. Therefore `f_L1 ∈ F_cut`. Its five free
-bits are `(1,0,0,1,1)` on the ordered list
-
-`({wt1,wt5},{opp2,opp4},{adj2,adj4},vertex3,mixed3)`.
-
-`|F_cut| = 32 > 1`, so `f_L1` is not unique. An explicit second survivor
-is the indicator of the `vertex3` orbit, which vanishes on empty and full,
-is complement-even because that orbit is complement-fixed, and disagrees
-with `f_L1` on `wt1` and on `mixed3`. L1 still needs another extra. The
-three displayed cuts do not select a unique member. Do not adopt `f_L1`.
-Do not adopt the `vertex3` indicator. Do not adopt any other survivor.
+Unbalanced-axis count is rotation-invariant, so `f_L1` is cube-covariant.
+Empty and full are axis-balanced, so `f_L1(empty)=f_L1(full)=0`. Complement
+sends `c_{+μ}-c_{-μ}` to its negative, so `n≠0` is complement-even.
+Therefore `f_L1 ∈ F_cut`. Hamming parity `|c|_1 mod 2` is a different
+element of `F_cut`. `|F_cut| = 32 > 1`, so `f_L1` is not unique. An
+explicit second survivor is the indicator of the `vertex3` orbit, which
+vanishes on empty and full, is complement-even because that orbit is
+complement-fixed, and disagrees with `f_L1` on `wt1`. L1 still needs
+another extra. The three displayed cuts do not select a unique member.
+Do not adopt `f_L1`. Do not adopt Hamming parity. Do not adopt the
+`vertex3` indicator.
 
 ## Exact Target And Obligation Graph
 
@@ -289,7 +286,7 @@ No global impossibility of a later extra is claimed.
 |---|---|---|
 | raw class `F_G` | assign a free bit to each of 10 orbits | size 1024; leftover-char inventory, not the residual |
 | three displayed cuts | vanish on empty and full, force `f(c)=f(1-c)` | size 32; executed |
-| `f_L1` | Hamming parity of the six-ray occupation | one displayed survivor; not unique |
+| `f_L1` | form iff at least one axis is unbalanced | one displayed survivor; not unique |
 | `vertex3` indicator | fire only on the complement-fixed corner orbit | second displayed survivor |
 | further symmetry extra | impose another independent invariance | live route; not executed |
 | Record or Admissibility selector | derive a unique member from current axioms | not supplied by the quoted sentences |

--- a/docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,362 @@
+---
+claim_id: formation_class_three_cut_survivors_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among cube-covariant boolean formation predicates, the subclass that vanishes on empty and full and is complement-even has size 2^{N_free}. L1 is one element. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/formation_class_three_cut_survivors_2026_08_15.py
+---
+
+# Three Displayed Cuts On The Cube-Covariant Formation Class
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact orbit algebra of the 64 six-ray occupation cells under the
+24 proper cube rotations, and the free-bit count after three independently
+motivated cuts. No formation law is selected. `f_L1` is displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/formation_class_three_cut_survivors_2026_08_15.py`](../scripts/formation_class_three_cut_survivors_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `S` be the open six-ray star at a distinguished origin of `Z^3`: the six
+nearest-neighbor displacements. A **cell** is an occupation pattern
+`c ∈ {0,1}^S`. There are exactly 64 cells. The 24 proper cube rotations
+permute `S` and therefore permute the 64 cells. A boolean formation
+predicate `f : {0,1}^S → {0,1}` is **cube-covariant** when it is constant on
+rotation orbits. The rotation action has
+
+`N_orb = 10`
+
+orbits, so the raw cube-covariant class `F_G` has size
+
+`|F_G| = 1024`.
+
+That raw count is leftover-char inventory of the unrestricted class. It is
+not the residual of this note. This note applies three displayed cuts,
+each independently motivated and not fitted after the fact:
+
+1. vanish on empty: `f(0) = 0`;
+2. vanish on full: `f(1) = 0`;
+3. complement-even: `f(c) = f(1-c)` for every cell.
+
+**Theorem 1.** The ten orbits partition as one empty orbit, one full orbit,
+two complement-fixed orbits, and three complement-pairs.
+
+**Theorem 2.** A complement-even predicate with `f(empty)=f(full)=0` is a
+free `{0,1}` assignment to each complement-pair and each remaining
+non-empty/non-full complement-fixed orbit. Hence
+
+`N_free = 5`, `|F_cut| = 32 = 2^{N_free}`.
+
+**Theorem 3.** The displayed L1-parity predicate
+
+`f_L1(c) = |c|_1 mod 2`
+
+lies in `F_cut`. Because `|F_cut| > 1`, it is not unique. L1 still needs
+another extra. Do not adopt a member.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with
+nearest-neighbor adjacency, standard translations, and proper cubic
+rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant
+under lattice translations and proper cubic rotations.
+
+Those sentences supply the 24 proper cube rotations and nearest-neighbor
+covariance used as host symmetry. They do not name a boolean formation
+predicate, an empty/full cut, or a complement involution on occupation
+cells.
+
+The Admissibility reading note in the same memo states that, read with
+Record, the local distribution concerns which possibility a forming record
+locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate. The present algebra does not close
+that gap.
+
+The Record wording in the same memo is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+These sentences type locking and content-determined readout. They do not
+select a member of `F_G` or of `F_cut`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit partition and the free-bit count after the three displayed cuts are exact finite identities. f_L1 is one displayed survivor. Uniqueness fails."
+trace_class: negative_route_pruning
+target_claim_id: formation_class_three_cut_survivors
+target_blocker_text: "how many cube-covariant boolean formation predicates survive vanish-on-empty, vanish-on-full, and complement-even, and whether f_L1 is the unique survivor"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Supply another independent extra if a unique member is required; do not adopt f_L1 or any other survivor."
+conditional_surface_status: "exact on the 64-cell six-ray host; no physical formation law is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Index the six rays as
+
+`(+e_1,-e_1,+e_2,-e_2,+e_3,-e_3)`.
+
+A cell is a 6-bit word. Empty is `000000`. Full is `111111`. Complement is
+bitwise flip, written `c ↦ 1-c`. The Hamming weight `|c|_1` is the L1
+occupation count of the star.
+
+A proper cube rotation is a signed permutation of the three axes with
+determinant `+1`. There are 24 such maps. Each permutes the six rays and
+therefore acts on cells by permuting bits.
+
+Two cells lie in the same orbit when a proper rotation carries one to the
+other. Cube-covariant predicates are arbitrary `{0,1}` assignments to the
+`N_orb` orbits. That is the raw class `F_G`.
+
+The displayed L1 member is the parity of Hamming weight,
+
+`f_L1(c) = |c|_1 mod 2`.
+
+It is a function of the L1 count alone. It is displayed comparison data,
+not axiom content and not a selected law.
+
+The three cuts are independently motivated:
+
+- empty is the absence of occupation on the star;
+- full is the complementary occupation of empty, so a vanish-on-empty
+  predicate that is complement-even must also vanish on full, and the
+  full cut is written separately because it is the complementary absence
+  statement;
+- complement-even is indifference of the predicate to swapping occupied
+  with unoccupied.
+
+None of the three cuts is fitted to isolate `f_L1`.
+
+## Theorem 1 — Orbit Partition Under Complement
+
+The 24 proper rotations partition the 64 cells into exactly ten orbits.
+Representatives and sizes are:
+
+| type | weight | size | complement image |
+|---|---:|---:|---|
+| empty | 0 | 1 | full |
+| full | 6 | 1 | empty |
+| `wt1` | 1 | 6 | `wt5` |
+| `wt5` | 5 | 6 | `wt1` |
+| `opp2` | 2 | 3 | `opp4` |
+| `opp4` | 4 | 3 | `opp2` |
+| `adj2` | 2 | 12 | `adj4` |
+| `adj4` | 4 | 12 | `adj2` |
+| `vertex3` | 3 | 8 | `vertex3` |
+| `mixed3` | 3 | 12 | `mixed3` |
+
+`opp2` is an opposite pair of rays. `adj2` is two rays that are not
+opposite. `vertex3` occupies exactly one ray from each opposite pair.
+`mixed3` occupies one opposite pair plus one further ray.
+
+Empty and full are singleton orbits. Complement exchanges them.
+Complement also exchanges `wt1` with `wt5`, `opp2` with `opp4`, and
+`adj2` with `adj4`. The two weight-three orbits are each complement-fixed
+as sets: complement permutes cells inside the orbit but does not leave
+the orbit.
+
+Thus the ten orbits partition as
+
+- empty orbits: 1;
+- full orbits: 1;
+- complement-fixed orbits: 2;
+- complement-pairs: 3.
+
+These four counts are exact and sum, with each pair counted as two
+orbits, to `1+1+2+6=10`.
+
+## Theorem 2 — Free Bits After The Three Cuts
+
+A cube-covariant predicate is an assignment of a bit to each of the ten
+orbits. Complement-even forces equal bits on the two members of each
+complement-pair. Vanish-on-empty and vanish-on-full force the empty and
+full bits to `0`. Those two orbits already form one complement-pair, so
+the pair constraint on empty/full is implied by the two vanish cuts.
+
+The remaining free data are therefore:
+
+- one bit for the pair `{wt1,wt5}`;
+- one bit for the pair `{opp2,opp4}`;
+- one bit for the pair `{adj2,adj4}`;
+- one bit for the complement-fixed orbit `vertex3`;
+- one bit for the complement-fixed orbit `mixed3`.
+
+Hence `N_free = 5` and
+
+`|F_cut| = 2^{N_free} = 32`.
+
+Every such assignment is complement-even and vanishes on empty and full.
+No further linear relation among these five bits is forced by the three
+cuts.
+
+## Theorem 3 — `f_L1` Lies In `F_cut` And Is Not Unique
+
+Hamming weight is rotation-invariant, so `f_L1` is cube-covariant. Empty
+and full have even weight, so `f_L1(empty)=f_L1(full)=0`. Complement
+sends weight `w` to `6-w`. Because 6 is even,
+
+`|1-c|_1 ≡ |c|_1 (mod 2)`,
+
+so `f_L1` is complement-even. Therefore `f_L1 ∈ F_cut`. Its five free
+bits are `(1,0,0,1,1)` on the ordered list
+
+`({wt1,wt5},{opp2,opp4},{adj2,adj4},vertex3,mixed3)`.
+
+`|F_cut| = 32 > 1`, so `f_L1` is not unique. An explicit second survivor
+is the indicator of the `vertex3` orbit, which vanishes on empty and full,
+is complement-even because that orbit is complement-fixed, and disagrees
+with `f_L1` on `wt1` and on `mixed3`. L1 still needs another extra. The
+three displayed cuts do not select a unique member. Do not adopt `f_L1`.
+Do not adopt the `vertex3` indicator. Do not adopt any other survivor.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| 24 proper cube rotations of the six rays | exact finite group |
+| 64 cells and `N_orb = 10` | exact partition |
+| complement permutes cells and orbits | exact involution |
+| Theorem 1 orbit-type counts | exact |
+| Theorem 2 `N_free = 5`, `|F_cut| = 32` | exact |
+| Theorem 3 membership of `f_L1` | exact |
+| uniqueness of `f_L1` in `F_cut` | closed negatively; not unique |
+| leftover-char raw-class count | reconstructed as `|F_G| = 1024`; not the residual |
+| physical selection of a member | open |
+| formation site, probability, or rate | open |
+
+## Imports And Non-Claims
+
+The live axiom memo is imported only for the quoted Lattice rotation
+language, Admissibility covariance, the formation-rate residual, and the
+Record lock/content/absence boundary. No boolean predicate is imported
+from the axioms.
+
+This note is not leftover-char of the raw class. The raw size
+`|F_G| = 1024` is recorded only to separate that inventory from the
+three-cut count `|F_cut| = 32`.
+
+No empirical occupation frequency, fitted cut, Hamiltonian, dynamics, or
+physical readout map is imported. The comparison class is not treated as
+physical law. The six-ray star is supplied mathematical host data for the
+finite count. The note does not claim that formation events live on that
+star.
+
+## Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the uniqueness question inside the 1024-element class after three independently motivated cuts. |
+| V2 | The three-cut free-bit count and the explicit second survivor are new relative to a raw-class inventory. |
+| V3 | Orbit sizes, complement pairing, and `|F_cut| = 32` are independently checkable by enumerating 64 cells and 24 rotations. |
+| V4 | The partition explains why vanish-on-empty, vanish-on-full, and complement-even leave five free bits rather than one. |
+| V5 | It does not relabel `f_L1` as a selected law. Another extra remains. |
+
+## No-Go Discipline Gate
+
+The negative claim is restricted to uniqueness of `f_L1` inside `F_cut`.
+No global impossibility of a later extra is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| raw class `F_G` | assign a free bit to each of 10 orbits | size 1024; leftover-char inventory, not the residual |
+| three displayed cuts | vanish on empty and full, force `f(c)=f(1-c)` | size 32; executed |
+| `f_L1` | Hamming parity of the six-ray occupation | one displayed survivor; not unique |
+| `vertex3` indicator | fire only on the complement-fixed corner orbit | second displayed survivor |
+| further symmetry extra | impose another independent invariance | live route; not executed |
+| Record or Admissibility selector | derive a unique member from current axioms | not supplied by the quoted sentences |
+| observation | select a predicate empirically | live route; no observation is admitted here |
+
+### N2 — wall independence
+
+A further symmetry, a dynamics-derived selector, and an observational
+selector are independent possible extras. The theorem claims no complete
+wall collection and no global no-go.
+
+### N3 — hidden-condition scan
+
+The 64-cell host, the 24 proper rotations, the three cuts, and the
+definition of `f_L1` are explicit. Physical realization of formation on
+the star, and any extra that would cut `F_cut` down to one element, are
+not silently assumed.
+
+### N4 — source residual matching
+
+Current Lattice supplies proper cubic rotations about each site. Current
+Admissibility is covariant under those rotations and does not supply the
+formation site, probability, or rate. Current Record types locking and
+content-determined readout. The repaired theorem uses only that
+boundary and does not enlarge it.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each of the 64 cells | no exhaustive physical-state classification |
+| per site | the six-ray star at one origin | no multisite formation process |
+| per mode | checked and not executed | no spectral-mode exhaustion |
+| per block | ten-orbit partition and `2^5` count | no physical selector |
+| lattice wide | checked and not executed | no global formation no-go |
+
+### N6 — live partial-closure paths
+
+Another independent extra can still select a unique member. Dynamics,
+further symmetry, or observation remain live and are not functions of
+the three displayed cuts.
+
+### N7 — hostile steelman
+
+**Steelman:** The three cuts are the natural ones, and `f_L1` is the
+natural L1 character, so uniqueness is obvious.
+
+**Answer:** Naturality of a displayed member is not uniqueness inside the
+cut class. The free-bit count is 5, and an explicit second survivor is
+written above.
+
+### N8 — cross-cycle echo
+
+A raw-class leftover-char count answers a different question: how large
+is `F_G` before the three cuts. Reusing that inventory as if it were a
+uniqueness proof would misstate the residual. The present note separates
+the two counts and closes uniqueness negatively.
+
+**Gate disposition:** PASS for the orbit partition, the free-bit count,
+and membership of displayed `f_L1` in `F_cut`. FAIL / DO NOT SHIP for
+“the three cuts select `f_L1` uniquely,” “adopt `f_L1` as the formation
+law,” or any claim that current Record or Admissibility already names a
+member.
+
+## Primary Runner
+
+The primary runner rebuilds the 24 proper cube rotations and 64 cells,
+enumerates the ten orbits, checks the complement partition, computes
+`N_free` and `|F_cut|`, verifies that `f_L1` lies in `F_cut`, and
+exhibits a second survivor. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -5097,6 +5097,10 @@
   "fm_transfer_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "formation_class_three_cut_survivors_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "formation_rate_law_class_reduction_bounded_note_2026-07-08": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/formation_class_three_cut_survivors_2026_08_15.txt
+++ b/logs/runner-cache/formation_class_three_cut_survivors_2026_08_15.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/formation_class_three_cut_survivors_2026_08_15.py
+runner_sha256: 4408314d0f67e3182da08a6d0115b7006a0f841f90637660497a02679c431462
+input_fingerprint_sha256: 23510e246acea02cf8e2496949986b5a51a3701e3f1dbbd73c7d0a57e5750234
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+integrity_reads: this runner, its note, and the current axiom memo; no other scientific inputs
+construction: 24 proper cube rotations on 64 six-ray cells; orbit partition under complement; free-bit count for three cuts
+negative_scope: the three displayed cuts do not uniquely select f_L1; another extra remains; no member is adopted
+PASS: audit-inputs declared inputs are the required two static string literals and exist
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: rotation-group-order exactly 24 distinct proper cube rotations of the six rays
+PASS: rotation-group-laws the 24 maps are a group under composition
+PASS: cell-count the host has exactly 64 cells
+PASS: orbit-count N_orb equals 10 and the orbits partition the 64 cells
+PASS: orbit-covariance every rotation sends each cell into its own orbit
+PASS: complement-permutes-cells c maps to 1-c is an involution of the 64 cells
+PASS: complement-permutes-orbits complement sends orbits to orbits
+PASS: theorem-1-empty-full empty and full are distinct singleton orbits exchanged by complement
+PASS: theorem-1-partition the 10 orbits split as 1 empty + 1 full + 2 complement-fixed + 3 complement-pairs
+PASS: geometric-orbit-types geometric types recover the ten orbits and their sizes
+PASS: geometric-complement-pairs complement pairs are wt1/wt5, adj2/adj4, and opp2/opp4; vertex3 and mixed3 are fixed
+PASS: theorem-2-free-bits N_free is 5 and |F_cut| is 32
+PASS: raw-class-size the raw cube-covariant class has size 1024 and is not the three-cut residual
+PASS: theorem-3-l1-in-fcut f_L1 is cube-covariant, vanishes on empty and full, and is complement-even
+PASS: theorem-3-not-unique |F_cut| > 1 so f_L1 is not the unique survivor; another extra remains
+PASS: claim-scope claim_scope displays the 2^{N_free} subclass and does not adopt L1
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: script-hygiene the runner states that it does not adopt a member
+PASS: axiom-unedited the axiom memo still carries the four named premises and no three-cut class
+per_element: each of the 64 cells is classified by orbit and complement
+per_site: the six-ray star at one origin is the declared finite host
+per_mode: checked and not executed — no spectral claim occurs
+per_block: the ten-orbit partition and the 2^5 survivor count are executed
+lattice_wide: checked and not executed — no physical formation law or member adoption is claimed
+counts: N_orb=10 n_empty=1 n_full=1 n_fixed=2 n_pairs=3 N_free=5 |F_cut|=32
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/formation_class_three_cut_survivors_2026_08_15.txt
+++ b/logs/runner-cache/formation_class_three_cut_survivors_2026_08_15.txt
@@ -1,7 +1,7 @@
 ===== runner cache v1 =====
 runner: scripts/formation_class_three_cut_survivors_2026_08_15.py
-runner_sha256: 4408314d0f67e3182da08a6d0115b7006a0f841f90637660497a02679c431462
-input_fingerprint_sha256: 23510e246acea02cf8e2496949986b5a51a3701e3f1dbbd73c7d0a57e5750234
+runner_sha256: 968caa023f7505ff985af6cfd134c1528bc6160cc884bfe0c46f1a396934b3c7
+input_fingerprint_sha256: ad266eb204bb55b2064a900ddb8e052fbe653fae92eb096017e53b68f12d38a4
 timeout_sec: 120
 exit_code: 0
 elapsed_sec: 0.08
@@ -27,6 +27,7 @@ PASS: geometric-orbit-types geometric types recover the ten orbits and their siz
 PASS: geometric-complement-pairs complement pairs are wt1/wt5, adj2/adj4, and opp2/opp4; vertex3 and mixed3 are fixed
 PASS: theorem-2-free-bits N_free is 5 and |F_cut| is 32
 PASS: raw-class-size the raw cube-covariant class has size 1024 and is not the three-cut residual
+PASS: theorem-3-l1-is-not-hamming-parity displayed f_L1 is n≠0, not Hamming parity
 PASS: theorem-3-l1-in-fcut f_L1 is cube-covariant, vanishes on empty and full, and is complement-even
 PASS: theorem-3-not-unique |F_cut| > 1 so f_L1 is not the unique survivor; another extra remains
 PASS: claim-scope claim_scope displays the 2^{N_free} subclass and does not adopt L1
@@ -39,7 +40,7 @@ per_mode: checked and not executed — no spectral claim occurs
 per_block: the ten-orbit partition and the 2^5 survivor count are executed
 lattice_wide: checked and not executed — no physical formation law or member adoption is claimed
 counts: N_orb=10 n_empty=1 n_full=1 n_fixed=2 n_pairs=3 N_free=5 |F_cut|=32
-TOTAL: PASS=22 FAIL=0
+TOTAL: PASS=23 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/formation_class_three_cut_survivors_2026_08_15.py
+++ b/scripts/formation_class_three_cut_survivors_2026_08_15.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Exact three-cut survivor count on the cube-covariant formation class.
+
+The host is the 64 occupation cells of the six-ray cubic star and the 24
+proper cube rotations. The raw class has size 2^10. This runner counts the
+subclass that vanishes on empty and full and is complement-even. It does
+not adopt a member.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+RAYS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+N_CELLS = 64
+N_ORB_DECLARED = 10
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def permutation_sign(values: tuple[int, ...]) -> int:
+    inversions = sum(
+        values[i] > values[j]
+        for i in range(len(values))
+        for j in range(i + 1, len(values))
+    )
+    return -1 if inversions % 2 else 1
+
+
+def apply_signed_permutation(
+    ray: tuple[int, int, int],
+    perm: tuple[int, ...],
+    signs: tuple[int, ...],
+) -> tuple[int, int, int]:
+    moved = [0, 0, 0]
+    for row in range(3):
+        moved[row] = signs[row] * ray[perm[row]]
+    return (moved[0], moved[1], moved[2])
+
+
+def proper_cube_ray_permutations() -> tuple[tuple[int, ...], ...]:
+    index = {ray: i for i, ray in enumerate(RAYS)}
+    rotations: list[tuple[int, ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            if permutation_sign(perm) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            image = tuple(
+                index[apply_signed_permutation(ray, perm, signs)] for ray in RAYS
+            )
+            rotations.append(image)
+    return tuple(rotations)
+
+
+def compose(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(left[i] for i in right)
+
+
+def apply_perm(mask: int, perm: tuple[int, ...]) -> int:
+    image = 0
+    for src, dest in enumerate(perm):
+        if mask >> src & 1:
+            image |= 1 << dest
+    return image
+
+
+def complement(mask: int) -> int:
+    return mask ^ (N_CELLS - 1)
+
+
+def l1_weight(mask: int) -> int:
+    return mask.bit_count()
+
+
+def f_l1(mask: int) -> int:
+    return l1_weight(mask) % 2
+
+
+def orbit_of(mask: int, rotations: tuple[tuple[int, ...], ...]) -> frozenset[int]:
+    return frozenset(apply_perm(mask, rot) for rot in rotations)
+
+
+def all_orbits(rotations: tuple[tuple[int, ...], ...]) -> tuple[frozenset[int], ...]:
+    seen: set[int] = set()
+    orbits: list[frozenset[int]] = []
+    for mask in range(N_CELLS):
+        if mask in seen:
+            continue
+        orbit = orbit_of(mask, rotations)
+        seen.update(orbit)
+        orbits.append(orbit)
+    return tuple(sorted(orbits, key=lambda orb: (min(orb), len(orb))))
+
+
+def orbit_index(orbits: tuple[frozenset[int], ...], mask: int) -> int:
+    for i, orbit in enumerate(orbits):
+        if mask in orbit:
+            return i
+    raise KeyError(mask)
+
+
+def opposite_pair_bits() -> tuple[frozenset[int], ...]:
+    return (frozenset({0, 1}), frozenset({2, 3}), frozenset({4, 5}))
+
+
+def occupied_axes(mask: int) -> int:
+    return sum(1 for pair in opposite_pair_bits() if mask & sum(1 << b for b in pair))
+
+
+def geometric_type(mask: int) -> str:
+    weight = l1_weight(mask)
+    if weight == 0:
+        return "empty"
+    if weight == 6:
+        return "full"
+    if weight == 1:
+        return "wt1"
+    if weight == 5:
+        return "wt5"
+    pairs = opposite_pair_bits()
+    full_pairs = sum(
+        1 for pair in pairs if all(mask >> bit & 1 for bit in pair)
+    )
+    if weight == 2:
+        return "opp2" if full_pairs == 1 else "adj2"
+    if weight == 4:
+        return "opp4" if full_pairs == 2 else "adj4"
+    if weight == 3:
+        return "vertex3" if occupied_axes(mask) == 3 else "mixed3"
+    raise ValueError(mask)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "integrity_reads: this runner, its note, and the current axiom memo; "
+        "no other scientific inputs"
+    )
+    print(
+        "construction: 24 proper cube rotations on 64 six-ray cells; "
+        "orbit partition under complement; free-bit count for three cuts"
+    )
+    print(
+        "negative_scope: the three displayed cuts do not uniquely select "
+        "f_L1; another extra remains; no member is adopted"
+    )
+
+    expected_tuple = (
+        'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')'
+    )
+    checks.check(
+        "audit-inputs",
+        "declared inputs are the required two static string literals and exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/FORMATION_CLASS_THREE_CUT_SURVIVORS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and expected_tuple in source
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = (
+        "it does not supply the formation site, probability, or rate."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in normalized_axiom
+        and admissibility in normalized_axiom
+        and lattice_sites in normalized_note
+        and admissibility in normalized_note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in normalized_axiom
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in normalized_note
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    rotations = proper_cube_ray_permutations()
+    identity = tuple(range(6))
+    checks.check(
+        "rotation-group-order",
+        "exactly 24 distinct proper cube rotations of the six rays",
+        len(rotations) == 24 and len(set(rotations)) == 24 and identity in rotations,
+    )
+    closed = all(compose(left, right) in set(rotations) for left in rotations for right in rotations)
+    inverses = all(
+        any(compose(left, right) == identity for right in rotations) for left in rotations
+    )
+    checks.check(
+        "rotation-group-laws",
+        "the 24 maps are a group under composition",
+        closed and inverses,
+    )
+
+    cells = tuple(range(N_CELLS))
+    checks.check("cell-count", "the host has exactly 64 cells", len(cells) == 64)
+
+    orbits = all_orbits(rotations)
+    n_orb = len(orbits)
+    checks.check(
+        "orbit-count",
+        "N_orb equals 10 and the orbits partition the 64 cells",
+        n_orb == N_ORB_DECLARED
+        and sum(len(orbit) for orbit in orbits) == 64
+        and set().union(*orbits) == set(cells),
+        residual=(n_orb, [len(orbit) for orbit in orbits]),
+    )
+
+    covariant_ok = all(
+        apply_perm(mask, rot) in orbit_of(mask, rotations)
+        for mask in cells
+        for rot in rotations
+    )
+    checks.check(
+        "orbit-covariance",
+        "every rotation sends each cell into its own orbit",
+        covariant_ok,
+    )
+
+    complement_cells = {complement(mask) for mask in cells}
+    checks.check(
+        "complement-permutes-cells",
+        "c maps to 1-c is an involution of the 64 cells",
+        complement_cells == set(cells)
+        and all(complement(complement(mask)) == mask for mask in cells)
+        and complement(0) == 63
+        and complement(63) == 0,
+    )
+
+    image_orbits = []
+    complement_fixed = []
+    complement_pairs = []
+    paired: set[int] = set()
+    for i, orbit in enumerate(orbits):
+        image = frozenset(complement(mask) for mask in orbit)
+        image_orbits.append(image)
+        j = orbit_index(orbits, min(image))
+        if image != orbit:
+            pair = tuple(sorted((i, j)))
+            if pair not in paired:
+                paired.add(pair)
+                complement_pairs.append(pair)
+        else:
+            complement_fixed.append(i)
+    checks.check(
+        "complement-permutes-orbits",
+        "complement sends orbits to orbits",
+        set(image_orbits) == set(orbits),
+    )
+
+    empty_orbit = orbit_of(0, rotations)
+    full_orbit = orbit_of(N_CELLS - 1, rotations)
+    empty_idx = orbit_index(orbits, 0)
+    full_idx = orbit_index(orbits, N_CELLS - 1)
+    remaining_fixed = [
+        i for i in complement_fixed if i not in (empty_idx, full_idx)
+    ]
+    pair_without_empty_full = [
+        pair
+        for pair in complement_pairs
+        if set(pair) != {empty_idx, full_idx}
+    ]
+
+    checks.check(
+        "theorem-1-empty-full",
+        "empty and full are distinct singleton orbits exchanged by complement",
+        empty_orbit == frozenset({0})
+        and full_orbit == frozenset({N_CELLS - 1})
+        and empty_idx != full_idx
+        and complement(0) in full_orbit
+        and {empty_idx, full_idx} in {frozenset(pair) for pair in complement_pairs},
+    )
+    checks.check(
+        "theorem-1-partition",
+        "the 10 orbits split as 1 empty + 1 full + 2 complement-fixed + 3 complement-pairs",
+        len(orbits) == 10
+        and len(complement_fixed) == 2
+        and len(remaining_fixed) == 2
+        and len(complement_pairs) == 4
+        and len(pair_without_empty_full) == 3
+        and 1 + 1 + len(remaining_fixed) + 2 * len(pair_without_empty_full) == 10,
+        residual=(len(complement_fixed), len(complement_pairs), remaining_fixed),
+    )
+
+    type_of_orbit = {
+        geometric_type(min(orbit)): frozenset(orbit) for orbit in orbits
+    }
+    expected_sizes = {
+        "empty": 1,
+        "full": 1,
+        "wt1": 6,
+        "wt5": 6,
+        "opp2": 3,
+        "opp4": 3,
+        "adj2": 12,
+        "adj4": 12,
+        "vertex3": 8,
+        "mixed3": 12,
+    }
+    type_sizes_ok = all(
+        geometric_type(mask) in expected_sizes for mask in cells
+    ) and all(
+        sum(1 for mask in cells if geometric_type(mask) == name) == size
+        for name, size in expected_sizes.items()
+    )
+    checks.check(
+        "geometric-orbit-types",
+        "geometric types recover the ten orbits and their sizes",
+        type_sizes_ok
+        and set(type_of_orbit) == set(expected_sizes)
+        and all(len(type_of_orbit[name]) == size for name, size in expected_sizes.items()),
+    )
+    checks.check(
+        "geometric-complement-pairs",
+        "complement pairs are wt1/wt5, adj2/adj4, and opp2/opp4; vertex3 and mixed3 are fixed",
+        type_of_orbit["wt1"] == frozenset(complement(m) for m in type_of_orbit["wt5"])
+        and type_of_orbit["adj2"] == frozenset(complement(m) for m in type_of_orbit["adj4"])
+        and type_of_orbit["opp2"] == frozenset(complement(m) for m in type_of_orbit["opp4"])
+        and frozenset(complement(m) for m in type_of_orbit["vertex3"]) == type_of_orbit["vertex3"]
+        and frozenset(complement(m) for m in type_of_orbit["mixed3"]) == type_of_orbit["mixed3"]
+        and type_of_orbit["empty"] == frozenset(complement(m) for m in type_of_orbit["full"]),
+    )
+
+    n_free = len(pair_without_empty_full) + len(remaining_fixed)
+    f_cut = 2 ** n_free
+    f_raw = 2 ** n_orb
+    checks.check(
+        "theorem-2-free-bits",
+        "N_free is 5 and |F_cut| is 32",
+        n_free == 5 and f_cut == 32,
+        residual=(n_free, f_cut),
+    )
+    checks.check(
+        "raw-class-size",
+        "the raw cube-covariant class has size 1024 and is not the three-cut residual",
+        f_raw == 1024 and "|F_G| = 1024" in note and "not leftover-char" in note,
+    )
+
+    def orbit_value(predicate, orbit: frozenset[int]) -> int:
+        values = {predicate(mask) for mask in orbit}
+        if len(values) != 1:
+            raise ValueError(values)
+        return next(iter(values))
+
+    l1_values = [orbit_value(f_l1, orbit) for orbit in orbits]
+    l1_empty = f_l1(0)
+    l1_full = f_l1(N_CELLS - 1)
+    l1_even = all(f_l1(mask) == f_l1(complement(mask)) for mask in cells)
+    l1_covariant = all(
+        f_l1(mask) == f_l1(apply_perm(mask, rot))
+        for mask in cells
+        for rot in rotations
+    )
+    checks.check(
+        "theorem-3-l1-in-fcut",
+        "f_L1 is cube-covariant, vanishes on empty and full, and is complement-even",
+        l1_covariant
+        and l1_empty == 0
+        and l1_full == 0
+        and l1_even
+        and l1_values[empty_idx] == 0
+        and l1_values[full_idx] == 0,
+    )
+
+    other = [0] * n_orb
+    vertex_idx = orbit_index(orbits, min(type_of_orbit["vertex3"]))
+    other[vertex_idx] = 1
+    other_fn = {
+        mask: other[orbit_index(orbits, mask)] for mask in cells
+    }
+    other_in_cut = (
+        other[empty_idx] == 0
+        and other[full_idx] == 0
+        and all(other_fn[mask] == other_fn[complement(mask)] for mask in cells)
+        and other != l1_values
+    )
+    checks.check(
+        "theorem-3-not-unique",
+        "|F_cut| > 1 so f_L1 is not the unique survivor; another extra remains",
+        f_cut > 1 and other_in_cut and "not unique" in note and "another extra" in note,
+    )
+
+    claim_scope = (
+        "Among cube-covariant boolean formation predicates, the subclass that "
+        "vanishes on empty and full and is complement-even has size 2^{N_free}. "
+        "L1 is one element. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope displays the 2^{N_free} subclass and does not adopt L1",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: negative_route_pruning",
+        "reachability_to_target: prunes",
+        'hypothetical_axiom_status: "no edit"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "N_free = 5",
+        "|F_cut| = 32",
+    )
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "new axiom",
+        "adopt f_L1 as the formation law",
+        "unique survivor of the three cuts is f_L1",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{i}" in note for i in range(1, 9))
+        and not any(phrase in note for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "script-hygiene",
+        "the runner states that it does not adopt a member",
+        "does not adopt a member" in source
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no three-cut class",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom,
+    )
+
+    print("per_element: each of the 64 cells is classified by orbit and complement")
+    print("per_site: the six-ray star at one origin is the declared finite host")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: the ten-orbit partition and the 2^5 survivor count are executed")
+    print(
+        "lattice_wide: checked and not executed — no physical formation law "
+        "or member adoption is claimed"
+    )
+    print(
+        f"counts: N_orb={n_orb} n_empty=1 n_full=1 n_fixed={len(remaining_fixed)} "
+        f"n_pairs={len(pair_without_empty_full)} N_free={n_free} |F_cut|={f_cut}"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/formation_class_three_cut_survivors_2026_08_15.py
+++ b/scripts/formation_class_three_cut_survivors_2026_08_15.py
@@ -95,8 +95,16 @@ def l1_weight(mask: int) -> int:
     return mask.bit_count()
 
 
-def f_l1(mask: int) -> int:
+def f_parity(mask: int) -> int:
     return l1_weight(mask) % 2
+
+
+def f_l1(mask: int) -> int:
+    # L1 form iff n≠0: at least one axis is unbalanced.
+    for plus, minus in ((0, 1), (2, 3), (4, 5)):
+        if ((mask >> plus) & 1) != ((mask >> minus) & 1):
+            return 1
+    return 0
 
 
 def orbit_of(mask: int, rotations: tuple[tuple[int, ...], ...]) -> frozenset[int]:
@@ -449,6 +457,11 @@ def main() -> int:
         f_l1(mask) == f_l1(apply_perm(mask, rot))
         for mask in cells
         for rot in rotations
+    )
+    checks.check(
+        "theorem-3-l1-is-not-hamming-parity",
+        "displayed f_L1 is n≠0, not Hamming parity",
+        any(f_l1(mask) != f_parity(mask) for mask in cells),
     )
     checks.check(
         "theorem-3-l1-in-fcut",


### PR DESCRIPTION
## Summary

Vanish-on-empty, vanish-on-full, and complement-even leave N_free=5 so |F_cut|=32. f_L1 is one survivor and is not unique. Displayed, not adopted.

## Runner

`scripts/formation_class_three_cut_survivors_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.