### PR TITLE
feat: mirror atoms and the free toggle group behind the class sets

### DIFF
--- a/docs/PHYSICAL_CELL_CUTTING_MIRROR_ATOM_TOGGLE_ORBIT_CYCLE799_NOTE_2026-08-15.md
+++ b/docs/PHYSICAL_CELL_CUTTING_MIRROR_ATOM_TOGGLE_ORBIT_CYCLE799_NOTE_2026-08-15.md
@@ -1,0 +1,222 @@
+# Physical cell cutting: the mirror atoms of a cutting and the free toggle group behind its class set
+
+Date: 2026-08-15
+Authority: none
+Audit: unset
+Status: proposed_retained
+Claim type: bounded_theorem
+Constitutional effect: none.
+
+## Trace gate
+
+- `trace_class: frontier_discovery`
+- `target_claim_id: null`
+- `target_blocker_text: null`
+- `source_of_blocker_text: frontier_question`
+- `reachability_to_target: unknown_frontier`
+- `artifact_role: theorem`
+- `next_trace_action: derive why the atom-size profiles of the declared cell are exactly the six lists (24), (4, 20), (12, 12), (4, 4, 16), (4, 4, 4, 12) and (4, 4, 4, 4, 4, 4) with fiber counts 2636, 552, 384, 336, 192 and 16, rather than merely enumerating them; derive why every atom has size divisible by 4; and derive the single per-cutting ascent census across the 4116 fiber heads, of which only the constancy inside a fiber is derived here; none of that is claimed here`
+
+## Status contract
+
+- `actual_current_surface_status: bounded-support`
+- `target_claim_type: bounded_theorem`
+- `trace_class: frontier_discovery`
+- `reachability_to_target: unknown_frontier`
+- `conditional_surface_status: null`
+- `hypothetical_axiom_status: null`
+- `admitted_observation_status: null`
+- `claim_type_reason: an exact determination, on the declared finite cell, that every one of the 192 used pieces is a five-corner chain whose four steps carry the four axes once each and whose four-letter word is fixed by its start corner and its axis order alone, 192 of 192; that the piece map of the pure fourth-axis flip agrees with the point flip of the sample grid at 192 of 192 used pieces, is an involution with 0 fixed pieces, and sends each chain word to its reversed complement, so that the 96 word classes are blind to it; that the 15800 cuttings fall into 4116 class-set fibers in which every member is the fiber head with a subset of its pieces replaced by their mirrors, 15800 of 15800; that inside every fiber the difference supports are closed under symmetric difference, 4116 of 4116, that every support is a union of least moving parts (atoms) and that the fiber size is two to the atom count, 4116 of 4116, which derives the multiplicity ladder 2, 4, 8, 16 and 64 with counts 2636, 936, 336, 192 and 16 rather than observing it; that the atoms admit a second and independent description as the flip-overlap components of the point masks of one cutting, agreeing with the first at 4116 of 4116 fibers and, over the first 500 fibers and all 2368 of their members, transporting correctly along the toggle, so the atom split is a property of each cutting alone; that the atom-size profiles are exactly six, every atom size divisible by 4, every profile summing to 24, with the induced recount of 15800 cuttings; and that toggling every atom of a fiber head returns its mirror, which is again a cutting at 15800 of 15800 with none fixed; the axis-order census over the 48 walk representations and the single per-cutting ascent census 1, 11, 11 and 1 across the fiber heads are anchored as measured, and no physical or lattice-wide identification is made`
+
+## Inputs and scope
+
+The declared finite object is the one this lane has carried throughout: the 16 corners of the unit
+four-cube, the 2672 five-corner unit-determinant pieces built on them, the 400 that survive at the
+adjacency-cost floor 6, the 15800 cuttings of 24 pieces each that those 400 assemble into, the 192
+pieces occurring in at least one cutting, and the 384 signed coordinate maps of the cell. Points are
+counted on the generic sample grid with per-axis offsets 1, 2, 4 and 8, that is 5 values on each of
+the four axes and 625 points in all, written here on the integer scale in which the cell has width
+80. Every count below is recomputed from that rebuild; nothing outside it enters.
+
+The note `PHYSICAL_CELL_CUTTING_PIECE_TAXONOMY_COUNT_LAW_CYCLE798_NOTE_2026-08-15.md` left
+one question sharp. Each of the 192 used pieces is a chain carrying a four-letter word; the class of
+a word is the smaller of the word and its reversed complement; the 192 words are pairwise distinct
+and pair into 96 classes of two; every cutting carries 24 distinct classes; and yet the 15800
+cuttings carry only 4116 distinct class sets, with multiplicities 2, 4, 8, 16 and 64. This note
+derives that ladder. The fibers of the class-set map are the orbits of a free action by toggles, and
+the toggleable units are pinned down twice over, once inside the fiber and once in the point
+geometry of a single cutting, with the two descriptions agreeing everywhere.
+
+## Chain coordinates and the word law
+
+Each used piece has five corners, four corner-adjacency edges, and degree list 1, 1, 2, 2, 2, so it
+is a path; walking it from its smaller-labelled end of degree one gives a canonical corner sequence
+whose four steps carry the four axes once each, 192 of 192. The word law is then exact: the letter
+of the step on axis `ax` is the offset of that axis when the corner bit rises along the step, and 16
+minus that offset when it falls, so the word is a function of the start corner and the axis order
+alone and needs no walk, at 192 of 192 chains. Because the letters of distinct axes never coincide,
+the four letters of a word are pairwise distinct and its three adjacent comparisons are all strict.
+
+## The mirror lemma
+
+The mirror is the pure fourth-axis flip. Two statements hold at 192 of 192 used pieces: the piece it
+sends `t` to is the piece whose point mask is the flip of the mask of `t`, and its word is the
+reversed complement of the word of `t`. The first makes the piece-level map and the point-level map
+one and the same object; the second makes the mirror blind on classes, since the class was defined
+as the smaller of a word and its reversed complement. The map is an involution with 0 fixed pieces,
+so the 192 chains fall into 96 mirror pairs, one per class.
+
+That gives the toggle criterion in both directions. Let a cutting cover each of the 625 sample
+points exactly once, let `S` be a subset of its pieces and let `U` be the union of their point sets.
+Replacing every piece of `S` by its mirror vacates `U` and lays down exactly the flip of `U`, since
+the mirror of a family of pieces with disjoint point sets is again a family with disjoint point
+sets, of the same total size. If `U` is carried to itself by the flip, the vacated region is
+re-covered exactly once and the result is again a cutting. Conversely, if the result is a cutting,
+the untouched pieces still cover the complement of `U` exactly once each, so the mirrored pieces
+must cover exactly `U`; but they cover exactly the flip of `U`, forcing the flip of `U` to be `U`.
+Since the mirror keeps every class, such a toggle never moves the class set of a cutting.
+
+## The toggle group of a fiber
+
+Grouping the 15800 cuttings by their set of 24 classes gives 4116 fibers. Taking the first member of
+a fiber as its head `A`, every member `B` of that fiber is exactly `A` with the pieces of the
+difference support `S` replaced by their mirrors, at 15800 of 15800 members: the converse direction
+of the criterion above is therefore not merely available in principle but realized by every member,
+and the difference supports of a fiber are pairwise distinct, so a fiber member and its support are
+the same information. Inside every fiber the supports are closed under symmetric difference, 4116 of
+4116, so they form a group of toggles acting on the head, and the fiber is one orbit of it. The
+action is free because a support determines its member.
+
+## The atoms and the derived ladder
+
+Partitioning the 24 pieces of the head by their membership profile across all the supports of the
+fiber gives the atoms of that fiber. Every support is then a union of atoms, and the fiber size is
+two to the number of atoms, at 4116 of 4116 fibers: the supports are exactly the unions of atoms and
+nothing else, so the toggle group is free on the atoms. The atom-count census is 1 at 2636 fibers, 2
+at 936, 3 at 336, 4 at 192 and 6 at 16, and raising two to those counts returns 2, 4, 8, 16 and 64
+with exactly the multiplicities of the recomputed ladder. The ladder is therefore derived, not observed: the powers of
+two are the subsets of a basis of independent toggles, and the value 64 is six atoms rather than a
+coincidence.
+
+## The two routes to the atoms
+
+The atoms have a second description that reads no fiber at all. Take one cutting, join two of its
+pieces whenever the point mask of one meets the flip of the point mask of the other, and take the
+components. This is a statement about the 625 points and the flip alone; it never looks at any other
+cutting, any class, or any support. The components of the head agree with the atoms of its fiber at
+4116 of 4116 fibers. The two routes share no input: one reads only point masks of a single cutting,
+the other only membership profiles across the members of a fiber, and a single mismatch anywhere
+would fail the check.
+
+The description also survives transport. Over the first 500 fibers and all 2368 of their members,
+carrying each atom of the head along the toggle, that is replacing its pieces that lie in the
+support by their mirrors, gives exactly the flip-overlap components of the member, 2368 of 2368. So
+the atom split is a property of each cutting on its own, not a privilege of the head, and the fiber
+inherits it rather than defining it.
+
+## The atom-size profiles
+
+The sizes of the atoms of a fiber, listed in increasing order, take exactly six values over all 4116
+fibers: (24) at 2636 fibers, (4, 20) at 552, (12, 12) at 384, (4, 4, 16) at 336, (4, 4, 4, 12) at
+192 and (4, 4, 4, 4, 4, 4) at 16. Every atom size is divisible by 4 and every profile sums to 24, as
+it must, since the atoms partition the pieces of the cutting. Weighting each profile by two to its
+length recovers 15800 cuttings, which reconciles the count with the rebuild. Toggling every atom at
+once sends a head to its full mirror image, again a cutting of the same fiber, at 4116 of 4116; over
+all 15800 cuttings the mirror image is again a cutting, with 0 fixed, so the mirror acts freely.
+
+## The ascent census inside a fiber
+
+The ascent count of a word is the number of its adjacent comparisons that increase, a value between
+0 and 3. Reversing a word exchanges its ascents with its descents, and complementing every letter in
+16 does the same, so the reversed complement, which is the mirror word, preserves the ascent count.
+With the mirror lemma this makes the per-cutting ascent census invariant under every toggle, hence
+constant on each of the 4116 fibers. The measured census is the single shape 1, 11, 11 and 1 at all
+15800 cuttings, and only its constancy inside a fiber is derived here.
+
+Two censuses are printed as measurements and gated as nothing. The axis-order census over the 48
+walk representations of a cutting, each chain read in both directions, takes exactly five shapes,
+with 9368 cuttings at the shape whose 24 axis orders each occur twice, 5664 at the shape of 12
+orders once and 12 orders three times, 552 at 8 orders twice and 8 orders four times, 120 at 12
+orders four times, and 96 at 16 orders twice and 4 orders four times.
+
+## Derived versus measured
+
+Derived at the declared finite scope. The chain structure, the axis-once property and the word law
+are checked at every one of the 192 used pieces, not sampled. The mirror lemma is checked as an
+identity of point masks at all 192, and the reversed-complement form of the mirror word at all 192,
+so the class blindness of the mirror is a consequence rather than an observation. The toggle form of
+every fiber member is checked at all 15800 members, the closure of the supports under symmetric
+difference at all 4116 fibers, and the atom law and the size law at all 4116, so the multiplicity
+ladder 2, 4, 8, 16 and 64 is derived from the atom counts. The agreement of the geometric and the
+fiber routes is derived by complete enumeration over all 4116 fibers, and its transport over all
+2368 members of the first 500 fibers. The divisibility of every atom size by 4 and the sum 24 are
+verified atom by atom. That the reversed complement preserves the ascent count, and hence that the
+ascent census is constant on a fiber, is derived in prose above and rests only on the mirror lemma.
+
+What is measured, not derived, at the declared finite scope: why the atom-size profiles are exactly
+those six and carry exactly those fiber counts; why every atom size is divisible by 4; the atom-count
+census 2636, 936, 336, 192 and 16 itself; the axis-order census with its five shapes and counts
+9368, 5664, 552, 120 and 96; and the fact that the per-cutting ascent census is the same shape 1,
+11, 11 and 1 at all 4116 fiber heads, of which the derivation above covers only the passage from a
+head to the rest of its fiber. The choice of the first member of a fiber as its head is a
+bookkeeping convention; the transport check is what makes the atom split independent of it.
+
+## Boundary and the honest auditor read
+
+All of the above are computational identities of the declared unit four-cube object, its 400 kept
+pieces, its 15800 cuttings, its 192 used pieces and the order-384 symmetry group of the cell. The
+point statements are made on the sample grid of 625 points on the integer scale of width 80 with the
+per-axis offsets 1, 2, 4 and 8, and the flip is the one of the fourth axis in that frame; nothing
+here claims the atom split survives a different offset choice or a different distinguished axis. The
+atom decomposition is established for the cutting family of this cell and is not claimed for any
+other cutting family. The word, class and ascent statements are stated in the labels of the declared
+letter frame and are not claimed to be frame-independent. No physical, dynamical, or lattice-wide
+identification is claimed, no continuum limit is taken, and nothing here is asserted about
+cell-cutting systems outside the declared object.
+
+## Next entrance
+
+Three questions are now sharp. The first is the profile law: the atoms partition 24 pieces into
+parts of sizes divisible by 4, and the six lists that occur are a small subset of the possibilities,
+so some structure is choosing them and it is not identified here. The second is the atom itself: the
+flip-overlap description says an atom is a chunk of the cutting that the flip cannot break, and its
+sizes 4, 12, 16, 20 and 24 invite a description of that chunk in the point frame directly. The third
+is the ascent census: its constancy inside a fiber is now derived, so what remains is constancy
+across the 4116 heads, a statement about which words can share a cutting rather than about the
+mirror at all.
+
+## Review record
+
+- The rebuild is recomputed from the 16 corners in the runner itself, with the candidate count, the
+  floor, the kept count, the cutting count, the used count and the group order all gated, so a drift
+  in the object fails before any new claim is reached.
+- The word law is checked in the honest direction: the word is walked first from the corner sequence,
+  the law then predicts it from the start corner and the axis order alone, and the gate requires
+  agreement at every used piece rather than a count match.
+- The mirror lemma is a two-route identity: the piece map is formed from the corner action of the
+  flip, the point flip is formed as a permutation of the 625 grid points, and the gate requires the
+  masks to agree exactly.
+- The two atom descriptions are computed by disjoint code paths. The geometric path reads only the
+  point masks of one cutting and the point flip; the fiber path reads only membership profiles across
+  the difference supports. Neither is derived from the other, and the gate requires equality of the
+  sorted decompositions, so a single fiber out of place fails it.
+- The multiplicity ladder is never pinned as an input: it is recomputed from the fibers and then
+  reproduced a second time by raising two to the measured atom counts, and the two must match.
+- The transport check over every member of the first 500 fibers is what rules out the reading that
+  the atom split is an artifact of the choice of head.
+- The exact immutable reviewed head and landing SHA belong in the PR review comment because a commit
+  cannot contain its own hash.
+- The new citation-graph node must be regenerated and co-landed with this note.
+- Independent review is required before any downstream use of these results.
+
+Within those boundaries the results above stand as exact finite computational identities on the
+declared object, and as nothing wider.
+
+## Reproduction
+
+Run the [runner](../scripts/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.py).
+The reviewed
+[cache](../logs/runner-cache/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.txt)
+belongs beside it and is regenerated by the reviewer. The runner declares an `AUDIT_TIMEOUT_SEC`
+budget, finishes in well under a minute on the reference machine, and stays far below one gigabyte.
+Its final line is `TOTAL: PASS=10 FAIL=0`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15726,
- "node_count": 5529,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13833,6 +13833,10 @@
   "physical_cell_cutting_least_computing_sets_cycle737_note_2026-08-05": {
    "deps_hash": "ba0326da985f",
    "out_degree": 3
+  },
+  "physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_note_2026-08-15": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "physical_cell_cutting_object_distance_cycle751_note_2026-08-09": {
    "deps_hash": "92314bbf23cc",

--- a/logs/runner-cache/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.txt
+++ b/logs/runner-cache/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.py
+runner_sha256: a86f2deb8f4400e25a3487c25283504c144b89dbe19c77224cc9b4dea4c577b0
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 12.52
+status: ok
+----- stdout -----
+PASS G1 the declared cell rebuilds from the corner list alone: 2672 candidates, floor 6, 400 kept, 15800 cuttings of 24, 192 used, 384 maps
+G1 detail: the generic grid carries 5 values per axis, 625 points in all, on the integer scale of width 80, offsets 1, 2, 4, 8
+PASS G2 every one of the 192 used pieces is a five-corner chain whose four steps carry the four axes once each, 192 of 192
+G2 detail: the word law reads each letter off the start corner and the step axis alone, offset (1, 2, 4, 8) up and 16 minus it down, 192 of 192
+PASS G3 the mirror map on the 192 used pieces is exactly the point flip, 192 of 192, an involution with 0 fixed pieces
+G3 detail: the mirror word is the reversed complement at 192 of 192, so the mirror keeps the class of every chain, 96 classes in all
+G3 detail: the 192 chain words are pairwise distinct, so a class has exactly the two chains of one mirror pair
+PASS G4 the 15800 cuttings fall into 4116 class-set fibers, and every member is the fiber head with a subset of its pieces replaced by mirrors
+G4 detail: the toggle form holds at 15800 of 15800 members, and the class-set multiplicity ladder is {2: 2636, 4: 936, 8: 336, 16: 192, 64: 16}
+PASS G5 inside every fiber the difference supports are closed under symmetric difference, hence a group of toggles, 4116 of 4116
+PASS G6 every difference support is a union of fiber atoms and every fiber has size two to its atom count, 4116 of 4116
+G6 detail: the atom-count census is {1: 2636, 2: 936, 3: 336, 4: 192, 6: 16}, and two to those counts is the ladder above
+PASS G7 the geometric atoms of the fiber head equal its fiber atoms at 4116 of 4116 fibers, two routes that share no input
+G7 detail: the geometric route reads only the point masks of that one cutting; the fiber route reads only membership across supports
+PASS G8 over the first 500 fibers the transported atoms equal the geometric atoms of every member, 2368 of 2368
+G8 detail: so the atom split is a property of each cutting on its own, carried along by the toggle rather than fixed by the fiber head
+PASS G9 the atom-size profiles are exactly 6, every size divisible by 4, every profile summing to 24, and the recount is 15800
+G9 detail: profile (24) at 2636 fibers, each carrying 2 cuttings
+G9 detail: profile (4, 20) at 552 fibers, each carrying 4 cuttings
+G9 detail: profile (12, 12) at 384 fibers, each carrying 4 cuttings
+G9 detail: profile (4, 4, 16) at 336 fibers, each carrying 8 cuttings
+G9 detail: profile (4, 4, 4, 12) at 192 fibers, each carrying 16 cuttings
+G9 detail: profile (4, 4, 4, 4, 4, 4) at 16 fibers, each carrying 64 cuttings
+PASS G10 toggling every atom of a fiber head gives its mirror, a cutting of the same fiber, at 4116 of 4116, and no cutting is its own mirror
+G10 detail: the mirror of a cutting is again a cutting at 15800 of 15800, with 0 fixed, so the mirror is a free involution on cuttings
+census: over the 48 walk representations of a cutting the axis-order census takes 5 shapes, written as multiplicity: orders
+census: {2: 24} at 9368, {1: 12, 3: 12} at 5664, {2: 8, 4: 8} at 552, {4: 12} at 120, {2: 16, 4: 4} at 96
+census: the ascent census inside a cutting is {0: 1, 1: 11, 2: 11, 3: 1} at all 15800 cuttings, one shape, kept by every toggle
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.py
+++ b/scripts/physical_cell_cutting_mirror_atom_toggle_orbit_cycle799_2026_08_15.py
@@ -1,0 +1,551 @@
+"""Cycle 799: the class-set fiber of a cell cutting is the free toggle group on its mirror atoms (finite checks).
+
+Standalone exact runner. Standard library only, no file input or output, no randomness, integer and exact rational arithmetic only.
+
+The preamble rebuilds the declared finite object from the 16 corners of the unit four-cube: the five-corner unit-determinant pieces, the
+adjacency cost floor, the kept pieces at that floor, the exact 24-piece cuttings, the used pieces, and the order-384 group of signed
+coordinate maps of the cell. Nothing outside that finite object enters any gate.
+
+The previous cycle counted the class sets: every used piece is a chain carrying a four-letter word, the class of a word is the smaller of
+the word and its reversed complement, every cutting carries 24 distinct classes, and the 15800 cuttings carry only 4116 distinct class sets
+with multiplicities 2, 4, 8, 16 and 64. This cycle derives that ladder. The mirror map is the pure fourth-axis flip; it sends each chain to
+the chain of the reversed complement word, hence keeps the class, so replacing some pieces of a cutting by their mirrors can leave the class
+set alone. The edits available inside one fiber are shown to form a group under symmetric difference; its least moving parts, the atoms, are
+characterized twice, once by membership profiles across the edits of the fiber and once by flip overlap in the point geometry of a single
+cutting; the two characterizations agree at every fiber and at every member, so the fiber is the free toggle group on the atoms and its size
+is two to the atom count.
+Gates G1 to G10, one line each with a few detail lines, then the measured censuses and the total line. Any failure exits nonzero.
+"""
+
+import itertools
+import sys
+from collections import Counter
+from fractions import Fraction as FRA
+
+AUDIT_TIMEOUT_SEC = 900
+
+OUT = [0]
+
+
+def emit(s):
+    txt = "{0}".format(s)
+    if ("9" + "9") in txt:
+        raise ValueError("barred digit pair in output")
+    if len(txt) > 148:
+        raise ValueError("output line over the length limit")
+    OUT[0] += len(txt) + 1
+    if OUT[0] >= 5800:
+        raise ValueError("output over the character budget")
+    print(txt)
+
+
+STAT = [0, 0]
+
+
+def gate(ok, tag, msg):
+    if ok:
+        STAT[0] += 1
+    else:
+        STAT[1] += 1
+    emit("{0} {1} {2}".format("PASS" if ok else "FAIL", tag, msg))
+
+
+def dshow(d):
+    return "{" + ", ".join("{0}: {1}".format(k, d[k]) for k in sorted(d)) + "}"
+
+
+def tshow(seq):
+    return "(" + ", ".join("{0}".format(x) for x in seq) + ")"
+
+
+# ---------------------------------------------------------------- the object
+
+CORN = [tuple((i >> b) & 1 for b in range(4)) for i in range(16)]
+CIDX = {c: i for i, c in enumerate(CORN)}
+
+
+def det4(M):
+    tot = 0
+    cols = (0, 1, 2, 3)
+    for c in itertools.combinations(cols, 2):
+        rest = tuple(x for x in cols if x not in c)
+        a = M[0][c[0]] * M[1][c[1]] - M[0][c[1]] * M[1][c[0]]
+        b = M[2][rest[0]] * M[3][rest[1]] - M[2][rest[1]] * M[3][rest[0]]
+        tot += ((-1) ** (c[0] + c[1] + 1)) * a * b
+    return tot
+
+
+def inv4(C):
+    n = 4
+    M = [[FRA(C[r][c]) for c in range(n)] + [FRA(1 if r == c else 0) for c in range(n)] for r in range(n)]
+    for c in range(n):
+        p = -1
+        for r in range(c, n):
+            if M[r][c] != 0:
+                p = r
+                break
+        if p < 0:
+            return None
+        M[c], M[p] = M[p], M[c]
+        pv = M[c][c]
+        M[c] = [x / pv for x in M[c]]
+        for r in range(n):
+            if r != c and M[r][c] != 0:
+                fq = M[r][c]
+                M[r] = [M[r][k] - fq * M[c][k] for k in range(2 * n)]
+    out = []
+    for r in range(n):
+        row = []
+        for c in range(n, 2 * n):
+            v = M[r][c]
+            if v.denominator != 1:
+                return None
+            row.append(int(v))
+        out.append(row)
+    return out
+
+
+def adjcost(S):
+    bad = 0
+    for a, b in itertools.combinations(S, 2):
+        d = sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4))
+        if d > 1:
+            bad += 1
+    return bad
+
+
+CAND = [S for S in itertools.combinations(range(16), 5)
+        if abs(det4([[CORN[S[j + 1]][r] - CORN[S[0]][r] for j in range(4)] for r in range(4)])) == 1]
+COSTS = [adjcost(S) for S in CAND]
+FLOOR = min(COSTS)
+KEPT = [CAND[i] for i in range(len(CAND)) if COSTS[i] == FLOOR]
+
+BARY = []
+for S in KEPT:
+    v0 = CORN[S[0]]
+    C = [[CORN[S[j + 1]][r] - v0[r] for j in range(4)] for r in range(4)]
+    BARY.append((v0, inv4(C)))
+
+NSHIFT, OFFS, RSTEP = 16, (1, 2, 4, 8), 5
+DIV = NSHIFT * RSTEP
+NPTS = RSTEP ** 4
+
+
+def buildmask(offs):
+    """Membership bitmasks of every kept piece on the sample points of one per-axis offset table, by exact integer barycentric tests."""
+    axval = [[NSHIFT * k + offs[i] for k in range(RSTEP)] for i in range(4)]
+    out = []
+    for (v0, Ci) in BARY:
+        off = [sum(Ci[i][c] * DIV * v0[c] for c in range(4)) for i in range(4)]
+        col = [[[Ci[i][ax] * u for i in range(4)] for u in axval[ax]] for ax in range(4)]
+        bits = 0
+        idx = 0
+        for a in col[0]:
+            s1 = [a[i] - off[i] for i in range(4)]
+            for b in col[1]:
+                s2 = [s1[i] + b[i] for i in range(4)]
+                for c in col[2]:
+                    s3 = [s2[i] + c[i] for i in range(4)]
+                    for d in col[3]:
+                        w = [s3[i] + d[i] for i in range(4)]
+                        sw = sum(w)
+                        if all(x > 0 for x in w) and sw < DIV:
+                            bits |= (1 << idx)
+                        idx += 1
+        out.append(bits)
+    return out
+
+
+MASK = buildmask(OFFS)
+UNIV = (1 << NPTS) - 1
+NK = len(KEPT)
+
+BYPT = [[] for _ in range(NPTS)]
+for t in range(NK):
+    mm = MASK[t]
+    while mm:
+        low = mm & (-mm)
+        BYPT[low.bit_length() - 1].append(t)
+        mm ^= low
+
+SOLS = []
+sys.setrecursionlimit(10000)
+
+
+def cover_search(cov, chosen):
+    if cov == UNIV:
+        SOLS.append(tuple(chosen))
+        return
+    free = UNIV & (~cov)
+    p = (free & (-free)).bit_length() - 1
+    for t in BYPT[p]:
+        m = MASK[t]
+        if m & cov:
+            continue
+        chosen.append(t)
+        cover_search(cov | m, chosen)
+        chosen.pop()
+
+
+cover_search(0, [])
+NS = len(SOLS)
+USED = sorted(set(t for s in SOLS for t in s))
+NU = len(USED)
+KIDX = {frozenset(S): t for t, S in enumerate(KEPT)}
+SSET = [frozenset(s) for s in SOLS]
+SIDX = dict((SSET[i], i) for i in range(NS))
+CSIZE = sorted(set(len(s) for s in SOLS))[0]
+PSIZE = len(set(len(s) for s in SOLS))
+
+P4 = list(itertools.permutations(range(4)))
+G384 = [(p, m) for p in P4 for m in range(16)]
+FLIPD = ((0, 1, 2, 3), 8)
+
+
+def actcorner(g, v):
+    p, m = g
+    x = CORN[v]
+    return CIDX[tuple(x[p[i]] ^ ((m >> p[i]) & 1) for i in range(4))]
+
+
+def piecemap(g, dom):
+    return dict((t, KIDX[frozenset(actcorner(g, v) for v in KEPT[t])]) for t in dom)
+
+
+MP8 = piecemap(FLIPD, sorted(USED))
+
+# The point flip: the permutation of the sample grid sending the fourth coordinate x to DIV minus x, that is the last index k to RSTEP-1-k.
+PERM = [0] * NPTS
+for k0 in range(RSTEP):
+    for k1 in range(RSTEP):
+        for k2 in range(RSTEP):
+            for k3 in range(RSTEP):
+                PERM[((k0 * RSTEP + k1) * RSTEP + k2) * RSTEP + k3] = ((k0 * RSTEP + k1) * RSTEP + k2) * RSTEP + (RSTEP - 1 - k3)
+
+
+def flipbits(m):
+    """The point mask carried through the fourth-axis point flip. This route reads the grid alone and never touches the piece map."""
+    out = 0
+    mm = m
+    while mm:
+        low = mm & (-mm)
+        out |= (1 << PERM[low.bit_length() - 1])
+        mm ^= low
+    return out
+
+
+FM = dict((t, flipbits(MASK[t])) for t in USED)
+
+# ============================================== G1 the declared cell preamble
+
+gate(len(CAND) == 2672 and FLOOR == 6 and NK == 400 and NS == 15800 and PSIZE == 1 and CSIZE == 24 and NU == 192
+     and len(G384) == 384 and NPTS == 625 and DIV == 80, "G1",
+     "the declared cell rebuilds from the corner list alone: {0} candidates, floor {1}, {2} kept, {3} cuttings of {4}, {5} used, {6} maps"
+     .format(len(CAND), FLOOR, NK, NS, CSIZE, NU, len(G384)))
+emit("G1 detail: the generic grid carries {0} values per axis, {1} points in all, on the integer scale of width {2}, offsets {3}"
+     .format(RSTEP, NPTS, DIV, ", ".join("{0}".format(o) for o in OFFS)))
+
+# ============================================== G2 chain coordinates and the word law
+
+
+def edges_of(t):
+    """The corner-adjacency edges of kept piece t: its corner pairs at coordinate distance one."""
+    S = KEPT[t]
+    return [(a, b) for a, b in itertools.combinations(S, 2)
+            if sum(abs(CORN[a][r] - CORN[b][r]) for r in range(4)) == 1]
+
+
+ADJ = {}
+CHAINOK = 0
+for t in USED:
+    ad = dict((v, []) for v in KEPT[t])
+    E = edges_of(t)
+    for a, b in E:
+        ad[a].append(b)
+        ad[b].append(a)
+    ADJ[t] = ad
+    seen = set([KEPT[t][0]])
+    stack = [KEPT[t][0]]
+    while stack:
+        v = stack.pop()
+        for u in ad[v]:
+            if u not in seen:
+                seen.add(u)
+                stack.append(u)
+    if len(KEPT[t]) == 5 and len(E) == 4 and len(seen) == 5 and sorted(len(ad[v]) for v in ad) == [1, 1, 2, 2, 2]:
+        CHAINOK += 1
+
+
+def walk_of(t):
+    """The corner sequence and the step list of a chain, walked from its smaller-labelled degree-one end."""
+    ad = ADJ[t]
+    ends = sorted(v for v in ad if len(ad[v]) == 1)
+    v = ends[0]
+    seq = [v]
+    prev = -1
+    while len(seq) < 5:
+        nxt = [u for u in ad[v] if u != prev][0]
+        seq.append(nxt)
+        prev, v = v, nxt
+    steps = []
+    for i in range(4):
+        ax = (seq[i] ^ seq[i + 1]).bit_length() - 1
+        steps.append((ax, (seq[i] >> ax) & 1))
+    return seq, steps
+
+
+def word_of(t):
+    """The effective-offset word of a chain: the axis offset when the corner bit rises and its complement in the shift when it falls."""
+    return tuple(OFFS[ax] if b == 0 else NSHIFT - OFFS[ax] for ax, b in walk_of(t)[1])
+
+
+def canon(w):
+    """The class of a word: the smaller of the word and its mirror, the reversed word with complemented letters."""
+    return min(w, tuple(NSHIFT - x for x in reversed(w)))
+
+
+def ascents(w):
+    return sum(1 for i in range(3) if w[i] < w[i + 1])
+
+
+WORD = dict((t, word_of(t)) for t in USED)
+CW = dict((t, canon(WORD[t])) for t in USED)
+AXO = dict((t, tuple(ax for ax, _ in walk_of(t)[1])) for t in USED)
+ASC = dict((t, ascents(WORD[t])) for t in USED)
+AXONE = sum(1 for t in USED if sorted(AXO[t]) == [0, 1, 2, 3])
+LAWOK = 0
+for t in USED:
+    c = walk_of(t)[0][0]
+    if WORD[t] == tuple(OFFS[ax] if ((c >> ax) & 1) == 0 else NSHIFT - OFFS[ax] for ax in AXO[t]):
+        LAWOK += 1
+
+gate(CHAINOK == NU and AXONE == NU and LAWOK == NU and NU == 192, "G2",
+     "every one of the {0} used pieces is a five-corner chain whose four steps carry the four axes once each, {0} of {0}".format(NU))
+emit("G2 detail: the word law reads each letter off the start corner and the step axis alone, offset {0} up and {1} minus it down, {2} of {2}"
+     .format(tshow(OFFS), NSHIFT, LAWOK))
+
+# ============================================== G3 the mirror lemma
+
+MOK = sum(1 for t in USED if MASK[MP8[t]] == FM[t])
+INV = sum(1 for t in USED if MP8[MP8[t]] == t)
+FIX = sum(1 for t in USED if MP8[t] == t)
+RCOK = sum(1 for t in USED if WORD[MP8[t]] == tuple(NSHIFT - x for x in reversed(WORD[t])))
+CWOK = sum(1 for t in USED if CW[MP8[t]] == CW[t])
+NCLS = len(set(CW.values()))
+NWRD = len(set(WORD.values()))
+
+gate(MOK == NU and INV == NU and FIX == 0 and RCOK == NU and CWOK == NU and NWRD == NU and NCLS == 96, "G3",
+     "the mirror map on the {0} used pieces is exactly the point flip, {0} of {0}, an involution with {1} fixed pieces".format(NU, FIX))
+emit("G3 detail: the mirror word is the reversed complement at {0} of {0}, so the mirror keeps the class of every chain, {1} classes in all"
+     .format(NU, NCLS))
+emit("G3 detail: the {0} chain words are pairwise distinct, so a class has exactly the two chains of one mirror pair".format(NWRD))
+
+# ============================================== G4 the fibers and the toggle form
+
+FIB = {}
+for i in range(NS):
+    FIB.setdefault(frozenset(CW[t] for t in SOLS[i]), []).append(i)
+FKEYS = list(FIB.keys())
+NFIB = len(FKEYS)
+TOGOK = 0
+NMEM = 0
+SUPS = {}
+for k in FKEYS:
+    mem = FIB[k]
+    A = SSET[mem[0]]
+    sup = []
+    for j in mem:
+        B = SSET[j]
+        S = A - B
+        sup.append(S)
+        NMEM += 1
+        if B == (A - S) | frozenset(MP8[t] for t in S):
+            TOGOK += 1
+    SUPS[k] = sup
+LAD = Counter(len(FIB[k]) for k in FKEYS)
+
+gate(NFIB == 4116 and TOGOK == NS and NMEM == NS and sum(k * LAD[k] for k in LAD) == NS
+     and all(len(set(SUPS[k])) == len(FIB[k]) for k in FKEYS)
+     and all(len(k) == CSIZE for k in FKEYS), "G4",
+     "the {0} cuttings fall into {1} class-set fibers, and every member is the fiber head with a subset of its pieces replaced by mirrors"
+     .format(NS, NFIB))
+emit("G4 detail: the toggle form holds at {0} of {0} members, and the class-set multiplicity ladder is {1}".format(NS, dshow(LAD)))
+
+# ============================================== G5 the supports form a subspace
+
+SUBOK = 0
+for k in FKEYS:
+    ss = set(SUPS[k])
+    ok = True
+    for a in ss:
+        for b in ss:
+            if (a ^ b) not in ss:
+                ok = False
+                break
+        if not ok:
+            break
+    if ok:
+        SUBOK += 1
+
+gate(SUBOK == NFIB and NFIB == 4116, "G5",
+     "inside every fiber the difference supports are closed under symmetric difference, hence a group of toggles, {0} of {0}".format(NFIB))
+
+# ============================================== G6 the atoms and the derived ladder
+
+
+def atoms_sorted(parts):
+    return sorted((tuple(sorted(p)) for p in parts), key=lambda a: (len(a), a))
+
+
+FATOM = {}
+UNIONOK = 0
+SIZEOK = 0
+for k in FKEYS:
+    A = SSET[FIB[k][0]]
+    sup = SUPS[k]
+    prof = {}
+    for t in sorted(A):
+        prof.setdefault(tuple(1 if t in S else 0 for S in sup), []).append(t)
+    aset = atoms_sorted(prof.values())
+    FATOM[k] = aset
+    good = True
+    for S in sup:
+        rem = set(S)
+        for a in aset:
+            sa = set(a)
+            if sa <= rem:
+                rem -= sa
+            elif sa & rem:
+                good = False
+                break
+        if not good or rem:
+            good = False
+            break
+    if good:
+        UNIONOK += 1
+    if len(FIB[k]) == 2 ** len(aset):
+        SIZEOK += 1
+ACOUNT = Counter(len(FATOM[k]) for k in FKEYS)
+
+gate(UNIONOK == NFIB and SIZEOK == NFIB and NFIB == 4116
+     and dict(Counter(2 ** a for a in ACOUNT.elements())) == dict(LAD), "G6",
+     "every difference support is a union of fiber atoms and every fiber has size two to its atom count, {0} of {0}".format(NFIB))
+emit("G6 detail: the atom-count census is {0}, and two to those counts is the ladder above".format(dshow(ACOUNT)))
+
+# ============================================== G7 the two-route atom theorem
+
+
+def geo_atoms(s):
+    """The atoms of one cutting read off the point geometry alone: join two pieces when one meets the point flip of the other."""
+    par = dict((t, t) for t in s)
+
+    def find(a):
+        while par[a] != a:
+            par[a] = par[par[a]]
+            a = par[a]
+        return a
+
+    for p in s:
+        fp = FM[p]
+        for q in s:
+            if MASK[q] & fp:
+                ra, rb = find(p), find(q)
+                if ra != rb:
+                    par[ra] = rb
+    comp = {}
+    for t in s:
+        comp.setdefault(find(t), []).append(t)
+    return atoms_sorted(comp.values())
+
+
+TWOOK = 0
+for k in FKEYS:
+    if geo_atoms(sorted(SSET[FIB[k][0]])) == FATOM[k]:
+        TWOOK += 1
+
+gate(TWOOK == NFIB and NFIB == 4116, "G7",
+     "the geometric atoms of the fiber head equal its fiber atoms at {0} of {0} fibers, two routes that share no input".format(NFIB))
+emit("G7 detail: the geometric route reads only the point masks of that one cutting; the fiber route reads only membership across supports")
+
+# ============================================== G8 member independence
+
+NPRE = 500
+MIOK = 0
+MITOT = 0
+for k in FKEYS[:NPRE]:
+    A = SSET[FIB[k][0]]
+    aset = FATOM[k]
+    for j in FIB[k]:
+        B = SSET[j]
+        S = A - B
+        tr = atoms_sorted([set(a) - S | frozenset(MP8[t] for t in (set(a) & S)) for a in aset])
+        MITOT += 1
+        if tr == geo_atoms(sorted(B)):
+            MIOK += 1
+
+gate(MIOK == MITOT and MITOT == 2368 and NPRE == 500, "G8",
+     "over the first {0} fibers the transported atoms equal the geometric atoms of every member, {1} of {1}".format(NPRE, MITOT))
+emit("G8 detail: so the atom split is a property of each cutting on its own, carried along by the toggle rather than fixed by the fiber head")
+
+# ============================================== G9 the atom-size profiles
+
+PROF = Counter(tuple(len(a) for a in FATOM[k]) for k in FKEYS)
+DIV4 = all((len(a) & 3) == 0 for k in FKEYS for a in FATOM[k])
+SUM24 = all(sum(len(a) for a in FATOM[k]) == CSIZE for k in FKEYS)
+RECOUNT = sum((2 ** len(p)) * PROF[p] for p in PROF)
+PTARGET = {(24,): 2636, (4, 20): 552, (12, 12): 384, (4, 4, 16): 336, (4, 4, 4, 12): 192, (4, 4, 4, 4, 4, 4): 16}
+
+gate(dict(PROF) == PTARGET and DIV4 and SUM24 and RECOUNT == NS and len(PROF) == 6, "G9",
+     "the atom-size profiles are exactly {0}, every size divisible by {1}, every profile summing to {2}, and the recount is {3}"
+     .format(len(PROF), 4, CSIZE, RECOUNT))
+for p in sorted(PROF, key=lambda q: (len(q), q)):
+    emit("G9 detail: profile {0} at {1} fibers, each carrying {2} cuttings".format(tshow(p), PROF[p], 2 ** len(p)))
+
+# ============================================== G10 the global mirror
+
+MIRIN = 0
+MIRFIX = 0
+for i in range(NS):
+    ms = frozenset(MP8[t] for t in SOLS[i])
+    if ms in SIDX:
+        MIRIN += 1
+        if ms == SSET[i]:
+            MIRFIX += 1
+FULLOK = 0
+for k in FKEYS:
+    A = SSET[FIB[k][0]]
+    allat = frozenset(t for a in FATOM[k] for t in a)
+    tog = frozenset(MP8[t] for t in allat)
+    if allat == A and tog in SIDX and tog in set(SSET[j] for j in FIB[k]) and A in set(SSET[j] for j in FIB[k]):
+        FULLOK += 1
+
+gate(MIRIN == NS and MIRFIX == 0 and FULLOK == NFIB and NFIB == 4116, "G10",
+     "toggling every atom of a fiber head gives its mirror, a cutting of the same fiber, at {0} of {0}, and no cutting is its own mirror"
+     .format(NFIB))
+emit("G10 detail: the mirror of a cutting is again a cutting at {0} of {0}, with {1} fixed, so the mirror is a free involution on cuttings"
+     .format(NS, MIRFIX))
+
+# ============================================== the measured censuses
+
+SHAPE = Counter()
+for s in SOLS:
+    c = Counter()
+    for t in s:
+        c[AXO[t]] += 1
+        c[tuple(reversed(AXO[t]))] += 1
+    SHAPE[tuple(sorted(c.values()))] += 1
+NWALKS = 2 * CSIZE
+emit("census: over the {0} walk representations of a cutting the axis-order census takes {1} shapes, written as multiplicity: orders"
+     .format(NWALKS, len(SHAPE)))
+emit("census: " + ", ".join("{0} at {1}".format(dshow(Counter(sh)), SHAPE[sh])
+                           for sh in sorted(SHAPE, key=lambda x: -SHAPE[x])))
+ACEN = Counter(tuple(sorted(Counter(ASC[t] for t in s).items())) for s in SOLS)
+if len(ACEN) != 1:
+    raise ValueError("the ascent census is not a single shape")
+ONE = sorted(ACEN)[0]
+emit("census: the ascent census inside a cutting is {0} at all {1} cuttings, one shape, kept by every toggle"
+     .format(dshow(dict(ONE)), ACEN[ONE]))
+
+emit("TOTAL: PASS={0} FAIL={1}".format(STAT[0], STAT[1]))
+if STAT[1]:
+    sys.exit(1)


### PR DESCRIPTION
## What this PR lands

One source note in `docs/`, its paired runner in `scripts/`, and the runner's fresh cache in `logs/runner-cache/` — the source-only triple — plus a separate audit-infra commit acknowledging the new note in the citation-graph manifest.

## The science

The taxonomy cycle ([PR #6387](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/6387)) left one question sharp: the fifteen thousand eight hundred cuttings of the declared cell carry only four thousand one hundred sixteen distinct class sets, and each class set is shared by exactly two, four, eight, sixteen or sixty-four cuttings. Why powers of two, and why those multiplicities?

This note derives the ladder:

- **Chain coordinates and the word law.** Every used piece is a five-corner chain whose four steps carry the four axes once each, and its four-letter word is a function of the start corner and the axis order alone — no walk needed.
- **The mirror lemma.** The piece map of the pure fourth-axis flip agrees with the point flip of the sample grid, is an involution with no fixed piece, and sends each chain word to its reversed complement, so word classes are blind to it.
- **Fibers are free toggle groups.** Every member of a class-set fiber is the fiber head with a subset of its pieces replaced by their mirrors; the difference supports are closed under symmetric difference; every support is a union of least moving parts (atoms); and the fiber size is two to the atom count. The ladder of two, four, eight, sixteen and sixty-four with its exact multiplicities is thereby derived, not observed.
- **Two independent routes to the atoms.** The membership-profile atoms computed inside a fiber coincide with the flip-overlap components computed from the point masks of a single cutting, at every fiber, and transport correctly along toggles — so the atom split is a property of each cutting alone.
- **The global mirror.** Toggling every atom at once returns the full mirror image of a cutting, which is again a cutting, with none fixed.
- **Ascent preservation.** Reversal and complementation each swap ascents and descents, so their composition preserves the ascent count — which is why the per-cutting ascent census is constant inside every fiber.

Measured and gated as nothing: the axis-order census over the walk representations, and the single per-cutting ascent census shape. Cross-fiber constancy of that shape remains an open question, alongside the law behind the six atom-size profiles.

## Verification

The runner rebuilds the cell from the corner list alone — candidates, floor, kept pieces, cuttings, used pieces and cell maps — and gates every derived claim above with discriminating checks; it prints `TOTAL: PASS=10 FAIL=0`. The cache is regenerated from that run, and my own independent re-run matched it byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
