### PR TITLE
feat(rawfill): 96 covariant maps fill the two-cube from one site

### DIFF
--- a/docs/COVARIANT_ONE_SITE_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/COVARIANT_ONE_SITE_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,338 @@
+---
+claim_id: covariant_one_site_fill_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among cube-covariant f with f(empty)=0, the number that fill the twelve-vertex two-cube from a 1-site seed with off-patch o=0 is 96. f_L1 is not the unique filler. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/covariant_one_site_fill_census_2026_08_15.py
+---
+
+# Cube-Covariant One-Site Fill Census On The Two-Cube
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock census of every cube-covariant Boolean
+map with `f(empty)=0` on the twelve-vertex two-cube from a 1-site seed
+with off-patch occupancy `0`. The unbalanced-axis map `f_L1` is displayed
+as one filler. It is not adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/covariant_one_site_fill_census_2026_08_15.py`](../scripts/covariant_one_site_fill_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The empty 6-tuple is a singleton orbit.
+There are exactly 512 maps with `f(empty)=0`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, seed `(0,0,0)` starts locked. Off-patch
+neighbors have occupancy `0`. Each tick, every unlocked on-patch vertex
+evaluates `f` on its six-neighbor occupancy tuple and locks if `f=1`. The
+process is synchronous and stops at a fixed point in at most 12 ticks.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+Exactly `N_fill = 96` of the 512 maps lock all twelve vertices. Exactly
+`N_empty = 256` have empty first wave. So `N_fill ≠ 1`: `f_L1` fills, but
+it is not the unique filler. A displayed second filler `f_★` is `1`
+exactly on the three orbits with at least one unbalanced axis and no fully
+occupied axis. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 24 rotations, 10 orbits, 512 empty-zero maps, and the exact pair (N_fill, N_empty) are enumerated. Uniqueness of f_L1 as a filler is false on this patch. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: covariant_one_site_fill_census
+target_blocker_text: "which cube-covariant occupancy predicates fill the two-cube from a 1-site seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded census; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for cube-covariant Boolean maps with f(empty)=0 on this twelve-vertex patch with off-patch o=0; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the 1-site seed `(0,0,0)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Count the cube-covariant Boolean maps with `f(empty)=0` that
+fill the two-cube from the 1-site seed, and decide uniqueness of `f_L1`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits.
+
+| `(u,b,e)` | orbit size |
+|---|---:|
+| `(0,0,3)` empty | 1 |
+| `(0,1,2)` | 3 |
+| `(0,2,1)` | 3 |
+| `(0,3,0)` | 1 |
+| `(1,0,2)` one unbalanced axis | 6 |
+| `(1,1,1)` | 12 |
+| `(1,2,0)` | 6 |
+| `(2,0,1)` | 12 |
+| `(2,1,0)` | 12 |
+| `(3,0,0)` | 8 |
+
+Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1,
+f_★(c)  = 1  iff  u(c) ≥ 1 and b(c) = 0,
+f_H(c)  = |c|_1 mod 2.
+```
+
+`f_L1` and `f_★` and `f_H` are cube-covariant and vanish on the empty
+orbit. `f_H` is used only as a displayed mutation: it is not `f_L1`.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+`N_fill` is the number of empty-zero cube-covariant `f` whose halt set has
+cardinality 12. `N_empty` is the number whose first tick adds no vertex.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. Exactly 512 cube-covariant maps satisfy `f(empty)=0`.
+The unbalanced-axis map `f_L1` is one of them. It is not Hamming parity.
+
+**Theorem 2.** On the twelve-vertex two-cube from seed `(0,0,0)` with
+off-patch occupancy `0`,
+
+```text
+N_fill = 96,     N_empty = 256.
+```
+
+Both counts are exact. The empty-first-wave count is the subclass with
+`f=0` on the one-unbalanced-axis orbit: that assignment leaves eight free
+orbits, so `2^8 = 256`.
+
+**Theorem 3.** `N_fill ≠ 1`. The map `f_L1` fills: lock cardinalities
+`(1,4,8,11,12)` and halt tick `4`. The displayed second filler `f_★` is
+distinct from `f_L1` and also fills, with the same lock cardinalities and
+the same halt tick. Displayed, not adopted. Hamming parity is a different
+empty-zero cube-covariant map and does not fill.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| 512 empty-zero covariant maps | `2^{9}` assignments after fixing the empty orbit to `0` |
+| `f_L1` is one of them | `u` is rotation-invariant and `u(empty)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `N_fill` and `N_empty` | exhaustive 512-run census to a fixed point |
+| uniqueness of `f_L1` | false; `f_★` is an explicit second filler |
+| physical Admissibility selection | open and not claimed |
+
+Every leaf needed for the stated census is discharged. No `Z^3`-wide
+formation law is claimed.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming does not fill.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Drop cube covariance: the class is no longer the 512 orbit assignments.
+4. Seed a second on-patch site: the 1-site first-wave and fill counts change.
+5. Assert `N_fill=1`: the explicit second filler `f_★` refutes uniqueness.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character count of a static subclass in place of this
+  dynamics census.
+- No blank-block, 2-site, or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness: `f_L1` is not the unique
+empty-zero cube-covariant filler of this patch. The positive counts
+`N_fill=96` and `N_empty=256` are exact enumerations, not walls.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| first-wave emptiness | Count maps whose first tick adds no vertex. | Theorem 2 and check `thm2-n-empty` give `N_empty = 256`. | **ATTEMPTED** |
+| fill census | Run every empty-zero covariant `f` to a fixed point. | Theorem 2 and check `thm2-n-fill` give `N_fill = 96`. | **ATTEMPTED** |
+| uniqueness of `f_L1` | Ask whether the filler class is a singleton. | Theorem 3 and checks `thm3-not-unique` / `thm3-displayed-other-filler`. | **ATTEMPTED** |
+| Hamming fill | Run Hamming parity on the same patch. | Theorem 3 and check `mutation-hamming-does-not-fill`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness fails. The explicit second
+filler and the cardinality `N_fill=96` are two certificates of the same
+non-uniqueness, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_fill=96` / displayed `f_★` | yes: a count larger than one is non-uniqueness | yes: one extra filler is non-uniqueness | collapse into the uniqueness failure |
+| `f_L1` fills / Hamming does not | no: one map filling does not classify Hamming | no: Hamming failing does not prove `f_L1` fills | independent positive/negative members, not two walls |
+| empty first wave / fill count | no: emptiness is a first-tick event | no: a fill can occur only after a nonempty first wave | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `f(empty)=0` | explicit class restriction; the other 512 covariant maps are excluded |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| `f_★` | displayed witness against uniqueness, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/covariant_one_site_fill_census_2026_08_15.py:58` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/covariant_one_site_fill_census_2026_08_15.py:97` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/covariant_one_site_fill_census_2026_08_15.py:203` | class census | exact `N_fill` and `N_empty` | yes |
+| `scripts/covariant_one_site_fill_census_2026_08_15.py:106` | uniqueness | displayed second filler `f_★` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every empty-zero cube-covariant `f` | the census is this class on this seed; other seeds are unclaimed |
+| per block | yes: the pair `(N_fill, N_empty)` | uniqueness fails because `N_fill=96` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does fill this patch from the 1-site seed. That positive member does not
+make `f_L1` unique and does not select it as the physical rule. The
+remaining physical choice — which, if any, cube-covariant map is the
+Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that several of the 96 fillers agree with `f_L1`
+on every 6-tuple that actually occurs along the 1-site filling trajectory,
+so uniqueness might be restored by restricting to “dynamically occurring”
+cells. That objection is correctly about a smaller class. It does not
+overturn the stated theorem: among all cube-covariant `f` with
+`f(empty)=0`, ninety-six fill. The displayed second filler `f_★` already
+differs from `f_L1` on orbits that are not needed for this particular
+trajectory, which is why it is a class-level extra filler and not a
+trajectory-level identity.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits, and
+512-map dynamics are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the census or restores uniqueness of `f_L1`
+inside the 512-map class.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact pair `(N_fill, N_empty)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, evaluates
+all 512 empty-zero cube-covariant maps on the two-cube, reports
+`N_fill = 96` and `N_empty = 256`, checks that `f_L1` fills and is not
+Hamming parity, and exhibits the displayed second filler `f_★`. Declared
+audit inputs are this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2745,6 +2745,10 @@
   "covariant_law_weight_compatibility_cycle974_theorem_note_2026-08-10": {
    "deps_hash": "910bffe93fd1",
    "out_degree": 3
+  },
+  "covariant_one_site_fill_census_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cpt_c3_cp_squared_scalar_narrow_theorem_note_2026-05-17": {
    "deps_hash": "381c41107f12",

--- a/logs/runner-cache/covariant_one_site_fill_census_2026_08_15.txt
+++ b/logs/runner-cache/covariant_one_site_fill_census_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/covariant_one_site_fill_census_2026_08_15.py
+runner_sha256: ca8cf827f2343539e5e940a1de038c074af211f7382eb35b5e5d8fa741fb3016
+input_fingerprint_sha256: 5ec3a2e72ae1df7e34d8aa965c5400977fe2979d323e927c014fd2e9942c4038
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/COVARIANT_ONE_SITE_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+n_maps_empty0=512
+N_fill=96
+N_empty=256
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_locks=12 halt=4 first_wave_empty=0 history=(1, 4, 8, 11, 12)
+f_star_locks=12 halt=4 history=(1, 4, 8, 11, 12)
+f_hamming_locks=9 distinct_from_L1=1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-five-hundred-twelve-maps cube-covariant f with f(empty)=0 number 512
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-twelve the two-cube has twelve vertices and contains the seed
+PASS: thm2-n-fill N_fill = 96 exactly
+PASS: thm2-n-empty N_empty = 256 exactly
+PASS: thm2-empty-wave-is-wt1-off first-wave emptiness is exactly f=0 on the one-unbalanced-axis orbit
+PASS: thm3-f-L1-fills f_L1 fills all twelve vertices at halt tick 4
+PASS: thm3-not-unique N_fill != 1; f_L1 is not the unique filler
+PASS: thm3-displayed-other-filler displayed f_star fills and is distinct from f_L1
+PASS: mutation-hamming-does-not-fill Hamming parity is a different cube-covariant map and does not fill
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness failure, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-other-filler the note displays a second filler rather than adopting uniqueness
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every cube-covariant f with f(empty)=0 is run to a fixed point
+per_block: checked exactly — N_fill and N_empty are whole-class cardinalities on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/covariant_one_site_fill_census_2026_08_15.py
+++ b/scripts/covariant_one_site_fill_census_2026_08_15.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Exact fill census of cube-covariant occupancy predicates on the two-cube.
+
+The class is every {0,1}-valued map on the ten proper-cube orbits of {0,1}^6
+with f(empty)=0.  Dynamics are occupancy-to-lock on the twelve-vertex
+two-cube from a 1-site seed with off-patch occupancy 0.  f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/COVARIANT_ONE_SITE_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/COVARIANT_ONE_SITE_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: Site = (0, 0, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_star(config: Config) -> int:
+    """Displayed non-unique filler: some unbalanced axis and no fully occupied axis."""
+    n_unbalanced, n_both, _n_empty = axis_type(config)
+    return int(n_unbalanced >= 1 and n_both == 0)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, bool, tuple[int, ...]]:
+    locked = {SEED}
+    history = [len(locked)]
+    first_wave_empty = False
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if tick == 0:
+            first_wave_empty = nxt == locked
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, first_wave_empty, tuple(history)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def census(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> tuple[int, int, list[tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    empty_index = orbit_types.index(axis_type(EMPTY))
+    free = [index for index in range(len(orbit_types)) if index != empty_index]
+    n_fill = 0
+    n_empty = 0
+    fillers: list[tuple[int, ...]] = []
+    for mask in range(1 << len(free)):
+        bits_list = [0] * len(orbit_types)
+        for rank, index in enumerate(free):
+            bits_list[index] = (mask >> rank) & 1
+        bits = tuple(bits_list)
+        n_locks, _halt, first_empty, _history = run_predicate(
+            predicate_from_bits(bits, orbit_types, type_of)
+        )
+        if first_empty:
+            n_empty += 1
+        if n_locks == 12:
+            n_fill += 1
+            fillers.append(bits)
+    return n_fill, n_empty, fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    n_maps = 2 ** (len(orbit_types) - 1)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    star_bits = bits_from_predicate(f_star, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_locks, l1_halt, l1_first_empty, l1_history = run_predicate(f_L1)
+    star_locks, star_halt, star_first_empty, star_history = run_predicate(f_star)
+    ham_locks, _ham_halt, _ham_first, _ham_history = run_predicate(f_hamming)
+    n_fill, n_empty, fillers = census(orbit_types, orbits)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"n_maps_empty0={n_maps}")
+    print(f"N_fill={n_fill}")
+    print(f"N_empty={n_empty}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_locks={l1_locks} halt={l1_halt} first_wave_empty={int(l1_first_empty)} history={l1_history}")
+    print(f"f_star_locks={star_locks} halt={star_halt} history={star_history}")
+    print(f"f_hamming_locks={ham_locks} distinct_from_L1={int(ham_bits != l1_bits)}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/COVARIANT_ONE_SITE_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-five-hundred-twelve-maps",
+        "cube-covariant f with f(empty)=0 number 512",
+        n_maps == 512 and axis_type(EMPTY) == (0, 0, 3) and l1_bits[orbit_types.index((0, 0, 3))] == 0,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2" not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-twelve",
+        "the two-cube has twelve vertices and contains the seed",
+        len(TWO_CUBE) == 12 and len(set(TWO_CUBE)) == 12 and SEED in TWO_CUBE,
+    )
+    checks.check(
+        "thm2-n-fill",
+        f"N_fill = {n_fill} exactly",
+        n_fill == 96 and f"N_fill = {n_fill}" in note,
+    )
+    checks.check(
+        "thm2-n-empty",
+        f"N_empty = {n_empty} exactly",
+        n_empty == 256 and f"N_empty = {n_empty}" in note,
+    )
+    checks.check(
+        "thm2-empty-wave-is-wt1-off",
+        "first-wave emptiness is exactly f=0 on the one-unbalanced-axis orbit",
+        n_empty == 2 ** 8,
+    )
+    checks.check(
+        "thm3-f-L1-fills",
+        "f_L1 fills all twelve vertices at halt tick 4",
+        l1_locks == 12
+        and l1_halt == 4
+        and l1_history == (1, 4, 8, 11, 12)
+        and not l1_first_empty,
+    )
+    checks.check(
+        "thm3-not-unique",
+        "N_fill != 1; f_L1 is not the unique filler",
+        n_fill != 1 and n_fill == len(fillers) and l1_bits in fillers and star_bits in fillers,
+    )
+    checks.check(
+        "thm3-displayed-other-filler",
+        "displayed f_star fills and is distinct from f_L1",
+        star_bits != l1_bits
+        and star_locks == 12
+        and star_halt == 4
+        and star_history == (1, 4, 8, 11, 12)
+        and not star_first_empty,
+    )
+    checks.check(
+        "mutation-hamming-does-not-fill",
+        "Hamming parity is a different cube-covariant map and does not fill",
+        ham_bits[orbit_types.index((0, 0, 3))] == 0
+        and ham_locks != 12
+        and ham_bits not in fillers,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness failure, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "f_L1 is not the unique filler" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-other-filler",
+        "the note displays a second filler rather than adopting uniqueness",
+        "displayed second filler `f_★`" in note
+        and "f_L1 is not the unique filler" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every cube-covariant f with f(empty)=0 is run to a fixed point")
+    print("per_block: checked exactly — N_fill and N_empty are whole-class cardinalities on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 512 cube-covariant occupancy maps with f(empty)=0, N_fill=96 fill the twelve-vertex two-cube from a 1-site seed with off-patch o=0, and N_empty=256 have empty first wave. f_L1 (n≠0 / unbalanced-axis, never Hamming) fills but is not unique. Displayed, not adopted.

## Runner

`scripts/covariant_one_site_fill_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
