### PR TITLE
feat(classblank): blank-block empties every 1-site first wave

### DIFF
--- a/docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,160 @@
+---
+claim_id: blank_block_empties_onesite_subclass_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the twelve-vertex two-cube, replacing off-patch o=0 by blank-block empties the 1-site first wave for every cube-covariant f, including every f with f(wt1)=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/blank_block_empties_onesite_subclass_2026_08_15.py
+---
+
+# Blank-Block Empties The One-Site First Wave For The Whole Ready Subclass
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the twelve-vertex two-cube; cube-covariant boolean formation
+predicates on occupancy 6-tuples; blank-block versus the off-patch occupancy-0
+default. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/blank_block_empties_onesite_subclass_2026_08_15.py`](../scripts/blank_block_empties_onesite_subclass_2026_08_15.py)
+
+## Result up front
+
+Treat a 1-site seed at `(0,0,0)` on the twelve-vertex two-cube
+`A ∪ B` with `A = {0,1}^3` and `B = {1,2} × {0,1}^2`. A cube-covariant
+formation predicate is a function `f : {0,1}^6 → {0,1}` constant on orbits of
+the 24 proper cube rotations acting on the six directed nearest-neighbor
+slots. Write `wt1` for the orbit of weight-1 cells (exactly one occupied
+slot). The subclass `f(wt1)=1` is the isolated one-axis contrast class: a
+site whose six-tuple is one occupied neighbor and five zeros is ready when
+off-patch occupancy is defaulted to `0`.
+
+Blank-block is a different neighbor rule. If any of the six lattice neighbors
+is off-patch, the 6-tuple is undefined and the site is not ready; `f` is not
+evaluated. That rule empties the first wave after the seed, for every
+cube-covariant `f`, including every member of `f(wt1)=1`. So every
+1-site-ready member needs the vacuum default `o=0` on this patch. The need
+is class-level, not only for L1.
+
+L1 is the displayed member `f_L1(c)=1` iff some axis is unbalanced
+(`c_{+μ} ≠ c_{-μ}`), equivalently `n≠0` with `n` the number of unbalanced
+axes. It is not Hamming parity `|c|_1 mod 2`. Those two maps agree on `wt1`
+and disagree on two-axis weight-2 cells such as `(1,0,1,0,0,0)`.
+
+This is not a second vacalt. Vacalt compared L1 under `o=0` with L1 under
+blank-block. The present object is the whole `f(wt1)=1` subclass. It is also
+not leftover character of the blank-versus-zero selector count: the census
+here is a first-wave emptiness statement on one patch, not an orbit count of
+maps on `{0,1,blank}^6`.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite two-cube neighbor listing and exact first-wave emptiness under blank-block; no formation law is adopted and no vacuum axiom is written."
+trace_class: selector_identification
+target_claim_id: onesite_ready_vacuum_default_class
+target_blocker_text: "1-site formation on the two-cube under blank-block has an empty first wave for every cube-covariant f, so a vacuum default is extra data for the whole f(wt1)=1 subclass"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "keep blank-block and the o=0 default as named extra selectors; do not write either as axiom text"
+conditional_surface_status: "exact only for the supplied twelve-vertex two-cube, 1-site seed, and blank-block rule"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+The current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+nearest-neighbor adjacency on `Z^3` and one fixed covariant admissibility
+rule for the local possibility distribution. It says:
+
+```text
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+```
+
+Admissibility does not name a formation predicate, a vacuum default, or a
+blank-block rule. Record says that records form, that a present record locks
+exactly one admissible local possibility, and that a site with no record
+cannot be read. Record does not assign occupancy `0` to an unread neighbor
+and does not define readiness.
+
+The two-cube, the seed, the class of cube-covariant `f`, blank-block, and
+the `o=0` default are declared test objects. None of them is written into
+the axiom memo.
+
+## Exact objects
+
+Slots are the six directed nearest neighbors in the order
+`(+x,-x,+y,-y,+z,-z)`. The 24 proper cube rotations permute those slots.
+Weight-1 cells form one orbit of size six. Cube-covariant predicates are
+exactly the `{0,1}`-colorings of the occupancy orbits.
+
+A site `v` on the patch is **blank-blocked** when at least one of
+`v±e_x`, `v±e_y`, `v±e_z` lies off the twelve-vertex set. Under
+blank-block such a `v` is not ready.
+
+Under the `o=0` default, an off-patch neighbor is occupancy `0` and an
+on-patch unread neighbor is occupancy `0`. The resulting 6-tuple is always
+defined, and `v` is ready when `f` of that 6-tuple is `1`.
+
+After only the seed, a neighbor is occupied-as-record only if it is the
+seed. No unlocked site then has six record neighbors.
+
+## Theorem 1 — the three first-wave candidates are blank-blocked
+
+Under `o=0`, the unlocked sites `(1,0,0)`, `(0,1,0)`, and `(0,0,1)` each
+see a weight-1 6-tuple: the seed occupies exactly one slot and the other
+five slots are `0`. Those three sites are the first-wave candidates for
+every `f` with `f(wt1)=1`.
+
+Each of those three sites has at least one off-patch lattice neighbor.
+Blank-block therefore leaves all three unready, independently of `f`.
+
+## Theorem 2 — the first wave is empty for every cube-covariant `f`
+
+The two-cube is the `3×2×2` box `{0,1,2}×{0,1}×{0,1}`. Every site, seed
+included, has `y∈{0,1}` and therefore misses at least one of `±e_y`; the
+same holds for `z`. No site has all six lattice neighbors on-patch.
+
+After only the seed, no unlocked on-patch site has all six neighbors
+on-patch and occupied-as-records. Blank-block therefore finds no ready
+site. The first wave is empty for every cube-covariant `f`, including every
+`f` with `f(wt1)=1`. The paired runner enumerates the whole covariant class
+and the `f(wt1)=1` subclass and checks emptiness directly.
+
+## Theorem 3 — the vacuum default is class-level extra
+
+Under `o=0`, the same seed makes those three axis sites ready for every
+`f` with `f(wt1)=1`, and in particular for `f_L1`. If also `f(empty)=0`,
+as holds for `f_L1`, they are the entire first wave; if `f(empty)=1`, the
+eight leftover unlocked sites see the all-zero 6-tuple and join the `o=0`
+wave. Blank-block removes every one of those candidates. Therefore 1-site
+formation on this patch requires the `o=0` default for the entire
+`f(wt1)=1` subclass, not only for L1.
+
+No member is adopted. Blank-block is not written as axiom text. Unread
+is not occupancy `0` in the Record axiom.
+
+## What this does not claim
+
+- It does not adopt L1, blank-block, or the `o=0` default as physical law.
+- It does not write a vacuum axiom or amend Lattice, Qubit, Admissibility,
+  or Record.
+- It does not identify `f_L1` with Hamming parity `|c|_1 mod 2`.
+- It does not count halt fillings, later ticks, or maps on `{0,1,blank}^6`.
+- It does not claim a formation rate, clock, or full-lattice history.
+- It does not treat this two-cube as the only possible patch.
+
+## Displayed claim scope
+
+On the twelve-vertex two-cube, replacing off-patch o=0 by blank-block
+empties the 1-site first wave for every cube-covariant f, including every f
+with f(wt1)=1. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1421,6 +1421,10 @@
   "bksf_holonomy_compression_cycle728_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2bdda41c6188",
    "out_degree": 3
+  },
+  "blank_block_empties_onesite_subclass_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "block_gaussian_schur_marginalization_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/blank_block_empties_onesite_subclass_2026_08_15.txt
+++ b/logs/runner-cache/blank_block_empties_onesite_subclass_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/blank_block_empties_onesite_subclass_2026_08_15.py
+runner_sha256: a9285a595d93870bee114c63a14cf0de1708b1ece33831b38f1dcc4a7448af4b
+input_fingerprint_sha256: 9226cfd8496d1dd54e15067de72499c0883cb9e145d45d0001d1ed5ae969c08e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+Blank-block empties the 1-site first wave on the two-cube
+AUDIT_INPUT_PATHS:
+  docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: twelve-vertex two-cube; cube-covariant f; blank-block vs o=0; displayed, not adopted
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-static-literals
+PASS: audit-timeout-declared
+PASS: no-cache-write
+PASS: two-cube-has-twelve-vertices
+PASS: two-cube-is-union-of-adjacent-cubes
+PASS: seed-on-patch
+PASS: axis-sites-on-patch
+PASS: proper-cube-rotation-count-is-24
+PASS: occupancy-cells-are-64
+PASS: orbit-cover-is-complete
+PASS: wt1-is-one-orbit-of-six  (n_wt1=6 n_reps=1)
+PASS: f-L1-is-unbalanced-axis-not-hamming
+PASS: hamming-disagrees-on-two-axis-weight-two  (n_disagree=24)
+PASS: f-L1-on-wt1-is-one
+PASS: f-L1-is-cube-covariant
+PASS: theorem1-axis-sites-are-wt1-under-o0  ((1, 0, 0):(0, 1, 0, 0, 0, 0),(0, 1, 0):(0, 0, 0, 1, 0, 0),(0, 0, 1):(0, 0, 0, 0, 0, 1))
+PASS: theorem1-axis-sites-are-blank-blocked  ((1, 0, 0):2,(0, 1, 0):3,(0, 0, 1):3)
+PASS: theorem2-no-unlocked-site-has-six-on-patch-neighbors
+PASS: theorem2-no-unlocked-site-has-six-record-neighbors  (max_record_nn=1)
+PASS: theorem2-blank-block-first-wave-empty-for-L1
+PASS: theorem2-blank-block-first-wave-empty-for-wt1-subclass  (|F_wt1|=512 n_orb=10)
+PASS: theorem2-blank-block-first-wave-empty-for-every-covariant-f  (|F_G|=1024)
+PASS: theorem3-o0-first-wave-contains-axis-sites-for-wt1-subclass
+PASS: theorem3-o0-first-wave-is-exactly-axis-sites-when-empty-is-zero  (|F_wt1_empty0|=256)
+PASS: theorem3-L1-is-in-the-wt1-ready-subclass
+PASS: mutation-hamming-parity-is-not-f-L1
+PASS: mutation-o0-is-not-blank-block-on-axis-sites
+PASS: axiom-unread-and-nn-sentences-current
+PASS: axiom-no-formation-site-or-rate
+PASS: note-claim-scope-matches-spec
+PASS: note-machine-status-complete
+PASS: note-one-hop-dependency-axioms-only
+PASS: note-displayed-not-adopted-and-not-l1-only
+PASS: note-avoids-forbidden-phrases
+PASS: note-states-f-L1-is-unbalanced-axis
+TOTAL: PASS=36 FAIL=0
+
+----- stderr -----
+

--- a/scripts/blank_block_empties_onesite_subclass_2026_08_15.py
+++ b/scripts/blank_block_empties_onesite_subclass_2026_08_15.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Blank-block empties the 1-site first wave for every f(wt1)=1 member.
+
+The paired note is
+docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+Displayed finite objects only: the twelve-vertex two-cube, cube-covariant
+boolean predicates on {0,1}^6, and the blank-block readiness rule. No law is
+adopted. No runner cache is written.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+# Six directed nearest-neighbor slots, in this fixed order.
+DIRS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+
+A_CUBE = frozenset(product((0, 1), (0, 1), (0, 1)))
+B_CUBE = frozenset(product((1, 2), (0, 1), (0, 1)))
+PATCH = frozenset(set(A_CUBE) | set(B_CUBE))
+SEED = (0, 0, 0)
+AXIS_SITES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(
+    site: tuple[int, int, int], direction: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+
+
+def neighbors(site: tuple[int, int, int]) -> tuple[tuple[int, int, int], ...]:
+    return tuple(add(site, direction) for direction in DIRS)
+
+
+def off_patch_neighbor_count(site: tuple[int, int, int]) -> int:
+    return sum(1 for neigh in neighbors(site) if neigh not in PATCH)
+
+
+def blank_blocked(site: tuple[int, int, int]) -> bool:
+    return off_patch_neighbor_count(site) > 0
+
+
+def occupancy_o0(
+    site: tuple[int, int, int], locks: frozenset[tuple[int, int, int]]
+) -> tuple[int, ...]:
+    """Off-patch neighbors default to occupancy 0. On-patch unread is 0."""
+    cell = []
+    for neigh in neighbors(site):
+        cell.append(1 if neigh in locks else 0)
+    return tuple(cell)
+
+
+def permutation_sign(perm: tuple[int, ...]) -> int:
+    sign = 1
+    values = list(perm)
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            if values[i] > values[j]:
+                sign *= -1
+    return sign
+
+
+def proper_cube_rotations() -> tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]:
+    """24 proper cube rotations as (axis permutation, axis signs).
+
+    R maps e_j to signs[j] * e_{perm[j]}. Det = sign(perm) * product(signs).
+    """
+    rotations: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for perm in permutations(range(3)):
+        perm_t = tuple(perm)
+        sign_perm = permutation_sign(perm_t)
+        for signs in product((-1, 1), repeat=3):
+            if sign_perm * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            rotations.append((perm_t, signs))
+    return tuple(rotations)
+
+
+def rotate_direction(
+    direction: tuple[int, int, int],
+    perm: tuple[int, ...],
+    signs: tuple[int, ...],
+) -> tuple[int, int, int]:
+    image = [0, 0, 0]
+    for axis in range(3):
+        image[perm[axis]] = signs[axis] * direction[axis]
+    return (image[0], image[1], image[2])
+
+
+def rotate_cell(
+    cell: tuple[int, ...],
+    perm: tuple[int, ...],
+    signs: tuple[int, ...],
+) -> tuple[int, ...]:
+    image = [0] * 6
+    for slot, direction in enumerate(DIRS):
+        image[DIR_INDEX[rotate_direction(direction, perm, signs)]] = cell[slot]
+    return tuple(image)
+
+
+def all_cells() -> tuple[tuple[int, ...], ...]:
+    return tuple(product((0, 1), repeat=6))
+
+
+def orbit_reps() -> tuple[tuple[int, ...], ...]:
+    rotations = proper_cube_rotations()
+    seen: set[tuple[int, ...]] = set()
+    reps: list[tuple[int, ...]] = []
+    for cell in all_cells():
+        if cell in seen:
+            continue
+        reps.append(cell)
+        stack = [cell]
+        seen.add(cell)
+        while stack:
+            current = stack.pop()
+            for perm, signs in rotations:
+                image = rotate_cell(current, perm, signs)
+                if image not in seen:
+                    seen.add(image)
+                    stack.append(image)
+    return tuple(reps)
+
+
+def cell_to_rep(
+    reps: tuple[tuple[int, ...], ...],
+) -> dict[tuple[int, ...], tuple[int, ...]]:
+    rotations = proper_cube_rotations()
+    mapping: dict[tuple[int, ...], tuple[int, ...]] = {}
+    for rep in reps:
+        stack = [rep]
+        mapping[rep] = rep
+        while stack:
+            current = stack.pop()
+            for perm, signs in rotations:
+                image = rotate_cell(current, perm, signs)
+                if image not in mapping:
+                    mapping[image] = rep
+                    stack.append(image)
+    return mapping
+
+
+def f_L1(cell: tuple[int, ...]) -> int:
+    """Form iff at least one axis is unbalanced. Not Hamming |c|_1 mod 2."""
+    return int(cell[0] != cell[1] or cell[2] != cell[3] or cell[4] != cell[5])
+
+
+def f_hamming_parity(cell: tuple[int, ...]) -> int:
+    return int(sum(cell) % 2)
+
+
+def is_wt1(cell: tuple[int, ...]) -> bool:
+    return sum(cell) == 1
+
+
+def first_wave_blank_block(
+    form: object,
+    locks: frozenset[tuple[int, int, int]],
+) -> tuple[tuple[int, int, int], ...]:
+    """Ready sites under blank-block. `form` is unused if any neighbor is off-patch."""
+    ready: list[tuple[int, int, int]] = []
+    for site in sorted(PATCH):
+        if site in locks:
+            continue
+        if blank_blocked(site):
+            continue
+        cell = occupancy_o0(site, locks)
+        if int(form(cell)) == 1:
+            ready.append(site)
+    return tuple(ready)
+
+
+def first_wave_o0(
+    form: object,
+    locks: frozenset[tuple[int, int, int]],
+) -> tuple[tuple[int, int, int], ...]:
+    ready: list[tuple[int, int, int]] = []
+    for site in sorted(PATCH):
+        if site in locks:
+            continue
+        cell = occupancy_o0(site, locks)
+        if int(form(cell)) == 1:
+            ready.append(site)
+    return tuple(ready)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("Blank-block empties the 1-site first wave on the two-cube")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "scope: twelve-vertex two-cube; cube-covariant f; blank-block vs o=0; "
+        "displayed, not adopted"
+    )
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and 'AUDIT_INPUT_PATHS = (\n    "docs/BLANK_BLOCK_EMPTIES_ONESITE_SUBCLASS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in self_source,
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check(
+        "no-cache-write",
+        "cache_write: false" in self_source
+        and "logs/" + "runner-cache" not in note,
+    )
+
+    checks.check("two-cube-has-twelve-vertices", len(PATCH) == 12)
+    checks.check(
+        "two-cube-is-union-of-adjacent-cubes",
+        len(A_CUBE) == 8
+        and len(B_CUBE) == 8
+        and len(A_CUBE & B_CUBE) == 4
+        and PATCH == A_CUBE | B_CUBE,
+    )
+    checks.check("seed-on-patch", SEED in PATCH and SEED in A_CUBE)
+    checks.check(
+        "axis-sites-on-patch",
+        all(site in PATCH for site in AXIS_SITES),
+    )
+
+    rotations = proper_cube_rotations()
+    checks.check("proper-cube-rotation-count-is-24", len(rotations) == 24)
+    reps = orbit_reps()
+    mapping = cell_to_rep(reps)
+    checks.check("occupancy-cells-are-64", len(all_cells()) == 64)
+    checks.check("orbit-cover-is-complete", len(mapping) == 64)
+    wt1_cells = tuple(cell for cell in all_cells() if is_wt1(cell))
+    wt1_reps = {mapping[cell] for cell in wt1_cells}
+    checks.check(
+        "wt1-is-one-orbit-of-six",
+        len(wt1_cells) == 6 and len(wt1_reps) == 1,
+        f"n_wt1={len(wt1_cells)} n_reps={len(wt1_reps)}",
+    )
+    wt1_rep = next(iter(wt1_reps))
+
+    checks.check(
+        "f-L1-is-unbalanced-axis-not-hamming",
+        all(f_L1(cell) == int(any(cell[2 * ax] != cell[2 * ax + 1] for ax in range(3))) for cell in all_cells())
+        and any(f_L1(cell) != f_hamming_parity(cell) for cell in all_cells()),
+    )
+    disagree = [cell for cell in all_cells() if f_L1(cell) != f_hamming_parity(cell)]
+    two_axis_wt2 = (1, 0, 1, 0, 0, 0)
+    checks.check(
+        "hamming-disagrees-on-two-axis-weight-two",
+        two_axis_wt2 in disagree
+        and f_L1(two_axis_wt2) == 1
+        and f_hamming_parity(two_axis_wt2) == 0
+        and sum(two_axis_wt2) == 2,
+        f"n_disagree={len(disagree)}",
+    )
+    checks.check(
+        "f-L1-on-wt1-is-one",
+        all(f_L1(cell) == 1 for cell in wt1_cells),
+    )
+    checks.check(
+        "f-L1-is-cube-covariant",
+        all(
+            f_L1(rotate_cell(cell, perm, signs)) == f_L1(cell)
+            for cell in all_cells()
+            for perm, signs in rotations
+        ),
+    )
+
+    locks = frozenset({SEED})
+    axis_cells = {site: occupancy_o0(site, locks) for site in AXIS_SITES}
+    checks.check(
+        "theorem1-axis-sites-are-wt1-under-o0",
+        all(is_wt1(cell) for cell in axis_cells.values())
+        and all(mapping[cell] == wt1_rep for cell in axis_cells.values()),
+        ",".join(f"{site}:{cell}" for site, cell in axis_cells.items()),
+    )
+    checks.check(
+        "theorem1-axis-sites-are-blank-blocked",
+        all(blank_blocked(site) for site in AXIS_SITES)
+        and all(off_patch_neighbor_count(site) >= 1 for site in AXIS_SITES),
+        ",".join(f"{site}:{off_patch_neighbor_count(site)}" for site in AXIS_SITES),
+    )
+
+    unlocked = tuple(sorted(site for site in PATCH if site != SEED))
+    checks.check(
+        "theorem2-no-unlocked-site-has-six-on-patch-neighbors",
+        all(blank_blocked(site) for site in unlocked)
+        and all(off_patch_neighbor_count(site) >= 1 for site in PATCH),
+    )
+    record_neighbor_counts = {
+        site: sum(1 for neigh in neighbors(site) if neigh in locks) for site in unlocked
+    }
+    checks.check(
+        "theorem2-no-unlocked-site-has-six-record-neighbors",
+        all(count < 6 for count in record_neighbor_counts.values())
+        and max(record_neighbor_counts.values()) == 1,
+        f"max_record_nn={max(record_neighbor_counts.values())}",
+    )
+
+    empty_wave = first_wave_blank_block(f_L1, locks)
+    checks.check(
+        "theorem2-blank-block-first-wave-empty-for-L1",
+        empty_wave == (),
+    )
+
+    empty_cell = (0, 0, 0, 0, 0, 0)
+    empty_rep = mapping[empty_cell]
+    subclass_empty = True
+    subclass_size = 0
+    o0_contains_axis = True
+    o0_exact_when_empty_zero = True
+    empty_zero_size = 0
+    n_orb = len(reps)
+    # Assign bits to orbits; wt1 orbit bit forced to 1.
+    wt1_index = reps.index(wt1_rep)
+    other_bits = n_orb - 1
+    for mask in range(1 << other_bits):
+        values = {}
+        bit_pos = 0
+        for index, rep in enumerate(reps):
+            if index == wt1_index:
+                values[rep] = 1
+            else:
+                values[rep] = (mask >> bit_pos) & 1
+                bit_pos += 1
+
+        def form(cell: tuple[int, ...], _values: dict = values) -> int:
+            return _values[mapping[cell]]
+
+        subclass_size += 1
+        if first_wave_blank_block(form, locks) != ():
+            subclass_empty = False
+        wave_o0 = first_wave_o0(form, locks)
+        if not set(AXIS_SITES) <= set(wave_o0):
+            o0_contains_axis = False
+        if values[empty_rep] == 0:
+            empty_zero_size += 1
+            if wave_o0 != tuple(sorted(AXIS_SITES)):
+                o0_exact_when_empty_zero = False
+
+    checks.check(
+        "theorem2-blank-block-first-wave-empty-for-wt1-subclass",
+        subclass_empty and subclass_size == (1 << other_bits) and subclass_size >= 1,
+        f"|F_wt1|={subclass_size} n_orb={n_orb}",
+    )
+
+    # Independence of f: blank-block never evaluates f on this patch after the seed.
+    any_f_empty = True
+    for mask in range(1 << n_orb):
+        values = {rep: (mask >> index) & 1 for index, rep in enumerate(reps)}
+
+        def form_any(cell: tuple[int, ...], _values: dict = values) -> int:
+            return _values[mapping[cell]]
+
+        if first_wave_blank_block(form_any, locks) != ():
+            any_f_empty = False
+            break
+    checks.check(
+        "theorem2-blank-block-first-wave-empty-for-every-covariant-f",
+        any_f_empty,
+        f"|F_G|={1 << n_orb}",
+    )
+
+    checks.check(
+        "theorem3-o0-first-wave-contains-axis-sites-for-wt1-subclass",
+        o0_contains_axis
+        and set(AXIS_SITES) <= set(first_wave_o0(f_L1, locks)),
+    )
+    checks.check(
+        "theorem3-o0-first-wave-is-exactly-axis-sites-when-empty-is-zero",
+        o0_exact_when_empty_zero
+        and empty_zero_size == (1 << (other_bits - 1))
+        and f_L1(empty_cell) == 0
+        and first_wave_o0(f_L1, locks) == tuple(sorted(AXIS_SITES)),
+        f"|F_wt1_empty0|={empty_zero_size}",
+    )
+    checks.check(
+        "theorem3-L1-is-in-the-wt1-ready-subclass",
+        f_L1(wt1_rep) == 1 and mapping[wt1_cells[0]] == wt1_rep,
+    )
+
+    # Mutations: Hamming parity is not L1; o=0 is not blank-block.
+    checks.check(
+        "mutation-hamming-parity-is-not-f-L1",
+        f_hamming_parity(two_axis_wt2) != f_L1(two_axis_wt2)
+        and all(f_hamming_parity(cell) == f_L1(cell) for cell in wt1_cells),
+    )
+    checks.check(
+        "mutation-o0-is-not-blank-block-on-axis-sites",
+        first_wave_o0(f_L1, locks) != first_wave_blank_block(f_L1, locks)
+        and first_wave_o0(f_L1, locks) == tuple(sorted(AXIS_SITES)),
+    )
+
+    unread = "A site with no record cannot be read."
+    nn_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    checks.check(
+        "axiom-unread-and-nn-sentences-current",
+        unread in axiom and nn_sentence in normalized_axiom,
+    )
+    checks.check(
+        "axiom-no-formation-site-or-rate",
+        "it does not supply the formation site, probability, or rate" in normalized_axiom,
+    )
+
+    claim_scope = (
+        "On the twelve-vertex two-cube, replacing off-patch o=0 by blank-block "
+        "empties the 1-site first wave for every cube-covariant f, including "
+        "every f with f(wt1)=1. Displayed, not adopted."
+    )
+    checks.check("note-claim-scope-matches-spec", claim_scope in note)
+    machine_markers = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "claim_type_reason:",
+        "hypothetical_axiom_status: no edit",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    checks.check(
+        "note-machine-status-complete",
+        all(marker in note for marker in machine_markers),
+    )
+    checks.check(
+        "note-one-hop-dependency-axioms-only",
+        "upstream_dependencies:\n  - minimal_axioms" in note
+        and "MINIMAL_AXIOMS_2026-06-29.md" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted-and-not-l1-only",
+        "Displayed, not adopted" in note
+        and "not only for L1" in normalized_note
+        and "not a second vacalt" in normalized_note,
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "note-avoids-forbidden-phrases",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "note-states-f-L1-is-unbalanced-axis",
+        "unbalanced" in normalized_note
+        and "Hamming" in note
+        and "n≠0" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the twelve-vertex two-cube, replacing off-patch o=0 by blank-block empties the 1-site first wave for every cube-covariant f, including every f with f(wt1)=1. The o=0 vacuum default is class-level, not L1-only. Displayed, not adopted.

## Runner

`scripts/blank_block_empties_onesite_subclass_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
