### PR TITLE
feat(hamdyn): Hamming-parity formation halts at T=4 with 9 locks

### DIFF
--- a/docs/HAMMING_PARITY_FORMATION_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/HAMMING_PARITY_FORMATION_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,193 @@
+---
+claim_id: hamming_parity_formation_dynamics_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Hamming-parity formation on the twelve-vertex two-cube from a 1-site seed with off-patch o=0 reaches a fixed point with reported (T, |locks|). Distinct from L1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/hamming_parity_formation_dynamics_2026_08_15.py
+---
+
+# Hamming-Parity Formation Dynamics On The Two-Cube
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-lock ticks of the displayed Hamming-parity ready rule
+`f_H(c) = |c|_1 mod 2` on one twelve-site two-cube carrier, from one
+1-site seed, with off-patch occupancy `o = 0`. The pair `(T, |locks_T|)`
+is a finite halt census. Distinct from L1. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/hamming_parity_formation_dynamics_2026_08_15.py`](../scripts/hamming_parity_formation_dynamics_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The two-cube patch has twelve vertices. Off-patch occupancy is `o = 0`.
+The displayed seed locks the origin corner `(0,0,0)`. Each tick locks
+every unlocked site whose six-neighbor occupancy 6-tuple `c` has
+`f_H(c) = |c|_1 mod 2` equal to 1.
+
+The first wave is the three axis sites. The process reaches a fixed
+point at halt tick `T = 4` with `|locks_4| = 9`. The twelve-vertex
+patch does not fill.
+
+Displayed contrast only (not an identity table): L1 from the same
+1-site seed fills, with horizon 4 and 12 locks. That is a different
+member. Hamming parity is never the unbalanced-axis rule. Do not call
+Hamming `f_L1`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact occupancy-lock halt census of displayed Hamming parity on one twelve-site two-cube carrier from a 1-site seed."
+trace_class: frontier_discovery
+target_claim_id: hamming_parity_formation_dynamics
+target_blocker_text: "whether displayed Hamming-parity occupancy ticks from a 1-site seed fill the twelve-site two-cube"
+source_of_blocker_text: handoff
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded halt census"
+conditional_surface_status: "exact on the supplied two-cube Hamming-parity patch and seed; other members and complexes remain separate"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+`cache_write: false`
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** live Lattice and Record sentences, quoted without rewrite.
+- **Explicit theorem-domain condition:** displayed Hamming-parity ready rule
+  `f_H(c) = |c|_1 mod 2`, two-cube patch, off-patch occupancy zero,
+  1-site seed `(0,0,0)`, simultaneous lock of every unlocked ready site.
+- **External empirical or literature inputs:** none.
+
+This note is occupancy-lock dynamics of one displayed member. It is not
+a static membership count of a cut class.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> Records form.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone.
+
+Their dependency role is limited to the cubic site set, lock permanence, and
+the unreadability of absence. The occupancy kernel, the two-cube patch, the
+seed, and the tick index are separately supplied.
+
+## Exact Objects
+
+All runner values are exact integers. No float is used.
+
+Cubes `A = {0,1} × {0,1} × {0,1}` and `B = {1,2} × {0,1} × {0,1}`.
+Patch `V = A ∪ B`, so `|V| = 12`. Occupancy of a site is `1` if the
+site is locked and `0` otherwise, including every off-patch neighbor.
+
+At an unlocked site `v`, write `c(v) ∈ {0,1}^6` for the occupancy of
+the six nearest neighbors `(v±e_x, v±e_y, v±e_z)`. The displayed
+ready rule is
+
+```text
+f_H(c) = |c|_1 mod 2.
+```
+
+A site is ready iff it is unlocked and `f_H(c(v)) = 1`. One tick
+replaces the lock set `L` by `L ∪ { v ∈ V \ L : f_H(c(v)) = 1 }`.
+Locked sites stay locked. Halt is at most 12 ticks.
+
+Displayed contrast member (not used as the ready rule here):
+
+```text
+f_L1(c) = 1  iff  some axis has c_{+μ} ≠ c_{-μ}
+         iff  n ≠ 0.
+```
+
+Weight-1 tuples are odd, so they are Hamming-ready. They are also
+L1-ready. Weight-2 tuples with two unbalanced axes are even, so they
+are Hamming-blank and L1-ready. The first waves therefore coincide;
+later waves do not.
+
+## Exact Target And Proof Obligations
+
+Check that the first wave is the three axis sites, that the iteration
+reaches a fixed point in at most 12 ticks, and report the exact pair
+`(T, |locks_T|)` together with whether `|locks_T| = 12`.
+
+## Theorems
+
+### Theorem 1 — first wave is the three axis sites
+
+At `L = {(0,0,0)}` the on-patch neighbors of the seed are
+`(1,0,0)`, `(0,1,0)`, and `(0,0,1)`. Each of those sites has a
+weight-1 occupancy 6-tuple (one occupied neighbor, the seed; every
+off-patch slot is 0). Weight 1 is odd, so `f_H = 1`. Every other
+unlocked patch site has weight 0. The first wave is
+
+```text
+{(1,0,0), (0,1,0), (0,0,1)}.
+```
+
+### Theorem 2 — a fixed point in at most 12 ticks
+
+The site set is finite of size 12, locks are permanent, and each
+non-halt tick adds at least one lock. The iteration therefore reaches
+a fixed point in at most 12 ticks.
+
+The computed orbit is
+
+```text
+t=0:  |locks| = 1   seed
+t=1:  |locks| = 4   three axis sites
+t=2:  |locks| = 5   add (2,0,0)
+t=3:  |locks| = 7   add (2,1,0), (2,0,1)
+t=4:  |locks| = 9   add (1,1,0), (1,0,1)
+t=5:  ready set empty.
+```
+
+So a fixed point is reached.
+
+### Theorem 3 — halt pair and fill boolean
+
+```text
+T = 4,   |locks_4| = 9,   locks_4 ≠ V.
+```
+
+The three remaining unlocked sites are `(0,1,1)`, `(1,1,1)`, and
+`(2,1,1)`. Each has even Hamming weight on its 6-tuple, so none is
+ready. The twelve-vertex patch does not fill.
+
+Displayed contrast only: L1 from the same seed fills, horizon 4,
+`|locks_4| = 12`. Those numbers are not an identity between the two
+rules.
+
+## What Is Not Claimed
+
+- No unique member of the axiom class, and no adoption of Hamming parity.
+- Hamming parity is not L1 and is not the unbalanced-axis rule.
+- No leftover-character classification of a static cut class.
+- No clock identity, no source identity, and no formation-count table.
+- No 4x4x4, torus, or line complex.
+- No axiom edit and no replacement of the live Record sentences.
+- Qubit remains `M_2(C)`.
+- No inverse-square law and no Newtonian identification.
+
+## Runner Contract
+
+The companion runner reconstructs the occupancy-lock ticks on the
+displayed patch and checks the theorems with exact integer arithmetic.
+It evaluates `f_H` on computed 6-tuples. It prints
+`TOTAL: PASS=... FAIL=...` and writes no cache. Declared review inputs
+are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6573,6 +6573,10 @@
   "half_plane_chart_equivalence_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "hamming_parity_formation_dynamics_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "hard_geometry_gravity_window_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/hamming_parity_formation_dynamics_2026_08_15.txt
+++ b/logs/runner-cache/hamming_parity_formation_dynamics_2026_08_15.txt
@@ -1,0 +1,80 @@
+===== runner cache v1 =====
+runner: scripts/hamming_parity_formation_dynamics_2026_08_15.py
+runner_sha256: 5ad0fd336fb54c09dffc6c9e28823a522be997ae430e19a835b761776a42712f
+input_fingerprint_sha256: 947734dda8f3825ad12812d401d9e4f5c792b694bb962628b06e80cfd0e2affc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+Hamming-parity formation dynamics on the two-cube
+AUDIT_INPUT_PATHS:
+  docs/HAMMING_PARITY_FORMATION_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: supplied two-cube Hamming-parity patch; 1-site seed halt census
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-relative
+PASS: audit-timeout-declared
+PASS: lattice-quote-present
+PASS: record-form-quote-present
+PASS: hygiene-avoids-'G_N'
+PASS: hygiene-avoids-'1/r'
+PASS: hygiene-avoids-'1/r^2'
+PASS: hygiene-avoids-'Lattice-named'
+PASS: hygiene-avoids-'not a TOE'
+PASS: hygiene-avoids-'exhausted'
+PASS: hygiene-avoids-'only route'
+PASS: hygiene-avoids-'we adopt'
+PASS: hygiene-avoids-'Codex'
+PASS: hygiene-avoids-'L_phys'
+PASS: note-has-no-runner-cache-path
+PASS: note-has-no-citation-manifest
+PASS: note-does-not-call-hamming-f-L1
+PASS: note-does-not-identify-hamming-with-L1
+PASS: patch-has-twelve-sites
+PASS: seed-is-origin
+PASS: seed-on-patch
+PASS: off-patch-occupancy-is-zero
+PASS: identity-f-H-on-weight-1  (c=(0, 1, 0, 0, 0, 0))
+PASS: weight-1-tuple-is-odd
+PASS: identity-f-H-on-weight-2-even
+PASS: displayed-f-L1-on-weight-2-unbalanced
+PASS: f-H-is-not-f-L1
+PASS: identity-f-H-empty-zero
+PASS: identity-f-H-full-zero
+PASS: theorem-1-first-wave-three-axis-sites
+PASS: theorem-1-first-wave-weight-1-odd
+PASS: theorem-2-halt-within-twelve
+PASS: theorem-2-halt-is-fixed-point
+PASS: seed-permanent-in-halt
+PASS: locks-monotone
+PASS: halt-tick-is-last-growth
+PASS: theorem-3-halt-tick  (T=4)
+PASS: theorem-3-lock-count  (|locks|=9)
+PASS: theorem-3-patch-does-not-fill
+PASS: unlocked-sites-have-even-hamming
+PASS: displayed-L1-fills-horizon-4
+PASS: hamming-and-L1-same-first-wave
+PASS: hamming-and-L1-different-halt-locks
+PASS: note-reports-halt-tick-four
+PASS: note-reports-nine-locks
+PASS: note-reports-does-not-fill
+PASS: note-displays-L1-horizon-four
+PASS: note-displayed-not-adopted
+first_wave: [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+halt_tick: 4
+lock_count: 9
+fills_patch: False
+displayed_L1_halt: 4
+displayed_L1_locks: 12
+per_element: 12 vertices
+per_site: occupancy lock
+per_mode: f_H Hamming parity
+per_block: halt census
+lattice_wide: checked and not executed
+TOTAL: PASS=49 FAIL=0
+
+----- stderr -----
+

--- a/scripts/hamming_parity_formation_dynamics_2026_08_15.py
+++ b/scripts/hamming_parity_formation_dynamics_2026_08_15.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Exact checks for Hamming-parity occupancy-lock dynamics on the two-cube.
+
+Reconstructs f_H(c) = |c|_1 mod 2 on six-neighbor occupancy tuples, with
+off-patch occupancy 0, from the 1-site seed (0,0,0). Distinct from f_L1,
+which is n!=0 / unbalanced-axis. Writes no cache and no governance surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/HAMMING_PARITY_FORMATION_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Vec = tuple[int, int, int]
+Cell = tuple[int, int, int, int, int, int]
+AXES: tuple[Vec, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+CUBE_A = frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+CUBE_B = frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+PATCH = CUBE_A | CUBE_B
+SEED: frozenset[Vec] = frozenset({(0, 0, 0)})
+AXIS_SITES: frozenset[Vec] = frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)})
+
+FORBIDDEN_NOTE_SUBSTRINGS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "exhausted",
+    "only route",
+    "we adopt",
+    "Codex",
+    "L_phys",
+)
+
+
+def plus(site: Vec, step: Vec) -> Vec:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def minus(site: Vec, step: Vec) -> Vec:
+    return (site[0] - step[0], site[1] - step[1], site[2] - step[2])
+
+
+def occupancy(site: Vec, locks: frozenset[Vec]) -> int:
+    return 1 if site in locks else 0
+
+
+def six_tuple(site: Vec, locks: frozenset[Vec]) -> Cell:
+    bits: list[int] = []
+    for axis in AXES:
+        bits.append(occupancy(plus(site, axis), locks))
+        bits.append(occupancy(minus(site, axis), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def f_H(cell: Cell) -> int:
+    """Hamming parity of the six-neighbor occupancy tuple."""
+    return sum(cell) % 2
+
+
+def f_L1(cell: Cell) -> int:
+    """Displayed contrast only: n!=0 / at least one unbalanced axis."""
+    return int(any(cell[2 * i] != cell[2 * i + 1] for i in range(3)))
+
+
+def ready_sites(locks: frozenset[Vec]) -> frozenset[Vec]:
+    return frozenset(
+        site for site in PATCH if site not in locks and f_H(six_tuple(site, locks)) == 1
+    )
+
+
+def ready_sites_l1(locks: frozenset[Vec]) -> frozenset[Vec]:
+    return frozenset(
+        site for site in PATCH if site not in locks and f_L1(six_tuple(site, locks)) == 1
+    )
+
+
+def step(locks: frozenset[Vec]) -> frozenset[Vec]:
+    return locks | ready_sites(locks)
+
+
+def step_l1(locks: frozenset[Vec]) -> frozenset[Vec]:
+    return locks | ready_sites_l1(locks)
+
+
+def evolve_until_halt(
+    seed: frozenset[Vec], stepper, max_ticks: int = 12
+) -> tuple[int, frozenset[Vec], list[frozenset[Vec]]]:
+    hist = [seed]
+    locks = seed
+    for tick in range(1, max_ticks + 1):
+        nxt = stepper(locks)
+        if nxt == locks:
+            return tick - 1, locks, hist
+        locks = nxt
+        hist.append(locks)
+    return max_ticks, locks, hist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def hygiene(checks: Checks, note: str, axiom: str) -> None:
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-paths-unique-relative",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(
+            not Path(path).is_absolute() and ".." not in Path(path).parts
+            for path in AUDIT_INPUT_PATHS
+        ),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check("lattice-quote-present", "proper cubic rotations" in axiom)
+    checks.check("record-form-quote-present", "Records form" in axiom)
+    for token in FORBIDDEN_NOTE_SUBSTRINGS:
+        checks.check(f"hygiene-avoids-{token!r}", token not in note)
+    checks.check("note-has-no-runner-cache-path", "runner-cache" not in note)
+    checks.check("note-has-no-citation-manifest", "citation_manifest" not in note)
+    checks.check("note-does-not-call-hamming-f-L1", "f_H" in note and "Hamming f_L1" not in note)
+    checks.check("note-does-not-identify-hamming-with-L1", "Hamming-as-L1" not in note)
+    checks.check("patch-has-twelve-sites", len(PATCH) == 12)
+    checks.check("seed-is-origin", SEED == frozenset({(0, 0, 0)}))
+    checks.check("seed-on-patch", SEED <= PATCH)
+    checks.check("off-patch-occupancy-is-zero", occupancy((3, 0, 0), SEED) == 0)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    print("Hamming-parity formation dynamics on the two-cube")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: supplied two-cube Hamming-parity patch; 1-site seed halt census")
+    hygiene(checks, note, axiom)
+
+    weight1 = six_tuple((1, 0, 0), SEED)
+    checks.check("identity-f-H-on-weight-1", f_H(weight1) == 1, f"c={weight1}")
+    checks.check("weight-1-tuple-is-odd", sum(weight1) == 1)
+    two_axis = (1, 0, 1, 0, 0, 0)
+    checks.check("identity-f-H-on-weight-2-even", f_H(two_axis) == 0)
+    checks.check("displayed-f-L1-on-weight-2-unbalanced", f_L1(two_axis) == 1)
+    checks.check("f-H-is-not-f-L1", f_H(two_axis) != f_L1(two_axis))
+    empty = (0, 0, 0, 0, 0, 0)
+    checks.check("identity-f-H-empty-zero", f_H(empty) == 0)
+    checks.check("identity-f-H-full-zero", f_H((1, 1, 1, 1, 1, 1)) == 0)
+
+    first_wave = ready_sites(SEED)
+    halt_tick, locks, hist = evolve_until_halt(SEED, step, 12)
+    post_halt = step(locks)
+    unlocked = PATCH - locks
+    l1_halt, l1_locks, _ = evolve_until_halt(SEED, step_l1, 12)
+
+    checks.check("theorem-1-first-wave-three-axis-sites", first_wave == AXIS_SITES)
+    checks.check(
+        "theorem-1-first-wave-weight-1-odd",
+        all(sum(six_tuple(site, SEED)) == 1 and f_H(six_tuple(site, SEED)) == 1 for site in first_wave),
+    )
+    checks.check("theorem-2-halt-within-twelve", halt_tick <= 12)
+    checks.check("theorem-2-halt-is-fixed-point", post_halt == locks)
+    checks.check("seed-permanent-in-halt", SEED <= locks)
+    checks.check(
+        "locks-monotone",
+        all(hist[i] <= hist[i + 1] for i in range(len(hist) - 1)),
+    )
+    if halt_tick > 0:
+        checks.check(
+            "halt-tick-is-last-growth",
+            step(hist[halt_tick - 1]) != hist[halt_tick - 1],
+        )
+    checks.check("theorem-3-halt-tick", halt_tick == 4, f"T={halt_tick}")
+    checks.check("theorem-3-lock-count", len(locks) == 9, f"|locks|={len(locks)}")
+    checks.check("theorem-3-patch-does-not-fill", locks != PATCH and len(locks) != 12)
+    checks.check(
+        "unlocked-sites-have-even-hamming",
+        all(f_H(six_tuple(site, locks)) == 0 for site in unlocked),
+    )
+    checks.check(
+        "displayed-L1-fills-horizon-4",
+        l1_halt == 4 and len(l1_locks) == 12 and l1_locks == PATCH,
+    )
+    checks.check("hamming-and-L1-same-first-wave", first_wave == ready_sites_l1(SEED))
+    checks.check("hamming-and-L1-different-halt-locks", locks != l1_locks)
+    checks.check("note-reports-halt-tick-four", "T = 4" in note)
+    checks.check("note-reports-nine-locks", "|locks_4| = 9" in note)
+    checks.check("note-reports-does-not-fill", "does not fill" in note)
+    checks.check("note-displays-L1-horizon-four", "horizon 4" in note)
+    checks.check("note-displayed-not-adopted", "not adopted" in note)
+
+    print(f"first_wave: {sorted(first_wave)}")
+    print(f"halt_tick: {halt_tick}")
+    print(f"lock_count: {len(locks)}")
+    print(f"fills_patch: {locks == PATCH}")
+    print(f"displayed_L1_halt: {l1_halt}")
+    print(f"displayed_L1_locks: {len(l1_locks)}")
+    print("per_element: 12 vertices")
+    print("per_site: occupancy lock")
+    print("per_mode: f_H Hamming parity")
+    print("per_block: halt census")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Hamming-parity occupancy ticks f_H(c)=|c|_1 mod 2 from a 1-site seed on the twelve-vertex two-cube halt at T=4 with 9 locks and do not fill. Distinct from L1. Do not call Hamming f_L1. Displayed, not adopted.

## Runner

`scripts/hamming_parity_formation_dynamics_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
