### PR TITLE
feat(v3dyn): vertex3 indicator has empty 1-site first wave

### DIFF
--- a/docs/VERTEX3_ORBIT_INDICATOR_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/VERTEX3_ORBIT_INDICATOR_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,231 @@
+---
+claim_id: vertex3_orbit_indicator_dynamics_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The vertex3-orbit indicator has empty 1-site first wave on the twelve-vertex two-cube with off-patch o=0 and does not fill. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py
+---
+
+# Vertex3-Orbit Indicator Dynamics On The Two-Cube
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-lock ticks of the displayed vertex3-orbit indicator
+on one twelve-site two-cube carrier, from one 1-site seed, with
+off-patch occupancy `o = 0`. First wave, halt, and fill. Displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py`](../scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Recompute the 24 proper cube rotations on the 64 occupation cells of the
+six-ray star. Those rotations partition the cells into ten orbits. The
+**vertex3** orbit is the complement-fixed orbit of weight-three cells
+that occupy exactly one ray from each opposite pair: the `+++` /
+cube-vertex type, together with every image of `+++` under a proper
+rotation. The displayed member is the orbit indicator
+
+```text
+f_v3(c) = 1  iff  c lies in the vertex3 orbit.
+```
+
+It vanishes off that orbit. In particular a weight-1 6-tuple is not in
+vertex3.
+
+The two-cube patch has twelve vertices. Off-patch occupancy is `o = 0`.
+The seed is the single site `(0,0,0)`. Each tick locks every unlocked
+site whose current 6-neighbor occupation word has `f_v3 = 1`.
+
+**Theorem 1.** The 1-site first wave is empty.
+
+**Theorem 2.** Halt is immediate: `T = 0` (already a fixed point), and
+the one-tick image is still the seed. Locks are the seed only, so
+`|locks| = 1`.
+
+**Theorem 3.** The twelve-vertex patch does not fill.
+
+This is not leftover-char of the static membership of the vertex3
+indicator in the three-cut class. That inventory only records that the
+indicator is one complement-even, empty-and-full-vanishing assignment.
+The present residual is the executable 1-site dynamics.
+
+Displayed contrast only, not an identity table and not an adoption:
+
+- `f_L1` is the unbalanced-axis predicate (`n ≠ 0`). It is not Hamming
+  parity `|c|_1 mod 2`. From the same 1-site seed with `o = 0`, L1 has
+  a nonempty first wave and fills the patch at horizon 4
+  (`T = 4`, `|locks| = 12`).
+- Hamming parity has a nonempty first wave: the three axis neighbors
+  of the seed (weight-1 words are odd).
+
+`f_v3` disagrees with both on every weight-1 cell. Displayed, not
+adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact first-wave, halt, and fill census of the displayed vertex3-orbit indicator on one twelve-site two-cube carrier from a 1-site seed with off-patch o=0."
+trace_class: frontier_discovery
+target_claim_id: vertex3_orbit_indicator_dynamics
+target_blocker_text: "whether the vertex3-orbit indicator has a nonempty 1-site first wave or fills the twelve-site two-cube"
+source_of_blocker_text: handoff
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded halt census"
+conditional_surface_status: "exact on the supplied two-cube vertex3 indicator and 1-site seed; other members and complexes remain separate"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+`cache_write: false`
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** live Lattice and Record sentences, quoted without rewrite.
+- **Explicit theorem-domain condition:** recomputed ten-orbit partition,
+  vertex3 = complement-fixed one-ray-per-axis weight-3 orbit, displayed
+  indicator `f_v3`, two-cube patch, off-patch occupancy zero, 1-site
+  seed, simultaneous lock of every unlocked ready site.
+- **External empirical or literature inputs:** none.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant
+> under lattice translations and proper cubic rotations.
+
+> Records form.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone.
+
+Their dependency role is limited to the cubic site set, proper cubic
+rotations, lock permanence, and the unreadability of absence. The
+occupation orbits, the indicator, the two-cube patch, the seed, and the
+tick index are separately supplied. Current Admissibility, read with
+Record, does not supply the formation site, probability, or rate.
+
+## Exact Objects
+
+All runner values are exact integers. No float is used.
+
+Index the six rays as
+
+```text
+(+e_x, −e_x, +e_y, −e_y, +e_z, −e_z).
+```
+
+A cell is a 6-bit occupation word. A proper cube rotation is a signed
+permutation of the three axes with determinant `+1`. There are 24 such
+maps. They partition the 64 cells into ten orbits. The vertex3 orbit is
+the orbit of `+++` (the three positive rays). It has size 8, occupies
+exactly one ray from each opposite pair, and is complement-fixed as a
+set. The mixed3 orbit (one opposite pair plus one further ray) is a
+different complement-fixed weight-3 orbit of size 12.
+
+```text
+f_v3(c) = 1  exactly on vertex3.
+```
+
+Cubes `A = {0,1} × {0,1} × {0,1}` and `B = {1,2} × {0,1} × {0,1}`.
+Patch `V = A ∪ B`, so `|V| = 12`. Occupancy of a site is `1` if the
+site is locked and `0` otherwise, including every off-patch neighbor.
+
+At an unlocked site `v` the 6-tuple is the occupation of the six
+lattice neighbors. The site is ready iff `f_v3` of that 6-tuple is 1.
+One tick replaces the lock set `L` by
+
+```text
+L ∪ { v ∈ V \ L : f_v3(c(v; L)) = 1 }.
+```
+
+Locked sites stay locked. Seed locks `{(0,0,0)}`. First wave is the
+ready set at that seed.
+
+The displayed L1 predicate is
+
+```text
+f_L1(c) = 1  iff  c_{+μ} ≠ c_{−μ} for some axis μ
+```
+
+(`n ≠ 0`). Hamming parity is `|c|_1 mod 2`. These are different
+functions on the 64 cells.
+
+## Exact Target And Proof Obligations
+
+Check that a weight-1 cell is not in vertex3, that the 1-site first
+wave is empty, that halt is immediate with locks equal to the seed,
+and that `|locks| ≠ 12`.
+
+## Theorems
+
+### Theorem 1 — the 1-site first wave is empty
+
+A weight-1 6-tuple occupies a single ray. Vertex3 consists only of
+weight-3 one-ray-per-axis cells. So `f_v3 = 0` on every weight-1 word.
+
+After the seed `(0,0,0)` is locked, the only unlocked on-patch sites
+with a nonempty 6-tuple are the three axis neighbors
+`(1,0,0)`, `(0,1,0)`, and `(0,0,1)`. Each sees exactly one occupied
+neighbor (the seed) and five blanks, including off-patch blanks at
+`o = 0`. Those words are weight 1, hence not vertex3. Every other
+on-patch site sees the empty word. The first wave is empty.
+
+### Theorem 2 — halt is immediate
+
+The seed lock set is already a fixed point: the first wave is empty,
+so one attempted tick adds nothing. Halt may be read as `T = 0`
+(already halted) or as `T = 1` with the same lock set. In either
+reading,
+
+```text
+locks = {(0,0,0)},   |locks| = 1.
+```
+
+The site set is finite, locks are permanent, and a non-halt tick would
+have to add a site. None is added.
+
+### Theorem 3 — the patch does not fill
+
+`|locks| = 1 ≠ 12`, so the lock set is not the patch. The
+vertex3-orbit indicator does not fill the twelve-vertex two-cube from
+this 1-site seed.
+
+Displayed contrast, not a clone table: L1 from the same seed fills at
+horizon 4 with 12 locks. Hamming parity from the same seed has a
+nonempty first wave (the three axis sites). Those are different
+members. Do not call Hamming `f_L1`. Do not adopt `f_v3`.
+
+## What Is Not Claimed
+
+- No unique member of the axiom class, and no adoption of `f_v3`.
+- No leftover-char restatement of static `F_cut` membership.
+- No identification of `f_v3` with `f_L1` or with Hamming parity.
+- `f_L1` remains the unbalanced-axis predicate `n ≠ 0`.
+- No clock identity, no source identity, and no formation-count table.
+- No 4x4x4, torus, or line complex.
+- No axiom edit and no replacement of the live Record sentences.
+- Qubit remains `M_2(C)`.
+- No inverse-square law and no Newtonian identification.
+
+## Runner Contract
+
+The companion runner recomputes the ten orbits, rebuilds `f_v3` as the
+vertex3 indicator, and checks the first-wave, halt, and fill theorems
+with exact integer arithmetic. It prints `TOTAL: PASS=... FAIL=...`
+and writes no cache. Declared review inputs are this note and the
+axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -19037,6 +19037,10 @@
   "velocity_rg_logflow_framework_internal_2026-06-21": {
    "deps_hash": "a30145e2e616",
    "out_degree": 8
+  },
+  "vertex3_orbit_indicator_dynamics_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "w_mass_derived_note": {
    "deps_hash": "246b81948e27",

--- a/logs/runner-cache/vertex3_orbit_indicator_dynamics_2026_08_15.txt
+++ b/logs/runner-cache/vertex3_orbit_indicator_dynamics_2026_08_15.txt
@@ -1,0 +1,82 @@
+===== runner cache v1 =====
+runner: scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py
+runner_sha256: 65b5c7e5444509a2b7c7f8259768f22903ed60782ab5f1f05011f7b69ab3bfed
+input_fingerprint_sha256: c95a752bebb8569b7d2848bc2a457372eed85e297fc037cb66c4c110b5e4dd19
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+vertex3-orbit indicator dynamics on the two-cube
+AUDIT_INPUT_PATHS:
+  docs/VERTEX3_ORBIT_INDICATOR_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: twelve-vertex two-cube; 1-site seed; off-patch o=0; f_v3 = indicator of the complement-fixed vertex3 orbit
+negative_scope: displayed, not adopted; not leftover-char static membership; not L1; f_L1 is n≠0, not Hamming parity
+PASS: audit-input-paths-static-literals
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-relative
+PASS: lattice-quote-present
+PASS: record-form-quote-present
+PASS: hygiene-avoids-'G_N'
+PASS: hygiene-avoids-'1/r'
+PASS: hygiene-avoids-'1/r^2'
+PASS: hygiene-avoids-'Lattice-named'
+PASS: hygiene-avoids-'not a TOE'
+PASS: hygiene-avoids-'exhausted'
+PASS: hygiene-avoids-'only route'
+PASS: hygiene-avoids-'we adopt'
+PASS: hygiene-avoids-'Codex'
+PASS: hygiene-avoids-'L_phys'
+PASS: note-has-no-runner-cache-path
+PASS: note-has-no-citation-manifest
+PASS: patch-has-twelve-sites
+PASS: seed-is-origin
+PASS: off-patch-occupancy-is-zero
+PASS: rotation-group-order
+PASS: orbit-count  (N_orb=10)
+PASS: vertex3-size-eight
+PASS: vertex3-is-one-per-axis
+PASS: vertex3-complement-fixed
+PASS: mixed3-is-distinct
+PASS: weight-1-not-in-vertex3
+PASS: f-v3-exactly-the-orbit
+PASS: theorem-1-first-wave-empty
+PASS: theorem-2-halt-is-zero-or-one  (T=0)
+PASS: theorem-2-locks-are-seed-only
+PASS: theorem-2-lock-count  (|locks|=1)
+PASS: theorem-2-halt-is-fixed-point
+PASS: theorem-2-one-tick-adds-nothing
+PASS: theorem-3-does-not-fill
+PASS: locks-monotone
+PASS: displayed-f-l1-is-unbalanced-axis-not-hamming
+PASS: hamming-first-wave-nonempty
+PASS: l1-first-wave-nonempty
+PASS: l1-displayed-fills-at-horizon-4  (L1 T=4 |locks|=12)
+PASS: f-v3-distinct-from-l1-and-hamming
+PASS: claim-scope
+PASS: note-reports-empty-first-wave
+PASS: note-reports-seed-only-locks
+PASS: note-reports-does-not-fill
+PASS: note-displays-not-adopted
+PASS: note-not-leftover-char
+PASS: note-authors-no-audit-verdict
+PASS: script-hygiene
+PASS: axiom-unedited
+halt_tick: 0
+lock_count: 1
+fills_patch: False
+first_wave_size: 0
+hamming_first_wave_size: 3
+l1_halt_tick: 4
+per_element: 12 vertices
+per_site: occupancy lock
+per_mode: f_v3 vertex3-orbit indicator
+per_block: first wave, halt, fill
+lattice_wide: checked and not executed
+TOTAL: PASS=50 FAIL=0
+
+----- stderr -----
+

--- a/scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py
+++ b/scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Exact checks for vertex3-orbit indicator dynamics on the two-cube.
+
+Recomputes the ten cube-covariant occupation orbits on the six-ray star
+and runs occupancy-lock ticks of the vertex3-orbit indicator (f_v3 = 1
+exactly on that complement-fixed orbit) from a 1-site seed with off-patch
+o=0. Writes no cache and no governance surface. Does not adopt a member.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/VERTEX3_ORBIT_INDICATOR_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Vec = tuple[int, int, int]
+RAYS: tuple[Vec, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[Vec, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+CUBE_A = frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+CUBE_B = frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+PATCH = CUBE_A | CUBE_B
+SEED: Vec = (0, 0, 0)
+N_CELLS = 64
+
+FORBIDDEN_NOTE_SUBSTRINGS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "exhausted",
+    "only route",
+    "we adopt",
+    "Codex",
+    "L_phys",
+)
+
+
+def plus(site: Vec, step: Vec) -> Vec:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def occupancy(site: Vec, locks: frozenset[Vec]) -> int:
+    return 1 if site in locks else 0
+
+
+def permutation_sign(values: tuple[int, ...]) -> int:
+    inversions = sum(
+        values[i] > values[j]
+        for i in range(len(values))
+        for j in range(i + 1, len(values))
+    )
+    return -1 if inversions % 2 else 1
+
+
+def apply_signed_permutation(
+    ray: Vec,
+    perm: tuple[int, ...],
+    signs: tuple[int, ...],
+) -> Vec:
+    moved = [0, 0, 0]
+    for row in range(3):
+        moved[row] = signs[row] * ray[perm[row]]
+    return (moved[0], moved[1], moved[2])
+
+
+def proper_cube_ray_permutations() -> tuple[tuple[int, ...], ...]:
+    index = {ray: i for i, ray in enumerate(RAYS)}
+    rotations: list[tuple[int, ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            if permutation_sign(perm) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            image = tuple(
+                index[apply_signed_permutation(ray, perm, signs)] for ray in RAYS
+            )
+            rotations.append(image)
+    return tuple(rotations)
+
+
+def apply_perm(mask: int, perm: tuple[int, ...]) -> int:
+    image = 0
+    for src, dest in enumerate(perm):
+        if mask >> src & 1:
+            image |= 1 << dest
+    return image
+
+
+def complement(mask: int) -> int:
+    return mask ^ (N_CELLS - 1)
+
+
+def orbit_of(mask: int, rotations: tuple[tuple[int, ...], ...]) -> frozenset[int]:
+    return frozenset(apply_perm(mask, rot) for rot in rotations)
+
+
+def all_orbits(rotations: tuple[tuple[int, ...], ...]) -> tuple[frozenset[int], ...]:
+    seen: set[int] = set()
+    orbits: list[frozenset[int]] = []
+    for mask in range(N_CELLS):
+        if mask in seen:
+            continue
+        orbit = orbit_of(mask, rotations)
+        seen.update(orbit)
+        orbits.append(orbit)
+    return tuple(sorted(orbits, key=lambda orb: (min(orb), len(orb))))
+
+
+def plus_plus_plus_mask() -> int:
+    # Occupied +x, +y, +z: bits 0, 2, 4.
+    return (1 << 0) | (1 << 2) | (1 << 4)
+
+
+def occupied_axes(mask: int) -> int:
+    pairs = ((0, 1), (2, 3), (4, 5))
+    return sum(1 for plus_bit, minus_bit in pairs if (mask >> plus_bit) & 1 or (mask >> minus_bit) & 1)
+
+
+def is_one_per_axis_weight3(mask: int) -> bool:
+    if mask.bit_count() != 3:
+        return False
+    pairs = ((0, 1), (2, 3), (4, 5))
+    return all(((mask >> plus_bit) & 1) + ((mask >> minus_bit) & 1) == 1 for plus_bit, minus_bit in pairs)
+
+
+def neighborhood_mask(site: Vec, locks: frozenset[Vec]) -> int:
+    mask = 0
+    for bit, ray in enumerate(RAYS):
+        if occupancy(plus(site, ray), locks):
+            mask |= 1 << bit
+    return mask
+
+
+def f_v3(mask: int, vertex3: frozenset[int]) -> int:
+    return 1 if mask in vertex3 else 0
+
+
+def f_l1(mask: int) -> int:
+    # L1 form iff n≠0: at least one axis is unbalanced.
+    for plus_bit, minus_bit in ((0, 1), (2, 3), (4, 5)):
+        if ((mask >> plus_bit) & 1) != ((mask >> minus_bit) & 1):
+            return 1
+    return 0
+
+
+def f_hamming(mask: int) -> int:
+    return mask.bit_count() % 2
+
+
+def ready_sites(locks: frozenset[Vec], predicate) -> frozenset[Vec]:
+    return frozenset(
+        site
+        for site in PATCH
+        if site not in locks and predicate(neighborhood_mask(site, locks)) == 1
+    )
+
+
+def step(locks: frozenset[Vec], predicate) -> frozenset[Vec]:
+    return locks | ready_sites(locks, predicate)
+
+
+def evolve_until_halt(
+    seed: frozenset[Vec],
+    predicate,
+    max_ticks: int = 12,
+) -> tuple[int, frozenset[Vec], list[frozenset[Vec]]]:
+    hist = [seed]
+    locks = seed
+    for tick in range(1, max_ticks + 1):
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            return tick - 1, locks, hist
+        locks = nxt
+        hist.append(locks)
+    return max_ticks, locks, hist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("vertex3-orbit indicator dynamics on the two-cube")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "scope: twelve-vertex two-cube; 1-site seed; off-patch o=0; "
+        "f_v3 = indicator of the complement-fixed vertex3 orbit"
+    )
+    print(
+        "negative_scope: displayed, not adopted; not leftover-char static "
+        "membership; not L1; f_L1 is n≠0, not Hamming parity"
+    )
+
+    expected_tuple = (
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/VERTEX3_ORBIT_INDICATOR_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")"
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/VERTEX3_ORBIT_INDICATOR_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and expected_tuple in source
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check("audit-input-paths-exist", all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS))
+    checks.check(
+        "audit-input-paths-unique-relative",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(not Path(path).is_absolute() and ".." not in Path(path).parts for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("lattice-quote-present", "proper cubic rotations" in axiom)
+    checks.check("record-form-quote-present", "Records form" in axiom)
+    for token in FORBIDDEN_NOTE_SUBSTRINGS:
+        checks.check(f"hygiene-avoids-{token!r}", token not in note)
+    checks.check("note-has-no-runner-cache-path", "runner-cache" not in note)
+    checks.check("note-has-no-citation-manifest", "citation_manifest" not in note)
+    checks.check("patch-has-twelve-sites", len(PATCH) == 12)
+    checks.check("seed-is-origin", SEED == (0, 0, 0) and SEED in PATCH)
+    checks.check("off-patch-occupancy-is-zero", occupancy((3, 0, 0), frozenset({SEED})) == 0)
+
+    rotations = proper_cube_ray_permutations()
+    identity = tuple(range(6))
+    checks.check(
+        "rotation-group-order",
+        len(rotations) == 24 and len(set(rotations)) == 24 and identity in rotations,
+    )
+
+    orbits = all_orbits(rotations)
+    checks.check(
+        "orbit-count",
+        len(orbits) == 10 and sum(len(orbit) for orbit in orbits) == 64,
+        f"N_orb={len(orbits)}",
+    )
+
+    vertex3 = orbit_of(plus_plus_plus_mask(), rotations)
+    mixed3 = orbit_of((1 << 0) | (1 << 1) | (1 << 2), rotations)
+    checks.check("vertex3-size-eight", len(vertex3) == 8)
+    checks.check(
+        "vertex3-is-one-per-axis",
+        all(is_one_per_axis_weight3(mask) for mask in vertex3)
+        and all(is_one_per_axis_weight3(mask) for mask in range(N_CELLS) if mask in vertex3)
+        and occupied_axes(plus_plus_plus_mask()) == 3,
+    )
+    checks.check(
+        "vertex3-complement-fixed",
+        frozenset(complement(mask) for mask in vertex3) == vertex3,
+    )
+    checks.check("mixed3-is-distinct", mixed3 != vertex3 and len(mixed3) == 12)
+    checks.check(
+        "weight-1-not-in-vertex3",
+        all(mask.bit_count() != 1 for mask in vertex3)
+        and all(f_v3(1 << bit, vertex3) == 0 for bit in range(6)),
+    )
+    checks.check(
+        "f-v3-exactly-the-orbit",
+        all((f_v3(mask, vertex3) == 1) == (mask in vertex3) for mask in range(N_CELLS)),
+    )
+
+    def pred_v3(mask: int) -> int:
+        return f_v3(mask, vertex3)
+
+    seed_locks = frozenset({SEED})
+    first_wave = ready_sites(seed_locks, pred_v3)
+    halt_tick, locks, hist = evolve_until_halt(seed_locks, pred_v3, 12)
+    post_halt = step(locks, pred_v3)
+    one_tick = step(seed_locks, pred_v3)
+
+    checks.check("theorem-1-first-wave-empty", first_wave == frozenset())
+    checks.check("theorem-2-halt-is-zero-or-one", halt_tick in (0, 1), f"T={halt_tick}")
+    checks.check("theorem-2-locks-are-seed-only", locks == seed_locks)
+    checks.check("theorem-2-lock-count", len(locks) == 1, f"|locks|={len(locks)}")
+    checks.check("theorem-2-halt-is-fixed-point", post_halt == locks)
+    checks.check("theorem-2-one-tick-adds-nothing", one_tick == seed_locks)
+    checks.check("theorem-3-does-not-fill", locks != PATCH and len(locks) != 12)
+    checks.check("locks-monotone", all(hist[i] <= hist[i + 1] for i in range(len(hist) - 1)))
+
+    hamming_wave = ready_sites(seed_locks, f_hamming)
+    l1_wave = ready_sites(seed_locks, f_l1)
+    l1_halt, l1_locks, _ = evolve_until_halt(seed_locks, f_l1, 12)
+    axis_sites = frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)})
+
+    checks.check(
+        "displayed-f-l1-is-unbalanced-axis-not-hamming",
+        any(f_l1(mask) != f_hamming(mask) for mask in range(N_CELLS))
+        and f_l1(1) == 1
+        and f_hamming(1) == 1
+        and f_l1(plus_plus_plus_mask()) == 1
+        and f_hamming(plus_plus_plus_mask()) == 1
+        and f_l1((1 << 0) | (1 << 1)) == 0
+        and f_hamming((1 << 0) | (1 << 1)) == 0
+        and f_l1((1 << 0) | (1 << 2)) == 1
+        and f_hamming((1 << 0) | (1 << 2)) == 0,
+    )
+    checks.check(
+        "hamming-first-wave-nonempty",
+        hamming_wave == axis_sites and len(hamming_wave) == 3,
+    )
+    checks.check("l1-first-wave-nonempty", l1_wave == axis_sites)
+    checks.check(
+        "l1-displayed-fills-at-horizon-4",
+        l1_halt == 4 and l1_locks == PATCH and len(l1_locks) == 12,
+        f"L1 T={l1_halt} |locks|={len(l1_locks)}",
+    )
+    checks.check(
+        "f-v3-distinct-from-l1-and-hamming",
+        any(pred_v3(mask) != f_l1(mask) for mask in range(N_CELLS))
+        and any(pred_v3(mask) != f_hamming(mask) for mask in range(N_CELLS))
+        and pred_v3(1) == 0
+        and f_l1(1) == 1
+        and f_hamming(1) == 1,
+    )
+
+    claim_scope = (
+        "The vertex3-orbit indicator has empty 1-site first wave on the "
+        "twelve-vertex two-cube with off-patch o=0 and does not fill. "
+        "Displayed, not adopted."
+    )
+    checks.check("claim-scope", claim_scope in note)
+    checks.check("note-reports-empty-first-wave", "empty" in note and "first wave" in note)
+    checks.check("note-reports-seed-only-locks", "|locks|" in note and "seed" in note)
+    checks.check("note-reports-does-not-fill", "does not fill" in note)
+    checks.check("note-displays-not-adopted", "Displayed, not adopted" in note)
+    checks.check("note-not-leftover-char", "not leftover-char" in note)
+    checks.check("note-authors-no-audit-verdict", "authors no audit verdict" in note)
+    checks.check(
+        "script-hygiene",
+        "Does not adopt a member" in source and "cache_write: false" in source,
+    )
+    checks.check(
+        "axiom-unedited",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "f_v3" not in axiom
+        and "vertex3" not in axiom,
+    )
+
+    print(f"halt_tick: {halt_tick}")
+    print(f"lock_count: {len(locks)}")
+    print(f"fills_patch: {locks == PATCH}")
+    print(f"first_wave_size: {len(first_wave)}")
+    print(f"hamming_first_wave_size: {len(hamming_wave)}")
+    print(f"l1_halt_tick: {l1_halt}")
+    print("per_element: 12 vertices")
+    print("per_site: occupancy lock")
+    print("per_mode: f_v3 vertex3-orbit indicator")
+    print("per_block: first wave, halt, fill")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The vertex3-orbit indicator has empty 1-site first wave on the twelve-vertex two-cube with off-patch o=0, halt is seed-only, and it does not fill. Distinct from L1 and from Hamming. Displayed, not adopted.

## Runner

`scripts/vertex3_orbit_indicator_dynamics_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
