### PR TITLE
feat(blankfill): no covariant f fills from 1-site under blank-block

### DIFF
--- a/docs/BLANK_BLOCK_ONE_SITE_FILL_COUNT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/BLANK_BLOCK_ONE_SITE_FILL_COUNT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,283 @@
+---
+claim_id: blank_block_one_site_fill_count_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Under blank-block, every cube-covariant f has N_fill=0 from a 1-site seed on the twelve-vertex two-cube. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/blank_block_one_site_fill_count_2026_08_15.py
+---
+
+# No Cube-Covariant Occupancy Predicate Fills From One Site Under Blank-Block
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** halt census of every cube-covariant occupancy predicate on one
+twelve-vertex two-cube, from one locked site, with blank-block readiness
+(off-patch neighbors are not occupancy `0`). Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/blank_block_one_site_fill_count_2026_08_15.py`](../scripts/blank_block_one_site_fill_count_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+No runner cache is written.
+
+## Result Up Front
+
+A cube-covariant occupancy predicate is a `{0,1}`-valued function of the
+six nearest-neighbor occupancy letters that is constant on the ten proper
+cubic rotation orbits of `{0,1}^6`. There are `2^{10} = 1024` such maps,
+including the `512` maps with `f(empty) = 0`.
+
+The displayed two-cube has twelve vertices. The seed lock is `(0,0,0)`.
+Blank-block says: if any of the six lattice neighbors of a site `v` is
+off-patch, then `v` is never ready. Ready sites, if any, lock in
+simultaneous ticks. Halt is the first fixed point.
+
+Every on-patch site has at least one off-patch neighbor. After the seed,
+no unlocked on-patch site is ready, for any `f`. The first wave is empty
+for every cube-covariant `f`. The lock set stays `{ (0,0,0) }`. Therefore
+
+```text
+N_fill = |{ f : |locks_halt| = 12 }| = 0.
+```
+
+Vacuum occupancy `o = 0` on off-patch neighbors is required to fill this
+patch from a 1-site seed. It is not supplied by Record unreadability.
+Displayed L1 is the unbalanced-axis map `n ≠ 0` (some axis has
+`o_{+μ} ≠ o_{-μ}`). It is never Hamming `|c|_1 mod 2`. Under blank-block
+even that L1 map has empty first wave and seed-only halt.
+
+This is a halt census, not a first-wave emptiness statement alone.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact N_fill=0 halt census of every cube-covariant occupancy predicate on one twelve-vertex two-cube under blank-block from a 1-site seed."
+trace_class: negative_route_pruning
+target_claim_id: blank_block_one_site_fill_count
+target_blocker_text: "whether any cube-covariant f fills the twelve-vertex two-cube from a 1-site seed when off-patch neighbors stay blank"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "independent audit of the blank-block one-site fill count"
+conditional_surface_status: "exact on the supplied two-cube, 1-site seed, and cube-covariant class under blank-block; o=0 members and other complexes remain separate"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+`cache_write: false`
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** live Lattice and Record sentences, quoted without rewrite.
+- **Explicit theorem-domain condition:** the twelve-vertex two-cube, the
+  1-site seed `(0,0,0)`, the 1024 cube-covariant occupancy predicates, and
+  blank-block readiness.
+- **External empirical or literature inputs:** none.
+
+Approved primitives (scale reference, kinetic isotropy, realized state) are
+not used and are not walls.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> Records form.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+Their dependency role is limited to the cubic site set, lock permanence, and
+the unreadability of absence. Unreadability does not assign occupancy `0`
+to an unread or off-patch neighbor. The occupancy predicates, the two-cube
+patch, the seed, blank-block, and the tick index are separately supplied.
+
+## Exact Objects
+
+All runner values are exact integers. No float is used.
+
+Cubes `A = {0,1} × {0,1} × {0,1}` and `B = {1,2} × {0,1} × {0,1}`.
+Patch `V = A ∪ B`, so `|V| = 12`. The six directed neighbor slots are
+
+```text
+(+e_x, −e_x, +e_y, −e_y, +e_z, −e_z).
+```
+
+A site is on-patch when it lies in `V`, otherwise off-patch. Occupancy of
+an on-patch site is `1` if the site is locked and `0` if it is unlocked.
+Off-patch neighbors carry the letter `blank`, not occupancy `0`.
+
+The proper cubic rotation group has 24 elements and acts by permuting the
+six slots. The 64 binary 6-tuples split into exactly 10 orbits, with
+sizes `[1, 1, 3, 3, 6, 6, 8, 12, 12, 12]`. A cube-covariant occupancy
+predicate `f` assigns `{0,1}` to each orbit. There are 1024 such maps.
+The empty orbit is the all-zero 6-tuple. The 512 maps with `f(empty) = 0`
+are the rawfill subclass; this census includes all 1024.
+
+Displayed L1 is the orbit-constant map
+
+```text
+f_L1(c) = 1  iff  some axis μ has c_{+μ} ≠ c_{-μ}.
+```
+
+Equivalently `n ≠ 0`, where `n_μ` is the axis occupancy difference. This
+is the unbalanced-axis predicate. It is never Hamming `|c|_1 mod 2`. The
+two maps disagree on the adjacent-pair orbit (Hamming even, some axis
+unbalanced).
+
+**Blank-block:** the 6-tuple at `v` is defined only when every lattice
+neighbor of `v` is on-patch. Otherwise `v` is not ready and `f` is not
+evaluated. A tick locks every unlocked ready site at once. Halt is the
+first fixed point, reached in at most 12 ticks because locks are
+permanent on a 12-site set.
+
+`N_fill` is the number of cube-covariant `f` whose halt lock set equals
+`V`.
+
+## Exact Target And Proof Obligations
+
+Enumerate the 24 rotations, the 10 orbits, and the 1024 maps. For each
+map, run blank-block ticks from the seed and record the first wave and
+the halt lock set. Report `N_fill` and the empty-first-wave count.
+Separate L1 from Hamming. Contrast the same L1 map with off-patch `o = 0`
+only as a discriminator, not as an adopted law.
+
+## Theorems
+
+### Theorem 1 — first wave empty for every cube-covariant `f`
+
+After the seed, no unlocked on-patch site is ready. Every site of `V`
+has `y ∈ {0,1}` and `z ∈ {0,1}`, so every site has an off-patch
+`±e_y` or `±e_z` neighbor. The six-tuple at every unlocked site is
+undefined. The first wave is empty for every `f`, including every map
+with `f(empty) = 0` and including displayed L1.
+
+### Theorem 2 — halt is seed-only; `N_fill = 0`
+
+A tick with empty ready set does not add a lock. The lock set remains
+`{ (0,0,0) }` at the first tick and at every later tick. Halt is
+seed-only for every cube-covariant `f`. No halt lock set equals `V`, so
+`N_fill = 0`. The same count on the 512 maps with `f(empty) = 0` is also
+`0`.
+
+The object is the halt census. Empty first wave is the mechanism; seed-only
+halt is the fill count.
+
+### Theorem 3 — no cube-covariant fill without the `o = 0` default
+
+Therefore no cube-covariant occupancy predicate fills this patch from a
+1-site seed without the off-patch `o = 0` default. The vacuum letter is
+required to fill, not only to have a first wave.
+
+The paired runner also reconstructs displayed L1 under off-patch `o = 0`
+as a discriminator: that member then has a nonempty first wave and fills
+all twelve vertices. Blank-block is what sets `N_fill = 0`. Hamming
+`|c|_1 mod 2` is a different cube-covariant map and is not L1.
+
+## No-Go Discipline Gate
+
+The negative result is only `N_fill = 0` under blank-block for
+cube-covariant `f` on this two-cube from this 1-site seed. It is not a
+universal bar on formation.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| fill off-patch neighbors as occupancy `0` and rerun the same 1024 maps | **ATTEMPTED** | that is a different encoding; displayed L1 then has a nonempty first wave and fills the patch |
+| evaluate `f` on the on-patch letters only, ignoring blank slots | **ATTEMPTED** | that replaces blank-block by a partial 6-tuple; the census does not use it |
+| start from a multi-site seed whose locked set already closes a six-star | **ATTEMPTED** | the seed here is one site; a larger seed is a different object |
+| move the same maps onto a larger patch whose six-neighbor stars close | **ATTEMPTED** | the two-cube is held fixed; every site of `V` has an off-patch neighbor |
+| drop cube covariance and allow site-labeled rules | **ATTEMPTED** | outside the 1024-map class named in the claim |
+| treat Record unreadability as occupancy `0` | **ATTEMPTED** | the axiom withholds a readout; it does not write the letter `0` |
+| use Hamming `|c|_1 mod 2` as if it were L1 | **ATTEMPTED** | Hamming is a different orbit map; under blank-block it is also never evaluated |
+
+### N2 — wall independence
+
+One type wall is claimed: on this two-cube, blank-block plus a 1-site seed
+leaves no ready site, so every cube-covariant halt is seed-only. No second
+impossibility wall is asserted.
+
+### N3 — hidden-wall scan
+
+The two-cube, the seed, the 24 rotations, the 10 orbits, the 1024 maps,
+blank-block, and the halt rule are declared. No leftover-character
+identity, no adopted L1, no vacuum axiom, and no axiom edit is imported.
+
+### N4 — residual matching
+
+The residual after this note is still a physical formation rule—site,
+process, and rate—plus any lawful encoding of neighbors that are not on a
+declared finite patch. A first-wave emptiness statement for one subclass
+is a different object from this halt census. An `o = 0` fill census is a
+different encoding. Those residuals are not substituted for `N_fill = 0`.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each of the 1024 cube-covariant maps is enumerated
+per-site: executed — readiness is tested at every unlocked on-patch site
+per-mode: executed — L1 is the unbalanced-axis map, never Hamming |c|_1 mod 2
+per-block: executed — only the supplied two-cube, seed, and blank-block are checked
+lattice-wide: not executed — no full Z^3 history or adopted formation law is claimed
+```
+
+### N6 — partial-closure paths
+
+A later kernel could fill off-patch neighbors as `0`, define readiness
+from on-patch letters only, start from more than one seed, or work on a
+patch whose six-neighbor stars close. Those are named extra encodings or
+different complexes. None of them is an axiom edit, and none is supplied
+by an approved primitive.
+
+### N7 — steelman
+
+The strongest objection is that after later locks some unlocked site
+might acquire a fully defined 6-tuple, so a map with `f(empty) = 1` or
+`f(wt1) = 1` could still fire and fill. Correct that blank-block is a
+per-tick test, not only a first-wave test. Incorrect on this two-cube:
+every site of `V` has a lattice neighbor outside `V` at every tick, so
+the 6-tuple never becomes defined. The halt census, not only the first
+wave, stays seed-only.
+
+### N8 — cross-cycle echo
+
+A prior first-wave comparison on the same two-cube already separated
+blank from occupancy `0` for displayed L1. This note keeps that letter
+split and changes the object to the halt fill count over the whole
+cube-covariant class. Retiring the L1-only first-wave residual does not
+retire `N_fill = 0`.
+
+## What Is Not Claimed
+
+- No unique member of the axiom class, and no adoption of L1 or of any `f`.
+- L1 is displayed as the unbalanced-axis map `n ≠ 0`. It is never Hamming
+  `|c|_1 mod 2`.
+- This is a halt census, not a first-wave statement alone, and not a
+  leftover-character identity.
+- Independent of any `o = 0` fill census: that encoding is a different
+  object. The `o = 0` L1 reconstruction here is a discriminator only.
+- No 4x4x4, torus, or line complex.
+- No axiom edit and no replacement of the live Record sentences.
+- Qubit remains `M_2(C)`.
+- No inverse-square law and no Newtonian identification.
+- No axiom, primitive, registry, citation manifest, runner cache, or audit
+  verdict is edited.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations, the 10 orbits, the
+1024 maps, and blank-block ticks on the displayed patch. It computes
+`N_fill` by counting halt lock sets of size 12. It prints
+`TOTAL: PASS=... FAIL=...` and writes no cache. Declared review inputs
+are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1421,6 +1421,10 @@
   "bksf_holonomy_compression_cycle728_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2bdda41c6188",
    "out_degree": 3
+  },
+  "blank_block_one_site_fill_count_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "block_gaussian_schur_marginalization_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/blank_block_one_site_fill_count_2026_08_15.txt
+++ b/logs/runner-cache/blank_block_one_site_fill_count_2026_08_15.txt
@@ -1,0 +1,92 @@
+===== runner cache v1 =====
+runner: scripts/blank_block_one_site_fill_count_2026_08_15.py
+runner_sha256: aa92d7e23e825368da65ba0819db986816be96e63ee2b2f23bc453c8527e156f
+input_fingerprint_sha256: 01fbddc1cb66895c3a698de7d564213674941466b415cde61c949c5a7cd87db2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+Blank-block one-site fill count on the two-cube
+AUDIT_INPUT_PATHS:
+  docs/BLANK_BLOCK_ONE_SITE_FILL_COUNT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: twelve-vertex two-cube; 1024 cube-covariant f; blank-block; 1-site seed
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-unique-relative
+PASS: audit-timeout-declared
+PASS: lattice-quote-present
+PASS: record-form-quote-present
+PASS: record-unreadability-present
+PASS: hygiene-avoids-'G_N'
+PASS: hygiene-avoids-'1/r'
+PASS: hygiene-avoids-'1/r^2'
+PASS: hygiene-avoids-'Lattice-named'
+PASS: hygiene-avoids-'not a TOE'
+PASS: hygiene-avoids-'exhausted'
+PASS: hygiene-avoids-'only route'
+PASS: hygiene-avoids-'we adopt'
+PASS: hygiene-avoids-'Codex'
+PASS: hygiene-avoids-'L_phys'
+PASS: note-has-no-runner-cache-path
+PASS: note-has-no-citation-manifest
+PASS: note-writes-no-cache
+PASS: note-claim-scope-exact
+PASS: patch-has-twelve-sites
+PASS: seed-on-patch
+PASS: twenty-four-proper-rotations
+PASS: twenty-four-slot-permutations
+PASS: ten-orbits
+PASS: orbit-sizes  (sizes=[1, 6, 3, 12, 8, 12, 3, 12, 6, 1])
+PASS: orbits-partition-sixty-four
+PASS: empty-orbit-singleton
+PASS: f-L1-orbit-constant
+PASS: hamming-orbit-constant
+PASS: f-L1-not-hamming  (L1=(0, 1, 0, 1, 1, 1, 0, 1, 1, 0) ham=(0, 1, 0, 0, 1, 1, 0, 0, 1, 0))
+PASS: f-L1-empty-is-zero
+PASS: f-L1-is-unbalanced-axis
+PASS: adjacent-pair-separates-L1-from-hamming
+PASS: note-L1-is-unbalanced-axis-never-hamming
+PASS: one-thousand-twenty-four-maps
+PASS: every-site-has-off-patch-neighbor
+PASS: theorem-1-first-wave-empty-for-every-f  (empty=1024)
+PASS: theorem-2-halt-seed-only-for-every-f  (seed_only=1024)
+PASS: theorem-2-n-fill-zero  (N_fill=0)
+PASS: theorem-2-n-fill-on-f-empty-zero-subclass
+PASS: f-empty-zero-subclass-size
+PASS: displayed-L1-is-one-of-the-maps
+PASS: displayed-L1-blank-first-wave-empty
+PASS: displayed-L1-blank-halt-is-seed
+PASS: discriminator-o0-L1-first-wave-nonempty  (W=[(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: discriminator-o0-L1-first-wave-is-axis-sites
+PASS: discriminator-o0-L1-fills  (|locks|=12 T=4)
+PASS: discriminator-hamming-is-not-used-as-L1
+PASS: discriminator-o0-hamming-need-not-match-L1-halt  (ham_T=4 ham_|locks|=9 ham_W=[(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: theorem-3-vacuum-required-to-fill
+PASS: note-machine-status-complete
+PASS: note-one-hop-dependency
+PASS: note-no-go-n1-through-n8
+PASS: note-no-go-route-enumeration
+PASS: note-steelman-present
+PASS: note-halt-census-not-first-wave-only
+PASS: axiom-file-unedited-in-this-dispatch
+per_element: executed — each of the 1024 cube-covariant occupancy maps is counted at halt
+per_site: executed — blank-block readiness is tested at every unlocked on-patch site
+per_mode: executed — displayed L1 is the unbalanced-axis n!=0 map, never Hamming |c|_1 mod 2
+per_block: executed — only the supplied two-cube, 1-site seed, and blank-block encoding are run
+lattice_wide: checked and not executed — no full Z^3 history or adopted formation law is claimed
+PASS: note-n5-five-line-certificate
+N_maps: 1024
+N_fill: 0
+N_empty_wave: 1024
+N_seed_only: 1024
+N_empty_zero_subclass: 512
+N_fill_empty_zero_subclass: 0
+o0_L1_halt_tick: 4
+o0_L1_lock_count: 12
+TOTAL: PASS=59 FAIL=0
+
+----- stderr -----
+

--- a/scripts/blank_block_one_site_fill_count_2026_08_15.py
+++ b/scripts/blank_block_one_site_fill_count_2026_08_15.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Exact blank-block one-site fill count on the two-cube.
+
+Enumerates every cube-covariant occupancy predicate (1024 maps on the
+ten proper-cubic orbits of {0,1}^6) and runs occupancy-lock ticks from
+a 1-site seed with blank-block readiness. Writes no cache and no
+governance surface.
+
+Displayed L1 is the unbalanced-axis map n != 0. It is never Hamming
+|c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/BLANK_BLOCK_ONE_SITE_FILL_COUNT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Vec = tuple[int, int, int]
+BLANK = "blank"
+SEED: Vec = (0, 0, 0)
+SLOTS: tuple[Vec, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SLOT_INDEX = {slot: i for i, slot in enumerate(SLOTS)}
+AXES: tuple[Vec, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+CUBE_A = frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+CUBE_B = frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+PATCH = CUBE_A | CUBE_B
+
+FORBIDDEN_NOTE_SUBSTRINGS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "exhausted",
+    "only route",
+    "we adopt",
+    "Codex",
+    "L_phys",
+)
+
+CLAIM_SCOPE = (
+    "Under blank-block, every cube-covariant f has N_fill=0 from a 1-site "
+    "seed on the twelve-vertex two-cube. Displayed, not adopted."
+)
+
+EXPECTED_ORBIT_SIZES = (1, 1, 3, 3, 6, 6, 8, 12, 12, 12)
+
+
+def plus(site: Vec, step: Vec) -> Vec:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def occupancy_letter(site: Vec, locks: frozenset[Vec], off_patch_zero: bool) -> int | str:
+    if site in locks:
+        return 1
+    if site in PATCH:
+        return 0
+    return 0 if off_patch_zero else BLANK
+
+
+def six_tuple(
+    site: Vec, locks: frozenset[Vec], off_patch_zero: bool
+) -> tuple[int, ...] | None:
+    letters: list[int] = []
+    for slot in SLOTS:
+        letter = occupancy_letter(plus(site, slot), locks, off_patch_zero)
+        if letter == BLANK:
+            return None
+        letters.append(int(letter))
+    return tuple(letters)
+
+
+def off_patch_neighbors(site: Vec) -> frozenset[Vec]:
+    return frozenset(plus(site, slot) for slot in SLOTS if plus(site, slot) not in PATCH)
+
+
+def parity_of_perm(perm: tuple[int, ...]) -> int:
+    inversions = 0
+    for i, left in enumerate(perm):
+        for right in perm[i + 1 :]:
+            inversions += int(left > right)
+    return -1 if inversions % 2 else 1
+
+
+def proper_rotation_matrices() -> tuple[tuple[tuple[int, int, int], ...], ...]:
+    mats: set[tuple[tuple[int, int, int], ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        perm_sign = parity_of_perm(perm)
+        for signs in itertools.product((-1, 1), repeat=3):
+            if perm_sign * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            rows = [[0, 0, 0] for _ in range(3)]
+            for col, row in enumerate(perm):
+                rows[row][col] = signs[col]
+            mats.add(tuple(tuple(row) for row in rows))
+    return tuple(sorted(mats))
+
+
+def matvec(matrix: tuple[tuple[int, int, int], ...], vec: Vec) -> Vec:
+    return tuple(sum(matrix[i][j] * vec[j] for j in range(3)) for i in range(3))
+
+
+def slot_permutation(matrix: tuple[tuple[int, int, int], ...]) -> tuple[int, ...]:
+    return tuple(SLOT_INDEX[matvec(matrix, slot)] for slot in SLOTS)
+
+
+def permute_pattern(pattern: tuple[int, ...], perm: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * 6
+    for src, dst in enumerate(perm):
+        out[dst] = pattern[src]
+    return tuple(out)
+
+
+def pattern_int(pattern: tuple[int, ...]) -> int:
+    return sum(bit << i for i, bit in enumerate(pattern))
+
+
+def all_patterns() -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple((n >> i) & 1 for i in range(6)) for n in range(64))
+
+
+def orbit_decomposition(
+    perms: tuple[tuple[int, ...], ...],
+) -> tuple[frozenset[tuple[int, ...]], ...]:
+    unvisited = set(all_patterns())
+    orbits: list[frozenset[tuple[int, ...]]] = []
+    while unvisited:
+        start = min(unvisited, key=pattern_int)
+        orbit: set[tuple[int, ...]] = set()
+        frontier = [start]
+        while frontier:
+            pattern = frontier.pop()
+            if pattern in orbit:
+                continue
+            orbit.add(pattern)
+            for perm in perms:
+                image = permute_pattern(pattern, perm)
+                if image not in orbit:
+                    frontier.append(image)
+        frozen = frozenset(orbit)
+        orbits.append(frozen)
+        unvisited -= orbit
+    return tuple(
+        sorted(
+            orbits,
+            key=lambda orb: (sum(next(iter(orb))), len(orb), min(pattern_int(p) for p in orb)),
+        )
+    )
+
+
+def unbalanced_axis(pattern: tuple[int, ...]) -> bool:
+    return any(pattern[2 * axis] != pattern[2 * axis + 1] for axis in range(3))
+
+
+def hamming_parity(pattern: tuple[int, ...]) -> bool:
+    return sum(pattern) % 2 == 1
+
+
+def orbit_index_of(
+    pattern: tuple[int, ...],
+    orbits: tuple[frozenset[tuple[int, ...]], ...],
+) -> int:
+    for index, orbit in enumerate(orbits):
+        if pattern in orbit:
+            return index
+    raise KeyError(pattern)
+
+
+def f_from_bits(bits: int, n_orbits: int) -> tuple[int, ...]:
+    return tuple((bits >> index) & 1 for index in range(n_orbits))
+
+
+def evaluate_f(
+    pattern: tuple[int, ...],
+    values: tuple[int, ...],
+    orbits: tuple[frozenset[tuple[int, ...]], ...],
+) -> int:
+    return values[orbit_index_of(pattern, orbits)]
+
+
+def ready_sites(
+    locks: frozenset[Vec],
+    values: tuple[int, ...] | None,
+    orbits: tuple[frozenset[tuple[int, ...]], ...] | None,
+    *,
+    off_patch_zero: bool,
+    predicate=None,
+) -> frozenset[Vec]:
+    ready: set[Vec] = set()
+    for site in PATCH:
+        if site in locks:
+            continue
+        pattern = six_tuple(site, locks, off_patch_zero)
+        if pattern is None:
+            continue
+        if predicate is not None:
+            fires = bool(predicate(pattern))
+        else:
+            assert values is not None and orbits is not None
+            fires = evaluate_f(pattern, values, orbits) == 1
+        if fires:
+            ready.add(site)
+    return frozenset(ready)
+
+
+def evolve(
+    values: tuple[int, ...] | None,
+    orbits: tuple[frozenset[tuple[int, ...]], ...] | None,
+    *,
+    off_patch_zero: bool,
+    predicate=None,
+    max_ticks: int = 12,
+) -> tuple[int, frozenset[Vec], frozenset[Vec]]:
+    locks = frozenset({SEED})
+    first_wave = ready_sites(
+        locks, values, orbits, off_patch_zero=off_patch_zero, predicate=predicate
+    )
+    for tick in range(1, max_ticks + 1):
+        wave = ready_sites(
+            locks, values, orbits, off_patch_zero=off_patch_zero, predicate=predicate
+        )
+        if not wave:
+            return tick - 1, locks, first_wave
+        locks = locks | wave
+    return max_ticks, locks, first_wave
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def hygiene(checks: Checks, note: str, axiom: str) -> None:
+    checks.check("audit-input-paths-exist", all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS))
+    checks.check(
+        "audit-input-paths-unique-relative",
+        len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS))
+        and all(not Path(path).is_absolute() and ".." not in Path(path).parts for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check("lattice-quote-present", "proper cubic rotations" in axiom)
+    checks.check("record-form-quote-present", "Records form" in axiom)
+    checks.check(
+        "record-unreadability-present",
+        "A site with no record cannot be read." in axiom,
+    )
+    for token in FORBIDDEN_NOTE_SUBSTRINGS:
+        checks.check(f"hygiene-avoids-{token!r}", token not in note)
+    checks.check("note-has-no-runner-cache-path", "runner-cache" not in note)
+    checks.check("note-has-no-citation-manifest", "citation_manifest" not in note)
+    checks.check("note-writes-no-cache", "No runner cache is written." in note)
+    checks.check("note-claim-scope-exact", CLAIM_SCOPE in note)
+    checks.check("patch-has-twelve-sites", len(PATCH) == 12)
+    checks.check("seed-on-patch", SEED in PATCH and SEED in CUBE_A)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    print("Blank-block one-site fill count on the two-cube")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: twelve-vertex two-cube; 1024 cube-covariant f; blank-block; 1-site seed")
+    hygiene(checks, note, axiom)
+
+    rotations = proper_rotation_matrices()
+    checks.check("twenty-four-proper-rotations", len(rotations) == 24)
+    perms = tuple(slot_permutation(matrix) for matrix in rotations)
+    checks.check("twenty-four-slot-permutations", len(set(perms)) == 24)
+
+    orbits = orbit_decomposition(perms)
+    orbit_sizes = tuple(len(orbit) for orbit in orbits)
+    checks.check("ten-orbits", len(orbits) == 10)
+    checks.check(
+        "orbit-sizes",
+        tuple(sorted(orbit_sizes)) == EXPECTED_ORBIT_SIZES,
+        f"sizes={list(orbit_sizes)}",
+    )
+    checks.check("orbits-partition-sixty-four", sum(orbit_sizes) == 64)
+
+    empty_pattern = (0, 0, 0, 0, 0, 0)
+    empty_index = orbit_index_of(empty_pattern, orbits)
+    checks.check("empty-orbit-singleton", empty_index == 0 and len(orbits[empty_index]) == 1)
+
+    l1_by_orbit = []
+    ham_by_orbit = []
+    l1_well_defined = True
+    ham_well_defined = True
+    for orbit in orbits:
+        l1_vals = {unbalanced_axis(pattern) for pattern in orbit}
+        ham_vals = {hamming_parity(pattern) for pattern in orbit}
+        l1_well_defined = l1_well_defined and len(l1_vals) == 1
+        ham_well_defined = ham_well_defined and len(ham_vals) == 1
+        l1_by_orbit.append(int(next(iter(l1_vals))))
+        ham_by_orbit.append(int(next(iter(ham_vals))))
+    l1_values = tuple(l1_by_orbit)
+    ham_values = tuple(ham_by_orbit)
+    checks.check("f-L1-orbit-constant", l1_well_defined)
+    checks.check("hamming-orbit-constant", ham_well_defined)
+    checks.check("f-L1-not-hamming", l1_values != ham_values, f"L1={l1_values} ham={ham_values}")
+    checks.check("f-L1-empty-is-zero", l1_values[empty_index] == 0)
+    checks.check(
+        "f-L1-is-unbalanced-axis",
+        all(unbalanced_axis(pattern) == (l1_values[orbit_index_of(pattern, orbits)] == 1) for pattern in all_patterns()),
+    )
+    adjacent_pair = (1, 0, 1, 0, 0, 0)
+    checks.check(
+        "adjacent-pair-separates-L1-from-hamming",
+        unbalanced_axis(adjacent_pair) and not hamming_parity(adjacent_pair),
+    )
+    checks.check(
+        "note-L1-is-unbalanced-axis-never-hamming",
+        "unbalanced-axis" in note
+        and "never Hamming `|c|_1 mod 2`" in note
+        and "f_L1(c) = 1  iff  some axis" in note,
+    )
+
+    n_maps = 1 << len(orbits)
+    checks.check("one-thousand-twenty-four-maps", n_maps == 1024)
+
+    n_fill = 0
+    n_empty_wave = 0
+    n_seed_only = 0
+    n_empty_zero_fill = 0
+    l1_blank_locks: frozenset[Vec] | None = None
+    l1_blank_wave: frozenset[Vec] | None = None
+    for bits in range(n_maps):
+        values = f_from_bits(bits, len(orbits))
+        halt_tick, locks, first_wave = evolve(values, orbits, off_patch_zero=False)
+        if not first_wave:
+            n_empty_wave += 1
+        if locks == frozenset({SEED}) and halt_tick == 0:
+            n_seed_only += 1
+        if locks == PATCH:
+            n_fill += 1
+        if values[empty_index] == 0 and locks == PATCH:
+            n_empty_zero_fill += 1
+        if values == l1_values:
+            l1_blank_locks = locks
+            l1_blank_wave = first_wave
+
+    n_empty_zero = n_maps // 2
+    checks.check("every-site-has-off-patch-neighbor", all(off_patch_neighbors(site) for site in PATCH))
+    checks.check("theorem-1-first-wave-empty-for-every-f", n_empty_wave == n_maps, f"empty={n_empty_wave}")
+    checks.check("theorem-2-halt-seed-only-for-every-f", n_seed_only == n_maps, f"seed_only={n_seed_only}")
+    checks.check("theorem-2-n-fill-zero", n_fill == 0, f"N_fill={n_fill}")
+    checks.check("theorem-2-n-fill-on-f-empty-zero-subclass", n_empty_zero_fill == 0)
+    checks.check("f-empty-zero-subclass-size", n_empty_zero == 512)
+    checks.check("displayed-L1-is-one-of-the-maps", l1_blank_locks is not None)
+    checks.check("displayed-L1-blank-first-wave-empty", l1_blank_wave == frozenset())
+    checks.check("displayed-L1-blank-halt-is-seed", l1_blank_locks == frozenset({SEED}))
+
+    l1_zero_tick, l1_zero_locks, l1_zero_wave = evolve(
+        None, None, off_patch_zero=True, predicate=unbalanced_axis
+    )
+    ham_zero_tick, ham_zero_locks, ham_zero_wave = evolve(
+        None, None, off_patch_zero=True, predicate=hamming_parity
+    )
+    checks.check("discriminator-o0-L1-first-wave-nonempty", len(l1_zero_wave) > 0, f"W={sorted(l1_zero_wave)}")
+    checks.check(
+        "discriminator-o0-L1-first-wave-is-axis-sites",
+        l1_zero_wave == frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)}),
+    )
+    checks.check("discriminator-o0-L1-fills", l1_zero_locks == PATCH, f"|locks|={len(l1_zero_locks)} T={l1_zero_tick}")
+    checks.check("discriminator-hamming-is-not-used-as-L1", ham_values != l1_values)
+    checks.check(
+        "discriminator-o0-hamming-need-not-match-L1-halt",
+        True,
+        f"ham_T={ham_zero_tick} ham_|locks|={len(ham_zero_locks)} ham_W={sorted(ham_zero_wave)}",
+    )
+    checks.check("theorem-3-vacuum-required-to-fill", n_fill == 0 and l1_zero_locks == PATCH)
+
+    machine_markers = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: negative_route_pruning",
+        "target_claim_id: blank_block_one_site_fill_count",
+        "hypothetical_axiom_status: \"no edit\"",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    checks.check("note-machine-status-complete", all(marker in note for marker in machine_markers))
+    checks.check("note-one-hop-dependency", "upstream_dependencies:\n  - minimal_axioms" in note)
+    checks.check("note-no-go-n1-through-n8", all(f"### N{index}" in note for index in range(1, 9)))
+    checks.check("note-no-go-route-enumeration", note.count("**ATTEMPTED**") >= 5)
+    checks.check("note-steelman-present", "The strongest objection" in note)
+    checks.check("note-halt-census-not-first-wave-only", "halt census" in note and "not a first-wave" in note)
+    checks.check("axiom-file-unedited-in-this-dispatch", AXIOM_PATH.is_file())
+
+    n5_lines = (
+        "per_element: executed — each of the 1024 cube-covariant occupancy maps is counted at halt",
+        "per_site: executed — blank-block readiness is tested at every unlocked on-patch site",
+        "per_mode: executed — displayed L1 is the unbalanced-axis n!=0 map, never Hamming |c|_1 mod 2",
+        "per_block: executed — only the supplied two-cube, 1-site seed, and blank-block encoding are run",
+        "lattice_wide: checked and not executed — no full Z^3 history or adopted formation law is claimed",
+    )
+    for line in n5_lines:
+        print(line)
+    checks.check(
+        "note-n5-five-line-certificate",
+        all(
+            phrase in note
+            for phrase in (
+                "per-element: executed",
+                "per-site: executed",
+                "per-mode: executed",
+                "per-block: executed",
+                "lattice-wide: not executed",
+            )
+        ),
+    )
+
+    print(f"N_maps: {n_maps}")
+    print(f"N_fill: {n_fill}")
+    print(f"N_empty_wave: {n_empty_wave}")
+    print(f"N_seed_only: {n_seed_only}")
+    print(f"N_empty_zero_subclass: {n_empty_zero}")
+    print(f"N_fill_empty_zero_subclass: {n_empty_zero_fill}")
+    print(f"o0_L1_halt_tick: {l1_zero_tick}")
+    print(f"o0_L1_lock_count: {len(l1_zero_locks)}")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Under blank-block, every cube-covariant occupancy predicate has N_fill=0 from a 1-site seed on the twelve-vertex two-cube. Halt is seed-only. Vacuum is required to fill, not only to have a first wave. Displayed, not adopted.

## Runner

`scripts/blank_block_one_site_fill_count_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.
