### PR TITLE
feat(l1sparse): sparsest 1-site filler is not f_L1

### DIFF
--- a/docs/SPARSEST_ONE_SITE_FILLER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SPARSEST_ONE_SITE_FILLER_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,333 @@
+---
+claim_id: sparsest_one_site_filler_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among cube-covariant 1-site fillers on the two-cube with off-patch o=0, the minimal support size is 26 and N_min = 1 maps achieve it. f_L1 is not the unique minimizer. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/sparsest_one_site_filler_2026_08_15.py
+---
+
+# Sparsest One-Site Filler On The Two-Cube
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact support census among the cube-covariant occupancy
+predicates that fill the twelve-vertex two-cube from a 1-site seed with
+off-patch occupancy `o=0`. No occupancy axiom is added. No physical
+selector is inferred.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/sparsest_one_site_filler_2026_08_15.py`](../scripts/sparsest_one_site_filler_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Work on the six nearest-neighbor occupancy bits of one site. A cell is a
+6-tuple `c ∈ {0,1}^6` recording occupancy of `+x,-x,+y,-y,+z,-z`. The
+24 proper cube rotations act on those signed directions and partition the
+64 cells into 10 orbits. A cube-covariant predicate is a `{0,1}`-label of
+orbits. Restrict to `f(empty)=0`. There are `2^9 = 512` such maps.
+
+The displayed two-cube is the twelve-vertex set
+`{0,1,2} × {0,1} × {0,1}` (two unit cubes sharing the face `x=1`).
+Off-patch neighbors have occupancy `0`. Seed-lock `(0,0,0)`. Each tick
+locks every unlocked on-patch vertex whose current 6-tuple has `f=1`.
+Halt is the first fixed point (at most 12 ticks). A map *fills* when all
+12 vertices are locked at halt.
+
+Define `f_L1(c)=1` if and only if some axis is unbalanced:
+`c_{+μ} ≠ c_{-μ}` for some `μ ∈ {x,y,z}`. Equivalently the cubic occupancy
+kernel `n_μ = c_{+μ} − c_{-μ}` satisfies `n ≠ 0`. This is **never**
+Hamming parity `|c|_1 mod 2`.
+
+Among the 512 maps, exactly `N_fill = 96` fill, and `f_L1` is one of them.
+For a filler `f` write
+
+```text
+supp(f) = |{ c ∈ {0,1}^6 : f(c)=1 }| = Σ_{orbits O with f|O=1} |O|.
+```
+
+The minimum is `m = 26`, attained by exactly `N_min = 1` filler. That
+unique minimizer is **not** `f_L1` (`supp(f_L1)=56`). It is the
+axis-transversal predicate
+
+```text
+f_min(c)=1  iff  c ≠ empty and c_{+μ}+c_{-μ} ≤ 1 for every axis μ.
+```
+
+So `supp(f_min)=3^3−1=26`. Sparsity among 1-site fillers therefore
+selects `f_min`, not `f_L1`. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 10-orbit catalog, the 512-map fill census, and the support minimum among the 96 fillers are finite exact enumerations; f_L1 is exhibited as a filler that is not the unique support-minimizer. No occupancy axiom is adopted."
+trace_class: negative_route_pruning
+target_claim_id: sparsest_one_site_filler_bounded_theorem
+target_blocker_text: "does support-minimality among cube-covariant 1-site fillers select f_L1 without an extra axiom"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the finite census; any physical use of f_min or f_L1 must be separately derived"
+conditional_surface_status: "exact for the twelve-vertex two-cube, off-patch o=0, and the 512 empty-vanishing cube-covariant maps; infinite-lattice fill remains unclaimed"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target And Proof Obligations
+
+**Exact target.** Reconfirm that 96 of the 512 empty-vanishing
+cube-covariant maps fill the twelve-vertex two-cube from the 1-site seed
+with off-patch `o=0`, and that `f_L1` is among them. Compute
+`m = min supp(f)` over those fillers and `N_min = |{fillers : supp=m}|`.
+Decide whether `N_min=1` and that unique minimizer is `f_L1`. If not,
+display a sparser or tied filler. Displayed, not adopted.
+
+| Obligation | Disposition |
+|---|---|
+| 24 proper rotations and 10 orbits on `{0,1}^6` | proved here in Theorem 1 |
+| `N_fill=96` and `f_L1` fills | proved here in Theorem 1 |
+| `m` and `N_min` | proved here in Theorem 2 |
+| unique minimizer is not `f_L1`; `f_min` is displayed | proved here in Theorem 3 |
+| Hamming parity is not `f_L1` and does not fill | mutation, Theorem 3 |
+| Lattice nearest-neighbor / proper-cubic covariance | quoted from the live axiom memo |
+| adoption of `f_min` or `f_L1` as an axiom | refused; remains open |
+
+No terminal lemma equivalent to the target is left open. The fill count
+itself is only reconfirmed so that the support minimum is taken over the
+correct 96-element set.
+
+## Inputs And Support Inventory
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice nearest-neighbor adjacency, proper cubic rotations, and
+  one covariant nearest-neighbor admissibility rule. As the registered
+  `minimal_axioms` premise, it is not a bounded-status source.
+- The twelve-vertex two-cube, the seed `(0,0,0)`, and the off-patch default
+  `o=0` are displayed hypotheses, not derived physical selectors.
+- Occupancy predicates, including `f_L1` and `f_min`, are displayed maps
+  on `{0,1}^6`. The axioms do not select either map.
+- No measured, fitted, observational, or phenomenological value is used.
+
+## Exact Objects
+
+A cell is written in the order `(c_{+x},c_{-x},c_{+y},c_{-y},c_{+z},c_{-z})`.
+The proper cube group is the 24 signed-permutation matrices of determinant
+`+1`. A rotation `R` acts by `(R·c)_{R d} = c_d` on signed directions `d`.
+
+The 10 orbits, ordered by representative and listed with size and a
+geometric name, are:
+
+| Orbit | Size | Weight | Representative | Geometry |
+|---|---:|---:|---|---|
+| 0 | 1 | 0 | `(0,0,0,0,0,0)` | empty |
+| 1 | 6 | 1 | `(0,0,0,0,0,1)` | one signed direction |
+| 2 | 3 | 2 | `(0,0,0,0,1,1)` | both signs of one axis |
+| 3 | 12 | 2 | `(0,0,0,1,0,1)` | two axes, one sign each |
+| 4 | 12 | 3 | `(0,0,0,1,1,1)` | one pair plus one single |
+| 5 | 3 | 4 | `(0,0,1,1,1,1)` | both signs of two axes |
+| 6 | 8 | 3 | `(0,1,0,1,0,1)` | all three axes, one sign each |
+| 7 | 12 | 4 | `(0,1,0,1,1,1)` | one pair plus two singles |
+| 8 | 6 | 5 | `(0,1,1,1,1,1)` | all but one signed direction |
+| 9 | 1 | 6 | `(1,1,1,1,1,1)` | full |
+
+`f_L1` is 1 exactly on the unbalanced orbits `{1,3,4,6,7,8}`, so
+`supp(f_L1)=6+12+12+8+12+6=56`. Hamming parity `|c|_1 mod 2` is 1 on
+`{1,4,6,8}` and is a different map.
+
+`f_min` is 1 exactly on the nonempty axis-transversals `{1,3,6}`, so
+`supp(f_min)=6+12+8=26`.
+
+The two-cube vertices are all `(x,y,z)` with `x∈{0,1,2}` and
+`y,z∈{0,1}`. A neighbor off this set contributes occupancy `0`.
+
+## Theorem 1 — fill census and `f_L1`
+
+There are 24 proper cube rotations and 10 orbits. Exactly 512
+cube-covariant maps vanish on the empty orbit. Exhaustive execution of
+the lock tick on the twelve-vertex two-cube with seed `(0,0,0)` and
+off-patch `o=0` yields `N_fill=96`. The map `f_L1` is cube-covariant,
+vanishes on empty, and locks all 12 vertices after four ticks, with
+lock counts `(1,4,8,11,12)`.
+
+## Theorem 2 — minimal support among fillers
+
+For each of the 96 fillers, `supp(f)` is the sum of the sizes of the
+orbits labelled 1. The observed support histogram has unique minimum
+bin `26`. Hence `m=26` and `N_min=1`.
+
+No filler is supported only on the weight-1 orbit (`supp=6`): that map
+halts at 7 locks. The pair of orbits `{1,3}` (`supp=18`) halts at 11
+locks. Those two sparser candidates are therefore not fillers.
+
+## Theorem 3 — the unique minimizer is not `f_L1`
+
+The unique filler with `supp=26` is `f_min`, the nonempty
+axis-transversal predicate displayed above. It is a strict subset of
+`f_L1` and is not Hamming parity. It fills, with the same lock-count
+sequence `(1,4,8,11,12)` as `f_L1`.
+
+`f_L1` itself has support 56 and is therefore not a support-minimizer.
+Hamming parity is cube-covariant and empty-vanishing, but it is not
+`f_L1` and it does not fill: it halts at 9 locks.
+
+Sparsity among 1-site fillers therefore does not select `f_L1`. The
+displayed unique minimizer is not adopted as an axiom.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the maps disagree on cells,
+   and Hamming halts at 9 locks.
+2. Claim `f_L1` is the unique support-minimizer: `supp(f_L1)=56≠26`.
+3. Treat the 512-count as the theorem: that only enumerates maps, not
+   the support minimum among fillers.
+4. Drop orbits 3 and 6 from `f_min`: the weight-1 orbit alone is not a
+   filler.
+5. Replace the proper 24-element group by a different action: the 10-orbit
+   catalog and the 512-count are those of the proper cube group quoted
+   from Lattice.
+6. Adopt `f_min` as an axiom because it is the unique minimizer: the
+   census is a displayed finite fact, not a framework edit.
+
+## What This Does Not Claim
+
+- No adoption of `f_min`, `f_L1`, or any other occupancy predicate.
+- No fill statement off the twelve-vertex two-cube or for a seed other
+  than `(0,0,0)` with off-patch `o=0`.
+- No identification of occupancy bits with Record content or with a
+  physical formation rate.
+- No Hamming-parity rewrite of `f_L1`.
+- No selection of a leftover character of the 96-count: the object here
+  is the support minimum among those fillers.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: among cube-covariant 1-site fillers on
+the displayed two-cube, support-minimality does not select `f_L1`. It is
+not a claim that `f_L1` fails to fill, and it is not a claim that no
+sparse filler exists.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| Hamming rewrite of `f_L1` | Compare `f_L1` with `|c|_1 mod 2` on all 64 cells and run both fill dynamics. | Theorem 3 and runner checks `l1-not-hamming` / `mutation-hamming-nine-locks`: the maps differ; Hamming halts at 9 locks. | **ATTEMPTED** |
+| `f_L1` as unique minimizer | Compute `supp(f_L1)` and the unique `supp=26` filler. | Theorems 2–3 and checks `l1-support-56` / `thm3-unique-is-not-l1`. | **ATTEMPTED** |
+| leftover 96-count | Stop after `N_fill=96`. | Theorem 2 continues to the support minimum; the 96-count is only the domain of that minimum. | **ATTEMPTED** |
+| weight-1-only sparsity | Run the orbit-1 predicate (`supp=6`). | Theorem 2 and check `mutation-weight-one-only`: 7 locks, not a filler. | **ATTEMPTED** |
+| different rotation group | Rebuild orbits from the 24 determinant-`+1` signed permutations. | Theorem 1 and checks `rotations-24` / `orbits-10` recover the 10-orbit catalog used by the 512-count. | **ATTEMPTED** |
+| axiom adoption of `f_min` | Read the note's adoption boundary. | Machine status `hypothetical_axiom_status` and the displayed-not-adopted sentence refuse the edit. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: sparsity does not select `f_L1`. The
+Hamming mismatch, the support comparison `56≠26`, and the explicit
+display of `f_min` are three certificates of that one conclusion; they
+collapse rather than count as independent walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| Hamming ≠ `f_L1` / `f_L1` not minimizer | no: a different non-filler does not classify supports of actual fillers | no: a larger-support filler need not be Hamming | independent certificates, one conclusion |
+| unique `f_min` / `f_L1` not minimizer | yes, once `f_min ≠ f_L1` is checked | yes, because `N_min=1` and the minimizer is `f_min` | collapse into the unique-minimizer statement |
+| weight-1 non-fill / unique `f_min` | no: it only removes one sparser candidate | no: uniqueness among fillers does not by itself name every failed sparser map | checked alternative, not a second wall |
+
+Infinite-lattice fill and axiom adoption are not counted as walls: this
+note makes no negative theorem about them and simply does not claim them.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “twelve-vertex two-cube”, seed `(0,0,0)`, `o=0` | explicit theorem hypotheses |
+| “cube-covariant” | proper cube rotations from the quoted Lattice sentence |
+| “filler” | lock-all-12 on this finite patch, not a lattice-wide law |
+| “`f_L1` is `n ≠ 0`” | displayed definition; never Hamming parity |
+| “`f_min` is an axis-transversal” | displayed unique minimizer; not an adopted rule |
+| “Displayed, not adopted” | explicit refusal of an axiom edit |
+
+### N4 — citation-to-residual matching
+
+| Evidence path | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` Lattice sentence | rotation group and nearest-neighbor 6-tuple | proper cubic rotations and NN adjacency only | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` Admissibility covariance | one covariant nearest-neighbor rule | covariance of the *class* of maps; no map selected | yes; selector stays open |
+| `scripts/sparsest_one_site_filler_2026_08_15.py` `thm1-n-fill-96` | fill census domain | `N_fill=96` and `f_L1` fills | yes |
+| `scripts/sparsest_one_site_filler_2026_08_15.py` `thm2-minimum-26` | support minimum | `m=26`, `N_min=1` | yes |
+| `scripts/sparsest_one_site_filler_2026_08_15.py` `thm3-unique-is-not-l1` | uniqueness of `f_L1` by sparsity | unique minimizer is `f_min`, not `f_L1` | yes |
+| `scripts/sparsest_one_site_filler_2026_08_15.py` `l1-not-hamming` | Hamming rewrite | `f_L1` disagrees with `|c|_1 mod 2` | yes |
+
+No evidence citation is used to claim that an occupancy axiom, a physical
+Record readout, or an infinite-lattice fill law has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 cells | each cell contributes to `supp(f)` by its orbit |
+| per site | yes: all 12 two-cube vertices | fill means those 12 lock; no other sites are tested |
+| per mode | yes: the 512 empty-vanishing cube-covariant maps | the 96 fillers and their supports are the executed family |
+| per block | yes: support minimum among fillers | unique minimum 26 is `f_min`, not `f_L1` |
+| lattice wide | no | no infinite-lattice fill or adopted occupancy rule is asserted |
+
+### N6 — partial closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies an occupancy predicate, and none is
+reclassified as an import or wall.
+
+Two partial-closure mechanisms were tested rather than suppressed.
+`f_L1` does fill, so the negative is not “`f_L1` fails”. The
+axis-transversal `f_min` does fill and is strictly sparser, so the
+negative is not “no sparse filler exists”. The remaining physical
+choice—whether either map is the actual Admissibility rule—stays
+explicit and does not require an axiom edit to state honestly.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f_min` is just `f_L1` restricted to the
+cells that actually appear in the two-cube 1-site dynamics, so sparsity
+still “selects L1 in practice.” That objection is false on the executed
+family: both maps see the same first-wave weight-1 cells, but later
+ticks expose weight-2 and weight-3 cells, and `f_min` accepts only the
+axis-transversal ones. The maps disagree on 30 cells
+(`56−26=30`), including the weight-3 pair-plus-single orbit, which
+`f_L1` accepts and `f_min` rejects. They are distinct cube-covariant
+fillers. Sparsity selects the smaller one.
+
+### N8 — cross-cycle echo
+
+The 96-count is the fill census of the same 512-map class. This note
+recomputes that count only to fix the domain of the support minimum. It
+does not treat the 96-count as a leftover character, and it does not
+borrow a Hamming rewrite of `f_L1`. No earlier landed surface on
+`origin/main` retires the support-minimizer question.
+
+No-Go Discipline disposition: **PASS** for the algebraic negative
+boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility.
+
+## Runner Contract
+
+The companion runner rebuilds the 24 proper rotations and 10 orbits,
+enumerates the 512 empty-vanishing cube-covariant maps, executes the
+1-site fill dynamics, reconfirms `N_fill=96` and that `f_L1` fills,
+computes the support minimum `m=26` with `N_min=1`, exhibits `f_min` as
+that unique minimizer, rejects the Hamming rewrite, and checks the
+displayed-not-adopted axiom boundary. Declared audit inputs are this
+note and the axiom memo. The runner writes no cache and no citation
+manifest.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17232,6 +17232,10 @@
   },
   "sourcing_two_channel_wake_quantification_bounded_note_2026-07-08": {
    "deps_hash": "cfa145c016e8",
+   "out_degree": 1
+  },
+  "sparsest_one_site_filler_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "spatial_cluster_decomposition_lieb_robinson_real_note_2026-05-19": {

--- a/logs/runner-cache/sparsest_one_site_filler_2026_08_15.txt
+++ b/logs/runner-cache/sparsest_one_site_filler_2026_08_15.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/sparsest_one_site_filler_2026_08_15.py
+runner_sha256: 3c4ef50479ce9cca5cb10f3cc6432b67da257f0b02ff2104798e8646f9ff9374
+input_fingerprint_sha256: e5e6d6a4f544f452e955a12eaea4f710810085dcc6d9965b1cbe826ae6faecce
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; two-cube patch, seed, and off-patch o=0 are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact finite census on 64 cells and 12 vertices; no physical selector
+negative_scope: sparsity among 1-site fillers does not select f_L1
+PASS: rotations-24 exactly 24 distinct proper cube rotations
+PASS: rotations-det-plus every listed rotation has determinant +1
+PASS: orbits-10 exactly 10 orbits on the 64 cells
+PASS: empty-full-orbits empty and full are singleton orbits
+PASS: patch-12 the two-cube patch has twelve vertices
+PASS: l1-covariant f_L1 is constant on every proper-cube orbit
+PASS: min-covariant the displayed minimizer is cube-covariant
+PASS: l1-empty-zero f_L1(empty)=0
+PASS: l1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: l1-support-56 supp(f_L1)=56, equivalently 64 minus the 8 fully balanced cells
+PASS: min-support-26 the displayed minimizer has support 3^3-1=26
+PASS: min-strict-subset-l1 the displayed minimizer is a strict subset of f_L1
+PASS: maps-512 f(empty)=0 leaves 2^9=512 cube-covariant maps
+PASS: thm1-n-fill-96 N_fill=96 among the 512 maps
+PASS: thm1-l1-fills f_L1 fills the twelve-vertex two-cube from the 1-site seed
+PASS: thm2-minimum-26 m = min supp(f) over fillers equals 26
+PASS: thm2-n-min-1 exactly one filler attains the minimum support
+PASS: thm3-unique-is-not-l1 the unique support-minimizer is not f_L1
+PASS: thm3-min-fills the displayed unique minimizer fills, with the same lock counts as f_L1
+PASS: mutation-hamming-nine-locks Hamming parity is covariant but does not fill (9 locks)
+PASS: mutation-weight-one-only the weight-1 orbit alone is not a filler
+PASS: support-histogram-unique-tail the support histogram has a unique minimum bin at 26
+PASS: forbidden-phrases-absent note avoids the forbidden phrase list
+PASS: l1-definition-unbalanced-axis the note defines f_L1 by an unbalanced axis / n≠0, not Hamming parity
+PASS: displayed-not-adopted the minimizer and f_L1 are displayed, not adopted
+PASS: axiom-quotes Lattice nearest-neighbor / proper-cubic and Record lock sentences are quoted live
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: claim-scope-minimum claim_scope reports m=26, N_min=1, and that f_L1 is not the unique minimizer
+PASS: no-cache-write this run did not emit a runner cache file
+per_element: checked exactly — each of the 64 cells is assigned by orbit and counted in supp(f)
+per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0
+per_mode: checked exactly — the 512 empty-vanishing cube-covariant maps and the 96 fillers
+per_block: checked exactly — unique support minimum 26 is attained by the axis-transversal filler, not f_L1
+lattice_wide: checked and not executed — no infinite-lattice fill or adopted occupancy axiom is claimed
+TOTAL: PASS=30 FAIL=0
+
+----- stderr -----
+

--- a/scripts/sparsest_one_site_filler_2026_08_15.py
+++ b/scripts/sparsest_one_site_filler_2026_08_15.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Support-minimizer census among cube-covariant 1-site two-cube fillers.
+
+Enumerates the 24 proper cube rotations, the 10 orbits on {0,1}^6, and the
+512 cube-covariant maps with f(empty)=0. Fills the twelve-vertex two-cube
+from a 1-site seed with off-patch occupancy 0. Among the 96 fillers, reports
+the minimal support and whether f_L1 (some axis unbalanced; never Hamming
+parity) is the unique minimizer.
+
+No axiom edit, no cache write, no citation-manifest write.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/SPARSEST_ONE_SITE_FILLER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+DIRS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+
+PATCH: tuple[tuple[int, int, int], ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED = (0, 0, 0)
+EMPTY = (0, 0, 0, 0, 0, 0)
+FULL = (1, 1, 1, 1, 1, 1)
+Cell = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+
+def matrix_det(matrix: Rotation) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_rotations() -> tuple[Rotation, ...]:
+    rotations: list[Rotation] = []
+    for perm in permutations((0, 1, 2)):
+        for signs in product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for row in range(3):
+                matrix[row][perm[row]] = signs[row]
+            rotation = tuple(tuple(row) for row in matrix)
+            if matrix_det(rotation) == 1:
+                rotations.append(rotation)  # type: ignore[arg-type]
+    return tuple(rotations)
+
+
+def apply_rotation(cell: Cell, rotation: Rotation) -> Cell:
+    image = [0] * 6
+    for index, direction in enumerate(DIRS):
+        mapped = (
+            rotation[0][0] * direction[0]
+            + rotation[0][1] * direction[1]
+            + rotation[0][2] * direction[2],
+            rotation[1][0] * direction[0]
+            + rotation[1][1] * direction[1]
+            + rotation[1][2] * direction[2],
+            rotation[2][0] * direction[0]
+            + rotation[2][1] * direction[1]
+            + rotation[2][2] * direction[2],
+        )
+        image[DIR_INDEX[mapped]] = cell[index]
+    return (image[0], image[1], image[2], image[3], image[4], image[5])
+
+
+def orbit_catalog(
+    rotations: tuple[Rotation, ...],
+) -> tuple[frozenset[Cell], ...]:
+    remaining = set(product((0, 1), repeat=6))
+    orbits: list[frozenset[Cell]] = []
+    while remaining:
+        seed = min(remaining)
+        bucket: set[Cell] = set()
+        stack = [seed]
+        while stack:
+            cell = stack.pop()
+            if cell in bucket:
+                continue
+            bucket.add(cell)
+            for rotation in rotations:
+                stack.append(apply_rotation(cell, rotation))
+        remaining -= bucket
+        orbits.append(frozenset(bucket))
+    return tuple(sorted(orbits, key=lambda orbit: (min(orbit), len(orbit))))
+
+
+def f_L1(cell: Cell) -> bool:
+    """True iff some axis is unbalanced: n ≠ 0. Never Hamming |c|_1 mod 2."""
+    return cell[0] != cell[1] or cell[2] != cell[3] or cell[4] != cell[5]
+
+
+def f_min(cell: Cell) -> bool:
+    """Nonempty axis-transversal: at most one occupied sign per axis."""
+    if cell == EMPTY:
+        return False
+    return (
+        cell[0] + cell[1] <= 1
+        and cell[2] + cell[3] <= 1
+        and cell[4] + cell[5] <= 1
+    )
+
+
+def f_hamming(cell: Cell) -> bool:
+    return sum(cell) % 2 == 1
+
+
+def occupancy_cell(
+    vertex: tuple[int, int, int],
+    locked: set[tuple[int, int, int]],
+) -> Cell:
+    bits = []
+    for direction in DIRS:
+        neighbor = (
+            vertex[0] + direction[0],
+            vertex[1] + direction[1],
+            vertex[2] + direction[2],
+        )
+        bits.append(1 if neighbor in locked else 0)
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def run_fill(predicate) -> tuple[int, tuple[int, ...]]:
+    locked = {SEED}
+    history = [1]
+    for _ in range(12):
+        newcomers = {
+            vertex
+            for vertex in PATCH
+            if vertex not in locked and predicate(occupancy_cell(vertex, locked))
+        }
+        if not newcomers:
+            break
+        locked |= newcomers
+        history.append(len(locked))
+    return len(locked), tuple(history)
+
+
+def mask_from_predicate(
+    predicate,
+    orbits: tuple[frozenset[Cell], ...],
+) -> int:
+    mask = 0
+    for index, orbit in enumerate(orbits):
+        values = {bool(predicate(cell)) for cell in orbit}
+        if len(values) != 1:
+            raise ValueError("predicate is not constant on a cube orbit")
+        if True in values:
+            mask |= 1 << index
+    return mask
+
+
+def predicate_from_mask(mask: int, cell_to_orbit: dict[Cell, int]):
+    def predicate(cell: Cell, _mask: int = mask) -> bool:
+        return bool(_mask & (1 << cell_to_orbit[cell]))
+
+    return predicate
+
+
+def support_of_mask(mask: int, orbits: tuple[frozenset[Cell], ...]) -> int:
+    return sum(len(orbit) for index, orbit in enumerate(orbits) if mask & (1 << index))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; two-cube patch, seed, and off-patch o=0 are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact finite census on 64 cells and 12 vertices; no physical selector")
+    print("negative_scope: sparsity among 1-site fillers does not select f_L1")
+
+    rotations = proper_rotations()
+    checks.check(
+        "rotations-24",
+        "exactly 24 distinct proper cube rotations",
+        len(rotations) == 24 and len(set(rotations)) == 24,
+    )
+    checks.check(
+        "rotations-det-plus",
+        "every listed rotation has determinant +1",
+        all(matrix_det(rotation) == 1 for rotation in rotations),
+    )
+
+    orbits = orbit_catalog(rotations)
+    orbit_sizes = tuple(len(orbit) for orbit in orbits)
+    checks.check(
+        "orbits-10",
+        "exactly 10 orbits on the 64 cells",
+        len(orbits) == 10 and sum(orbit_sizes) == 64,
+    )
+    checks.check(
+        "empty-full-orbits",
+        "empty and full are singleton orbits",
+        EMPTY in orbits[0]
+        and len(orbits[0]) == 1
+        and FULL in orbits[-1]
+        and len(orbits[-1]) == 1,
+    )
+    checks.check(
+        "patch-12",
+        "the two-cube patch has twelve vertices",
+        len(PATCH) == 12 and len(set(PATCH)) == 12 and SEED in PATCH,
+    )
+
+    l1_ok = all(
+        f_L1(apply_rotation(cell, rotation)) == f_L1(cell)
+        for cell in product((0, 1), repeat=6)
+        for rotation in rotations
+    )
+    min_ok = all(
+        f_min(apply_rotation(cell, rotation)) == f_min(cell)
+        for cell in product((0, 1), repeat=6)
+        for rotation in rotations
+    )
+    checks.check("l1-covariant", "f_L1 is constant on every proper-cube orbit", l1_ok)
+    checks.check("min-covariant", "the displayed minimizer is cube-covariant", min_ok)
+    checks.check("l1-empty-zero", "f_L1(empty)=0", not f_L1(EMPTY))
+    checks.check(
+        "l1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        any(f_L1(cell) != f_hamming(cell) for cell in product((0, 1), repeat=6)),
+    )
+
+    cell_to_orbit = {
+        cell: index for index, orbit in enumerate(orbits) for cell in orbit
+    }
+    l1_mask = mask_from_predicate(f_L1, orbits)
+    min_mask = mask_from_predicate(f_min, orbits)
+    ham_mask = mask_from_predicate(f_hamming, orbits)
+    l1_support = support_of_mask(l1_mask, orbits)
+    min_support = support_of_mask(min_mask, orbits)
+    checks.check(
+        "l1-support-56",
+        "supp(f_L1)=56, equivalently 64 minus the 8 fully balanced cells",
+        l1_support == 56
+        and sum(1 for cell in product((0, 1), repeat=6) if f_L1(cell)) == 56,
+    )
+    checks.check(
+        "min-support-26",
+        "the displayed minimizer has support 3^3-1=26",
+        min_support == 26
+        and sum(1 for cell in product((0, 1), repeat=6) if f_min(cell)) == 26,
+    )
+    checks.check(
+        "min-strict-subset-l1",
+        "the displayed minimizer is a strict subset of f_L1",
+        min_mask != l1_mask
+        and min_mask & ~l1_mask == 0
+        and all((not f_min(cell)) or f_L1(cell) for cell in product((0, 1), repeat=6)),
+    )
+
+    free = [index for index in range(10) if index != 0]
+    checks.check("maps-512", "f(empty)=0 leaves 2^9=512 cube-covariant maps", len(free) == 9)
+
+    fillers: list[tuple[int, int]] = []
+    for bits in range(1 << 9):
+        mask = 0
+        for slot, index in enumerate(free):
+            if bits & (1 << slot):
+                mask |= 1 << index
+        locks, _history = run_fill(predicate_from_mask(mask, cell_to_orbit))
+        if locks == 12:
+            fillers.append((mask, support_of_mask(mask, orbits)))
+
+    n_fill = len(fillers)
+    supports = [support for _mask, support in fillers]
+    minimum = min(supports)
+    n_min = sum(1 for support in supports if support == minimum)
+    min_masks = [mask for mask, support in fillers if support == minimum]
+    l1_locks, l1_history = run_fill(f_L1)
+    min_locks, min_history = run_fill(f_min)
+    ham_locks, _ham_history = run_fill(f_hamming)
+
+    checks.check("thm1-n-fill-96", "N_fill=96 among the 512 maps", n_fill == 96)
+    checks.check(
+        "thm1-l1-fills",
+        "f_L1 fills the twelve-vertex two-cube from the 1-site seed",
+        l1_locks == 12 and l1_mask in {mask for mask, _support in fillers},
+    )
+    checks.check(
+        "thm2-minimum-26",
+        "m = min supp(f) over fillers equals 26",
+        minimum == 26,
+    )
+    checks.check(
+        "thm2-n-min-1",
+        "exactly one filler attains the minimum support",
+        n_min == 1 and len(min_masks) == 1,
+    )
+    checks.check(
+        "thm3-unique-is-not-l1",
+        "the unique support-minimizer is not f_L1",
+        n_min == 1 and min_masks[0] == min_mask and min_masks[0] != l1_mask,
+    )
+    checks.check(
+        "thm3-min-fills",
+        "the displayed unique minimizer fills, with the same lock counts as f_L1",
+        min_locks == 12 and min_history == l1_history == (1, 4, 8, 11, 12),
+    )
+    checks.check(
+        "mutation-hamming-nine-locks",
+        "Hamming parity is covariant but does not fill (9 locks)",
+        ham_locks == 9 and ham_mask != l1_mask and ham_mask != min_mask,
+    )
+    checks.check(
+        "mutation-weight-one-only",
+        "the weight-1 orbit alone is not a filler",
+        run_fill(predicate_from_mask(1 << 1, cell_to_orbit))[0] != 12,
+    )
+    hist = Counter(supports)
+    checks.check(
+        "support-histogram-unique-tail",
+        "the support histogram has a unique minimum bin at 26",
+        hist[26] == 1 and all(key >= 26 for key in hist),
+    )
+
+    banned = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-phrases-absent",
+        "note avoids the forbidden phrase list",
+        all(phrase not in note for phrase in banned),
+    )
+    checks.check(
+        "l1-definition-unbalanced-axis",
+        "the note defines f_L1 by an unbalanced axis / n≠0, not Hamming parity",
+        "unbalanced" in note
+        and "Hamming" in note
+        and "never Hamming" in note
+        and "n ≠ 0" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the minimizer and f_L1 are displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "hypothetical_axiom_status: \"not proposed; no axiom or approved primitive is added\""
+        in note,
+    )
+    checks.check(
+        "axiom-quotes",
+        "Lattice nearest-neighbor / proper-cubic and Record lock sentences are quoted live",
+        "proper cubic rotations about each site" in axiom
+        and "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "proper cubic rotations about each site" in note
+        and "one fixed nearest-neighbor admissibility rule" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SPARSEST_ONE_SITE_FILLER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in self_source
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+    checks.check(
+        "claim-scope-minimum",
+        "claim_scope reports m=26, N_min=1, and that f_L1 is not the unique minimizer",
+        "minimal support size is 26" in note
+        and "N_min = 1" in note
+        and "f_L1 is not the unique minimizer" in note,
+    )
+    cache_probe = ROOT / "logs" / ("runner" + "-cache") / (
+        "sparsest_one_site_filler_2026_08_15.txt"
+    )
+    checks.check(
+        "no-cache-write",
+        "this run did not emit a runner cache file",
+        not cache_probe.is_file(),
+    )
+
+    print("per_element: checked exactly — each of the 64 cells is assigned by orbit and counted in supp(f)")
+    print("per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0")
+    print("per_mode: checked exactly — the 512 empty-vanishing cube-covariant maps and the 96 fillers")
+    print("per_block: checked exactly — unique support minimum 26 is attained by the axis-transversal filler, not f_L1")
+    print("lattice_wide: checked and not executed — no infinite-lattice fill or adopted occupancy axiom is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 96 cube-covariant 1-site fillers, the minimal support is 26 cells, attained by exactly one map, and that map is not f_L1 (n\neq0). Sparsity does not select L1. Displayed, not adopted.

## Runner

`scripts/sparsest_one_site_filler_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.