### PR TITLE
feat(fill2site): 64 maps fill from a 2-site face-diagonal seed

### DIFF
--- a/docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,380 @@
+---
+claim_id: two_site_face_diagonal_fill_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among cube-covariant f with f(empty)=0, N_fill_2 = 64 fill the twelve-vertex two-cube from the face-diagonal 2-site seed with off-patch o=0. f_L1 is not unique in that set. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_site_face_diagonal_fill_census_2026_08_15.py
+---
+
+# Two-Site Face-Diagonal Fill Census Of The 512 Cube-Covariant Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock census of the 512 cube-covariant
+predicates that vanish on empty, on the twelve-vertex two-cube from the
+face-diagonal 2-site seed `{(0,0,0),(1,1,0)}` with off-patch occupancy `0`.
+The unbalanced-axis map `f_L1` is displayed as one filler. The two-axis
+map `f_two` is displayed as a non-filler. Neither is adopted as the
+physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_site_face_diagonal_fill_census_2026_08_15.py`](../scripts/two_site_face_diagonal_fill_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. Restricting to `f(empty)=0` leaves
+nine free bits, so there are exactly 512 such maps.
+
+That 512-count is leftover-character inventory of the covariance class.
+The 1-site fill census of the same 512 maps is a different leftover
+inventory: it used seed `(0,0,0)` alone. A separate halt run of the single
+map `f_two` from this same 2-site seed is also a different residual. This
+note asks how many of the 512 maps fill from the face-diagonal pair.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, seed `{(0,0,0),(1,1,0)}` starts
+locked. Off-patch neighbors have occupancy `0`. Each tick, every unlocked
+on-patch vertex evaluates `f` on its six-neighbor occupancy tuple and
+locks if `f=1`. The process is synchronous and stops at a fixed point in
+at most 12 ticks. Fill means `|locks_halt|=12`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+`f_two(c)=1` if and only if at least two axes are unbalanced. This is
+**not** `f_L1`.
+
+**Theorem 1.** `f_L1` is one of the 512 maps and fills from this seed:
+lock cardinalities `(2,7,11,12)` and halt tick `3`.
+
+**Theorem 2.** `f_two` is a different one of the 512 maps and does not
+fill: first wave `{(1,0,0),(0,1,0)}`, lock cardinalities `(2,4)`, halt
+tick `1`, so `|locks_halt|=4`.
+
+**Theorem 3.** Exactly `N_fill_2 = 64` of the 512 maps fill. So
+`N_fill_2 > 1`: `f_L1` is not unique. A displayed second filler `f_any`
+is `1` on every nonempty 6-tuple. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 512-map class, membership of f_L1 and f_two, the f_L1 fill, the f_two four-lock halt, and the exact fill count N_fill_2=64 are enumerated. Uniqueness of f_L1 as a 2-site filler is false on this patch. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: two_site_face_diagonal_fill_census
+target_blocker_text: "how many cube-covariant f with f(empty)=0 fill the two-cube from the face-diagonal 2-site seed, and whether f_L1 is the unique filler"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the 2-site fill census; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for the 512 maps on this twelve-vertex patch with off-patch o=0 and the displayed 2-site seed; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the face-diagonal 2-site seed `{(0,0,0),(1,1,0)}`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of the 1-site fill census. Not a second f_two face-diagonal halt run.
+
+## Exact Target And Objects
+
+**Target.** Count the cube-covariant maps with `f(empty)=0` that fill the
+two-cube from the face-diagonal 2-site seed, and decide uniqueness of
+`f_L1` inside that set.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits.
+
+| `(u,b,e)` | orbit size | role in this census |
+|---|---:|---|
+| `(0,0,3)` empty | 1 | forced `f=0` by the class |
+| `(0,3,0)` full | 1 | free bit |
+| `(0,1,2)` opposite pair | 3 | free bit |
+| `(0,2,1)` | 3 | free bit |
+| `(1,0,2)` one unbalanced axis | 6 | forced `f=1` on every filler |
+| `(1,2,0)` | 6 | free bit |
+| `(2,0,1)` two unbalanced axes | 12 | forced `f=1` on every filler |
+| `(2,1,0)` | 12 | free bit |
+| `(1,1,1)` mixed triple | 12 | free bit |
+| `(3,0,0)` three unbalanced axes | 8 | forced `f=1` on every filler |
+
+Define
+
+```text
+f_L1(c)   = 1  iff  u(c) ≥ 1,
+f_two(c)  = 1  iff  u(c) ≥ 2,
+f_any(c)  = 1  iff  c ≠ empty,
+f_H(c)    = |c|_1 mod 2.
+```
+
+All four are cube-covariant. `f_L1`, `f_two`, and `f_any` vanish on empty
+and are therefore among the 512 maps. `f_H` is used only as a displayed
+mutation: it is not `f_L1`. `f_any` is a displayed second filler: it is
+not adopted. `f_two` is a displayed non-filler: it is not adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+`N_fill_2` is the number of the 512 maps whose halt set has cardinality 12.
+
+The three orbits that actually fire along the common filling trajectory
+are `(1,0,2)`, `(2,0,1)`, and `(3,0,0)`. Every filler is `1` on those
+three orbits and `0` on empty; the other six orbit bits remain free, so
+the filler class has size `2^6 = 64`. That characterization is a
+post-census identity, not an input.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The vanish-on-empty cut leaves 512 cube-covariant
+maps. The unbalanced-axis map `f_L1` is one of them. It is not Hamming
+parity. On the twelve-vertex two-cube from seed `{(0,0,0),(1,1,0)}` with
+off-patch occupancy `0`, `f_L1` fills: lock cardinalities `(2,7,11,12)`
+and halt tick `3`.
+
+**Theorem 2.** The two-axis map `f_two` is a different one of the 512
+maps. It does not fill. Its first wave is exactly `{(1,0,0),(0,1,0)}`.
+Its lock cardinalities are `(2,4)` and its halt tick is `1`, so
+`|locks_halt|=4`.
+
+**Theorem 3.** Exhaustive enumeration of the 512 maps gives
+
+```text
+N_fill_2 = 64.
+```
+
+So `N_fill_2 > 1`. The map `f_L1` fills, but it is not unique. The
+displayed second filler `f_any` is distinct from `f_L1` (they disagree on
+every balanced nonempty orbit) and also fills, with the same lock
+cardinalities `(2,7,11,12)` and halt tick `3`. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| 512 maps | nine free orbit bits after `f(empty)=0` |
+| `f_L1` is in the 512 | `u` is rotation-invariant and `u(empty)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| `f_L1` fills | halt set has cardinality 12 at tick 3 |
+| `f_two` is `u≥2` and does not fill | halt set has cardinality 4 at tick 1 |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| seed is the displayed face-diagonal pair | `{(0,0,0),(1,1,0)}` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `N_fill_2` | exhaustive 512-run census to a fixed point |
+| uniqueness of `f_L1` | false; `f_any` is an explicit second filler |
+| physical Admissibility selection | open and not claimed |
+
+Every leaf needed for the stated census is discharged. No `Z^3`-wide
+formation law is claimed.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit. Hamming is not the unbalanced-axis rule.
+2. Replace `f_L1` by `f_two`: first wave still locks `(1,0,0)` and
+   `(0,1,0)`, but sites with a single unbalanced axis never lock, and
+   the process halts at four sites.
+3. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+4. Seed only `(0,0,0)`: the 1-site fill count is a different residual.
+5. Assert `N_fill_2=1`: the explicit second filler `f_any` refutes
+   uniqueness.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character count of the 1-site fill census in place of this
+  2-site dynamics census.
+- No second halt-only run of `f_two` in place of the 512-map census.
+- No blank-block, 1-site, or 3-site variant as the stated residual.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness: `f_L1` is not the unique 2-site
+filler of this patch. The positive count `N_fill_2 = 64` is an exact
+enumeration, not a wall. The four-lock halt of `f_two` is a displayed
+member contrast, not a compiler impossibility.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| vanish-on-empty class | Force `f(empty)=0` on cube-covariant maps. | Theorem 1 and check `thm1-five-twelve-maps` give 512 maps. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `f_L1` fill | Run `f_L1` from the face-diagonal 2-site seed. | Theorem 1 and check `thm1-f-L1-fills` give twelve locks at tick 3. | **ATTEMPTED** |
+| `f_two` halt | Run `f_two` (`u≥2`) from the same seed. | Theorem 2 and check `thm2-f-two-does-not-fill` give four locks. | **ATTEMPTED** |
+| 2-site fill census | Run every vanish-on-empty cube-covariant map to a fixed point. | Theorem 3 and checks `thm3-n-fill-2` / `thm3-not-unique`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness fails. The explicit second
+filler and the cardinality `N_fill_2 = 64` are two certificates of the
+same non-uniqueness, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_fill_2=64` / displayed `f_any` | yes: a count larger than one is non-uniqueness | yes: one extra filler is non-uniqueness | collapse into the uniqueness failure |
+| `f_L1` fills / `f_two` does not | no: one map filling does not classify `f_two` | no: `f_two` failing does not prove `f_L1` fills | independent positive/negative members, not two walls |
+| 1-site fill count / `N_fill_2` | no: a different seed is a different census | no: a 2-site count does not replace the 1-site count | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| vanish-on-empty | explicit class filter; maps with `f(empty)=1` are excluded |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| `f_two` | displayed non-filler, not a selected law |
+| `f_any` | displayed witness against uniqueness, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/two_site_face_diagonal_fill_census_2026_08_15.py:64` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/two_site_face_diagonal_fill_census_2026_08_15.py:103` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/two_site_face_diagonal_fill_census_2026_08_15.py:108` | `f_two` definition | two-unbalanced-axis predicate, not `f_L1` | yes |
+| `scripts/two_site_face_diagonal_fill_census_2026_08_15.py:212` | class census | exact `N_fill_2` on the 512 maps | yes |
+| `scripts/two_site_face_diagonal_fill_census_2026_08_15.py:117` | uniqueness | displayed second filler `f_any` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every vanish-on-empty cube-covariant map | the census is this class on this seed; other seeds are unclaimed |
+| per block | yes: the pair `(512, N_fill_2)` | uniqueness fails because `N_fill_2=64` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does fill this patch from the face-diagonal 2-site seed. That positive
+member does not make `f_L1` unique and does not select it as the physical
+rule. The remaining physical choice — which, if any, of the 64 fillers is
+the Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that all 64 fillers share the same lock history
+`(2,7,11,12)`, so uniqueness might be restored by identifying maps that
+agree on every 6-tuple that occurs along that trajectory. That objection
+is correctly about a smaller, trajectory-level quotient. It does not
+overturn the stated theorem: among all 512 cube-covariant maps with
+`f(empty)=0`, sixty-four fill. The displayed second filler `f_any`
+already differs from `f_L1` on every balanced nonempty orbit. Those
+orbits are idle on this seed, but they remain distinct class-level maps.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits, 512
+maps, and 2-site dynamics are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+| `docs/INFORMATIVE_FRACTION_COVARIANT_RULE_QUANTIZATION_OCCUPANCY_RESIDUAL_THEOREM_NOTE_2026-07-02.md` | the same 10 orbits on `{0,1}^6` | orbit sizes are recomputed; the informative-fraction residual is unused |
+
+No earlier mechanism retires the 2-site fill census or restores uniqueness
+of `f_L1` inside the 512-map class.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact pair `(512, N_fill_2)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+the 512 vanish-on-empty cube-covariant maps, evaluates all 512 maps on the
+two-cube from the face-diagonal 2-site seed, reports `N_fill_2 = 64`,
+checks that `f_L1` fills and is not Hamming parity, checks that `f_two`
+halts at four locks, and exhibits the displayed second filler `f_any`.
+Declared audit inputs are this note and the axiom memo. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18557,6 +18557,10 @@
   "two_sign_comparison_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "two_site_face_diagonal_fill_census_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_site_factor_swap_uniquely_names_rank3_corner_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_site_face_diagonal_fill_census_2026_08_15.txt
+++ b/logs/runner-cache/two_site_face_diagonal_fill_census_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/two_site_face_diagonal_fill_census_2026_08_15.py
+runner_sha256: f99a55eb275ffe6f117f34b75ee84ed10a16063a3e1ff91ea09c842c6261c4c3
+input_fingerprint_sha256: 8cf8995f6eb4b7793c8b6823115cf8fd6d343dc7c35ab95fda0bc785105ea629
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+n_maps=512
+N_fill_2=64
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_locks=12 halt=3 history=(2, 7, 11, 12)
+f_two_bits=(0, 0, 0, 0, 0, 0, 0, 1, 1, 1)
+f_two_locks=4 halt=1 history=(2, 4) wave=[(0, 1, 0), (1, 0, 0)]
+f_any_locks=12 halt=3 history=(2, 7, 11, 12)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-five-twelve-maps cube-covariant maps with f(empty)=0 number 512
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f-L1-fills f_L1 fills all twelve vertices from the face-diagonal 2-site seed
+PASS: thm1-two-cube-and-seed the two-cube has twelve vertices and contains both seed sites
+PASS: thm2-f-two-is-u-at-least-two f_two is 1 iff at least two axes are unbalanced
+PASS: thm2-f-two-does-not-fill f_two halts with four locks and does not fill
+PASS: thm3-n-fill-2 N_fill_2 = 64 exactly
+PASS: thm3-not-unique N_fill_2 > 1; f_L1 is not the unique 2-site filler
+PASS: thm3-displayed-other-filler displayed f_any fills, vanishes on empty, and is distinct from f_L1
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness failure, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-census the note reports N_fill_2 = 64 and a second displayed filler
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-one-site-or-ftwo-run the residual is the 2-site fill count, not the 1-site census or an f_two halt run
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every cube-covariant f with f(empty)=0 is run to a fixed point
+per_block: checked exactly — N_fill_2 is the 2-site fill cardinality on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_site_face_diagonal_fill_census_2026_08_15.py
+++ b/scripts/two_site_face_diagonal_fill_census_2026_08_15.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Exact 2-site face-diagonal fill census of the 512 cube-covariant maps.
+
+The class is cube-covariant f with f(empty)=0. Dynamics are occupancy-to-lock
+on the twelve-vertex two-cube from seed {(0,0,0),(1,1,0)} with off-patch
+occupancy 0. f_L1 is the unbalanced-axis predicate (some n_mu != 0), never
+Hamming |c|_1 mod 2. f_two is u>=2, never f_L1.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: frozenset[Site] = frozenset(((0, 0, 0), (1, 1, 0)))
+FORCED_FILL_TYPES: frozenset[OrbitType] = frozenset(
+    ((1, 0, 2), (2, 0, 1), (3, 0, 0))
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_two(config: Config) -> int:
+    """1 iff at least two axes are unbalanced.  Not f_L1."""
+    return int(axis_type(config)[0] >= 2)
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_any(config: Config) -> int:
+    """Displayed extra filler: 1 iff the 6-tuple is nonempty.  Not adopted."""
+    return int(config != EMPTY)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, bool, tuple[int, ...], frozenset[Site]]:
+    locked = set(SEED)
+    history = [len(locked)]
+    first_wave = evolve(locked, predicate)
+    first_wave_empty = first_wave == locked
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, first_wave_empty, tuple(history), frozenset(first_wave - SEED)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def census_fillers(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+) -> tuple[int, list[tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    free_types = [orbit_type for orbit_type in orbit_types if orbit_type != empty_type]
+    fillers: list[tuple[int, ...]] = []
+    for mask in range(1 << len(free_types)):
+        assignment = {empty_type: 0}
+        for rank, orbit_type in enumerate(free_types):
+            assignment[orbit_type] = (mask >> rank) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        n_locks, _halt, _first_empty, _history, _wave = run_predicate(
+            predicate_from_bits(bits, orbit_types, type_of)
+        )
+        if n_locks == 12:
+            fillers.append(bits)
+    return len(fillers), fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    n_maps = 1 << (len(orbit_types) - 1)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    two_bits = bits_from_predicate(f_two, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    any_bits = bits_from_predicate(f_any, orbit_types, orbits)
+    l1_locks, l1_halt, l1_first_empty, l1_history, l1_wave = run_predicate(f_L1)
+    two_locks, two_halt, two_first_empty, two_history, two_wave = run_predicate(f_two)
+    any_locks, any_halt, any_first_empty, any_history, _any_wave = run_predicate(f_any)
+    n_fill, fillers = census_fillers(orbit_types, orbits, empty_type)
+    free_unforced = [
+        orbit_type
+        for orbit_type in orbit_types
+        if orbit_type != empty_type and orbit_type not in FORCED_FILL_TYPES
+    ]
+    forced_class: list[tuple[int, ...]] = []
+    for mask in range(1 << len(free_unforced)):
+        assignment = {empty_type: 0}
+        for orbit_type in FORCED_FILL_TYPES:
+            assignment[orbit_type] = 1
+        for rank, orbit_type in enumerate(free_unforced):
+            assignment[orbit_type] = (mask >> rank) & 1
+        forced_class.append(tuple(assignment[orbit_type] for orbit_type in orbit_types))
+    forced_ok = n_fill == 64 and set(fillers) == set(forced_class)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"n_maps={n_maps}")
+    print(f"N_fill_2={n_fill}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_locks={l1_locks} halt={l1_halt} history={l1_history}")
+    print(f"f_two_bits={two_bits}")
+    print(f"f_two_locks={two_locks} halt={two_halt} history={two_history} wave={sorted(two_wave)}")
+    print(f"f_any_locks={any_locks} halt={any_halt} history={any_history}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/TWO_SITE_FACE_DIAGONAL_FILL_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-five-twelve-maps",
+        "cube-covariant maps with f(empty)=0 number 512",
+        n_maps == 512 and empty_type == (0, 0, 3) and full_type == (0, 3, 0),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_two", 1)[0],
+    )
+    checks.check(
+        "thm1-f-L1-fills",
+        "f_L1 fills all twelve vertices from the face-diagonal 2-site seed",
+        l1_locks == 12
+        and l1_halt == 3
+        and l1_history == (2, 7, 11, 12)
+        and not l1_first_empty
+        and l1_bits in fillers,
+    )
+    checks.check(
+        "thm1-two-cube-and-seed",
+        "the two-cube has twelve vertices and contains both seed sites",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and SEED <= set(TWO_CUBE)
+        and (1, 1, 0) in TWO_CUBE,
+    )
+    checks.check(
+        "thm2-f-two-is-u-at-least-two",
+        "f_two is 1 iff at least two axes are unbalanced",
+        all(
+            f_two(config) == int(axis_type(config)[0] >= 2)
+            for config in product((0, 1), repeat=6)
+        )
+        and two_bits != l1_bits,
+    )
+    checks.check(
+        "thm2-f-two-does-not-fill",
+        "f_two halts with four locks and does not fill",
+        two_locks == 4
+        and two_halt == 1
+        and two_history == (2, 4)
+        and two_wave == frozenset(((1, 0, 0), (0, 1, 0)))
+        and not two_first_empty
+        and two_bits not in fillers,
+    )
+    checks.check(
+        "thm3-n-fill-2",
+        f"N_fill_2 = {n_fill} exactly",
+        n_fill == 64 and n_fill == len(fillers) and f"N_fill_2 = {n_fill}" in note,
+    )
+    checks.check(
+        "thm3-not-unique",
+        "N_fill_2 > 1; f_L1 is not the unique 2-site filler",
+        n_fill > 1 and l1_bits in fillers and any_bits in fillers and any_bits != l1_bits,
+    )
+    checks.check(
+        "thm3-displayed-other-filler",
+        "displayed f_any fills, vanishes on empty, and is distinct from f_L1",
+        any_bits != l1_bits
+        and any_bits[orbit_types.index(empty_type)] == 0
+        and any_locks == 12
+        and any_halt == 3
+        and any_history == (2, 7, 11, 12)
+        and not any_first_empty
+        and forced_ok,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness failure, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "f_L1 is not unique" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-census",
+        "the note reports N_fill_2 = 64 and a second displayed filler",
+        "N_fill_2 = 64" in note
+        and "displayed second filler `f_any`" in note
+        and "f_L1 is not unique" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-one-site-or-ftwo-run",
+        "the residual is the 2-site fill count, not the 1-site census or an f_two halt run",
+        "Not leftover-character of the 1-site fill census" in note
+        and "Not a second f_two face-diagonal halt run" in note,
+    )
+
+    print(
+        "per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit"
+    )
+    print(
+        "per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil"
+    )
+    print(
+        "per_mode: checked exactly — every cube-covariant f with f(empty)=0 is run to a fixed point"
+    )
+    print(
+        "per_block: checked exactly — N_fill_2 is the 2-site fill cardinality on this patch"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 512 cube-covariant f with f(empty)=0, exactly 64 fill the twelve-vertex two-cube from the face-diagonal 2-site seed with off-patch o=0. f_L1 (n\neq0) fills and is not unique. f_two does not fill. Displayed, not adopted.

## Runner

`scripts/two_site_face_diagonal_fill_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.