### PR TITLE
feat(v31fill): four of eight F_cut fillers fire vertex3

### DIFF
--- a/docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,348 @@
+---
+claim_id: f_cut_fillers_vertex3_ready_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 8 F_cut 1-site fillers, N_v31 = 4 have f(vertex3)=1. f_L1 is not unique in that subset. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_fillers_vertex3_ready_2026_08_15.py
+---
+
+# How Many Of The Eight `F_cut` Fillers Fire `vertex3`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact bit-count of the eight `F_cut` 1-site fillers on the
+complement-fixed `vertex3` orbit. The unbalanced-axis map `f_L1` is
+displayed as one member of that subset. It is not adopted as the
+physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_fillers_vertex3_ready_2026_08_15.py`](../scripts/f_cut_fillers_vertex3_ready_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations partition the 64 neighbor 6-tuples into 10
+orbits. Cube-covariant predicates are `{0,1}`-assignments to those orbits.
+The three displayed cuts `f(empty)=0`, `f(full)=0`, and `f(c)=f(1-c)`
+leave five free bits, so `|F_cut|=32`. On the twelve-vertex two-cube
+`{0,1,2}×{0,1}×{0,1}` from seed `(0,0,0)` with off-patch occupancy `0`,
+exactly eight of those 32 maps fill (`|locks_halt|=12`). That eight-map
+list is recomputed here; it is not leftover-character of a prior static
+count.
+
+`vertex3` is the complement-fixed orbit of one-from-each-axis cells: the
+`+++` / cube-vertex type. Equivalently, it is the axis-type class
+`(u,b,e)=(3,0,0)` of size 8. A three-axis contrast forms when `f` is `1`
+on that orbit. This note does **not** run the `vertex3`-orbit *indicator*
+as a member: that indicator is a different map, used only as a contrast
+in a different residual.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+**Theorem 1.** `f_L1(vertex3)=1`.
+
+**Theorem 2.** Exactly `N_v31 = 4` of the eight `F_cut` 1-site fillers
+satisfy `f(vertex3)=1`.
+
+**Theorem 3.** So `N_v31 > 1`: `f_L1` is not unique in that subset. A
+displayed second filler `f_♯` agrees with `f_L1` except that it is silent
+on the mixed-triple orbit `(1,1,1)`. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The eight F_cut fillers are recomputed and evaluated on the vertex3 orbit. Exactly four fire vertex3. Uniqueness of f_L1 in that subset is false on this patch. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_fillers_vertex3_ready
+target_blocker_text: "how many of the eight F_cut 1-site fillers have f(vertex3)=1, and whether f_L1 is unique in that subset"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the vertex3-ready filler count; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for the eight F_cut fillers on this twelve-vertex patch with off-patch o=0; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the 1-site seed `(0,0,0)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of the vertex3-orbit-indicator member. That residual
+asks whether the indicator of `vertex3` itself fills. This residual asks how
+many of the eight fillers assign `1` to that orbit.
+
+## Exact Target And Objects
+
+**Target.** Among the eight `F_cut` maps that fill the two-cube from a
+1-site seed, count those with `f(vertex3)=1`, and decide uniqueness of
+`f_L1` inside that subset.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+`vertex3` is the orbit of the cell with occupied slots `+x,+y,+z` and of
+every proper-rotation image of that cell. That orbit is exactly the class
+`(3,0,0)`, of size 8. It is complement-fixed: complement of a
+one-from-each-axis cell is again one-from-each-axis.
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits
+(mixed triple `(1,1,1)` and `vertex3`), so `|F_cut|=32`.
+
+On the two-cube, seed `(0,0,0)` starts locked. Off-patch neighbors have
+occupancy `0`. Each tick, every unlocked on-patch vertex evaluates `f` on
+its six-neighbor occupancy tuple and locks if `f=1`. Fill means
+`|locks_halt|=12`. The eight fillers are the members of `F_cut` that fill.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+f_♯(c)      = 1  iff  u(c) ≥ 1 and (u,b,e) ≠ (1,1,1),
+f_H(c)      = |c|_1 mod 2.
+```
+
+`f_L1` and `f_♯` both lie in `F_cut` and both fill. `f_H` is a displayed
+mutation only: it is not `f_L1`. `f_♯` is a displayed second
+`vertex3`-ready filler: it is not adopted.
+
+`N_v31` is the number of the eight fillers with `f(vertex3)=1`.
+
+## Theorems
+
+**Theorem 1.** The unbalanced-axis map `f_L1` is one of the eight `F_cut`
+1-site fillers. It is not Hamming parity. Every `vertex3` cell has three
+unbalanced axes, so `f_L1(vertex3)=1`. Lock cardinalities of `f_L1` on
+this patch are `(1,4,8,11,12)` and the halt tick is `4`.
+
+**Theorem 2.** Exhaustive evaluation of the eight fillers on the `vertex3`
+orbit gives
+
+```text
+N_v31 = 4.
+```
+
+**Theorem 3.** So `N_v31 > 1`. The map `f_L1` fires `vertex3`, but it is
+not unique in that subset. The displayed second filler `f_♯` is distinct
+from `f_L1` (they disagree on the mixed-triple orbit) and also fires
+`vertex3` and fills, with the same lock cardinalities `(1,4,8,11,12)` and
+halt tick `4`. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free |
+| eight fillers | exhaustive 32-run census of `F_cut` to a twelve-lock halt |
+| `vertex3` orbit | complement-fixed class `(3,0,0)` of the `+++` cell; size 8 |
+| `f_L1` is unbalanced-axis | `u ≥ 1`, not Hamming `|c|_1 mod 2` |
+| `f_L1(vertex3)=1` | `u=3` on every `vertex3` cell |
+| `N_v31` | four of the eight fillers assign `1` to `vertex3` |
+| uniqueness of `f_L1` in that subset | false; `f_♯` is an explicit second `vertex3`-ready filler |
+| physical Admissibility selection | open and not claimed |
+
+Every leaf needed for the stated bit-count is discharged. No `Z^3`-wide
+formation law is claimed.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming is not a filler.
+2. Replace the bit `f(vertex3)` by the `vertex3`-orbit *indicator* as a
+   member: that is a different residual (one map's dynamics, not a count
+   among the eight fillers).
+3. Drop complement-even or the vanish cuts: the class is no longer
+   `F_cut` and the eight-map list changes.
+4. Seed a second on-patch site: the filler list can change.
+5. Assert `N_v31=1`: the explicit second filler `f_♯` refutes uniqueness.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character of the vertex3-orbit-indicator member in place of
+  this filler-bit count.
+- No blank-block, 2-site, or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness: `f_L1` is not the unique `F_cut`
+filler with `f(vertex3)=1`. The positive count `N_v31=4` is an exact
+enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and identify `vertex3` as `(3,0,0)`. | Theorem 1 and check `thm1-vertex3-orbit`. | **ATTEMPTED** |
+| `f_L1` on `vertex3` | Evaluate the unbalanced-axis predicate on every `vertex3` cell. | Theorem 1 and check `thm1-f-L1-fires-vertex3`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| eight-filler census | Rebuild `F_cut` and retain the maps that fill. | Theorem 1 and check `thm1-f-L1-is-filler` give eight fillers. | **ATTEMPTED** |
+| `vertex3`-ready count | Evaluate each filler on the `vertex3` orbit. | Theorem 2 and check `thm2-n-v31` give `N_v31 = 4`. | **ATTEMPTED** |
+| uniqueness of `f_L1` | Ask whether the `vertex3`-ready filler class is a singleton. | Theorem 3 and checks `thm3-not-unique` / `thm3-displayed-other-filler`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness fails. The explicit second
+filler and the cardinality `N_v31=4` are two certificates of the same
+non-uniqueness, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_v31=4` / displayed `f_♯` | yes: a count larger than one is non-uniqueness | yes: one extra filler is non-uniqueness | collapse into the uniqueness failure |
+| `f_L1(vertex3)=1` / Hamming differs | no: firing `vertex3` does not classify Hamming | no: Hamming differing does not evaluate `f_L1` on `vertex3` | independent positive/negative members, not two walls |
+| eight-filler list / `N_v31` | no: filling is not the `vertex3` bit | no: a bit-count does not replace the fill census | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| eight fillers | explicit fill-halt subclass of `F_cut` |
+| `vertex3` | explicit complement-fixed orbit `(3,0,0)`, not the indicator member |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| `f_♯` | displayed witness against uniqueness, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_fillers_vertex3_ready_2026_08_15.py:61` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_fillers_vertex3_ready_2026_08_15.py:105` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_fillers_vertex3_ready_2026_08_15.py:110` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_fillers_vertex3_ready_2026_08_15.py:114` | uniqueness | displayed second filler `f_♯` | yes |
+| `scripts/f_cut_fillers_vertex3_ready_2026_08_15.py:249` | class census | exact `N_v31` on the eight fillers | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every `F_cut` filler | the census is this class on this seed; other seeds are unclaimed |
+| per block | yes: the pair `(8, N_v31)` | uniqueness fails because `N_v31=4` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does fire `vertex3` and does fill this patch from the 1-site seed. That
+positive member does not make `f_L1` unique among `vertex3`-ready fillers
+and does not select it as the physical rule. The remaining physical
+choice — which, if any, `F_cut` map is the Admissibility occupancy
+predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that `vertex3` cells need not appear on every
+1-site filling trajectory, so uniqueness of `f_L1` might be restored by
+restricting to “dynamically occurring” cells. That objection is correctly
+about a smaller class. It does not overturn the stated theorem: among the
+eight maps in `F_cut` that fill, four assign `1` to the `vertex3` orbit.
+The displayed second filler `f_♯` already differs from `f_L1` on the
+mixed-triple orbit, fires `vertex3`, and fills. That is a class-level
+extra filler, not a trajectory-level identity.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the eight fillers, and the `vertex3` bit are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `vertex3`-ready filler count or restores
+uniqueness of `f_L1` inside that four-map subset.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact count `N_v31` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, identifies the eight 1-site fillers, evaluates `f(vertex3)` on
+each, reports `N_v31 = 4`, checks that `f_L1` fires `vertex3` and is not
+Hamming parity, and exhibits the displayed second filler `f_♯`. Declared
+audit inputs are this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15726,
- "node_count": 5529,
+ "edge_count": 15727,
+ "node_count": 5530,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_fillers_vertex3_ready_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_fillers_vertex3_ready_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_fillers_vertex3_ready_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_fillers_vertex3_ready_2026_08_15.py
+runner_sha256: 80357738901e41b928b395da4deaab936649d83b7cc2ab23a9963249bf4cfd52
+input_fingerprint_sha256: df3ed9b82a612c8df70aa4c9aa49d961234bb9c1bd3a0bd284e75374d3e727cd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+|F_cut|=32
+N_fillers=8
+N_v31=4
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_vertex3=1
+f_L1_locks=12 halt=4 history=(1, 4, 8, 11, 12)
+f_sharp_bits=(0, 0, 0, 0, 1, 0, 1, 1, 1, 1)
+f_sharp_vertex3=1
+f_sharp_locks=12 halt=4 history=(1, 4, 8, 11, 12)
+vertex3_orbit_size=8
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-vertex3-orbit vertex3 is the complement-fixed +++ orbit of size 8
+PASS: thm1-f-L1-fires-vertex3 f_L1(vertex3)=1 because every vertex3 cell has three unbalanced axes
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f-L1-is-filler f_L1 lies in F_cut and is one of the eight 1-site fillers
+PASS: thm2-n-v31 N_v31 = 4 exactly
+PASS: thm3-not-unique N_v31 > 1; f_L1 is not unique among fillers with f(vertex3)=1
+PASS: thm3-displayed-other-filler displayed f_sharp fires vertex3, fills, and is distinct from f_L1
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness failure, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-other-filler the note displays a second vertex3-ready filler rather than adopting uniqueness
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: not-leftover-indicator the residual is the filler-bit count, not the vertex3-orbit-indicator member
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut filler is evaluated on the vertex3 orbit
+per_block: checked exactly — N_v31 is the vertex3-ready cardinality among the eight fillers
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_fillers_vertex3_ready_2026_08_15.py
+++ b/scripts/f_cut_fillers_vertex3_ready_2026_08_15.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""How many of the eight F_cut 1-site fillers fire vertex3.
+
+vertex3 is the complement-fixed orbit of one-from-each-axis cells
+(the +++ / cube-vertex type).  f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+PLUS_PLUS_PLUS: Config = (1, 0, 1, 0, 1, 0)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: Site = (0, 0, 0)
+VERTEX3_TYPE: OrbitType = (3, 0, 0)
+MIXED3_TYPE: OrbitType = (1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_sharp(config: Config) -> int:
+    """Displayed extra v31 filler: f_L1 except silent on mixed3.  Not adopted."""
+    return int(axis_type(config)[0] >= 1 and axis_type(config) != MIXED3_TYPE)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, bool, tuple[int, ...]]:
+    locked = {SEED}
+    history = [len(locked)]
+    first_wave_empty = False
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if tick == 0:
+            first_wave_empty = nxt == locked
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, first_wave_empty, tuple(history)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def census_f_cut_fillers(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[int, ...]]:
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    fillers: list[tuple[int, ...]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        n_locks, _halt, _first_empty, _history = run_predicate(
+            predicate_from_bits(bits, orbit_types, type_of)
+        )
+        if n_locks == 12:
+            fillers.append(bits)
+    return fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    vertex3_index = orbit_types.index(VERTEX3_TYPE)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    sharp_bits = bits_from_predicate(f_sharp, orbit_types, orbits)
+    l1_locks, l1_halt, l1_first_empty, l1_history = run_predicate(f_L1)
+    sharp_locks, sharp_halt, sharp_first_empty, sharp_history = run_predicate(f_sharp)
+    fillers = census_f_cut_fillers(orbit_types, orbits, empty_type, full_type)
+    v31 = [bits for bits in fillers if bits[vertex3_index] == 1]
+    n_v31 = len(v31)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"|F_cut|={n_cut}")
+    print(f"N_fillers={len(fillers)}")
+    print(f"N_v31={n_v31}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_vertex3={l1_bits[vertex3_index]}")
+    print(f"f_L1_locks={l1_locks} halt={l1_halt} history={l1_history}")
+    print(f"f_sharp_bits={sharp_bits}")
+    print(f"f_sharp_vertex3={sharp_bits[vertex3_index]}")
+    print(f"f_sharp_locks={sharp_locks} halt={sharp_halt} history={sharp_history}")
+    print(f"vertex3_orbit_size={orbit_sizes[VERTEX3_TYPE]}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_FILLERS_VERTEX3_READY_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-vertex3-orbit",
+        "vertex3 is the complement-fixed +++ orbit of size 8",
+        VERTEX3_TYPE in orbits
+        and orbit_sizes[VERTEX3_TYPE] == 8
+        and PLUS_PLUS_PLUS in orbits[VERTEX3_TYPE]
+        and axis_type(PLUS_PLUS_PLUS) == VERTEX3_TYPE
+        and complement_type(VERTEX3_TYPE) == VERTEX3_TYPE
+        and VERTEX3_TYPE in free_fixed
+        and all(sum(member) == 3 and axis_type(member) == VERTEX3_TYPE for member in orbits[VERTEX3_TYPE]),
+    )
+    checks.check(
+        "thm1-f-L1-fires-vertex3",
+        "f_L1(vertex3)=1 because every vertex3 cell has three unbalanced axes",
+        f_L1(PLUS_PLUS_PLUS) == 1
+        and l1_bits[vertex3_index] == 1
+        and all(f_L1(member) == 1 for member in orbits[VERTEX3_TYPE]),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-f-L1-is-filler",
+        "f_L1 lies in F_cut and is one of the eight 1-site fillers",
+        in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and l1_locks == 12
+        and l1_halt == 4
+        and l1_history == (1, 4, 8, 11, 12)
+        and not l1_first_empty
+        and l1_bits in fillers
+        and len(fillers) == 8
+        and n_cut == 32,
+    )
+    checks.check(
+        "thm2-n-v31",
+        f"N_v31 = {n_v31} exactly",
+        n_v31 == 4 and n_v31 == len(v31) and f"N_v31 = {n_v31}" in note,
+    )
+    checks.check(
+        "thm3-not-unique",
+        "N_v31 > 1; f_L1 is not unique among fillers with f(vertex3)=1",
+        n_v31 > 1 and l1_bits in v31 and sharp_bits in v31,
+    )
+    checks.check(
+        "thm3-displayed-other-filler",
+        "displayed f_sharp fires vertex3, fills, and is distinct from f_L1",
+        sharp_bits != l1_bits
+        and sharp_bits[vertex3_index] == 1
+        and in_f_cut(sharp_bits, orbit_types, empty_type, full_type)
+        and sharp_locks == 12
+        and sharp_halt == 4
+        and sharp_history == (1, 4, 8, 11, 12)
+        and not sharp_first_empty
+        and sharp_bits in fillers,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness failure, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "f_L1 is not unique" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-other-filler",
+        "the note displays a second vertex3-ready filler rather than adopting uniqueness",
+        "displayed second filler `f_♯`" in note
+        and "f_L1 is not unique" in note
+        and "N_v31 = 4" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+    checks.check(
+        "not-leftover-indicator",
+        "the residual is the filler-bit count, not the vertex3-orbit-indicator member",
+        "Not leftover-character of the vertex3-orbit-indicator member" in note
+        and "f(vertex3)=1" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut filler is evaluated on the vertex3 orbit")
+    print("per_block: checked exactly — N_v31 is the vertex3-ready cardinality among the eight fillers")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 8 F_cut 1-site fillers, N_v31=4 have f(vertex3)=1. f_L1 (n\neq0, not Hamming) is not unique. Displayed, not adopted.

## Runner

`scripts/f_cut_fillers_vertex3_ready_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.