### PR TITLE
feat(mix3fill): mixed3=1 holds for 48 of the 96 1-site fillers

### DIFF
--- a/docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,431 @@
+---
+claim_id: one_site_fillers_mixed3_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 96 cube-covariant 1-site fillers on the two-cube with off-patch o=0, N_mix3 = 48 have f(mixed3)=1. f_L1 is not unique in that subset. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/one_site_fillers_mixed3_2026_08_15.py
+---
+
+# Mixed3 Among The Ninety-Six One-Site Fillers
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact count of how many of the 96 cube-covariant 1-site
+fillers of the twelve-vertex two-cube fire the mixed-triple orbit
+`mixed3`. The unbalanced-axis map `f_L1` is displayed as one such
+filler. It is not adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/one_site_fillers_mixed3_2026_08_15.py`](../scripts/one_site_fillers_mixed3_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. Restrict to `f(empty)=0`: there are
+512 such maps. On the two-cube `{0,1,2}×{0,1}×{0,1}`, seed `(0,0,0)`
+starts locked. Off-patch neighbors have occupancy `0`. Each tick, every
+unlocked on-patch vertex evaluates `f` on its six-neighbor occupancy
+tuple and locks if `f=1`. Fill means `|locks_halt|=12`. Reconstructing
+that dynamics on every cube-covariant map with `f(empty)=0` yields
+exactly 96 fillers.
+
+That 96-element fill set is leftover-character inventory of the raw
+1-site fill census (#6393). It is not the residual of this note. This
+note asks an independently motivated extra on those 96: how many fire
+`mixed3`. It is not a fifth bit-split of the eight `F_cut` fillers.
+
+`mixed3` is the `G`-orbit of axis type `(1,1,1)`: one unbalanced axis,
+one fully occupied axis, and one empty axis. A representative is
+`(c_{+x},c_{-x},c_{+y},c_{-y},c_{+z},c_{-z})=(1,0,1,1,0,0)`. The orbit
+has size `12`. `f(mixed3)=1` means a mixed-triple cell forms. L1 fires
+`mixed3`.
+
+The remaining named orbits used only to display a rival member are
+
+| name | `(u,b,e)` | geometric reading | L1 value |
+|---|---|---|---:|
+| `wt1` | `(1,0,2)` | one-axis contrast; a 1-site wave | 1 |
+| `opp2` | `(0,1,2)` | opposite pair; balanced axis silent | 0 |
+| `adj2` | `(2,0,1)` | two-axis contrast forms | 1 |
+| `vertex3` | `(3,0,0)` | three-axis contrast; cube-vertex type | 1 |
+| `mixed3` | `(1,1,1)` | mixed triple | 1 |
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+**Theorem 1.** `f_L1` is one of the 96 fillers and `f_L1(mixed3)=1`.
+Lock cardinalities `(1,4,8,11,12)` and halt tick `4`.
+
+**Theorem 2.** Exactly
+
+```text
+N_mix3 = 48
+```
+
+members of the 96 fillers satisfy `f(mixed3)=1`.
+
+**Theorem 3.** `N_mix3 > 1`, so `mixed3=1` does not select `f_L1` among
+the 96. A displayed second filler `f_♦` is `1` exactly when the
+unbalanced-axis count `u` satisfies `u ≥ 1` and the cell is not of
+vertex type `(3,0,0)`. Its remaining-bit tuple is
+`(wt1,opp2,adj2,vertex3,mixed3)=(1,0,1,0,1)`. It also has
+`f(mixed3)=1` and fills, with lock cardinalities `(1,4,8,10,11,12)` and
+halt tick `5`. Displayed, not adopted. Do not write mixed3 into
+Admissibility.
+
+Not leftover-character of #6404 (that AND-ed mixed3 on the 10→eight).
+Not leftover-character of #6402. Not leftover-character of #6403.
+Not leftover-character of #6405 (those split the eight). This is an
+independently motivated extra on the 96.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 96 1-site fillers, membership of f_L1, f_L1(mixed3)=1, and the exact count N_mix3=48 are enumerated. Uniqueness of f_L1 among mixed3=1 fillers is false on this patch. mixed3 is displayed, not written into Admissibility."
+trace_class: upstream_support
+target_claim_id: one_site_fillers_mixed3
+target_blocker_text: "how many of the 96 cube-covariant 1-site fillers fire mixed3, and whether f_L1 is unique in that subset"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the mixed3 filler count; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for the 96 1-site fillers on this twelve-vertex patch with off-patch o=0; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the 1-site seed `(0,0,0)`;
+- the mixed-triple orbit `mixed3`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of #6393. That census only named the 96 maps. This
+note evaluates them on `mixed3`. Not leftover-character of #6404. Not
+leftover-character of the eight-filler bit splits #6402/#6403/#6405.
+
+## Exact Target And Objects
+
+**Target.** Count how many of the 96 cube-covariant 1-site fillers fire
+`mixed3`, and decide uniqueness of `f_L1` inside that subset.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| `(u,b,e)` | name | orbit size | complement image |
+|---|---|---:|---|
+| `(0,0,3)` | empty | 1 | `(0,3,0)` full |
+| `(0,3,0)` | full | 1 | `(0,0,3)` empty |
+| `(0,1,2)` | `opp2` | 3 | `(0,2,1)` `opp4` |
+| `(0,2,1)` | `opp4` | 3 | `(0,1,2)` `opp2` |
+| `(1,0,2)` | `wt1` | 6 | `(1,2,0)` `wt5` |
+| `(1,2,0)` | `wt5` | 6 | `(1,0,2)` `wt1` |
+| `(2,0,1)` | `adj2` | 12 | `(2,1,0)` `adj4` |
+| `(2,1,0)` | `adj4` | 12 | `(2,0,1)` `adj2` |
+| `(1,1,1)` | `mixed3` | 12 | `(1,1,1)` |
+| `(3,0,0)` | `vertex3` | 8 | `(3,0,0)` |
+
+`mixed3` is complement-fixed: it is the unique weight-3 orbit with one
+axis of each kind. The class under study is every cube-covariant `f` with
+`f(empty)=0`, not the three-cut subclass `F_cut`. There are `2^9=512`
+such maps.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+f_♦(c)      = 1  iff  u(c) ≥ 1 and (u,b,e) ≠ (3,0,0),
+f_H(c)      = |c|_1 mod 2.
+```
+
+All three are cube-covariant and vanish on empty. On `mixed3` one has
+`u=1`, so `f_L1(mixed3)=f_♦(mixed3)=1`. Hamming parity also fires
+`mixed3` because that orbit has odd weight `3`, but Hamming is not a
+filler: it does not halt with twelve locks. Hamming is used only as a
+displayed mutation: it is not `f_L1`. `f_♦` is a displayed second
+`mixed3=1` filler: it is not adopted. Its remaining-bit tuple is
+`(1,0,1,0,1)`, which differs from L1's tuple `(1,0,1,1,1)` on
+`vertex3`.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+The 96 fillers are the cube-covariant maps with `f(empty)=0` whose halt
+set has cardinality `12`. `N_mix3` is the number of those 96 maps with
+`f(mixed3)=1`. Do not write mixed3 into Admissibility.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. Exactly 512 cube-covariant maps vanish on empty.
+Exactly 96 of them fill the twelve-vertex two-cube from seed `(0,0,0)`
+with off-patch occupancy `0`. The mixed-triple orbit `mixed3` is the
+size-`12` class `(u,b,e)=(1,1,1)`. The unbalanced-axis map `f_L1` is one
+of those 96 fillers, is not Hamming parity, and satisfies
+`f_L1(mixed3)=1`. Its remaining-bit tuple is
+`(wt1,opp2,adj2,vertex3,mixed3)=(1,0,1,1,1)`. Its lock cardinalities are
+`(1,4,8,11,12)` and its halt tick is `4`.
+
+**Theorem 2.** Exhaustive evaluation of the 96 fillers on `mixed3` gives
+
+```text
+N_mix3 = 48.
+```
+
+Equivalently, exactly half of the 96 fillers fire `mixed3`. Flipping the
+`mixed3` bit of any filler yields another filler: the 1-site fill
+dynamics on this patch with off-patch occupancy `0` never uses a
+`mixed3` neighborhood as a lock predicate.
+
+**Theorem 3.** So `N_mix3 > 1`. The map `f_L1` fires `mixed3` and fills,
+but it is not unique in that subset. The displayed second filler `f_♦`
+is distinct from `f_L1` (they disagree on the three-unbalanced-axis
+orbit), also has `f(mixed3)=1`, has remaining-bit tuple `(1,0,1,0,1)`,
+and fills with lock cardinalities `(1,4,8,10,11,12)` and halt tick `5`.
+Displayed, not adopted. The predicate `f(mixed3)=1` therefore does not
+select `f_L1` among the 96 fillers. Do not write mixed3 into
+Admissibility.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| 512 empty-vanishing maps | nine free orbit bits after `f(empty)=0` |
+| 96 fillers | exhaustive 512-run census to a fixed point with `|locks|=12` |
+| `mixed3` orbit | representative `(1,0,1,1,0,0)`; type `(1,1,1)`; size `12` |
+| `f_L1` is in the 96 | halt set has cardinality 12 at tick 4 |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit `adj2` has even weight and `f_L1=1` |
+| `f_L1(mixed3)=1` | `u(mixed3)=1` so the unbalanced-axis predicate fires |
+| `N_mix3` | count of the 96 whose `mixed3` bit equals 1 |
+| uniqueness of mixed3-ready `f_L1` | false; `f_♦` is an explicit second mixed3-ready filler |
+| Hamming on `mixed3` | also fires, but Hamming is not a filler |
+| physical Admissibility selection | open and not claimed; mixed3 is not written in |
+
+Every leaf needed for the stated mixed3 census is discharged. No
+`Z^3`-wide formation law is claimed.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: both fire `mixed3`, but
+   Hamming is not a filler and disagrees with `f_L1` on the
+   two-unbalanced-axis orbit.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Restrict the class to `F_cut` and AND mixed3 with the other L1 bits:
+   that is leftover-character of #6404, a different residual.
+4. Split only the eight `F_cut` fillers on one remaining bit: that is
+   leftover-character of #6402/#6403/#6405.
+5. Assert `N_mix3=1`: the explicit second mixed3-ready filler `f_♦`
+   refutes uniqueness.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 96-filler census (#6393), of
+  the #6404 AND on the eight, or of the #6402/#6403/#6405 bit-splits of
+  the eight, in place of this mixed3 count on the 96.
+- No blank-block, 2-site, or 3-site variant.
+- No axiom edit: mixed3 is displayed, not written into Admissibility.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness: `f_L1` is not the unique 1-site
+filler with `f(mixed3)=1`. The positive count `N_mix3=48` is an exact
+enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| 96-filler reconstruction | Run every empty-vanishing cube-covariant map to a fixed point and keep `|locks|=12`. | Theorem 1 and check `thm1-ninety-six-fillers` give 96 fillers. | **ATTEMPTED** |
+| `mixed3` orbit | Identify the size-`12` one-unbalanced / one-both / one-empty orbit. | Theorem 1 and check `thm1-mixed3-orbit`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `N_mix3` census | Filter the 96 fillers by `f(mixed3)=1`. | Theorem 2 and check `thm2-n-mix3` give `N_mix3 = 48`. | **ATTEMPTED** |
+| uniqueness of mixed3-ready `f_L1` | Ask whether the mixed3-ready class is a singleton. | Theorem 3 and checks `thm3-not-unique` / `thm3-displayed-other`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness of mixed3-ready `f_L1`
+fails. The explicit second mixed3-ready filler and the cardinality
+`N_mix3=48` are two certificates of the same non-uniqueness, so they
+collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_mix3=48` / displayed `f_♦` | yes: a count larger than one is non-uniqueness | yes: one extra mixed3-ready filler is non-uniqueness | collapse into the uniqueness failure |
+| `f_L1(mixed3)=1` / Hamming also fires | no: one map firing does not classify Hamming | no: Hamming firing does not prove `f_L1` fills | independent member facts, not two walls |
+| 96-filler count / `N_mix3` | no: naming the 96 does not evaluate `mixed3` | no: a mixed3 count does not replace the fill census | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| the 96 fillers | explicit empty-vanishing 1-site fill set; not leftover-character of #6393 |
+| `mixed3` | explicit mixed-triple orbit; independently motivated extra on the 96 |
+| remaining-bit tuple | display label for a rival member; not a #6404 AND |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| `f_♦` | displayed witness against uniqueness, not a selected law |
+| `N_mix3=48` | displayed non-uniqueness inside the 96, not an Admissibility clause |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:72` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:111` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:116` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:49` | `mixed3` representative | one unbalanced, one both-occupied, one empty axis | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:221` | 96-filler reconstruction | empty-vanishing maps with `|locks|=12` | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:298` | `N_mix3` | mixed3=1 cardinality inside the 96 | yes |
+| `scripts/one_site_fillers_mixed3_2026_08_15.py:120` | uniqueness | displayed second mixed3-ready filler `f_♦` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every cube-covariant `f` with `f(empty)=0` | the census is this class on this seed; other seeds are unclaimed |
+| per block | yes: the pair `(96, N_mix3)` | uniqueness fails because `N_mix3=48` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does fill this patch from the 1-site seed and does fire `mixed3`. That
+positive member does not make `f_L1` unique among mixed3-ready fillers
+and does not select it as the physical rule. The remaining physical
+choice — which, if any, occupancy predicate is the Admissibility rule —
+stays explicit. Do not write mixed3 into Admissibility.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f(mixed3)=1` is independently motivated
+— a mixed-triple cell should form — so it should be enough to pick
+`f_L1` among the 96 fillers. That motivation is correctly about a
+further cut. It does not overturn the stated theorem: among the 96
+fillers, 48 already fire `mixed3`. The displayed second filler `f_♦`
+already differs from `f_L1` on the three-unbalanced-axis orbit, fires
+`mixed3`, and fills by a different lock history. Hamming also fires
+`mixed3` and is not even a filler, so readiness on `mixed3` is not a
+stand-in for the unbalanced-axis predicate. A second objection is that
+this note is leftover-character of #6404, which already used `mixed3=1`
+inside an AND on the eight `F_cut` fillers. That is a different class
+and a different residual: the present count is `N_mix3` among the 96,
+with no AND and no `F_cut` restriction.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+96 fillers, `mixed3` evaluation, and `N_mix3` are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+The 96-filler census (#6393) is the class this note filters. It is not a
+parent and does not close `N_mix3`. The eight-filler AND (#6404) and the
+eight-filler bit splits (#6402/#6403/#6405) are different residuals.
+
+No earlier mechanism retires the mixed3 count on the 96 or writes mixed3
+into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact pair `(96, N_mix3)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits,
+reconstructs the 96 1-site fillers, evaluates them on `mixed3`, reports
+`N_mix3 = 48`, checks that `f_L1` is one of the 96 and fires `mixed3`
+and is not Hamming parity, and exhibits the displayed second
+mixed3-ready filler `f_♦` by its remaining-bit tuple `(1,0,1,0,1)`.
+Declared audit inputs are this note and the axiom memo. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15728,
- "node_count": 5530,
+ "edge_count": 15729,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13472,6 +13472,10 @@
   },
   "one_parameter_reduced_shell_law_note": {
    "deps_hash": "03d023bc9c3c",
+   "out_degree": 1
+  },
+  "one_site_fillers_mixed3_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "one_time_dimension_dt1_reduces_to_emergent_dynamics_gate_open_gate_note_2026-06-17": {

--- a/logs/runner-cache/one_site_fillers_mixed3_2026_08_15.txt
+++ b/logs/runner-cache/one_site_fillers_mixed3_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/one_site_fillers_mixed3_2026_08_15.py
+runner_sha256: ce57aa49cddaf7293efc8468b5f22fd481dae2c8f62feae894dc19e73b418dfe
+input_fingerprint_sha256: ae409d62d81ed182813b5fec72785fe838f59ede184b1a99499f7de299a204d9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+n_maps_empty0=512
+N_fill=96
+mixed3_type=(1, 1, 1) size=12 rep=(1, 0, 1, 1, 0, 0)
+L1_tuple={'wt1': 1, 'opp2': 0, 'adj2': 1, 'vertex3': 1, 'mixed3': 1}
+diamond_tuple={'wt1': 1, 'opp2': 0, 'adj2': 1, 'vertex3': 0, 'mixed3': 1}
+N_mix3=48
+f_L1_locks=12 halt=4 history=(1, 4, 8, 11, 12)
+f_diamond_locks=12 halt=5 history=(1, 4, 8, 10, 11, 12)
+hamming_locks=9
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 axis-type orbits partition the 64 cells
+PASS: thm1-mixed3-orbit mixed3 is the size-12 G-orbit of axis type (1,1,1)
+PASS: thm1-ninety-six-fillers exactly 96 cube-covariant maps with f(empty)=0 fill the two-cube
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_- (n != 0)
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f-L1-in-96-and-mixed3 f_L1 is one of the 96 fillers and f_L1(mixed3)=1
+PASS: thm1-two-cube-twelve the two-cube has twelve vertices and contains the seed
+PASS: thm2-n-mix3 N_mix3 = 48 is the number of the 96 fillers with f(mixed3)=1
+PASS: thm3-not-unique N_mix3>1 so mixed3=1 does not select f_L1 among the 96
+PASS: thm3-displayed-other displayed f_♦ fills, fires mixed3, and has tuple (1,0,1,0,1)
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted mixed3 count, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit mixed3 is not written into Admissibility
+PASS: not-leftover-6404 the residual is N_mix3 on the 96, not leftover-character of the eight-filler bit splits
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-scope-and-n-mix3 claim_scope reports N_mix3 among the 96 and does not adopt mixed3
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every cube-covariant f with f(empty)=0 is classified as filler or not
+per_block: checked exactly — N_mix3 is the mixed3=1 cardinality inside the 96-filler set
+lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/one_site_fillers_mixed3_2026_08_15.py
+++ b/scripts/one_site_fillers_mixed3_2026_08_15.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""mixed3 among the 96 cube-covariant 1-site fillers on the two-cube.
+
+Recompute the 24 proper cube rotations, the ten axis-type orbits, and the
+96 maps with f(empty)=0 that fill the twelve-vertex two-cube from the
+1-site seed with off-patch occupancy 0.  mixed3 is the G-orbit of axis
+type (1,1,1): one unbalanced axis, one fully occupied, one empty.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2.  N_mix3 counts fillers with f(mixed3)=1.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: Site = (0, 0, 0)
+MIXED3_REP: Config = (1, 0, 1, 1, 0, 0)
+
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+BIT_TYPES: dict[str, OrbitType] = {
+    "wt1": (1, 0, 2),
+    "opp2": (0, 1, 2),
+    "adj2": (2, 0, 1),
+    "vertex3": (3, 0, 0),
+    "mixed3": (1, 1, 1),
+}
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+DIAMOND_TUPLE: tuple[int, ...] = (1, 0, 1, 0, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_diamond(config: Config) -> int:
+    """Displayed extra 1-site filler with f(mixed3)=1.  Not adopted."""
+    orbit = axis_type(config)
+    return int(orbit[0] >= 1 and orbit != (3, 0, 0))
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, bool, tuple[int, ...]]:
+    locked = {SEED}
+    history = [len(locked)]
+    first_wave_empty = False
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if tick == 0:
+            first_wave_empty = nxt == locked
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, first_wave_empty, tuple(history)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def named_tuple_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[BIT_TYPES[name]] for name in BIT_NAMES)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def census_fillers(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, ...]]:
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    empty_index = orbit_types.index(axis_type(EMPTY))
+    free = [index for index in range(len(orbit_types)) if index != empty_index]
+    fillers: list[tuple[int, ...]] = []
+    for mask in range(1 << len(free)):
+        bits_list = [0] * len(orbit_types)
+        for rank, index in enumerate(free):
+            bits_list[index] = (mask >> rank) & 1
+        bits = tuple(bits_list)
+        n_locks, _halt, _first_empty, _history = run_predicate(
+            predicate_from_bits(bits, orbit_types, type_of)
+        )
+        if n_locks == 12:
+            fillers.append(bits)
+    return fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    n_maps = 2 ** (len(orbit_types) - 1)
+    mix_type = BIT_TYPES["mixed3"]
+    mix_index = orbit_types.index(mix_type)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    diamond_bits = bits_from_predicate(f_diamond, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_assign = dict(zip(orbit_types, l1_bits, strict=True))
+    diamond_assign = dict(zip(orbit_types, diamond_bits, strict=True))
+    l1_named = named_tuple_from_assignment(l1_assign)
+    diamond_named = named_tuple_from_assignment(diamond_assign)
+    l1_locks, l1_halt, l1_first_empty, l1_history = run_predicate(f_L1)
+    diamond_locks, diamond_halt, diamond_first_empty, diamond_history = run_predicate(
+        f_diamond
+    )
+    ham_locks, _ham_halt, _ham_first, _ham_history = run_predicate(f_hamming)
+
+    fillers = census_fillers(orbit_types, orbits)
+    mixers = [bits for bits in fillers if bits[mix_index] == 1]
+    n_mix3 = len(mixers)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"n_maps_empty0={n_maps}")
+    print(f"N_fill={len(fillers)}")
+    print(f"mixed3_type={mix_type} size={orbit_sizes[mix_type]} rep={MIXED3_REP}")
+    print(f"L1_tuple={dict(zip(BIT_NAMES, l1_named))}")
+    print(f"diamond_tuple={dict(zip(BIT_NAMES, diamond_named))}")
+    print(f"N_mix3={n_mix3}")
+    print(f"f_L1_locks={l1_locks} halt={l1_halt} history={l1_history}")
+    print(f"f_diamond_locks={diamond_locks} halt={diamond_halt} history={diamond_history}")
+    print(f"hamming_locks={ham_locks}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/ONE_SITE_FILLERS_MIXED3_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 axis-type orbits partition the 64 cells",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-mixed3-orbit",
+        "mixed3 is the size-12 G-orbit of axis type (1,1,1)",
+        orbit_sizes == expected_sizes
+        and BIT_TYPES["mixed3"] == (1, 1, 1)
+        and axis_type(MIXED3_REP) == (1, 1, 1)
+        and MIXED3_REP in orbits[mix_type]
+        and len(orbits[mix_type]) == 12
+        and BIT_TYPES["wt1"] == (1, 0, 2)
+        and BIT_TYPES["opp2"] == (0, 1, 2)
+        and BIT_TYPES["adj2"] == (2, 0, 1)
+        and BIT_TYPES["vertex3"] == (3, 0, 0),
+    )
+    checks.check(
+        "thm1-ninety-six-fillers",
+        "exactly 96 cube-covariant maps with f(empty)=0 fill the two-cube",
+        n_maps == 512
+        and len(fillers) == 96
+        and len(set(fillers)) == 96
+        and axis_type(EMPTY) == (0, 0, 3)
+        and l1_bits[orbit_types.index(axis_type(EMPTY))] == 0,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_- (n != 0)",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-f-L1-in-96-and-mixed3",
+        "f_L1 is one of the 96 fillers and f_L1(mixed3)=1",
+        l1_bits in fillers
+        and l1_named == L1_TUPLE
+        and l1_assign[mix_type] == 1
+        and f_L1(MIXED3_REP) == 1
+        and l1_locks == 12
+        and l1_halt == 4
+        and not l1_first_empty
+        and l1_history == (1, 4, 8, 11, 12),
+    )
+    checks.check(
+        "thm1-two-cube-twelve",
+        "the two-cube has twelve vertices and contains the seed",
+        len(TWO_CUBE) == 12 and len(set(TWO_CUBE)) == 12 and SEED in TWO_CUBE,
+    )
+    checks.check(
+        "thm2-n-mix3",
+        f"N_mix3 = {n_mix3} is the number of the 96 fillers with f(mixed3)=1",
+        n_mix3 == 48
+        and n_mix3 == sum(1 for bits in fillers if bits[mix_index] == 1)
+        and n_mix3 == len(fillers) // 2
+        and f"N_mix3 = {n_mix3}" in note,
+    )
+    checks.check(
+        "thm3-not-unique",
+        "N_mix3>1 so mixed3=1 does not select f_L1 among the 96",
+        n_mix3 > 1
+        and l1_bits in mixers
+        and diamond_bits in mixers
+        and diamond_bits != l1_bits,
+    )
+    checks.check(
+        "thm3-displayed-other",
+        "displayed f_♦ fills, fires mixed3, and has tuple (1,0,1,0,1)",
+        diamond_named == DIAMOND_TUPLE
+        and diamond_assign[mix_type] == 1
+        and f_diamond(MIXED3_REP) == 1
+        and diamond_locks == 12
+        and diamond_halt == 5
+        and not diamond_first_empty
+        and diamond_history == (1, 4, 8, 10, 11, 12)
+        and diamond_bits in fillers
+        and ham_bits not in fillers
+        and ham_locks != 12,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted mixed3 count, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "mixed3 is not written into Admissibility",
+        "Do not write mixed3 into Admissibility" in note
+        and "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+    checks.check(
+        "not-leftover-6404",
+        "the residual is N_mix3 on the 96, not leftover-character of the eight-filler bit splits",
+        "Not leftover-character of #6404" in note
+        and "Not leftover-character of #6402" in note
+        and "Not leftover-character of #6403" in note
+        and "Not leftover-character of #6405" in note
+        and "independently motivated extra on the 96" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-scope-and-n-mix3",
+        "claim_scope reports N_mix3 among the 96 and does not adopt mixed3",
+        "Among the 96 cube-covariant 1-site fillers" in note
+        and "N_mix3 = 48 have f(mixed3)=1" in note
+        and "f_L1 is not unique in that subset" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every cube-covariant f with f(empty)=0 is classified as filler or not")
+    print("per_block: checked exactly — N_mix3 is the mixed3=1 cardinality inside the 96-filler set")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 96 cube-covariant 1-site fillers, N_mix3=48 have f(mixed3)=1 so mixed3 does not isolate f_L1. Displayed, not adopted. Not a fifth split of the eight.

## Runner

`scripts/one_site_fillers_mixed3_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.