### PR TITLE
feat(cutsparse): F_cut support min is 36, not f_L1

### DIFF
--- a/docs/F_CUT_FILLERS_SPARSEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_FILLERS_SPARSEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,423 @@
+---
+claim_id: f_cut_fillers_sparsest_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the eight F_cut 1-site fillers on the two-cube with off-patch o=0, the minimal support is 36 and N_min_cut = 1 maps achieve it. f_L1 is not the unique minimizer. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_fillers_sparsest_2026_08_15.py
+---
+
+# Sparsest Filler Inside The Three-Cut Class `F_cut`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact support census among the eight cube-covariant
+complement-even 1-site fillers of the twelve-vertex two-cube that vanish
+on empty and full, with off-patch occupancy `o=0`. The unbalanced-axis
+map `f_L1` is displayed as one filler. It is not adopted as the physical
+Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_fillers_sparsest_2026_08_15.py`](../scripts/f_cut_fillers_sparsest_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut|=32`. On the two-cube
+`{0,1,2}×{0,1}×{0,1}`, seed `(0,0,0)` starts locked. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. Fill means
+`|locks_halt|=12`.
+
+Exactly eight members of `F_cut` fill. That 8-count is leftover-character
+inventory of the `F_cut` fill census. It is not the residual of this note.
+The unique support-26 filler among the 96 cube-covariant 1-site fillers is
+outside `F_cut`. That 96-map support minimum is a different leftover
+inventory. This note asks the restricted question: among those eight
+`F_cut` fillers, who is sparsest?
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The definition is never Hamming.
+
+For a map `f` write
+
+```text
+supp(f) = |{ c ∈ {0,1}^6 : f(c)=1 }|.
+```
+
+**Theorem 1.** The eight `F_cut` 1-site fillers reconfirm. `f_L1` is one
+of them, and `supp(f_L1)=56`.
+
+**Theorem 2.** Let `m_cut` be the minimum of `supp` over those eight, and
+let `N_min_cut` be the number of those eight that attain `m_cut`. Then
+
+```text
+m_cut = 36,    N_min_cut = 1.
+```
+
+**Theorem 3.** `N_min_cut=1`, but that unique minimizer is **not**
+`f_L1`. It is the remaining-bit tuple
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 0, 0).
+```
+
+Displayed, not adopted. The three cuts plus sparsity therefore do not
+select `f_L1`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the eight 1-site fillers, and the support minimum among those eight are enumerated. Uniqueness of f_L1 as the F_cut support-minimizer is false on this patch. No physical law is selected."
+trace_class: negative_route_pruning
+target_claim_id: f_cut_fillers_sparsest
+target_blocker_text: "whether support-minimality among the eight F_cut 1-site fillers selects f_L1 without an extra axiom"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F_cut support census; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut on this twelve-vertex patch with off-patch o=0; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the 1-site seed `(0,0,0)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of the 96-map support minimum. Not leftover-character
+of the static 32-count of `F_cut` or of the 8-count of `F_cut` fillers.
+
+## Exact Target And Objects
+
+**Target.** Among the eight `F_cut` 1-site fillers, compute the support
+minimum and decide whether `f_L1` is the unique minimizer.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| `(u,b,e)` | displayed name | orbit size | complement image |
+|---|---|---:|---|
+| `(0,0,3)` | empty | 1 | `(0,3,0)` full |
+| `(0,3,0)` | full | 1 | `(0,0,3)` empty |
+| `(0,1,2)` | `opp2` | 3 | `(0,2,1)` |
+| `(0,2,1)` | complement of `opp2` | 3 | `(0,1,2)` |
+| `(1,0,2)` | `wt1` | 6 | `(1,2,0)` |
+| `(1,2,0)` | complement of `wt1` | 6 | `(1,0,2)` |
+| `(2,0,1)` | `adj2` | 12 | `(2,1,0)` |
+| `(2,1,0)` | complement of `adj2` | 12 | `(2,0,1)` |
+| `(1,1,1)` | `mixed3` | 12 | `(1,1,1)` |
+| `(3,0,0)` | `vertex3` | 8 | `(3,0,0)` |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are the three complement-pair bits `wt1`, `opp2`, `adj2` and the two
+complement-fixed orbit bits `vertex3`, `mixed3`, so `|F_cut|=32`. Each
+member is recorded as the remaining-bit tuple
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) ∈ {0,1}^5.
+```
+
+Support is then exact:
+
+```text
+supp = 12·wt1 + 6·opp2 + 24·adj2 + 8·vertex3 + 12·mixed3.
+```
+
+Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1.
+```
+
+Its remaining-bit tuple is `(1, 0, 1, 1, 1)`, so `supp(f_L1)=56`. This is
+never Hamming `|c|_1 mod 2`, whose tuple is `(1, 0, 0, 1, 1)`.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+The eight `F_cut` fillers and their supports are the exact finite domain
+of `m_cut`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. Exactly eight
+members of `F_cut` fill the twelve-vertex two-cube from seed `(0,0,0)`
+with off-patch occupancy `0`. The unbalanced-axis map `f_L1` is one of
+those eight. It is not Hamming parity. Its support is
+
+```text
+supp(f_L1) = 56.
+```
+
+Lock cardinalities of `f_L1` are `(1,4,8,11,12)` and the halt tick is `4`.
+
+**Theorem 2.** Exhaustive support evaluation of those eight fillers gives
+
+```text
+m_cut = 36,    N_min_cut = 1.
+```
+
+The eight remaining-bit tuples and supports are
+
+| `(wt1, opp2, adj2, vertex3, mixed3)` | `supp` | halt history |
+|---|---:|---|
+| `(1, 0, 1, 0, 0)` | 36 | `(1,4,8,10,11,12)` |
+| `(1, 1, 1, 0, 0)` | 42 | `(1,4,8,10,11,12)` |
+| `(1, 0, 1, 1, 0)` | 44 | `(1,4,8,11,12)` |
+| `(1, 0, 1, 0, 1)` | 48 | `(1,4,8,10,11,12)` |
+| `(1, 1, 1, 1, 0)` | 50 | `(1,4,8,11,12)` |
+| `(1, 1, 1, 0, 1)` | 54 | `(1,4,8,10,11,12)` |
+| `(1, 0, 1, 1, 1)` (`f_L1`) | 56 | `(1,4,8,11,12)` |
+| `(1, 1, 1, 1, 1)` | 62 | `(1,4,8,11,12)` |
+
+**Theorem 3.** `N_min_cut=1`, so there is a unique `F_cut` support
+minimizer, and it is **not** `f_L1`. The unique minimizer is the displayed
+tuple `(1, 0, 1, 0, 0)`: on the `wt1` and `adj2` complement-pairs, off on
+`opp2`, `vertex3`, and `mixed3`. Displayed, not adopted.
+
+The unique support-26 filler among the 96 empty-vanishing cube-covariant
+1-site fillers is a different map: it fails complement-evenness, so it
+lies outside `F_cut`. Restricting the same minimizer to `F_cut` therefore
+opens a new domain; it does not inherit that 26-support winner.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| eight `F_cut` fillers | exhaustive 32-run census to a fixed point with `|locks_halt|=12` |
+| `f_L1` is in `F_cut` and fills | remaining-bit tuple `(1,0,1,1,1)`; halt set has cardinality 12 |
+| `supp(f_L1)=56` | `12+24+8+12` from the `wt1`, `adj2`, `vertex3`, and `mixed3` orbits |
+| `f_L1` is not Hamming | Hamming is `(1,0,0,1,1)` and does not fill |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `m_cut` and `N_min_cut` | exhaustive support evaluation of the eight fillers |
+| uniqueness of `f_L1` as `F_cut` sparsest | false; displayed tuple `(1,0,1,0,0)` has support 36 |
+| 96-map support-26 winner | outside `F_cut`; not this domain |
+| physical Admissibility selection | open and not claimed |
+
+Every leaf needed for the stated census is discharged. No `Z^3`-wide
+formation law is claimed.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming does not fill.
+2. Replace the eight-element `F_cut` domain by the 96 empty-vanishing
+   fillers: the unique support minimum becomes 26 and still is not
+   `f_L1`, but that winner is outside `F_cut`.
+3. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+4. Drop complement-even or the vanish-on-full cut: the class is no longer
+   the 32-element `F_cut`.
+5. Assert that `f_L1` is the unique `F_cut` support-minimizer: the
+   displayed tuple `(1, 0, 1, 0, 0)` refutes uniqueness.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character count of the 96-map support minimum, of the
+  static 32, or of the 8-count of `F_cut` fillers in place of this
+  restricted support census.
+- No blank-block, 2-site, or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness: `f_L1` is not the unique support
+minimizer among the eight `F_cut` 1-site fillers. The pair
+`(m_cut, N_min_cut)=(36,1)` is an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class and eight fillers | Force the three cuts and run every map in `F_cut`. | Theorem 1 and checks `thm1-f-cut-cardinality` / `thm1-eight-fillers`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-l1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `f_L1` support | Count `{c : f_L1(c)=1}` on the 64 cells. | Theorem 1 and check `thm1-l1-support-56` give `56`. | **ATTEMPTED** |
+| `F_cut` support census | Evaluate `supp` on each of the eight fillers. | Theorem 2 and checks `thm2-m-cut` / `thm2-n-min-cut`. | **ATTEMPTED** |
+| uniqueness of `f_L1` | Ask whether the unique `m_cut` map is `f_L1`. | Theorem 3 and checks `thm3-unique-is-not-l1` / `thm3-displayed-tuple`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness of `f_L1` as the `F_cut`
+sparsest filler fails. The explicit displayed tuple and the pair
+`(m_cut, N_min_cut)=(36,1)` with that tuple not equal to `f_L1` are two
+certificates of the same non-uniqueness, so they collapse rather than
+count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `m_cut=36` / displayed `(1,0,1,0,0)` | yes: that tuple has support 36 | yes: a support-36 `F_cut` filler is the minimum | collapse into the uniqueness failure |
+| eight fillers / `supp(f_L1)=56` | no: a fill count does not evaluate support | no: one support does not list the eight | independent positive members, not two walls |
+| 96-map support-26 winner / `F_cut` minimum | no: that winner is outside `F_cut` | no: an `F_cut` minimum does not classify the 96 | separate domains |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| “the eight fillers” | explicit 1-site fill subset of `F_cut` |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| tuple `(1, 0, 1, 0, 0)` | displayed witness against uniqueness, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_fillers_sparsest_2026_08_15.py:78` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_fillers_sparsest_2026_08_15.py:122` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_fillers_sparsest_2026_08_15.py:127` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_fillers_sparsest_2026_08_15.py:269` | support | exact orbit-size sum on remaining bits | yes |
+| `scripts/f_cut_fillers_sparsest_2026_08_15.py:303` | class census | exact eight fillers and their supports | yes |
+| `scripts/f_cut_fillers_sparsest_2026_08_15.py:131` | 96-map winner | unique support-26 map is outside `F_cut` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit and counted in `supp(f)` |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut`; the eight fillers | the support domain is this class on this seed; other seeds are unclaimed |
+| per block | yes: the pair `(m_cut, N_min_cut)` | uniqueness of `f_L1` fails because the unique minimizer is `(1,0,1,0,0)` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does fill this patch from the 1-site seed, does lie in `F_cut`, and has a
+definite support `56`. That positive member does not make `f_L1` the
+sparsest `F_cut` filler and does not select it as the physical rule. The
+remaining physical choice — which, if any, `F_cut` map is the
+Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f_L1` might still be the unique sparsest
+map once one restricts to cells that occur along its own 1-site filling
+trajectory, so a “dynamically occurring support” could restore uniqueness.
+That objection is correctly about a smaller class. It does not overturn
+the stated theorem: among all eight `F_cut` fillers, the unique
+support-minimizer is the displayed tuple `(1, 0, 1, 0, 0)`, whose support
+is `36` rather than `56`. That is a class-level extra sparser filler, not
+a trajectory-level identity.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the eight fillers, and their supports are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/CUBIC_NN_CONDITION_DOMAIN_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-13.md` | nearest-neighbor condition domain | the six-direction occupancy stencil is the Boolean shadow of that domain |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `F_cut` support census or restores
+uniqueness of `f_L1` as the sparsest of the eight.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact pair `(m_cut, N_min_cut)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube, isolates the eight fillers,
+computes `supp` on each, reports `m_cut = 36` and `N_min_cut = 1`, checks
+that `f_L1` fills with `supp(f_L1)=56` and is not Hamming parity, and
+exhibits the displayed unique minimizer `(1, 0, 1, 0, 0)`. Declared audit
+inputs are this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15728,
- "node_count": 5530,
+ "edge_count": 15729,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_fillers_sparsest_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_fillers_sparsest_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_fillers_sparsest_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_fillers_sparsest_2026_08_15.py
+runner_sha256: 3e19eef145a63102eebd86c70d81cfa276cd0ae5ec6669e0826574e194d641a2
+input_fingerprint_sha256: efd8ce7d4e883640c0157ab3ff378899b909e31ac735282c485d7842ab954e8c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none; two-cube patch, seed, and off-patch o=0 are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact finite census on 64 cells, 32 F_cut maps, and 12 vertices; no physical selector
+negative_scope: sparsity among the eight F_cut 1-site fillers does not select f_L1
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_FILLERS_SPARSEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+N_free=5
+|F_cut|=32
+N_fill_cut=8
+f_L1_bits=(1, 0, 1, 1, 1) supp=56 locks=12 history=(1, 4, 8, 11, 12)
+f_hamming_bits=(1, 0, 0, 1, 1) locks=9 history=(1, 4, 5, 7, 9)
+global_min_bits=(1, 0, 1, 1, 0) in_F_cut=False
+fillers=(1, 0, 1, 0, 0):36,(1, 1, 1, 0, 0):42,(1, 0, 1, 1, 0):44,(1, 1, 1, 1, 0):50,(1, 0, 1, 0, 1):48,(1, 1, 1, 0, 1):54,(1, 0, 1, 1, 1):56,(1, 1, 1, 1, 1):62
+m_cut=36
+N_min_cut=1
+displayed_minimizer=(1, 0, 1, 0, 0)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-eight-fillers exactly eight F_cut maps fill from the 1-site seed
+PASS: thm1-l1-in-f-cut-and-fills f_L1 lies in F_cut, fills, and is one of the eight
+PASS: thm1-l1-support-56 supp(f_L1)=56, equivalently 64 minus the 8 fully balanced cells
+PASS: thm1-l1-not-hamming f_L1 is n!=0 / unbalanced-axis, not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-twelve the two-cube has twelve vertices and contains the seed
+PASS: thm2-m-cut m_cut = min supp over the eight equals 36
+PASS: thm2-n-min-cut N_min_cut = 1: exactly one of the eight attains m_cut
+PASS: thm3-unique-is-not-l1 the unique F_cut support-minimizer is not f_L1
+PASS: thm3-displayed-tuple the displayed minimizer is the remaining-bit tuple (1, 0, 1, 0, 0)
+PASS: mutation-global-min-outside-f-cut the unique support-26 filler among the 96 is outside F_cut
+PASS: mutation-hamming-nine-locks Hamming parity is in F_cut but is not a filler
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: displayed-not-adopted the F_cut minimizer and f_L1 are displayed, not adopted
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: claim-scope-minimum claim_scope reports m_cut=36, N_min_cut=1, and that f_L1 is not the unique minimizer
+PASS: not-leftover-of-ninetysix the residual is F_cut sparsity, not the 96-map support minimum
+PASS: no-cache-write this run did not emit a runner cache file
+per_element: checked exactly — each of the 64 cells is assigned by orbit and counted in supp(f)
+per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0
+per_mode: checked exactly — every F_cut map is run; the eight fillers are the support domain
+per_block: checked exactly — unique F_cut support minimum 36 is not attained by f_L1
+lattice_wide: checked and not executed — no infinite-lattice fill or adopted occupancy axiom is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_fillers_sparsest_2026_08_15.py
+++ b/scripts/f_cut_fillers_sparsest_2026_08_15.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Support-minimizer census among the eight F_cut 1-site two-cube fillers.
+
+Recomputes the 24 proper cube rotations, the 10 orbits on {0,1}^6, and the
+32-element three-cut class F_cut (f(empty)=f(full)=0 and f(c)=f(1-c)).
+Fills the twelve-vertex two-cube from a 1-site seed with off-patch
+occupancy 0. Among the eight F_cut fillers, reports the minimal support
+and whether f_L1 (some axis unbalanced; never Hamming parity) is the
+unique minimizer.
+
+No axiom edit, no cache write, no citation-manifest write.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_FILLERS_SPARSEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+BitTuple = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: Site = (0, 0, 0)
+
+# Remaining free F_cut bits, in the displayed order
+# (wt1, opp2, adj2, vertex3, mixed3).
+WT1: OrbitType = (1, 0, 2)
+OPP2: OrbitType = (0, 1, 2)
+ADJ2: OrbitType = (2, 0, 1)
+VERTEX3: OrbitType = (3, 0, 0)
+MIXED3: OrbitType = (1, 1, 1)
+L1_BITS: BitTuple = (1, 0, 1, 1, 1)
+ORBIT_PAIR_SIZE = {
+    WT1: 12,  # (1,0,2) and (1,2,0)
+    OPP2: 6,  # (0,1,2) and (0,2,1)
+    ADJ2: 24,  # (2,0,1) and (2,1,0)
+    VERTEX3: 8,
+    MIXED3: 12,
+}
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_global_min(config: Config) -> int:
+    """Unique support-26 filler among the 96; outside F_cut. Not adopted."""
+    if config == EMPTY:
+        return 0
+    return int(
+        config[0] + config[1] <= 1
+        and config[2] + config[3] <= 1
+        and config[4] + config[5] <= 1
+    )
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_kind = axis_type(config)
+        if any(axis_type(member) != orbit_kind for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_kind] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, tuple[int, ...]]:
+    locked = {SEED}
+    history = [len(locked)]
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, tuple(history)
+
+
+def bits_from_predicate(
+    predicate,
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> BitTuple:
+    assignment: dict[OrbitType, int] = {}
+    for orbit_kind in orbit_types:
+        sample = next(iter(orbits[orbit_kind]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_kind]):
+            raise RuntimeError("predicate is not cube-covariant")
+        assignment[orbit_kind] = value
+    return (
+        assignment[WT1],
+        assignment[OPP2],
+        assignment[ADJ2],
+        assignment[VERTEX3],
+        assignment[MIXED3],
+    )
+
+
+def assignment_from_bits(bits: BitTuple) -> dict[OrbitType, int]:
+    assignment = {
+        (0, 0, 3): 0,
+        (0, 3, 0): 0,
+        WT1: bits[0],
+        (1, 2, 0): bits[0],
+        OPP2: bits[1],
+        (0, 2, 1): bits[1],
+        ADJ2: bits[2],
+        (2, 1, 0): bits[2],
+        VERTEX3: bits[3],
+        MIXED3: bits[4],
+    }
+    return assignment
+
+
+def predicate_from_bits(bits: BitTuple, type_of: dict[Config, OrbitType]):
+    assignment = assignment_from_bits(bits)
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def complement_cell(config: Config) -> Config:
+    return (1 - config[0], 1 - config[1], 1 - config[2], 1 - config[3], 1 - config[4], 1 - config[5])
+
+
+def predicate_in_f_cut(predicate) -> bool:
+    if int(predicate(EMPTY)) != 0 or int(predicate(FULL)) != 0:
+        return False
+    return all(
+        int(predicate(config)) == int(predicate(complement_cell(config)))
+        for config in product((0, 1), repeat=6)
+    )
+
+
+def in_f_cut(bits: BitTuple) -> bool:
+    return predicate_in_f_cut(predicate_from_bits(bits, {
+        config: axis_type(config) for config in product((0, 1), repeat=6)
+    }))
+
+
+def support_of_bits(bits: BitTuple) -> int:
+    return (
+        ORBIT_PAIR_SIZE[WT1] * bits[0]
+        + ORBIT_PAIR_SIZE[OPP2] * bits[1]
+        + ORBIT_PAIR_SIZE[ADJ2] * bits[2]
+        + ORBIT_PAIR_SIZE[VERTEX3] * bits[3]
+        + ORBIT_PAIR_SIZE[MIXED3] * bits[4]
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    empty_type = (0, 0, 3)
+    full_type = (0, 3, 0)
+    for orbit_kind in orbit_types:
+        if orbit_kind in used:
+            continue
+        image = complement_type(orbit_kind)
+        if image == orbit_kind:
+            fixed.append(orbit_kind)
+        else:
+            pair = tuple(sorted((orbit_kind, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_kind)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_kind for orbit_kind in fixed if orbit_kind not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def census_f_cut_fillers(
+    type_of: dict[Config, OrbitType],
+) -> list[tuple[BitTuple, int, int, tuple[int, ...]]]:
+    fillers: list[tuple[BitTuple, int, int, tuple[int, ...]]] = []
+    for mask in range(32):
+        bits: BitTuple = (
+            (mask >> 0) & 1,
+            (mask >> 1) & 1,
+            (mask >> 2) & 1,
+            (mask >> 3) & 1,
+            (mask >> 4) & 1,
+        )
+        n_locks, halt_tick, history = run_predicate(predicate_from_bits(bits, type_of))
+        if n_locks == 12:
+            fillers.append((bits, support_of_bits(bits), halt_tick, history))
+    return fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("external_scientific_inputs: none; two-cube patch, seed, and off-patch o=0 are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact finite census on 64 cells, 32 F_cut maps, and 12 vertices; no physical selector")
+    print("negative_scope: sparsity among the eight F_cut 1-site fillers does not select f_L1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_kind: len(orbits[orbit_kind]) for orbit_kind in orbit_types}
+    type_of = {
+        config: orbit_kind for orbit_kind, members in orbits.items() for config in members
+    }
+    free_pairs, free_fixed = f_cut_free_data(orbit_types)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    global_min_bits = bits_from_predicate(f_global_min, orbit_types, orbits)
+    l1_locks, l1_halt, l1_history = run_predicate(f_L1)
+    ham_locks, _ham_halt, ham_history = run_predicate(f_hamming)
+    l1_support = support_of_bits(l1_bits)
+    l1_support_direct = sum(1 for cell in product((0, 1), repeat=6) if f_L1(cell))
+
+    fillers = census_f_cut_fillers(type_of)
+    n_fill = len(fillers)
+    supports = [support for _bits, support, _halt, _history in fillers]
+    m_cut = min(supports)
+    n_min_cut = sum(1 for support in supports if support == m_cut)
+    min_bits_list = [bits for bits, support, _halt, _history in fillers if support == m_cut]
+    displayed_min = min_bits_list[0] if len(min_bits_list) == 1 else None
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"N_fill_cut={n_fill}")
+    print(f"f_L1_bits={l1_bits} supp={l1_support} locks={l1_locks} history={l1_history}")
+    print(f"f_hamming_bits={ham_bits} locks={ham_locks} history={ham_history}")
+    print(
+        f"global_min_bits={global_min_bits} "
+        f"in_F_cut={predicate_in_f_cut(f_global_min)}"
+    )
+    print("fillers=" + ",".join(f"{bits}:{support}" for bits, support, _h, _hist in fillers))
+    print(f"m_cut={m_cut}")
+    print(f"N_min_cut={n_min_cut}")
+    print(f"displayed_minimizer={displayed_min}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_FILLERS_SPARSEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_FILLERS_SPARSEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2,
+    )
+    checks.check(
+        "thm1-eight-fillers",
+        "exactly eight F_cut maps fill from the 1-site seed",
+        n_fill == 8 and n_fill == len(set(bits for bits, _s, _h, _hist in fillers)),
+    )
+    checks.check(
+        "thm1-l1-in-f-cut-and-fills",
+        "f_L1 lies in F_cut, fills, and is one of the eight",
+        l1_bits == L1_BITS
+        and in_f_cut(l1_bits)
+        and l1_locks == 12
+        and l1_halt == 4
+        and l1_history == (1, 4, 8, 11, 12)
+        and any(bits == l1_bits for bits, _s, _h, _hist in fillers),
+    )
+    checks.check(
+        "thm1-l1-support-56",
+        "supp(f_L1)=56, equivalently 64 minus the 8 fully balanced cells",
+        l1_support == 56
+        and l1_support_direct == 56
+        and l1_support == support_of_bits(L1_BITS),
+    )
+    checks.check(
+        "thm1-l1-not-hamming",
+        "f_L1 is n!=0 / unbalanced-axis, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-twelve",
+        "the two-cube has twelve vertices and contains the seed",
+        len(TWO_CUBE) == 12 and len(set(TWO_CUBE)) == 12 and SEED in TWO_CUBE,
+    )
+    checks.check(
+        "thm2-m-cut",
+        f"m_cut = min supp over the eight equals {m_cut}",
+        m_cut == 36 and all(support >= 36 for support in supports),
+    )
+    checks.check(
+        "thm2-n-min-cut",
+        "N_min_cut = 1: exactly one of the eight attains m_cut",
+        n_min_cut == 1 and len(min_bits_list) == 1,
+    )
+    checks.check(
+        "thm3-unique-is-not-l1",
+        "the unique F_cut support-minimizer is not f_L1",
+        n_min_cut == 1
+        and displayed_min is not None
+        and displayed_min != l1_bits
+        and l1_support == 56
+        and l1_support > m_cut,
+    )
+    checks.check(
+        "thm3-displayed-tuple",
+        "the displayed minimizer is the remaining-bit tuple (1, 0, 1, 0, 0)",
+        displayed_min == (1, 0, 1, 0, 0)
+        and support_of_bits((1, 0, 1, 0, 0)) == 36
+        and in_f_cut((1, 0, 1, 0, 0))
+        and run_predicate(predicate_from_bits((1, 0, 1, 0, 0), type_of))[0] == 12,
+    )
+    checks.check(
+        "mutation-global-min-outside-f-cut",
+        "the unique support-26 filler among the 96 is outside F_cut",
+        not predicate_in_f_cut(f_global_min)
+        and global_min_bits != l1_bits
+        and sum(1 for cell in product((0, 1), repeat=6) if f_global_min(cell)) == 26
+        and any(
+            f_global_min(config) != f_global_min(complement_cell(config))
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "mutation-hamming-nine-locks",
+        "Hamming parity is in F_cut but is not a filler",
+        in_f_cut(ham_bits)
+        and ham_locks == 9
+        and ham_history == (1, 4, 5, 7, 9)
+        and ham_bits not in {bits for bits, _s, _h, _hist in fillers},
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom
+        and "proper cubic rotations about each site" in note
+        and "one fixed nearest-neighbor admissibility rule" in note,
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note
+        and "never Hamming" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the F_cut minimizer and f_L1 are displayed, not adopted",
+        "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "claim-scope-minimum",
+        "claim_scope reports m_cut=36, N_min_cut=1, and that f_L1 is not the unique minimizer",
+        "minimal support is 36" in note
+        and "N_min_cut = 1" in note
+        and "f_L1 is not the unique minimizer" in note,
+    )
+    checks.check(
+        "not-leftover-of-ninetysix",
+        "the residual is F_cut sparsity, not the 96-map support minimum",
+        "Not leftover-character of the 96-map support minimum" in note
+        and "outside `F_cut`" in note,
+    )
+    cache_probe = ROOT / "logs" / ("runner" + "-cache") / (
+        "f_cut_fillers_sparsest_2026_08_15.txt"
+    )
+    checks.check(
+        "no-cache-write",
+        "this run did not emit a runner cache file",
+        not cache_probe.is_file(),
+    )
+
+    print("per_element: checked exactly — each of the 64 cells is assigned by orbit and counted in supp(f)")
+    print("per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0")
+    print("per_mode: checked exactly — every F_cut map is run; the eight fillers are the support domain")
+    print("per_block: checked exactly — unique F_cut support minimum 36 is not attained by f_L1")
+    print("lattice_wide: checked and not executed — no infinite-lattice fill or adopted occupancy axiom is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the eight F_cut 1-site fillers on the two-cube with off-patch o=0, unique minimal support is 36 at remaining-bit tuple (1,0,1,0,0). f_L1 has supp=56 and is not the minimizer. Displayed, not adopted. f_L1 is n≠0 / unbalanced axis, not Hamming.

## Runner

`scripts/f_cut_fillers_sparsest_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.