### PR TITLE
feat(cut2list): list four F_cut 2-site filler remaining-bit tuples

### DIFF
--- a/docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,411 @@
+---
+claim_id: f_cut_two_site_filler_tuples_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The four F_cut maps that fill the two-cube from the face-diagonal 2-site seed with off-patch o=0 are classified by their (wt1, opp2, adj2, vertex3, mixed3) tuples. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_two_site_filler_tuples_2026_08_15.py
+---
+
+# Four `F_cut` 2-Site Filler Remaining-Bit Tuples
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact remaining-bit taxonomy of the four cube-covariant
+complement-even maps that fill the twelve-vertex two-cube from the
+face-diagonal 2-site seed `{(0,0,0),(1,1,0)}` with off-patch occupancy
+`0`. Each filler is named once by its `(wt1, opp2, adj2, vertex3,
+mixed3)` tuple. The four tuples are displayed rival members. None is
+adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_two_site_filler_tuples_2026_08_15.py`](../scripts/f_cut_two_site_filler_tuples_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut|=32`. On the two-cube
+`{0,1,2}×{0,1}×{0,1}`, seed `{(0,0,0),(1,1,0)}` starts locked. Off-patch
+neighbors have occupancy `0`. Each tick, every unlocked on-patch vertex
+evaluates `f` on its six-neighbor occupancy tuple and locks if `f=1`.
+Fill means `|locks_halt|=12`. Reconstructing that dynamics on every map
+in `F_cut` yields exactly four fillers.
+
+Investment #6413 counted `N_cut2=4` and displayed one non-L1 tuple
+`(1, 0, 1, 1, 0)`. That only counted 4. It did not name the four members.
+Investment #6410 named eight remaining-bit tuples; those eight are 1-site
+fillers. This note is the four-member 2-site taxonomy, not a second
+count of four and not the 1-site eight.
+
+The axis type of a 6-tuple `c` is the triple `(u,b,e)` with `u+b+e=3`,
+where `u` is the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`.
+The remaining free orbits after the vanish cuts, and the names used here,
+are
+
+| name | `(u,b,e)` | geometric reading |
+|---|---|---|
+| `wt1` | `(1,0,2)` | one-axis contrast; a 1-site wave |
+| `opp2` | `(0,1,2)` | opposite pair; balanced axis |
+| `adj2` | `(2,0,1)` | two-axis contrast |
+| `vertex3` | `(3,0,0)` | three-axis contrast; cube-vertex type |
+| `mixed3` | `(1,1,1)` | mixed triple |
+
+Complement-even forces `wt5=wt1`, `adj4=adj2`, and `opp4=opp2`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+**Theorem 1.** `f_L1` is one of the four and its tuple is
+`(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 1)`. Another of the
+four is `(1, 0, 1, 1, 0)`.
+
+**Theorem 2.** The four remaining-bit tuples, listed once each in
+lexicographic order, are
+
+```text
+(1, 0, 1, 1, 0)
+(1, 0, 1, 1, 1)
+(1, 1, 1, 1, 0)
+(1, 1, 1, 1, 1)
+```
+
+```text
+N_distinct = 4.
+```
+
+Exactly one row is `(1, 0, 1, 1, 1)`.
+
+**Theorem 3.** The four tuples are the displayed 2-site `F_cut` rivals.
+Do not adopt any. Do not write the table into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the four F_cut 2-site fillers, membership of f_L1, the displayed other tuple (1, 0, 1, 1, 0), the four remaining-bit tuples, and N_distinct=4 are enumerated. The table is displayed, not written into Admissibility."
+trace_class: upstream_support
+target_claim_id: f_cut_two_site_filler_tuples
+target_blocker_text: "the four F_cut 2-site fillers remain unnamed as remaining-bit tuples"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the four-tuple 2-site taxonomy; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for the four F_cut 2-site fillers on this twelve-vertex patch with off-patch o=0 and the face-diagonal seed; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the face-diagonal 2-site seed `{(0,0,0),(1,1,0)}`;
+- the named remaining bits `wt1`, `opp2`, `adj2`, `vertex3`, `mixed3`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of #6413. That only counted 4 and displayed one
+non-L1 tuple. Not leftover-character of #6410: those eight are 1-site fillers.
+This note lists each remaining 2-site filler once.
+
+## Exact Target And Objects
+
+**Target.** Name each of the four `F_cut` maps that fill from the
+face-diagonal 2-site seed by its remaining-bit tuple, count the distinct
+tuples, and record that `f_L1` is one named row.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The ten axis-type classes `(u,b,e)` are exactly the ten orbits. Complement
+sends `(u,b,e)` to `(u,e,b)`.
+
+| `(u,b,e)` | name | orbit size | complement image |
+|---|---|---:|---|
+| `(0,0,3)` | empty | 1 | `(0,3,0)` full |
+| `(0,3,0)` | full | 1 | `(0,0,3)` empty |
+| `(0,1,2)` | `opp2` | 3 | `(0,2,1)` `opp4` |
+| `(0,2,1)` | `opp4` | 3 | `(0,1,2)` `opp2` |
+| `(1,0,2)` | `wt1` | 6 | `(1,2,0)` `wt5` |
+| `(1,2,0)` | `wt5` | 6 | `(1,0,2)` `wt1` |
+| `(2,0,1)` | `adj2` | 12 | `(2,1,0)` `adj4` |
+| `(2,1,0)` | `adj4` | 12 | `(2,0,1)` `adj2` |
+| `(1,1,1)` | `mixed3` | 12 | `(1,1,1)` |
+| `(3,0,0)` | `vertex3` | 8 | `(3,0,0)` |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+The four fillers are the maps in `F_cut` whose halt set from this seed
+has cardinality 12. Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1.
+```
+
+The remaining-bit tuple of a filler is the assignment
+`(wt1,opp2,adj2,vertex3,mixed3)`. Complements are forced, so the tuple
+names the map inside `F_cut`. `N_distinct` is the number of distinct
+tuples among the four fillers.
+
+Do not write the table into Admissibility.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. Exactly four
+members of `F_cut` fill the twelve-vertex two-cube from seed
+`{(0,0,0),(1,1,0)}` with off-patch occupancy `0`. The unbalanced-axis
+map `f_L1` is one of those four. It is not Hamming parity. Its
+remaining-bit tuple is `(wt1,opp2,adj2,vertex3,mixed3)=(1, 0, 1, 1, 1)`,
+and complement-even forces `wt5=1`, `adj4=1`, `opp4=0`. Its lock
+cardinalities are `(2,7,11,12)` and its halt tick is `3`. Another of the
+four is `(1, 0, 1, 1, 0)`.
+
+**Theorem 2.** Exhaustive naming of the four reconstructed fillers
+gives the four tuples listed above and
+
+```text
+N_distinct = 4.
+```
+
+Exactly one row is `(1, 0, 1, 1, 1)`.
+
+**Theorem 3.** The four tuples are the displayed 2-site `F_cut` rivals.
+None is adopted. The table is not an Admissibility clause.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| four fillers | exhaustive 32-run census of `F_cut` to a fixed point with `|locks|=12` from this seed |
+| `f_L1` is in the four | halt set has cardinality 12 at tick 3 |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit `adj2` has even weight and `f_L1=1` |
+| L1 bit tuple | `(1, 0, 1, 1, 1)` |
+| displayed other | remaining-bit tuple `(1, 0, 1, 1, 0)` is a second filler |
+| four tuples | lexicographic list of the four remaining-bit assignments |
+| `N_distinct` | four distinct tuples |
+| unique L1 row | exactly one of the four equals `(1, 0, 1, 1, 1)` |
+| no Admissibility rewrite | displayed rival members only |
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming does not fill from this seed.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Drop complement-even or the vanish-on-full cut: the class is no longer
+   the 32-element `F_cut`.
+4. Seed only `(0,0,0)`: the 1-site eight-tuple table is a different
+   residual.
+5. Collapse the four rows to the count `N_cut2=4`: that is leftover
+   character of #6413, not this taxonomy.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the `N_cut2=4` count, and no
+  restatement of the eight 1-site filler tuples, in place of the
+  four-tuple 2-site table.
+- No blank-block or 3-site variant.
+- No axiom edit: the table is displayed, not written into Admissibility.
+
+## No-Go Discipline Gate
+
+The only negative claim is that the four members are not a single
+unnamed class: they are four named tuples, and only one of those
+tuples is L1. The taxonomy is an exact enumeration, not a wall, and it
+is not an Admissibility clause.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| four-filler reconstruction | Run every map in `F_cut` to a fixed point from this seed and keep `|locks|=12`. | Theorem 1 and check `thm1-four-fillers` give four fillers. | **ATTEMPTED** |
+| L1 membership and tuple | Evaluate `f_L1` on the named orbits and on the two-cube. | Theorem 1 and check `thm1-f-L1-in-four-and-tuple`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| four-tuple taxonomy | Name each filler by `(wt1,opp2,adj2,vertex3,mixed3)` and count distinct rows. | Theorem 2 and checks `thm2-four-tuples-listed` / `thm2-n-distinct`. | **ATTEMPTED** |
+| unique L1 row and displayed other | Count L1 rows and exhibit `(1, 0, 1, 1, 0)`. | Theorem 1–2 and checks `thm1-displayed-other-tuple` / `thm2-exactly-one-l1-row`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: the four members are not anonymous,
+and L1 is not the whole table. The distinct-tuple count and the unique
+L1-row count are two certificates of the same table, so they collapse
+rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_distinct=4` / unique L1 row | no: four distinct rows do not name which row is L1 | no: a unique L1 row does not force four distinct rows | independent table properties |
+| four-filler count / four-tuple table | no: membership in the four does not name the tuples | no: a tuple table does not replace the fill census | separate exact objects |
+| displayed `(1, 0, 1, 1, 0)` / unique L1 row | yes: a second named row is non-uniqueness of L1 | yes: uniqueness of the L1 row plus four rows requires a non-L1 row | collapse into the named-table claim |
+| 1-site eight / this four-tuple table | no: a different seed | no: this seed does not classify the 1-site eight | different seed, different residual |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| the four fillers | explicit `F_cut` 2-site fill set; the other 28 maps in `F_cut` are excluded |
+| remaining-bit tuples | explicit orbit bits; not leftover-character of #6413 or #6410 |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| `N_distinct=4` | displayed taxonomy inside the four, not an Admissibility clause |
+| face-diagonal 2-site seed | explicit seed; the 1-site eight is a different residual |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_two_site_filler_tuples_2026_08_15.py:79` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_two_site_filler_tuples_2026_08_15.py:124` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_two_site_filler_tuples_2026_08_15.py:129` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_two_site_filler_tuples_2026_08_15.py:54` | remaining bits | named tuple `(wt1,opp2,adj2,vertex3,mixed3)` | yes |
+| `scripts/f_cut_two_site_filler_tuples_2026_08_15.py:267` | four-filler reconstruction | `F_cut` maps with `|locks|=12` from this seed | yes |
+| `scripts/f_cut_two_site_filler_tuples_2026_08_15.py:350` | `N_distinct` | distinct remaining-bit tuples among the four | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut`, then every 2-site filler | the taxonomy is this class on this seed; other seeds are unclaimed |
+| per block | yes: the four-tuple table | `N_distinct` and the unique L1 row are table properties |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: the
+four `F_cut` 2-site fillers are named by remaining-bit tuples, and L1
+is exactly one of those four rows. That table does not write the tuples
+into Admissibility and does not select `f_L1` as the physical rule. The
+remaining physical choice — which, if any, occupancy predicate is the
+Admissibility rule — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that the five remaining bits *are* the free
+data of `F_cut`, so listing four tuples is leftover-character of the
+`N_cut2=4` count: among four maps that already vary on `(opp2,mixed3)`
+with `wt1=adj2=vertex3=1` forced by fill, writing the four combinations
+is tautological. That objection is correctly about the algebraic shape
+of the four. It does not overturn the stated theorem. #6413 counted four
+and displayed one non-L1 tuple; the members stayed unnamed. The object
+here is the four-row table itself. A collision (`N_distinct<4`) would
+have been displayed. It does not occur.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+four fillers, remaining-bit tuples, and `N_distinct` are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| [`docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md`](ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md) | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| [`docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md`](PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md) | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| [`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+The `N_cut2=4` count #6413 and the 1-site eight-tuple table #6410 are
+the leftover-character this note refuses to repeat. They are not parents
+and do not close the four-tuple 2-site taxonomy.
+
+No earlier mechanism names the four 2-site members or writes the table
+into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the four-tuple taxonomy,
+`N_distinct = 4`, and the unique L1 row stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, reconstructs the four 2-site fillers, checks that `f_L1` is
+among them with tuple `(1, 0, 1, 1, 1)`, checks that `(1, 0, 1, 1, 0)`
+is another filler, lists the four remaining-bit tuples, and reports
+`N_distinct = 4`. Declared audit inputs are this note and the axiom
+memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5530,
+ "edge_count": 15734,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4657,6 +4657,10 @@
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
+  },
+  "f_cut_two_site_filler_tuples_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "77195208e16c",
+   "out_degree": 3
   },
   "f_wedge_f_top_form_forces_d_four_narrow_theorem_note_2026-05-26": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/f_cut_two_site_filler_tuples_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_two_site_filler_tuples_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_two_site_filler_tuples_2026_08_15.py
+runner_sha256: 5a4cdaed3293ff0997a0a32a708eba2aff00c8cee75e046717daf4e248a33dba
+input_fingerprint_sha256: f7c6b1e512eb9d363cd8f23a7fc9288fa8a9b31804a54d029c9b5255071ff739
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+|F_cut|=32
+N_cut2=4
+L1_tuple={'wt1': 1, 'opp2': 0, 'adj2': 1, 'vertex3': 1, 'mixed3': 1}
+four_tuples=(1, 0, 1, 1, 0),(1, 0, 1, 1, 1),(1, 1, 1, 1, 0),(1, 1, 1, 1, 1)
+N_distinct=4
+n_l1_rows=1
+displayed_other=(1, 0, 1, 1, 0) present=True
+f_L1_locks=12 halt=3 history=(2, 7, 11, 12)
+hamming_locks=9
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 axis-type orbits partition the 64 cells
+PASS: thm1-named-orbit-types wt1/opp2/adj2/vertex3/mixed3 are the listed axis-type orbits
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_- (n != 0)
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f-L1-in-four-and-tuple f_L1 is one of the four and its tuple is (1, 0, 1, 1, 1)
+PASS: thm1-displayed-other-tuple another of the four is remaining-bit tuple (1, 0, 1, 1, 0)
+PASS: thm1-four-fillers exactly four F_cut maps fill from the face-diagonal 2-site seed
+PASS: thm1-two-cube-and-seed the two-cube has twelve vertices and contains both face-diagonal seed sites
+PASS: thm2-four-tuples-listed the note lists each reconstructed remaining-bit tuple once
+PASS: thm2-n-distinct N_distinct = 4 is the number of distinct remaining-bit tuples
+PASS: thm2-exactly-one-l1-row exactly one of the four rows is (1, 0, 1, 1, 1)
+PASS: thm3-displayed-not-adopted the four tuples are displayed 2-site F_cut rivals and none is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted taxonomy, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the four-tuple table is not written into Admissibility
+PASS: not-leftover-count-or-onesite the residual is the four-member 2-site taxonomy, not the count or the 1-site eight
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-scope-taxonomy claim_scope classifies the four 2-site F_cut fillers by remaining-bit tuples
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is classified as 2-site filler or not, then named by its remaining-bit tuple
+per_block: checked exactly — N_distinct and the unique L1 row are properties of the four-tuple table
+lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_two_site_filler_tuples_2026_08_15.py
+++ b/scripts/f_cut_two_site_filler_tuples_2026_08_15.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Four F_cut 2-site filler remaining-bit tuples on the two-cube.
+
+Reconstruct the 24 proper cube rotations, the ten axis-type orbits, the
+32-element three-cut class F_cut, and the maps that fill the
+twelve-vertex two-cube from the face-diagonal 2-site seed
+{(0,0,0),(1,1,0)} with off-patch occupancy 0. Each filler is named once
+by its remaining-bit tuple (wt1, opp2, adj2, vertex3, mixed3).
+Complements are forced by F_cut. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: frozenset[Site] = frozenset(((0, 0, 0), (1, 1, 0)))
+
+# Remaining bits of F_cut after empty and full are forced to 0.
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+BIT_TYPES: dict[str, OrbitType] = {
+    "wt1": (1, 0, 2),
+    "opp2": (0, 1, 2),
+    "adj2": (2, 0, 1),
+    "vertex3": (3, 0, 0),
+    "mixed3": (1, 1, 1),
+}
+COMPLEMENT_NAMES: dict[str, str] = {
+    "wt1": "wt5",
+    "opp2": "opp4",
+    "adj2": "adj4",
+}
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+DISPLAYED_OTHER: tuple[int, ...] = (1, 0, 1, 1, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    """Identity gate: axis type is (n_unbalanced, n_both, n_empty)."""
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, bool, tuple[int, ...]]:
+    locked = set(SEED)
+    history = [len(locked)]
+    first_wave_empty = False
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if tick == 0:
+            first_wave_empty = nxt == locked
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, first_wave_empty, tuple(history)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def named_tuple_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[BIT_TYPES[name]] for name in BIT_NAMES)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def census_f_cut_fillers(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[int, ...]]:
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    fillers: list[tuple[int, ...]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        n_locks, _halt, _first_empty, _history = run_predicate(
+            predicate_from_bits(bits, orbit_types, type_of)
+        )
+        if n_locks == 12:
+            fillers.append(bits)
+    return fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_assign = dict(zip(orbit_types, l1_bits, strict=True))
+    l1_named = named_tuple_from_assignment(l1_assign)
+    l1_locks, l1_halt, l1_first_empty, l1_history = run_predicate(f_L1)
+    ham_locks, _ham_halt, _ham_first, _ham_history = run_predicate(f_hamming)
+
+    fillers = census_f_cut_fillers(orbit_types, orbits, empty_type, full_type)
+    filler_named = [
+        named_tuple_from_assignment(dict(zip(orbit_types, bits, strict=True)))
+        for bits in fillers
+    ]
+    tuples_sorted = tuple(sorted(filler_named))
+    n_distinct = len(set(filler_named))
+    n_l1_rows = sum(1 for named in filler_named if named == L1_TUPLE)
+    n_other_rows = sum(1 for named in filler_named if named == DISPLAYED_OTHER)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"|F_cut|={n_cut}")
+    print(f"N_cut2={len(fillers)}")
+    print(f"L1_tuple={dict(zip(BIT_NAMES, l1_named))}")
+    print("four_tuples=" + ",".join(str(named) for named in tuples_sorted))
+    print(f"N_distinct={n_distinct}")
+    print(f"n_l1_rows={n_l1_rows}")
+    print(f"displayed_other={DISPLAYED_OTHER} present={n_other_rows == 1}")
+    print(f"f_L1_locks={l1_locks} halt={l1_halt} history={l1_history}")
+    print(f"hamming_locks={ham_locks}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_TWO_SITE_FILLER_TUPLES_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 axis-type orbits partition the 64 cells",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-named-orbit-types",
+        "wt1/opp2/adj2/vertex3/mixed3 are the listed axis-type orbits",
+        orbit_sizes == expected_sizes
+        and BIT_TYPES["wt1"] == (1, 0, 2)
+        and BIT_TYPES["opp2"] == (0, 1, 2)
+        and BIT_TYPES["adj2"] == (2, 0, 1)
+        and BIT_TYPES["vertex3"] == (3, 0, 0)
+        and BIT_TYPES["mixed3"] == (1, 1, 1),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_- (n != 0)",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-f-L1-in-four-and-tuple",
+        "f_L1 is one of the four and its tuple is (1, 0, 1, 1, 1)",
+        in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and l1_bits in fillers
+        and l1_named == L1_TUPLE
+        and l1_locks == 12
+        and l1_halt == 3
+        and not l1_first_empty
+        and l1_history == (2, 7, 11, 12),
+    )
+    checks.check(
+        "thm1-displayed-other-tuple",
+        "another of the four is remaining-bit tuple (1, 0, 1, 1, 0)",
+        DISPLAYED_OTHER in filler_named
+        and DISPLAYED_OTHER != L1_TUPLE
+        and n_other_rows == 1,
+    )
+    checks.check(
+        "thm1-four-fillers",
+        "exactly four F_cut maps fill from the face-diagonal 2-site seed",
+        len(fillers) == 4 and len(set(fillers)) == 4 and n_cut == 32,
+    )
+    checks.check(
+        "thm1-two-cube-and-seed",
+        "the two-cube has twelve vertices and contains both face-diagonal seed sites",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and SEED <= set(TWO_CUBE)
+        and (0, 0, 0) in TWO_CUBE
+        and (1, 1, 0) in TWO_CUBE,
+    )
+    checks.check(
+        "thm2-four-tuples-listed",
+        "the note lists each reconstructed remaining-bit tuple once",
+        all(str(named) in note for named in tuples_sorted)
+        and len(tuples_sorted) == 4,
+    )
+    checks.check(
+        "thm2-n-distinct",
+        f"N_distinct = {n_distinct} is the number of distinct remaining-bit tuples",
+        n_distinct == len(set(filler_named))
+        and n_distinct == 4
+        and f"N_distinct = {n_distinct}" in note,
+    )
+    checks.check(
+        "thm2-exactly-one-l1-row",
+        "exactly one of the four rows is (1, 0, 1, 1, 1)",
+        n_l1_rows == 1
+        and filler_named.count(L1_TUPLE) == 1
+        and ham_bits not in fillers,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the four tuples are displayed 2-site F_cut rivals and none is adopted",
+        "Displayed, not adopted" in note
+        and "Do not write the table into Admissibility" in note
+        and "four tuples are the displayed 2-site" in note_flat,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted taxonomy, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the four-tuple table is not written into Admissibility",
+        "Do not write the table into Admissibility" in note
+        and "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+    checks.check(
+        "not-leftover-count-or-onesite",
+        "the residual is the four-member 2-site taxonomy, not the count or the 1-site eight",
+        "Not leftover-character of #6413" in note
+        and "Not leftover-character of #6410" in note
+        and "those eight are 1-site fillers" in note
+        and "That only counted 4" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-scope-taxonomy",
+        "claim_scope classifies the four 2-site F_cut fillers by remaining-bit tuples",
+        "The four F_cut maps that fill the two-cube" in note
+        and "face-diagonal 2-site seed" in note
+        and "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is classified as 2-site filler or not, then named by its remaining-bit tuple")
+    print("per_block: checked exactly — N_distinct and the unique L1 row are properties of the four-tuple table")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The four F_cut maps that fill the two-cube from the face-diagonal seed {(0,0,0),(1,1,0)} with off-patch o=0 have remaining-bit tuples (1,0,1,1,0), (1,0,1,1,1), (1,1,1,1,0), (1,1,1,1,1). N_distinct=4. f_L1 is the unbalanced-axis / n≠0 map with tuple (1,0,1,1,1). Displayed, not adopted.

## Runner

`scripts/f_cut_two_site_filler_tuples_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.