### PR TITLE
feat(min2site): f_min fills from the face-diagonal 2-site seed

### DIFF
--- a/docs/F_MIN_TWO_SITE_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_MIN_TWO_SITE_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,312 @@
+---
+claim_id: f_min_two_site_fill_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the nonempty n_both=0 map f_min does fill from the face-diagonal 2-site seed. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_min_two_site_fill_2026_08_15.py
+---
+
+# The Nonempty n_both=0 Map Fills From The Face-Diagonal 2-Site Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact lock dynamics of two displayed cube-covariant maps on the
+twelve-site two-cube `{0,1,2}×{0,1}×{0,1}` with off-patch occupancy `o=0`,
+started from the face-diagonal seed `S={(0,0,0),(1,1,0)}`. The nonempty
+`n_both=0` map `f_min` is displayed, not adopted. It is not written into
+Admissibility.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_min_two_site_fill_2026_08_15.py`](../scripts/f_min_two_site_fill_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve lattice sites `{0,1,2}×{0,1}×{0,1}`. Off-patch
+nearest-neighbor slots carry occupancy `0`. A site starts locked exactly when
+it belongs to the seed. At each tick every unlocked site is inspected on its
+six-neighbor occupancy word `c`. The word is scored by axis type
+`(n_unbalanced, n_both, n_empty)` with
+`n_unbalanced + n_both + n_empty = 3`. The process halts when a tick adds no
+new lock.
+
+The displayed maps are:
+
+- `f_L1(c)=1` if and only if some axis is unbalanced (`n_unbalanced≥1`).
+  f_L1 is n≠0, not Hamming.
+- `f_min(c)=1` if and only if `n_both(c)=0` and some axis is unbalanced.
+
+On this seed, `f_L1` fills: `T=3`, `|locks_halt|=12`, lock history
+`(2, 7, 11, 12)`. The same run of `f_min` also fills: `T=3`,
+`|locks_halt|=12`, lock history `(2, 7, 11, 12)`. The two maps therefore
+have the same lock history on this seed. That agreement is a computed
+comparison, not an identity of the maps: they still disagree on the mixed3
+orbit `(1,1,1)`, and `f_min` is not in `F_cut`.
+
+Do not adopt `f_min`. Displayed, not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of Admissibility is to identify the local nearest-neighbor
+condition domain. The axiom does not specify lock-update values and
+does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no scalar collection functional, no finite additivity, and no
+value at absence. Using the computed locks as physical records would require a
+formation rule and a content/readout identification; both remain open. The
+lock process below is a displayed occupancy-to-readiness map on a finite
+patch, not a Record derivation.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The face-diagonal 2-site halt histories of f_min and f_L1 are finite exact enumerations on a 12-site patch; f_min is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_min_two_site_fill
+target_blocker_text: "whether the nonempty n_both=0 map fills from the face-diagonal 2-site seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded fill comparison; do not adopt f_min"
+conditional_surface_status: "exact on the twelve-site two-cube with off-patch o=0 and the displayed face-diagonal seed; no axiom edit and no physical formation compiler"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+The two-cube is the set
+
+```text
+V = {0,1,2} × {0,1} × {0,1},    |V| = 12.
+```
+
+Each site has six lattice neighbor slots, two per axis. A slot that lands
+outside `V` is off-patch and carries occupancy `o=0`. For a lock set `L`, the
+occupancy of a slot at `x±e_i` is `1` if that neighbor is in `L`, else `0` on
+`V`, else `o`. An axis is empty, unbalanced, or both-occupied according as its
+two slots contain `0`, `1`, or `2` locked neighbors.
+
+The axis-type orbits used to name cube-covariant maps are
+
+```text
+wt1=(1,0,2), opp2=(0,1,2), adj2=(2,0,1), vertex3=(3,0,0), mixed3=(1,1,1).
+```
+
+Empty is `(0,0,3)` and full is `(0,3,0)`. Complement of occupancy bits sends
+`(n_unbalanced, n_both, n_empty)` to `(n_unbalanced, n_empty, n_both)`. The
+class `F_cut` consists of the cube-covariant maps with `f(empty)=f(full)=0`
+and `f(c)=f(1-c)` for every six-bit word.
+
+On those orbits, `f_min` has bits `(1,0,1,1,0)` and `f_L1` has bits
+`(1,0,1,1,1)`. In particular `f_min(mixed3)=0` while `f_L1(mixed3)=1`, so
+the maps are distinct. Complement takes `wt1` to `(1,2,0)`, where
+`f_min=0`, so `f_min` is not complement-even and is not in `F_cut`. By
+contrast `n_unbalanced` is complement-invariant, `f_L1(empty)=f_L1(full)=0`,
+and `f_L1` does sit in `F_cut`.
+
+The seed is the face-diagonal pair `S={(0,0,0),(1,1,0)}`. Graph distance
+inside `V` is `2`; the pair is not a nearest-neighbor edge.
+
+A run of a map `f` is the nondecreasing lock-count tuple starting from `|S|`,
+updated synchronously by locking every unlocked site whose current six-neighbor
+word has `f=1`, until a tick adds nothing. Fill means `|locks_halt|=12`. The
+halt tick `T` is the last tick that added a lock.
+
+## Theorem 1 — `f_L1` fills from the face-diagonal seed
+
+Run `f_L1` from `S` with `o=0`. The first wave locks the five sites
+
+```text
+(0,0,1), (0,1,0), (1,0,0), (1,1,1), (2,1,0).
+```
+
+Each of those sites sees at least one unbalanced axis against the two seed
+locks. The second wave locks four further sites; the third wave locks the
+remaining site `(2,0,1)`. The run therefore has
+
+```text
+T=3,    |locks_halt|=12,    history (2, 7, 11, 12).
+```
+
+So `f_L1` fills from this seed. That is the same fill boolean previously
+displayed for this seed; it is recomputed here and is not imported as a
+status.
+
+## Theorem 2 — `f_min` fills from the same seed
+
+Run `f_min` from the same `S` with the same `o=0`. Every site that `f_L1`
+locks on this run has `n_both=0` at the tick it becomes ready, so `f_min`
+accepts the same words. The run has
+
+```text
+T=3,    |locks_halt|=12,    history (2, 7, 11, 12).
+```
+
+Therefore `f_min` fills from the face-diagonal 2-site seed. Fill is a
+computed halt fact on this finite patch, not an identity of `f_min` with
+`f_L1` and not a membership of `f_min` in `F_cut`.
+
+The 1-site seed `(0,0,0)` and the 3-site long-axis seed
+`{(0,0,0),(1,0,0),(2,0,0)}` are different seeds. Their lock histories
+`(1, 4, 8, 11, 12)` and `(3, 9, 12)` are recovered by the same engine as a
+sanity check; they are not this theorem.
+
+## Theorem 3 — comparison is displayed; `f_min` is not adopted
+
+On this seed the two halt records agree: same `T`, same `|locks_halt|`,
+same lock history. The comparison is displayed.
+
+The maps remain distinct. `f_L1` fires on mixed3 and is one of the
+complement-even fillers of this seed. `f_min` kills mixed3, is the unique
+support-26 1-site filler among cube-covariant maps with `f(empty)=0`, and
+is not in `F_cut`. Hamming parity of the six-bit word is a third map:
+from this seed it halts at `9` locks and does not fill. The `u≥2` map
+from this seed locks only `4` sites. Those contrasts are mutation controls,
+not adopted members.
+
+Do not adopt `f_min`. Do not write `f_min` into Admissibility. Displayed,
+not adopted.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice, Admissibility, and Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, face-diagonal seed | declared finite data |
+| `f_L1` is n≠0, not Hamming | executed orbit contrast |
+| `f_min` definition and `F_cut` non-membership | executed on axis-type orbits |
+| `f_L1` fill from `S` | executed; fills |
+| `f_min` halt locks, `T`, history, fill boolean | executed; fills |
+| comparison without adoption | displayed; no axiom edit |
+| physical formation / Record compiler | open |
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice, Admissibility, and Record
+  sentences quoted above. They are quoted without rewrite.
+- **Explicit theorem-domain condition:** the twelve-site two-cube, off-patch
+  occupancy `0`, the face-diagonal seed, and the two displayed predicates.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** formation site, record content, and any writing of
+  `f_min` or `f_L1` into Admissibility remain outside the target proved here.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the already-named nonempty `n_both=0` map fills from the face-diagonal 2-site seed. |
+| V2 | The 1-site and 3-site-line histories of `f_min` are different seeds; the `F_cut` census of this seed does not include `f_min`. |
+| V3 | Both runs are independently finite and exact. |
+| V4 | Agreement of histories on this seed is not an identity of the maps and does not place `f_min` in `F_cut`. |
+| V5 | The map is not adopted and is not written into Admissibility. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: fill on this seed does not adopt `f_min`,
+does not identify it with `f_L1`, and does not write a lock rule into
+Admissibility. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| `f_L1` (`n≠0`) | run from `S` | fills; history `(2, 7, 11, 12)` |
+| `f_min` (`n_both=0` and `n_unbalanced≥1`) | run from `S` | fills; same history |
+| Hamming parity | run from `S` | does not fill; different history |
+| `u≥2` | run from `S` | four locks; no fill |
+| 1-site seed | same maps, different seed | history `(1, 4, 8, 11, 12)`; not this theorem |
+| 3-site line seed | same maps, different seed | history `(3, 9, 12)`; not this theorem |
+| off-patch occupancy `1` | change the off-patch selector | different `f_min` history |
+| write `f_min` into Admissibility | treat the displayed bits as axiom content | refused; no edit |
+
+### N2 — wall independence
+
+Non-membership in `F_cut`, disagreement on mixed3, and the missing formation
+mechanism are distinct residuals. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the off-patch value `0`, the seed, the synchronous lock update,
+and both predicates are declared. Cube covariance of the predicates is the
+restriction to axis-type orbits already used to name them. No continuum
+limit, no Hamming-as-`f_L1` identification, and no physical readout are
+assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate and the
+local-law sentence. Admissibility is not a dynamics axiom and does not supply
+the formation site, probability, or rate. The residual therefore matches
+current sources: a displayed finite lock map, not an axiom clause.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | six-neighbor axis-type words | no exhaustive 64-bit naming beyond orbits |
+| per site | readiness at each of the twelve sites | no physical record at those sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | face-diagonal runs of `f_min` and `f_L1` | no `F_cut` census in this note |
+| lattice wide | checked and not executed | no infinite-lattice fill theorem |
+
+### N6 — live partial-closure paths
+
+Live routes are a derived formation mechanism, a content/readout
+identification, and any later decision to adopt or reject `f_min` as a
+named member. Distinguishing seeds on which the two histories part, if any,
+are a separate map.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `f_min` and `f_L1` share the 1-site history, the
+3-site-line history, and now the face-diagonal history, they are the same
+filler and `f_min` may be treated as the L1 member.
+
+**Answer:** They disagree on mixed3, and `f_min` fails complement-evenness.
+Shared halt history on three displayed seeds is a comparison of runs, not
+an identity of predicates. Hamming and `u≥2` from the same seed already
+produce different halt records.
+
+### N8 — cross-cycle echo
+
+Prior 1-site and 3-site-line runs of `f_min` are different seeds. Prior
+`F_cut` fill counts on this seed do not include `f_min`. This note does not
+retroactively enlarge those claims and does not write a seed or a predicate
+into Admissibility.
+
+**Gate disposition:** PASS for the finite fill comparison on the displayed
+seed. FAIL / DO NOT SHIP for “`f_min` is adopted,” “`f_min` is `f_L1`,”
+“`f_min` is in `F_cut`,” or “Admissibility now contains this lock rule.”
+
+## Primary Runner
+
+The primary runner recomputes axis-type bits, `F_cut` non-membership, the
+1-site and line sanity histories, the face-diagonal runs of `f_min` and
+`f_L1`, Hamming and `u≥2` mutation controls, the current premise boundary,
+and the display-only contract. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5530,
+ "edge_count": 15732,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_min_two_site_fill_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_min_two_site_fill_2026_08_15.txt
+++ b/logs/runner-cache/f_min_two_site_fill_2026_08_15.txt
@@ -1,0 +1,50 @@
+===== runner cache v1 =====
+runner: scripts/f_min_two_site_fill_2026_08_15.py
+runner_sha256: 4d7c1244b627323e6cb647bc929fee2b0794fc9b38e77e96a50723b6fe7b677c
+input_fingerprint_sha256: 4f93ac0beb1605c919bdbc84b82f8de68275f46c048837c4920012fbbb01c5f8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries only; no observations or fits
+integrity_reads: this runner, its note, and the live axiom memo
+construction: two-cube lock dynamics from a displayed face-diagonal 2-site seed
+negative_scope: f_min is displayed, not adopted, and is not written into Admissibility
+PASS: audit-inputs the required two source-bound inputs exist
+PASS: audit-input-literal AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-no-dynamics Admissibility remains not a dynamics axiom
+PASS: two-cube-cardinality the two-cube is the twelve-site set {0,1,2}x{0,1}x{0,1}
+PASS: face-seed the seed is the displayed face-diagonal pair
+PASS: f-min-definition f_min is 1 iff n_both=0 and some axis is unbalanced
+PASS: f-l1-definition f_L1 is the n≠0 map: 1 iff some axis is unbalanced
+PASS: f-min-not-f-cut f_min is not complement-even, so it is not in F_cut
+PASS: f-l1-not-hamming f_L1 is n≠0 and is not Hamming parity
+PASS: engine-one-site the lock engine recovers the displayed 1-site L1 history
+PASS: engine-line the lock engine recovers the displayed 3-site line L1 history
+f_L1 face-diagonal: T=3 halt_locks=12 history=(2, 7, 11, 12) fills=True
+f_min face-diagonal: T=3 halt_locks=12 history=(2, 7, 11, 12) fills=True
+PASS: thm1-l1-fills f_L1 fills the two-cube from the face-diagonal seed
+PASS: thm1-l1-history f_L1 halt tick and lock history are reported
+PASS: thm2-fmin-fills f_min fills the two-cube from the face-diagonal seed
+PASS: thm2-fmin-history f_min halt locks, T, and lock history are reported
+PASS: thm3-comparison the two maps have the same face-diagonal history; comparison is displayed
+PASS: thm3-not-adopted f_min is displayed and is not written into Admissibility
+PASS: mutation-f-two the u≥2 map from the same seed does not fill
+PASS: mutation-hamming Hamming parity from the same seed does not match either history
+PASS: mutation-off-patch off-patch occupancy 1 changes the f_min run
+PASS: note-contract machine fields, display-only scope, N1-N8, and forbidden-phrase hygiene hold
+PASS: claim-scope claim_scope states that f_min does fill from the face-diagonal seed
+per_element: axis-type words and six-neighbor occupancy bits are enumerated exactly
+per_site: lock readiness is evaluated at each of the twelve two-cube sites
+per_mode: checked and not executed — no spectral claim occurs
+per_block: the face-diagonal seed run of f_min and f_L1 is executed to halt
+lattice_wide: checked and not executed — no infinite-lattice or axiom edit is claimed
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_min_two_site_fill_2026_08_15.py
+++ b/scripts/f_min_two_site_fill_2026_08_15.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Face-diagonal 2-site halt dynamics of f_min versus f_L1.
+
+On the twelve-site two-cube with off-patch occupancy 0, run the nonempty
+n_both=0 map f_min and the n≠0 map f_L1 from the face-diagonal seed
+{(0,0,0),(1,1,0)}. Report halt locks, tick, and lock history. Display the
+comparison. Do not adopt f_min and do not write it into Admissibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_MIN_TWO_SITE_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_MIN_TWO_SITE_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Site = tuple[int, int, int]
+Counts = tuple[int, int, int]
+
+SITES: tuple[Site, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+AXES: tuple[tuple[Site, Site], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+FACE_SEED: tuple[Site, ...] = ((0, 0, 0), (1, 1, 0))
+ONE_SITE: tuple[Site, ...] = ((0, 0, 0),)
+LINE_SEED: tuple[Site, ...] = ((0, 0, 0), (1, 0, 0), (2, 0, 0))
+
+
+def add(left: Site, right: Site) -> Site:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Site, locks: frozenset[Site], off_patch: int) -> int:
+    if site in locks:
+        return 1
+    if site not in SITE_SET:
+        return off_patch
+    return 0
+
+
+def axis_counts(site: Site, locks: frozenset[Site], off_patch: int) -> Counts:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for plus, minus in AXES:
+        occupied = occupancy(add(site, plus), locks, off_patch) + occupancy(
+            add(site, minus), locks, off_patch
+        )
+        if occupied == 0:
+            n_empty += 1
+        elif occupied == 2:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_l1(counts: Counts) -> bool:
+    """n≠0: fire iff some axis is unbalanced."""
+    return counts[0] >= 1
+
+
+def f_min(counts: Counts) -> bool:
+    """Nonempty n_both=0: fire iff no axis is both-occupied and some axis is unbalanced."""
+    return counts[1] == 0 and counts[0] >= 1
+
+
+def f_two(counts: Counts) -> bool:
+    return counts[0] >= 2
+
+
+def f_hamming(counts: Counts) -> bool:
+    """Hamming parity of the six-neighbor occupancy word: |c|_1 = n_unbalanced + 2 n_both."""
+    return (counts[0] + 2 * counts[1]) % 2 == 1
+
+
+def complement_counts(counts: Counts) -> Counts:
+    n_unbalanced, n_both, n_empty = counts
+    return (n_unbalanced, n_empty, n_both)
+
+
+def run_map(
+    predicate,
+    seed: tuple[Site, ...],
+    off_patch: int = 0,
+    max_ticks: int = 12,
+) -> tuple[int, int, tuple[int, ...], frozenset[Site]]:
+    locks = frozenset(seed)
+    history = [len(locks)]
+    for tick in range(1, max_ticks + 1):
+        newly = frozenset(
+            site
+            for site in SITES
+            if site not in locks and predicate(axis_counts(site, locks, off_patch))
+        )
+        if not newly:
+            return tick - 1, len(locks), tuple(history), locks
+        locks = locks | newly
+        history.append(len(locks))
+    return max_ticks, len(locks), tuple(history), locks
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries only; no observations or fits")
+    print("integrity_reads: this runner, its note, and the live axiom memo")
+    print("construction: two-cube lock dynamics from a displayed face-diagonal 2-site seed")
+    print("negative_scope: f_min is displayed, not adopted, and is not written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "the required two source-bound inputs exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_MIN_TWO_SITE_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        'AUDIT_INPUT_PATHS = (\n    "docs/F_MIN_TWO_SITE_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in self_source,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    no_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalized_axiom and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-no-dynamics",
+        "Admissibility remains not a dynamics axiom",
+        no_dynamics in axiom and no_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-cardinality",
+        "the two-cube is the twelve-site set {0,1,2}x{0,1}x{0,1}",
+        len(SITES) == 12 and len(SITE_SET) == 12,
+    )
+    checks.check(
+        "face-seed",
+        "the seed is the displayed face-diagonal pair",
+        FACE_SEED == ((0, 0, 0), (1, 1, 0))
+        and sum(abs(FACE_SEED[0][i] - FACE_SEED[1][i]) for i in range(3)) == 2,
+    )
+
+    wt1: Counts = (1, 0, 2)
+    opp2: Counts = (0, 1, 2)
+    adj2: Counts = (2, 0, 1)
+    vertex3: Counts = (3, 0, 0)
+    mixed3: Counts = (1, 1, 1)
+    empty: Counts = (0, 0, 3)
+    full: Counts = (0, 3, 0)
+    orbit_bits = tuple(int(f_min(counts)) for counts in (wt1, opp2, adj2, vertex3, mixed3))
+    checks.check(
+        "f-min-definition",
+        "f_min is 1 iff n_both=0 and some axis is unbalanced",
+        orbit_bits == (1, 0, 1, 1, 0)
+        and not f_min(empty)
+        and not f_min(full)
+        and f_min(wt1)
+        and not f_min(mixed3),
+    )
+    checks.check(
+        "f-l1-definition",
+        "f_L1 is the n≠0 map: 1 iff some axis is unbalanced",
+        tuple(int(f_l1(counts)) for counts in (wt1, opp2, adj2, vertex3, mixed3))
+        == (1, 0, 1, 1, 1)
+        and not f_l1(empty)
+        and not f_l1(full)
+        and f_l1(mixed3)
+        and f_min != f_l1,
+    )
+    checks.check(
+        "f-min-not-f-cut",
+        "f_min is not complement-even, so it is not in F_cut",
+        f_min(empty) == f_min(full) == False
+        and f_min(wt1) != f_min(complement_counts(wt1))
+        and f_l1(wt1) == f_l1(complement_counts(wt1))
+        and f_l1(empty) == f_l1(full) == False,
+    )
+    checks.check(
+        "f-l1-not-hamming",
+        "f_L1 is n≠0 and is not Hamming parity",
+        f_l1(wt1)
+        and f_hamming(wt1)
+        and f_l1(adj2)
+        and not f_hamming(adj2)
+        and not f_l1(opp2)
+        and not f_hamming(opp2),
+    )
+
+    l1_one = run_map(f_l1, ONE_SITE)
+    min_one = run_map(f_min, ONE_SITE)
+    l1_line = run_map(f_l1, LINE_SEED)
+    min_line = run_map(f_min, LINE_SEED)
+    checks.check(
+        "engine-one-site",
+        "the lock engine recovers the displayed 1-site L1 history",
+        l1_one[0] == 4
+        and l1_one[1] == 12
+        and l1_one[2] == (1, 4, 8, 11, 12)
+        and min_one[2] == l1_one[2],
+        residual=(l1_one[2], min_one[2]),
+    )
+    checks.check(
+        "engine-line",
+        "the lock engine recovers the displayed 3-site line L1 history",
+        l1_line[0] == 2
+        and l1_line[1] == 12
+        and l1_line[2] == (3, 9, 12)
+        and min_line[2] == l1_line[2],
+        residual=(l1_line[2], min_line[2]),
+    )
+
+    l1_face = run_map(f_l1, FACE_SEED)
+    min_face = run_map(f_min, FACE_SEED)
+    two_face = run_map(f_two, FACE_SEED)
+    ham_face = run_map(f_hamming, FACE_SEED)
+    l1_t, l1_halt, l1_hist, l1_locks = l1_face
+    min_t, min_halt, min_hist, min_locks = min_face
+
+    print(f"f_L1 face-diagonal: T={l1_t} halt_locks={l1_halt} history={l1_hist} fills={l1_halt == 12}")
+    print(f"f_min face-diagonal: T={min_t} halt_locks={min_halt} history={min_hist} fills={min_halt == 12}")
+
+    checks.check(
+        "thm1-l1-fills",
+        "f_L1 fills the two-cube from the face-diagonal seed",
+        l1_halt == 12 and len(l1_locks) == 12 and l1_locks == SITE_SET,
+        residual=l1_hist,
+    )
+    checks.check(
+        "thm1-l1-history",
+        "f_L1 halt tick and lock history are reported",
+        l1_t >= 1 and l1_hist[0] == 2 and l1_hist[-1] == 12 and len(l1_hist) == l1_t + 1,
+        residual=(l1_t, l1_hist),
+    )
+    checks.check(
+        "thm2-fmin-fills",
+        "f_min fills the two-cube from the face-diagonal seed",
+        min_halt == 12 and len(min_locks) == 12 and min_locks == SITE_SET,
+        residual=min_hist,
+    )
+    checks.check(
+        "thm2-fmin-history",
+        "f_min halt locks, T, and lock history are reported",
+        min_t >= 1
+        and min_hist[0] == 2
+        and min_hist[-1] == min_halt
+        and len(min_hist) == min_t + 1
+        and f"T={min_t}" in note
+        and str(min_hist) in note
+        and f"|locks_halt|={min_halt}" in note,
+        residual=(min_t, min_hist),
+    )
+    checks.check(
+        "thm3-comparison",
+        "the two maps have the same face-diagonal history; comparison is displayed",
+        min_hist == l1_hist
+        and min_t == l1_t
+        and min_halt == l1_halt
+        and "same lock history" in normalized_note
+        and "does fill" in normalized_note,
+        residual=(min_hist, l1_hist),
+    )
+    checks.check(
+        "thm3-not-adopted",
+        "f_min is displayed and is not written into Admissibility",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in normalized_note
+        and "do not adopt f_min" in normalized_note.lower(),
+    )
+    checks.check(
+        "mutation-f-two",
+        "the u≥2 map from the same seed does not fill",
+        two_face[1] != 12 and two_face[1] == 4 and two_face[2] == (2, 4),
+        residual=two_face[2],
+    )
+    checks.check(
+        "mutation-hamming",
+        "Hamming parity from the same seed does not match either history",
+        ham_face[2] != min_hist and ham_face[1] != 12,
+        residual=ham_face[2],
+    )
+    checks.check(
+        "mutation-off-patch",
+        "off-patch occupancy 1 changes the f_min run",
+        run_map(f_min, FACE_SEED, off_patch=1)[2] != min_hist,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "f_L1 is n≠0",
+        "not Hamming",
+    )
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "new axiom",
+        "trace_class: direct_blocker_closure",
+        "reachability_to_target: partially_closes",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, display-only scope, N1-N8, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{i}" in note for i in range(1, 9))
+        and not any(phrase in note for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "hypothetical_axiom_status: \"no edit\"" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope states that f_min does fill from the face-diagonal seed",
+        "the nonempty n_both=0 map f_min does fill from the face-diagonal 2-site seed"
+        in normalized_note,
+    )
+
+    print("per_element: axis-type words and six-neighbor occupancy bits are enumerated exactly")
+    print("per_site: lock readiness is evaluated at each of the twelve two-cube sites")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: the face-diagonal seed run of f_min and f_L1 is executed to halt")
+    print("lattice_wide: checked and not executed — no infinite-lattice or axiom edit is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, f_min fills from {(0,0,0),(1,1,0)} with lock history (2, 7, 11, 12), matching f_L1 on this seed. Displayed, not adopted.

## Runner

`scripts/f_min_two_site_fill_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.