### PR TITLE
feat(diff2count): 4 of 66 two-site seeds split f_min from f_L1

### DIFF
--- a/docs/F_MIN_L1_TWO_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_MIN_L1_TWO_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,318 @@
+---
+claim_id: f_min_l1_two_site_split_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 66 two-site seeds on the two-cube with off-patch o=0, 4 distinguish f_min from f_L1 by fill or lock history. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_min_l1_two_site_split_census_2026_08_15.py
+---
+
+# Two-Site Split Census Of `f_min` Versus `f_L1`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exhaustive lock-step census of the 66 unordered two-site seeds on
+the twelve-vertex two-cube `{0,1,2} × {0,1} × {0,1}` with off-patch occupancy
+`o=0`. The integer `N_split` is displayed. No seed is adopted and no selector
+is written into Admissibility.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_min_l1_two_site_split_census_2026_08_15.py`](../scripts/f_min_l1_two_site_split_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+On the two-cube, a lock-step run of a displayed readiness map from a seed `S`
+is the synchronous wave process that begins with `S` locked and, at each tick,
+locks every still-unlocked site whose six-neighbor occupancy 3-tuple satisfies
+the map. The lock-history tuple is the sequence of lock counts after the seed
+and after each nonempty wave, until halt. Fill means `|locks_halt| = 12`.
+
+Write `n_unbalanced`, `n_both`, and `n_empty` for the number of cubic axes
+whose two opposite neighbors are occupied on exactly one side, on both sides,
+or on neither side. Off-patch neighbors contribute occupancy `0`. Then
+
+- `f_L1` fires iff `n_unbalanced ≠ 0` (some axis is unbalanced; not Hamming
+  weight of the six occupancy bits);
+- `f_min` fires iff the occupancy is nonempty and `n_both = 0`
+  (equivalently `n_unbalanced ≠ 0` and `n_both = 0`).
+
+A two-site seed *splits* the two maps when the fill bits differ or the
+lock-history tuples differ.
+
+The census of all `C(12,2) = 66` unordered pairs is
+
+`N_split = 4`
+
+`N_fill_L1 = 62`
+
+`N_fill_min = 58`
+
+`N_fill_both = 58`
+
+Every split is the same displayed pattern: `f_L1` fills with history
+`(2, 8, 12)` and `f_min` halts unfilled at `(2, 8, 10)`. The four seeds are
+exactly the displacement-`(2,1,1)` pairs
+
+`{(0,0,0),(2,1,1)}`, `{(0,0,1),(2,1,0)}`, `{(0,1,0),(2,0,1)}`,
+`{(0,1,1),(2,0,0)}`.
+
+The face-diagonal seed `{(0,0,0),(1,1,0)}` does not split: both maps fill with
+history `(2, 7, 11, 12)`. These four integers and four seeds are displayed
+census output. They are not adopted as a physical selector.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 66 two-site seeds, both lock-step runs, and the four census integers are finite exact statements on a declared twelve-site patch; no seed is selected and no Admissibility clause is added."
+trace_class: frontier_discovery
+target_claim_id: f_min_l1_two_site_split_census
+target_blocker_text: "how many two-site seeds on the two-cube distinguish f_min from f_L1 by fill or lock history"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the twelve-vertex two-cube with off-patch occupancy 0 and the two displayed readiness maps; no selector is adopted"
+hypothetical_axiom_status: "none; f_min and the four splitting seeds are displayed and are not proposed as axiom content"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded census; do not write a selector into Admissibility"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** Lattice, Admissibility, and Record are quoted from
+  the live axiom memo without rewrite. They identify the cubic nearest-neighbor
+  graph, the local-condition domain, and the lock/content/absence wording.
+  They do not supply the two readiness maps or the two-cube patch.
+- **Explicit theorem-domain condition:** the twelve sites
+  `{0,1,2} × {0,1} × {0,1}`, off-patch occupancy identically `0`, the two
+  displayed maps `f_L1` and `f_min`, and the synchronous lock-step dynamics
+  above are supplied mathematical data for this census.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing either map, or any of the four splitting
+  seeds, into Admissibility remains a separate, open obligation. This note
+  does not adopt them.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility
+
+does not supply the formation site, probability, or rate.
+
+The two readiness maps are displayed occupancy predicates on the six-neighbor
+condition tuple. They are not Admissibility content. Using a lock-step wave as
+physical Record formation would require a separately derived formation
+mechanism; that mechanism is not supplied here.
+
+## Exact Objects
+
+The two-cube is the twelve-point set
+
+`V = {0,1,2} × {0,1} × {0,1} ⊂ Z^3`.
+
+The open nearest-neighbor set of a site `x` is
+`N(x) = {x ± e_1, x ± e_2, x ± e_3}`. A neighbor in `V` that is already
+locked contributes occupancy `1`; a neighbor outside `V` contributes
+occupancy `0`. For each of the three axes one records the pair
+`(c_{+μ}, c_{-μ}) ∈ {0,1}^2` and tallies
+
+- unbalanced if the pair is `(1,0)` or `(0,1)`,
+- both if the pair is `(1,1)`,
+- empty if the pair is `(0,0)`.
+
+On this patch, `n_both > 0` is possible only at the middle face `x = 1`, and
+only on the long axis: every transverse neighbor in the `-y` or `-z` direction
+from `y = 0` or `z = 0` is off-patch.
+
+A seed is an unordered pair `S ⊂ V` with `|S| = 2`. There are exactly
+`C(12,2) = 66` such seeds. The run of a map `f` from `S` begins with
+`locks_0 = S`. At tick `t ≥ 1` every unlocked `x ∈ V` with `f(c(x, locks_{t-1})) = 1`
+locks simultaneously. The history is
+`(|locks_0|, |locks_1|, …, |locks_T|)` at the first `T` with no further ready
+site. Fill is the boolean `|locks_T| = 12`.
+
+`f_L1(c) = 1` iff `n_unbalanced ≠ 0`. This is not the Hamming weight of the
+six occupancy bits: the opposite-pair occupancy at `(1,0,0)` with
+`{(0,0,0),(2,0,0)}` locked has Hamming weight `2` and
+`(n_unbalanced, n_both, n_empty) = (0,1,2)`, so `f_L1` does not fire.
+
+`f_min(c) = 1` iff `n_both = 0` and `n_unbalanced ≠ 0`. The maps therefore
+disagree exactly when at least one axis is unbalanced and at least one axis
+is doubly occupied. On this patch that first occurs as mixed type `(1,1,1)`
+at a middle-face site.
+
+## Theorem 1 — Two Displayed Seeds
+
+**Face-diagonal non-split.** From `S_face = {(0,0,0),(1,1,0)}` both maps
+produce the lock-history `(2, 7, 11, 12)` and fill. The first wave locks
+`(1,0,0)`, `(0,1,0)`, `(0,0,1)`, `(1,1,1)`, and `(2,1,0)`; the second wave
+locks the remaining four sites except `(2,0,1)`; the third wave locks
+`(2,0,1)`. Every ready neighborhood in this run has `n_both = 0`, so the two
+predicates agree at every unlocked site.
+
+**Distinguisher split.** From `S_* = {(0,0,0),(2,1,1)}` the first wave is
+common and reaches eight locks. At the second wave, the four remaining sites
+include two mixed-type middle-face neighborhoods
+`(1,1,0)` and `(1,0,1)`, each with `n_both = 1` and `n_unbalanced = 2`.
+`f_L1` locks all four remaining sites and fills with history `(2, 8, 12)`.
+`f_min` locks only `(0,1,1)` and `(2,0,0)` and then halts at ten locks with
+history `(2, 8, 10)`. The fill bits and the histories both differ, so `S_*`
+splits.
+
+## Theorem 2 — Exhaustive Two-Site Census
+
+Every one of the 66 seeds is run independently under both maps. The four
+census integers are
+
+`N_split = 4`,
+`N_fill_L1 = 62`,
+`N_fill_min = 58`,
+`N_fill_both = 58`.
+
+The complementary counts are displayed, not selected: four seeds fail to fill
+under `f_L1`, eight fail under `f_min`, and `N_fill_min = N_fill_both`, so
+every `f_min`-filling seed also fills under `f_L1`. No history-only split
+occurs: whenever the histories differ, the fill bits differ, and conversely.
+
+Partitioning the 66 pairs by coordinate displacement
+`(|Δx|, |Δy|, |Δz|)` isolates the split:
+
+| displacement | count | `f_L1` fill | `f_min` fill | common history | split |
+|---|---:|---:|---:|---|---|
+| `(1,0,0)`, `(1,0,1)`, `(1,1,0)` | 24 | 24 | 24 | `(2, 7, 11, 12)` | no |
+| `(1,1,1)` | 8 | 8 | 8 | `(2, 9, 12)` | no |
+| `(0,*,*)` (same `x` face) | 18 | 18 | 18 | `(2, 6, 10, 12)` or `(2, 8, 12)` | no |
+| `(2,0,1)`, `(2,1,0)` | 8 | 8 | 8 | `(2, 8, 12)` | no |
+| `(2,0,0)` | 4 | 0 | 0 | `(2, 6, 8)` | no |
+| `(2,1,1)` | 4 | 4 | 0 | L1 `(2, 8, 12)`; min `(2, 8, 10)` | yes |
+
+The four non-filling long-axis pairs
+`{(0,y,z),(2,y,z)}` halt at eight locks under both maps. They are not
+splits. The four displacement-`(2,1,1)` pairs are exactly the splits.
+
+## Theorem 3 — Display, Do Not Adopt
+
+The integer `N_split = 4` is the object of the census. The four seeds and
+the three fill counts are reported with it. They are displayed, not adopted:
+do not adopt a seed, and do not adopt either map. A selector is not written
+into Admissibility. A later derivation that used one of these seeds as a
+physical rule would be a different claim.
+
+## What This Does Not Claim
+
+- It does not claim that either map is the Admissibility rule.
+- It does not claim that lock-step waves are physical Record formation.
+- It does not claim a unique physically preferred two-site seed.
+- It does not extend the census to `|S| ≠ 2` or to a larger patch.
+- It does not identify `f_min` with Hamming weight, graph distance, or any
+  map other than nonempty `n_both = 0`.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the two-site split-count question for the two displayed maps on the declared patch. |
+| V2 | Current main has the axiom memo and no landed exhaustive two-site split census of these two maps. |
+| V3 | All 66 pairs, both runs, and the four integers are independently finite and exact. |
+| V4 | The census is more than a restatement of the single distinguisher `{(0,0,0),(2,1,1)}`: it counts every two-site seed. |
+| V5 | It is not a physical compiler and writes no selector into Admissibility. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: most two-site seeds do not split these two
+maps, and the four that do are not hereby adopted. No global compiler
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| face-diagonal 2-site seed | run both maps from `{(0,0,0),(1,1,0)}` | no split; both fill with `(2, 7, 11, 12)` |
+| displacement `(2,1,1)` | run both maps from each of the four pairs | all four split by fill and history |
+| long-axis `(2,0,0)` | run both maps from `{(0,y,z),(2,y,z)}` | neither fills; same history; not a split |
+| Hamming-weight predicate | fire on six-bit weight | executed counterexample: opp2 has weight 2 and `f_L1 = 0` |
+| adopt a seed | write one splitter into Admissibility | refused; displayed, not adopted |
+| larger seed census | enumerate `|S| ≠ 2` | live different object |
+
+### N2 — wall independence
+
+The missing formation mechanism, the missing Admissibility selector, and any
+extension off this twelve-site patch are distinct premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch occupancy `0`, the two predicates, and the
+synchronous wave rule are declared. Hamming weight is not silently used.
+No seed is treated as axiom content.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate, the
+local-condition sentence, and the lock/content/absence wording used here.
+It does not supply `f_min`, `f_L1`, or a two-site selector. The residual
+matches those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 66 pairs, two maps, lock-count histories | no continuum or larger-patch census |
+| per site | six-neighbor occupancy 3-tuples | no derived kernel values |
+| per mode | no mode calculation | no spectral statement |
+| per block | two-cube lock-step dynamics | no physical formation compiler |
+| lattice wide | checked and not executed | no infinite-volume claim |
+
+### N6 — live partial-closure paths
+
+Live routes are an independently derived formation mechanism, a derivation
+that would force one of the two maps, and any census at a different seed
+cardinality or patch. Those routes remain open.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `f_min` and `f_L1` already disagree on mixed-type
+neighborhoods, almost every two-site seed should split.
+
+**Answer:** On this patch, mixed type occurs only at `x = 1` and only after
+both long-axis neighbors are locked. Fifty-eight of the 66 two-site seeds
+never present such a neighborhood before fill, so the runs agree. Only the
+four displacement-`(2,1,1)` seeds produce a mixed-type second wave.
+
+### N8 — cross-cycle echo
+
+A prior displayed computation isolated one distinguishing seed of size at
+most three. This note does not recycle that single-seed existence claim as
+the census. It enumerates every two-site seed and reports `N_split = 4`.
+
+**Gate disposition:** PASS for the 66-seed census and the four displayed
+integers above. FAIL / DO NOT SHIP for “Admissibility is `f_min`,” “adopt
+this seed,” or “the maps agree on every finite seed.”
+
+## Primary Runner
+
+The primary runner recomputes both displayed seeds, enumerates all 66 pairs,
+checks that `f_L1` is `n_unbalanced ≠ 0` rather than Hamming weight, checks
+that `f_min` is nonempty `n_both = 0`, and checks that this note displays
+`N_split = 4` without adopting a selector. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5530,
+ "edge_count": 15732,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_min_l1_two_site_split_census_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_min_l1_two_site_split_census_2026_08_15.txt
+++ b/logs/runner-cache/f_min_l1_two_site_split_census_2026_08_15.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/f_min_l1_two_site_split_census_2026_08_15.py
+runner_sha256: d6ac1fd1d402e38bfb6af3272e4198f4e9e2996ef2f5ac0dc0d26271d9f52893
+input_fingerprint_sha256: 6ceca2936cf2532488687c998cc1adb420d145b153e729ea756bd2ab5ed22790
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: exhaustive two-site lock-step census on the twelve-vertex two-cube with off-patch occupancy 0
+negative_scope: N_split is displayed; no seed is adopted and no selector is written into Admissibility
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: two-cube-cardinality the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}
+PASS: pair-count there are C(12,2)=66 unordered two-site seeds
+PASS: theorem-1-face-diagonal the face-diagonal seed fills under both maps with history (2, 7, 11, 12)
+PASS: theorem-1-distinguisher the seed {(0,0,0),(2,1,1)} splits fill or lock history
+census: N_split=4 N_fill_L1=62 N_fill_min=58 N_fill_both=58 N_history_only=0 N_fill_bit_only=0
+PASS: theorem-2-census-range the four census integers lie in 0..66 and N_fill_both <= min(N_fill_L1, N_fill_min)
+PASS: theorem-2-split-positive at least the displayed distinguisher contributes to N_split
+PASS: theorem-3-display the note displays the computed N_split and does not adopt a seed
+PASS: theorem-3-fill-counts the note reports the three fill counts
+PASS: identity-l1-not-hamming opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire
+PASS: identity-min-nboth-zero f_min fires on nonempty n_both=0 and refuses mixed3
+PASS: forbidden-phrases the note avoids the dispatch-forbidden phrases
+PASS: no-admissibility-selector the note does not write a seed selector into Admissibility
+PASS: claim-scope the YAML claim_scope states the 66-seed display
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_min_l1_two_site_split_census_2026_08_15.py
+++ b/scripts/f_min_l1_two_site_split_census_2026_08_15.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Two-site split census of f_min versus f_L1 on the twelve-vertex two-cube.
+
+Enumerates every unordered pair of the twelve sites of
+{0,1,2} x {0,1} x {0,1} with off-patch occupancy 0. A split is a
+different fill bit or a different lock-count history. The census
+displays N_split; it does not adopt a seed or write a selector into
+Admissibility.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_MIN_L1_TWO_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_MIN_L1_TWO_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+AXES: tuple[Point, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SITES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+FACE_DIAGONAL = frozenset(((0, 0, 0), (1, 1, 0)))
+DISTINGUISHER = frozenset(((0, 0, 0), (2, 1, 1)))
+FACE_HISTORY = (2, 7, 11, 12)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locked: frozenset[Point]) -> int:
+    """On-patch occupancy is the lock bit; off-patch occupancy is 0."""
+    if site not in SITE_SET:
+        return 0
+    return 1 if site in locked else 0
+
+
+def axis_type(site: Point, locked: frozenset[Point]) -> tuple[int, int, int]:
+    """Return (n_unbalanced, n_both, n_empty) for the three cubic axes."""
+    n_unbalanced = n_both = n_empty = 0
+    for axis in AXES:
+        plus = occupancy(add(site, axis), locked)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+        if plus == minus == 0:
+            n_empty += 1
+        elif plus == minus == 1:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fire_l1(counts: tuple[int, int, int]) -> bool:
+    """f_L1: some axis is unbalanced (n != 0). Not Hamming weight."""
+    n_unbalanced, _n_both, _n_empty = counts
+    return n_unbalanced != 0
+
+
+def fire_min(counts: tuple[int, int, int]) -> bool:
+    """f_min: nonempty and n_both = 0."""
+    n_unbalanced, n_both, _n_empty = counts
+    return n_both == 0 and n_unbalanced != 0
+
+
+def run(seed: frozenset[Point], fire) -> tuple[tuple[int, ...], bool]:
+    locked = frozenset(seed)
+    history = [len(locked)]
+    for _tick in range(len(SITES)):
+        ready = [
+            site
+            for site in SITES
+            if site not in locked and fire(axis_type(site, locked))
+        ]
+        if not ready:
+            break
+        locked = locked.union(ready)
+        history.append(len(locked))
+    return (tuple(history), len(locked) == len(SITES))
+
+
+def census() -> dict[str, object]:
+    n_split = n_fill_l1 = n_fill_min = n_fill_both = 0
+    n_history_only = n_fill_only = 0
+    pairs = tuple(frozenset(pair) for pair in combinations(SITES, 2))
+    for seed in pairs:
+        hist_l1, fill_l1 = run(seed, fire_l1)
+        hist_min, fill_min = run(seed, fire_min)
+        n_fill_l1 += int(fill_l1)
+        n_fill_min += int(fill_min)
+        n_fill_both += int(fill_l1 and fill_min)
+        fill_diff = fill_l1 != fill_min
+        hist_diff = hist_l1 != hist_min
+        if fill_diff or hist_diff:
+            n_split += 1
+            n_fill_only += int(fill_diff and not hist_diff)
+            n_history_only += int(hist_diff and not fill_diff)
+    return {
+        "n_pairs": len(pairs),
+        "n_split": n_split,
+        "n_fill_l1": n_fill_l1,
+        "n_fill_min": n_fill_min,
+        "n_fill_both": n_fill_both,
+        "n_history_only": n_history_only,
+        "n_fill_only": n_fill_only,
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: exhaustive two-site lock-step census on the twelve-vertex two-cube with off-patch occupancy 0")
+    print("negative_scope: N_split is displayed; no seed is adopted and no selector is written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_MIN_L1_TWO_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    checks.check("two-cube-cardinality", "the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}", len(SITES) == 12 and len(SITE_SET) == 12)
+    checks.check("pair-count", "there are C(12,2)=66 unordered two-site seeds", len(tuple(combinations(SITES, 2))) == 66)
+
+    hist_l1_face, fill_l1_face = run(FACE_DIAGONAL, fire_l1)
+    hist_min_face, fill_min_face = run(FACE_DIAGONAL, fire_min)
+    checks.check(
+        "theorem-1-face-diagonal",
+        "the face-diagonal seed fills under both maps with history (2, 7, 11, 12)",
+        fill_l1_face
+        and fill_min_face
+        and hist_l1_face == FACE_HISTORY
+        and hist_min_face == FACE_HISTORY,
+        residual=(hist_l1_face, hist_min_face, fill_l1_face, fill_min_face),
+    )
+
+    hist_l1_star, fill_l1_star = run(DISTINGUISHER, fire_l1)
+    hist_min_star, fill_min_star = run(DISTINGUISHER, fire_min)
+    splits_star = (fill_l1_star != fill_min_star) or (hist_l1_star != hist_min_star)
+    checks.check(
+        "theorem-1-distinguisher",
+        "the seed {(0,0,0),(2,1,1)} splits fill or lock history",
+        splits_star and fill_l1_star and not fill_min_star,
+        residual=(hist_l1_star, hist_min_star, fill_l1_star, fill_min_star),
+    )
+
+    counts = census()
+    n_split = int(counts["n_split"])
+    n_fill_l1 = int(counts["n_fill_l1"])
+    n_fill_min = int(counts["n_fill_min"])
+    n_fill_both = int(counts["n_fill_both"])
+    print(
+        "census: "
+        f"N_split={n_split} N_fill_L1={n_fill_l1} "
+        f"N_fill_min={n_fill_min} N_fill_both={n_fill_both} "
+        f"N_history_only={counts['n_history_only']} "
+        f"N_fill_bit_only={counts['n_fill_only']}"
+    )
+    checks.check(
+        "theorem-2-census-range",
+        "the four census integers lie in 0..66 and N_fill_both <= min(N_fill_L1, N_fill_min)",
+        counts["n_pairs"] == 66
+        and 0 <= n_split <= 66
+        and 0 <= n_fill_both <= min(n_fill_l1, n_fill_min)
+        and n_fill_l1 <= 66
+        and n_fill_min <= 66,
+    )
+    checks.check(
+        "theorem-2-split-positive",
+        "at least the displayed distinguisher contributes to N_split",
+        n_split >= 1 and splits_star,
+    )
+
+    checks.check(
+        "theorem-3-display",
+        "the note displays the computed N_split and does not adopt a seed",
+        f"N_split = {n_split}" in note
+        and "displayed, not adopted" in normalized_note
+        and "do not adopt" in normalized_note,
+        residual=n_split,
+    )
+    checks.check(
+        "theorem-3-fill-counts",
+        "the note reports the three fill counts",
+        f"N_fill_L1 = {n_fill_l1}" in note
+        and f"N_fill_min = {n_fill_min}" in note
+        and f"N_fill_both = {n_fill_both}" in note,
+        residual=(n_fill_l1, n_fill_min, n_fill_both),
+    )
+
+    # Identity: f_L1 is n != 0, not Hamming weight of the six occupancy bits.
+    # On this two-cube, n_both is possible only on the long axis at x=1.
+    locked_opp = frozenset(((0, 0, 0), (2, 0, 0)))
+    opp2 = axis_type((1, 0, 0), locked_opp)
+    hamming_opp = sum(
+        occupancy(add((1, 0, 0), shift), locked_opp)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    checks.check(
+        "identity-l1-not-hamming",
+        "opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire",
+        opp2 == (0, 1, 2) and hamming_opp == 2 and not fire_l1(opp2) and not fire_min(opp2),
+    )
+    locked_mixed = frozenset(((0, 0, 0), (2, 0, 0), (1, 1, 0)))
+    mixed3 = axis_type((1, 0, 0), locked_mixed)
+    locked_wt1 = frozenset(((0, 0, 0),))
+    wt1 = axis_type((1, 0, 0), locked_wt1)
+    checks.check(
+        "identity-min-nboth-zero",
+        "f_min fires on nonempty n_both=0 and refuses mixed3",
+        wt1 == (1, 0, 2)
+        and mixed3 == (1, 1, 1)
+        and fire_min(wt1)
+        and fire_l1(wt1)
+        and not fire_min(mixed3)
+        and fire_l1(mixed3),
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-phrases",
+        "the note avoids the dispatch-forbidden phrases",
+        all(phrase not in note for phrase in forbidden),
+    )
+    checks.check(
+        "no-admissibility-selector",
+        "the note does not write a seed selector into Admissibility",
+        "not written into Admissibility" in normalized_note
+        and "selector" in normalized_note,
+    )
+    checks.check(
+        "claim-scope",
+        "the YAML claim_scope states the 66-seed display",
+        "Among the 66 two-site seeds" in note and f"{n_split}" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 66 two-site seeds on the two-cube with off-patch o=0, N_split=4 distinguish f_min from f_L1 by fill or lock history. Displayed, not adopted. f_L1 is n≠0 / unbalanced axis, not Hamming.

## Runner

`scripts/f_min_l1_two_site_split_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.