### PR TITLE
feat(split4list): list the four two-site seeds that split f_min from f_L1

### DIFF
--- a/docs/F_MIN_L1_FOUR_SPLIT_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_MIN_L1_FOUR_SPLIT_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,300 @@
+---
+claim_id: f_min_l1_four_split_seeds_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The four two-site seeds on the two-cube that distinguish f_min from f_L1 are listed. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_min_l1_four_split_seeds_2026_08_15.py
+---
+
+# Four Two-Site Seeds That Split `f_min` From `f_L1`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exhaustive lock-step census of the 66 unordered two-site seeds on
+the twelve-vertex two-cube `{0,1,2} × {0,1} × {0,1}` with off-patch occupancy
+`o=0`. The four seeds that distinguish `f_min` from `f_L1` are listed in
+lexicographic order. They are displayed. No seed is adopted and no selector
+is written into Admissibility.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_min_l1_four_split_seeds_2026_08_15.py`](../scripts/f_min_l1_four_split_seeds_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+On the two-cube, a lock-step run of a displayed readiness map from a seed `S`
+is the synchronous wave process that begins with `S` locked and, at each tick,
+locks every still-unlocked site whose six-neighbor occupancy 3-tuple satisfies
+the map. The lock-history tuple is the sequence of lock counts after the seed
+and after each nonempty wave, until halt. Fill means `|locks_halt| = 12`.
+
+Write `n_unbalanced`, `n_both`, and `n_empty` for the number of cubic axes
+whose two opposite neighbors are occupied on exactly one side, on both sides,
+or on neither side. Off-patch neighbors contribute occupancy `0`. Then
+
+- `f_L1` fires iff `n_unbalanced ≠ 0` (some axis is unbalanced; not Hamming
+  weight of the six occupancy bits);
+- `f_min` fires iff the occupancy is nonempty and `n_both = 0`
+  (equivalently `n_unbalanced ≠ 0` and `n_both = 0`).
+
+A two-site seed *splits* the two maps when the fill bits differ or the
+lock-history tuples differ.
+
+A prior count-only census reported `N_split = 4` of the 66 two-site seeds and
+named one splitter `{(0,0,0),(2,1,1)}`. Not leftover-character of #6422: that only counted. This note is the four-seed set.
+
+Recomputing every unordered pair gives
+
+`N_split = 4`
+
+`N_fill_L1 = 62`
+
+`N_fill_min = 58`
+
+and confirms that `{(0,0,0),(2,1,1)}` is one split.
+
+The four seeds, in lexicographic order of sorted site pairs, are
+
+`{(0,0,0),(2,1,1)}`
+
+`{(0,0,1),(2,1,0)}`
+
+`{(0,1,0),(2,0,1)}`
+
+`{(0,1,1),(2,0,0)}`.
+
+Each has `f_L1` history `(2, 8, 12)` and fills, and each has `f_min` halt
+unfilled at history `(2, 8, 10)`. The four-seed set is displayed census
+output. It is not adopted as a physical selector.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 66 two-site seeds, both lock-step runs, and the four listed splitters are finite exact statements on a declared twelve-site patch; no seed is selected and no Admissibility clause is added."
+trace_class: frontier_discovery
+target_claim_id: f_min_l1_four_split_seeds
+target_blocker_text: "which four two-site seeds on the two-cube distinguish f_min from f_L1"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the twelve-vertex two-cube with off-patch occupancy 0 and the two displayed readiness maps; no selector is adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of the four-seed list; do not write a selector into Admissibility"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** Lattice, Admissibility, and Record are quoted from
+  the live axiom memo without rewrite. They identify the cubic nearest-neighbor
+  graph, the local-condition domain, and the lock/content/absence wording.
+  They do not supply the two readiness maps or the two-cube patch.
+- **Explicit theorem-domain condition:** the twelve sites
+  `{0,1,2} × {0,1} × {0,1}`, off-patch occupancy identically `0`, the two
+  displayed maps `f_L1` and `f_min`, and the synchronous lock-step dynamics
+  above are supplied mathematical data for this list.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing either map, or any of the four splitting
+  seeds, into Admissibility remains a separate, open obligation. This note
+  does not adopt them.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility
+
+does not supply the formation site, probability, or rate.
+
+The two readiness maps are displayed occupancy predicates on the six-neighbor
+condition tuple. They are not Admissibility content. Using a lock-step wave as
+physical Record formation would require a separately derived formation
+mechanism; that mechanism is not supplied here.
+
+## Exact Objects
+
+The two-cube is the twelve-point set
+
+`V = {0,1,2} × {0,1} × {0,1} ⊂ Z^3`.
+
+The open nearest-neighbor set of a site `x` is
+`N(x) = {x ± e_1, x ± e_2, x ± e_3}`. A neighbor in `V` that is already
+locked contributes occupancy `1`; a neighbor outside `V` contributes
+occupancy `0`. For each of the three axes one records the pair
+`(c_{+μ}, c_{-μ}) ∈ {0,1}^2` and tallies
+
+- unbalanced if the pair is `(1,0)` or `(0,1)`,
+- both if the pair is `(1,1)`,
+- empty if the pair is `(0,0)`.
+
+A seed is an unordered pair `S ⊂ V` with `|S| = 2`. There are exactly
+`C(12,2) = 66` such seeds. Lexicographic order of a seed is the ordered pair
+of its two sites after each site is written in coordinate order
+`(x,y,z)` and the two sites are then sorted.
+
+The run of a map `f` from `S` begins with `locks_0 = S`. At tick `t ≥ 1`
+every unlocked `x ∈ V` with `f(c(x, locks_{t-1})) = 1` locks simultaneously.
+The history is `(|locks_0|, |locks_1|, …, |locks_T|)` at the first `T` with
+no further ready site. Fill is the boolean `|locks_T| = 12`.
+
+`f_L1(c) = 1` iff `n_unbalanced ≠ 0`. This is not the Hamming weight of the
+six occupancy bits: the opposite-pair occupancy at `(1,0,0)` with
+`{(0,0,0),(2,0,0)}` locked has Hamming weight `2` and
+`(n_unbalanced, n_both, n_empty) = (0,1,2)`, so `f_L1` does not fire.
+
+`f_min(c) = 1` iff `n_both = 0` and `n_unbalanced ≠ 0`. The maps therefore
+disagree exactly when at least one axis is unbalanced and at least one axis
+is doubly occupied.
+
+## Theorem 1 — Census Reconfirmation
+
+Every one of the 66 seeds is run independently under both maps. The census
+integers are
+
+`N_split = 4`,
+`N_fill_L1 = 62`,
+`N_fill_min = 58`.
+
+The named pair `S_* = {(0,0,0),(2,1,1)}` is one split: `f_L1` fills with
+history `(2, 8, 12)` and `f_min` halts unfilled at `(2, 8, 10)`.
+
+## Theorem 2 — The Four Seeds In Lexicographic Order
+
+The four splitters, listed once each in lexicographic site-pair order, are
+
+`{(0,0,0),(2,1,1)}`,
+`{(0,0,1),(2,1,0)}`,
+`{(0,1,0),(2,0,1)}`,
+`{(0,1,1),(2,0,0)}`.
+
+Each of the four has the same displayed pair of runs: `f_L1` history
+`(2, 8, 12)` and fill, `f_min` history `(2, 8, 10)` and unfilled halt at ten
+locks. No other two-site seed splits the maps. The four pairs are exactly
+the displacement-`(2,1,1)` pairs of the two-cube.
+
+## Theorem 3 — Display, Do Not Adopt
+
+The four-seed set is the object of this note. Display the four seeds. Do not adopt a selector. Do not write them into Admissibility. A selector is not written into Admissibility. A later derivation
+that used one of these seeds as a physical rule would be a different claim.
+
+## What This Does Not Claim
+
+- It does not claim that either map is the Admissibility rule.
+- It does not claim that lock-step waves are physical Record formation.
+- It does not claim a unique physically preferred two-site seed.
+- It does not extend the list to `|S| ≠ 2` or to a larger patch.
+- It does not identify `f_min` with Hamming weight, graph distance, or any
+  map other than nonempty `n_both = 0`.
+- It does not treat the prior count `N_split = 4` as a naming of the four
+  seeds.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the four-seed identity question for the two displayed maps on the declared patch. |
+| V2 | Current main has the axiom memo and no landed list of these four two-site splitters. |
+| V3 | All 66 pairs, both runs, and the four listed seeds are independently finite and exact. |
+| V4 | The list is more than a restatement of the integer `N_split = 4`: it names each seed. |
+| V5 | It is not a physical compiler and writes no selector into Admissibility. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: the four listed seeds are not hereby adopted.
+No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| named splitter | run both maps from `{(0,0,0),(2,1,1)}` | split; L1 `(2, 8, 12)` fills, min `(2, 8, 10)` does not |
+| remaining three displacement `(2,1,1)` pairs | run both maps from each | the same split pattern; they complete the list of four |
+| long-axis `(2,0,0)` | run both maps from `{(0,y,z),(2,y,z)}` | neither fills; same history; not a split |
+| Hamming-weight predicate | fire on six-bit weight | executed counterexample: opp2 has weight 2 and `f_L1 = 0` |
+| adopt a seed | write one splitter into Admissibility | refused; displayed, not adopted |
+| count-only census | report `N_split` without names | leftover-character of the count; this note lists the set |
+
+### N2 — wall independence
+
+The missing formation mechanism, the missing Admissibility selector, and any
+extension off this twelve-site patch are distinct premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch occupancy `0`, the two predicates, and the
+synchronous wave rule are declared. Hamming weight is not silently used.
+No seed is treated as axiom content.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate, the
+local-condition sentence, and the lock/content/absence wording used here.
+It does not supply `f_min`, `f_L1`, or a two-site selector. The residual
+matches those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 66 pairs, two maps, lock-count histories | no continuum or larger-patch census |
+| per site | six-neighbor occupancy 3-tuples | no derived kernel values |
+| per mode | no mode calculation | no spectral statement |
+| per block | two-cube lock-step dynamics | no physical formation compiler |
+| lattice wide | checked and not executed | no infinite-volume claim |
+
+### N6 — live partial-closure paths
+
+Live routes are an independently derived formation mechanism, a derivation
+that would force one of the two maps, and any census at a different seed
+cardinality or patch. Those routes remain open.
+
+### N7 — hostile steelman
+
+**Steelman:** Because a prior census already reported `N_split = 4` and
+named one splitter, listing the four seeds adds no object.
+
+**Answer:** A count is not a list. The four-seed set is a new displayed
+object: the lex-ordered pairs and the common history pair
+`(2, 8, 12)` versus `(2, 8, 10)`. The count-only row did not name the
+set.
+
+### N8 — cross-cycle echo
+
+A prior displayed computation counted four two-site splits. This note does
+not recycle that integer as the four-seed identity. It recomputes every
+two-site run and lists the four seeds.
+
+**Gate disposition:** PASS for the four-seed list and the reconfirmed census
+integers above. FAIL / DO NOT SHIP for “Admissibility is `f_min`,” “adopt
+this seed,” or “the maps agree on every two-site seed.”
+
+## Primary Runner
+
+The primary runner recomputes all 66 pairs, reconfirms
+`N_split = 4`, `N_fill_L1 = 62`, `N_fill_min = 58`, and that
+`{(0,0,0),(2,1,1)}` is one split, lists the four seeds in lexicographic
+order, checks that each has `f_L1` history `(2, 8, 12)` and `f_min`
+unfilled `(2, 8, 10)`, and checks that this note displays that list without
+adopting a selector. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5530,
+ "edge_count": 15732,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_min_l1_four_split_seeds_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_min_l1_four_split_seeds_2026_08_15.txt
+++ b/logs/runner-cache/f_min_l1_four_split_seeds_2026_08_15.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/f_min_l1_four_split_seeds_2026_08_15.py
+runner_sha256: e7cb1f03b15d0431856b2c6f0fe288743dba16b34455ec0fd11687e83c911564
+input_fingerprint_sha256: f38927e3477287b5a26b9c8c56e1702d6c45ce843c6268bcb4808b05c6f2336c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: exhaustive two-site lock-step census; the four split seeds are listed in lex order
+negative_scope: the four seeds are displayed; no selector is adopted or written into Admissibility
+cache_write: false
+PASS: audit-inputs the two declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: two-cube-cardinality the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}
+PASS: pair-count there are C(12,2)=66 unordered two-site seeds
+census: N_split=4 N_fill_L1=62 N_fill_min=58
+four_split_seeds_lex: {(0,0,0),(2,1,1)}, {(0,0,1),(2,1,0)}, {(0,1,0),(2,0,1)}, {(0,1,1),(2,0,0)}
+  {(0,0,0),(2,1,1)} hist_L1=(2, 8, 12) fill_L1=True hist_min=(2, 8, 10) fill_min=False
+  {(0,0,1),(2,1,0)} hist_L1=(2, 8, 12) fill_L1=True hist_min=(2, 8, 10) fill_min=False
+  {(0,1,0),(2,0,1)} hist_L1=(2, 8, 12) fill_L1=True hist_min=(2, 8, 10) fill_min=False
+  {(0,1,1),(2,0,0)} hist_L1=(2, 8, 12) fill_L1=True hist_min=(2, 8, 10) fill_min=False
+PASS: theorem-1-census N_split=4, N_fill_L1=62, and N_fill_min=58 on the 66 two-site seeds
+PASS: theorem-1-named-splitter the seed {(0,0,0),(2,1,1)} is one split
+PASS: theorem-2-lex-list the four seeds are listed in lexicographic site-pair order
+PASS: theorem-2-histories each listed seed has f_L1 history (2, 8, 12) and f_min unfilled (2, 8, 10)
+PASS: theorem-3-display the note displays the four computed seeds in lex order and does not adopt a selector
+PASS: identity-l1-not-hamming opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire
+PASS: identity-min-nboth-zero f_min fires on nonempty n_both=0 and refuses mixed3
+PASS: forbidden-phrases the note and runner avoid the dispatch-forbidden phrases
+PASS: no-admissibility-selector the note does not write a seed selector into Admissibility
+PASS: claim-scope the YAML claim_scope states the four-seed display
+PASS: not-leftover-count the claim is the four-seed set, not leftover character of the count-only census
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_min_l1_four_split_seeds_2026_08_15.py
+++ b/scripts/f_min_l1_four_split_seeds_2026_08_15.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""List the four two-site seeds that split f_min from f_L1.
+
+Recomputes every unordered pair of the twelve two-cube sites with
+off-patch occupancy 0. A split is a different fill bit or a different
+lock-count history. The four seeds are listed in lexicographic order;
+they are displayed, not adopted, and are not written into Admissibility.
+f_L1 is the some-axis-unbalanced (n != 0) map, not Hamming weight.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_MIN_L1_FOUR_SPLIT_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_MIN_L1_FOUR_SPLIT_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+AXES: tuple[Point, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SITES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+NAMED_SPLITTER = frozenset(((0, 0, 0), (2, 1, 1)))
+L1_SPLIT_HISTORY = (2, 8, 12)
+MIN_SPLIT_HISTORY = (2, 8, 10)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locked: frozenset[Point]) -> int:
+    """On-patch occupancy is the lock bit; off-patch occupancy is 0."""
+    if site not in SITE_SET:
+        return 0
+    return 1 if site in locked else 0
+
+
+def axis_type(site: Point, locked: frozenset[Point]) -> tuple[int, int, int]:
+    """Return (n_unbalanced, n_both, n_empty) for the three cubic axes."""
+    n_unbalanced = n_both = n_empty = 0
+    for axis in AXES:
+        plus = occupancy(add(site, axis), locked)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+        if plus == minus == 0:
+            n_empty += 1
+        elif plus == minus == 1:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fire_l1(counts: tuple[int, int, int]) -> bool:
+    """f_L1: some axis is unbalanced (n != 0). Not Hamming weight."""
+    n_unbalanced, _n_both, _n_empty = counts
+    return n_unbalanced != 0
+
+
+def fire_min(counts: tuple[int, int, int]) -> bool:
+    """f_min: nonempty and n_both = 0."""
+    n_unbalanced, n_both, _n_empty = counts
+    return n_both == 0 and n_unbalanced != 0
+
+
+def run(seed: frozenset[Point], fire) -> tuple[tuple[int, ...], bool]:
+    locked = frozenset(seed)
+    history = [len(locked)]
+    for _tick in range(len(SITES)):
+        ready = [
+            site
+            for site in SITES
+            if site not in locked and fire(axis_type(site, locked))
+        ]
+        if not ready:
+            break
+        locked = locked.union(ready)
+        history.append(len(locked))
+    return (tuple(history), len(locked) == len(SITES))
+
+
+def seed_key(seed: frozenset[Point]) -> tuple[Point, ...]:
+    return tuple(sorted(seed))
+
+
+def seed_display(seed: frozenset[Point]) -> str:
+    left, right = seed_key(seed)
+    return f"{{({left[0]},{left[1]},{left[2]}),({right[0]},{right[1]},{right[2]})}}"
+
+
+def census() -> dict[str, object]:
+    n_split = n_fill_l1 = n_fill_min = 0
+    splits: list[frozenset[Point]] = []
+    histories: dict[tuple[Point, ...], tuple[tuple[int, ...], bool, tuple[int, ...], bool]] = {}
+    pairs = tuple(frozenset(pair) for pair in combinations(SITES, 2))
+    for seed in pairs:
+        hist_l1, fill_l1 = run(seed, fire_l1)
+        hist_min, fill_min = run(seed, fire_min)
+        n_fill_l1 += int(fill_l1)
+        n_fill_min += int(fill_min)
+        if (fill_l1 != fill_min) or (hist_l1 != hist_min):
+            n_split += 1
+            splits.append(seed)
+            histories[seed_key(seed)] = (hist_l1, fill_l1, hist_min, fill_min)
+    splits_lex = tuple(sorted(splits, key=seed_key))
+    return {
+        "n_pairs": len(pairs),
+        "n_split": n_split,
+        "n_fill_l1": n_fill_l1,
+        "n_fill_min": n_fill_min,
+        "splits_lex": splits_lex,
+        "histories": histories,
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: exhaustive two-site lock-step census; the four split seeds are listed in lex order")
+    print("negative_scope: the four seeds are displayed; no selector is adopted or written into Admissibility")
+    print("cache_write: false")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_MIN_L1_FOUR_SPLIT_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_MIN_L1_FOUR_SPLIT_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    checks.check(
+        "two-cube-cardinality",
+        "the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}",
+        len(SITES) == 12 and len(SITE_SET) == 12 and SITES[0] == (0, 0, 0) and SITES[-1] == (2, 1, 1),
+    )
+    checks.check("pair-count", "there are C(12,2)=66 unordered two-site seeds", len(tuple(combinations(SITES, 2))) == 66)
+
+    counts = census()
+    n_split = int(counts["n_split"])
+    n_fill_l1 = int(counts["n_fill_l1"])
+    n_fill_min = int(counts["n_fill_min"])
+    splits_lex = counts["splits_lex"]
+    histories = counts["histories"]
+    assert isinstance(splits_lex, tuple)
+    assert isinstance(histories, dict)
+    displays = [seed_display(seed) for seed in splits_lex]
+    print(
+        "census: "
+        f"N_split={n_split} N_fill_L1={n_fill_l1} N_fill_min={n_fill_min}"
+    )
+    print("four_split_seeds_lex: " + ", ".join(displays))
+    for seed in splits_lex:
+        hist_l1, fill_l1, hist_min, fill_min = histories[seed_key(seed)]
+        print(
+            f"  {seed_display(seed)} "
+            f"hist_L1={hist_l1} fill_L1={fill_l1} "
+            f"hist_min={hist_min} fill_min={fill_min}"
+        )
+
+    checks.check(
+        "theorem-1-census",
+        "N_split=4, N_fill_L1=62, and N_fill_min=58 on the 66 two-site seeds",
+        counts["n_pairs"] == 66 and n_split == 4 and n_fill_l1 == 62 and n_fill_min == 58,
+        residual=(n_split, n_fill_l1, n_fill_min),
+    )
+
+    hist_l1_star, fill_l1_star = run(NAMED_SPLITTER, fire_l1)
+    hist_min_star, fill_min_star = run(NAMED_SPLITTER, fire_min)
+    splits_star = (fill_l1_star != fill_min_star) or (hist_l1_star != hist_min_star)
+    checks.check(
+        "theorem-1-named-splitter",
+        "the seed {(0,0,0),(2,1,1)} is one split",
+        splits_star
+        and fill_l1_star
+        and not fill_min_star
+        and hist_l1_star == L1_SPLIT_HISTORY
+        and hist_min_star == MIN_SPLIT_HISTORY
+        and NAMED_SPLITTER in splits_lex,
+        residual=(hist_l1_star, hist_min_star, fill_l1_star, fill_min_star),
+    )
+
+    keys = [seed_key(seed) for seed in splits_lex]
+    checks.check(
+        "theorem-2-lex-list",
+        "the four seeds are listed in lexicographic site-pair order",
+        len(splits_lex) == 4
+        and keys == sorted(keys)
+        and all(len(key) == 2 and key == tuple(sorted(key)) for key in keys),
+        residual=keys,
+    )
+
+    history_ok = all(
+        histories[seed_key(seed)] == (L1_SPLIT_HISTORY, True, MIN_SPLIT_HISTORY, False)
+        for seed in splits_lex
+    )
+    checks.check(
+        "theorem-2-histories",
+        "each listed seed has f_L1 history (2, 8, 12) and f_min unfilled (2, 8, 10)",
+        history_ok and len(splits_lex) == 4,
+        residual=[(seed_display(seed), histories[seed_key(seed)]) for seed in splits_lex],
+    )
+
+    note_has_each = all(display in note.replace(" ", "") for display in displays)
+    order_ok = True
+    cursor = 0
+    compact_note = note.replace(" ", "")
+    for display in displays:
+        found = compact_note.find(display, cursor)
+        if found < 0:
+            order_ok = False
+            break
+        cursor = found + len(display)
+    checks.check(
+        "theorem-3-display",
+        "the note displays the four computed seeds in lex order and does not adopt a selector",
+        note_has_each
+        and order_ok
+        and "displayed, not adopted" in normalized_note.lower()
+        and "do not adopt" in normalized_note.lower()
+        and f"N_split = {n_split}" in note
+        and f"N_fill_L1 = {n_fill_l1}" in note
+        and f"N_fill_min = {n_fill_min}" in note,
+        residual=displays,
+    )
+
+    locked_opp = frozenset(((0, 0, 0), (2, 0, 0)))
+    opp2 = axis_type((1, 0, 0), locked_opp)
+    hamming_opp = sum(
+        occupancy(add((1, 0, 0), shift), locked_opp)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    checks.check(
+        "identity-l1-not-hamming",
+        "opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire",
+        opp2 == (0, 1, 2) and hamming_opp == 2 and not fire_l1(opp2) and not fire_min(opp2),
+    )
+    locked_mixed = frozenset(((0, 0, 0), (2, 0, 0), (1, 1, 0)))
+    mixed3 = axis_type((1, 0, 0), locked_mixed)
+    locked_wt1 = frozenset(((0, 0, 0),))
+    wt1 = axis_type((1, 0, 0), locked_wt1)
+    checks.check(
+        "identity-min-nboth-zero",
+        "f_min fires on nonempty n_both=0 and refuses mixed3",
+        wt1 == (1, 0, 2)
+        and mixed3 == (1, 1, 1)
+        and fire_min(wt1)
+        and fire_l1(wt1)
+        and not fire_min(mixed3)
+        and fire_l1(mixed3),
+    )
+
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note and runner avoid the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "no-admissibility-selector",
+        "the note does not write a seed selector into Admissibility",
+        "not written into Admissibility" in normalized_note
+        and "selector" in normalized_note
+        and "Do not write" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "the YAML claim_scope states the four-seed display",
+        "The four two-site seeds on the two-cube that distinguish f_min from f_L1 are listed." in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-leftover-count",
+        "the claim is the four-seed set, not leftover character of the count-only census",
+        "Not leftover-character of #6422" in note and "that only counted" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Recompute the 66 two-site runs on the two-cube. N_split=4, N_fill_L1=62, N_fill_min=58. The four seeds in lex order are listed. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_min_l1_four_split_seeds_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.