### PR TITLE
feat(splitorbit): count cube-orbits of the four f_min/f_L1 split seeds

### DIFF
--- a/docs/F_MIN_L1_SPLIT_SEED_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_MIN_L1_SPLIT_SEED_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,311 @@
+---
+claim_id: f_min_l1_split_seed_orbit_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The four two-site seeds that distinguish f_min from f_L1 form N_orb orbits under two-cube-preserving proper cube rotations. Here N_orb=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_min_l1_split_seed_orbit_2026_08_15.py
+---
+
+# Split-Seed Orbit Count Of `f_min` Versus `f_L1`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** orbit count of the four two-site seeds on the twelve-vertex
+two-cube `{0,1,2} × {0,1} × {0,1}` that distinguish `f_min` from `f_L1`,
+under the proper cube rotations about the box center `(1, 1/2, 1/2)` that
+permute those twelve sites. The integer `N_orb` is displayed. No seed is
+adopted and no orbit is written into Admissibility.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_min_l1_split_seed_orbit_2026_08_15.py`](../scripts/f_min_l1_split_seed_orbit_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+On the two-cube, a lock-step run of a displayed readiness map from a seed `S`
+is the synchronous wave process that begins with `S` locked and, at each tick,
+locks every still-unlocked site whose six-neighbor occupancy 3-tuple satisfies
+the map. The lock-history tuple is the sequence of lock counts after the seed
+and after each nonempty wave, until halt. Fill means `|locks_halt| = 12`.
+
+Write `n_unbalanced`, `n_both`, and `n_empty` for the number of cubic axes
+whose two opposite neighbors are occupied on exactly one side, on both sides,
+or on neither side. Off-patch neighbors contribute occupancy `0`. Then
+
+- `f_L1` fires iff `n_unbalanced ≠ 0` (some axis is unbalanced; not Hamming
+  weight of the six occupancy bits);
+- `f_min` fires iff the occupancy is nonempty and `n_both = 0`
+  (equivalently `n_unbalanced ≠ 0` and `n_both = 0`).
+
+A two-site seed *splits* the two maps when the fill bits differ or the
+lock-history tuples differ. Recomputing every unordered pair on the twelve
+sites recovers exactly four splitters, each with `f_L1` history `(2, 8, 12)`
+and `f_min` halt unfilled at `(2, 8, 10)`:
+
+`{(0,0,0),(2,1,1)}`, `{(0,0,1),(2,1,0)}`, `{(0,1,0),(2,0,1)}`,
+`{(0,1,1),(2,0,0)}`.
+
+These four pairs are the four space diagonals of the long box: opposite
+corners through the center `(1, 1/2, 1/2)`.
+
+The ambient proper cubic group about that center has 24 matrices (signed
+permutations of the three axes with determinant `+1`). Sixteen of those
+matrices send at least one of the twelve sites off the two-cube and are
+not used. The remaining eight permute the twelve sites and induce the
+group `G` of this note.
+
+`N_orb = 1`
+
+The four split seeds form a single `G`-orbit. The split is one geometric
+type — opposite corners of the long box — not four independent extras.
+`N_orb` is displayed census output. It is not adopted as a physical
+selector, and the orbit is not written into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The four split seeds, the 24 ambient proper cube rotations, the eight two-cube-preserving site-permutations, and the single orbit integer are finite exact statements on a declared twelve-site patch; no seed is selected and no Admissibility clause is added."
+trace_class: frontier_discovery
+target_claim_id: f_min_l1_split_seed_orbit
+target_blocker_text: "whether the four two-site seeds that split f_min from f_L1 form one orbit under two-cube-preserving proper cube rotations"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the twelve-vertex two-cube with off-patch occupancy 0 and the two displayed readiness maps; no selector is adopted"
+hypothetical_axiom_status: "none; f_min and the four splitting seeds are displayed and are not proposed as axiom content"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded orbit count; do not write an orbit into Admissibility"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** Lattice, Admissibility, and Record are quoted from
+  the live axiom memo without rewrite. They identify the cubic nearest-neighbor
+  graph, the local-condition domain, and the lock/content/absence wording.
+  They do not supply the two readiness maps, the two-cube patch, or an orbit
+  of seeds.
+- **Explicit theorem-domain condition:** the twelve sites
+  `{0,1,2} × {0,1} × {0,1}`, off-patch occupancy identically `0`, the two
+  displayed maps `f_L1` and `f_min`, the synchronous lock-step dynamics,
+  and the proper cube rotations about `(1, 1/2, 1/2)` that permute those
+  twelve sites are supplied mathematical data for this orbit count.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing either map, any of the four splitting
+  seeds, or their orbit into Admissibility remains a separate, open
+  obligation. This note does not adopt them.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility
+
+does not supply the formation site, probability, or rate.
+
+The two readiness maps are displayed occupancy predicates on the six-neighbor
+condition tuple. They are not Admissibility content. Using a lock-step wave as
+physical Record formation would require a separately derived formation
+mechanism; that mechanism is not supplied here.
+
+## Exact Objects
+
+The two-cube is the twelve-point set
+
+`V = {0,1,2} × {0,1} × {0,1} ⊂ Z^3`.
+
+The open nearest-neighbor set of a site `x` is
+`N(x) = {x ± e_1, x ± e_2, x ± e_3}`. A neighbor in `V` that is already
+locked contributes occupancy `1`; a neighbor outside `V` contributes
+occupancy `0`. For each of the three axes one records the pair
+`(c_{+μ}, c_{-μ}) ∈ {0,1}^2` and tallies
+
+- unbalanced if the pair is `(1,0)` or `(0,1)`,
+- both if the pair is `(1,1)`,
+- empty if the pair is `(0,0)`.
+
+A seed is an unordered pair `S ⊂ V` with `|S| = 2`. The run of a map `f`
+from `S` begins with `locks_0 = S`. At tick `t ≥ 1` every unlocked
+`x ∈ V` with `f(c(x, locks_{t-1})) = 1` locks simultaneously. The history
+is `(|locks_0|, |locks_1|, …, |locks_T|)` at the first `T` with no further
+ready site. Fill is the boolean `|locks_T| = 12`.
+
+`f_L1(c) = 1` iff `n_unbalanced ≠ 0`. This is not the Hamming weight of the
+six occupancy bits: the opposite-pair occupancy at `(1,0,0)` with
+`{(0,0,0),(2,0,0)}` locked has Hamming weight `2` and
+`(n_unbalanced, n_both, n_empty) = (0,1,2)`, so `f_L1` does not fire.
+
+`f_min(c) = 1` iff `n_both = 0` and `n_unbalanced ≠ 0`.
+
+The ambient group of proper cube rotations about the box center
+`c = (1, 1/2, 1/2)` is the set of maps `x ↦ c + R(x − c)` where `R` is a
+`3 × 3` signed-permutation matrix with `det R = +1`. There are
+`3! × 2^3 / 2 = 24` such matrices. A rotation is used only when it
+permutes `V`. The sixteen matrices that send a site of `V` off the
+two-cube are discarded. The remaining eight form `G` and act on
+unordered pairs by `g · {p, q} = {g(p), g(q)}`.
+
+## Theorem 1 — Four Split Seeds, One Orbit
+
+Recomputing all `C(12,2) = 66` two-site seeds recovers `N_split = 4`.
+The four seeds, in lexicographic order, are
+
+`{(0,0,0),(2,1,1)}`, `{(0,0,1),(2,1,0)}`, `{(0,1,0),(2,0,1)}`,
+`{(0,1,1),(2,0,0)}`.
+
+Each has `f_L1` history `(2, 8, 12)` and `f_min` halt unfilled at
+`(2, 8, 10)`.
+
+The quarter-turn about the long axis through `c`,
+
+`(x, y, z) ↦ (x, 1 − z, y)`,
+
+is one of the eight elements of `G`. It cycles the four seeds
+
+`{(0,0,0),(2,1,1)} → {(0,1,0),(2,0,1)} → {(0,1,1),(2,0,0)} → {(0,0,1),(2,1,0)}`.
+
+Therefore the four seeds lie in a single `G`-orbit:
+
+`N_orb = 1`.
+
+## Theorem 2 — One Geometric Type
+
+Because `N_orb = 1`, the split is one geometric type: opposite corners of
+the long box. There is no second orbit to display. The four pairs are the
+four space diagonals through `c`. They are not four independent extras.
+
+A rotation that fails to preserve the twelve-set is not used to manufacture
+a larger group or a second type.
+
+## Theorem 3 — Display, Do Not Adopt
+
+The integer `N_orb = 1` is the object of the count. The four seeds and the
+order `|G| = 8` of the two-cube-preserving subgroup are reported with it.
+They are displayed, not adopted: do not adopt a seed, and do not adopt the
+orbit. An orbit is not written into Admissibility. A later derivation that
+used this orbit as a physical rule would be a different claim.
+
+## What This Does Not Claim
+
+- It does not claim that either map is the Admissibility rule.
+- It does not claim that lock-step waves are physical Record formation.
+- It does not claim a unique physically preferred two-site seed.
+- It does not claim that all 24 proper cube rotations permute the two-cube.
+- It does not write the orbit, or any seed, into Admissibility.
+- It does not identify `f_min` with Hamming weight, graph distance, or any
+  map other than nonempty `n_both = 0`.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the orbit-count question for the four displayed split seeds under two-cube-preserving proper cube rotations. |
+| V2 | Current main has the axiom memo and no landed orbit count of these four seeds. |
+| V3 | The four seeds, the 24 ambient matrices, the eight preservers, and `N_orb` are independently finite and exact. |
+| V4 | The orbit integer is more than a restatement of the four-seed list: it is a new object, the number of geometric types. |
+| V5 | It is not a physical compiler and writes no orbit into Admissibility. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: the four splitters are one `G`-orbit on this
+patch, and that orbit is not hereby adopted. No global compiler impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| recompute the 66 pairs | lock-step both maps | `N_split = 4`, same four seeds |
+| full 24 about the box center | apply every proper cubic matrix | 16 fail to permute `V` and are unused |
+| two-cube-preserving `G` | act with the remaining 8 | one orbit; `N_orb = 1` |
+| Hamming-weight predicate | fire on six-bit weight | executed counterexample: opp2 has weight 2 and `f_L1 = 0` |
+| adopt the orbit | write `G · S_*` into Admissibility | refused; displayed, not adopted |
+| a second geometric type | exhibit a split seed outside the long-box diagonals | none among the four |
+
+### N2 — wall independence
+
+The missing formation mechanism, the missing Admissibility selector, and any
+extension off this twelve-site patch are distinct premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch occupancy `0`, the two predicates, the synchronous
+wave rule, and the restriction to site-permuting proper cube rotations are
+declared. Hamming weight is not silently used. No seed or orbit is treated
+as axiom content.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate, the
+local-condition sentence, and the lock/content/absence wording used here.
+It does not supply `f_min`, `f_L1`, or a two-site orbit. The residual
+matches those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 66 pairs, two maps, 24 ambient rotations, 8 preservers | no continuum or larger-patch census |
+| per site | six-neighbor occupancy 3-tuples | no derived kernel values |
+| per mode | no mode calculation | no spectral statement |
+| per block | two-cube lock-step dynamics and box-center rotations | no physical formation compiler |
+| lattice wide | checked and not executed | no infinite-volume claim |
+
+### N6 — live partial-closure paths
+
+Live routes are an independently derived formation mechanism, a derivation
+that would force one of the two maps, and any orbit count at a different
+seed cardinality or patch. Those routes remain open.
+
+### N7 — hostile steelman
+
+**Steelman:** The two-cube is elongated, so the 24 proper cube rotations
+cannot act, and the four space diagonals could be four types under the
+surviving group.
+
+**Answer:** Sixteen of the 24 matrices are discarded because they do not
+permute the twelve sites. The remaining eight still contain the long-axis
+quarter-turn, which cycles all four space diagonals. The four seeds are
+one type.
+
+### N8 — cross-cycle echo
+
+A prior displayed computation counted `N_split = 4` and listed the four
+seeds. This note does not recycle that count as the orbit integer. It
+recomputes the four seeds and reports `N_orb = 1` under the
+two-cube-preserving proper cube rotations.
+
+**Gate disposition:** PASS for the orbit count and the displayed integer
+`N_orb = 1` above. FAIL / DO NOT SHIP for “Admissibility is `f_min`,”
+“adopt this orbit,” or “the 24 ambient rotations all permute the two-cube.”
+
+## Primary Runner
+
+The primary runner recomputes the four split seeds, enumerates the 24
+proper cube rotations about the box center, keeps only the eight that
+permute the twelve sites, counts `G`-orbits, checks that `f_L1` is
+`n_unbalanced ≠ 0` rather than Hamming weight, checks that `f_min` is
+nonempty `n_both = 0`, and checks that this note displays `N_orb = 1`
+without adopting a seed or writing an orbit into Admissibility. It
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5530,
+ "edge_count": 15732,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_min_l1_split_seed_orbit_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_min_l1_split_seed_orbit_2026_08_15.txt
+++ b/logs/runner-cache/f_min_l1_split_seed_orbit_2026_08_15.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/f_min_l1_split_seed_orbit_2026_08_15.py
+runner_sha256: fe83288e3caee0b659127aa07e074942ee4cca28605893c70b1ac66e5ace0981
+input_fingerprint_sha256: 3db59c8d8997c3fd78d82dea2946ab55837d7123aab189fdba5c9e0bb989c1a0
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: four split seeds recomputed; G-orbits under two-cube-preserving proper cube rotations
+negative_scope: N_orb is displayed; no seed is adopted and no orbit is written into Admissibility
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+orbit: N_split=4 N_ambient=24 |G|=8 N_orb=1
+split_seeds: ((0, 0, 0), (2, 1, 1)); ((0, 0, 1), (2, 1, 0)); ((0, 1, 0), (2, 0, 1)); ((0, 1, 1), (2, 0, 0))
+PASS: two-cube-and-ambient the two-cube has twelve sites and the ambient proper cubic group has 24 matrices
+PASS: group-preserves-twelve only site-permutations of the two-cube induced by proper cube rotations are used
+PASS: unused-non-permutations rotations that do not permute the twelve sites are discarded
+PASS: theorem-1-four-split-seeds recomputed N_split=4 with f_L1 history (2,8,12) and f_min halt (2,8,10)
+PASS: theorem-1-n-orb N_orb is the number of G-orbits among the four seeds
+PASS: theorem-2-geometric-type N_orb=1: the note reports one geometric type (opposite corners of the long box)
+PASS: theorem-3-display the note displays the computed N_orb and does not adopt a seed or orbit
+PASS: identity-l1-not-hamming opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire
+PASS: identity-min-nboth-zero f_min fires on nonempty n_both=0 and refuses mixed3
+PASS: forbidden-phrases the note avoids the dispatch-forbidden phrases
+PASS: no-admissibility-orbit the note does not write an orbit into Admissibility
+PASS: claim-scope the YAML claim_scope states the orbit-count display
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_min_l1_split_seed_orbit_2026_08_15.py
+++ b/scripts/f_min_l1_split_seed_orbit_2026_08_15.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Orbit count of the four f_min/f_L1 split seeds under two-cube rotations.
+
+Recomputes the four two-site seeds that split f_min from f_L1 on
+{0,1,2} x {0,1} x {0,1} with off-patch occupancy 0, then counts
+G-orbits under the proper cube rotations about the box center
+(1, 1/2, 1/2) that permute those twelve sites. Displays N_orb; does
+not adopt a seed or write an orbit into Admissibility.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_MIN_L1_SPLIT_SEED_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_MIN_L1_SPLIT_SEED_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+AXES: tuple[Point, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SITES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+L1_SPLIT_HISTORY = (2, 8, 12)
+MIN_SPLIT_HISTORY = (2, 8, 10)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locked: frozenset[Point]) -> int:
+    """On-patch occupancy is the lock bit; off-patch occupancy is 0."""
+    if site not in SITE_SET:
+        return 0
+    return 1 if site in locked else 0
+
+
+def axis_type(site: Point, locked: frozenset[Point]) -> tuple[int, int, int]:
+    """Return (n_unbalanced, n_both, n_empty) for the three cubic axes."""
+    n_unbalanced = n_both = n_empty = 0
+    for axis in AXES:
+        plus = occupancy(add(site, axis), locked)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+        if plus == minus == 0:
+            n_empty += 1
+        elif plus == minus == 1:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fire_l1(counts: tuple[int, int, int]) -> bool:
+    """f_L1: some axis is unbalanced (n != 0). Not Hamming weight."""
+    n_unbalanced, _n_both, _n_empty = counts
+    return n_unbalanced != 0
+
+
+def fire_min(counts: tuple[int, int, int]) -> bool:
+    """f_min: nonempty and n_both = 0."""
+    n_unbalanced, n_both, _n_empty = counts
+    return n_both == 0 and n_unbalanced != 0
+
+
+def run(seed: frozenset[Point], fire) -> tuple[tuple[int, ...], bool]:
+    locked = frozenset(seed)
+    history = [len(locked)]
+    for _tick in range(len(SITES)):
+        ready = [
+            site
+            for site in SITES
+            if site not in locked and fire(axis_type(site, locked))
+        ]
+        if not ready:
+            break
+        locked = locked.union(ready)
+        history.append(len(locked))
+    return (tuple(history), len(locked) == len(SITES))
+
+
+def split_seeds() -> tuple[frozenset[Point], ...]:
+    found: list[frozenset[Point]] = []
+    for pair in combinations(SITES, 2):
+        seed = frozenset(pair)
+        hist_l1, fill_l1 = run(seed, fire_l1)
+        hist_min, fill_min = run(seed, fire_min)
+        if fill_l1 != fill_min or hist_l1 != hist_min:
+            found.append(seed)
+    return tuple(found)
+
+
+def det3(matrix: Matrix) -> int:
+    a, b, c = matrix
+    return (
+        a[0] * (b[1] * c[2] - b[2] * c[1])
+        - a[1] * (b[0] * c[2] - b[2] * c[0])
+        + a[2] * (b[0] * c[1] - b[1] * c[0])
+    )
+
+
+def proper_cube_rotations() -> tuple[Matrix, ...]:
+    """The 24 proper cubic matrices: signed permutations with det +1."""
+    mats: list[Matrix] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for i in range(3):
+                rows[i][perm[i]] = signs[i]
+            matrix = (tuple(rows[0]), tuple(rows[1]), tuple(rows[2]))
+            if det3(matrix) == 1:
+                mats.append(matrix)
+    return tuple(mats)
+
+
+def apply_about_center(matrix: Matrix, point: Point) -> Point | None:
+    """Apply R about the box center (1, 1/2, 1/2) in doubled integer coordinates."""
+    delta = (2 * point[0] - 2, 2 * point[1] - 1, 2 * point[2] - 1)
+    image = tuple(sum(matrix[i][j] * delta[j] for j in range(3)) for i in range(3))
+    if (image[0] + 2) % 2 != 0 or (image[1] + 1) % 2 != 0 or (image[2] + 1) % 2 != 0:
+        return None
+    return ((image[0] + 2) // 2, (image[1] + 1) // 2, (image[2] + 1) // 2)
+
+
+def two_cube_preserving_rotations() -> tuple[Matrix, ...]:
+    """Keep only proper cube rotations that permute the twelve sites."""
+    kept: list[Matrix] = []
+    for matrix in proper_cube_rotations():
+        images = [apply_about_center(matrix, site) for site in SITES]
+        if all(image in SITE_SET for image in images) and set(images) == SITE_SET:
+            kept.append(matrix)
+    return tuple(kept)
+
+
+def act_on_seed(matrix: Matrix, seed: frozenset[Point]) -> frozenset[Point] | None:
+    images = [apply_about_center(matrix, site) for site in seed]
+    if any(image is None or image not in SITE_SET for image in images):
+        return None
+    return frozenset(images)  # type: ignore[arg-type]
+
+
+def orbit_count(seeds: tuple[frozenset[Point], ...], group: tuple[Matrix, ...]) -> int:
+    unused = set(range(len(seeds)))
+    n_orb = 0
+    while unused:
+        start = min(unused)
+        unused.remove(start)
+        stack = [start]
+        n_orb += 1
+        while stack:
+            index = stack.pop()
+            for matrix in group:
+                image = act_on_seed(matrix, seeds[index])
+                if image is None:
+                    continue
+                for other, seed in enumerate(seeds):
+                    if seed == image and other in unused:
+                        unused.remove(other)
+                        stack.append(other)
+    return n_orb
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: four split seeds recomputed; G-orbits under two-cube-preserving proper cube rotations")
+    print("negative_scope: N_orb is displayed; no seed is adopted and no orbit is written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_MIN_L1_SPLIT_SEED_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    ambient = proper_cube_rotations()
+    group = two_cube_preserving_rotations()
+    seeds = split_seeds()
+    n_split = len(seeds)
+    n_orb = orbit_count(seeds, group)
+    print(
+        "orbit: "
+        f"N_split={n_split} N_ambient={len(ambient)} "
+        f"|G|={len(group)} N_orb={n_orb}"
+    )
+    print("split_seeds: " + "; ".join(str(tuple(sorted(seed))) for seed in seeds))
+
+    checks.check(
+        "two-cube-and-ambient",
+        "the two-cube has twelve sites and the ambient proper cubic group has 24 matrices",
+        len(SITES) == 12 and len(SITE_SET) == 12 and len(ambient) == 24 and len(set(ambient)) == 24,
+    )
+    checks.check(
+        "group-preserves-twelve",
+        "only site-permutations of the two-cube induced by proper cube rotations are used",
+        0 < len(group) <= 24
+        and all(det3(matrix) == 1 for matrix in group)
+        and all(
+            {apply_about_center(matrix, site) for site in SITES} == SITE_SET
+            for matrix in group
+        ),
+        residual=len(group),
+    )
+    unused_count = len(ambient) - len(group)
+    checks.check(
+        "unused-non-permutations",
+        "rotations that do not permute the twelve sites are discarded",
+        unused_count == 16 and unused_count + len(group) == 24,
+        residual=unused_count,
+    )
+
+    all_split_histories = True
+    lex_seeds = tuple(tuple(sorted(seed)) for seed in seeds)
+    for seed in seeds:
+        hist_l1, fill_l1 = run(seed, fire_l1)
+        hist_min, fill_min = run(seed, fire_min)
+        if not (
+            fill_l1
+            and not fill_min
+            and hist_l1 == L1_SPLIT_HISTORY
+            and hist_min == MIN_SPLIT_HISTORY
+        ):
+            all_split_histories = False
+    expected_lex = (
+        ((0, 0, 0), (2, 1, 1)),
+        ((0, 0, 1), (2, 1, 0)),
+        ((0, 1, 0), (2, 0, 1)),
+        ((0, 1, 1), (2, 0, 0)),
+    )
+    checks.check(
+        "theorem-1-four-split-seeds",
+        "recomputed N_split=4 with f_L1 history (2,8,12) and f_min halt (2,8,10)",
+        n_split == 4 and all_split_histories and lex_seeds == expected_lex,
+        residual=lex_seeds,
+    )
+    checks.check(
+        "theorem-1-n-orb",
+        "N_orb is the number of G-orbits among the four seeds",
+        n_orb >= 1 and n_orb <= n_split == 4,
+        residual=n_orb,
+    )
+
+    if n_orb == 1:
+        theorem2_ok = (
+            "N_orb = 1" in note
+            and "one geometric type" in normalized_note
+            and "opposite corners" in normalized_note
+        )
+        theorem2_statement = "N_orb=1: the note reports one geometric type (opposite corners of the long box)"
+    else:
+        second = tuple(sorted(seeds[1])) if n_split > 1 else ()
+        theorem2_ok = (
+            f"N_orb = {n_orb}" in note
+            and "second orbit" in normalized_note
+            and str(second) in note.replace(" ", "")
+        )
+        theorem2_statement = "N_orb>1: the note displays one seed from a second orbit"
+    checks.check("theorem-2-geometric-type", theorem2_statement, theorem2_ok, residual=n_orb)
+
+    checks.check(
+        "theorem-3-display",
+        "the note displays the computed N_orb and does not adopt a seed or orbit",
+        f"N_orb = {n_orb}" in note
+        and "displayed, not adopted" in normalized_note
+        and "do not adopt" in normalized_note
+        and "not written into Admissibility" in normalized_note,
+        residual=n_orb,
+    )
+
+    locked_opp = frozenset(((0, 0, 0), (2, 0, 0)))
+    opp2 = axis_type((1, 0, 0), locked_opp)
+    hamming_opp = sum(
+        occupancy(add((1, 0, 0), shift), locked_opp)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    checks.check(
+        "identity-l1-not-hamming",
+        "opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire",
+        opp2 == (0, 1, 2) and hamming_opp == 2 and not fire_l1(opp2) and not fire_min(opp2),
+    )
+    locked_mixed = frozenset(((0, 0, 0), (2, 0, 0), (1, 1, 0)))
+    mixed3 = axis_type((1, 0, 0), locked_mixed)
+    locked_wt1 = frozenset(((0, 0, 0),))
+    wt1 = axis_type((1, 0, 0), locked_wt1)
+    checks.check(
+        "identity-min-nboth-zero",
+        "f_min fires on nonempty n_both=0 and refuses mixed3",
+        wt1 == (1, 0, 2)
+        and mixed3 == (1, 1, 1)
+        and fire_min(wt1)
+        and fire_l1(wt1)
+        and not fire_min(mixed3)
+        and fire_l1(mixed3),
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-phrases",
+        "the note avoids the dispatch-forbidden phrases",
+        all(phrase not in note for phrase in forbidden),
+    )
+    checks.check(
+        "no-admissibility-orbit",
+        "the note does not write an orbit into Admissibility",
+        "not written into Admissibility" in normalized_note
+        and "orbit" in normalized_note,
+    )
+    checks.check(
+        "claim-scope",
+        "the YAML claim_scope states the orbit-count display",
+        "form" in note and "orbits under two-cube-preserving proper cube rotations" in note and f"{n_orb}" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The four two-site split seeds form N_orb=1 orbit under two-cube-preserving proper cube rotations — opposite corners of the long box, not four independent extras. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_min_l1_split_seed_orbit_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.