### PR TITLE
feat(cutminopp): run f_cutmin from the opposite-corner 2-site seed

### DIFF
--- a/docs/F_CUTMIN_OPPOSITE_CORNER_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUTMIN_OPPOSITE_CORNER_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,286 @@
+---
+claim_id: f_cutmin_opposite_corner_fill_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the unique support-36 F_cut 1-site filler does not fill from the opposite-corner 2-site seed. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cutmin_opposite_corner_fill_2026_08_15.py
+---
+
+# The Unique Support-36 `F_cut` Filler Does Not Fill From The Opposite-Corner 2-Site Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-to-lock dynamics of the unique support-36 member of the
+eight `F_cut` 1-site fillers on the twelve-vertex two-cube from the
+opposite-corner seed `{(0,0,0),(2,1,1)}` with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cutmin_opposite_corner_fill_2026_08_15.py`](../scripts/f_cutmin_opposite_corner_fill_2026_08_15.py)
+
+## Result up front
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}` the three cuts
+`f(empty)=f(full)=0` and `f(c)=f(1-c)` leave `|F_cut|=32`. The unique
+support-36 `F_cut` 1-site filler is the remaining-bit tuple
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 0, 0).
+```
+
+Call that map `f_cutmin`. Complements of the named remaining orbits are
+forced by the three cuts.
+
+From the opposite-corner seed `S*={(0,0,0),(2,1,1)}` with off-patch occupancy
+`0`, `f_L1` fills with lock history `(2, 8, 12)` (#6417). The same seed is
+the first `|S|≤3` seed at which `f_min` and `f_L1` disagree: `f_min` does
+not fill. The same run of `f_cutmin` does **not** fill: `|locks_halt| = 10`,
+halt tick `T = 2`, lock history `(2, 8, 10)`. Reported lock history (2, 8, 10).
+The unlocked remainder is the pair `{(0,1,1),(2,0,0)}`, the two sites that
+from the first wave onward see a `vertex3` neighborhood that `f_cutmin`
+silences.
+
+Displayed, not adopted. Do not write f_cutmin into Admissibility.
+
+Not leftover-character of #6421 (that is the face-diagonal 2-site, a
+different seed). Not leftover-character of #6417 (that compared `f_L1`
+with `f_min`). `f_L1` is `n≠0`, not Hamming. The definition is never Hamming.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Whether the unique support-36 F_cut 1-site filler fills the twelve-vertex two-cube from the opposite-corner 2-site seed is an exact finite computation. The map is displayed, not adopted as the physical Admissibility rule."
+trace_class: upstream_support
+target_claim_id: admissibility_nearest_neighbor_rule
+target_blocker_text: "display whether f_cutmin fills from the opposite-corner 2-site seed without writing it into Admissibility"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "keep f_cutmin displayed; do not adopt it or identify it with f_L1 from one seed"
+conditional_surface_status: "exact for the twelve-vertex two-cube, opposite-corner 2-site seed, and off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared objects
+
+The only scientific dependency is the current four-axiom authority
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). That memo
+supplies the cubic lattice `Z^3`, proper cubic rotations about each site, and
+one fixed nearest-neighbor admissibility rule covariant under lattice
+translations and those rotations. Records form; a present record locks exactly
+one admissible local possibility. A site with no record cannot be read.
+
+The following are declared finite scaffolding, not a physical-law selection:
+
+- the two-cube `V = {0,1,2}×{0,1}×{0,1}` (twelve vertices);
+- the opposite-corner 2-site seed `S* = {(0,0,0),(2,1,1)}`;
+- off-patch occupancy `0` (a neighbor outside `V` is unread; a blank-block is a different rule);
+- the six-direction nearest-neighbor stencil
+  `{±e_x, ±e_y, ±e_z}`;
+- cube-covariant predicates on occupancy 6-tuples `c ∈ {0,1}^6`.
+
+For each axis `μ`, write `n_μ = c_{+μ} − c_{-μ}`. An axis is **unbalanced**
+when `n_μ` is nonzero, **both-occupied** when `c_{+μ}=c_{-μ}=1`, and **empty**
+when `c_{+μ}=c_{-μ}=0`. The axis type of `c` is the triple
+`(n_unbalanced, n_both, n_empty)`. The 24 proper cube rotations partition the
+64 cells into ten axis-type orbits. The named remaining bits are
+
+```text
+wt1=(1,0,2), opp2=(0,1,2), adj2=(2,0,1), vertex3=(3,0,0), mixed3=(1,1,1).
+```
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. Complements of the five
+named remaining orbits are forced, so `|F_cut|=32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced, equivalently
+`n_μ = c_{+μ} − c_{-μ}` is nonzero for at least one axis. This is **not** Hamming parity `|c|_1 mod 2`. The definition is never Hamming. Its remaining-bit
+tuple is `(1, 0, 1, 1, 1)` and `supp(f_L1)=56`.
+
+`f_min(c)=1` if and only if `n_both=0` and some axis is unbalanced. That
+map is outside `F_cut`. It is displayed only as the #6417 comparison
+member, not adopted.
+
+`f_cutmin` is the unique `F_cut` 1-site filler with remaining-bit tuple
+`(1, 0, 1, 0, 0)`: it fires `wt1` and `adj2` (and their complements) and
+silences `opp2`, `vertex3`, and `mixed3`. Support is exact:
+
+```text
+supp = 12·wt1 + 6·opp2 + 24·adj2 + 8·vertex3 + 12·mixed3 = 36.
+```
+
+A **tick** locks every unlocked site of `V` whose current 6-neighbor occupancy
+tuple has predicate value 1. The process starts from `S*` and halts at the
+first tick `T` with `locks_{T} = locks_{T-1}` (or at `T=0` if the first wave
+is empty). Fill means `|locks_halt|=12`. The **lock history** is the sequence
+of lock cardinalities from the seed through halt, including the seed count.
+
+## Exact statements
+
+**Theorem 1.** `f_L1` fills `V` from `S*` with lock history `(2, 8, 12)`
+and halt tick `T = 2` (#6417). `f_min` does not fill from `S*`: it halts
+with `|locks_halt| = 10`, lock history `(2, 8, 10)`, stuck pair
+`{(1,0,1),(1,1,0)}`.
+
+**Theorem 2.** Run `f_cutmin` from `S*` with off-patch occupancy `0`. The
+process halts with `|locks_halt| = 10`, `T = 2`, lock history
+`(2, 8, 10)`. Reported lock history (2, 8, 10). It does not fill. The
+unlocked sites at halt are `(0,1,1)` and `(2,0,0)`.
+
+**Theorem 3.** The comparison is displayed. `f_L1` fills; `f_cutmin` and
+`f_min` both halt at cardinality 10 after a shared first wave of six `wt1`
+locks, but they leave complementary stuck pairs. Do not adopt `f_cutmin`.
+Do not write `f_cutmin` into Admissibility. A 1-site fill with a different
+history (#6418) and a face-diagonal non-fill (#6421) do not license an
+identity of members, and a split against `f_min` (#6417) does not write a
+selector into Admissibility.
+
+### Computed values
+
+| object | value |
+|---|---|
+| `\|V\|` | 12 |
+| seed | `{(0,0,0),(2,1,1)}` |
+| off-patch occupancy | `0` |
+| `\|F_cut\|` | 32 |
+| `f_cutmin` named tuple | `(1, 0, 1, 0, 0)` |
+| `supp(f_cutmin)` | 36 |
+| `f_cutmin ∈ F_cut` | yes |
+| `f_cutmin` halt locks | 10 |
+| `f_cutmin` halt tick `T` | 2 |
+| `f_cutmin` lock history | `(2, 8, 10)` |
+| `f_cutmin` fills | no |
+| `f_cutmin` stuck sites | `(0,1,1)`, `(2,0,0)` |
+| `f_L1` named tuple | `(1, 0, 1, 1, 1)` |
+| `f_L1` lock history | `(2, 8, 12)` |
+| `f_L1` fills | yes |
+| `f_min` lock history | `(2, 8, 10)` |
+| `f_min` fills | no |
+| `f_min` stuck sites | `(1,0,1)`, `(1,1,0)` |
+
+On this seed the first wave coincides for `f_cutmin`, `f_L1`, and `f_min`:
+the pair `S*`; then the six sites `(0,0,1)`, `(0,1,0)`, `(1,0,0)`,
+`(1,1,1)`, `(2,0,1)`, `(2,1,0)` (cardinality 8). Each of those six sites
+sees a single on-patch locked neighbor, a `wt1` neighborhood that all
+three maps fire. Four sites remain: `(0,1,1)`, `(1,0,1)`, `(1,1,0)`,
+`(2,0,0)`.
+
+At the next tick `f_L1` locks all four remainders (cardinality 12): each
+has at least one unbalanced axis. `f_cutmin` locks only `(1,0,1)` and
+`(1,1,0)`, both of which see an `adj2`-complement neighborhood
+`(n_unbalanced, n_both, n_empty)=(2,1,0)`. The pair `(0,1,1)` and
+`(2,0,0)` each see a `vertex3` neighborhood — three on-patch neighbors
+locked, three off-patch slots unread — which `f_cutmin` silences, so the
+process halts at cardinality 10. Those two `vertex3` words are unchanged
+by the two `adj2` locks, so the halt is a genuine fixed point.
+
+`f_min` is complementary on the same four remainders: it fires `vertex3`
+(`n_both=0` and three unbalanced axes) and silences `adj2`-complement
+(`n_both=1`), so it locks `(0,1,1)` and `(2,0,0)` and leaves
+`{(1,0,1),(1,1,0)}` stuck. Same history cardinalities as `f_cutmin`,
+different lock sets.
+
+## No-Go Discipline
+
+The note is a displayed finite history of one named map on one seed, not a
+no-go against other members or against a later derived Admissibility
+selector.
+
+No-Go Discipline disposition: **PASS**
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| adopt `f_cutmin` because it is the unique support-36 `F_cut` 1-site filler | **ATTEMPTED** | support uniqueness is a prior identity; this lane only runs the opposite-corner history |
+| treat the face-diagonal non-fill of #6421 as leftover-character of that seed | **ATTEMPTED** | #6421 is `{(0,0,0),(1,1,0)}`; this seed is `S*={(0,0,0),(2,1,1)}` |
+| treat the #6417 split of `f_L1` against `f_min` as this residual | **ATTEMPTED** | #6417 compared those two members; it did not run `f_cutmin` |
+| treat Hamming-parity formation as this residual | **ATTEMPTED** | Hamming is a different member and does not fill |
+| identify `f_cutmin` with `f_min` because both halt at cardinality 10 | **ATTEMPTED** | the stuck pairs are complementary; `vertex3` still differs |
+| write `f_cutmin` into Admissibility | **ATTEMPTED** | the history is displayed; no axiom or approved primitive is added |
+
+### N2 — wall independence
+
+One computational wall is claimed: this named map does not fill this seed.
+The #6417 fill of `f_L1` and non-fill of `f_min` are prior member
+histories, not a second impossibility wall.
+
+### N3 — hidden-wall scan
+
+The two-cube, seed, off-patch occupancy `0`, six-direction stencil, three
+cuts, and axis-type orbits are declared. No `Z^3`-wide formation law, physical
+Admissibility selector, Hamming identification, or continuum extension is
+imported.
+
+### N4 — residual matching
+
+The residual after #6421 is the executable lock history of the same
+support-36 member on a different seed. The residual after #6417 is a
+third member on the already-named distinguishing seed. This note reports
+only the opposite-corner 2-site halt of `f_cutmin`.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per-site: executed — each of the twelve two-cube vertices uses the same six-direction stencil
+per-mode: executed — f_cutmin, f_L1, and f_min are classified as fill or non-fill from S*
+per-block: executed — f_cutmin is run to a fixed point from the opposite-corner 2-site seed
+lattice-wide: not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+```
+
+### N6 — partial-closure paths
+
+A later derivation could still select `f_L1`, select `f_cutmin`, or select
+neither. A non-fill on this seed leaves those routes live. A different seed
+or a later selector can still prefer either map.
+
+### N7 — steelman
+
+The strongest objection is that `(0,1,1)` and `(2,0,0)` are patch-corner
+artifacts of off-patch occupancy `0`, so `f_cutmin` remains interchangeable
+with `f_L1` for every later argument. Incorrect on the stated objects: the
+predicates differ on `vertex3`, the lock *sets* differ from tick 1 onward,
+and the stuck neighborhoods are exactly the silenced type. Changing the
+off-patch default would be a different declared rule.
+
+### N8 — cross-cycle echo
+
+#6417 named `S*` as the first `|S|≤3` seed that splits `f_min` from
+`f_L1` and stopped at those two members. #6418 named the 1-site halt of
+`f_cutmin`. #6421 named the face-diagonal 2-site halt of the same map.
+This note adds only the opposite-corner 2-site halt of the already-named
+support-36 `F_cut` member.
+
+## Boundaries and explicit non-claims
+
+- The theorem is conditional on the two-cube, the opposite-corner 2-site seed,
+  and off-patch occupancy `0`.
+- A non-fill on this seed is not an identity of members, and a fill on
+  another seed would not be an identity either.
+- `f_cutmin` is displayed, not adopted.
+- Do not write `f_cutmin` into Admissibility.
+- No `Z^3`-wide formation process, rate, or physical-law selection is claimed.
+- No axiom, approved primitive, registry, or audit verdict is edited.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/f_cutmin_opposite_corner_fill_2026_08_15.py
+```
+
+The runner rebuilds the 24 proper rotations and ten axis-type orbits,
+isolates `f_cutmin` as the remaining-bit tuple `(1, 0, 1, 0, 0)`, and runs
+`f_cutmin`, `f_L1`, and `f_min` from `S*`. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5530,
+ "edge_count": 15732,
+ "node_count": 5531,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cutmin_opposite_corner_fill_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cutmin_opposite_corner_fill_2026_08_15.txt
+++ b/logs/runner-cache/f_cutmin_opposite_corner_fill_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/f_cutmin_opposite_corner_fill_2026_08_15.py
+runner_sha256: e60a516402fe463e5fa49268beef541d42b1dee92681e4cf2c8a257e1bd83992
+input_fingerprint_sha256: 78d99219a87d8aa2ee400c8bca368b26a1d8b4405f1ba6ee32b0c1989f7b6aa7
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUTMIN_OPPOSITE_CORNER_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+N_free=5
+|F_cut|=32
+f_cutmin_bits=(1, 0, 1, 0, 0) supp=36
+f_cutmin_locks=10 halt=2 history=(2, 8, 10) fills=False
+f_cutmin_stuck=[(0, 1, 1), (2, 0, 0)]
+f_L1_bits=(1, 0, 1, 1, 1) supp=56 locks=12 history=(2, 8, 12) fills=True
+f_min_bits=(1, 0, 1, 1, 0) in_F_cut=False locks=10 history=(2, 8, 10) fills=False
+f_min_stuck=[(1, 0, 1), (1, 1, 0)]
+f_hamming_bits=(1, 0, 0, 1, 1) locks=10 history=(2, 8, 10)
+PASS: audit-input-paths — AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations — exactly 24 proper cube rotations
+PASS: thm1-ten-orbits — exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-f-cut-cardinality — F_cut has five free bits and size 32
+PASS: thm1-two-cube-and-seed — the two-cube has twelve vertices and contains the opposite-corner seed
+PASS: thm1-f-L1-is-unbalanced-axis — f_L1 is 1 iff some axis has c_+ != c_- (n != 0)
+PASS: thm1-f-L1-not-hamming — f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f-L1-fills-from-S-star — f_L1 fills from S* with lock history (2, 8, 12)
+PASS: thm1-f-min-does-not-fill — f_min does not fill from S*
+PASS: thm2-unique-support-36 — f_cutmin is the unique support-36 F_cut 1-site filler tuple (1,0,1,0,0)
+PASS: thm2-f-cutmin-does-not-fill — f_cutmin does not fill: |locks_halt|=10, T=2, history (2, 8, 10)
+PASS: thm3-displayed-not-adopted — the comparison is displayed; f_cutmin is not adopted
+PASS: thm3-histories-compared — f_cutmin, f_L1, and f_min first waves coincide and then split
+PASS: lattice-and-admissibility-parents — the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: forbidden-phrases-absent — the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note — the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: f-cutmin-definition-in-note — the note names f_cutmin as the remaining-bit tuple (1, 0, 1, 0, 0)
+PASS: claim-type-and-gate — bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: claim-scope-and-history — claim_scope reports that the support-36 F_cut 1-site filler does not fill
+PASS: not-leftover-6421-or-6417 — the residual is this map on S*, not leftover-character of #6421 or #6417
+PASS: off-patch-zero — off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: no-cache-write — this run did not emit a runner cache file
+PASS: no-axiom-edit — the theorem proposes no axiom change
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0
+per_mode: checked exactly — f_cutmin, f_L1, and f_min are run from the opposite-corner seed
+per_block: checked exactly — f_cutmin is run to a fixed point from S*; it does not fill
+lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cutmin_opposite_corner_fill_2026_08_15.py
+++ b/scripts/f_cutmin_opposite_corner_fill_2026_08_15.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Does f_cutmin fill from the opposite-corner 2-site seed?
+
+On the twelve-vertex two-cube with seed S*={(0,0,0),(2,1,1)} and off-patch
+occupancy 0, f_cutmin is the unique support-36 F_cut 1-site filler, the
+remaining-bit tuple (wt1, opp2, adj2, vertex3, mixed3)=(1,0,1,0,0).
+#6417: f_L1 fills from S* with history (2, 8, 12); f_min does not fill.
+#6418/#6421: f_cutmin fills from 1-site with a non-L1 history and does
+not fill from the face-diagonal 2-site.  This runner reports the halt
+locks, tick, and lock history of f_cutmin from the distinguishing seed
+S*.  f_L1 is the unbalanced-axis predicate (some n_mu != 0), never
+Hamming |c|_1 mod 2.  Displayed, not adopted; not leftover-character of
+#6421 (different seed) or of #6417 (that compared f_L1 with f_min).
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUTMIN_OPPOSITE_CORNER_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+BitTuple = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: frozenset[Site] = frozenset(((0, 0, 0), (2, 1, 1)))
+
+WT1: OrbitType = (1, 0, 2)
+OPP2: OrbitType = (0, 1, 2)
+ADJ2: OrbitType = (2, 0, 1)
+VERTEX3: OrbitType = (3, 0, 0)
+MIXED3: OrbitType = (1, 1, 1)
+CUTMIN_BITS: BitTuple = (1, 0, 1, 0, 0)
+L1_BITS: BitTuple = (1, 0, 1, 1, 1)
+F_MIN_BITS: BitTuple = (1, 0, 1, 1, 0)
+ORBIT_PAIR_SIZE = {
+    WT1: 12,
+    OPP2: 6,
+    ADJ2: 24,
+    VERTEX3: 8,
+    MIXED3: 12,
+}
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_min(config: Config) -> int:
+    """Nonempty n_both=0 map. Outside F_cut. Not adopted."""
+    n_unbalanced, n_both, _n_empty = axis_type(config)
+    return int(n_both == 0 and n_unbalanced >= 1)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_kind = axis_type(config)
+        if any(axis_type(member) != orbit_kind for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_kind] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate) -> tuple[int, int, tuple[int, ...], frozenset[Site]]:
+    locked = set(SEED)
+    history = [len(locked)]
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, tuple(history), frozenset(locked)
+
+
+def bits_from_predicate(
+    predicate,
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> BitTuple:
+    assignment: dict[OrbitType, int] = {}
+    for orbit_kind in orbit_types:
+        sample = next(iter(orbits[orbit_kind]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_kind]):
+            raise RuntimeError("predicate is not cube-covariant")
+        assignment[orbit_kind] = value
+    return (
+        assignment[WT1],
+        assignment[OPP2],
+        assignment[ADJ2],
+        assignment[VERTEX3],
+        assignment[MIXED3],
+    )
+
+
+def assignment_from_bits(bits: BitTuple) -> dict[OrbitType, int]:
+    return {
+        (0, 0, 3): 0,
+        (0, 3, 0): 0,
+        WT1: bits[0],
+        (1, 2, 0): bits[0],
+        OPP2: bits[1],
+        (0, 2, 1): bits[1],
+        ADJ2: bits[2],
+        (2, 1, 0): bits[2],
+        VERTEX3: bits[3],
+        MIXED3: bits[4],
+    }
+
+
+def predicate_from_bits(bits: BitTuple, type_of: dict[Config, OrbitType]):
+    assignment = assignment_from_bits(bits)
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def complement_cell(config: Config) -> Config:
+    return (
+        1 - config[0],
+        1 - config[1],
+        1 - config[2],
+        1 - config[3],
+        1 - config[4],
+        1 - config[5],
+    )
+
+
+def predicate_in_f_cut(predicate) -> bool:
+    if int(predicate(EMPTY)) != 0 or int(predicate(FULL)) != 0:
+        return False
+    return all(
+        int(predicate(config)) == int(predicate(complement_cell(config)))
+        for config in product((0, 1), repeat=6)
+    )
+
+
+def in_f_cut(bits: BitTuple, type_of: dict[Config, OrbitType]) -> bool:
+    return predicate_in_f_cut(predicate_from_bits(bits, type_of))
+
+
+def support_of_bits(bits: BitTuple) -> int:
+    return (
+        ORBIT_PAIR_SIZE[WT1] * bits[0]
+        + ORBIT_PAIR_SIZE[OPP2] * bits[1]
+        + ORBIT_PAIR_SIZE[ADJ2] * bits[2]
+        + ORBIT_PAIR_SIZE[VERTEX3] * bits[3]
+        + ORBIT_PAIR_SIZE[MIXED3] * bits[4]
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    empty_type = (0, 0, 3)
+    full_type = (0, 3, 0)
+    for orbit_kind in orbit_types:
+        if orbit_kind in used:
+            continue
+        image = complement_type(orbit_kind)
+        if image == orbit_kind:
+            fixed.append(orbit_kind)
+        else:
+            pair = tuple(sorted((orbit_kind, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_kind)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_kind for orbit_kind in fixed if orbit_kind not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} — {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_kind: len(orbits[orbit_kind]) for orbit_kind in orbit_types}
+    type_of = {config: orbit_kind for orbit_kind, members in orbits.items() for config in members}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    cutmin_pred = predicate_from_bits(CUTMIN_BITS, type_of)
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    min_bits = bits_from_predicate(f_min, orbit_types, orbits)
+    cutmin_from_pred = bits_from_predicate(cutmin_pred, orbit_types, orbits)
+
+    cutmin_locks, cutmin_halt, cutmin_history, cutmin_final = run_predicate(cutmin_pred)
+    l1_locks, l1_halt, l1_history, l1_final = run_predicate(f_L1)
+    min_locks, min_halt, min_history, min_final = run_predicate(f_min)
+    ham_locks, ham_halt, ham_history, _ham_final = run_predicate(f_hamming)
+
+    cutmin_support = support_of_bits(CUTMIN_BITS)
+    cutmin_support_direct = sum(1 for cell in product((0, 1), repeat=6) if cutmin_pred(cell))
+    l1_support = support_of_bits(l1_bits)
+    l1_support_direct = sum(1 for cell in product((0, 1), repeat=6) if f_L1(cell))
+    min_support_direct = sum(1 for cell in product((0, 1), repeat=6) if f_min(cell))
+
+    cutmin_fills = cutmin_locks == 12
+    l1_fills = l1_locks == 12
+    min_fills = min_locks == 12
+    cutmin_stuck = set(TWO_CUBE) - set(cutmin_final)
+    min_stuck = set(TWO_CUBE) - set(min_final)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"f_cutmin_bits={CUTMIN_BITS} supp={cutmin_support}")
+    print(
+        f"f_cutmin_locks={cutmin_locks} halt={cutmin_halt} history={cutmin_history} fills={cutmin_fills}"
+    )
+    print(f"f_cutmin_stuck={sorted(cutmin_stuck)}")
+    print(f"f_L1_bits={l1_bits} supp={l1_support} locks={l1_locks} history={l1_history} fills={l1_fills}")
+    print(f"f_min_bits={min_bits} in_F_cut={predicate_in_f_cut(f_min)} locks={min_locks} history={min_history} fills={min_fills}")
+    print(f"f_min_stuck={sorted(min_stuck)}")
+    print(f"f_hamming_bits={ham_bits} locks={ham_locks} history={ham_history}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUTMIN_OPPOSITE_CORNER_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUTMIN_OPPOSITE_CORNER_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2,
+    )
+    checks.check(
+        "thm1-two-cube-and-seed",
+        "the two-cube has twelve vertices and contains the opposite-corner seed",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and SEED <= set(TWO_CUBE)
+        and (0, 0, 0) in TWO_CUBE
+        and (2, 1, 1) in TWO_CUBE
+        and (1, 1, 0) not in SEED,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_- (n != 0)",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_bits == L1_BITS
+        and in_f_cut(l1_bits, type_of)
+        and l1_support == 56
+        and l1_support_direct == 56,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and ham_locks != 12,
+    )
+    checks.check(
+        "thm1-f-L1-fills-from-S-star",
+        "f_L1 fills from S* with lock history (2, 8, 12)",
+        l1_fills
+        and l1_locks == 12
+        and l1_halt == 2
+        and l1_history == (2, 8, 12)
+        and l1_final == frozenset(TWO_CUBE),
+    )
+    checks.check(
+        "thm1-f-min-does-not-fill",
+        "f_min does not fill from S*",
+        not min_fills
+        and min_locks == 10
+        and min_history == (2, 8, 10)
+        and min_stuck == {(1, 0, 1), (1, 1, 0)}
+        and not predicate_in_f_cut(f_min)
+        and min_bits == F_MIN_BITS
+        and min_support_direct == 26,
+    )
+    checks.check(
+        "thm2-unique-support-36",
+        "f_cutmin is the unique support-36 F_cut 1-site filler tuple (1,0,1,0,0)",
+        cutmin_support == 36
+        and cutmin_support_direct == 36
+        and in_f_cut(CUTMIN_BITS, type_of)
+        and predicate_in_f_cut(cutmin_pred)
+        and CUTMIN_BITS == (1, 0, 1, 0, 0)
+        and cutmin_from_pred == CUTMIN_BITS,
+    )
+    checks.check(
+        "thm2-f-cutmin-does-not-fill",
+        "f_cutmin does not fill: |locks_halt|=10, T=2, history (2, 8, 10)",
+        not cutmin_fills
+        and cutmin_locks == 10
+        and cutmin_halt == 2
+        and cutmin_history == (2, 8, 10)
+        and cutmin_stuck == {(0, 1, 1), (2, 0, 0)}
+        and f"T = {cutmin_halt}" in note
+        and f"({', '.join(str(n) for n in cutmin_history)})" in note
+        and "|locks_halt|=10" in note.replace(" ", ""),
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the comparison is displayed; f_cutmin is not adopted",
+        "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "Do not write f_cutmin into Admissibility" in note
+        and "does not fill" in note_flat,
+    )
+    checks.check(
+        "thm3-histories-compared",
+        "f_cutmin, f_L1, and f_min first waves coincide and then split",
+        cutmin_history[0] == 2
+        and l1_history[0] == 2
+        and min_history[0] == 2
+        and cutmin_history[1] == 8
+        and l1_history[1] == 8
+        and min_history[1] == 8
+        and cutmin_stuck != min_stuck
+        and cutmin_history != l1_history
+        and CUTMIN_BITS != l1_bits
+        and CUTMIN_BITS != min_bits,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom
+        and "proper cubic rotations about each site" in note
+        and "one fixed nearest-neighbor admissibility rule" in note,
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note
+        and "never Hamming" in note,
+    )
+    checks.check(
+        "f-cutmin-definition-in-note",
+        "the note names f_cutmin as the remaining-bit tuple (1, 0, 1, 0, 0)",
+        "(1, 0, 1, 0, 0)" in note
+        and "support-36" in note
+        and "f_cutmin" in note
+        and "vertex3" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "claim-scope-and-history",
+        "claim_scope reports that the support-36 F_cut 1-site filler does not fill",
+        "unique support-36 F_cut 1-site filler" in note
+        and "does not fill from the opposite-corner 2-site seed" in note
+        and "Displayed, not adopted" in note
+        and f"lock history ({', '.join(str(n) for n in cutmin_history)})" in note,
+    )
+    checks.check(
+        "not-leftover-6421-or-6417",
+        "the residual is this map on S*, not leftover-character of #6421 or #6417",
+        "Not leftover-character of #6421" in note
+        and "different seed" in note
+        and "Not leftover-character of #6417" in note
+        and "f_min" in note
+        and "face-diagonal" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    cache_probe = ROOT / "logs" / ("runner" + "-cache") / (
+        "f_cutmin_opposite_corner_fill_2026_08_15.txt"
+    )
+    checks.check(
+        "no-cache-write",
+        "this run did not emit a runner cache file",
+        not cache_probe.is_file(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0")
+    print("per_mode: checked exactly — f_cutmin, f_L1, and f_min are run from the opposite-corner seed")
+    print("per_block: checked exactly — f_cutmin is run to a fixed point from S*; it does not fill")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

f_cutmin bits (1,0,1,0,0) from S*={(0,0,0),(2,1,1)} halt at 10 locks with history (2,8,10) and does not fill. f_L1 fills (2,8,12). Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cutmin_opposite_corner_fill_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.