### PR TITLE
feat(min3split): count 3-site seeds that split f_min from f_L1

### DIFF
--- a/docs/F_MIN_L1_THREE_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_MIN_L1_THREE_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,311 @@
+---
+claim_id: f_min_l1_three_site_split_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 220 three-site seeds on the two-cube with off-patch o=0, 60 distinguish f_min from f_L1 by fill or lock history. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_min_l1_three_site_split_census_2026_08_15.py
+---
+
+# Three-Site Split Census Of `f_min` Versus `f_L1`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exhaustive lock-step census of the 220 unordered three-site seeds on
+the twelve-vertex two-cube `{0,1,2} × {0,1} × {0,1}` with off-patch occupancy
+`o=0`. The integer `N_split3` is displayed. No seed is adopted and no selector
+is written into Admissibility.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_min_l1_three_site_split_census_2026_08_15.py`](../scripts/f_min_l1_three_site_split_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+On the two-cube, a lock-step run of a displayed readiness map from a seed `S`
+is the synchronous wave process that begins with `S` locked and, at each tick,
+locks every still-unlocked site whose six-neighbor occupancy 3-tuple satisfies
+the map. The lock-history tuple is the sequence of lock counts after the seed
+and after each nonempty wave, until halt. Fill means `|locks_halt| = 12`.
+
+Write `n_unbalanced`, `n_both`, and `n_empty` for the number of cubic axes
+whose two opposite neighbors are occupied on exactly one side, on both sides,
+or on neither side. Off-patch neighbors contribute occupancy `0`. Then
+
+- `f_L1` fires iff `n_unbalanced ≠ 0` (some axis is unbalanced; not Hamming
+  weight of the six occupancy bits);
+- `f_min` fires iff the occupancy is nonempty and `n_both = 0`
+  (equivalently `n_unbalanced ≠ 0` and `n_both = 0`).
+
+A three-site seed *splits* the two maps when the fill bits differ or the
+lock-history tuples differ.
+
+The census of all `C(12,3) = 220` unordered triples is
+
+`N_split3 = 60`
+
+`N_fill_L1_3 = 220`
+
+`N_fill_min_3 = 160`
+
+Every three-site seed fills under `f_L1`. The sixty splits are exactly the
+sixty seeds that halt unfilled under `f_min`. No history-only split occurs:
+whenever the histories differ, the fill bits differ, and conversely. The
+long-axis line seed `{(0,0,0),(1,0,0),(2,0,0)}` does not split: both maps fill
+with history `(3, 9, 12)`. These integers are displayed census output. They
+are not adopted as a physical selector.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 220 three-site seeds, both lock-step runs, and the three census integers are finite exact statements on a declared twelve-site patch; no seed is selected and no Admissibility clause is added."
+trace_class: frontier_discovery
+target_claim_id: f_min_l1_three_site_split_census
+target_blocker_text: "how many three-site seeds on the two-cube distinguish f_min from f_L1 by fill or lock history"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the twelve-vertex two-cube with off-patch occupancy 0 and the two displayed readiness maps; no selector is adopted"
+hypothetical_axiom_status: "none; f_min and the sixty splitting seeds are displayed and are not proposed as axiom content"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded census; do not write a selector into Admissibility"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** Lattice, Admissibility, and Record are quoted from
+  the live axiom memo without rewrite. They identify the cubic nearest-neighbor
+  graph, the local-condition domain, and the lock/content/absence wording.
+  They do not supply the two readiness maps or the two-cube patch.
+- **Explicit theorem-domain condition:** the twelve sites
+  `{0,1,2} × {0,1} × {0,1}`, off-patch occupancy identically `0`, the two
+  displayed maps `f_L1` and `f_min`, and the synchronous lock-step dynamics
+  above are supplied mathematical data for this census.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing either map, or any of the sixty splitting
+  seeds, into Admissibility remains a separate, open obligation. This note
+  does not adopt them.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility
+
+does not supply the formation site, probability, or rate.
+
+The two readiness maps are displayed occupancy predicates on the six-neighbor
+condition tuple. They are not Admissibility content. Using a lock-step wave as
+physical Record formation would require a separately derived formation
+mechanism; that mechanism is not supplied here.
+
+## Exact Objects
+
+The two-cube is the twelve-point set
+
+`V = {0,1,2} × {0,1} × {0,1} ⊂ Z^3`.
+
+The open nearest-neighbor set of a site `x` is
+`N(x) = {x ± e_1, x ± e_2, x ± e_3}`. A neighbor in `V` that is already
+locked contributes occupancy `1`; a neighbor outside `V` contributes
+occupancy `0`. For each of the three axes one records the pair
+`(c_{+μ}, c_{-μ}) ∈ {0,1}^2` and tallies
+
+- unbalanced if the pair is `(1,0)` or `(0,1)`,
+- both if the pair is `(1,1)`,
+- empty if the pair is `(0,0)`.
+
+On this patch, `n_both > 0` is possible only at the middle face `x = 1`, and
+only on the long axis: every transverse neighbor in the `-y` or `-z` direction
+from `y = 0` or `z = 0` is off-patch.
+
+A seed is an unordered triple `S ⊂ V` with `|S| = 3`. There are exactly
+`C(12,3) = 220` such seeds. The run of a map `f` from `S` begins with
+`locks_0 = S`. At tick `t ≥ 1` every unlocked `x ∈ V` with `f(c(x, locks_{t-1})) = 1`
+locks simultaneously. The history is
+`(|locks_0|, |locks_1|, …, |locks_T|)` at the first `T` with no further ready
+site. Fill is the boolean `|locks_T| = 12`.
+
+`f_L1(c) = 1` iff `n_unbalanced ≠ 0`. This is not the Hamming weight of the
+six occupancy bits: the opposite-pair occupancy at `(1,0,0)` with
+`{(0,0,0),(2,0,0)}` locked has Hamming weight `2` and
+`(n_unbalanced, n_both, n_empty) = (0,1,2)`, so `f_L1` does not fire.
+
+`f_min(c) = 1` iff `n_both = 0` and `n_unbalanced ≠ 0`. The maps therefore
+disagree exactly when at least one axis is unbalanced and at least one axis
+is doubly occupied. On this patch that first occurs as mixed type `(1,1,1)`
+at a middle-face site.
+
+## Theorem 1 — Line Seed Does Not Split
+
+From the long-axis line `S_line = {(0,0,0),(1,0,0),(2,0,0)}` both maps
+produce the lock-history `(3, 9, 12)` and fill. The first wave locks the
+remaining three sites of the `y = 0` face together with the three sites of
+the `z = 0` face that are not already locked, reaching nine locks. The
+second wave locks the last three sites. Every ready neighborhood in this
+run has `n_both = 0`, so the two predicates agree at every unlocked site.
+The line seed is therefore not a split.
+
+## Theorem 2 — Exhaustive Three-Site Census
+
+Every one of the 220 seeds is run independently under both maps. The three
+census integers are
+
+`N_split3 = 60`,
+`N_fill_L1_3 = 220`,
+`N_fill_min_3 = 160`.
+
+The complementary counts are displayed, not selected: no three-site seed
+fails to fill under `f_L1`, sixty fail under `f_min`, and those sixty are
+exactly the splits. One explicit splitter is
+`{(0,0,0),(0,0,1),(2,0,0)}`, which fills under `f_L1` with history
+`(3, 8, 11, 12)` and halts unfilled under `f_min` at `(3, 8, 10)`.
+
+Every split seed meets both end faces of the two-cube (it contains at least
+one site with `x = 0` and one with `x = 2`). The 108 seeds that miss an end
+face never split. Every split seed also contains at least one pair of
+displacement `(2,0,0)` or `(2,1,1)`: twenty-eight contain only a long-axis
+pair, twenty-four contain only an opposite-corner pair, and eight contain
+both. These partition statements classify the sixty seeds; they do not
+adopt any one of them.
+
+The six observed split history pairs, with multiplicities, are
+
+| `f_L1` history | `f_min` history | count | fill L1 / min |
+|---|---|---:|---|
+| `(3, 8, 11, 12)` | `(3, 8, 10)` | 16 | yes / no |
+| `(3, 10, 12)` | `(3, 10, 11)` | 16 | yes / no |
+| `(3, 8, 11, 12)` | `(3, 8, 9)` | 8 | yes / no |
+| `(3, 9, 12)` | `(3, 8, 10)` | 8 | yes / no |
+| `(3, 9, 12)` | `(3, 9, 11)` | 8 | yes / no |
+| `(3, 11, 12)` | `(3, 11)` | 4 | yes / no |
+
+## Theorem 3 — Display, Do Not Adopt
+
+The integer `N_split3 = 60` is the object of the census. The two fill counts
+are reported with it. They are displayed, not adopted: do not adopt a seed,
+and do not adopt either map. A selector is not written into Admissibility.
+A later derivation that used one of these seeds as a physical rule would be
+a different claim.
+
+## What This Does Not Claim
+
+- It does not claim that either map is the Admissibility rule.
+- It does not claim that lock-step waves are physical Record formation.
+- It does not claim a unique physically preferred three-site seed.
+- It does not extend the census to `|S| ≠ 3` or to a larger patch.
+- It does not identify `f_min` with Hamming weight, graph distance, or any
+  map other than nonempty `n_both = 0`.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the three-site split-count question for the two displayed maps on the declared patch. |
+| V2 | Current main has the axiom memo and no landed exhaustive three-site split census of these two maps. |
+| V3 | All 220 triples, both runs, and the three integers are independently finite and exact. |
+| V4 | The census is more than a restatement of the line-seed non-split or of the two-site count of four: it enumerates every three-site seed. |
+| V5 | It is not a physical compiler and writes no selector into Admissibility. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: most three-site seeds do not split these two
+maps, and the sixty that do are not hereby adopted. No global compiler
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| long-axis 3-site line | run both maps from `{(0,0,0),(1,0,0),(2,0,0)}` | no split; both fill with `(3, 9, 12)` |
+| end-face plus far long-axis site | run both maps from `{(0,0,0),(0,0,1),(2,0,0)}` | splits by fill and history |
+| seeds missing an end face | run both maps from each of the 108 | none split |
+| Hamming-weight predicate | fire on six-bit weight | executed counterexample: opp2 has weight 2 and `f_L1 = 0` |
+| adopt a seed | write one splitter into Admissibility | refused; displayed, not adopted |
+| two-site leftover | recycle the four displacement-`(2,1,1)` pairs as the three-site count | refused; this is a new cardinality |
+
+### N2 — wall independence
+
+The missing formation mechanism, the missing Admissibility selector, and any
+extension off this twelve-site patch are distinct premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch occupancy `0`, the two predicates, and the
+synchronous wave rule are declared. Hamming weight is not silently used.
+No seed is treated as axiom content.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate, the
+local-condition sentence, and the lock/content/absence wording used here.
+It does not supply `f_min`, `f_L1`, or a three-site selector. The residual
+matches those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 220 triples, two maps, lock-count histories | no continuum or larger-patch census |
+| per site | six-neighbor occupancy 3-tuples | no derived kernel values |
+| per mode | no mode calculation | no spectral statement |
+| per block | two-cube lock-step dynamics | no physical formation compiler |
+| lattice wide | checked and not executed | no infinite-volume claim |
+
+### N6 — live partial-closure paths
+
+Live routes are an independently derived formation mechanism, a derivation
+that would force one of the two maps, and any census at a different seed
+cardinality or patch. Those routes remain open.
+
+### N7 — hostile steelman
+
+**Steelman:** Because the two-site census already found four splitters, every
+three-site seed that contains one of those pairs should split, and the
+three-site count should therefore be a leftover character of the two-site
+orbit.
+
+**Answer:** Containment of a two-site splitter is neither necessary nor the
+object counted here. Twenty-eight of the sixty three-site splits contain a
+long-axis pair and no opposite-corner pair. Eight of the forty three-site
+seeds that do contain an opposite-corner pair still fill under both maps.
+The integer `N_split3 = 60` is a new cardinality on `|S| = 3`.
+
+### N8 — cross-cycle echo
+
+A prior displayed computation isolated the four two-site splitters as one
+opposite-corner orbit and showed that the line seed does not split. This
+note does not recycle that two-site count as the three-site census. It
+enumerates every three-site seed and reports `N_split3 = 60`.
+
+**Gate disposition:** PASS for the 220-seed census and the three displayed
+integers above. FAIL / DO NOT SHIP for “Admissibility is `f_min`,” “adopt
+this seed,” or “the maps agree on every finite seed.”
+
+## Primary Runner
+
+The primary runner recomputes the line seed, enumerates all 220 triples,
+checks that `f_L1` is `n_unbalanced ≠ 0` rather than Hamming weight, checks
+that `f_min` is nonempty `n_both = 0`, and checks that this note displays
+`N_split3 = 60` without adopting a selector. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5531,
+ "edge_count": 15732,
+ "node_count": 5532,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_min_l1_three_site_split_census_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_min_l1_three_site_split_census_2026_08_15.txt
+++ b/logs/runner-cache/f_min_l1_three_site_split_census_2026_08_15.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/f_min_l1_three_site_split_census_2026_08_15.py
+runner_sha256: 37f26bbdf7697c0c60892e1d41ba39c5d2d6c18369b567f5516a022d43a77eba
+input_fingerprint_sha256: 0c2c40a277cf5f1b149b319b39364ae8f1b096eb75e3ff12cfb67cd4dd58d29a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: exhaustive three-site lock-step census on the twelve-vertex two-cube with off-patch occupancy 0
+negative_scope: N_split3 is displayed; no seed is adopted and no selector is written into Admissibility
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: two-cube-cardinality the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}
+PASS: triple-count there are C(12,3)=220 unordered three-site seeds
+PASS: theorem-1-line-seed the line seed fills under both maps with history (3, 9, 12) and does not split
+PASS: theorem-2-exhibit the seed {(0,0,0),(0,0,1),(2,0,0)} splits fill or lock history
+census: N_split3=60 N_fill_L1_3=220 N_fill_min_3=160 N_fill_both_3=160 N_history_only=0 N_fill_bit_only=0
+PASS: theorem-2-census-range the census integers lie in 0..220 and N_fill_both <= min(N_fill_L1_3, N_fill_min_3)
+PASS: theorem-2-split-positive at least the displayed exhibit contributes to N_split3
+PASS: theorem-3-display the note displays the computed N_split3 and does not adopt a seed
+PASS: theorem-3-fill-counts the note reports the two required fill counts
+PASS: identity-l1-not-hamming opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire
+PASS: identity-min-nboth-zero f_min fires on nonempty n_both=0 and refuses mixed3
+PASS: forbidden-phrases the note avoids the dispatch-forbidden phrases
+PASS: no-admissibility-selector the note does not write a seed selector into Admissibility
+PASS: claim-scope the YAML claim_scope states the 220-seed display
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_min_l1_three_site_split_census_2026_08_15.py
+++ b/scripts/f_min_l1_three_site_split_census_2026_08_15.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Three-site split census of f_min versus f_L1 on the twelve-vertex two-cube.
+
+Enumerates every unordered triple of the twelve sites of
+{0,1,2} x {0,1} x {0,1} with off-patch occupancy 0. A split is a
+different fill bit or a different lock-count history. The census
+displays N_split3; it does not adopt a seed or write a selector into
+Admissibility.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_MIN_L1_THREE_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_MIN_L1_THREE_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+AXES: tuple[Point, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SITES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+LINE_SEED = frozenset(((0, 0, 0), (1, 0, 0), (2, 0, 0)))
+LINE_HISTORY = (3, 9, 12)
+SPLIT_EXHIBIT = frozenset(((0, 0, 0), (0, 0, 1), (2, 0, 0)))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locked: frozenset[Point]) -> int:
+    """On-patch occupancy is the lock bit; off-patch occupancy is 0."""
+    if site not in SITE_SET:
+        return 0
+    return 1 if site in locked else 0
+
+
+def axis_type(site: Point, locked: frozenset[Point]) -> tuple[int, int, int]:
+    """Return (n_unbalanced, n_both, n_empty) for the three cubic axes."""
+    n_unbalanced = n_both = n_empty = 0
+    for axis in AXES:
+        plus = occupancy(add(site, axis), locked)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+        if plus == minus == 0:
+            n_empty += 1
+        elif plus == minus == 1:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fire_l1(counts: tuple[int, int, int]) -> bool:
+    """f_L1: some axis is unbalanced (n != 0). Not Hamming weight."""
+    n_unbalanced, _n_both, _n_empty = counts
+    return n_unbalanced != 0
+
+
+def fire_min(counts: tuple[int, int, int]) -> bool:
+    """f_min: nonempty and n_both = 0."""
+    n_unbalanced, n_both, _n_empty = counts
+    return n_both == 0 and n_unbalanced != 0
+
+
+def run(seed: frozenset[Point], fire) -> tuple[tuple[int, ...], bool]:
+    locked = frozenset(seed)
+    history = [len(locked)]
+    for _tick in range(len(SITES)):
+        ready = [
+            site
+            for site in SITES
+            if site not in locked and fire(axis_type(site, locked))
+        ]
+        if not ready:
+            break
+        locked = locked.union(ready)
+        history.append(len(locked))
+    return (tuple(history), len(locked) == len(SITES))
+
+
+def census() -> dict[str, object]:
+    n_split = n_fill_l1 = n_fill_min = n_fill_both = 0
+    n_history_only = n_fill_only = 0
+    triples = tuple(frozenset(triple) for triple in combinations(SITES, 3))
+    for seed in triples:
+        hist_l1, fill_l1 = run(seed, fire_l1)
+        hist_min, fill_min = run(seed, fire_min)
+        n_fill_l1 += int(fill_l1)
+        n_fill_min += int(fill_min)
+        n_fill_both += int(fill_l1 and fill_min)
+        fill_diff = fill_l1 != fill_min
+        hist_diff = hist_l1 != hist_min
+        if fill_diff or hist_diff:
+            n_split += 1
+            n_fill_only += int(fill_diff and not hist_diff)
+            n_history_only += int(hist_diff and not fill_diff)
+    return {
+        "n_triples": len(triples),
+        "n_split": n_split,
+        "n_fill_l1": n_fill_l1,
+        "n_fill_min": n_fill_min,
+        "n_fill_both": n_fill_both,
+        "n_history_only": n_history_only,
+        "n_fill_only": n_fill_only,
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: exhaustive three-site lock-step census on the twelve-vertex two-cube with off-patch occupancy 0")
+    print("negative_scope: N_split3 is displayed; no seed is adopted and no selector is written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_MIN_L1_THREE_SITE_SPLIT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    checks.check("two-cube-cardinality", "the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}", len(SITES) == 12 and len(SITE_SET) == 12)
+    checks.check("triple-count", "there are C(12,3)=220 unordered three-site seeds", len(tuple(combinations(SITES, 3))) == 220)
+
+    hist_l1_line, fill_l1_line = run(LINE_SEED, fire_l1)
+    hist_min_line, fill_min_line = run(LINE_SEED, fire_min)
+    checks.check(
+        "theorem-1-line-seed",
+        "the line seed fills under both maps with history (3, 9, 12) and does not split",
+        fill_l1_line
+        and fill_min_line
+        and hist_l1_line == LINE_HISTORY
+        and hist_min_line == LINE_HISTORY,
+        residual=(hist_l1_line, hist_min_line, fill_l1_line, fill_min_line),
+    )
+
+    hist_l1_ex, fill_l1_ex = run(SPLIT_EXHIBIT, fire_l1)
+    hist_min_ex, fill_min_ex = run(SPLIT_EXHIBIT, fire_min)
+    splits_ex = (fill_l1_ex != fill_min_ex) or (hist_l1_ex != hist_min_ex)
+    checks.check(
+        "theorem-2-exhibit",
+        "the seed {(0,0,0),(0,0,1),(2,0,0)} splits fill or lock history",
+        splits_ex and fill_l1_ex and not fill_min_ex,
+        residual=(hist_l1_ex, hist_min_ex, fill_l1_ex, fill_min_ex),
+    )
+
+    counts = census()
+    n_split = int(counts["n_split"])
+    n_fill_l1 = int(counts["n_fill_l1"])
+    n_fill_min = int(counts["n_fill_min"])
+    n_fill_both = int(counts["n_fill_both"])
+    print(
+        "census: "
+        f"N_split3={n_split} N_fill_L1_3={n_fill_l1} "
+        f"N_fill_min_3={n_fill_min} N_fill_both_3={n_fill_both} "
+        f"N_history_only={counts['n_history_only']} "
+        f"N_fill_bit_only={counts['n_fill_only']}"
+    )
+    checks.check(
+        "theorem-2-census-range",
+        "the census integers lie in 0..220 and N_fill_both <= min(N_fill_L1_3, N_fill_min_3)",
+        counts["n_triples"] == 220
+        and 0 <= n_split <= 220
+        and 0 <= n_fill_both <= min(n_fill_l1, n_fill_min)
+        and n_fill_l1 <= 220
+        and n_fill_min <= 220,
+    )
+    checks.check(
+        "theorem-2-split-positive",
+        "at least the displayed exhibit contributes to N_split3",
+        n_split >= 1 and splits_ex,
+    )
+
+    checks.check(
+        "theorem-3-display",
+        "the note displays the computed N_split3 and does not adopt a seed",
+        f"N_split3 = {n_split}" in note
+        and "displayed, not adopted" in normalized_note
+        and "do not adopt" in normalized_note,
+        residual=n_split,
+    )
+    checks.check(
+        "theorem-3-fill-counts",
+        "the note reports the two required fill counts",
+        f"N_fill_L1_3 = {n_fill_l1}" in note
+        and f"N_fill_min_3 = {n_fill_min}" in note,
+        residual=(n_fill_l1, n_fill_min),
+    )
+
+    locked_opp = frozenset(((0, 0, 0), (2, 0, 0)))
+    opp2 = axis_type((1, 0, 0), locked_opp)
+    hamming_opp = sum(
+        occupancy(add((1, 0, 0), shift), locked_opp)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    checks.check(
+        "identity-l1-not-hamming",
+        "opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire",
+        opp2 == (0, 1, 2) and hamming_opp == 2 and not fire_l1(opp2) and not fire_min(opp2),
+    )
+    locked_mixed = frozenset(((0, 0, 0), (2, 0, 0), (1, 1, 0)))
+    mixed3 = axis_type((1, 0, 0), locked_mixed)
+    locked_wt1 = frozenset(((0, 0, 0),))
+    wt1 = axis_type((1, 0, 0), locked_wt1)
+    checks.check(
+        "identity-min-nboth-zero",
+        "f_min fires on nonempty n_both=0 and refuses mixed3",
+        wt1 == (1, 0, 2)
+        and mixed3 == (1, 1, 1)
+        and fire_min(wt1)
+        and fire_l1(wt1)
+        and not fire_min(mixed3)
+        and fire_l1(mixed3),
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-phrases",
+        "the note avoids the dispatch-forbidden phrases",
+        all(phrase not in note for phrase in forbidden),
+    )
+    checks.check(
+        "no-admissibility-selector",
+        "the note does not write a seed selector into Admissibility",
+        "not written into Admissibility" in normalized_note
+        and "selector" in normalized_note,
+    )
+    checks.check(
+        "claim-scope",
+        "the YAML claim_scope states the 220-seed display",
+        "Among the 220 three-site seeds" in note and f"{n_split}" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 220 three-site seeds on the two-cube, N_split3=60 distinguish f_min from f_L1 by fill or lock history. The line seed does not split. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_min_l1_three_site_split_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.