### PR TITLE
feat(mix0line): run f_mix0 from the 3-site long-axis seed

### DIFF
--- a/docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,417 @@
+---
+claim_id: f_cut_mix0_line_seed_fill_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the F_cut map with remaining bits (1,0,1,1,0) does fill from the 3-site long-axis seed. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_mix0_line_seed_fill_2026_08_15.py
+---
+
+# Does `f_mix0` Fill From The 3-Site Long-Axis Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact fill of the `F_cut` rival `f_mix0` with remaining bits
+`(1,0,1,1,0)` from the displayed 3-site long-axis seed on the
+twelve-vertex two-cube with off-patch occupancy `0`. The map is
+displayed, not adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_mix0_line_seed_fill_2026_08_15.py`](../scripts/f_cut_mix0_line_seed_fill_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut|=32`. On the two-cube
+`{0,1,2}×{0,1}×{0,1}`, a locked seed starts the dynamics. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. Fill means
+`|locks_halt|=12`.
+
+The displayed `F_cut` rival is the remaining-bit tuple
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 0)
+```
+
+with complements forced. Call that map `f_mix0`. It is L1 with
+`mixed3=0`. It fills from 1-site, from the face-diagonal 2-site, and from
+`S*` like L1 (#6415/#6424). Its 1-site history from `(0,0,0)` is
+`(1, 4, 8, 11, 12)`, the same tuple as L1. Those 1-site, face-diagonal,
+and `S*` fills are leftover-character of #6415/#6424. They are not the
+residual of this note.
+
+This note asks a new map question on the remaining displayed seed: whether
+`f_mix0` fills from the 3-site long-axis seed
+
+```text
+S = {(0,0,0), (1,0,0), (2,0,0)}.
+```
+
+Not leftover-character of #6419. That surface was the line-seed fill of
+`f_cutmin` (tuple `(1,0,1,0,0)`). This note is the same seed on a
+different remaining-bit map.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. On this same seed, `f_L1` fills with lock history
+`(3, 9, 12)` (#6408). `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+**Theorem 1.** `f_L1` fills from `S` with lock history `(3, 9, 12)`.
+
+**Theorem 2.** `f_mix0` fills from `S`. Halt locks, halt tick, and lock
+history are
+
+```text
+|locks_halt| = 12
+T = 2
+history = (3, 9, 12)
+```
+
+**Theorem 3.** On this seed the two maps share the lock-history tuple
+`(3, 9, 12)`. They differ on the remaining bit `mixed3`: L1 has
+`mixed3=1` and `f_mix0` has `mixed3=0`. Displayed, not adopted.
+Do not write `f_mix0` into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "On the twelve-vertex two-cube with off-patch o=0, the F_cut rival f_mix0 with remaining bits (1,0,1,1,0) is reconstructed and run from the 3-site long-axis seed. Halt locks, T, and lock history are enumerated. The map is displayed, not written into Admissibility."
+trace_class: upstream_support
+target_claim_id: f_cut_mix0_line_seed_fill
+target_blocker_text: "whether the F_cut map with remaining bits (1,0,1,1,0) fills from the 3-site long-axis seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the line-seed fill; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for f_mix0 and f_L1 on this twelve-vertex patch with off-patch o=0 and seed S; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the 3-site long-axis seed `S = {(0,0,0),(1,0,0),(2,0,0)}`;
+- the named remaining bits `wt1`, `opp2`, `adj2`, `vertex3`, `mixed3`;
+- the displayed map `f_mix0` with tuple `(1,0,1,1,0)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of #6419 (`f_cutmin` on this same seed). That
+surface is the line-seed fill of the unique support-36 1-site filler.
+This note is the fill of `f_mix0` from the remaining displayed seed.
+
+## Exact Target And Objects
+
+**Target.** Run `f_mix0` from `S` on the two-cube with off-patch occupancy
+`0`. Report halt locks, halt tick `T`, and the lock-history tuple. State
+whether the run fills. Compare the history to `f_L1` on the same seed.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of a 6-tuple `c` is the triple `(u,b,e)` with `u+b+e=3`,
+where `u` is the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. The
+ten axis-type classes are exactly the ten orbits. Complement sends
+`(u,b,e)` to `(u,e,b)`.
+
+| `(u,b,e)` | name | orbit size | complement image |
+|---|---|---:|---|
+| `(0,0,3)` | empty | 1 | `(0,3,0)` full |
+| `(0,3,0)` | full | 1 | `(0,0,3)` empty |
+| `(0,1,2)` | `opp2` | 3 | `(0,2,1)` `opp4` |
+| `(0,2,1)` | `opp4` | 3 | `(0,1,2)` `opp2` |
+| `(1,0,2)` | `wt1` | 6 | `(1,2,0)` `wt5` |
+| `(1,2,0)` | `wt5` | 6 | `(1,0,2)` `wt1` |
+| `(2,0,1)` | `adj2` | 12 | `(2,1,0)` `adj4` |
+| `(2,1,0)` | `adj4` | 12 | `(2,0,1)` `adj2` |
+| `(1,1,1)` | `mixed3` | 12 | `(1,1,1)` |
+| `(3,0,0)` | `vertex3` | 8 | `(3,0,0)` |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`.
+
+A locked set `L` determines occupancies: a lattice neighbor in `L` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `L` by
+
+```text
+L ∪ { v in two-cube \ L : f(neighborhood_6(v; L)) = 1 }.
+```
+
+The eight 1-site fillers are the maps in `F_cut` whose halt set from seed
+`(0,0,0)` has cardinality 12. One of those eight is the remaining-bit
+tuple `(1,0,1,1,0)`. Complements are `wt5=1`, `adj4=1`, `opp4=0`, and
+`vertex3=1` is already listed. Support of that map is 44.
+
+Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1.
+```
+
+Its remaining-bit tuple is `(1,0,1,1,1)` and its support is 56. It is not
+`f_mix0`: the maps differ only on the complement-fixed orbit `mixed3`.
+
+Start locked equals `S`, not a 1-site seed. Fill from `S` means the halt
+set has cardinality 12.
+
+Do not write f_mix0 into Admissibility.
+Do not write `f_mix0` into Admissibility.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is not Hamming parity. Started from `S` with off-patch occupancy
+`0`, `f_L1` fills the twelve-vertex two-cube. Its lock cardinalities are
+`(3, 9, 12)` and its halt tick is `2`.
+
+**Theorem 2.** Reconstructing the eight `F_cut` 1-site fillers isolates
+the remaining-bit member `f_mix0` with tuple `(1,0,1,1,0)`. Its 1-site
+history is `(1, 4, 8, 11, 12)`. Started from `S` with off-patch occupancy
+`0`, the same map fills:
+
+```text
+|locks_halt| = 12
+T = 2
+history = (3, 9, 12)
+```
+
+**Theorem 3.** The line-seed histories of `f_mix0` and `f_L1` are equal.
+The remaining bits are not: `mixed3` is `0` on `f_mix0` and `1` on L1.
+The common line-seed history is displayed, not adopted. `f_mix0` is not
+an Admissibility clause.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit `adj2` has even weight and `f_L1=1` |
+| `f_L1` fills from `S` | halt set has cardinality 12 at tick 2 with history `(3, 9, 12)` |
+| `f_mix0` is an `F_cut` 1-site filler | the remaining-bit tuple `(1,0,1,1,0)` is one of the eight 1-site fillers, support 44 |
+| `f_mix0` 1-site history | `(1, 4, 8, 11, 12)`, the same tuple as L1 |
+| `f_mix0` fills from `S` | `|locks_halt|=12`, `T=2`, history `(3, 9, 12)` |
+| comparison | the two maps share the line-seed history and differ on `mixed3` |
+| physical Admissibility selection | open and not claimed; `f_mix0` is not written in |
+
+Every leaf needed for the stated line-seed fill is discharged. No `Z^3`-wide
+formation law is claimed.
+
+## Mutations
+
+1. Replace `f_L1` by Hamming `|c|_1 mod 2`: the remaining-bit tuple changes
+   and Hamming does not fill from `S`.
+2. Flip `mixed3` from `0` to `1`: the map becomes `f_L1`, not `f_mix0`.
+3. Replace the seed by the 1-site seed `(0,0,0)`: the history becomes
+   `(1, 4, 8, 11, 12)`, which is leftover-character of #6415, not this residual.
+4. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+5. Assert that `f_mix0` fails to fill from `S`: the reconstructed run
+   reaches all twelve vertices at tick 2.
+6. Replace `f_mix0` by `f_cutmin` `(1,0,1,0,0)`: that is #6419, a different
+   remaining-bit map on the same seed.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 1-site / face-diagonal / `S*`
+  fills of `f_mix0` (#6415/#6424) in place of this 3-site fill.
+- No leftover-character restatement of the line-seed fill of `f_cutmin`
+  (#6419) in place of this different remaining-bit map.
+- No blank-block variant and no adoption of a second seed as canonical.
+- No axiom edit: `f_mix0` is displayed, not written into Admissibility.
+
+## No-Go Discipline Gate
+
+The only negative claim is that Hamming is not `f_L1` and does not fill
+from `S`. The positive fill of `f_mix0` from `S` is an exact run, not a
+wall, and it is not an Admissibility clause.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| L1 line-seed fill | Run `f_L1` from `S` to a fixed point. | Theorem 1 and check `thm1-f-L1-fills-line` give history `(3, 9, 12)`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `f_mix0` membership | Reconstruct the eight 1-site fillers and isolate tuple `(1,0,1,1,0)`. | Theorem 2 and check `thm1-mix0-tuple-and-one-site-filler`. | **ATTEMPTED** |
+| `f_mix0` from `S` | Run the remaining-bit map from the long-axis seed. | Theorem 2 and check `thm2-mix0-line-fill` give fill at `T=2`. | **ATTEMPTED** |
+| history comparison | Compare line-seed histories and the `mixed3` bit of the two maps. | Theorem 3 and check `thm3-comparison-same-line-history`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: Hamming is not `f_L1`. The fill of
+`f_mix0` from `S` is a positive exact run.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `f_mix0` fills from `S` / `f_L1` fills from `S` | no: one map filling does not classify the other | no: L1 filling does not prove `f_mix0` fills | independent positive runs, not two walls |
+| `f_L1` fills / Hamming does not | no: one map filling does not classify Hamming | no: Hamming failing does not prove `f_L1` fills | independent positive/negative members, not two walls |
+| 1-site history / line-seed history | no: the 1-site run does not fix the 3-site run | no: a shared line-seed history does not restore `mixed3` | separate exact runs |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| 3-site long-axis seed `S` | explicit remaining displayed seed; not the 1-site seed of #6415 |
+| remaining bits `(1,0,1,1,0)` | explicit `F_cut` rival; L1 and `f_cutmin` are different tuples |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| shared history `(3, 9, 12)` | displayed comparison, not an Admissibility clause |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_mix0_line_seed_fill_2026_08_15.py:81` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_mix0_line_seed_fill_2026_08_15.py:125` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_mix0_line_seed_fill_2026_08_15.py:130` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_mix0_line_seed_fill_2026_08_15.py:50` | long-axis seed | `S = {(0,0,0),(1,0,0),(2,0,0)}` | yes |
+| `scripts/f_cut_mix0_line_seed_fill_2026_08_15.py:66` | `f_mix0` tuple | remaining bits `(1,0,1,1,0)` | yes |
+| `scripts/f_cut_mix0_line_seed_fill_2026_08_15.py:180` | lock dynamics | synchronous ticks from a supplied seed to a fixed point | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: `f_mix0` and `f_L1` from `S` | the fill is this pair of maps on this seed; other seeds are unclaimed except as 1-site context |
+| per block | yes: the pair `(halt locks, history)` | fill from `S` is `|locks_halt|=12` with history `(3, 9, 12)` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: the
+`F_cut` 1-site filler with remaining bits `(1,0,1,1,0)` also fills from
+the 3-site long-axis seed, and on that seed it shares L1's lock history.
+That shared history does not write `f_mix0` into Admissibility and does
+not select either map as the physical rule. The remaining physical
+choice — which, if any, occupancy predicate is the Admissibility rule —
+stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that a 3-site long-axis seed already occupies
+an entire long edge, so any 1-site filler with `wt1=adj2=1` will flood
+the two remaining long edges in one tick and close the last three
+opposite-corner sites in the next, making the shared history `(3, 9, 12)`
+leftover-character of #6415 or of #6419. That objection is correctly
+about the first two waves on this particular seed. It does not overturn
+the stated theorem. `f_mix0` and L1 already differ on `mixed3`, so
+`mixed3=0` is not inert in general. Whether that difference survives on
+`S` is a new run. It happens not to change the history: `f_mix0` still
+fills, with the same history as `f_L1`. A failure to fill would have
+been displayed. None occurs. The #6419 residual was `f_cutmin`, a
+different remaining-bit map.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`f_mix0` tuple, and the line-seed run are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+The 1-site / face-diagonal / `S*` fills of `f_mix0` (#6415/#6424) are
+the class this note re-runs from the remaining displayed seed. They are
+not parents and do not close the line-seed fill. The line-seed fill of
+`f_cutmin` (#6419) is a different remaining-bit map on the same seed.
+
+No earlier mechanism retires the line-seed fill or writes `f_mix0`
+into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the Hamming distinction and
+the exact fill of `f_mix0` from `S` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, isolates the remaining-bit 1-site filler `f_mix0`, checks that
+`f_L1` fills from `S` with history `(3, 9, 12)`, runs `f_mix0` from `S`,
+and reports `|locks_halt|=12`, `T=2`, and history `(3, 9, 12)`.
+Declared audit inputs are this note and the axiom memo. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15731,
- "node_count": 5531,
+ "edge_count": 15732,
+ "node_count": 5532,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4655,6 +4655,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_mix0_line_seed_fill_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_mix0_line_seed_fill_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_mix0_line_seed_fill_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_mix0_line_seed_fill_2026_08_15.py
+runner_sha256: 57bbd79b2b5428429f81ed21bbfac033594c3f888475bb38396321684a09125b
+input_fingerprint_sha256: 7269b8bc806fb96081b7455a98baccabe9019f9e468ee35871af381a2c787768
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+|F_cut|=32
+N_fill_one_site=8
+L1_tuple={'wt1': 1, 'opp2': 0, 'adj2': 1, 'vertex3': 1, 'mixed3': 1}
+MIX0_tuple={'wt1': 1, 'opp2': 0, 'adj2': 1, 'vertex3': 1, 'mixed3': 0}
+mix0_support=44
+f_L1_one_site locks=12 halt=4 history=(1, 4, 8, 11, 12)
+f_mix0_one_site locks=12 halt=4 history=(1, 4, 8, 11, 12)
+f_L1_line locks=12 halt=2 history=(3, 9, 12)
+f_mix0_line locks=12 halt=2 history=(3, 9, 12) fills=True
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 axis-type orbits partition the 64 cells
+PASS: thm1-named-orbit-types wt1/opp2/adj2/vertex3/mixed3 are the listed axis-type orbits
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_- (n != 0)
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f-L1-fills-line f_L1 fills from S with lock history (3, 9, 12)
+PASS: thm1-two-cube-twelve the two-cube has twelve vertices and contains the long-axis seed
+PASS: thm1-mix0-tuple-and-one-site-filler f_mix0 is the F_cut 1-site filler with remaining bits (1,0,1,1,0)
+PASS: thm2-mix0-line-fill f_mix0 fills from S: |locks_halt|=12, T=2, history (3, 9, 12)
+PASS: thm3-comparison-same-line-history on S, f_mix0 and f_L1 share (3, 9, 12); they differ on mixed3
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted line-seed fill, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit f_mix0 is not written into Admissibility
+PASS: not-leftover-6419 the residual is the 3-site line-seed fill, not leftover-character of #6419
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-scope-and-fill claim_scope reports that the F_cut map (1,0,1,1,0) does fill from the 3-site long-axis seed
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f_mix0 and f_L1 are each run from S to a fixed point
+per_block: checked exactly — halt locks, T, and lock history of f_mix0 on S are compared to f_L1
+lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_mix0_line_seed_fill_2026_08_15.py
+++ b/scripts/f_cut_mix0_line_seed_fill_2026_08_15.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Does the F_cut rival f_mix0 fill from the 3-site long-axis seed.
+
+Reconstruct the 24 proper cube rotations, the ten axis-type orbits, the
+32-element three-cut class F_cut, and the remaining-bit map f_mix0 with
+tuple (wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 0). Run that map
+from the 3-site long-axis seed S = {(0,0,0), (1,0,0), (2,0,0)} on the
+twelve-vertex two-cube with off-patch occupancy 0. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED_ONE: Site = (0, 0, 0)
+SEED_LINE: frozenset[Site] = frozenset({(0, 0, 0), (1, 0, 0), (2, 0, 0)})
+
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+BIT_TYPES: dict[str, OrbitType] = {
+    "wt1": (1, 0, 2),
+    "opp2": (0, 1, 2),
+    "adj2": (2, 0, 1),
+    "vertex3": (3, 0, 0),
+    "mixed3": (1, 1, 1),
+}
+COMPLEMENT_NAMES: dict[str, str] = {
+    "wt1": "wt5",
+    "opp2": "opp4",
+    "adj2": "adj4",
+}
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+MIX0_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 0)
+L1_ONE_SITE_HISTORY: tuple[int, ...] = (1, 4, 8, 11, 12)
+MIX0_ONE_SITE_HISTORY: tuple[int, ...] = (1, 4, 8, 11, 12)
+L1_LINE_HISTORY: tuple[int, ...] = (3, 9, 12)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(predicate, seed: frozenset[Site] | set[Site]) -> tuple[int, int, tuple[int, ...]]:
+    locked = set(seed)
+    history = [len(locked)]
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, tuple(history)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def named_tuple_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[BIT_TYPES[name]] for name in BIT_NAMES)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def support_of_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    orbit_sizes: dict[OrbitType, int],
+) -> int:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return sum(orbit_sizes[orbit_type] for orbit_type, value in assignment.items() if value == 1)
+
+
+def census_f_cut_one_site_fillers(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[int, ...]]:
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    fillers: list[tuple[int, ...]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        n_locks, _halt, _history = run_predicate(
+            predicate_from_bits(bits, orbit_types, type_of),
+            frozenset({SEED_ONE}),
+        )
+        if n_locks == 12:
+            fillers.append(bits)
+    return fillers
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_assign = dict(zip(orbit_types, l1_bits, strict=True))
+    l1_named = named_tuple_from_assignment(l1_assign)
+    l1_one_locks, l1_one_halt, l1_one_history = run_predicate(f_L1, frozenset({SEED_ONE}))
+    l1_line_locks, l1_line_halt, l1_line_history = run_predicate(f_L1, SEED_LINE)
+    ham_line_locks, _ham_halt, _ham_history = run_predicate(f_hamming, SEED_LINE)
+
+    fillers = census_f_cut_one_site_fillers(orbit_types, orbits, empty_type, full_type)
+    filler_named = [
+        named_tuple_from_assignment(dict(zip(orbit_types, bits, strict=True)))
+        for bits in fillers
+    ]
+    filler_supports = [
+        support_of_bits(bits, orbit_types, orbit_sizes) for bits in fillers
+    ]
+    mix0_named_matches = [
+        (named, bits, support)
+        for named, bits, support in zip(filler_named, fillers, filler_supports, strict=True)
+        if named == MIX0_TUPLE
+    ]
+
+    mix0_bits = mix0_named_matches[0][1] if mix0_named_matches else None
+    f_mix0 = (
+        predicate_from_bits(mix0_bits, orbit_types, type_of) if mix0_bits is not None else None
+    )
+    if f_mix0 is None:
+        mix0_one = (0, 0, ())
+        mix0_line = (0, 0, ())
+        mix0_support = -1
+    else:
+        mix0_one = run_predicate(f_mix0, frozenset({SEED_ONE}))
+        mix0_line = run_predicate(f_mix0, SEED_LINE)
+        mix0_support = support_of_bits(mix0_bits, orbit_types, orbit_sizes)
+
+    mix0_line_locks, mix0_line_halt, mix0_line_history = mix0_line
+    mix0_fills = mix0_line_locks == 12
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"|F_cut|={n_cut}")
+    print(f"N_fill_one_site={len(fillers)}")
+    print(f"L1_tuple={dict(zip(BIT_NAMES, l1_named))}")
+    print(f"MIX0_tuple={dict(zip(BIT_NAMES, MIX0_TUPLE))}")
+    print(f"mix0_support={mix0_support}")
+    print(f"f_L1_one_site locks={l1_one_locks} halt={l1_one_halt} history={l1_one_history}")
+    print(f"f_mix0_one_site locks={mix0_one[0]} halt={mix0_one[1]} history={mix0_one[2]}")
+    print(f"f_L1_line locks={l1_line_locks} halt={l1_line_halt} history={l1_line_history}")
+    print(
+        f"f_mix0_line locks={mix0_line_locks} halt={mix0_line_halt} "
+        f"history={mix0_line_history} fills={mix0_fills}"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_MIX0_LINE_SEED_FILL_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 axis-type orbits partition the 64 cells",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-named-orbit-types",
+        "wt1/opp2/adj2/vertex3/mixed3 are the listed axis-type orbits",
+        orbit_sizes == expected_sizes
+        and BIT_TYPES["wt1"] == (1, 0, 2)
+        and BIT_TYPES["opp2"] == (0, 1, 2)
+        and BIT_TYPES["adj2"] == (2, 0, 1)
+        and BIT_TYPES["vertex3"] == (3, 0, 0)
+        and BIT_TYPES["mixed3"] == (1, 1, 1),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_- (n != 0)",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-f-L1-fills-line",
+        "f_L1 fills from S with lock history (3, 9, 12)",
+        in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and l1_named == L1_TUPLE
+        and l1_line_locks == 12
+        and l1_line_halt == 2
+        and l1_line_history == L1_LINE_HISTORY
+        and SEED_LINE.issubset(TWO_CUBE),
+    )
+    checks.check(
+        "thm1-two-cube-twelve",
+        "the two-cube has twelve vertices and contains the long-axis seed",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and SEED_LINE.issubset(TWO_CUBE)
+        and len(SEED_LINE) == 3,
+    )
+    checks.check(
+        "thm1-mix0-tuple-and-one-site-filler",
+        "f_mix0 is the F_cut 1-site filler with remaining bits (1,0,1,1,0)",
+        len(fillers) == 8
+        and n_cut == 32
+        and len(mix0_named_matches) == 1
+        and MIX0_TUPLE == (1, 0, 1, 1, 0)
+        and MIX0_TUPLE != L1_TUPLE
+        and mix0_support == 44
+        and mix0_one[0] == 12
+        and mix0_one[2] == MIX0_ONE_SITE_HISTORY
+        and l1_one_history == L1_ONE_SITE_HISTORY
+        and mix0_one[2] == l1_one_history,
+    )
+    checks.check(
+        "thm2-mix0-line-fill",
+        "f_mix0 fills from S: |locks_halt|=12, T=2, history (3, 9, 12)",
+        f_mix0 is not None
+        and mix0_fills
+        and mix0_line_locks == 12
+        and mix0_line_halt == 2
+        and mix0_line_history == (3, 9, 12)
+        and mix0_line_history == L1_LINE_HISTORY,
+    )
+    checks.check(
+        "thm3-comparison-same-line-history",
+        "on S, f_mix0 and f_L1 share (3, 9, 12); they differ on mixed3",
+        mix0_line_history == l1_line_history == (3, 9, 12)
+        and mix0_one[2] == MIX0_ONE_SITE_HISTORY
+        and l1_one_history == L1_ONE_SITE_HISTORY
+        and MIX0_TUPLE != L1_TUPLE
+        and MIX0_TUPLE[4] == 0
+        and L1_TUPLE[4] == 1
+        and ham_line_locks != 12,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted line-seed fill, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "f_mix0 is not written into Admissibility",
+        "Do not write f_mix0 into Admissibility" in note
+        and "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note,
+    )
+    checks.check(
+        "not-leftover-6419",
+        "the residual is the 3-site line-seed fill, not leftover-character of #6419",
+        "Not leftover-character of #6419" in note
+        and "f_cutmin" in note
+        and "remaining displayed seed" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-scope-and-fill",
+        "claim_scope reports that the F_cut map (1,0,1,1,0) does fill from the 3-site long-axis seed",
+        "F_cut map with remaining bits (1,0,1,1,0) does fill from the 3-site long-axis seed" in note
+        and "Displayed, not adopted" in note
+        and "|locks_halt| = 12" in note_flat
+        and "T = 2" in note
+        and "(3, 9, 12)" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f_mix0 and f_L1 are each run from S to a fixed point")
+    print("per_block: checked exactly — halt locks, T, and lock history of f_mix0 on S are compared to f_L1")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

f_mix0 remaining bits (1,0,1,1,0) fills from the line seed with the same history (3,9,12) as f_L1. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_mix0_line_seed_fill_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.