### PR TITLE
feat(opp0ival): name both F_cut opp2=0 coverage maximizers

### DIFF
--- a/docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,421 @@
+---
+claim_id: f_cut_opp2_silent_coverage_maximizers_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The two F_cut maps with opp2=0 that attain max 2-site coverage 62 on the two-cube with off-patch o=0 are identified by remaining-bit tuples. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py
+---
+
+# Two Opp2-Silent `F_cut` Coverage Maximizers Named By Remaining-Bit Tuple
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact naming of the two cube-covariant complement-even predicates
+that vanish on `opp2` and attain maximum 2-site fill coverage on the
+twelve-vertex two-cube with off-patch occupancy `0`. Each maximizer is
+identified once by its `(wt1, opp2, adj2, vertex3, mixed3)` remaining-bit
+tuple. The two-map F0 set is displayed. Neither map is adopted as the
+physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py`](../scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut|=32`. Write
+
+```text
+F0 = { f in F_cut : f(opp2)=0 }.
+```
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered pair of vertices is
+a 2-site seed. There are `C(12,2)=66` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov(f) = |{ S : |S|=2 and f fills from S }|.
+```
+
+The F0 ranking of those 16 maps is a different leftover inventory: that
+only reported m0 and N0. Not leftover-character of the F0 ranking. The
+new object here is the two-map F0 set: the two remaining-bit tuples in
+`F0` that attain the restricted maximum.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Membership in `F0` is the extra cut `opp2=0`.
+
+**Theorem 1.** Exhaustive recomputation of `cov` on all of `F0` and all
+66 two-site seeds reconfirms
+
+```text
+|F0| = 16
+m0 = 62
+N0 = 2
+cov(f_L1) = 62.
+```
+
+**Theorem 2.** The two maximizers, named by remaining-bit tuple, are
+
+```text
+(1, 0, 1, 1, 0)
+(1, 0, 1, 1, 1)
+```
+
+Confirm that `(1, 0, 1, 1, 1)` is `f_L1`. Equivalently, a map in `F0`
+attains `m0` if and only if `wt1=adj2=vertex3=1` and `opp2=0`, with
+`mixed3` free.
+
+**Theorem 3.** Display both. Do not adopt either. Do not write them into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the silent subclass F0 of size 16, the ranking pair (m0,N0)=(62,2), cov(f_L1)=62, and the two remaining-bit tuples that attain m0 are enumerated. The two-map F0 set is displayed, not written into Admissibility."
+trace_class: upstream_support
+target_claim_id: f_cut_opp2_silent_coverage_maximizers
+target_blocker_text: "the two F_cut maps with opp2=0 that attain max 2-site coverage remain unnamed as remaining-bit tuples"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the named two-map F0 set; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for the two F0 maximizers on this twelve-vertex patch with off-patch o=0 and all 66 two-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 66 unordered 2-site seeds;
+- the opposite-pair orbit `opp2`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of the F0 ranking (that only reported m0 and N0).
+The ranking pair is recomputed only so the two attaining maps can be named.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm the coverage ranking pair on `F0`, then name the
+two maps that attain the maximum by remaining-bit tuple.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`opp2` is the orbit of a cell with exactly one axis fully occupied and the
+other four slots `0`. A representative is
+`(c_{+x},c_{-x},c_{+y},c_{-y},c_{+z},c_{-z})=(1,1,0,0,0,0)`. The orbit has
+size `3`. Complement-even maps have `f(opp2)=f(opp4)`.
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`. Then `F0` is the half of `F_cut`
+with the `opp2` bit equal to `0`, so `|F0|=16`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and lies in `F0`. The
+two displayed maximizers have remaining-bit tuples `(1, 0, 1, 1, 0)` and
+`(1, 0, 1, 1, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov(f)` is the number of 2-site seeds whose halt set has cardinality
+12, `m0` is the maximum of `cov` over `F0`, and `N0` is the number of
+maps in `F0` attaining `m0`. The two-map F0 set is the pair of
+remaining-bit tuples in `F0` with `cov=m0`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The extra cut
+`f(opp2)=0` leaves `|F0| = 16`. The unbalanced-axis map `f_L1` is one
+element of `F0`. It is not Hamming parity. On the twelve-vertex two-cube
+with off-patch occupancy `0`, exhaustive ranking of all 16 maps in `F0`
+on all 66 two-site seeds reconfirms
+
+```text
+|F0| = 16
+m0 = 62
+N0 = 2
+cov(f_L1) = 62.
+```
+
+**Theorem 2.** The two remaining-bit tuples that attain `m0` are
+
+```text
+(1, 0, 1, 1, 0)
+(1, 0, 1, 1, 1)
+```
+
+Confirm that `(1, 0, 1, 1, 1)` is `f_L1`. Equivalently, a map in `F0`
+attains `m0` if and only if `wt1=adj2=vertex3=1`. The bit `mixed3`
+remains free.
+
+**Theorem 3.** Display both. Do not adopt either. Do not write them into Admissibility. The two-map F0 set is a displayed rival pair, not a selected
+occupancy law.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `|F0|=16` | the extra cut `opp2=0` halves `F_cut` |
+| `f_L1` is in `F0` | `u` is rotation- and complement-invariant, `u(empty)=u(full)=0`, and `u(opp2)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| `cov(f_L1)=62` | exhaustive 66-seed fill census of `f_L1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 66 two-site seeds | `C(12,2)` unordered pairs |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `m0` and `N0` | exhaustive 16-map ranking of `cov` on `F0`; recomputed, then used only to name the attaining pair |
+| two-map F0 set | remaining-bit tuples `(1, 0, 1, 1, 0)` and `(1, 0, 1, 1, 1)` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit). It also has `opp2=0`,
+   so it lies in `F0`, but it is not a coverage maximizer.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Drop complement-even or the vanish-on-full cut: the class is no longer
+   the 32-element `F_cut`, so `F0` is no longer this sixteen-element set.
+4. Report only `m0` and `N0`: that leftover is the F0 ranking, not the
+   named two-map F0 set.
+5. Rank all 32 maps in `F_cut` without the `opp2=0` cut: that leftover is
+   the unrestricted coverage ranking, whose maximizers have `opp2=1`.
+6. Adopt either remaining-bit tuple as the physical rule: the note
+   displays both and writes neither into Admissibility.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the F0 ranking pair
+  `(m0, N0)` in place of the named two-map F0 set.
+- No blank-block or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is that the coverage maximizer inside `F0` is
+not a singleton. The named two-map F0 set is an exact enumeration, not
+a wall. One of the two maps is `f_L1`; that membership is displayed, not
+a uniqueness theorem.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class and `F0` | Force vanish-on-empty, vanish-on-full, `f(c)=f(1-c)`, and `opp2=0`. | Theorem 1 and checks `thm1-f-cut-cardinality` / `thm1-reconfirm-f0-ranking` give `|F0|=16`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| F0 ranking reconfirm | Score every map in `F0` by `cov`. | Theorem 1 and check `thm1-reconfirm-f0-ranking` give `|F0| = 16`, `m0 = 62`, `N0 = 2`, `cov(f_L1) = 62`. | **ATTEMPTED** |
+| name both maximizers | List remaining-bit tuples in `F0` with `cov=m0`. | Theorem 2 and checks `thm2-named-two-map-set` / `thm2-10111-is-f-L1`. | **ATTEMPTED** |
+| display, do not adopt | Ask whether either tuple is written into Admissibility. | Theorem 3 and check `thm3-display-both-not-adopted`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: the maximizer class inside `F0` is not
+a singleton. Naming both remaining-bit tuples and the cardinality `N0=2`
+are two certificates of the same two-map F0 set, so they collapse rather
+than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N0=2` / named pair | yes: a count of two is the pair's size | yes: two named tuples give the count | collapse into the two-map F0 set |
+| `cov(f_L1)=62` / `m0=62` | no: a score does not name the second maximizer | no: the max does not by itself identify `f_L1` | independent positive integers |
+| static `|F0|=16` / two-map F0 set | no: membership is not dynamics | no: naming maximizers does not replace the silent subclass | separate exact counts |
+| leftover of the F0 ranking / this two-map F0 set | no: that leftover reported only `m0` and `N0` | no: naming the pair does not replace the ranking residual | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| `F0` | explicit extra cut `f(opp2)=0` inside `F_cut` |
+| all 66 two-site seeds | explicit seed class; a one-seed fill is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuples `(1, 0, 1, 1, 0)` and `(1, 0, 1, 1, 1)` | displayed two-map F0 set, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:81` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:125` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:130` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:51` | 66 two-site seeds | `C(12,2)` unordered pairs on the two-cube | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:210` | `cov(f)` | number of 2-site seeds a map fills | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:312` | F0 ranking | exact `(m0, N0)` used to name the attaining pair | yes |
+| `scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py:144` | two-map F0 set | displayed maximizer `(1, 0, 1, 1, 0)` and partner `(1, 0, 1, 1, 1)` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F0` | the two maximizers are named inside this class on all 66 seeds |
+| per block | yes: the two-map F0 set | both remaining-bit tuples attain `m0`; one of them is `f_L1` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does lie in `F0` and does attain `m0=62`. That positive member does not
+make `f_L1` unique among F0 maximizers and does not select either named
+tuple as the physical rule. The remaining physical choice — which, if any,
+`F_cut` map is the Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that the two maximizers differ only on
+`mixed3`, so naming them might be called leftover-character of the F0
+ranking that already reported `m0=62` and `N0=2`. That objection is
+correctly about the ranking pair. It does not overturn the stated
+theorem: the F0 ranking residual stopped at the pair of integers; the
+two-map F0 set residual is the pair of remaining-bit tuples. Displaying
+both tuples names that set. Confirming that `(1, 0, 1, 1, 1)` is `f_L1`
+identifies one member and does not adopt it.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the subclass `F0`, the 16-map 66-seed ranking, and the two
+remaining-bit tuples are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the named two-map F0 set or writes either
+remaining-bit tuple into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the named two-map F0 set and
+the reconfirmed ranking pair `(m0, N0)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut` and the silent subclass `F0`, evaluates all 16 maps in `F0` on
+the two-cube from every 2-site seed, reconfirms `|F0| = 16`, reconfirms
+`cov(f_L1) = 62`, reconfirms `m0 = 62` and `N0 = 2`, names both
+maximizers by remaining-bit tuple `(1, 0, 1, 1, 0)` and
+`(1, 0, 1, 1, 1)`, confirms that `(1, 0, 1, 1, 1)` is `f_L1`, checks
+that `f_L1` is not Hamming parity, and does not adopt either map.
+Declared audit inputs are this note and the axiom memo. No runner cache
+is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15737,
- "node_count": 5533,
+ "edge_count": 15738,
+ "node_count": 5534,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_opp2_silent_coverage_maximizers_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_opp2_silent_coverage_maximizers_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_opp2_silent_coverage_maximizers_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py
+runner_sha256: de14d5a4edf3f100bc73acd8c3bdf2f09ba4a2c24702b47dfe83dfeadfa5300a
+input_fingerprint_sha256: ece6eaf486eb9dfb351adf1bfc91e5b9cec43a2b6cc58cb708e0c21a0b567724
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+|F0|=16
+n_two_site_seeds=66
+cov_f_L1=62
+m0=62
+N0=2
+maximizer_remaining=[(1, 0, 1, 1, 0), (1, 0, 1, 1, 1)]
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+f_hamming_remaining=(1, 0, 0, 1, 1)
+f_hamming_cov=16
+displayed_remaining=(1, 0, 1, 1, 0)
+displayed_cov=62
+other_remaining=(1, 0, 1, 1, 1)
+other_cov=62
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-sixty-six-seeds the two-cube has twelve vertices and C(12,2)=66 two-site seeds
+PASS: thm1-reconfirm-f0-ranking reconfirm |F0|=16, m0=62, N0=2, and cov(f_L1)=62
+PASS: thm2-named-two-map-set the two F0 maximizers are remaining-bit tuples (1, 0, 1, 1, 0) and (1, 0, 1, 1, 1)
+PASS: thm2-10111-is-f-L1 remaining-bit tuple (1, 0, 1, 1, 1) is f_L1
+PASS: thm3-display-both-not-adopted both F0 maximizers are displayed and neither is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted two-map F0 set, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-two-map-set the note names both F0 maximizers by remaining-bit tuple
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-f0-ranking the residual is the two-map F0 set, not leftover-character of the F0 ranking
+PASS: claim-scope-two-map-set claim_scope identifies the two F0 maximizers by remaining-bit tuples
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F0 map is scored, then the two maximizers are named by remaining-bit tuple
+per_block: checked exactly — the two-map F0 set is the named pair of remaining-bit tuples that attain m0
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py
+++ b/scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Name the two F_cut opp2=0 2-site coverage maximizers by remaining-bit tuple.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+F0 is the opp2-silent subclass {f in F_cut : f(opp2)=0}. Dynamics are
+occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0.
+Coverage cov(f) is the number of unordered 2-site seeds from which f fills.
+The new object is the two-map F0 set of maximizers. That is not
+leftover-character of the F0 ranking, which only reported m0 and N0.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. Both maximizers are displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+OPP2_TYPE: OrbitType = (0, 1, 2)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+DISPLAYED_MAXIMIZER: tuple[int, ...] = (1, 0, 1, 1, 0)
+OTHER_MAXIMIZER: tuple[int, ...] = (1, 0, 1, 1, 1)
+NAMED_MAXIMIZERS: tuple[tuple[int, ...], ...] = (
+    DISPLAYED_MAXIMIZER,
+    OTHER_MAXIMIZER,
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f_displayed(config: Config) -> int:
+    """Displayed F0 maximizer: remaining bits (1, 0, 1, 1, 0).  Not adopted."""
+    return remaining_value(config, DISPLAYED_MAXIMIZER)
+
+
+def f_other(config: Config) -> int:
+    """Other F0 maximizer: remaining bits (1, 0, 1, 1, 1), which is f_L1.  Not adopted."""
+    return remaining_value(config, OTHER_MAXIMIZER)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def coverage_ranking(
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, tuple[int, ...], tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    ranked: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = []
+    for bits, remaining in members:
+        cov = coverage(predicate_from_bits(bits, orbit_types, type_of))
+        ranked.append((cov, remaining, bits))
+    return ranked
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    f0_members = [item for item in members if item[1][1] == 0]
+    ranked = coverage_ranking(f0_members, orbit_types, orbits)
+    cov_by_remaining = {remaining: cov for cov, remaining, _bits in ranked}
+    n_f0 = len(f0_members)
+    m0 = max(cov for cov, _remaining, _bits in ranked)
+    maximizers = sorted(remaining for cov, remaining, _bits in ranked if cov == m0)
+    n0 = len(maximizers)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    extra_bits = bits_from_predicate(f_displayed, orbit_types, orbits)
+    other_bits = bits_from_predicate(f_other, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    extra_remaining = remaining_bits_from_full(extra_bits, orbit_types)
+    other_remaining = remaining_bits_from_full(other_bits, orbit_types)
+    cov_l1 = cov_by_remaining[l1_remaining]
+    cov_extra = cov_by_remaining[extra_remaining]
+    cov_other = cov_by_remaining[other_remaining]
+    cov_ham = coverage(f_hamming)
+    ham_remaining = remaining_bits_from_full(ham_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"|F0|={n_f0}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"cov_f_L1={cov_l1}")
+    print(f"m0={m0}")
+    print(f"N0={n0}")
+    print(f"maximizer_remaining={maximizers}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"f_hamming_remaining={ham_remaining}")
+    print(f"f_hamming_cov={cov_ham}")
+    print(f"displayed_remaining={extra_remaining}")
+    print(f"displayed_cov={cov_extra}")
+    print(f"other_remaining={other_remaining}")
+    print(f"other_cov={cov_other}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_OPP2_SILENT_COVERAGE_MAXIMIZERS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-sixty-six-seeds",
+        "the two-cube has twelve vertices and C(12,2)=66 two-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-reconfirm-f0-ranking",
+        "reconfirm |F0|=16, m0=62, N0=2, and cov(f_L1)=62",
+        n_f0 == 16
+        and m0 == 62
+        and n0 == 2
+        and cov_l1 == 62
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and l1_remaining == L1_REMAINING
+        and l1_remaining[1] == 0
+        and cov_l1 == coverage(f_L1)
+        and f"|F0| = {n_f0}" in note
+        and f"m0 = {m0}" in note
+        and f"N0 = {n0}" in note
+        and f"cov(f_L1) = {cov_l1}" in note,
+    )
+    checks.check(
+        "thm2-named-two-map-set",
+        "the two F0 maximizers are remaining-bit tuples (1, 0, 1, 1, 0) and (1, 0, 1, 1, 1)",
+        maximizers == [(1, 0, 1, 1, 0), (1, 0, 1, 1, 1)]
+        and extra_remaining == DISPLAYED_MAXIMIZER
+        and other_remaining == OTHER_MAXIMIZER
+        and extra_remaining in maximizers
+        and other_remaining in maximizers
+        and cov_extra == m0
+        and cov_other == m0
+        and extra_remaining[1] == 0
+        and other_remaining[1] == 0
+        and in_f_cut(extra_bits, orbit_types, empty_type, full_type)
+        and in_f_cut(other_bits, orbit_types, empty_type, full_type)
+        and all(str(named) in note for named in maximizers),
+    )
+    checks.check(
+        "thm2-10111-is-f-L1",
+        "remaining-bit tuple (1, 0, 1, 1, 1) is f_L1",
+        OTHER_MAXIMIZER == L1_REMAINING
+        and other_remaining == l1_remaining
+        and other_remaining == (1, 0, 1, 1, 1)
+        and extra_remaining != l1_remaining
+        and extra_remaining == (1, 0, 1, 1, 0)
+        and "(1, 0, 1, 1, 1)" in note
+        and "(1, 0, 1, 1, 0)" in note,
+    )
+    checks.check(
+        "thm3-display-both-not-adopted",
+        "both F0 maximizers are displayed and neither is adopted",
+        extra_remaining != other_remaining
+        and set(maximizers) == set(NAMED_MAXIMIZERS)
+        and "Displayed, not adopted" in note
+        and "Do not write them into Admissibility" in note
+        and "Do not adopt either" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted two-map F0 set, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-two-map-set",
+        "the note names both F0 maximizers by remaining-bit tuple",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 0, 1, 1, 0)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "|F0| = 16" in note
+        and "m0 = 62" in note
+        and "N0 = 2" in note
+        and "cov(f_L1) = 62" in note
+        and "two-map F0 set" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write them into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-f0-ranking",
+        "the residual is the two-map F0 set, not leftover-character of the F0 ranking",
+        "Not leftover-character of the F0 ranking" in note
+        and "that only reported m0 and N0" in note
+        and "two-map F0 set" in note,
+    )
+    checks.check(
+        "claim-scope-two-map-set",
+        "claim_scope identifies the two F0 maximizers by remaining-bit tuples",
+        "The two F_cut maps with opp2=0 that attain max 2-site coverage 62" in note
+        and "off-patch o=0" in note
+        and "identified by remaining-bit tuples" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F0 map is scored, then the two maximizers are named by remaining-bit tuple")
+    print("per_block: checked exactly — the two-map F0 set is the named pair of remaining-bit tuples that attain m0")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The two remaining-bit tuples that attain m0=62 on F0 are (1,0,1,1,0) and (1,0,1,1,1). f_L1 is the second. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_opp2_silent_coverage_maximizers_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.