### PR TITLE
feat(l1miss2): list the four two-site seeds f_L1 does not fill

### DIFF
--- a/docs/F_L1_TWO_SITE_MISS_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_L1_TWO_SITE_MISS_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,317 @@
+---
+claim_id: f_l1_two_site_miss_seeds_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The four two-site seeds on the two-cube from which f_L1 does not fill are listed. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_l1_two_site_miss_seeds_2026_08_15.py
+---
+
+# Four Two-Site Seeds From Which `f_L1` Does Not Fill
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exhaustive lock-step census of the 66 unordered two-site seeds on
+the twelve-vertex two-cube `{0,1,2} × {0,1} × {0,1}` with off-patch occupancy
+`o=0`. The four seeds from which `f_L1` does not fill are listed in
+lexicographic order, each with halt lock-count and lock-history. They are
+displayed. No seed is adopted and no selector is written into Admissibility.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_l1_two_site_miss_seeds_2026_08_15.py`](../scripts/f_l1_two_site_miss_seeds_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+On the two-cube, a lock-step run of a displayed readiness map from a seed `S`
+is the synchronous wave process that begins with `S` locked and, at each tick,
+locks every still-unlocked site whose six-neighbor occupancy 3-tuple satisfies
+the map. The lock-history tuple is the sequence of lock counts after the seed
+and after each nonempty wave, until halt. Fill means `|locks_halt| = 12`.
+
+Write `n_unbalanced`, `n_both`, and `n_empty` for the number of cubic axes
+whose two opposite neighbors are occupied on exactly one side, on both sides,
+or on neither side. Off-patch neighbors contribute occupancy `0`. Then
+`f_L1` fires iff `n_unbalanced ≠ 0` (some axis is unbalanced). This is
+not Hamming parity of the six occupancy bits: `n_μ = c_{+μ} − c_{-μ}` is
+nonzero on an axis if and only if that axis is unbalanced.
+
+A prior coverage ranking reported `cov(f_L1) = 62` of the 66 two-site seeds
+and left the four misses unnamed. A different four, the opposite-corner
+pairs on which `f_L1` fills and `f_min` does not, were already listed.
+Not leftover-character of #6422: that was the opposite-corner four (L1 fills, f_min does not). This note is the four-seed miss set of `f_L1` itself.
+
+Recomputing every unordered pair under `f_L1` gives
+
+`cov(f_L1) = 62`
+
+and confirms that the four opposite-corner seeds
+
+`{(0,0,0),(2,1,1)}`
+
+`{(0,0,1),(2,1,0)}`
+
+`{(0,1,0),(2,0,1)}`
+
+`{(0,1,1),(2,0,0)}`
+
+are fills, each with history `(2, 8, 12)`, and are not among the misses.
+
+The four miss seeds, in lexicographic order of sorted site pairs, are
+
+`{(0,0,0),(2,0,0)}`
+
+`{(0,0,1),(2,0,1)}`
+
+`{(0,1,0),(2,1,0)}`
+
+`{(0,1,1),(2,1,1)}`.
+
+Each has halt lock-count 8 and history `(2, 6, 8)`. The four-seed set is
+displayed census output. It is not adopted as a physical selector.
+Do not adopt a seed. Do not write them into Admissibility. A selector is not written into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 66 two-site seeds, the f_L1 lock-step runs, and the four listed misses are finite exact statements on a declared twelve-site patch; no seed is selected and no Admissibility clause is added."
+trace_class: frontier_discovery
+target_claim_id: f_l1_two_site_miss_seeds
+target_blocker_text: "which four two-site seeds on the two-cube does f_L1 fail to fill"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the twelve-vertex two-cube with off-patch occupancy 0 and the displayed readiness map f_L1; no selector is adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of the four miss-seed list; do not write a selector into Admissibility"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** Lattice, Admissibility, and Record are quoted from
+  the live axiom memo without rewrite. They identify the cubic nearest-neighbor
+  graph, the local-condition domain, and the lock/content/absence wording.
+  They do not supply the readiness map `f_L1` or the two-cube patch.
+- **Explicit theorem-domain condition:** the twelve sites
+  `{0,1,2} × {0,1} × {0,1}`, off-patch occupancy identically `0`, the
+  displayed map `f_L1`, and the synchronous lock-step dynamics above are
+  supplied mathematical data for this list.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `f_L1`, or any of the four miss seeds,
+  into Admissibility remains a separate, open obligation. This note does
+  not adopt them.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility
+
+does not supply the formation site, probability, or rate.
+
+The readiness map `f_L1` is a displayed occupancy predicate on the
+six-neighbor condition tuple. It is not Admissibility content. Using a
+lock-step wave as physical Record formation would require a separately
+derived formation mechanism; that mechanism is not supplied here.
+
+## Exact Objects
+
+The two-cube is the twelve-point set
+
+`V = {0,1,2} × {0,1} × {0,1} ⊂ Z^3`.
+
+The open nearest-neighbor set of a site `x` is
+`N(x) = {x ± e_1, x ± e_2, x ± e_3}`. A neighbor in `V` that is already
+locked contributes occupancy `1`; a neighbor outside `V` contributes
+occupancy `0`. For each of the three axes one records the pair
+`(c_{+μ}, c_{-μ}) ∈ {0,1}^2` and tallies
+
+- unbalanced if the pair is `(1,0)` or `(0,1)`,
+- both if the pair is `(1,1)`,
+- empty if the pair is `(0,0)`.
+
+A seed is an unordered pair `S ⊂ V` with `|S| = 2`. There are exactly
+`C(12,2) = 66` such seeds. Lexicographic order of a seed is the ordered pair
+of its two sites after each site is written in coordinate order
+`(x,y,z)` and the two sites are then sorted.
+
+The run of `f_L1` from `S` begins with `locks_0 = S`. At tick `t ≥ 1`
+every unlocked `x ∈ V` with `f_L1(c(x, locks_{t-1})) = 1` locks
+simultaneously. The history is `(|locks_0|, |locks_1|, …, |locks_T|)` at
+the first `T` with no further ready site. Fill is the boolean
+`|locks_T| = 12`. Coverage is
+`cov(f_L1) = |{S : |S|=2 and f_L1 fills from S}|`.
+
+`f_L1(c) = 1` iff `n_unbalanced ≠ 0`. This is not the Hamming weight of the
+six occupancy bits: the opposite-pair occupancy at `(1,0,0)` with
+`{(0,0,0),(2,0,0)}` locked has Hamming weight `2` and
+`(n_unbalanced, n_both, n_empty) = (0,1,2)`, so `f_L1` does not fire.
+
+The opposite-corner four of the earlier `f_min` versus `f_L1` split are the
+displacement-`(2,1,1)` pairs. They are a different four: `f_L1` fills each
+of them.
+
+## Theorem 1 — Coverage And Opposite-Corner Fills
+
+Every one of the 66 seeds is run independently under `f_L1`. The coverage
+integer is
+
+`cov(f_L1) = 62`.
+
+The four opposite-corner seeds
+
+`{(0,0,0),(2,1,1)}`,
+`{(0,0,1),(2,1,0)}`,
+`{(0,1,0),(2,0,1)}`,
+`{(0,1,1),(2,0,0)}`
+
+each fill under `f_L1` with history `(2, 8, 12)`. They are fills, not
+misses.
+
+## Theorem 2 — The Four Miss Seeds In Lexicographic Order
+
+The four seeds from which `f_L1` does not fill, listed once each in
+lexicographic site-pair order, are
+
+`{(0,0,0),(2,0,0)}`,
+`{(0,0,1),(2,0,1)}`,
+`{(0,1,0),(2,1,0)}`,
+`{(0,1,1),(2,1,1)}`.
+
+Each of the four has halt lock-count 8 and history `(2, 6, 8)`. No other
+two-site seed is a miss. The four pairs are exactly the long-axis
+displacement-`(2,0,0)` pairs of the two-cube.
+
+## Theorem 3 — Display, Do Not Adopt
+
+The four-seed miss set is the object of this note. Display the four. Do not
+adopt a seed. Do not write them into Admissibility. A selector is not
+written into Admissibility. A later derivation that used one of these seeds
+as a physical rule would be a different claim.
+
+## What This Does Not Claim
+
+- It does not claim that `f_L1` is the Admissibility rule.
+- It does not claim that lock-step waves are physical Record formation.
+- It does not claim a unique physically preferred two-site seed.
+- It does not extend the list to `|S| ≠ 2` or to a larger patch.
+- It does not identify `f_L1` with Hamming weight, graph distance, or any
+  map other than some-axis-unbalanced.
+- It does not treat the prior coverage integer `62` as a naming of the four
+  misses, and it does not recycle the opposite-corner split four as this
+  miss set.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the four-miss-seed identity question for `f_L1` on the declared patch. |
+| V2 | Current main has the axiom memo and no landed list of these four two-site misses. |
+| V3 | All 66 pairs, the `f_L1` runs, and the four listed misses are independently finite and exact. |
+| V4 | The list is more than a restatement of `cov(f_L1) = 62`: it names each miss and its halt history. |
+| V5 | It is not a physical compiler and writes no selector into Admissibility. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: the four listed miss seeds are not hereby
+adopted. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| coverage integer | recompute all 66 two-site runs under `f_L1` | `cov(f_L1) = 62`; four misses remain |
+| opposite-corner four | run `f_L1` from each displacement-`(2,1,1)` pair | each fills with `(2, 8, 12)`; not the miss set |
+| long-axis `(2,0,0)` | run `f_L1` from each `{(0,y,z),(2,y,z)}` | each misses with halt lock-count 8 and history `(2, 6, 8)` |
+| Hamming-weight predicate | fire on six-bit weight | executed counterexample: opp2 has weight 2 and `f_L1 = 0` |
+| adopt a seed | write one miss into Admissibility | refused; displayed, not adopted |
+| count-only coverage | report `cov = 62` without names | leftover-character of the coverage integer; this note lists the set |
+
+### N2 — wall independence
+
+The missing formation mechanism, the missing Admissibility selector, and any
+extension off this twelve-site patch are distinct premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch occupancy `0`, the predicate `f_L1`, and the
+synchronous wave rule are declared. Hamming weight is not silently used.
+No seed is treated as axiom content.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate, the
+local-condition sentence, and the lock/content/absence wording used here.
+It does not supply `f_L1` or a two-site selector. The residual matches
+those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 66 pairs, `f_L1` lock-count histories | no continuum or larger-patch census |
+| per site | six-neighbor occupancy 3-tuples | no derived kernel values |
+| per mode | no mode calculation | no spectral statement |
+| per block | two-cube lock-step dynamics | no physical formation compiler |
+| lattice wide | checked and not executed | no infinite-volume claim |
+
+### N6 — live partial-closure paths
+
+Live routes are an independently derived formation mechanism, a derivation
+that would force `f_L1`, and any census at a different seed cardinality or
+patch. Those routes remain open.
+
+### N7 — hostile steelman
+
+**Steelman:** Because a prior census already reported `cov(f_L1) = 62` and
+another note already listed four two-site seeds, listing four misses adds
+no object.
+
+**Answer:** A coverage integer is not a list, and the opposite-corner four
+are fills under `f_L1`. The four-seed miss set is a new displayed object:
+the lex-ordered long-axis pairs and the common unfilled history
+`(2, 6, 8)` with halt lock-count 8. The coverage row did not name the
+set. The split-four row named a different four.
+
+### N8 — cross-cycle echo
+
+A prior displayed computation counted `cov(f_L1) = 62` and listed the four
+seeds on which `f_min` and `f_L1` disagree. This note does not recycle
+either object as the miss-seed identity. It recomputes every two-site run
+under `f_L1` and lists the four seeds from which that map does not fill.
+
+**Gate disposition:** PASS for the four-miss list, the reconfirmed coverage
+integer, and the opposite-corner fill confirmation above. FAIL / DO NOT
+SHIP for “Admissibility is `f_L1`,” “adopt this seed,” or “`f_L1` fills
+every two-site seed.”
+
+## Primary Runner
+
+The primary runner recomputes all 66 pairs, reconfirms
+`cov(f_L1) = 62` and that the four opposite-corner seeds fill with
+history `(2, 8, 12)`, lists the four miss seeds in lexicographic order,
+checks that each has halt lock-count 8 and history `(2, 6, 8)`, and
+checks that this note displays that list without adopting a seed. It
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5534,
+ "edge_count": 15739,
+ "node_count": 5535,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_l1_two_site_miss_seeds_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_l1_two_site_miss_seeds_2026_08_15.txt
+++ b/logs/runner-cache/f_l1_two_site_miss_seeds_2026_08_15.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/f_l1_two_site_miss_seeds_2026_08_15.py
+runner_sha256: ca04152d846fca1a1b2183d14650f7aa0fe9ef550052f40b2b3520b512d78c27
+input_fingerprint_sha256: 24e938b9258e04728e7074ee2c1d0f1db100f0ccc8d7ebb0e0b3eafa25991fba
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: exhaustive two-site lock-step census under f_L1; the four miss seeds are listed in lex order
+negative_scope: the four miss seeds are displayed; no seed is adopted or written into Admissibility
+cache_write: false
+PASS: audit-inputs the two declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: two-cube-cardinality the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}
+PASS: pair-count there are C(12,2)=66 unordered two-site seeds
+census: cov(f_L1)=62 n_miss=4 n_pairs=66
+four_miss_seeds_lex: {(0,0,0),(2,0,0)}, {(0,0,1),(2,0,1)}, {(0,1,0),(2,1,0)}, {(0,1,1),(2,1,1)}
+  {(0,0,0),(2,0,0)} hist_L1=(2, 6, 8) halt=8 fill=False
+  {(0,0,1),(2,0,1)} hist_L1=(2, 6, 8) halt=8 fill=False
+  {(0,1,0),(2,1,0)} hist_L1=(2, 6, 8) halt=8 fill=False
+  {(0,1,1),(2,1,1)} hist_L1=(2, 6, 8) halt=8 fill=False
+opp_corner_seeds_are_fills:
+  {(0,0,0),(2,1,1)} hist_L1=(2, 8, 12) halt=12 fill=True
+  {(0,0,1),(2,1,0)} hist_L1=(2, 8, 12) halt=12 fill=True
+  {(0,1,0),(2,0,1)} hist_L1=(2, 8, 12) halt=12 fill=True
+  {(0,1,1),(2,0,0)} hist_L1=(2, 8, 12) halt=12 fill=True
+PASS: theorem-1-cov-sixty-two cov(f_L1)=62 among the 66 two-site seeds
+PASS: theorem-1-opp-corner-fills the four opposite-corner seeds of #6423 fill under f_L1 and are not misses
+PASS: theorem-2-lex-list the four miss seeds are listed in lexicographic site-pair order
+PASS: theorem-2-histories each miss seed has halt lock-count 8 and history (2, 6, 8)
+PASS: theorem-3-display the note displays the four computed miss seeds in lex order and does not adopt a seed
+PASS: identity-l1-not-hamming opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire
+PASS: forbidden-phrases the note and runner avoid the dispatch-forbidden phrases
+PASS: no-admissibility-selector the note does not write a seed selector into Admissibility
+PASS: claim-scope the YAML claim_scope states the four miss-seed display
+PASS: not-leftover-6422 the four misses are a new object, not leftover character of the opposite-corner split four
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_l1_two_site_miss_seeds_2026_08_15.py
+++ b/scripts/f_l1_two_site_miss_seeds_2026_08_15.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""List the four two-site seeds from which f_L1 does not fill.
+
+Recomputes every unordered pair of the twelve two-cube sites with
+off-patch occupancy 0. Coverage is the number of those seeds from
+which f_L1 fills. The four misses are listed in lexicographic order
+with halt lock-count and lock-history; they are displayed, not
+adopted, and are not written into Admissibility. The four
+opposite-corner seeds of the f_min/f_L1 split are fills, not misses.
+f_L1 is the some-axis-unbalanced (n != 0) map, not Hamming weight.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_L1_TWO_SITE_MISS_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_L1_TWO_SITE_MISS_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+AXES: tuple[Point, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SITES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+OPP_CORNER_SEEDS: tuple[frozenset[Point], ...] = (
+    frozenset(((0, 0, 0), (2, 1, 1))),
+    frozenset(((0, 0, 1), (2, 1, 0))),
+    frozenset(((0, 1, 0), (2, 0, 1))),
+    frozenset(((0, 1, 1), (2, 0, 0))),
+)
+L1_OPP_HISTORY = (2, 8, 12)
+L1_MISS_HISTORY = (2, 6, 8)
+L1_MISS_HALT = 8
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locked: frozenset[Point]) -> int:
+    """On-patch occupancy is the lock bit; off-patch occupancy is 0."""
+    if site not in SITE_SET:
+        return 0
+    return 1 if site in locked else 0
+
+
+def axis_type(site: Point, locked: frozenset[Point]) -> tuple[int, int, int]:
+    """Return (n_unbalanced, n_both, n_empty) for the three cubic axes."""
+    n_unbalanced = n_both = n_empty = 0
+    for axis in AXES:
+        plus = occupancy(add(site, axis), locked)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+        if plus == minus == 0:
+            n_empty += 1
+        elif plus == minus == 1:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fire_l1(counts: tuple[int, int, int]) -> bool:
+    """f_L1: some axis is unbalanced (n != 0). Not Hamming weight."""
+    n_unbalanced, _n_both, _n_empty = counts
+    return n_unbalanced != 0
+
+
+def run(seed: frozenset[Point]) -> tuple[tuple[int, ...], bool]:
+    locked = frozenset(seed)
+    history = [len(locked)]
+    for _tick in range(len(SITES)):
+        ready = [
+            site
+            for site in SITES
+            if site not in locked and fire_l1(axis_type(site, locked))
+        ]
+        if not ready:
+            break
+        locked = locked.union(ready)
+        history.append(len(locked))
+    return (tuple(history), len(locked) == len(SITES))
+
+
+def seed_key(seed: frozenset[Point]) -> tuple[Point, ...]:
+    return tuple(sorted(seed))
+
+
+def seed_display(seed: frozenset[Point]) -> str:
+    left, right = seed_key(seed)
+    return f"{{({left[0]},{left[1]},{left[2]}),({right[0]},{right[1]},{right[2]})}}"
+
+
+def census() -> dict[str, object]:
+    n_fill = 0
+    misses: list[frozenset[Point]] = []
+    histories: dict[tuple[Point, ...], tuple[tuple[int, ...], int, bool]] = {}
+    pairs = tuple(frozenset(pair) for pair in combinations(SITES, 2))
+    for seed in pairs:
+        hist, fill = run(seed)
+        histories[seed_key(seed)] = (hist, hist[-1], fill)
+        if fill:
+            n_fill += 1
+        else:
+            misses.append(seed)
+    misses_lex = tuple(sorted(misses, key=seed_key))
+    return {
+        "n_pairs": len(pairs),
+        "n_fill": n_fill,
+        "n_miss": len(misses),
+        "misses_lex": misses_lex,
+        "histories": histories,
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: exhaustive two-site lock-step census under f_L1; the four miss seeds are listed in lex order")
+    print("negative_scope: the four miss seeds are displayed; no seed is adopted or written into Admissibility")
+    print("cache_write: false")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_L1_TWO_SITE_MISS_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_L1_TWO_SITE_MISS_SEEDS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    checks.check(
+        "two-cube-cardinality",
+        "the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}",
+        len(SITES) == 12 and len(SITE_SET) == 12 and SITES[0] == (0, 0, 0) and SITES[-1] == (2, 1, 1),
+    )
+    checks.check("pair-count", "there are C(12,2)=66 unordered two-site seeds", len(tuple(combinations(SITES, 2))) == 66)
+
+    counts = census()
+    n_fill = int(counts["n_fill"])
+    n_miss = int(counts["n_miss"])
+    misses_lex = counts["misses_lex"]
+    histories = counts["histories"]
+    assert isinstance(misses_lex, tuple)
+    assert isinstance(histories, dict)
+    miss_displays = [seed_display(seed) for seed in misses_lex]
+    opp_displays = [seed_display(seed) for seed in OPP_CORNER_SEEDS]
+    print(f"census: cov(f_L1)={n_fill} n_miss={n_miss} n_pairs={counts['n_pairs']}")
+    print("four_miss_seeds_lex: " + ", ".join(miss_displays))
+    for seed in misses_lex:
+        hist, halt, fill = histories[seed_key(seed)]
+        print(f"  {seed_display(seed)} hist_L1={hist} halt={halt} fill={fill}")
+    print("opp_corner_seeds_are_fills:")
+    for seed in OPP_CORNER_SEEDS:
+        hist, halt, fill = histories[seed_key(seed)]
+        print(f"  {seed_display(seed)} hist_L1={hist} halt={halt} fill={fill}")
+
+    checks.check(
+        "theorem-1-cov-sixty-two",
+        "cov(f_L1)=62 among the 66 two-site seeds",
+        counts["n_pairs"] == 66 and n_fill == 62 and n_miss == 4 and n_fill + n_miss == 66,
+        residual=(n_fill, n_miss),
+    )
+
+    opp_ok = all(
+        histories[seed_key(seed)] == (L1_OPP_HISTORY, 12, True)
+        for seed in OPP_CORNER_SEEDS
+    )
+    disjoint = all(seed not in misses_lex for seed in OPP_CORNER_SEEDS)
+    checks.check(
+        "theorem-1-opp-corner-fills",
+        "the four opposite-corner seeds of #6423 fill under f_L1 and are not misses",
+        len(OPP_CORNER_SEEDS) == 4
+        and opp_ok
+        and disjoint
+        and all(display in note.replace(" ", "") for display in opp_displays),
+        residual=[(seed_display(seed), histories[seed_key(seed)]) for seed in OPP_CORNER_SEEDS],
+    )
+
+    keys = [seed_key(seed) for seed in misses_lex]
+    checks.check(
+        "theorem-2-lex-list",
+        "the four miss seeds are listed in lexicographic site-pair order",
+        len(misses_lex) == 4
+        and keys == sorted(keys)
+        and all(len(key) == 2 and key == tuple(sorted(key)) for key in keys),
+        residual=keys,
+    )
+
+    history_ok = all(
+        histories[seed_key(seed)] == (L1_MISS_HISTORY, L1_MISS_HALT, False)
+        for seed in misses_lex
+    )
+    checks.check(
+        "theorem-2-histories",
+        "each miss seed has halt lock-count 8 and history (2, 6, 8)",
+        history_ok and len(misses_lex) == 4,
+        residual=[(seed_display(seed), histories[seed_key(seed)]) for seed in misses_lex],
+    )
+
+    note_has_each = all(display in note.replace(" ", "") for display in miss_displays)
+    order_ok = True
+    cursor = 0
+    compact_note = note.replace(" ", "")
+    for display in miss_displays:
+        found = compact_note.find(display, cursor)
+        if found < 0:
+            order_ok = False
+            break
+        cursor = found + len(display)
+    checks.check(
+        "theorem-3-display",
+        "the note displays the four computed miss seeds in lex order and does not adopt a seed",
+        note_has_each
+        and order_ok
+        and "displayed, not adopted" in normalized_note.lower()
+        and "do not adopt" in normalized_note.lower()
+        and f"cov(f_L1) = {n_fill}" in note
+        and "(2, 6, 8)" in note
+        and "halt lock-count 8" in note,
+        residual=miss_displays,
+    )
+
+    locked_opp = frozenset(((0, 0, 0), (2, 0, 0)))
+    opp2 = axis_type((1, 0, 0), locked_opp)
+    hamming_opp = sum(
+        occupancy(add((1, 0, 0), shift), locked_opp)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    checks.check(
+        "identity-l1-not-hamming",
+        "opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire",
+        opp2 == (0, 1, 2) and hamming_opp == 2 and not fire_l1(opp2),
+    )
+
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note and runner avoid the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "no-admissibility-selector",
+        "the note does not write a seed selector into Admissibility",
+        "not written into Admissibility" in normalized_note
+        and "Do not write" in note
+        and "Do not adopt a seed" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "the YAML claim_scope states the four miss-seed display",
+        "The four two-site seeds on the two-cube from which f_L1 does not fill are listed." in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-leftover-6422",
+        "the four misses are a new object, not leftover character of the opposite-corner split four",
+        "Not leftover-character of #6422" in note
+        and "opposite-corner" in note
+        and "L1 fills" in note
+        and "f_min does not" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "some axis is unbalanced" in normalized_note
+        and "n_unbalanced" in note
+        and "not Hamming" in normalized_note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The four two-site seeds from which f_L1 does not fill are listed. They are not the opposite-corner four (those L1 fills). Displayed, not adopted. f_L1 is n≠0 / unbalanced axis, not Hamming.

## Runner

`scripts/f_l1_two_site_miss_seeds_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.