### PR TITLE
feat(l1misswhy): L1 misses the long-axis 2-site seeds by refusing opp2

### DIFF
--- a/docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,422 @@
+---
+claim_id: f_l1_two_site_miss_mechanism_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the first neighborhood at which f_L1 refuses and the cov=66 map (1,1,1,1,1) fires, on the lex-first 2-site seed f_L1 does not fill, is reported by tick, site, and axis type. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_l1_two_site_miss_mechanism_2026_08_15.py
+---
+
+# First Refused Neighborhood On The Four `f_L1` Two-Site Miss Seeds
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** independent occupancy-to-lock runs from each of the four
+unordered 2-site seeds that `f_L1` does not fill, on the twelve-vertex
+two-cube `{0,1,2}×{0,1}×{0,1}` with off-patch occupancy `0`. The
+`F_cut` map `f1` with remaining-bit tuple `(1, 1, 1, 1, 1)` fills each
+of those four seeds. On the lex-first miss, the first neighborhood at
+which `f_L1=0` and `f1=1` is reported by tick, site, and axis type. The
+other three misses share that first axis type. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_l1_two_site_miss_mechanism_2026_08_15.py`](../scripts/f_l1_two_site_miss_mechanism_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut| = 32`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered pair of vertices is
+a 2-site seed. There are `C(12,2)=66` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov(f) = |{ S : |S|=2 and f fills from S }|.
+```
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is
+`(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 1)`.
+
+Write `f1` for the `F_cut` map with remaining-bit tuple `(1, 1, 1, 1, 1)`.
+That map is one of the two `cov=66` coverage maximizers. It is displayed,
+not adopted.
+
+New object. Not leftover of #6420: that was f_min versus f_L1 on a seed f_L1 fills.
+The four opposite-corner splitters of that leftover are fills for `f_L1`.
+The four misses here are a different four-seed set.
+
+**Theorem 1.** Independent recomputation of every 2-site seed reconfirms
+exactly four misses for `f_L1`, and `f1` fills each of them. In
+lexicographic order of sorted site pairs the misses are
+
+```text
+{(0,0,0),(2,0,0)}
+{(0,0,1),(2,0,1)}
+{(0,1,0),(2,1,0)}
+{(0,1,1),(2,1,1)}
+```
+
+On each, `f_L1` halts unfilled with lock-count history `(2, 6, 8)` and
+`f1` fills with history `(2, 7, 11, 12)`. Equivalently
+`cov(f_L1) = 62` and `cov(f1) = 66`.
+
+**Theorem 2.** On the lex-first miss `{(0,0,0),(2,0,0)}`, the first
+neighborhood at which `f_L1` refuses and `f1` fires is
+
+```text
+t = 1
+x = (1, 0, 0)
+axis type = opp2 = (0, 1, 2)
+```
+
+The six-neighbor occupancy is `(1, 1, 0, 0, 0, 0)`: both ends of the
+long `x` axis are occupied and the other two axes are empty. That is a
+filled axis. An extra `f_L1` refuses. The same first event is seen on
+the independent `f_L1` run and on the independent `f1` run.
+
+**Theorem 3.** The other three miss seeds have the same first axis type
+`opp2`. Their first refused sites are `(1, 0, 1)`, `(1, 1, 0)`, and
+`(1, 1, 1)` respectively, each at `t = 1`. Display. Do not adopt opp2.
+Do not write it into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The four f_L1 2-site misses, the independent f1 fills, and the first refused neighborhood on the lex-first miss (tick, site, axis type) are enumerated. opp2 is displayed, not written into Admissibility."
+trace_class: frontier_discovery
+target_claim_id: f_l1_two_site_miss_mechanism
+target_blocker_text: "the first neighborhood at which f_L1 refuses and the cov=66 map (1,1,1,1,1) fires, on the lex-first 2-site miss, remains unnamed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed first refused neighborhood; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for f_L1 and f1 on this twelve-vertex patch with off-patch o=0 and the four 2-site misses; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws. Admissibility does not supply the formation site, probability, or rate.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 66 unordered 2-site seeds;
+- independent lock-step runs of `f_L1` and of `f1` from each miss.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover of #6420. That leftover compared `f_min` versus `f_L1` on a
+seed `f_L1` fills. This residual is the first refused neighborhood on a
+seed `f_L1` does not fill.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm the four 2-site misses of `f_L1` and that `f1`
+fills each of them by an independent run, then name the first
+`(tick, site, axis type)` at which `f_L1` refuses and `f1` fires on the
+lex-first miss.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The remaining-bit tuple is those five free bits in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1,
+f1(c)   = remaining-value of (1, 1, 1, 1, 1).
+```
+
+So `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and `f1` has
+`(1, 1, 1, 1, 1)`. They differ on `opp2` and on its complement
+`(0, 2, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+An independent run of `f` from a seed is that iteration started at the
+seed and continued to a fixed point. A miss is a 2-site seed whose
+`f_L1` halt set has cardinality strictly less than 12. The first refused
+neighborhood on a run is the lexicographically first unlocked site, at
+the earliest tick, whose neighborhood has `f_L1=0` and `f1=1`. Tick
+`t = 1` is the first evaluation on the seed occupancy.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The unbalanced-axis map `f_L1` is one element of
+`F_cut`. It is not Hamming parity. On the twelve-vertex two-cube with
+off-patch occupancy `0`, exhaustive fill census of all 66 two-site seeds
+reconfirms exactly four `f_L1` misses, listed above in lex order. The
+`F_cut` map `f1` with remaining-bit tuple `(1, 1, 1, 1, 1)` fills each
+of those four seeds on an independent run. The lock-count histories are
+`(2, 6, 8)` for `f_L1` and `(2, 7, 11, 12)` for `f1`.
+
+**Theorem 2.** On the lex-first miss `{(0,0,0),(2,0,0)}`, the first
+neighborhood with `f_L1(nbhd)=0` and `f1(nbhd)=1` is tick `t = 1`, site
+`(1, 0, 0)`, axis type `opp2` `= (0, 1, 2)`. Coverage maximizers that
+fire `opp2` form on that filled axis; an extra `f_L1` refuses.
+
+**Theorem 3.** The other three miss seeds have the same first axis type.
+Display. Do not adopt opp2. Do not write it into Admissibility. The
+first refused neighborhood is a displayed census output, not a selected
+occupancy law.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| four `f_L1` misses | exhaustive 66-seed fill census; lex list as above |
+| `f1` fills each miss | independent run from each of the four seeds fills with history `(2, 7, 11, 12)` |
+| `cov(f_L1)=62`, `cov(f1)=66` | 66 minus four misses; `f1` fills every 2-site seed |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 66 two-site seeds | `C(12,2)` unordered pairs |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| first refused neighborhood | `t = 1`, site `(1, 0, 0)`, axis type `opp2` on the lex-first miss |
+| same first axis type on the other three | each first refusal is `opp2` at `t = 1` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit) and is not this
+   miss-set residual.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave
+   candidates become undefined; that is a different census.
+3. Start from an opposite-corner seed such as `{(0,0,0),(2,1,1)}`:
+   `f_L1` fills that seed; that leftover of #6420 is not a miss.
+4. Report only `cov(f_L1)=62`: that leftover names the miss count, not
+   the first refused neighborhood.
+5. Adopt `opp2` as the physical rule: the note displays the first axis
+   type and writes nothing into Admissibility.
+6. Score only the `f1` run: the theorem requires independent runs of
+   both maps from each miss.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover restatement of the `f_min` versus `f_L1` split on a seed
+  `f_L1` fills.
+- No adoption of `opp2`.
+- No blank-block or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is that `f_L1` refuses a filled-axis
+neighborhood that `f1` fires, on each of the four 2-site misses. The
+first refused neighborhood is an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| four-miss reconfirm | Score every 2-site seed under `f_L1` and under `f1`. | Theorem 1 and check `thm1-four-misses-and-f1-fills`. | **ATTEMPTED** |
+| lex-first refusal | Name the first `(t, x, axis type)` on `{(0,0,0),(2,0,0)}`. | Theorem 2 and check `thm2-lex-first-refusal`. | **ATTEMPTED** |
+| other-three type | Compare first axis types on the remaining three misses. | Theorem 3 and check `thm3-other-three-same-axis-type`. | **ATTEMPTED** |
+| display, do not adopt | Ask whether `opp2` is written into Admissibility. | Theorem 3 and check `thm3-display-not-adopt-opp2`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: `f_L1` refuses `opp2` on these four
+misses while `f1` fires it. Naming the first refused neighborhood and
+stating that the other three share the same first axis type are two
+certificates of the same filled-axis refusal, so they collapse rather
+than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| four misses / first `opp2` refusal | no: a miss list does not name a neighborhood | no: one neighborhood does not list the four seeds | independent exact objects |
+| lex-first `(t,x,type)` / other-three type | yes: the type is the shared mechanism | no: a shared type does not name the lex-first site | collapse into the refused-axis type |
+| `cov(f_L1)=62` / four named misses | yes: four misses give the count | yes: the count is the size of the four-set | collapse into the miss set |
+| leftover of #6420 / this first refusal | no: that leftover is `f_min` versus `f_L1` on a fill | no: a miss neighborhood does not replace that split | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| four 2-site misses | explicit seed class; a one-seed fill leftover is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| first axis type `opp2` | displayed mechanism, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:90` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:134` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:139` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:153` | `f1` definition | remaining-bit tuple `(1, 1, 1, 1, 1)` | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:53` | 66 two-site seeds | `C(12,2)` unordered pairs on the two-cube | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:204` | independent runs | lock-step evolution from each miss seed | yes |
+| `scripts/f_l1_two_site_miss_mechanism_2026_08_15.py:262` | first refused neighborhood | earliest `(tick, site, axis type)` with `f_L1=0` and `f1=1` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: `f_L1` and `f1` from each miss | independent runs; `f1` fills; `f_L1` misses |
+| per block | yes: the first refused neighborhood | tick, site, and axis type on the lex-first miss; same type on the other three |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does lie in `F_cut` and does fill 62 of the 66 two-site seeds. That
+positive member does not make `f_L1` a maximizer and does not write
+`opp2` into Admissibility. The remaining physical choice — which, if any,
+`F_cut` map is the Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f_L1` is already known to miss four
+2-site seeds because its remaining bit `opp2` is `0`, so naming the
+first refused neighborhood might be called leftover-character of the
+coverage ranking or of the miss-set list. That objection is correctly
+about the miss count and the remaining-bit tuple. It does not overturn
+the stated theorem: the new object is the first `(tick, site, axis type)`
+on the lex-first miss, together with the statement that the other three
+misses share that first axis type. Displaying `opp2` names that
+mechanism. `opp2` is not adopted.
+
+A second steelman is that this is leftover of #6420, the `f_min` versus
+`f_L1` split. That leftover lives on seeds `f_L1` fills (opposite-corner
+pairs). The four misses here are the long-axis pairs `f_L1` does not
+fill. Different object.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`f_L1`, `f1`, the four misses, and the first refused neighborhood are
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the first refused neighborhood or writes
+`opp2` into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the four-miss reconfirm, the
+independent `f1` fills, and the displayed first refused neighborhood
+stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, evaluates
+`f_L1` and `f1` independently from every 2-site seed, reconfirms the four
+`f_L1` misses and that `f1` fills each of them, names the first refused
+neighborhood on the lex-first miss by tick, site, and axis type, checks
+that the other three misses share that first axis type, checks that
+`f_L1` is not Hamming parity, and does not adopt `opp2`. Declared audit
+inputs are this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5534,
+ "edge_count": 15739,
+ "node_count": 5535,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_l1_two_site_miss_mechanism_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_l1_two_site_miss_mechanism_2026_08_15.txt
+++ b/logs/runner-cache/f_l1_two_site_miss_mechanism_2026_08_15.txt
@@ -1,0 +1,64 @@
+===== runner cache v1 =====
+runner: scripts/f_l1_two_site_miss_mechanism_2026_08_15.py
+runner_sha256: c252449e9598cedcb64ffd2e5ef34a7b7ea75b69a03829e88b46bc431b63cd88
+input_fingerprint_sha256: 6100321bdc09da1e48e56875ce0384c0f8e74cca6e28715cc0388efae22903df
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: independent occupancy-to-lock runs from each f_L1 2-site miss
+negative_scope: opp2 is displayed, not adopted or written into Admissibility
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+n_two_site_seeds=66
+cov_f_L1=62
+cov_f1=66
+f_L1_remaining=(1, 0, 1, 1, 1)
+f1_remaining=(1, 1, 1, 1, 1)
+n_l1_miss=4
+miss_seeds_lex={(0,0,0),(2,0,0)}, {(0,0,1),(2,0,1)}, {(0,1,0),(2,1,0)}, {(0,1,1),(2,1,1)}
+  {(0,0,0),(2,0,0)} hist_L1=(2, 6, 8) fill_L1=False hist_f1=(2, 7, 11, 12) fill_f1=True first=t=1 x=(1, 0, 0) type=opp2(0, 1, 2)
+  {(0,0,1),(2,0,1)} hist_L1=(2, 6, 8) fill_L1=False hist_f1=(2, 7, 11, 12) fill_f1=True first=t=1 x=(1, 0, 1) type=opp2(0, 1, 2)
+  {(0,1,0),(2,1,0)} hist_L1=(2, 6, 8) fill_L1=False hist_f1=(2, 7, 11, 12) fill_f1=True first=t=1 x=(1, 1, 0) type=opp2(0, 1, 2)
+  {(0,1,1),(2,1,1)} hist_L1=(2, 6, 8) fill_L1=False hist_f1=(2, 7, 11, 12) fill_f1=True first=t=1 x=(1, 1, 1) type=opp2(0, 1, 2)
+lex_first_refusal=t=1 x=(1, 0, 0) type=opp2(0, 1, 2) cfg=(1, 1, 0, 0, 0, 0)
+other_three_first_axis_types=['opp2', 'opp2', 'opp2']
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-sixty-six-seeds the two-cube has twelve vertices and C(12,2)=66 two-site seeds
+PASS: thm1-four-misses-and-f1-fills exactly four 2-site seeds miss under f_L1, and f1 fills each independently
+PASS: thm2-lex-first-refusal lex-first miss first refusal is t=1, site (1,0,0), axis type opp2
+PASS: thm3-other-three-same-axis-type the other three miss seeds have the same first axis type opp2
+PASS: thm3-display-not-adopt-opp2 opp2 is displayed and is not adopted or written into Admissibility
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted first refusal, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-first-refusal the note reports the four misses, f1 fill, and the lex-first (t, x, axis type)
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6420 the residual is the first refused neighborhood, not leftover of #6420
+PASS: claim-scope claim_scope reports the first refused neighborhood on the lex-first miss
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f_L1 and f1 are run independently from each of the four miss seeds
+per_block: checked exactly — the first refused neighborhood is named by tick, site, and axis type
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_l1_two_site_miss_mechanism_2026_08_15.py
+++ b/scripts/f_l1_two_site_miss_mechanism_2026_08_15.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""First refused neighborhood on the four 2-site seeds f_L1 does not fill.
+
+Independent occupancy-to-lock runs start from each 2-site miss seed on the
+twelve-vertex two-cube with off-patch occupancy 0.  The four misses of
+f_L1 are recomputed; the F_cut map f1 with remaining bits (1,1,1,1,1)
+fills each of them.  On the lex-first miss, the first (tick, site,
+axis-type) with f_L1(nbhd)=0 and f1(nbhd)=1 is displayed, not adopted.
+The other three misses share that first axis type.  opp2 is not written
+into Admissibility.  f_L1 is the unbalanced-axis predicate (some n_mu
+!= 0), never Hamming |c|_1 mod 2.  New object: not leftover of #6420
+(that was f_min versus f_L1 on a seed f_L1 fills).
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Seed = tuple[Site, Site]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+AXIS_TYPE_NAME: dict[OrbitType, str] = {
+    (0, 0, 3): "empty",
+    (0, 3, 0): "full",
+    (1, 0, 2): "wt1",
+    (1, 2, 0): "wt1_comp",
+    (0, 1, 2): "opp2",
+    (0, 2, 1): "opp2_comp",
+    (2, 0, 1): "adj2",
+    (2, 1, 0): "adj2_comp",
+    (3, 0, 0): "vertex3",
+    (1, 1, 1): "mixed3",
+}
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F1_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 1)
+F1_LABEL = "f1"
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f1(config: Config) -> int:
+    """F_cut remaining bits (1, 1, 1, 1, 1).  Displayed cov=66 map.  Not adopted."""
+    return remaining_value(config, F1_REMAINING)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_from_seed(predicate, seed: frozenset[Site], halt_bound: int = 13) -> dict:
+    locked = set(seed)
+    history = [len(locked)]
+    for _tick in range(halt_bound):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            break
+        locked = nxt
+        history.append(len(locked))
+    return {
+        "fill": len(locked) == 12,
+        "history": tuple(history),
+        "locks": frozenset(locked),
+        "halt_tick": len(history) - 1,
+    }
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    return bool(run_from_seed(predicate, seed)["fill"])
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def seed_key(seed: frozenset[Site]) -> Seed:
+    ordered = tuple(sorted(seed))
+    return (ordered[0], ordered[1])
+
+
+def seed_display(seed: frozenset[Site] | Seed) -> str:
+    a, b = seed_key(frozenset(seed))
+    return f"{{({a[0]},{a[1]},{a[2]}),({b[0]},{b[1]},{b[2]})}}"
+
+
+def refusal_events(locked: set[Site]) -> list[dict]:
+    rows: list[dict] = []
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        config = neighborhood(site, locked)
+        value_l1 = f_L1(config)
+        value_f1 = f1(config)
+        if value_l1 == 0 and value_f1 == 1:
+            kind = axis_type(config)
+            rows.append(
+                {
+                    "site": site,
+                    "config": config,
+                    "axis_type": kind,
+                    "axis_name": AXIS_TYPE_NAME[kind],
+                    "f_L1": value_l1,
+                    "f1": value_f1,
+                }
+            )
+    return rows
+
+
+def first_refusal(seed: frozenset[Site], predicate, halt_bound: int = 13) -> dict | None:
+    """Independent run: first (tick, site, axis-type) with f_L1=0 and f1=1."""
+    locked = set(seed)
+    for tick in range(1, halt_bound + 1):
+        events = refusal_events(locked)
+        if events:
+            first = events[0]
+            return {
+                "tick": tick,
+                "site": first["site"],
+                "config": first["config"],
+                "axis_type": first["axis_type"],
+                "axis_name": first["axis_name"],
+                "n_events": len(events),
+                "events": tuple(events),
+            }
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return None
+        locked = nxt
+    return None
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: independent occupancy-to-lock runs from each f_L1 2-site miss")
+    print("negative_scope: opp2 is displayed, not adopted or written into Admissibility")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    f1_bits = bits_from_predicate(f1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f1_remaining = remaining_bits_from_full(f1_bits, orbit_types)
+
+    miss_seeds = [seed for seed in TWO_SITE_SEEDS if not fills_from_seed(f_L1, seed)]
+    miss_seeds.sort(key=seed_key)
+    lex_first = miss_seeds[0]
+    independent = []
+    for seed in miss_seeds:
+        run_l1 = run_from_seed(f_L1, seed)
+        run_f1 = run_from_seed(f1, seed)
+        first_on_f1 = first_refusal(seed, f1)
+        first_on_l1 = first_refusal(seed, f_L1)
+        independent.append(
+            {
+                "seed": seed_key(seed),
+                "display": seed_display(seed),
+                "l1": run_l1,
+                "f1": run_f1,
+                "first_f1": first_on_f1,
+                "first_l1": first_on_l1,
+            }
+        )
+    first_lex = independent[0]["first_f1"]
+    cov_l1 = 66 - len(miss_seeds)
+    cov_f1 = coverage(f1)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"cov_f_L1={cov_l1}")
+    print(f"cov_f1={cov_f1}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f1_remaining={f1_remaining}")
+    print(f"n_l1_miss={len(miss_seeds)}")
+    print("miss_seeds_lex=" + ", ".join(row["display"] for row in independent))
+    for row in independent:
+        first = row["first_f1"]
+        print(
+            f"  {row['display']} "
+            f"hist_L1={row['l1']['history']} fill_L1={row['l1']['fill']} "
+            f"hist_f1={row['f1']['history']} fill_f1={row['f1']['fill']} "
+            f"first=t={first['tick']} x={first['site']} type={first['axis_name']}{first['axis_type']}"
+        )
+    print(
+        "lex_first_refusal="
+        f"t={first_lex['tick']} x={first_lex['site']} "
+        f"type={first_lex['axis_name']}{first_lex['axis_type']} "
+        f"cfg={first_lex['config']}"
+    )
+    other_types = [row["first_f1"]["axis_name"] for row in independent[1:]]
+    print(f"other_three_first_axis_types={other_types}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_L1_TWO_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-sixty-six-seeds",
+        "the two-cube has twelve vertices and C(12,2)=66 two-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-four-misses-and-f1-fills",
+        "exactly four 2-site seeds miss under f_L1, and f1 fills each independently",
+        len(miss_seeds) == 4
+        and cov_l1 == 62
+        and cov_f1 == 66
+        and f1_remaining == F1_REMAINING
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type)
+        and all(not row["l1"]["fill"] for row in independent)
+        and all(row["f1"]["fill"] for row in independent)
+        and all(row["l1"]["history"] == (2, 6, 8) for row in independent)
+        and all(row["f1"]["history"] == (2, 7, 11, 12) for row in independent)
+        and [row["display"] for row in independent]
+        == [
+            "{(0,0,0),(2,0,0)}",
+            "{(0,0,1),(2,0,1)}",
+            "{(0,1,0),(2,1,0)}",
+            "{(0,1,1),(2,1,1)}",
+        ],
+    )
+    checks.check(
+        "thm2-lex-first-refusal",
+        "lex-first miss first refusal is t=1, site (1,0,0), axis type opp2",
+        first_lex is not None
+        and seed_display(lex_first) == "{(0,0,0),(2,0,0)}"
+        and first_lex["tick"] == 1
+        and first_lex["site"] == (1, 0, 0)
+        and first_lex["axis_type"] == (0, 1, 2)
+        and first_lex["axis_name"] == "opp2"
+        and first_lex["config"] == (1, 1, 0, 0, 0, 0)
+        and first_lex["n_events"] == 1
+        and independent[0]["first_l1"]["tick"] == 1
+        and independent[0]["first_l1"]["site"] == (1, 0, 0)
+        and independent[0]["first_l1"]["axis_name"] == "opp2",
+    )
+    checks.check(
+        "thm3-other-three-same-axis-type",
+        "the other three miss seeds have the same first axis type opp2",
+        len(independent) == 4
+        and all(row["first_f1"]["tick"] == 1 for row in independent)
+        and all(row["first_f1"]["axis_name"] == "opp2" for row in independent)
+        and all(row["first_f1"]["axis_type"] == (0, 1, 2) for row in independent)
+        and [row["first_f1"]["site"] for row in independent]
+        == [(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+        and all(row["first_l1"]["axis_name"] == "opp2" for row in independent),
+    )
+    checks.check(
+        "thm3-display-not-adopt-opp2",
+        "opp2 is displayed and is not adopted or written into Admissibility",
+        first_lex["axis_name"] == "opp2"
+        and "Do not adopt opp2" in note
+        and "Do not write it into Admissibility" in note
+        and "Displayed, not adopted" in note,
+    )
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_absence = "A site with no record cannot be read."
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        lattice_sentence in axiom
+        and "proper cubic rotations about each site." in axiom
+        and admissibility_sentence in axiom
+        and record_lock in axiom
+        and record_absence in axiom
+        and lattice_sentence in note
+        and record_absence in note,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted first refusal, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-first-refusal",
+        "the note reports the four misses, f1 fill, and the lex-first (t, x, axis type)",
+        all(
+            display in note.replace(" ", "")
+            for display in (
+                "{(0,0,0),(2,0,0)}",
+                "{(0,0,1),(2,0,1)}",
+                "{(0,1,0),(2,1,0)}",
+                "{(0,1,1),(2,1,1)}",
+            )
+        )
+        and "(1, 1, 1, 1, 1)" in note
+        and "t = 1" in note
+        and "(1, 0, 0)" in note
+        and "`opp2`" in note
+        and "(0, 1, 2)" in note
+        and "same first axis type" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write it into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6420",
+        "the residual is the first refused neighborhood, not leftover of #6420",
+        "Not leftover of #6420" in note
+        and "f_min versus f_L1 on a seed f_L1 fills" in note
+        and "New object" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the first refused neighborhood on the lex-first miss",
+        "On the two-cube with off-patch o=0, the first neighborhood at which f_L1 refuses and the cov=66 map (1,1,1,1,1) fires, on the lex-first 2-site seed f_L1 does not fill, is reported by tick, site, and axis type."
+        in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        "does not supply the formation site, probability, or rate" in axiom_flat
+        and "does not supply the formation site, probability, or rate" in note_flat,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f_L1 and f1 are run independently from each of the four miss seeds")
+    print("per_block: checked exactly — the first refused neighborhood is named by tick, site, and axis type")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the lex-first 2-site seed f_L1 does not fill, the first neighborhood f_L1 refuses and the cov=66 map fires is opp2 at t=1. The other three misses share that first axis type. Displayed, not adopted. f_L1 is n≠0 / unbalanced axis, not Hamming.

## Runner

`scripts/f_l1_two_site_miss_mechanism_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.