### PR TITLE
feat(opp0miss): every silent-opp2 F_cut map misses the four long-axis seeds

### DIFF
--- a/docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,413 @@
+---
+claim_id: f_cut_opp2_silent_long_axis_miss_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among F_cut maps with f(opp2)=0 on the two-cube with off-patch o=0, every map misses all four long-axis 2-site seeds. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py
+---
+
+# Silent-Opp2 Implies The Four Long-Axis Two-Site Misses
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock census of every cube-covariant
+complement-even predicate that vanishes on empty, full, *and* the
+opposite-pair orbit `opp2`, on the twelve-vertex two-cube, from each of
+the four long-axis 2-site endpairs, with off-patch occupancy `0`. The
+unbalanced-axis map `f_L1` is displayed as one member of that subclass.
+It is not adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py`](../scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut| = 32`.
+
+`opp2` is the orbit of a cell with exactly one axis fully occupied and the
+other four slots `0`. A representative is
+`(c_{+x},c_{-x},c_{+y},c_{-y},c_{+z},c_{-z})=(1,1,0,0,0,0)`. The axis type
+is `(u,b,e)=(0,1,2)`: no unbalanced axis, one both-occupied axis, two
+empty axes. The orbit has size `3`. `f(opp2)=0` means a filled axis does
+not form.
+
+Write
+
+```text
+F0 = { f ∈ F_cut : f(opp2) = 0 }.
+```
+
+The `opp2` bit is one of the five free remaining bits, so `|F0| = 16`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered pair of vertices is
+a 2-site seed. Off-patch neighbors have occupancy `0`. Each tick, every
+unlocked on-patch vertex evaluates `f` on its six-neighbor occupancy
+tuple and locks if `f=1`. The process is synchronous and stops at a
+fixed point in at most 12 ticks. Fill means `|locks_halt|=12`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is
+`(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 1)`, so `f_L1 ∈ F0`.
+
+Write `M` for the four long-axis 2-site endpairs of the two-cube, in
+lexicographic order of sorted site pairs:
+
+```text
+{(0,0,0),(2,0,0)}
+{(0,0,1),(2,0,1)}
+{(0,1,0),(2,1,0)}
+{(0,1,1),(2,1,1)}
+```
+
+These are exactly the four 2-site seeds listed as `f_L1` misses. New
+object. Not leftover-character of #6438 (that was listing L1's four).
+This note is the class statement: whether every map in `F0` misses every
+seed in `M`.
+
+**Theorem 1.** `f_L1 ∈ F0` and misses every seed in `M`. On each seed the
+independent `f_L1` run halts unfilled with lock-count history `(2, 6, 8)`.
+
+**Theorem 2.** Every `f` in `F0` misses every seed in `M`. Exhaustive
+enumeration of the 16 maps against the four seeds gives 64 misses and
+zero fills. Silent-opp2 therefore implies the long-axis misses. There is
+no counterexample remaining-bit tuple and no filled seed in `M`.
+
+**Theorem 3.** Display. Do not adopt opp2. Do not write it into Admissibility.
+
+`claim_scope`: Among F_cut maps with f(opp2)=0 on the two-cube with
+off-patch o=0, every map misses all four long-axis 2-site seeds.
+Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the 16-element F0, membership of f_L1, the four long-axis seeds M, and the exact 16-by-4 miss table are enumerated. Silent-opp2 implies the long-axis misses on this patch. No physical law is selected."
+trace_class: frontier_discovery
+target_claim_id: f_cut_opp2_silent_long_axis_miss
+target_blocker_text: "whether every F_cut map with f(opp2)=0 misses the four long-axis 2-site seeds"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F0 x M miss table; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F0 on this twelve-vertex patch with off-patch o=0 and the four long-axis 2-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws. Admissibility
+does not supply the formation site, probability, or rate.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the four long-axis 2-site seeds `M`;
+- the opposite-pair orbit `opp2` and the subclass `F0`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of #6438 (that was listing L1's four). New object:
+the class miss of every `F0` map on `M`.
+
+## Exact Target And Objects
+
+**Target.** Restrict the 32-member class `F_cut` to the independently
+motivated extra `f(opp2)=0`, reconfirm that `f_L1` lies in that subclass
+and misses every seed in `M`, and decide whether every other map in `F0`
+misses every seed in `M`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The remaining-bit tuple is those five free bits in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`. The subclass `F0` freezes the
+`opp2` bit at `0` and leaves the other four bits free, so `|F0|=16`.
+
+Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and lies in `F0`.
+Neither `f_L1` nor silent-opp2 is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+An independent run of `f` from a seed is that iteration started at the
+seed and continued to a fixed point. A miss is a 2-site seed whose halt
+set has cardinality strictly less than 12.
+
+`M` is the four long-axis displacement-`(2,0,0)` pairs. `|M| = 4`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut` and of `F0`: it vanishes on `opp2`.
+It is not Hamming parity. On the twelve-vertex two-cube with off-patch
+occupancy `0`, each of the four seeds in `M` is a miss for `f_L1`, with
+history `(2, 6, 8)`.
+
+**Theorem 2.** Exhaustive run of every map in `F0` from every seed in `M`
+gives
+
+```text
+|F0| = 16
+|M| = 4
+miss events = 64
+fill events = 0.
+```
+
+Every `f` in `F0` misses every seed in `M`. Silent-opp2 implies the
+long-axis misses. No remaining-bit tuple in `F0` fills any seed of `M`.
+
+**Theorem 3.** Display. Do not adopt opp2. Do not write it into Admissibility.
+The class miss is displayed census output. It is not a physical selector.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `|F0|=16` | the `opp2` remaining bit is frozen at `0`; four free bits remain |
+| `f_L1` is in `F0` | `u` is rotation- and complement-invariant, `u(empty)=u(full)=0`, and `u(opp2)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| `M` is the four long-axis endpairs | lex list of displacement-`(2,0,0)` pairs on the two-cube |
+| `f_L1` misses every seed in `M` | four independent runs halt unfilled at history `(2, 6, 8)` |
+| every `F0` map misses every seed in `M` | exhaustive 16-by-4 lock-step table; 64 misses, 0 fills |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| no adoption of `opp2` | displayed class condition, not an Admissibility clause |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit) and is not the
+   unbalanced-axis predicate.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Drop complement-even or the vanish-on-full cut: the class is no longer
+   the 32-element `F_cut`, so `F0` is no longer this 16-element subclass.
+4. List only `f_L1`'s four misses: that leftover is #6438, not the class
+   statement on `F0`.
+5. Turn `opp2` on: maps with `f(opp2)=1` are outside `F0` and are a
+   different residual; this note does not adopt that bit.
+6. Assert that some `F0` map fills a long-axis seed: the 16-by-4 table
+   is empty of fills and refutes the assertion.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of listing L1's four (#6438) in
+  place of this `F0` class miss.
+- No adoption of `opp2` and no write of silent-opp2 into Admissibility.
+- No blank-block or 3-site variant.
+
+## No-Go Discipline Gate
+
+The negative content is narrow: silent-opp2 is not hereby adopted. The
+positive class miss is an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class and `F0` | Force vanish-on-empty, vanish-on-full, `f(c)=f(1-c)`, and `f(opp2)=0`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32` and `|F0|=16`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `f_L1` membership and `M` | Read the `opp2` bit of `f_L1` and run it from each seed in `M`. | Theorem 1 and check `thm1-f-L1-in-F0-misses-M`. | **ATTEMPTED** |
+| `F0` class miss | Run every map in `F0` from every seed in `M`. | Theorem 2 and check `thm2-every-F0-misses-every-M` give 64 misses. | **ATTEMPTED** |
+| adopt `opp2` | Write silent-opp2 into Admissibility. | Theorem 3 and check `thm3-display-not-adopt`; refused. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: `opp2` is not adopted. The 16-map miss
+table and the four `f_L1` histories are certificates of the same class
+miss, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `f_L1` misses `M` / every `F0` map misses `M` | no: one member is not the class | yes: the class includes `f_L1` | class statement strictly stronger |
+| leftover of #6438 / this class miss | no: listing L1's four is not a class theorem | no: a class miss does not replace the L1 list | different object |
+| static `|F0|=16` / 16-by-4 table | no: membership is not dynamics | no: a miss table does not replace the `opp2=0` cut | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| `F0` | explicit `opp2=0` subclass of `F_cut` |
+| four long-axis 2-site seeds `M` | explicit seed class; a one-seed fill is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| silent-opp2 | displayed class condition, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:80` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:124` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:129` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:52` | four long-axis seeds | lex endpairs of displacement `(2,0,0)` | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:179` | lock-step run | independent occupancy-to-lock from a seed | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:272` | `F_cut` census | 32 remaining-bit assignments | yes |
+| `scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py:66` | `opp2` orbit | axis type `(0,1,2)` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F0` | the miss table is this subclass on the four long-axis seeds |
+| per block | yes: the `F0 × M` fill table | every silent-opp2 map misses every seed in `M` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does lie in `F0` and does miss every seed in `M`. That positive member
+does not select silent-opp2 as the physical rule. The remaining physical
+choice — which, if any, `F0` map is the Admissibility occupancy
+predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that because `f_L1` already misses these four
+seeds, and because `f_L1` is the most permissive remaining-bit pattern
+inside `F0` except that `mixed3` may be turned off, the class miss is a
+leftover of listing L1's four. That objection is correctly about the
+static remaining-bit table and about the earlier four-seed list. It does
+not overturn the stated theorem: among maps in `F_cut` that already
+silence `opp2`, no map fills any long-axis 2-site seed. The 16-by-4
+table is a class object, not a restatement of one map's miss set.
+Predicate support is not monotone for fill — a weaker map can in
+principle occupy a different neighborhood and fire where a stronger map
+sees `opp2` — so the class statement is not a corollary of the `f_L1`
+list. It is recomputed.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, `F0`, `M`, and 16-by-4 miss table are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `F0` long-axis class miss or adopts
+`opp2` as Admissibility content.
+
+No-Go Discipline disposition: **PASS** for the class miss and the
+displayed, not adopted, silent-opp2 condition stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, restricts to `F0`, evaluates all 16 maps on the two-cube from
+each of the four long-axis seeds, reports that `f_L1 ∈ F0` misses every
+seed in `M` with history `(2, 6, 8)`, reports `|F0| = 16`, `|M| = 4`,
+and 64 miss events, checks that `f_L1` is not Hamming parity, and
+checks that this note displays the class miss without adopting `opp2`.
+Declared audit inputs are this note and the axiom memo. No runner cache
+is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5534,
+ "edge_count": 15739,
+ "node_count": 5535,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_opp2_silent_long_axis_miss_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_opp2_silent_long_axis_miss_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_opp2_silent_long_axis_miss_2026_08_15.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py
+runner_sha256: 22c050a83180aac3ad25ac63585b2dbe4d93f2e12f7fc7a4a335a3234cbc86ed
+input_fingerprint_sha256: cedaf4ebe478a764f642b7bcad7fe818b6b23af1b89eff616b4f9a3081bc7f18
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: exhaustive F0 x M lock-step census; silent-opp2 class miss is displayed
+negative_scope: opp2 is displayed; no map or seed is adopted or written into Admissibility
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+|F0|=16
+n_two_site_seeds=66
+|M|=4
+M_lex={(0,0,0),(2,0,0)}, {(0,0,1),(2,0,1)}, {(0,1,0),(2,1,0)}, {(0,1,1),(2,1,1)}
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+f_L1_in_F0=True
+  f_L1 {(0,0,0),(2,0,0)} hist=(2, 6, 8) fill=False
+  f_L1 {(0,0,1),(2,0,1)} hist=(2, 6, 8) fill=False
+  f_L1 {(0,1,0),(2,1,0)} hist=(2, 6, 8) fill=False
+  f_L1 {(0,1,1),(2,1,1)} hist=(2, 6, 8) fill=False
+F0_remaining=[(0, 0, 0, 0, 0), (0, 0, 0, 0, 1), (0, 0, 0, 1, 0), (0, 0, 0, 1, 1), (0, 0, 1, 0, 0), (0, 0, 1, 0, 1), (0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (1, 0, 0, 0, 0), (1, 0, 0, 0, 1), (1, 0, 0, 1, 0), (1, 0, 0, 1, 1), (1, 0, 1, 0, 0), (1, 0, 1, 0, 1), (1, 0, 1, 1, 0), (1, 0, 1, 1, 1)]
+miss_events=64
+fill_events=[]
+every_F0_misses_every_M=True
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32; F0 has size 16
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-M M is the four lex long-axis displacement-(2,0,0) endpairs
+PASS: thm1-f-L1-in-F0-misses-M f_L1 is in F0 and misses every seed in M with history (2, 6, 8)
+PASS: thm2-every-F0-misses-every-M every map in F0 misses every seed in M; no counterexample fill exists
+PASS: thm3-display-not-adopt the note displays the class miss and does not adopt opp2
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted class miss, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6438 the residual is the F0 class miss, not leftover-character of listing L1's four
+PASS: claim-scope-class-miss claim_scope states that every F0 map misses all four long-axis 2-site seeds
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F0 map is scored on each of the four long-axis seeds
+per_block: checked exactly — the class miss is the F0 x M fill table on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py
+++ b/scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Class theorem: every F_cut map with f(opp2)=0 misses the four long-axis seeds.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+F0 is the subclass with f(opp2)=0: a filled axis does not form. M is the
+four long-axis 2-site endpairs of the two-cube. Dynamics are occupancy-to-lock
+with off-patch occupancy 0. f_L1 is the unbalanced-axis predicate (some
+n_mu != 0), never Hamming |c|_1 mod 2. Silent-opp2 is displayed, not
+adopted, and is not written into Admissibility.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+LONG_AXIS_SEEDS: tuple[frozenset[Site], ...] = (
+    frozenset(((0, 0, 0), (2, 0, 0))),
+    frozenset(((0, 0, 1), (2, 0, 1))),
+    frozenset(((0, 1, 0), (2, 1, 0))),
+    frozenset(((0, 1, 1), (2, 1, 1))),
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+OPP2_TYPE: OrbitType = (0, 1, 2)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+L1_MISS_HISTORY: tuple[int, ...] = (2, 6, 8)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_from_seed(predicate, seed: frozenset[Site]) -> tuple[tuple[int, ...], bool]:
+    locked = set(seed)
+    history = [len(locked)]
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return (tuple(history), len(locked) == 12)
+        locked = nxt
+        history.append(len(locked))
+    return (tuple(history), False)
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    _history, fill = run_from_seed(predicate, seed)
+    return fill
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def seed_key(seed: frozenset[Site]) -> tuple[Site, ...]:
+    return tuple(sorted(seed))
+
+
+def seed_display(seed: frozenset[Site]) -> str:
+    left, right = seed_key(seed)
+    return f"{{({left[0]},{left[1]},{left[2]}),({right[0]},{right[1]},{right[2]})}}"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: exhaustive F0 x M lock-step census; silent-opp2 class miss is displayed")
+    print("negative_scope: opp2 is displayed; no map or seed is adopted or written into Admissibility")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    f0_members = [(bits, remaining) for bits, remaining in members if remaining[1] == 0]
+    n_f0 = len(f0_members)
+    opp2_index = REMAINING_LABELS.index("opp2")
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    l1_histories = {seed_key(seed): run_from_seed(f_L1, seed) for seed in LONG_AXIS_SEEDS}
+    l1_misses_all = all(not fill for _hist, fill in l1_histories.values())
+    l1_hist_ok = all(hist == L1_MISS_HISTORY and not fill for hist, fill in l1_histories.values())
+
+    miss_events = 0
+    fill_events: list[tuple[tuple[int, ...], tuple[Site, ...], tuple[int, ...]]] = []
+    halt_by_remaining: dict[tuple[int, ...], dict[tuple[Site, ...], tuple[tuple[int, ...], bool]]] = {}
+    for bits, remaining in f0_members:
+        predicate = predicate_from_bits(bits, orbit_types, type_of)
+        halt_by_remaining[remaining] = {}
+        for seed in LONG_AXIS_SEEDS:
+            hist, fill = run_from_seed(predicate, seed)
+            halt_by_remaining[remaining][seed_key(seed)] = (hist, fill)
+            if fill:
+                fill_events.append((remaining, seed_key(seed), hist))
+            else:
+                miss_events += 1
+
+    every_f0_misses_every_m = miss_events == n_f0 * len(LONG_AXIS_SEEDS) and not fill_events
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"|F0|={n_f0}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"|M|={len(LONG_AXIS_SEEDS)}")
+    print("M_lex=" + ", ".join(seed_display(seed) for seed in LONG_AXIS_SEEDS))
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"f_L1_in_F0={l1_remaining[opp2_index] == 0}")
+    for seed in LONG_AXIS_SEEDS:
+        hist, fill = l1_histories[seed_key(seed)]
+        print(f"  f_L1 {seed_display(seed)} hist={hist} fill={fill}")
+    print(f"F0_remaining={sorted(remaining for _bits, remaining in f0_members)}")
+    print(f"miss_events={miss_events}")
+    print(f"fill_events={fill_events}")
+    print(f"every_F0_misses_every_M={every_f0_misses_every_m}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_OPP2_SILENT_LONG_AXIS_MISS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32; F0 has size 16",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and n_f0 == 16
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    miss_displays = [seed_display(seed) for seed in LONG_AXIS_SEEDS]
+    checks.check(
+        "thm1-two-cube-and-M",
+        "M is the four lex long-axis displacement-(2,0,0) endpairs",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(LONG_AXIS_SEEDS) == 4
+        and tuple(seed_key(seed) for seed in LONG_AXIS_SEEDS)
+        == tuple(sorted(seed_key(seed) for seed in LONG_AXIS_SEEDS))
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in LONG_AXIS_SEEDS)
+        and all(left[1:] == right[1:] and left[0] == 0 and right[0] == 2 for left, right in (seed_key(seed) for seed in LONG_AXIS_SEEDS)),
+    )
+    checks.check(
+        "thm1-f-L1-in-F0-misses-M",
+        "f_L1 is in F0 and misses every seed in M with history (2, 6, 8)",
+        in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and l1_remaining == L1_REMAINING
+        and l1_remaining[opp2_index] == 0
+        and l1_misses_all
+        and l1_hist_ok
+        and all(display in note.replace(" ", "") for display in miss_displays),
+    )
+    checks.check(
+        "thm2-every-F0-misses-every-M",
+        "every map in F0 misses every seed in M; no counterexample fill exists",
+        every_f0_misses_every_m
+        and n_f0 == 16
+        and miss_events == 64
+        and fill_events == []
+        and all(remaining[opp2_index] == 0 for _bits, remaining in f0_members)
+        and all(
+            not fill
+            for remaining_halts in halt_by_remaining.values()
+            for _hist, fill in remaining_halts.values()
+        ),
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the note displays the class miss and does not adopt opp2",
+        "every map misses all four long-axis 2-site seeds" in note
+        and "Displayed, not adopted" in note
+        and "Do not adopt opp2" in note
+        and "Do not write it into Admissibility" in note
+        and f"|F0| = {n_f0}" in note
+        and "|M| = 4" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted class miss, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "every map misses all four long-axis 2-site seeds" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write it into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6438",
+        "the residual is the F0 class miss, not leftover-character of listing L1's four",
+        "Not leftover-character of #6438" in note
+        and "listing L1" in note
+        and "New object" in note,
+    )
+    checks.check(
+        "claim-scope-class-miss",
+        "claim_scope states that every F0 map misses all four long-axis 2-site seeds",
+        "Among F_cut maps with f(opp2)=0" in note
+        and "off-patch o=0" in note
+        and "every map misses all four long-axis 2-site seeds" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        "When present, a record locks exactly one admissible local possibility." in axiom
+        and "A readout value is determined by record content" in axiom
+        and "A site with no record cannot be read." in axiom
+        and "When present, a record locks exactly one admissible local possibility." in note
+        and "A site with no record cannot be read." in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F0 map is scored on each of the four long-axis seeds")
+    print("per_block: checked exactly — the class miss is the F0 x M fill table on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among F_cut maps with f(opp2)=0 on the two-cube (off-patch o=0), every map misses all four long-axis 2-site seeds. f_L1 is n≠0, not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_opp2_silent_long_axis_miss_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.