### PR TITLE
feat(opp2fill4): four long-axis fills are not equivalent to opp2=1

### DIFF
--- a/docs/F_CUT_OPP2_LONG_AXIS_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_OPP2_LONG_AXIS_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,282 @@
+---
+claim_id: f_cut_opp2_long_axis_fill_equivalence_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, filling all four long-axis 2-site seeds is not equivalent to f(opp2)=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py
+---
+
+# F_cut Long-Axis Four-Seed Fill Is Not The Opp2 Bit
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 32 cube-covariant complement-even formation predicates that
+vanish on empty and full, run as occupancy dynamics on the twelve-vertex
+two-cube with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py`](../scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py)
+
+## Result Up Front
+
+Write `V={0,1,2}×{0,1}×{0,1}` for the twelve-vertex two-cube. Let `M` be the
+four long-axis 2-site seeds
+
+`{((0,0,0),(2,0,0)), ((0,0,1),(2,0,1)), ((0,1,0),(2,1,0)), ((0,1,1),(2,1,1))}`.
+
+These are exactly the four 2-site seeds from which the unbalanced-axis
+predicate `f_L1` (`n≠0` on the six-neighbor occupancy tuple; not Hamming
+parity) fails to lock all twelve vertices. For each of the 32 `F_cut` maps,
+let
+
+`k(f)=|{S∈M : |locks_halt(f,S)|=12}|`.
+
+Then `f_L1` has `k=0` and `f_L1(opp2)=0`. Filling every seed in `M` is
+**not** equivalent to `f(opp2)=1`, and `k(f)=0` is **not** equivalent to
+`f(opp2)=0`. The lex-first counterexample remaining-bit tuple
+`(wt1, opp2, adj2, vertex3, mixed3)=(0, 1, 0, 0, 0)` has `k=0` while
+`f(opp2)=1`. Every silent-`opp2` map still has `k=0`, so that one direction
+holds; the converse fails. The four maps that do attain `k=4` are exactly
+those with `(wt1, opp2, adj2)=(1,1,1)`.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) remains
+untouched:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+This note displays a selector on a finite predicate class. It does not write
+`opp2` into Admissibility and does not adopt any remaining-bit tuple.
+
+## Exact Objects And The Dynamics
+
+The six-neighbor occupancy cell at a site is the `{0,1}^6` tuple of locked
+status on the ordered shifts `±e_1, ±e_2, ±e_3`. Off-patch neighbors contribute
+occupancy `0`. A cell is assigned one of ten orbits under the 24 proper cube
+rotations:
+
+| orbit | representative type | size |
+|---|---|---|
+| empty | all unoccupied | 1 |
+| wt1 | a single occupied slot | 6 |
+| opp2 | both ends of one axis occupied | 3 |
+| adj2 | two occupied slots on distinct axes | 12 |
+| vertex3 | one slot on each axis, no opposite pair | 8 |
+| mixed3 | one full axis plus one extra slot | 12 |
+| opp4 | complement of opp2 | 3 |
+| adj4 | complement of adj2 | 12 |
+| wt5 | complement of wt1 | 6 |
+| full | all occupied | 1 |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Complement-evenness identifies `wt5` with `wt1`, `opp4` with
+`opp2`, and `adj4` with `adj2`, and leaves `vertex3` and `mixed3`
+complement-fixed, so `|F_cut|=2^5=32`. Remaining-bit tuples are written in
+the order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced. That rule evaluates to
+`(1, 0, 1, 1, 1)` and is therefore one `F_cut` element. Hamming parity
+`|c|_1 mod 2` evaluates to `(1, 0, 0, 1, 1)` and is a different element.
+
+A run from a seed `S` starts with `S` locked. Each tick, every unlocked
+on-patch site evaluates `f` on its current six-neighbor occupancy tuple and
+locks if `f=1`. Halt is the first fixed point (at most twelve ticks). Fill
+means halt lock-count `12`.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility identifies the six-neighbor condition domain and covariance
+under proper cubic rotations. It
+does not supply the formation site, probability, or rate.
+The boolean occupancy predicates and the lock-update rule are explicit
+bounded mathematical input, not axiom text.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Permanence of a lock once formed is used only as the declared update rule on
+this finite patch. No physical readout, content map, or formation rate is
+identified.
+
+## Theorem 1
+
+`f_L1` lies in `F_cut`, has `f(opp2)=0`, and has `k(f_L1)=0`. On each seed
+in `M` the lock history is `(2, 6, 8)`: the two long-axis endpoints grow
+along the two short axes and then stall, leaving the shared-face slice
+unlocked. The same predicate fills from the 1-site seed `{(0,0,0)}` with
+history `(1, 4, 8, 11, 12)`, so the misses are seed-dependent rather than a
+global failure to form.
+
+## Theorem 2
+
+Enumerate all 32 remaining-bit tuples. The pairs `(k(f), f(opp2))` occupy
+only three bins:
+
+- 16 maps with `f(opp2)=0`, all of them `k=0`;
+- 12 maps with `f(opp2)=1` and `k=0`;
+- 4 maps with `f(opp2)=1` and `k=4`.
+
+Therefore `k(f)=4` if and only if `f(opp2)=1` is false, and `k(f)=0` if and
+only if `f(opp2)=0` is false. The lex-first counterexample tuple is
+`(0, 1, 0, 0, 0)`, which has `k=0`. Its first-seed history is `(2, 3)`: the
+middle long-axis site locks by `opp2`, then the run halts because `wt1=0`.
+A second displayed witness with `wt1=1` is `(1, 1, 0, 1, 1)`, which reaches
+halt lock-count `9` and still misses every seed in `M`.
+
+The four maps with `k=4` are
+
+`(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)`.
+
+So filling all four long-axis seeds detects the conjunction
+`wt1=adj2=opp2=1`, not the single bit `opp2`. No value `k∈{1,2,3}` occurs:
+by the residual long-axis symmetry of the two-cube, a map fills every seed
+in `M` or none.
+
+## Theorem 3
+
+The failed equivalence and the counterexample tuple are displayed. They are
+not adopted. The Admissibility sentence is not edited. In particular `opp2`
+is not written into the nearest-neighbor rule, and `f_L1` remains the
+unbalanced-axis predicate `n≠0` rather than Hamming parity.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact enumeration of 32 F_cut maps on the twelve-vertex two-cube; k(f) versus f(opp2) is a displayed selector, not a physical law."
+trace_class: upstream_support
+target_claim_id: admissibility_formation_predicate_selection
+target_blocker_text: "select a formation predicate from the axioms rather than by a displayed finite extra"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep opp2 and the long-axis four-seed count as displayed extras; do not promote either to Admissibility."
+conditional_surface_status: "exact for the declared two-cube, off-patch o=0, and the 32 F_cut maps; no axiom selector"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Boundary And Non-Claims
+
+- The four seeds and the integer `k(f)` are constructed objects on one
+  twelve-vertex patch. They are not a lattice-wide formation law.
+- Off-patch occupancy `0` is a declared default. Blank-block (undefined
+  off-patch slots) is a different rule and is not run here.
+- `F_cut` is the three-cut subclass of cube-covariant predicates. Maps
+  outside that subclass are not ranked.
+- No remaining-bit tuple is written into Admissibility.
+- No Record readout, content alphabet, or formation rate is selected.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the four long-axis 2-site seeds detect the single remaining bit `opp2` inside `F_cut`. |
+| V2 | Current main has the axiom memo but no landed census of this `k(f)` versus `f(opp2)` comparison. |
+| V3 | All orbit sizes, the 32-map table, and every halt lock-count are finite and exact. |
+| V4 | The theorem is more than restating `n≠0`: it separates a one-way implication from a failed biconditional. |
+| V5 | Displayed, not adopted. The extras remain conditional. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: on this patch and class, `k(f)=4` does not
+characterize `f(opp2)=1`. No global formation impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| silent `opp2` | set `f(opp2)=0` | executed; every such map has `k=0` |
+| `opp2` alone | set `f(opp2)=1` with `wt1=0` | executed counterexample; `k=0` |
+| `opp2` and `wt1` without `adj2` | tuple `(1,1,0,*,*)` | executed; still `k=0` |
+| conjunction `wt1=adj2=opp2=1` | the four `k=4` maps | executed fill of every seed in `M` |
+| Hamming parity | `|c|_1 mod 2` | different `F_cut` tuple; also `k=0` |
+| 1-site seed | run `f_L1` from `{(0,0,0)}` | fills; misses are seed-dependent |
+
+### N2 — wall independence
+
+The missing axiom-level selector, physical formation rate, and Record
+content map are distinct open premises. This note claims no wall collection.
+
+### N3 — hidden-condition scan
+
+The six-neighbor order, off-patch default, simultaneous lock update, and
+`F_cut` cuts are declared. No continuum, Hamming, or fitted prefactor is
+used.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate, the
+local-distribution sentence, and the formation-site/probability/rate
+boundary used here. The residual is a displayed extra on a finite class,
+matching those sources rather than an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | all 32 remaining-bit tuples | no ranking of the 512 maps with only `f(empty)=0` |
+| per seed | all four long-axis endpairs | no claim about the other 62 two-site seeds |
+| per tick | halt histories for `f_L1` and the displayed counterexamples | no physical clock |
+| lattice wide | checked and not executed | no infinite-volume formation law |
+
+### N6 — live partial-closure paths
+
+Live routes are an independent derivation of a formation predicate from
+Admissibility, a justification of the off-patch default, and a Record
+content identification. Other seeds and other cuts remain live.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `f_L1` misses `M` by refusing `opp2`, filling all four
+seeds should be the same extra as `f(opp2)=1`.
+
+**Answer:** Silent `opp2` does force `k=0`, but firing `opp2` is not enough
+to fill. The lex-first map with `f(opp2)=1` and `f(wt1)=0` locks only the
+middle long-axis site and stops at three locks. The four-seed fill therefore
+detects a three-bit conjunction, not the single bit.
+
+### N8 — cross-cycle echo
+
+This is a new selector, not a leftover listing of `f_L1`'s four misses and
+not a first-neighborhood comparison of one rival map. The four seeds are
+recomputed here from the `n≠0` rule.
+
+**Gate disposition:** PASS for the finite failed equivalence and the
+displayed counterexample. FAIL / DO NOT SHIP for “`opp2` is Admissibility”
+or “the four seeds select `f_L1`.”
+
+## Inputs And Dependency Roles
+
+- **Framework context:** the Lattice nearest-neighbor cubic graph and the
+  Admissibility condition-domain sentence.
+- **Explicit bounded mathematical input:** the two-cube vertex set, off-patch
+  occupancy `0`, the ten-orbit classification, the three `F_cut` cuts, and
+  the simultaneous lock-update rule.
+- **Not imported:** any unmerged census of a different seed, any Hamming
+  identity for `f_L1`, and any axiom edit.
+
+## Primary Runner
+
+The primary runner recomputes the ten orbits, the 32 `F_cut` maps, `k(f)`
+on the four long-axis seeds, the failed biconditionals, the lex-first
+counterexample, the one-way silent implication, and the current premise
+boundary. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5534,
+ "edge_count": 15739,
+ "node_count": 5535,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_opp2_long_axis_fill_equivalence_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py
+runner_sha256: 6e4acf0953fe4ef4fe1cc9bd0a85a4dc60bf400690697476d043688f9f3599f6
+input_fingerprint_sha256: e9cbe9db6ca3894920f562fc1bde5d264b1114df4e90bef4a436591d74c8e76b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo
+construction: 32 cube-covariant complement-even predicates on the two-cube, off-patch occupancy 0
+negative_scope: displayed selector only; opp2 is not written into Admissibility
+PASS: audit-inputs declared source-bound pair exists
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: vertex-count two-cube has twelve vertices
+PASS: orbit-partition proper-cube action on six-tuples has ten orbits with derived sizes
+PASS: complement-action complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3
+PASS: f-cut-cardinality five free remaining bits give 32 F_cut maps
+PASS: l1-bits n≠0 evaluates to remaining-bit tuple (1,0,1,1,1) and lies in F_cut
+PASS: l1-not-hamming Hamming parity is a different F_cut tuple
+PASS: theorem1-opp2 f_L1(opp2)=0
+PASS: theorem1-k f_L1 has k=0 and halt lock-count 8 on each long-axis seed
+PASS: l1-onesite-control same predicate fills from a 1-site seed
+k_eq_4_iff_f_opp2: False
+k_eq_0_iff_f_opp2_silent: False
+lex_counterexample_tuple: (0, 1, 0, 0, 0) k=0
+k_spectrum: {0: 28, 4: 4}
+k4_maps: [(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+PASS: theorem2-iff-k4 k(f)=4 is not equivalent to f(opp2)=1
+PASS: theorem2-iff-k0 k(f)=0 is not equivalent to f(opp2)=0
+PASS: theorem2-counterexample lex-first counterexample is (0,1,0,0,0) with k=0 and f(opp2)=1
+PASS: silent-one-way every silent-opp2 map still has k=0 (one direction holds)
+PASS: k4-characterization k=4 exactly on the four maps with (wt1,opp2,adj2)=(1,1,1)
+PASS: mutation-zero-and-fullbits zero map has k=0; remaining-bit (1,1,1,1,1) has k=4
+PASS: note-scope note reports the failed equivalence, displays a counterexample, and does not adopt opp2
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py
+++ b/scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Exact F_cut census: filling the four long-axis 2-site seeds vs f(opp2)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_OPP2_LONG_AXIS_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_OPP2_LONG_AXIS_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Cell = tuple[int, int, int, int, int, int]
+Bits = tuple[int, int, int, int, int]
+
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+FREE_ORBITS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+VERTICES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+PATCH = frozenset(VERTICES)
+LONG_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    ((0, 0, 0), (2, 0, 0)),
+    ((0, 0, 1), (2, 0, 1)),
+    ((0, 1, 0), (2, 1, 0)),
+    ((0, 1, 1), (2, 1, 1)),
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def orbit_name(cell: Cell) -> str:
+    weight = sum(cell)
+    n_full = sum(1 for i, j in AXES if cell[i] == 1 and cell[j] == 1)
+    if weight == 0:
+        return "empty"
+    if weight == 6:
+        return "full"
+    if weight == 1:
+        return "wt1"
+    if weight == 5:
+        return "wt5"
+    if weight == 2:
+        return "opp2" if n_full == 1 else "adj2"
+    if weight == 4:
+        return "opp4" if n_full == 2 else "adj4"
+    if weight == 3:
+        return "mixed3" if n_full == 1 else "vertex3"
+    raise ValueError(cell)
+
+
+def all_cells() -> tuple[Cell, ...]:
+    return tuple(product((0, 1), repeat=6))  # type: ignore[return-value]
+
+
+def complement(cell: Cell) -> Cell:
+    return tuple(1 - bit for bit in cell)  # type: ignore[return-value]
+
+
+def axis_unbalanced(cell: Cell) -> bool:
+    return any(cell[i] != cell[j] for i, j in AXES)
+
+
+def f_l1(cell: Cell) -> int:
+    """Formation on a 6-tuple iff some axis is unbalanced (n≠0)."""
+    return int(axis_unbalanced(cell))
+
+
+def hamming_parity(cell: Cell) -> int:
+    return sum(cell) % 2
+
+
+def f_cut_from_bits(bits: Bits):
+    wt1, opp2, adj2, vertex3, mixed3 = bits
+    table = {
+        "empty": 0,
+        "full": 0,
+        "wt1": wt1,
+        "wt5": wt1,
+        "opp2": opp2,
+        "opp4": opp2,
+        "adj2": adj2,
+        "adj4": adj2,
+        "vertex3": vertex3,
+        "mixed3": mixed3,
+    }
+    return lambda cell: table[orbit_name(cell)]
+
+
+def remaining_bits(predicate) -> Bits:
+    reps: dict[str, Cell] = {}
+    for cell in all_cells():
+        name = orbit_name(cell)
+        if name not in reps:
+            reps[name] = cell
+    return tuple(int(predicate(reps[name])) for name in FREE_ORBITS)  # type: ignore[return-value]
+
+
+def neighborhood(site: Point, locked: set[Point]) -> Cell:
+    bits = []
+    for shift in SHIFTS:
+        neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        bits.append(1 if neighbor in locked else 0)
+    return tuple(bits)  # type: ignore[return-value]
+
+
+def run_locks(predicate, seed: tuple[Point, ...]) -> tuple[int, tuple[int, ...]]:
+    locked: set[Point] = set(seed)
+    history = [len(locked)]
+    for _ in range(len(VERTICES)):
+        fresh = {
+            site
+            for site in VERTICES
+            if site not in locked and predicate(neighborhood(site, locked))
+        }
+        if not fresh:
+            break
+        locked |= fresh
+        history.append(len(locked))
+    return len(locked), tuple(history)
+
+
+def fills(predicate, seed: tuple[Point, ...]) -> bool:
+    halt, _history = run_locks(predicate, seed)
+    return halt == len(VERTICES)
+
+
+def k_of(predicate) -> int:
+    return sum(1 for seed in LONG_AXIS_SEEDS if fills(predicate, seed))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo")
+    print("construction: 32 cube-covariant complement-even predicates on the two-cube, off-patch occupancy 0")
+    print("negative_scope: displayed selector only; opp2 is not written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound pair exists",
+        len(AUDIT_INPUT_PATHS) == 2
+        and AUDIT_TIMEOUT_SEC == 120
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_OPP2_LONG_AXIS_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalize(axiom) and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalize(axiom) and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalize(axiom) for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+
+    cells = all_cells()
+    orbit_counts = Counter(orbit_name(cell) for cell in cells)
+    expected_counts = {
+        "empty": 1,
+        "full": 1,
+        "wt1": 6,
+        "wt5": 6,
+        "opp2": 3,
+        "adj2": 12,
+        "vertex3": 8,
+        "mixed3": 12,
+        "opp4": 3,
+        "adj4": 12,
+    }
+    checks.check("vertex-count", "two-cube has twelve vertices", len(VERTICES) == 12 == len(set(VERTICES)))
+    checks.check(
+        "orbit-partition",
+        "proper-cube action on six-tuples has ten orbits with derived sizes",
+        orbit_counts == expected_counts,
+        residual=dict(orbit_counts),
+    )
+    complement_pairs = {
+        (orbit_name(cell), orbit_name(complement(cell)))
+        for cell in cells
+    }
+    checks.check(
+        "complement-action",
+        "complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3",
+        complement_pairs
+        == {
+            ("empty", "full"),
+            ("full", "empty"),
+            ("wt1", "wt5"),
+            ("wt5", "wt1"),
+            ("opp2", "opp4"),
+            ("opp4", "opp2"),
+            ("adj2", "adj4"),
+            ("adj4", "adj2"),
+            ("vertex3", "vertex3"),
+            ("mixed3", "mixed3"),
+        },
+        residual=complement_pairs,
+    )
+
+    f_cut_maps = tuple(product((0, 1), repeat=5))
+    checks.check("f-cut-cardinality", "five free remaining bits give 32 F_cut maps", len(f_cut_maps) == 32)
+
+    l1_bits = remaining_bits(f_l1)
+    ham_bits = remaining_bits(hamming_parity)
+    checks.check(
+        "l1-bits",
+        "n≠0 evaluates to remaining-bit tuple (1,0,1,1,1) and lies in F_cut",
+        l1_bits == (1, 0, 1, 1, 1)
+        and f_l1((0, 0, 0, 0, 0, 0)) == 0
+        and f_l1((1, 1, 1, 1, 1, 1)) == 0
+        and all(f_l1(cell) == f_l1(complement(cell)) for cell in cells),
+        residual=l1_bits,
+    )
+    checks.check(
+        "l1-not-hamming",
+        "Hamming parity is a different F_cut tuple",
+        ham_bits == (1, 0, 0, 1, 1) and ham_bits != l1_bits,
+        residual=ham_bits,
+    )
+    checks.check("theorem1-opp2", "f_L1(opp2)=0", l1_bits[1] == 0)
+
+    l1_k = k_of(f_l1)
+    l1_histories = tuple(run_locks(f_l1, seed) for seed in LONG_AXIS_SEEDS)
+    checks.check(
+        "theorem1-k",
+        "f_L1 has k=0 and halt lock-count 8 on each long-axis seed",
+        l1_k == 0 and all(halt == 8 and history == (2, 6, 8) for halt, history in l1_histories),
+        residual=(l1_k, l1_histories),
+    )
+    onesite_halt, onesite_hist = run_locks(f_l1, ((0, 0, 0),))
+    checks.check(
+        "l1-onesite-control",
+        "same predicate fills from a 1-site seed",
+        onesite_halt == 12 and onesite_hist == (1, 4, 8, 11, 12),
+        residual=(onesite_halt, onesite_hist),
+    )
+
+    rows = []
+    for bits in f_cut_maps:
+        predicate = f_cut_from_bits(bits)
+        kk = k_of(predicate)
+        rows.append((bits, kk, bits[1]))
+    k_eq_4_iff_opp = all((kk == 4) == (opp == 1) for _bits, kk, opp in rows)
+    k_eq_0_iff_silent = all((kk == 0) == (opp == 0) for _bits, kk, opp in rows)
+    counterexamples = [(bits, kk) for bits, kk, opp in rows if (kk == 4) != (opp == 1)]
+    silent_hold = all(kk == 0 for _bits, kk, opp in rows if opp == 0)
+    k_values = Counter(kk for _bits, kk, _opp in rows)
+    k4_maps = [bits for bits, kk, _opp in rows if kk == 4]
+    lex_cex = min(counterexamples)
+
+    print(f"k_eq_4_iff_f_opp2: {k_eq_4_iff_opp}")
+    print(f"k_eq_0_iff_f_opp2_silent: {k_eq_0_iff_silent}")
+    print(f"lex_counterexample_tuple: {lex_cex[0]} k={lex_cex[1]}")
+    print(f"k_spectrum: {dict(sorted(k_values.items()))}")
+    print(f"k4_maps: {k4_maps}")
+
+    checks.check("theorem2-iff-k4", "k(f)=4 is not equivalent to f(opp2)=1", k_eq_4_iff_opp is False)
+    checks.check("theorem2-iff-k0", "k(f)=0 is not equivalent to f(opp2)=0", k_eq_0_iff_silent is False)
+    checks.check(
+        "theorem2-counterexample",
+        "lex-first counterexample is (0,1,0,0,0) with k=0 and f(opp2)=1",
+        lex_cex == ((0, 1, 0, 0, 0), 0) and len(counterexamples) == 12,
+        residual=lex_cex,
+    )
+    checks.check(
+        "silent-one-way",
+        "every silent-opp2 map still has k=0 (one direction holds)",
+        silent_hold and sum(1 for _bits, _kk, opp in rows if opp == 0) == 16,
+    )
+    checks.check(
+        "k4-characterization",
+        "k=4 exactly on the four maps with (wt1,opp2,adj2)=(1,1,1)",
+        k4_maps == [(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+        and set(k_values) == {0, 4},
+        residual=k4_maps,
+    )
+    checks.check(
+        "mutation-zero-and-fullbits",
+        "zero map has k=0; remaining-bit (1,1,1,1,1) has k=4",
+        k_of(f_cut_from_bits((0, 0, 0, 0, 0))) == 0
+        and k_of(f_cut_from_bits((1, 1, 1, 1, 1))) == 4,
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "note-scope",
+        "note reports the failed equivalence, displays a counterexample, and does not adopt opp2",
+        "is not equivalent" in note
+        and "(0, 1, 0, 0, 0)" in note
+        and "Displayed, not adopted" in note
+        and "hypothetical_axiom_status: \"no edit\"" in note
+        and all(token not in note for token in forbidden),
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), filling all four long-axis 2-site seeds is not equivalent to f(opp2)=1. f_L1 is n≠0, not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_opp2_long_axis_fill_equivalence_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.