### PR TITLE
feat(k4site): k=4 1-site coverage is 12 iff vertex3=1

### DIFF
--- a/docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,301 @@
+---
+claim_id: f_cut_k4_one_site_coverage_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the four F_cut maps with (wt1, opp2, adj2)=(1,1,1) on the two-cube with off-patch o=0, 1-site coverage is 12 iff vertex3=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_k4_one_site_coverage_2026_08_15.py
+---
+
+# One-Site Coverage Of The Four k=4 `F_cut` Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill counts on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the twelve one-site seeds, for the
+four cube-covariant cut maps with remaining bits
+`(wt1, opp2, adj2)=(1,1,1)` and `vertex3 × mixed3` free.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_k4_one_site_coverage_2026_08_15.py`](../scripts/f_cut_k4_one_site_coverage_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6432/#6435 proved that four maps fill all twelve one-site seeds:
+the `opp2 × mixed3` square with `vertex3=1` (and `wt1=adj2=1`). Investment
+#6443 named a different four, the k=4 class, as the maps with
+`(wt1, opp2, adj2)=(1,1,1)` that fill the four long-axis 2-site seeds. That
+class includes two maps with `vertex3=0`. This note scores 1-site coverage
+on that newly named four. New domain on the newly named 4. Not
+leftover-character of #6435 (that named the four 1-site maximizers among all
+32). Not leftover-character of #6443 (that only reported k).
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+Remaining bits are ordered as `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`, which
+is not a k=4 map (`opp2=0`).
+
+Write `k4cov` for the four remaining-bit tuples
+
+```text
+(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+On the two-cube with off-patch occupancy `0`, write
+`cov1(f) = |{x : f fills from {x}}|`. Then:
+
+- Theorem 1. The two maps with `vertex3=1` reconfirm `cov1 = 12`
+  (`#6435`): `cov1((1, 1, 1, 1, 0)) = 12` and
+  `cov1((1, 1, 1, 1, 1)) = 12`.
+- Theorem 2. The two maps with `vertex3=0` miss one-site seeds:
+  `cov1((1, 1, 1, 0, 0)) = 8` and `cov1((1, 1, 1, 0, 1)) = 8`. Each misses
+  the four shared-face sites `(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`.
+- Theorem 3. Inside this four, `cov1 = 12` if and only if `vertex3=1`.
+  Displayed, not adopted.
+
+Inside `k4cov`, `vertex3=1` is required for 1-site totality. Do not adopt
+`vertex3`. Do not write `vertex3` into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The four k=4 F_cut maps are scored exactly on the twelve one-site seeds of the two-cube. The two vertex3=1 maps have cov1=12; the two vertex3=0 maps have cov1=8. Inside this four, cov1=12 iff vertex3=1. Displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_k4_one_site_coverage
+target_blocker_text: "whether the two vertex3=0 maps in the k=4 class miss 1-site seeds"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded k=4 1-site coverage table; do not adopt vertex3"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the four-map set `k4cov` with remaining bits
+  `(wt1, opp2, adj2)=(1,1,1)` and `vertex3 × mixed3` free.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Score `cov1` on the four `k4cov` maps and state whether
+`cov1=12` is equivalent to `vertex3=1` inside that four.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The one-site seeds are the twelve singletons `{x}` for `x ∈ T`. Then
+`cov1(f)` is the number of those singletons from which `f` fills.
+
+## Theorems
+
+### Theorem 1 — the two `vertex3=1` maps have `cov1=12`
+
+The maps `(1, 1, 1, 1, 0)` and `(1, 1, 1, 1, 1)` are the `vertex3=1` side
+of `k4cov`. Direct evolution on each of the twelve singletons reconfirms
+
+```text
+cov1((1, 1, 1, 1, 0)) = 12
+cov1((1, 1, 1, 1, 1)) = 12
+```
+
+as in #6435. Each fills every one-site seed.
+
+### Theorem 2 — the two `vertex3=0` maps have `cov1=8`
+
+The maps `(1, 1, 1, 0, 0)` and `(1, 1, 1, 0, 1)` are the `vertex3=0` side
+of `k4cov`. Direct evolution gives
+
+```text
+cov1((1, 1, 1, 0, 0)) = 8
+cov1((1, 1, 1, 0, 1)) = 8
+```
+
+Each fills the eight corner-ring sites with `x ∈ {0,2}` and misses the four
+shared-face sites
+
+```text
+(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1).
+```
+
+They miss 1-site seeds.
+
+### Theorem 3 — `cov1=12` iff `vertex3=1` inside this four
+
+Among the four `k4cov` maps, `cov1=12` if and only if `vertex3=1`. The two
+maps with `vertex3=0` have `cov1=8 < 12`. Displayed, not adopted. Do not
+write `vertex3` into Admissibility.
+
+Inside this four, `vertex3` is required for 1-site totality. That is a
+displayed equivalence on a named four-map set, not a physical selector.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` remaining-bit order | declared |
+| `k4cov` as the four `(1,1,1,*,*)` maps | declared |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, twelve one-site seeds, off-patch 0 | declared finite patch |
+| `cov1` of the two `vertex3=1` maps is 12 | proved by evolution |
+| `cov1` of the two `vertex3=0` maps is 8 | proved by evolution |
+| `cov1=12` iff `vertex3=1` inside this four | proved; displayed, not adopted |
+| leftover-character of #6435 or #6443 | refused; new domain on the named 4 |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6435: that named the four 1-site maximizers among
+all 32 `F_cut` maps. Not leftover-character of #6443: that only reported `k`
+on the long-axis four. The present count is `cov1` of those four maps on
+twelve singletons.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write `vertex3` into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the two `vertex3=0` k=4 maps miss 1-site seeds. |
+| V2 | Current main has the 32-map 1-site ranking but no landed `cov1` table of the k=4 four. |
+| V3 | The four maps, 12 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared four-map class. |
+| V5 | It is not a physical selector: the `vertex3` equivalence is displayed, not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: inside the four k=4 maps, 1-site totality
+requires `vertex3=1`. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover 1-site ranking | treat the k=4 table as leftover-character of #6435 | **ATTEMPTED** |
+| leftover k-count | treat `cov1` as leftover-character of #6443 | **ATTEMPTED** |
+| adopt `vertex3` | write `vertex3=1` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch count to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed `vertex3=0` totality, the Hamming contrast, and the off-patch
+convention are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the twelve singletons, off-patch occupancy `0`, occupancy-to-lock
+ticks, the `F_cut` remaining-bit order, and the named four `k4cov` maps are
+declared. Physical selection of `vertex3` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the 1-site coverage
+table of the k=4 four on the declared patch, not leftover-character of #6435
+or #6443.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the four `k4cov` maps scored on 12 seeds | no physical law selection |
+| per block | `cov1=12` iff `vertex3=1` on this four | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than 1-site totality inside `k4cov`, and any independently
+derived physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** the k=4 bits already fill every long-axis 2-site seed, so they
+fill every one-site seed as well.
+
+**Answer:** The two `vertex3=0` maps fill only eight of the twelve one-site
+seeds. Inside this four, 1-site totality requires the extra bit `vertex3=1`.
+That extra is displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6435 already showed that the 1-site maximizers are exactly the
+`opp2 × mixed3` square with `vertex3=1`. The present count is a new domain:
+the k=4 four, two of which lie off that square. Echoing the maximizer list
+is not a substitute for scoring those two maps.
+
+No-Go Discipline disposition: **PASS** for the finite four-map table and the
+narrow displayed equivalence. FAIL / DO NOT SHIP for “`vertex3` is the
+physical rule” or “the k=4 bits already give 1-site totality.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner builds the four `k4cov` maps from remaining bits, scores
+`cov1` on the twelve one-site seeds, reconfirms that the two `vertex3=1` maps
+have `cov1=12`, reports `cov1=8` for the two `vertex3=0` maps, and checks
+that `cov1=12` if and only if `vertex3=1` inside this four. Declared audit
+inputs are this note and the axiom memo; the runner writes no cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5536,
+ "edge_count": 15739,
+ "node_count": 5537,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_k4_one_site_coverage_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_k4_one_site_coverage_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_k4_one_site_coverage_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_k4_one_site_coverage_2026_08_15.py
+runner_sha256: 36e25282f378852dcc63f2afd989457cf970458ccfa04294821a15fe5dad0b97
+input_fingerprint_sha256: 71485a6a8953a98f6faffed58e7bf84faaa00d10e19b5fb247c33b41f78eb6cf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+k4cov=[(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+n_one_site_seeds=12
+cov1(1, 1, 1, 0, 0)=8 missed=((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+cov1(1, 1, 1, 0, 1)=8 missed=((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+cov1(1, 1, 1, 1, 0)=12 missed=()
+cov1(1, 1, 1, 1, 1)=12 missed=()
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_in_k4cov=False
+cov1_eq_12_iff_vertex3=True
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-f-L1-not-hamming f_L1 is unbalanced-axis and is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-twelve-seeds the two-cube has twelve vertices and twelve one-site seeds
+PASS: thm1-k4cov-in-f-cut the four k=4 remaining-bit tuples are F_cut maps with (wt1,opp2,adj2)=(1,1,1)
+PASS: thm1-vertex3-one-cov1-twelve cov1((1,1,1,1,0))=12 and cov1((1,1,1,1,1))=12
+PASS: thm2-vertex3-zero-cov1-eight cov1((1,1,1,0,0))=8 and cov1((1,1,1,0,1))=8
+PASS: thm3-cov1-twelve-iff-vertex3 inside k4cov, cov1=12 iff vertex3=1
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted vertex3 equivalence, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt vertex3
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6435-or-6443 the residual is k=4 1-site coverage, not leftover-character of #6435 or #6443
+PASS: claim-scope-equivalence claim_scope states cov1=12 iff vertex3=1 inside the four k=4 maps
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the four k=4 maps is scored on the 12 one-site seeds
+per_block: checked exactly — inside k4cov, cov1=12 iff vertex3=1
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_k4_one_site_coverage_2026_08_15.py
+++ b/scripts/f_cut_k4_one_site_coverage_2026_08_15.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Exact 1-site fill coverage of the four k=4 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The four k=4 maps are remaining-bit tuples with
+(wt1, opp2, adj2)=(1,1,1) and vertex3 x mixed3 free. Coverage cov1(f) is
+the number of one-site seeds from which f fills. f_L1 is the unbalanced-axis
+predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+ONE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset([site]) for site in TWO_CUBE
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+K4COV: tuple[tuple[int, ...], ...] = (
+    (1, 1, 1, 0, 0),
+    (1, 1, 1, 0, 1),
+    (1, 1, 1, 1, 0),
+    (1, 1, 1, 1, 1),
+)
+SHARED_FACE: frozenset[Site] = frozenset(
+    ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def predicate_from_remaining(remaining: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(config, remaining)
+
+    return predicate
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage_and_misses(predicate) -> tuple[int, tuple[Site, ...]]:
+    missed: list[Site] = []
+    filled = 0
+    for seed in ONE_SITE_SEEDS:
+        if fills_from_seed(predicate, seed):
+            filled += 1
+        else:
+            missed.append(next(iter(seed)))
+    return filled, tuple(sorted(missed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut_remaining(remaining: tuple[int, ...]) -> bool:
+    if len(remaining) != 5 or any(bit not in (0, 1) for bit in remaining):
+        return False
+    predicate = predicate_from_remaining(remaining)
+    if predicate(EMPTY) != 0 or predicate(FULL) != 0:
+        return False
+    return all(
+        predicate(config)
+        == predicate(tuple(1 - bit for bit in config))  # type: ignore[arg-type]
+        for config in product((0, 1), repeat=6)
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    scored: dict[tuple[int, ...], tuple[int, tuple[Site, ...]]] = {}
+    for remaining in K4COV:
+        predicate = predicate_from_remaining(remaining)
+        scored[remaining] = coverage_and_misses(predicate)
+    cov_by_remaining = {remaining: scored[remaining][0] for remaining in K4COV}
+    miss_by_remaining = {remaining: scored[remaining][1] for remaining in K4COV}
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    iff_vertex3 = all(
+        (cov_by_remaining[remaining] == 12) == (remaining[3] == 1) for remaining in K4COV
+    )
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"k4cov={list(K4COV)}")
+    print(f"n_one_site_seeds={len(ONE_SITE_SEEDS)}")
+    for remaining in K4COV:
+        print(
+            f"cov1{remaining}={cov_by_remaining[remaining]} "
+            f"missed={miss_by_remaining[remaining]}"
+        )
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_L1_in_k4cov={l1_remaining in K4COV}")
+    print(f"cov1_eq_12_iff_vertex3={iff_vertex3}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_K4_ONE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is unbalanced-axis and is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and l1_remaining == (1, 0, 1, 1, 1)
+        and l1_remaining not in K4COV
+        and all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-twelve-seeds",
+        "the two-cube has twelve vertices and twelve one-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(ONE_SITE_SEEDS) == 12
+        and len(set(ONE_SITE_SEEDS)) == 12
+        and all(seed <= set(TWO_CUBE) and len(seed) == 1 for seed in ONE_SITE_SEEDS)
+        and SHARED_FACE <= set(TWO_CUBE)
+        and len(SHARED_FACE) == 4,
+    )
+    checks.check(
+        "thm1-k4cov-in-f-cut",
+        "the four k=4 remaining-bit tuples are F_cut maps with (wt1,opp2,adj2)=(1,1,1)",
+        all(in_f_cut_remaining(remaining) for remaining in K4COV)
+        and all(remaining[:3] == (1, 1, 1) for remaining in K4COV)
+        and {remaining[3:] for remaining in K4COV} == {(0, 0), (0, 1), (1, 0), (1, 1)},
+    )
+    checks.check(
+        "thm1-vertex3-one-cov1-twelve",
+        "cov1((1,1,1,1,0))=12 and cov1((1,1,1,1,1))=12",
+        cov_by_remaining[(1, 1, 1, 1, 0)] == 12
+        and cov_by_remaining[(1, 1, 1, 1, 1)] == 12
+        and miss_by_remaining[(1, 1, 1, 1, 0)] == ()
+        and miss_by_remaining[(1, 1, 1, 1, 1)] == ()
+        and "cov1((1, 1, 1, 1, 0)) = 12" in note
+        and "cov1((1, 1, 1, 1, 1)) = 12" in note,
+    )
+    checks.check(
+        "thm2-vertex3-zero-cov1-eight",
+        "cov1((1,1,1,0,0))=8 and cov1((1,1,1,0,1))=8",
+        cov_by_remaining[(1, 1, 1, 0, 0)] == 8
+        and cov_by_remaining[(1, 1, 1, 0, 1)] == 8
+        and set(miss_by_remaining[(1, 1, 1, 0, 0)]) == set(SHARED_FACE)
+        and set(miss_by_remaining[(1, 1, 1, 0, 1)]) == set(SHARED_FACE)
+        and "cov1((1, 1, 1, 0, 0)) = 8" in note
+        and "cov1((1, 1, 1, 0, 1)) = 8" in note,
+    )
+    checks.check(
+        "thm3-cov1-twelve-iff-vertex3",
+        "inside k4cov, cov1=12 iff vertex3=1",
+        iff_vertex3
+        and all(remaining[3] == 1 for remaining in K4COV if cov_by_remaining[remaining] == 12)
+        and all(remaining[3] == 0 for remaining in K4COV if cov_by_remaining[remaining] != 12)
+        and "`cov1=12` if and only if `vertex3=1`" in note_flat,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted vertex3 equivalence, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt vertex3",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write `vertex3` into Admissibility" in note
+        and "Do not adopt" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6435-or-6443",
+        "the residual is k=4 1-site coverage, not leftover-character of #6435 or #6443",
+        "Not leftover-character of #6435" in note
+        and "Not leftover-character of #6443" in note
+        and "that only reported k" in note
+        and "New domain on the newly named 4" in note,
+    )
+    checks.check(
+        "claim-scope-equivalence",
+        "claim_scope states cov1=12 iff vertex3=1 inside the four k=4 maps",
+        "Among the four F_cut maps with" in note
+        and "(wt1, opp2, adj2)=(1,1,1)" in note
+        and "off-patch o=0" in note
+        and "1-site coverage is 12 iff vertex3=1" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the four k=4 maps is scored on the 12 one-site seeds")
+    print("per_block: checked exactly — inside k4cov, cov1=12 iff vertex3=1")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the four F_cut maps with (wt1, opp2, adj2)=(1,1,1) on the two-cube (off-patch o=0), 1-site coverage is 12 iff vertex3=1. f_L1 is n≠0, not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_k4_one_site_coverage_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.