### PR TITLE
feat(k4v30dyn): k=4 map (1,1,1,0,0) 1-site history disagrees with L1

### DIFF
--- a/docs/F_CUT_K4_V30_ONE_SITE_HALT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_K4_V30_ONE_SITE_HALT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,263 @@
+---
+claim_id: f_cut_k4_v30_one_site_halt_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the F_cut map (1, 1, 1, 0, 0) has the reported 1-site lock history (1, 4, 8, 10, 11, 12). Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py
+---
+
+# One-Site Halt Of The `k=4` Map `(1, 1, 1, 0, 0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-to-lock dynamics of the `F_cut` remaining-bit tuple
+`(wt1, opp2, adj2, vertex3, mixed3)=(1, 1, 1, 0, 0)` on the twelve-vertex
+two-cube from the seed `(0,0,0)` with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py`](../scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py)
+
+## Result up front
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}` the three cuts
+`f(empty)=f(full)=0` and `f(c)=f(1-c)` leave `|F_cut|=32`. Remaining-bit
+tuples are written in the order `(wt1, opp2, adj2, vertex3, mixed3)`. The
+four maps with `(wt1, opp2, adj2)=(1, 1, 1)` are exactly the maps that fill
+all four long-axis 2-site seeds (`k=4`). Among those four, the two
+`vertex3=1` maps are the cov=66 maximizers. The displayed member
+
+```text
+f = (1, 1, 1, 0, 0)
+```
+
+is a `k=4` long-axis filler that is **not** a cov=66 maximizer (`vertex3=0`;
+`cov(f)=36`). Complements of the named remaining orbits are forced by the
+three cuts.
+
+From the 1-site seed `(0,0,0)` with off-patch occupancy `0` the map fills:
+`|locks_halt|=12`, halt tick `T = 5`, lock history `(1, 4, 8, 10, 11, 12)`.
+
+The L1 map `f_L1(c)=1` if and only if some axis is unbalanced fills from the
+same seed with history `(1, 4, 8, 11, 12)`. The two histories do **not**
+agree. The 1-site lock sequence of this named bit-tuple is dynamically
+distinct from L1. Displayed, not adopted. Do not write f into Admissibility.
+
+Not leftover-character of #6443 (that named the `k=4` long-axis filler and
+that it is not a cov=66 maximizer; it did not report the 1-site lock
+history). `f_L1` is `n≠0`, not Hamming.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The F_cut map (1, 1, 1, 0, 0) fills the four long-axis 2-site seeds and has an exact 1-site lock history on the twelve-vertex two-cube. The map is displayed, not adopted as the physical Admissibility rule."
+trace_class: upstream_support
+target_claim_id: admissibility_nearest_neighbor_rule
+target_blocker_text: "display the 1-site lock history of the k=4 non-maximizer (1, 1, 1, 0, 0) without writing it into Admissibility"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "keep f displayed; do not adopt it or identify it with f_L1 from one 1-site history"
+conditional_surface_status: "exact for the twelve-vertex two-cube, 1-site seed, and off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared objects
+
+The only scientific dependency is the current four-axiom authority
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). That memo
+supplies the cubic lattice `Z^3`, proper cubic rotations about each site, and
+one fixed nearest-neighbor admissibility rule covariant under lattice
+translations and those rotations. Records form; a present record locks exactly
+one admissible local possibility. A site with no record cannot be read.
+
+The following are declared finite scaffolding, not a physical-law selection:
+
+- the two-cube `V = {0,1,2}×{0,1}×{0,1}` (twelve vertices);
+- the 1-site seed `S_0 = {(0,0,0)}`;
+- off-patch occupancy `0` (a neighbor outside `V` is unread; a blank-block is a different rule);
+- the six-direction nearest-neighbor stencil
+  `{±e_x, ±e_y, ±e_z}`;
+- cube-covariant predicates on occupancy 6-tuples `c ∈ {0,1}^6`.
+
+For each axis `μ`, write `n_μ = c_{+μ} − c_{-μ}`. An axis is **unbalanced**
+when `n_μ` is nonzero, **both-occupied** when `c_{+μ}=c_{-μ}=1`, and **empty**
+when `c_{+μ}=c_{-μ}=0`. The axis type of `c` is the triple
+`(n_unbalanced, n_both, n_empty)`. The 24 proper cube rotations partition the
+64 cells into ten axis-type orbits. The named remaining bits are
+
+```text
+wt1=(1,0,2), opp2=(0,1,2), adj2=(2,0,1), vertex3=(3,0,0), mixed3=(1,1,1).
+```
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. Complements of the five
+named remaining orbits are forced, so `|F_cut|=32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced, equivalently
+`n_μ = c_{+μ} − c_{-μ}` is nonzero for at least one axis. This is **not** Hamming parity `|c|_1 mod 2`. The definition is never Hamming. Its remaining-bit
+tuple is `(1, 0, 1, 1, 1)`.
+
+The four long-axis 2-site seeds are
+
+```text
+M = {((0,0,0),(2,0,0)), ((0,0,1),(2,0,1)), ((0,1,0),(2,1,0)), ((0,1,1),(2,1,1))}.
+```
+
+`k(f)` is the number of seeds in `M` from which `f` fills `V`. The four maps
+with `(wt1, opp2, adj2)=(1, 1, 1)` are exactly the maps with `k=4`.
+
+A **tick** locks every unlocked site of `V` whose current 6-neighbor occupancy
+tuple has predicate value 1. The process starts from `S_0` and halts at the
+first tick `T` with `locks_{T} = locks_{T-1}` (or at `T=0` if the first wave
+is empty). Fill means `|locks_halt|=12`. The **lock history** is the sequence
+of lock cardinalities from the seed through halt, including the seed count.
+Coverage `cov(f)` is the number of unordered 2-site seeds of `V` from which
+`f` fills.
+
+## Exact statements
+
+**Theorem 1.** The `F_cut` map `f` with remaining-bit tuple `(1, 1, 1, 0, 0)`
+fills all four long-axis 2-site seeds: `k(f)=4`. It is not a cov=66
+maximizer: `vertex3=0` and `cov(f)=36`.
+
+**Theorem 2.** Run `f` from `(0,0,0)` with off-patch occupancy `0`. It fills:
+`|locks_halt|=12`, `T = 5`, lock history `(1, 4, 8, 10, 11, 12)`.
+
+**Theorem 3.** `f_L1` fills from the same seed with lock history
+`(1, 4, 8, 11, 12)`. The two histories do not agree. The history
+`(1, 4, 8, 10, 11, 12)` is displayed. Do not adopt `f`. Do not write `f`
+into Admissibility. Unequal 1-site histories do not license an identity of
+members.
+
+### Computed values
+
+| object | value |
+|---|---|
+| `\|V\|` | 12 |
+| seed | `(0,0,0)` |
+| off-patch occupancy | `0` |
+| `\|F_cut\|` | 32 |
+| `f` named tuple | `(1, 1, 1, 0, 0)` |
+| `f ∈ F_cut` | yes |
+| `k(f)` on the long-axis four | 4 |
+| `vertex3(f)` | 0 |
+| `cov(f)` | 36 |
+| cov=66 maximizers | `(1, 1, 1, 1, 0)`, `(1, 1, 1, 1, 1)` |
+| `f` halt locks | 12 |
+| `f` halt tick `T` | 5 |
+| `f` lock history | `(1, 4, 8, 10, 11, 12)` |
+| `f_L1` named tuple | `(1, 0, 1, 1, 1)` |
+| `f_L1` lock history | `(1, 4, 8, 11, 12)` |
+| histories equal | no |
+
+On this seed the first two waves coincide with L1: the seed; then the three
+axis neighbors; then the four weight-2 sites of the seeded cube together with
+`(2,0,0)`. At the next tick `f_L1` locks three further sites (cardinality 11),
+while `f` locks only `(2,0,1)` and `(2,1,0)` (cardinality 10): the
+space-diagonal site `(1,1,1)` first sees a `vertex3` neighborhood, which `f`
+silences. Tick 4 then locks `(2,1,1)` (cardinality 11). Tick 5 locks
+`(1,1,1)` once its neighborhood has left `vertex3`, completing the two-cube.
+
+## No-Go Discipline
+
+The note is a displayed finite history, not a no-go against other members or
+against a later derived Admissibility selector.
+
+No-Go Discipline disposition: **PASS**
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| adopt `f` because it is a `k=4` long-axis filler | **ATTEMPTED** | `#6443` names the filler; this lane only runs the 1-site history |
+| treat the 1-site history as identifying `f` with `f_L1` | **ATTEMPTED** | the histories differ; `opp2`, `vertex3`, and `mixed3` still differ |
+| treat this residual as leftover-character of #6443 | **ATTEMPTED** | #6443 named `k=4` and non-maximizer status; it did not report `T` or the lock sequence |
+| treat this residual as leftover of the cov=66 ranking | **ATTEMPTED** | coverage ranking selected the two `vertex3=1` maps; `f` is not a maximizer |
+| treat Hamming-parity formation as this residual | **ATTEMPTED** | Hamming is a different member and does not fill |
+| write `f` into Admissibility | **ATTEMPTED** | the history is displayed; no axiom or approved primitive is added |
+
+### N2 — wall independence
+
+One computational wall is claimed: the halt tick and lock history of this
+named map on this seed. The `k=4` identity and the non-maximizer status are
+prior identities, not a second impossibility wall.
+
+### N3 — hidden-wall scan
+
+The two-cube, seed, off-patch occupancy `0`, six-direction stencil, three
+cuts, long-axis four, and axis-type orbits are declared. No `Z^3`-wide
+formation law, physical Admissibility selector, Hamming identification, or
+continuum extension is imported.
+
+### N4 — residual matching
+
+The residual after #6443 is the executable 1-site lock history of the named
+`k=4` non-maximizer, not a restatement of `k` or of coverage. This note
+reports only that 1-site halt history and its disagreement with L1.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per-site: executed — each of the twelve two-cube vertices uses the same six-direction stencil
+per-mode: executed — the named F_cut map is run from the 1-site seed and from the four long-axis seeds
+per-block: executed — the named map is run to a fixed point from the 1-site seed
+lattice-wide: not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+```
+
+### N6 — partial-closure paths
+
+A later derivation could still select `f_L1`, select `f`, or select neither.
+Unequal 1-site histories leave those routes live. A different seed or a later
+selector can still prefer either map.
+
+### N7 — steelman
+
+The strongest objection is that a one-tick delay on two sites is a patch
+artifact of silencing `vertex3` on this seed, so the maps remain interchangeable
+for every later argument. Incorrect on the stated objects: the predicates
+differ on `opp2`, `vertex3`, and `mixed3`, the lock *sets* differ from tick 3
+onward, and a neighborhood of a silenced type can split them on this patch or
+another seed.
+
+### N8 — cross-cycle echo
+
+#6443 named `(1, 1, 1, 0, 0)` as a long-axis filler that is not a cov=66
+maximizer and stopped there. Coverage ranking named the two `vertex3=1`
+maximizers. Hamming and L1 1-site lanes execute other members. This note adds
+only the 1-site halt history of the already-named `k=4` non-maximizer.
+
+## Boundaries and explicit non-claims
+
+- The theorem is conditional on the two-cube, the 1-site seed, and off-patch
+  occupancy `0`.
+- Unequal lock histories are not an identity of members, and equal histories
+  on another seed would not be an identity either.
+- `f` is displayed, not adopted.
+- Do not write `f` into Admissibility.
+- No `Z^3`-wide formation process, rate, or physical-law selection is claimed.
+- No axiom, approved primitive, registry, or audit verdict is edited.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py
+```
+
+The runner rebuilds the 24 proper rotations and ten axis-type orbits,
+recomputes the 32-element `F_cut`, confirms `k(f)=4` on the long-axis four,
+and runs `f` and `f_L1` from `(0,0,0)`.
+Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5536,
+ "edge_count": 15739,
+ "node_count": 5537,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_k4_v30_one_site_halt_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_k4_v30_one_site_halt_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_k4_v30_one_site_halt_2026_08_15.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py
+runner_sha256: e768a65f90a4f12647fb1281f5809e82c6b46cbeb3f90d801462645f85d34f25
+input_fingerprint_sha256: 6acbbb1b38228cec01fe5fa26d1aee62417298fc1330449ad3f841b21bc20f41
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_K4_V30_ONE_SITE_HALT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+N_free=5
+|F_cut|=32
+n_long_axis_seeds=4
+f_bits=(1, 1, 1, 0, 0) supp=42 k=4 cov=36
+f_locks=12 halt=5 history=(1, 4, 8, 10, 11, 12)
+f_L1_bits=(1, 0, 1, 1, 1) locks=12 history=(1, 4, 8, 11, 12)
+histories_equal=False
+f_hamming_bits=(1, 0, 0, 1, 1) locks=9 history=(1, 4, 5, 7, 9)
+k4_members=[(1, 1, 1, 0, 0), (1, 1, 1, 1, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 1)]
+maximizer_cov={(1, 1, 1, 1, 0): 66, (1, 1, 1, 1, 1): 66}
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-two-cube-twelve the two-cube has twelve vertices and contains the seed
+PASS: thm1-four-long-axis-seeds exactly four long-axis 2-site seeds of the form ((0,y,z),(2,y,z))
+PASS: thm1-f-fills-long-axis f=(1,1,1,0,0) fills all four long-axis 2-site seeds
+PASS: thm1-not-cov66-maximizer f is not a cov=66 maximizer: vertex3=0 and cov(f)=36
+PASS: thm2-f-from-origin-fills f fills from (0,0,0): |locks_halt|=12 with reported T and history
+PASS: thm2-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_- (n != 0)
+PASS: thm2-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm2-f-L1-history f_L1 fills with history (1,4,8,11,12)
+PASS: thm3-histories-unequal f lock history does not equal the L1 history on this seed
+PASS: thm3-displayed-not-adopted the named k=4 map and f_L1 are displayed, not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: f-definition-in-note the note names f as the remaining-bit tuple (1, 1, 1, 0, 0)
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: claim-scope-and-history claim_scope reports the lock history and does not adopt f
+PASS: not-leftover-6443 the residual is the 1-site halt history, not leftover-character of #6443
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: no-cache-write this run did not emit a runner cache file
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0
+per_mode: checked exactly — the named F_cut map is run from the 1-site seed and the long-axis four
+per_block: checked exactly — named k=4 non-maximizer is run to a fixed point from the 1-site seed
+lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py
+++ b/scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""1-site halt of the k=4 F_cut map (1,1,1,0,0).
+
+On the twelve-vertex two-cube with seed (0,0,0) and off-patch occupancy 0,
+f is the F_cut remaining-bit tuple (wt1, opp2, adj2, vertex3, mixed3)=(1,1,1,0,0).
+It fills the four long-axis 2-site seeds (k=4) and is not a cov=66 maximizer
+(vertex3=0).  Report T, lock history, and whether the history agrees with
+f_L1.  f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2.  The history is displayed, not adopted, and is not leftover-
+character of the #6443 k=4 naming.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_K4_V30_ONE_SITE_HALT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+BitTuple = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: Site = (0, 0, 0)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+LONG_AXIS_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(((0, y, z), (2, y, z))) for y in (0, 1) for z in (0, 1)
+)
+
+WT1: OrbitType = (1, 0, 2)
+OPP2: OrbitType = (0, 1, 2)
+ADJ2: OrbitType = (2, 0, 1)
+VERTEX3: OrbitType = (3, 0, 0)
+MIXED3: OrbitType = (1, 1, 1)
+DISPLAYED_BITS: BitTuple = (1, 1, 1, 0, 0)
+L1_BITS: BitTuple = (1, 0, 1, 1, 1)
+MAXIMIZER_BITS: tuple[BitTuple, ...] = ((1, 1, 1, 1, 0), (1, 1, 1, 1, 1))
+K4_PREFIX: tuple[int, int, int] = (1, 1, 1)
+ORBIT_PAIR_SIZE = {
+    WT1: 12,
+    OPP2: 6,
+    ADJ2: 24,
+    VERTEX3: 8,
+    MIXED3: 12,
+}
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_kind = axis_type(config)
+        if any(axis_type(member) != orbit_kind for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_kind] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_predicate(
+    predicate, seed: frozenset[Site] | set[Site]
+) -> tuple[int, int, tuple[int, ...]]:
+    locked = set(seed)
+    history = [len(locked)]
+    halt_tick = 0
+    for tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            halt_tick = tick
+            break
+        locked = nxt
+        history.append(len(locked))
+    else:
+        halt_tick = 13
+    return len(locked), halt_tick, tuple(history)
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    n_locks, _halt, _history = run_predicate(predicate, seed)
+    return n_locks == 12
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def long_axis_k(predicate) -> int:
+    return sum(1 for seed in LONG_AXIS_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate,
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> BitTuple:
+    assignment: dict[OrbitType, int] = {}
+    for orbit_kind in orbit_types:
+        sample = next(iter(orbits[orbit_kind]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_kind]):
+            raise RuntimeError("predicate is not cube-covariant")
+        assignment[orbit_kind] = value
+    return (
+        assignment[WT1],
+        assignment[OPP2],
+        assignment[ADJ2],
+        assignment[VERTEX3],
+        assignment[MIXED3],
+    )
+
+
+def assignment_from_bits(bits: BitTuple) -> dict[OrbitType, int]:
+    return {
+        (0, 0, 3): 0,
+        (0, 3, 0): 0,
+        WT1: bits[0],
+        (1, 2, 0): bits[0],
+        OPP2: bits[1],
+        (0, 2, 1): bits[1],
+        ADJ2: bits[2],
+        (2, 1, 0): bits[2],
+        VERTEX3: bits[3],
+        MIXED3: bits[4],
+    }
+
+
+def predicate_from_bits(bits: BitTuple, type_of: dict[Config, OrbitType]):
+    assignment = assignment_from_bits(bits)
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def complement_cell(config: Config) -> Config:
+    return (
+        1 - config[0],
+        1 - config[1],
+        1 - config[2],
+        1 - config[3],
+        1 - config[4],
+        1 - config[5],
+    )
+
+
+def predicate_in_f_cut(predicate) -> bool:
+    if int(predicate(EMPTY)) != 0 or int(predicate(FULL)) != 0:
+        return False
+    return all(
+        int(predicate(config)) == int(predicate(complement_cell(config)))
+        for config in product((0, 1), repeat=6)
+    )
+
+
+def in_f_cut(bits: BitTuple, type_of: dict[Config, OrbitType]) -> bool:
+    return predicate_in_f_cut(predicate_from_bits(bits, type_of))
+
+
+def support_of_bits(bits: BitTuple) -> int:
+    return (
+        ORBIT_PAIR_SIZE[WT1] * bits[0]
+        + ORBIT_PAIR_SIZE[OPP2] * bits[1]
+        + ORBIT_PAIR_SIZE[ADJ2] * bits[2]
+        + ORBIT_PAIR_SIZE[VERTEX3] * bits[3]
+        + ORBIT_PAIR_SIZE[MIXED3] * bits[4]
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    empty_type = (0, 0, 3)
+    full_type = (0, 3, 0)
+    for orbit_kind in orbit_types:
+        if orbit_kind in used:
+            continue
+        image = complement_type(orbit_kind)
+        if image == orbit_kind:
+            fixed.append(orbit_kind)
+        else:
+            pair = tuple(sorted((orbit_kind, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_kind)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_kind for orbit_kind in fixed if orbit_kind not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_remaining_bits() -> list[BitTuple]:
+    members: list[BitTuple] = []
+    for mask in range(32):
+        bits: BitTuple = (
+            (mask >> 0) & 1,
+            (mask >> 1) & 1,
+            (mask >> 2) & 1,
+            (mask >> 3) & 1,
+            (mask >> 4) & 1,
+        )
+        members.append(bits)
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_kind: len(orbits[orbit_kind]) for orbit_kind in orbit_types}
+    type_of = {config: orbit_kind for orbit_kind, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    displayed_pred = predicate_from_bits(DISPLAYED_BITS, type_of)
+    displayed_locks, displayed_halt, displayed_history = run_predicate(
+        displayed_pred, {SEED}
+    )
+    displayed_k = long_axis_k(displayed_pred)
+    displayed_cov = coverage(displayed_pred)
+    displayed_support = support_of_bits(DISPLAYED_BITS)
+    displayed_support_direct = sum(
+        1 for cell in product((0, 1), repeat=6) if displayed_pred(cell)
+    )
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_locks, l1_halt, l1_history = run_predicate(f_L1, {SEED})
+    ham_locks, _ham_halt, ham_history = run_predicate(f_hamming, {SEED})
+    l1_support_direct = sum(1 for cell in product((0, 1), repeat=6) if f_L1(cell))
+    histories_equal = displayed_history == l1_history
+
+    maximizer_cov = {
+        bits: coverage(predicate_from_bits(bits, type_of)) for bits in MAXIMIZER_BITS
+    }
+    k4_members = [
+        bits for bits in enumerate_remaining_bits() if bits[:3] == K4_PREFIX
+    ]
+    k4_k_values = {
+        bits: long_axis_k(predicate_from_bits(bits, type_of)) for bits in k4_members
+    }
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_long_axis_seeds={len(LONG_AXIS_SEEDS)}")
+    print(f"f_bits={DISPLAYED_BITS} supp={displayed_support} k={displayed_k} cov={displayed_cov}")
+    print(f"f_locks={displayed_locks} halt={displayed_halt} history={displayed_history}")
+    print(f"f_L1_bits={l1_bits} locks={l1_locks} history={l1_history}")
+    print(f"histories_equal={histories_equal}")
+    print(f"f_hamming_bits={ham_bits} locks={ham_locks} history={ham_history}")
+    print(f"k4_members={k4_members}")
+    print(f"maximizer_cov={maximizer_cov}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_K4_V30_ONE_SITE_HALT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_K4_V30_ONE_SITE_HALT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and in_f_cut(DISPLAYED_BITS, type_of),
+    )
+    checks.check(
+        "thm1-two-cube-twelve",
+        "the two-cube has twelve vertices and contains the seed",
+        len(TWO_CUBE) == 12 and len(set(TWO_CUBE)) == 12 and SEED in TWO_CUBE,
+    )
+    checks.check(
+        "thm1-four-long-axis-seeds",
+        "exactly four long-axis 2-site seeds of the form ((0,y,z),(2,y,z))",
+        len(LONG_AXIS_SEEDS) == 4
+        and len(set(LONG_AXIS_SEEDS)) == 4
+        and all(len(seed) == 2 and seed <= set(TWO_CUBE) for seed in LONG_AXIS_SEEDS)
+        and LONG_AXIS_SEEDS
+        == (
+            frozenset(((0, 0, 0), (2, 0, 0))),
+            frozenset(((0, 0, 1), (2, 0, 1))),
+            frozenset(((0, 1, 0), (2, 1, 0))),
+            frozenset(((0, 1, 1), (2, 1, 1))),
+        ),
+    )
+    checks.check(
+        "thm1-f-fills-long-axis",
+        "f=(1,1,1,0,0) fills all four long-axis 2-site seeds",
+        displayed_k == 4
+        and DISPLAYED_BITS[:3] == K4_PREFIX
+        and all(k4_k_values[bits] == 4 for bits in k4_members)
+        and len(k4_members) == 4
+        and "k(f)=4" in note_flat.replace(" ", ""),
+    )
+    checks.check(
+        "thm1-not-cov66-maximizer",
+        "f is not a cov=66 maximizer: vertex3=0 and cov(f)=36",
+        DISPLAYED_BITS[3] == 0
+        and displayed_cov == 36
+        and displayed_cov < 66
+        and displayed_support == 42
+        and displayed_support_direct == 42
+        and maximizer_cov == {(1, 1, 1, 1, 0): 66, (1, 1, 1, 1, 1): 66}
+        and DISPLAYED_BITS not in MAXIMIZER_BITS
+        and "cov(f)=36" in note_flat.replace(" ", ""),
+    )
+    checks.check(
+        "thm2-f-from-origin-fills",
+        "f fills from (0,0,0): |locks_halt|=12 with reported T and history",
+        displayed_locks == 12
+        and displayed_halt == 5
+        and displayed_history == (1, 4, 8, 10, 11, 12)
+        and f"T = {displayed_halt}" in note
+        and f"({', '.join(str(n) for n in displayed_history)})" in note,
+    )
+    checks.check(
+        "thm2-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_- (n != 0)",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_bits == L1_BITS
+        and in_f_cut(l1_bits, type_of)
+        and l1_support_direct == 56,
+    )
+    checks.check(
+        "thm2-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and ham_locks != 12,
+    )
+    checks.check(
+        "thm2-f-L1-history",
+        "f_L1 fills with history (1,4,8,11,12)",
+        l1_locks == 12
+        and l1_halt == 4
+        and l1_history == (1, 4, 8, 11, 12),
+    )
+    checks.check(
+        "thm3-histories-unequal",
+        "f lock history does not equal the L1 history on this seed",
+        not histories_equal
+        and displayed_history != l1_history
+        and displayed_halt != l1_halt
+        and DISPLAYED_BITS != l1_bits
+        and "do not agree" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the named k=4 map and f_L1 are displayed, not adopted",
+        "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "Do not write f into Admissibility" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom
+        and "proper cubic rotations about each site" in note
+        and "one fixed nearest-neighbor admissibility rule" in note,
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note
+        and "never Hamming" in note,
+    )
+    checks.check(
+        "f-definition-in-note",
+        "the note names f as the remaining-bit tuple (1, 1, 1, 0, 0)",
+        "(1, 1, 1, 0, 0)" in note
+        and "vertex3=0" in note
+        and "k=4" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and "actual_current_surface_status: bounded-support" in note,
+    )
+    checks.check(
+        "claim-scope-and-history",
+        "claim_scope reports the lock history and does not adopt f",
+        "F_cut map (1, 1, 1, 0, 0)" in note
+        and "1-site lock history (1, 4, 8, 10, 11, 12)" in note
+        and "Displayed, not adopted" in note
+        and "off-patch o=0" in note,
+    )
+    checks.check(
+        "not-leftover-6443",
+        "the residual is the 1-site halt history, not leftover-character of #6443",
+        "Not leftover-character of #6443" in note
+        and "did not report the 1-site lock" in note
+        and "not a cov=66 maximizer" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    cache_probe = ROOT / "logs" / ("runner" + "-cache") / (
+        "f_cut_k4_v30_one_site_halt_2026_08_15.txt"
+    )
+    checks.check(
+        "no-cache-write",
+        "this run did not emit a runner cache file",
+        not cache_probe.is_file(),
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the 12 two-cube vertices is a lock site under o=0")
+    print("per_mode: checked exactly — the named F_cut map is run from the 1-site seed and the long-axis four")
+    print("per_block: checked exactly — named k=4 non-maximizer is run to a fixed point from the 1-site seed")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or Admissibility rewrite is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube from (0,0,0), F_cut (1,1,1,0,0) fills with history (1, 4, 8, 10, 11, 12), not L1 (1, 4, 8, 11, 12). f_L1 is n≠0, not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_k4_v30_one_site_halt_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.