### PR TITLE
feat(k4cov): k=4 2-site coverage is 66 iff vertex3=1

### DIFF
--- a/docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,288 @@
+---
+claim_id: f_cut_k4_two_site_coverage_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the four F_cut maps with (wt1, opp2, adj2)=(1,1,1) on the two-cube with off-patch o=0, 2-site coverage is 66 iff vertex3=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_k4_two_site_coverage_2026_08_15.py
+---
+
+# Two-Site Coverage Of The Four k=4 F_cut Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock coverage of the four F_cut maps with
+remaining-bit prefix `(wt1, opp2, adj2)=(1, 1, 1)` on the twelve-vertex
+two-cube with off-patch occupancy `0`. No physical Admissibility selector
+is asserted. The four-map ranking and the `vertex3` bit are displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_k4_two_site_coverage_2026_08_15.py`](../scripts/f_cut_k4_two_site_coverage_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+On the two-cube `x ∈ {0,1,2}`, `y,z ∈ {0,1}` with off-patch occupancy `0`,
+the cube-covariant class `F_cut` consists of the maps
+`f:{0,1}^6 → {0,1}` with `f(empty)=f(full)=0` and `f(c)=f(1-c)`. After
+those constraints, five remaining bits
+`(wt1, opp2, adj2, vertex3, mixed3)` label the 32 maps.
+
+The newly named 4 is the `k=4` class: the four remaining-bit tuples
+
+```text
+(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+These are exactly the maps with `(wt1, opp2, adj2)=(1, 1, 1)` and
+`vertex3 × mixed3` free. Each fills all four long-axis two-site seeds
+(reconfirming `k = 4`). The two maps with `vertex3=1` fill every one of
+the 66 two-site seeds:
+
+```text
+cov((1, 1, 1, 1, 0)) = 66
+cov((1, 1, 1, 1, 1)) = 66
+```
+
+The two maps with `vertex3=0` do not:
+
+```text
+cov((1, 1, 1, 0, 0)) = 36
+cov((1, 1, 1, 0, 1)) = 36
+```
+
+Inside this four, `cov = 66 iff vertex3 = 1`. Mixed3 is free on both
+sides of the cut. Full two-site coverage on top of the `k=4` bits
+therefore requires `vertex3=1` on this patch. Displayed, not adopted.
+Do not adopt vertex3. Do not write them into Admissibility.
+
+This is not leftover-character of #6443: that only reported k. The
+present ranking is the two-site coverage of the newly named 4.
+
+`f_L1(c)=1` if and only if some axis is unbalanced, equivalently if
+`n_μ = c_{+μ} − c_{-μ}` is nonzero on at least one axis. This is **not** Hamming parity
+`|c|_1 mod 2`. The L1 remaining-bit tuple is
+`(1, 0, 1, 1, 1)` and is not a member of the newly named 4.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact two-site fill counts on the twelve-vertex two-cube rank the four k=4 F_cut maps and display cov=66 iff vertex3=1 inside that four."
+trace_class: frontier_discovery
+target_claim_id: f_cut_k4_two_site_coverage
+target_blocker_text: "whether the four k=4 F_cut maps all attain cov=66, or whether vertex3 is required on top of those bits"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the supplied two-cube with off-patch occupancy 0; no physical Admissibility selector is asserted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded four-map coverage ranking"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice, Admissibility, and Record
+  sentences below supply the cubic nearest-neighbor geometry, covariance,
+  and unreadability of an empty site. They are quoted without rewrite.
+- **Explicit theorem-domain condition:** the two-cube, the off-patch
+  occupancy-`0` default, the `F_cut` class, the remaining-bit labels, the
+  four long-axis seeds, and occupancy-to-lock dynamics are supplied
+  mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selection of one remaining-bit tuple, including
+  `vertex3`, by Record or Admissibility remains a separate obligation.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+
+The axioms do not name `F_cut`, the remaining-bit tuple, `k`, or `cov`.
+Those objects are theorem data.
+
+## Exact Objects
+
+A neighbor 6-tuple `c = (c_{+x}, c_{-x}, c_{+y}, c_{-y}, c_{+z}, c_{-z})`
+records occupancy of the six coordinate neighbors. Axis type is
+`(n_unbalanced, n_both, n_empty)`. Complement swaps both with empty.
+Proper cube rotations act on 6-tuples; they partition `{0,1}^6` into ten
+orbits.
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Empty and full are fixed at 0, leaving five free bits in
+the order `(wt1, opp2, adj2, vertex3, mixed3)`:
+
+```text
+wt1     ↔ (1, 0, 2)  and its complement (1, 2, 0)
+opp2    ↔ (0, 1, 2)  and its complement (0, 2, 1)
+adj2    ↔ (2, 0, 1)  and its complement (2, 1, 0)
+vertex3 ↔ (3, 0, 0)
+mixed3  ↔ (1, 1, 1)
+```
+
+The two-cube is the twelve sites `(x,y,z)` with `x ∈ {0,1,2}` and
+`y,z ∈ {0,1}`. Off-patch occupancy `0` means a neighbor not among those
+twelve is unoccupied. A blank-block is a different rule and is not used.
+
+A tick locks every unlocked two-cube site whose current neighbor 6-tuple
+has `f=1`. A seed fills when the lock set reaches all twelve sites.
+
+The four long-axis two-site seeds are the opposite-end pairs of the four
+length-2 edges:
+
+```text
+{(0,0,0),(2,0,0)}, {(0,0,1),(2,0,1)}, {(0,1,0),(2,1,0)}, {(0,1,1),(2,1,1)}.
+```
+
+`k(f)` is the number of those four seeds that fill. `cov(f)` is the
+number of the `C(12,2)=66` unordered two-site seeds that fill.
+
+## Exact Target And Proof Obligations
+
+1. Reconfirm that each of the four maps has `k = 4`, and that
+   `(1, 1, 1, 1, 0)` and `(1, 1, 1, 1, 1)` have `cov = 66`.
+2. Compute `cov` of `(1, 1, 1, 0, 0)` and `(1, 1, 1, 0, 1)`.
+3. State whether, inside this four, `cov = 66 iff vertex3 = 1`.
+
+All three obligations are closed by exact enumeration of the 66 seeds
+under occupancy-to-lock. No float is used.
+
+## Theorem 1
+
+The 32 `F_cut` remaining-bit tuples include exactly four with prefix
+`(wt1, opp2, adj2)=(1, 1, 1)`. Those four are the newly named 4 listed
+above. Direct evolution from each of the four long-axis seeds shows
+`k = 4` for every member. Among all 32 maps, these are exactly the maps
+with `k = 4`.
+
+The same evolution on all 66 two-site seeds reconfirms
+
+```text
+cov((1, 1, 1, 1, 0)) = 66
+cov((1, 1, 1, 1, 1)) = 66
+```
+
+Those two are the `vertex3=1` members of the four.
+
+## Theorem 2
+
+The `vertex3=0` members of the four do not fill every two-site seed:
+
+```text
+cov((1, 1, 1, 0, 0)) = 36
+cov((1, 1, 1, 0, 1)) = 36
+```
+
+Both values are strictly less than 66. Mixed3 does not change `cov`
+inside either `vertex3` slice.
+
+## Theorem 3
+
+Inside the newly named 4 the ranking is therefore
+
+| remaining-bit tuple | vertex3 | mixed3 | k | cov |
+|---|---|---|---|---|
+| `(1, 1, 1, 0, 0)` | 0 | 0 | 4 | 36 |
+| `(1, 1, 1, 0, 1)` | 0 | 1 | 4 | 36 |
+| `(1, 1, 1, 1, 0)` | 1 | 0 | 4 | 66 |
+| `(1, 1, 1, 1, 1)` | 1 | 1 | 4 | 66 |
+
+So `cov = 66 iff vertex3 = 1`. On this patch, `vertex3` is required for
+full two-site coverage on top of the `k=4` bits. Displayed, not adopted.
+Do not adopt vertex3.
+
+Not leftover-character of #6443: that only reported k. The present
+object is the two-site coverage ranking of the newly named 4.
+
+## No-Go Discipline
+
+The result is a four-map ranking on one finite patch. It is not a
+universal no-go against other `F_cut` maps, other seeds, or a later
+derived selector.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| treat leftover `k=4` as already ranking two-site coverage | **ATTEMPTED** | #6443 only reported `k`; `cov` of the `vertex3=0` maps is a new count |
+| replace `f_L1` by Hamming parity | **ATTEMPTED** | Hamming `|c|_1 mod 2` is a different predicate and is not `f_L1` |
+| adopt `vertex3` into Admissibility because `cov=66` requires it here | **ATTEMPTED** | the iff is displayed on four maps; it is not an axiom selector |
+| use a blank-block in place of off-patch occupancy `0` | **ATTEMPTED** | blank-block is a different rule |
+| score one seed or only the long-axis four | **ATTEMPTED** | `k` is already 4 for every member; the residual is the 66-seed `cov` |
+| import a Hamiltonian, continuum kernel, or physical Record law | **ATTEMPTED** | those objects are outside the finite occupancy-to-lock ranking |
+
+### N2 — wall independence
+
+One displayed cut is claimed: inside the four, `cov=66` holds exactly
+when `vertex3=1`. That is not a second impossibility wall and is not an
+axiom-necessity claim.
+
+### N3 — hidden-wall scan
+
+The two-cube, the off-patch default, the `F_cut` bits, the long-axis
+four, and the 66 two-site seeds are all declared. No full-lattice
+embedding, formation rate, or realized-state selector is imported.
+
+### N4 — residual matching
+
+The residual after #6443 was the two-site coverage of the maps that
+already have `k=4`. This note fills that residual and does not enlarge
+it to a physical selector.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per-site: executed — each of the twelve two-cube vertices uses the same six-direction stencil
+per-mode: executed — each of the four k=4 maps is scored on the long-axis four and on all 66 two-site seeds
+per-block: executed — the four-map ranking is the newly named k=4 class
+lattice-wide: not executed — no Z^3-wide formation law is claimed
+```
+
+### N6 — partial-closure paths
+
+A later derived selector could still distinguish the two `vertex3=1`
+maps, or could fail on a larger patch. Those routes remain live and need
+not alter the axioms.
+
+### N7 — steelman
+
+The strongest objection is that `k=4` already selected the physically
+relevant maps, so a `cov<66` count is leftover bookkeeping. Correct that
+#6443 named the four. Incorrect that `k` ranks them: the two
+`vertex3=0` maps miss 30 of the 66 two-site seeds.
+
+### N8 — cross-cycle echo
+
+Earlier `F_cut` coverage work displayed two maximizers with `cov=66`,
+both with `vertex3=1`. This note agrees with that pair and adds the
+`cov` of the other two `k=4` maps.
+
+No-Go Discipline disposition: **PASS**
+
+## Boundaries and explicit non-claims
+
+- The theorem is conditional on the supplied two-cube and off-patch
+  occupancy `0`.
+- `vertex3` is displayed data, not an approved primitive.
+- The ranking does not select between `(1, 1, 1, 1, 0)` and
+  `(1, 1, 1, 1, 1)`.
+- No axiom or approved primitive is added.
+- Do not write them into Admissibility.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15738,
- "node_count": 5536,
+ "edge_count": 15739,
+ "node_count": 5537,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_k4_two_site_coverage_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_k4_two_site_coverage_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_k4_two_site_coverage_2026_08_15.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_k4_two_site_coverage_2026_08_15.py
+runner_sha256: 59241074e9b96f79f615063993a23c1c1175f79a84c4550771307a094c52439a
+input_fingerprint_sha256: 303ad23f12dffd0d682c72dca325912e30cc5b3a6d87fa950bf8f2f3542bd8ec
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_two_site_seeds=66
+n_long_axis_seeds=4
+k4_class=[(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+k4_from_k=[(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+f_L1_remaining=(1, 0, 1, 1, 1)
+remaining=(1, 1, 1, 0, 0) vertex3=0 mixed3=0 k=4 cov=36
+remaining=(1, 1, 1, 0, 1) vertex3=0 mixed3=1 k=4 cov=36
+remaining=(1, 1, 1, 1, 0) vertex3=1 mixed3=0 k=4 cov=66
+remaining=(1, 1, 1, 1, 1) vertex3=1 mixed3=1 k=4 cov=66
+cov_iff_vertex3=True
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-long-axis-four the two-cube has twelve vertices, C(12,2)=66 two-site seeds, and four long-axis seeds
+PASS: thm1-each-k4-map-has-k-four each of the four maps with (wt1, opp2, adj2)=(1, 1, 1) has k=4
+PASS: thm1-vertex3-one-maps-have-cov-66 the two vertex3=1 maps reconfirm cov=66
+PASS: thm2-vertex3-zero-coverage the two vertex3=0 maps have computed cov strictly below 66
+PASS: thm3-cov-66-iff-vertex3 inside this four, cov=66 if and only if vertex3=1
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted iff, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-four-map-ranking the note reports k and cov for the newly named four
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6443 the residual is the coverage ranking of the four, not leftover-character of #6443
+PASS: claim-scope-iff claim_scope states the four-map iff on this two-cube
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the four k=4 maps is scored on the long-axis four and on all 66 two-site seeds
+per_block: checked exactly — the four-map ranking is the newly named k=4 class, not leftover k of #6443
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_k4_two_site_coverage_2026_08_15.py
+++ b/scripts/f_cut_k4_two_site_coverage_2026_08_15.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""2-site coverage ranking of the four k=4 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The four maps are the remaining-bit tuples with
+(wt1, opp2, adj2)=(1, 1, 1) and vertex3 x mixed3 free. k is the number of
+the four long-axis 2-site seeds that fill. cov is the number of all 66
+two-site seeds that fill. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2. The iff statement is
+displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+LONG_AXIS_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset({(0, y, z), (2, y, z)}) for y in (0, 1) for z in (0, 1)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+K4_PREFIX: tuple[int, int, int] = (1, 1, 1)
+K4_CLASS: tuple[tuple[int, ...], ...] = (
+    (1, 1, 1, 0, 0),
+    (1, 1, 1, 0, 1),
+    (1, 1, 1, 1, 0),
+    (1, 1, 1, 1, 1),
+)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def predicate_from_remaining(remaining: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(config, remaining)
+
+    return predicate
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate, seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[int, ...]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[int, ...]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        members.append(remaining_bits_from_assignment(assignment))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    k4_from_prefix = tuple(
+        sorted(remaining for remaining in members if remaining[:3] == K4_PREFIX)
+    )
+
+    k_by_remaining: dict[tuple[int, ...], int] = {}
+    cov_by_remaining: dict[tuple[int, ...], int] = {}
+    for remaining in members:
+        predicate = predicate_from_remaining(remaining)
+        k_by_remaining[remaining] = coverage(predicate, LONG_AXIS_SEEDS)
+        if remaining in K4_CLASS:
+            cov_by_remaining[remaining] = coverage(predicate, TWO_SITE_SEEDS)
+
+    k4_from_k = tuple(
+        sorted(remaining for remaining, k_value in k_by_remaining.items() if k_value == 4)
+    )
+    cov_rows = [(remaining, cov_by_remaining[remaining]) for remaining in K4_CLASS]
+    vertex3_zero = [remaining for remaining in K4_CLASS if remaining[3] == 0]
+    vertex3_one = [remaining for remaining in K4_CLASS if remaining[3] == 1]
+    cov_iff_vertex3 = all(
+        (cov_by_remaining[remaining] == 66) == (remaining[3] == 1) for remaining in K4_CLASS
+    )
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"n_long_axis_seeds={len(LONG_AXIS_SEEDS)}")
+    print(f"k4_class={list(K4_CLASS)}")
+    print(f"k4_from_k={list(k4_from_k)}")
+    print(f"f_L1_remaining={l1_remaining}")
+    for remaining, cov in cov_rows:
+        print(
+            f"remaining={remaining} vertex3={remaining[3]} mixed3={remaining[4]} "
+            f"k={k_by_remaining[remaining]} cov={cov}"
+        )
+    print(f"cov_iff_vertex3={cov_iff_vertex3}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_K4_TWO_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and l1_remaining == L1_REMAINING
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-long-axis-four",
+        "the two-cube has twelve vertices, C(12,2)=66 two-site seeds, and four long-axis seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and len(LONG_AXIS_SEEDS) == 4
+        and len(set(LONG_AXIS_SEEDS)) == 4
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS)
+        and all(
+            seed <= set(TWO_CUBE)
+            and len(seed) == 2
+            and {site[1] for site in seed} == {y}
+            and {site[2] for site in seed} == {z}
+            and {site[0] for site in seed} == {0, 2}
+            for seed, (y, z) in zip(
+                LONG_AXIS_SEEDS, ((0, 0), (0, 1), (1, 0), (1, 1))
+            )
+        ),
+    )
+    checks.check(
+        "thm1-each-k4-map-has-k-four",
+        "each of the four maps with (wt1, opp2, adj2)=(1, 1, 1) has k=4",
+        k4_from_prefix == tuple(sorted(K4_CLASS))
+        and k4_from_k == tuple(sorted(K4_CLASS))
+        and all(k_by_remaining[remaining] == 4 for remaining in K4_CLASS)
+        and all(f"{remaining}" in note for remaining in K4_CLASS)
+        and "k = 4" in note,
+    )
+    checks.check(
+        "thm1-vertex3-one-maps-have-cov-66",
+        "the two vertex3=1 maps reconfirm cov=66",
+        vertex3_one == [(1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+        and all(cov_by_remaining[remaining] == 66 for remaining in vertex3_one)
+        and f"cov((1, 1, 1, 1, 0)) = {cov_by_remaining[(1, 1, 1, 1, 0)]}" in note
+        and f"cov((1, 1, 1, 1, 1)) = {cov_by_remaining[(1, 1, 1, 1, 1)]}" in note,
+    )
+    checks.check(
+        "thm2-vertex3-zero-coverage",
+        "the two vertex3=0 maps have computed cov strictly below 66",
+        vertex3_zero == [(1, 1, 1, 0, 0), (1, 1, 1, 0, 1)]
+        and all(cov_by_remaining[remaining] < 66 for remaining in vertex3_zero)
+        and f"cov((1, 1, 1, 0, 0)) = {cov_by_remaining[(1, 1, 1, 0, 0)]}" in note
+        and f"cov((1, 1, 1, 0, 1)) = {cov_by_remaining[(1, 1, 1, 0, 1)]}" in note
+        and cov_by_remaining[(1, 1, 1, 0, 0)] == cov_by_remaining[(1, 1, 1, 0, 1)],
+    )
+    checks.check(
+        "thm3-cov-66-iff-vertex3",
+        "inside this four, cov=66 if and only if vertex3=1",
+        cov_iff_vertex3
+        and mixed3_free_inside_k4(cov_by_remaining)
+        and "cov = 66 iff vertex3 = 1" in note
+        and "Do not adopt vertex3" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted iff, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-four-map-ranking",
+        "the note reports k and cov for the newly named four",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(wt1, opp2, adj2)=(1, 1, 1)" in note
+        and all(str(remaining) in note for remaining in K4_CLASS)
+        and "newly named 4" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write them into Admissibility" in note
+        and "Do not adopt vertex3" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6443",
+        "the residual is the coverage ranking of the four, not leftover-character of #6443",
+        "Not leftover-character of #6443" in note
+        and "that only reported k" in note
+        and "newly named 4" in note,
+    )
+    checks.check(
+        "claim-scope-iff",
+        "claim_scope states the four-map iff on this two-cube",
+        "Among the four F_cut maps with" in note
+        and "(wt1, opp2, adj2)=(1,1,1)" in note
+        and "off-patch o=0" in note
+        and "2-site coverage is 66 iff vertex3=1" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the four k=4 maps is scored on the long-axis four and on all 66 two-site seeds")
+    print("per_block: checked exactly — the four-map ranking is the newly named k=4 class, not leftover k of #6443")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+def mixed3_free_inside_k4(cov_by_remaining: dict[tuple[int, ...], int]) -> bool:
+    return all(
+        cov_by_remaining[(1, 1, 1, vertex3, 0)] == cov_by_remaining[(1, 1, 1, vertex3, 1)]
+        for vertex3 in (0, 1)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the four F_cut maps with (wt1, opp2, adj2)=(1,1,1) on the two-cube (off-patch o=0), 2-site coverage is 66 iff vertex3=1. f_L1 is n≠0, not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_k4_two_site_coverage_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.