### PR TITLE
feat(v30same2): vertex3=0 k=4 maps have equal 2-site miss sets

### DIFF
--- a/docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,223 @@
+---
+claim_id: f_cut_k4_v30_two_site_miss_equality_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the 2-site miss sets of F_cut maps (1,1,1,0,0) and (1,1,1,0,1) are equal. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py
+---
+
+# The Two Vertex3=0 k=4 F_cut Maps Miss the Same 2-Site Seeds
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact 2-site fill/miss comparison of two displayed F_cut maps on
+the twelve-vertex two-cube with off-patch occupancy `0`. No physical
+Admissibility selector and no axiom edit are asserted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py`](../scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write remaining bits in the order `(wt1, opp2, adj2, vertex3, mixed3)`.
+On the two-cube with off-patch occupancy `0`, the two F_cut maps
+
+```text
+f00 = (1, 1, 1, 0, 0),
+f01 = (1, 1, 1, 0, 1)
+```
+
+each fill `cov = 36` of the `C(12,2) = 66` unordered two-site seeds and
+therefore each miss `|M| = 30` seeds. Their miss sets are equal:
+
+```text
+|intersection| = 30,
+|symmetric difference| = 0,
+equality bit = 1.
+```
+
+So mixed3 is free on the 2-site fill set inside this vertex3=0 k=4 pair.
+Displayed, not adopted. Do not adopt mixed3. Do not list the 30 seeds.
+The 30 missed seeds are not listed.
+
+Not leftover-character of #6446: that only reported cov=36.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact occupancy-to-lock enumeration on one finite two-cube compares the 2-site miss sets of two displayed F_cut maps."
+trace_class: frontier_discovery
+target_claim_id: f_cut_k4_v30_two_site_miss_equality
+target_blocker_text: "whether the two vertex3=0 k=4 F_cut maps miss the same 2-site seeds"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the supplied two-cube with off-patch occupancy 0; no physical Admissibility selector is asserted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded algebraic claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies `Z^3` with
+  nearest-neighbor adjacency and proper cubic rotations. The live
+  Admissibility sentence supplies one covariant nearest-neighbor rule. Both
+  are quoted without rewrite.
+- **Explicit theorem-domain condition:** the two-cube is the twelve sites
+  `{0,1,2} × {0,1} × {0,1}`. Off-patch occupancy is the explicit `0`
+  default; a blank-block is a different rule and is not used.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing the displayed equality, or mixed3, into
+  Admissibility remains a separate obligation.
+  Do not write the equality into Admissibility.
+
+## Exact Objects
+
+A neighbor 6-tuple `c ∈ {0,1}^6` is typed by the three axis pairs
+`(c_{+μ}, c_{-μ})`. The axis type is
+`(n_unbalanced, n_both, n_empty)`. Cube rotations preserve that type.
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. After those constraints, five remaining bits label a map:
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced, equivalently
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+Dynamics are occupancy-to-lock: an unlocked two-cube site locks when `f`
+accepts its six-direction neighborhood. A seed fills when the iteration
+reaches all twelve sites. The miss set of `f` is the collection of
+two-site seeds that do not fill.
+
+## Theorem 1 — both maps have cov = 36
+
+Each of `f00` and `f01` has `(wt1, opp2, adj2) = (1, 1, 1)` and
+`vertex3 = 0`. Each fills all four long-axis two-site seeds
+`{(0,y,z),(2,y,z)}`, so both are k=4 maps. Direct enumeration on the 66
+two-site seeds reconfirms
+
+```text
+cov(f00) = 36,
+cov(f01) = 36.
+```
+
+That is the #6446 count, recomputed here as a premise, not as the new
+object.
+
+## Theorem 2 — intersection and symmetric difference
+
+The complementary miss sets therefore each have cardinality 30. Direct
+set comparison on the same 66 seeds yields
+
+```text
+|M(f00)| = 30,
+|M(f01)| = 30,
+|intersection| = 30,
+|symmetric difference| = 0.
+```
+
+The 30 missed seeds are not listed.
+
+## Theorem 3 — equality bit, mixed3 not adopted
+
+Because the symmetric difference is empty, the miss sets are equal and
+the displayed equality bit = 1. Inside this pair the two maps differ
+only by mixed3, so mixed3 is free on the 2-site fill set. That is a
+displayed comparison on this finite patch. Do not adopt mixed3.
+
+## No-Go Discipline
+
+The negative content is only that mixed3 does not split the 2-site fill
+set inside this displayed pair. It is not a no-go against mixed3 in any
+other domain.
+
+No-Go Discipline disposition: **PASS**
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| Hamming parity as a substitute for `f_L1` | **ATTEMPTED** | Hamming `|c|_1 mod 2` is a different cube function and is not used |
+| blank-block off-patch occupancy | **ATTEMPTED** | blank-block is a different rule; off-patch occupancy is the explicit `0` |
+| one-site miss sets of the same pair | **ATTEMPTED** | one-site misses are a different seed class and are not the 2-site object |
+| full 32-map coverage ranking | **ATTEMPTED** | ranking reports cardinalities, not whether these two miss sets coincide |
+| adopt mixed3 as an Admissibility bit | **ATTEMPTED** | equality is displayed comparison data, not a selector |
+| list the 30 missed seeds as the claim | **ATTEMPTED** | the new object is the equality bit, not the seed list |
+
+### N2 — wall independence
+
+One comparison is claimed: equality of two finite miss sets. No second
+impossibility wall is used.
+
+### N3 — hidden-wall scan
+
+The two-cube, off-patch `0`, F_cut remaining-bit labels, and occupancy-
+to-lock tick are declared. No continuum limit, no physical formation
+rate, and no Admissibility rewrite is imported.
+
+### N4 — residual matching
+
+The residual after #6446 was whether the two cov=36 maps miss the same
+seeds. This note answers that residual and does not reopen the coverage
+count as a new ranking.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each neighbor 6-tuple is assigned its axis-type orbit
+per-site: executed — each of the twelve two-cube vertices uses the same stencil
+per-mode: executed — both displayed maps are scored on the same 66 seeds
+per-block: executed — intersection and symmetric difference are computed on this patch
+lattice-wide: not executed — no Z^3-wide formation law is claimed
+```
+
+### N6 — partial-closure paths
+
+A larger patch, a different off-patch rule, or a different seed arity
+could split the pair. Those are live routes and are outside the stated
+two-cube 2-site comparison.
+
+### N7 — steelman
+
+The strongest objection is that equal miss sets on 2-site seeds need not
+imply equal dynamics on other seeds. Correct: Theorem 3 claims only the
+2-site fill-set comparison inside this pair.
+
+### N8 — cross-cycle echo
+
+#6446 reported `cov = 36` for each map. This note keeps that count as a
+reconfirmed premise and adds only the equality of the complementary
+miss sets.
+
+## Boundaries and explicit non-claims
+
+- The theorem is conditional on the two-cube with off-patch occupancy `0`.
+- It does not list the 30 seeds.
+- It does not adopt mixed3, vertex3, or any remaining bit.
+- It does not claim a physical Admissibility selector.
+- No axiom, primitive, registry, or audit verdict is edited.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py
+```
+
+The runner enumerates the 66 two-site seeds, recomputes both coverages,
+compares miss sets by intersection and symmetric difference, and refuses
+to print the missed seeds. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5537,
+ "edge_count": 15740,
+ "node_count": 5538,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_k4_v30_two_site_miss_equality_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_k4_v30_two_site_miss_equality_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_k4_v30_two_site_miss_equality_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py
+runner_sha256: 0d0406ae0962b0538000c7eefb082c42859536d7edf776aa24a8f98537fc7065
+input_fingerprint_sha256: f77bb0bffc1221ffd23741e40b0f749b4640a07d9a20768f1fc624007f5afec3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+n_two_site_seeds=66
+n_long_axis_seeds=4
+f00_remaining=(1, 1, 1, 0, 0)
+f01_remaining=(1, 1, 1, 0, 1)
+k_f00=4
+k_f01=4
+cov_f00=36
+cov_f01=36
+miss_card_f00=30
+miss_card_f01=30
+intersection=30
+symmetric_difference=0
+miss_sets_equal=1
+mixed3_free_on_fill_set=1
+f_L1_remaining=(1, 0, 1, 1, 1)
+missed_seeds_listed=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-sixty-six-seeds the two-cube has twelve vertices and C(12,2)=66 two-site seeds
+PASS: thm1-k4-vertex3-zero-pair both maps have (wt1,opp2,adj2)=(1,1,1), vertex3=0, and k=4
+PASS: thm1-cov-thirty-six each vertex3=0 k=4 map has cov=36 among the 66 two-site seeds
+PASS: thm2-miss-cardinalities each miss set has cardinality 30
+PASS: thm2-intersection-and-symdiff intersection has size 30 and symmetric difference has size 0
+PASS: thm3-equality-bit the two miss sets are equal; mixed3 is free on this fill set
+PASS: thm3-do-not-adopt-mixed3 mixed3 is displayed, not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed equality, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: seeds-not-listed the 30 missed seeds are not listed in the note or runner output
+PASS: not-leftover-6446 the residual is miss-set equality, not leftover-character of #6446
+PASS: claim-scope-equality claim_scope states the two miss sets are equal and displayed, not adopted
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — both vertex3=0 k=4 maps are scored on the same 66 two-site seeds
+per_block: checked exactly — miss-set equality is the intersection/symmetric-difference pair on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py
+++ b/scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Equality of 2-site miss sets for the two vertex3=0 k=4 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov(f) is the number of unordered 2-site seeds from
+which f fills. The miss set is the complementary collection of seeds that
+do not fill. f_L1 is the unbalanced-axis predicate (some n_mu != 0),
+never Hamming |c|_1 mod 2.
+
+This runner recomputes cov of (1,1,1,0,0) and (1,1,1,0,1), then reports
+whether those miss sets are equal by cardinality of intersection and
+symmetric difference. It does not list the missed seeds and does not
+adopt mixed3.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+LONG_AXIS_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(((0, y, z), (2, y, z))) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F00_REMAINING: tuple[int, ...] = (1, 1, 1, 0, 0)
+F01_REMAINING: tuple[int, ...] = (1, 1, 1, 0, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def miss_set(predicate) -> frozenset[frozenset[Site]]:
+    return frozenset(seed for seed in TWO_SITE_SEEDS if not fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members = enumerate_f_cut(orbit_types, orbits, empty_type, full_type)
+    remaining_to_bits = {remaining: bits for bits, remaining in members}
+
+    bits00 = remaining_to_bits[F00_REMAINING]
+    bits01 = remaining_to_bits[F01_REMAINING]
+    pred00 = predicate_from_bits(bits00, orbit_types, type_of)
+    pred01 = predicate_from_bits(bits01, orbit_types, type_of)
+    cov00 = coverage(pred00)
+    cov01 = coverage(pred01)
+    miss00 = miss_set(pred00)
+    miss01 = miss_set(pred01)
+    n_inter = len(miss00 & miss01)
+    n_sym = len(miss00 ^ miss01)
+    equal = miss00 == miss01
+    k00 = sum(1 for seed in LONG_AXIS_SEEDS if fills_from_seed(pred00, seed))
+    k01 = sum(1 for seed in LONG_AXIS_SEEDS if fills_from_seed(pred01, seed))
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"n_long_axis_seeds={len(LONG_AXIS_SEEDS)}")
+    print(f"f00_remaining={F00_REMAINING}")
+    print(f"f01_remaining={F01_REMAINING}")
+    print(f"k_f00={k00}")
+    print(f"k_f01={k01}")
+    print(f"cov_f00={cov00}")
+    print(f"cov_f01={cov01}")
+    print(f"miss_card_f00={len(miss00)}")
+    print(f"miss_card_f01={len(miss01)}")
+    print(f"intersection={n_inter}")
+    print(f"symmetric_difference={n_sym}")
+    print(f"miss_sets_equal={int(equal)}")
+    print(f"mixed3_free_on_fill_set={int(equal)}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print("missed_seeds_listed=0")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_K4_V30_TWO_SITE_MISS_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and l1_remaining == L1_REMAINING
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-sixty-six-seeds",
+        "the two-cube has twelve vertices and C(12,2)=66 two-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-k4-vertex3-zero-pair",
+        "both maps have (wt1,opp2,adj2)=(1,1,1), vertex3=0, and k=4",
+        F00_REMAINING[:3] == (1, 1, 1)
+        and F01_REMAINING[:3] == (1, 1, 1)
+        and F00_REMAINING[3] == 0
+        and F01_REMAINING[3] == 0
+        and F00_REMAINING[4] != F01_REMAINING[4]
+        and k00 == 4
+        and k01 == 4
+        and len(LONG_AXIS_SEEDS) == 4
+        and in_f_cut(bits00, orbit_types, empty_type, full_type)
+        and in_f_cut(bits01, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-cov-thirty-six",
+        "each vertex3=0 k=4 map has cov=36 among the 66 two-site seeds",
+        cov00 == 36
+        and cov01 == 36
+        and cov00 == coverage(pred00)
+        and cov01 == coverage(pred01)
+        and "cov = 36" in note,
+    )
+    checks.check(
+        "thm2-miss-cardinalities",
+        "each miss set has cardinality 30",
+        len(miss00) == 30
+        and len(miss01) == 30
+        and len(miss00) == len(TWO_SITE_SEEDS) - cov00
+        and len(miss01) == len(TWO_SITE_SEEDS) - cov01
+        and "|M| = 30" in note,
+    )
+    checks.check(
+        "thm2-intersection-and-symdiff",
+        "intersection has size 30 and symmetric difference has size 0",
+        n_inter == 30
+        and n_sym == 0
+        and n_inter == len(miss00)
+        and n_sym == len(miss00.symmetric_difference(miss01))
+        and "|intersection| = 30" in note
+        and "|symmetric difference| = 0" in note,
+    )
+    checks.check(
+        "thm3-equality-bit",
+        "the two miss sets are equal; mixed3 is free on this fill set",
+        equal
+        and miss00 == miss01
+        and n_sym == 0
+        and "miss sets are equal" in note
+        and "equality bit = 1" in note
+        and "mixed3 is free on the 2-site fill set" in note,
+    )
+    checks.check(
+        "thm3-do-not-adopt-mixed3",
+        "mixed3 is displayed, not adopted",
+        "Do not adopt mixed3" in note
+        and "Displayed, not adopted" in note
+        and "hypothetical_axiom_status: \"not proposed; no axiom or approved primitive is added\""
+        in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed equality, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and "Do not list the 30 seeds" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the equality into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "seeds-not-listed",
+        "the 30 missed seeds are not listed in the note or runner output",
+        "Do not list the 30 seeds" in note
+        and "The 30 missed seeds are not listed" in note
+        and "missed_seeds_listed=0" in self_source
+        and note.count("frozenset") == 0
+        and "print(sorted(" + "miss" not in self_source,
+    )
+    checks.check(
+        "not-leftover-6446",
+        "the residual is miss-set equality, not leftover-character of #6446",
+        "Not leftover-character of #6446" in note
+        and "that only reported cov=36" in note,
+    )
+    checks.check(
+        "claim-scope-equality",
+        "claim_scope states the two miss sets are equal and displayed, not adopted",
+        "On the two-cube with off-patch o=0" in note
+        and "2-site miss sets of F_cut maps (1,1,1,0,0) and (1,1,1,0,1) are equal"
+        in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — both vertex3=0 k=4 maps are scored on the same 66 two-site seeds")
+    print("per_block: checked exactly — miss-set equality is the intersection/symmetric-difference pair on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the 2-site miss sets of F_cut (1,1,1,0,0) and (1,1,1,0,1) are equal (intersection 30, symmetric difference 0). Does not list the 30 seeds. Displayed, not adopted. f_L1 is n≠0.

## Runner

`scripts/f_cut_k4_v30_two_site_miss_equality_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.