### PR TITLE
feat(v30miss1): list four 1-site misses of the vertex3=0 k=4 maps

### DIFF
--- a/docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,282 @@
+---
+claim_id: f_cut_k4_v30_one_site_misses_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the F_cut maps (1,1,1,0,0) and (1,1,1,0,1) miss the reported 1-site seeds, and those miss sets are equal. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py
+---
+
+# One-Site Miss Sets Of The Two `vertex3=0` k=4 `F_cut` Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock miss lists on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the twelve one-site seeds, for the
+two cube-covariant cut maps with remaining bits `(1,1,1,0,0)` and
+`(1,1,1,0,1)`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py`](../scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6444 reported that the two `vertex3=0` k=4 maps
+`(1,1,1,0,0)` and `(1,1,1,0,1)` each have `cov1=8`, so each misses four of
+the twelve one-site seeds. That note reported the count 8. The present
+object is the missed corners themselves: the four missed one-site seeds of
+each map, in lex order, and whether those two miss sets agree.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+Remaining bits are ordered as `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`,
+which is not a `vertex3=0` k=4 map.
+
+Write `f00` for remaining bits `(1, 1, 1, 0, 0)` and `f01` for
+`(1, 1, 1, 0, 1)`. On the two-cube with off-patch occupancy `0`, write
+`cov1(f)` for the number of one-site seeds from which `f` fills, and write
+`Miss(f)` for the complementary set of missed one-site seeds, listed in
+lex order. Then:
+
+- Theorem 1. Reconfirm `#6444`: `cov1(f00) = 8` and `cov1(f01) = 8`.
+- Theorem 2. The missed one-site seeds, in lex order, are
+  `Miss(f00) = ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))` and
+  `Miss(f01) = ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))`.
+- Theorem 3. The two miss sets are equal. Displayed, not adopted.
+
+The four missed sites are the shared-face corners of the two-cube
+(`x=1`). Do not adopt `vertex3`. Do not write `vertex3` into
+Admissibility.
+
+New object (the missed corners). Not leftover-character of #6444 (that only reported 8).
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two vertex3=0 k=4 F_cut maps are scored exactly on the twelve one-site seeds of the two-cube. Each has cov1=8. Each misses the same four lex-ordered shared-face sites. The miss sets are equal. Displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_k4_v30_one_site_misses
+target_blocker_text: "which four 1-site seeds each vertex3=0 k=4 map misses, and whether those miss sets agree"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded miss lists; do not adopt vertex3"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the two maps `f00=(1,1,1,0,0)` and `f01=(1,1,1,0,1)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** List the four missed one-site seeds of each `vertex3=0` k=4
+map, in lex order, and state whether the two miss sets are equal.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The one-site seeds are the twelve singletons `{x}` for `x ∈ T`, listed in
+lex order of `x`. Then `Miss(f)` is the tuple of those `x` from which `f`
+does not fill.
+
+## Theorems
+
+### Theorem 1 — reconfirm `cov1=8` for each map
+
+Direct evolution on each of the twelve singletons reconfirms `#6444`:
+
+```text
+cov1((1, 1, 1, 0, 0)) = 8
+cov1((1, 1, 1, 0, 1)) = 8
+```
+
+Each fills eight one-site seeds and therefore misses four.
+
+### Theorem 2 — the four missed seeds, lex order
+
+The missed one-site seeds, listed in lex order of the two-cube vertices,
+are
+
+```text
+Miss((1, 1, 1, 0, 0)) = ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+Miss((1, 1, 1, 0, 1)) = ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+```
+
+These are the four shared-face corners (`x=1`). Each map fills the eight
+sites with `x ∈ {0,2}`.
+
+### Theorem 3 — the two miss sets are equal
+
+`Miss(f00) = Miss(f01)`. The mixed3 bit that distinguishes the two maps
+does not change the 1-site miss set on this patch. Displayed, not adopted.
+Do not write `vertex3` into Admissibility. Do not adopt `vertex3`.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` remaining-bit order | declared |
+| `f00` and `f01` as the two `vertex3=0` k=4 maps | declared |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, twelve one-site seeds, off-patch 0 | declared finite patch |
+| `cov1(f00)=cov1(f01)=8` | reconfirmed by evolution |
+| four missed seeds of each map, lex order | proved by evolution |
+| the two miss sets are equal | proved; displayed, not adopted |
+| leftover-character of #6444 | refused; new object is the missed corners |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6444: that only reported `cov1=8`. The present
+object is the missed-corner list of each map and the equality of those
+lists. New object (the missed corners).
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write `vertex3` into
+Admissibility. Do not adopt `vertex3`.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It lists the four missed 1-site seeds of each `vertex3=0` k=4 map and states that the miss sets are equal. |
+| V2 | Current main has the `cov1=8` count (#6444) but no landed miss-set equality of those two maps. |
+| V3 | The two maps, 12 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it lists a declared miss set. |
+| V5 | It is not a physical selector: the miss lists are displayed, not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: these two maps miss the same four shared-face
+one-site seeds. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover count 8 | treat the miss lists as leftover-character of #6444 | **ATTEMPTED** |
+| mixed3 split | assume the free mixed3 bit splits the miss sets | **ATTEMPTED** |
+| adopt `vertex3` | write `vertex3=1` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch miss list to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the leftover-count substitution, and the off-patch
+convention are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the twelve singletons in lex order, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the two named
+maps are declared. Physical selection of `vertex3` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the missed-corner list
+of the two `vertex3=0` k=4 maps on the declared patch, not leftover-character
+of #6444.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the two maps scored on 12 seeds | no physical law selection |
+| per block | lex miss lists and their equality | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than 1-site miss-set equality, and any independently derived
+physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** `f00` and `f01` differ by the mixed3 bit, so they must miss
+different one-site seeds.
+
+**Answer:** Direct evolution gives the same four missed sites for both maps.
+The mixed3 bit is free on this pair and does not split the 1-site miss set.
+The equality is displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6444 already reported `cov1=8`. Echoing that count is not a
+substitute for listing the four missed corners of each map and checking
+equality. The present object is those lists.
+
+No-Go Discipline disposition: **PASS** for the finite miss lists and the
+narrow displayed equality. FAIL / DO NOT SHIP for “`vertex3` is the
+physical rule” or “the miss lists adopt a formation selector.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner builds the two maps from remaining bits, reconfirms
+`cov1=8` for each, lists the four missed one-site seeds of each map in lex
+order, and checks that the two miss sets are equal. Declared audit inputs
+are this note and the axiom memo; the runner writes no cache and authors no
+audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5537,
+ "edge_count": 15740,
+ "node_count": 5538,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_k4_v30_one_site_misses_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_k4_v30_one_site_misses_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_k4_v30_one_site_misses_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py
+runner_sha256: 292ae6fe5a8a7e85cb42146eb8fa2841cf4af88f710a560cabe4701cafd084d9
+input_fingerprint_sha256: 9bcf560faf3af116557ea72194e446e3500acc070ba1b16a027d9179bd607b97
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+n_one_site_seeds=12
+f00=(1, 1, 1, 0, 0)
+f01=(1, 1, 1, 0, 1)
+cov1_f00=8
+cov1_f01=8
+miss_f00=((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+miss_f01=((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))
+miss_sets_equal=True
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-rotations-and-orbits exactly 24 proper cube rotations and 10 axis-type orbits
+PASS: thm1-f-L1-not-hamming f_L1 is unbalanced-axis and is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-twelve-seeds the two-cube has twelve vertices in lex order and twelve one-site seeds
+PASS: thm1-maps-in-f-cut f00 and f01 are F_cut maps with vertex3=0 and (wt1,opp2,adj2)=(1,1,1)
+PASS: thm1-cov1-eight reconfirm cov1((1,1,1,0,0))=8 and cov1((1,1,1,0,1))=8
+PASS: thm2-miss-f00-lex Miss(f00) is the four shared-face sites in lex order
+PASS: thm2-miss-f01-lex Miss(f01) is the four shared-face sites in lex order
+PASS: thm3-miss-sets-equal the two miss sets are equal
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted equality, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt vertex3
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6444 the residual is the missed-corner lists, not leftover-character of #6444
+PASS: claim-scope-equality claim_scope states the two maps miss the reported seeds and the miss sets are equal
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the two vertex3=0 k=4 maps is scored on the 12 one-site seeds
+per_block: checked exactly — the two lex miss sets are equal on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py
+++ b/scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Exact 1-site miss lists of the two vertex3=0 k=4 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. For f00=(1,1,1,0,0) and f01=(1,1,1,0,1), the runner reconfirms
+cov1=8, lists the four missed one-site seeds in lex order, and checks that
+the two miss sets are equal. f_L1 is the unbalanced-axis predicate (some
+n_mu != 0), never Hamming |c|_1 mod 2. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+ONE_SITE_SEEDS: tuple[Site, ...] = TWO_CUBE
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F00: tuple[int, ...] = (1, 1, 1, 0, 0)
+F01: tuple[int, ...] = (1, 1, 1, 0, 1)
+SHARED_FACE: tuple[Site, ...] = (
+    (1, 0, 0),
+    (1, 0, 1),
+    (1, 1, 0),
+    (1, 1, 1),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: Site) -> bool:
+    locked = {seed}
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def miss_tuple(predicate) -> tuple[Site, ...]:
+    return tuple(site for site in ONE_SITE_SEEDS if not fills_from_seed(predicate, site))
+
+
+def coverage(predicate) -> int:
+    return sum(1 for site in ONE_SITE_SEEDS if fills_from_seed(predicate, site))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut_remaining(remaining: tuple[int, ...]) -> bool:
+    if len(remaining) != 5:
+        return False
+    assignment = {
+        axis_type(EMPTY): 0,
+        axis_type(FULL): 0,
+    }
+    for orbit_type, value in zip(REMAINING_ORDER, remaining, strict=True):
+        assignment[orbit_type] = value
+        image = complement_type(orbit_type)
+        assignment[image] = value
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in assignment
+    ) and assignment[axis_type(EMPTY)] == 0 and assignment[axis_type(FULL)] == 0
+
+
+def predicate_from_remaining(remaining: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(config, remaining)
+
+    return predicate
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    pred00 = predicate_from_remaining(F00)
+    pred01 = predicate_from_remaining(F01)
+    miss00 = miss_tuple(pred00)
+    miss01 = miss_tuple(pred01)
+    cov00 = coverage(pred00)
+    cov01 = coverage(pred01)
+    equal = miss00 == miss01
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"n_one_site_seeds={len(ONE_SITE_SEEDS)}")
+    print(f"f00={F00}")
+    print(f"f01={F01}")
+    print(f"cov1_f00={cov00}")
+    print(f"cov1_f01={cov01}")
+    print(f"miss_f00={miss00}")
+    print(f"miss_f01={miss01}")
+    print(f"miss_sets_equal={equal}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_K4_V30_ONE_SITE_MISSES_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-rotations-and-orbits",
+        "exactly 24 proper cube rotations and 10 axis-type orbits",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is unbalanced-axis and is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and l1_remaining == L1_REMAINING
+        and l1_remaining not in (F00, F01)
+        and all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-twelve-seeds",
+        "the two-cube has twelve vertices in lex order and twelve one-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and TWO_CUBE == tuple(sorted(TWO_CUBE))
+        and ONE_SITE_SEEDS == TWO_CUBE
+        and set(SHARED_FACE) <= set(TWO_CUBE)
+        and len(SHARED_FACE) == 4,
+    )
+    checks.check(
+        "thm1-maps-in-f-cut",
+        "f00 and f01 are F_cut maps with vertex3=0 and (wt1,opp2,adj2)=(1,1,1)",
+        in_f_cut_remaining(F00)
+        and in_f_cut_remaining(F01)
+        and F00[:3] == (1, 1, 1)
+        and F01[:3] == (1, 1, 1)
+        and F00[3] == 0
+        and F01[3] == 0
+        and F00[4] == 0
+        and F01[4] == 1,
+    )
+    checks.check(
+        "thm1-cov1-eight",
+        "reconfirm cov1((1,1,1,0,0))=8 and cov1((1,1,1,0,1))=8",
+        cov00 == 8
+        and cov01 == 8
+        and cov00 == 12 - len(miss00)
+        and cov01 == 12 - len(miss01)
+        and "cov1((1, 1, 1, 0, 0)) = 8" in note
+        and "cov1((1, 1, 1, 0, 1)) = 8" in note,
+    )
+    checks.check(
+        "thm2-miss-f00-lex",
+        "Miss(f00) is the four shared-face sites in lex order",
+        miss00 == SHARED_FACE
+        and miss00 == tuple(sorted(miss00))
+        and len(miss00) == 4
+        and "Miss((1, 1, 1, 0, 0)) = ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))"
+        in note,
+    )
+    checks.check(
+        "thm2-miss-f01-lex",
+        "Miss(f01) is the four shared-face sites in lex order",
+        miss01 == SHARED_FACE
+        and miss01 == tuple(sorted(miss01))
+        and len(miss01) == 4
+        and "Miss((1, 1, 1, 0, 1)) = ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1))"
+        in note,
+    )
+    checks.check(
+        "thm3-miss-sets-equal",
+        "the two miss sets are equal",
+        equal
+        and miss00 == miss01
+        and set(miss00) == set(SHARED_FACE)
+        and "The two miss sets are equal" in note
+        and "`Miss(f00) = Miss(f01)`" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted equality, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt vertex3",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write `vertex3` into Admissibility" in note
+        and "Do not adopt `vertex3`" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6444",
+        "the residual is the missed-corner lists, not leftover-character of #6444",
+        "Not leftover-character of #6444" in note
+        and "that only reported 8" in note
+        and "New object (the missed corners)" in note,
+    )
+    checks.check(
+        "claim-scope-equality",
+        "claim_scope states the two maps miss the reported seeds and the miss sets are equal",
+        "On the two-cube with off-patch o=0" in note
+        and "(1,1,1,0,0)" in note
+        and "(1,1,1,0,1)" in note
+        and "miss the reported 1-site seeds" in note
+        and "those miss sets are equal" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the two vertex3=0 k=4 maps is scored on the 12 one-site seeds")
+    print("per_block: checked exactly — the two lex miss sets are equal on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, F_cut maps (1,1,1,0,0) and (1,1,1,0,1) each miss the same four 1-site seeds (shared-face corners). Miss sets equal. Displayed, not adopted. f_L1 is n≠0.

## Runner

`scripts/f_cut_k4_v30_one_site_misses_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.