### PR TITLE
feat(v3face): fill-from-(1,0,0) is not equivalent to vertex3=1

### DIFF
--- a/docs/F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,334 @@
+---
+claim_id: f_cut_vertex3_shared_face_fill_equivalence_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, filling from the shared-face 1-site seed (1,0,0) is not equivalent to f(vertex3)=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py
+---
+
+# Shared-Face Seed Fill Is Not The Vertex3 Bit
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill from the shared-face 1-site seed
+`(1,0,0)` on the twelve-vertex two-cube with off-patch occupancy `0`, scored
+for all 32 cube-covariant cut maps `F_cut`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py`](../scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6448 showed that the two `vertex3=0` k=4 maps miss the
+shared-face seed `(1,0,0)` and that the two `vertex3=1` k=4 maps fill all
+twelve one-site seeds. That was a four-map table. This note asks the class
+question among all 32 `F_cut` maps: is filling from `(1,0,0)` equivalent to
+`f(vertex3)=1`? New selector, not leftover of #6448.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write `fill(f)` for the
+boolean “`f` fills from the singleton `{(1,0,0)}`.” Then:
+
+- Theorem 1. `f_L1` has `vertex3=1` and `fill(f_L1)=1`. The lock history
+  is `(1, 5, 10, 12)`.
+- Theorem 2. `fill(f)` if and only if `f(vertex3)=1` is false. The counts
+  are `N_fill = 4`, `N_v3 = 16`, `N_both = 4`. The lex-first counterexample
+  remaining-bit tuple is `(0, 0, 0, 1, 0)`: `f(vertex3)=1` and `fill=0`.
+- Theorem 3. The failed equivalence and the counterexample are displayed.
+  Do not adopt `vertex3`.
+
+Fill implies `vertex3=1` (the four fillers all fire that bit), but the
+converse fails on twelve maps. Filling from `(1,0,0)` detects the
+conjunction `wt1=adj2=vertex3=1`, not the single bit `vertex3`.
+
+Do not write `vertex3` into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the shared-face 1-site seed (1,0,0). N_fill, N_v3, and N_both are finite exact counts. The failed biconditional is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_vertex3_shared_face_fill_equivalence
+target_blocker_text: "whether fill-from-(1,0,0) is equivalent to f(vertex3)=1 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded failed equivalence; do not adopt vertex3"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- the shared-face 1-site seed `{(1,0,0)}`;
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Among the 32 members of `F_cut`, decide whether filling from
+`{(1,0,0)}` is equivalent to `f(vertex3)=1`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+Write `N_fill` for the number of `F_cut` maps with `fill(f)=1`, `N_v3` for
+the number with `f(vertex3)=1`, and `N_both` for the number with both.
+
+## Theorems
+
+### Theorem 1 — `f_L1` has `vertex3=1` and fills from `(1,0,0)`
+
+`f_L1` is the `F_cut` map with remaining-bit tuple `(1, 0, 1, 1, 1)`.
+Equivalently, `f_L1(c)=1` if and only if some axis is unbalanced. This is
+**not** Hamming parity. In particular `f_L1(vertex3)=1`. Direct evolution
+from `{(1,0,0)}` reaches all twelve vertices with lock history
+`(1, 5, 10, 12)`.
+
+### Theorem 2 — fill-from-`(1,0,0)` is not equivalent to `f(vertex3)=1`
+
+Enumerate all 32 remaining-bit tuples. The pairs `(fill(f), f(vertex3))`
+occupy only three bins:
+
+- 16 maps with `f(vertex3)=0`, all of them `fill=0`;
+- 12 maps with `f(vertex3)=1` and `fill=0`;
+- 4 maps with `f(vertex3)=1` and `fill=1`.
+
+Therefore
+
+```text
+N_fill = 4
+N_v3 = 16
+N_both = 4
+```
+
+and `N_fill = N_v3 = N_both` is false. Fill if and only if `f(vertex3)=1`
+fails. The one-way implication “`fill` implies `vertex3=1`” holds; the
+converse fails.
+
+The lex-first counterexample remaining-bit tuple is
+`(wt1, opp2, adj2, vertex3, mixed3) = (0, 0, 0, 1, 0)`. That map fires
+`vertex3` and still has halt lock-count `1`: the first neighborhoods of
+`(1,0,0)` are `wt1` or empty, so a silent `wt1` never grows.
+
+The four maps with `fill=1` are
+
+```text
+(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+So filling from `(1,0,0)` detects the conjunction `wt1=adj2=vertex3=1`,
+not the single bit `vertex3`. The second of these four is `f_L1`.
+
+### Theorem 3 — display; do not adopt `vertex3`
+
+The failed equivalence, the three counts, and the counterexample tuple
+`(0, 0, 0, 1, 0)` are displayed. They are not adopted. Do not adopt
+`vertex3`. Do not write `vertex3` into Admissibility. `f_L1` remains the
+unbalanced-axis predicate `n≠0` rather than Hamming parity.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, seed `(1,0,0)`, off-patch 0 | declared finite patch |
+| `f_L1` has `vertex3=1` and fills | proved by remaining bits and evolution |
+| `N_fill`, `N_v3`, `N_both` | proved by exhaustive census |
+| fill iff `f(vertex3)=1` | fails; counterexample displayed |
+| leftover-character of #6448 | refused; new 32-map selector |
+| physical Admissibility selector | open |
+
+## Current premise boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility identifies the six-neighbor condition domain and covariance
+under proper cubic rotations; it does not supply the formation site, probability, or rate.
+The boolean occupancy predicates and the lock-update rule are explicit
+bounded mathematical input, not axiom text.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Permanence of a lock once formed is used only as the declared update rule on
+this finite patch. No physical readout, content map, or formation rate is
+identified.
+
+## Boundary and imports
+
+Not leftover-character of #6448: that listed 1-site misses of the two
+`vertex3=0` k=4 maps and 1-site totality of the two `vertex3=1` k=4 maps.
+The present count is the biconditional among all 32 `F_cut` maps on one
+shared-face seed.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write `vertex3` into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the shared-face seed `(1,0,0)` detects the single remaining bit `vertex3` inside `F_cut`. |
+| V2 | Current main has the k=4 four-map table (#6448) but no landed 32-map census of this seed versus `vertex3`. |
+| V3 | The 32 maps, one seed, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it separates a one-way implication from a failed biconditional. |
+| V5 | It is not a physical selector: the failed equivalence is displayed, and `vertex3` is not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: on this patch and class, fill-from-`(1,0,0)`
+does not characterize `f(vertex3)=1`. No global compiler impossibility is
+claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover #6448 | treat the 32-map biconditional as leftover-character of the k=4 table | **ATTEMPTED** |
+| `vertex3` alone | set `f(vertex3)=1` with `wt1=0` | **ATTEMPTED** |
+| adopt `vertex3` | write the bit into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch count to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed biconditional extra, the Hamming contrast, and the off-patch
+convention are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the seed `(1,0,0)`, off-patch occupancy `0`, occupancy-to-lock
+ticks, and the `F_cut` remaining-bit order are declared. Equivalence of fill
+to `vertex3` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the 32-map comparison
+of fill-from-`(1,0,0)` with `f(vertex3)`, not leftover-character of #6448.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on one seed | no physical law selection |
+| per block | `N_fill`, `N_v3`, `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed, a different off-patch rule, a selector
+other than this shared-face fill, and any independently derived physical map
+from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** Because the two `vertex3=0` k=4 maps miss `(1,0,0)` and the
+two `vertex3=1` k=4 maps fill every one-site seed, the shared-face seed
+detects the `vertex3` bit among all of `F_cut`.
+
+**Answer:** Silent `vertex3` does force `fill=0`, but firing `vertex3` is
+not enough. Twelve maps with `vertex3=1` still miss `(1,0,0)`, including
+the lex-first tuple `(0, 0, 0, 1, 0)`, which never leaves the seed because
+the first neighborhoods are `wt1` or empty. The seed therefore detects a
+three-bit conjunction, not the single bit.
+
+### N8 — cross-cycle echo
+
+Investment #6448 already listed the k=4 1-site misses. The present census
+is a new selector: one seed versus one remaining bit, scored on all 32
+maps. Echoing the four-map table is not a substitute for this count.
+
+No-Go Discipline disposition: **PASS** for the finite failed equivalence and
+the displayed counterexample. FAIL / DO NOT SHIP for “`vertex3` is selected
+by the shared-face seed” or “`vertex3` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores fill from
+`{(1,0,0)}`, reconfirms that `f_L1` has `vertex3=1` and fills, reports
+`N_fill`, `N_v3`, and `N_both`, and checks that the displayed remaining-bit
+tuple `(0, 0, 0, 1, 0)` is a counterexample. Declared audit inputs are this
+note and the axiom memo; the runner writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5537,
+ "edge_count": 15740,
+ "node_count": 5538,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_vertex3_shared_face_fill_equivalence_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py
+runner_sha256: 452fc657a592980ccf64ef194bc37d736807adb4b4a86d100fa8b279424913a0
+input_fingerprint_sha256: 9682655acf7cce43b026ee00218d2c3f5a4127731950d9923dbc178b94860d15
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo
+construction: 32 cube-covariant complement-even predicates on the two-cube, off-patch occupancy 0, seed (1,0,0)
+negative_scope: displayed selector only; vertex3 is not adopted
+PASS: audit-inputs declared inputs are the required two static string literals and exist
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-local-distribution current local-distribution wording is pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: vertex-count two-cube has twelve vertices and the seed is the shared-face site (1,0,0)
+PASS: orbit-partition proper-cube action on six-tuples has ten orbits with derived sizes
+PASS: complement-action complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3
+PASS: f-cut-cardinality five free remaining bits give 32 F_cut maps
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis is unbalanced, and evaluates to (1,0,1,1,1)
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-vertex3 f_L1 has vertex3=1
+PASS: thm1-fill f_L1 fills from (1,0,0) with history (1, 5, 10, 12)
+N_fill=4
+N_v3=16
+N_both=4
+equivalent=False
+lex_counterexample_tuple=(0, 0, 0, 1, 0)
+fillers=[(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+first_neighborhoods=['empty', 'wt1']
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_history=(1, 5, 10, 12)
+PASS: thm2-counts N_fill=4, N_v3=16, N_both=4
+PASS: thm2-not-equivalent fill-from-(1,0,0) is not equivalent to f(vertex3)=1
+PASS: thm2-counterexample lex-first counterexample is (0,0,0,1,0) with fill=0 and vertex3=1
+PASS: thm2-one-way every silent-vertex3 map still has fill=0; all four fillers have vertex3=1
+PASS: thm2-first-neighborhoods first neighborhoods of (1,0,0) are only wt1 or empty, so vertex3 alone cannot grow
+PASS: thm2-conjunction fill detects wt1=adj2=vertex3=1, not the single vertex3 bit
+PASS: note-reports-counts the note reports N_fill, N_v3, N_both, and the counterexample tuple
+PASS: claim-scope claim_scope states the failed equivalence and does not adopt vertex3
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness failure, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6448 the residual is the 32-map selector, not leftover-character of #6448
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt vertex3
+PASS: note-hygiene machine retained fields are the only retained lines; no cache or citation surface
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut class
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on the shared-face seed (1,0,0)
+per_block: checked exactly — N_fill, N_v3, and N_both are the 32-map census on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=30 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py
+++ b/scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Exact F_cut census: fill-from-(1,0,0) versus f(vertex3).
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The scored seed is the shared-face 1-site seed (1,0,0).
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. The failed equivalence is displayed; vertex3 is not adopted.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Cell = tuple[int, int, int, int, int, int]
+Bits = tuple[int, int, int, int, int]
+
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+FREE_ORBITS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+VERTICES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: tuple[Point, ...] = ((1, 0, 0),)
+L1_REMAINING: Bits = (1, 0, 1, 1, 1)
+DISPLAYED_COUNTEREXAMPLE: Bits = (0, 0, 0, 1, 0)
+FILLERS: tuple[Bits, ...] = (
+    (1, 0, 1, 1, 0),
+    (1, 0, 1, 1, 1),
+    (1, 1, 1, 1, 0),
+    (1, 1, 1, 1, 1),
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def orbit_name(cell: Cell) -> str:
+    weight = sum(cell)
+    n_full = sum(1 for i, j in AXES if cell[i] == 1 and cell[j] == 1)
+    if weight == 0:
+        return "empty"
+    if weight == 6:
+        return "full"
+    if weight == 1:
+        return "wt1"
+    if weight == 5:
+        return "wt5"
+    if weight == 2:
+        return "opp2" if n_full == 1 else "adj2"
+    if weight == 4:
+        return "opp4" if n_full == 2 else "adj4"
+    if weight == 3:
+        return "mixed3" if n_full == 1 else "vertex3"
+    raise ValueError(cell)
+
+
+def all_cells() -> tuple[Cell, ...]:
+    return tuple(product((0, 1), repeat=6))  # type: ignore[return-value]
+
+
+def complement(cell: Cell) -> Cell:
+    return tuple(1 - bit for bit in cell)  # type: ignore[return-value]
+
+
+def axis_unbalanced(cell: Cell) -> bool:
+    return any(cell[i] != cell[j] for i, j in AXES)
+
+
+def f_L1(cell: Cell) -> int:
+    """Formation on a 6-tuple iff some axis is unbalanced (n != 0)."""
+    return int(axis_unbalanced(cell))
+
+
+def f_hamming(cell: Cell) -> int:
+    return sum(cell) % 2
+
+
+def f_cut_from_bits(bits: Bits):
+    wt1, opp2, adj2, vertex3, mixed3 = bits
+    table = {
+        "empty": 0,
+        "full": 0,
+        "wt1": wt1,
+        "wt5": wt1,
+        "opp2": opp2,
+        "opp4": opp2,
+        "adj2": adj2,
+        "adj4": adj2,
+        "vertex3": vertex3,
+        "mixed3": mixed3,
+    }
+    return lambda cell: table[orbit_name(cell)]
+
+
+def remaining_bits(predicate) -> Bits:
+    reps: dict[str, Cell] = {}
+    for cell in all_cells():
+        name = orbit_name(cell)
+        if name not in reps:
+            reps[name] = cell
+    return tuple(int(predicate(reps[name])) for name in FREE_ORBITS)  # type: ignore[return-value]
+
+
+def neighborhood(site: Point, locked: set[Point]) -> Cell:
+    bits = []
+    for shift in SHIFTS:
+        neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        bits.append(1 if neighbor in locked else 0)
+    return tuple(bits)  # type: ignore[return-value]
+
+
+def run_locks(predicate, seed: tuple[Point, ...]) -> tuple[int, tuple[int, ...]]:
+    locked: set[Point] = set(seed)
+    history = [len(locked)]
+    for _tick in range(13):
+        fresh = {
+            site
+            for site in VERTICES
+            if site not in locked and predicate(neighborhood(site, locked))
+        }
+        if not fresh:
+            break
+        locked |= fresh
+        history.append(len(locked))
+    return len(locked), tuple(history)
+
+
+def fills_from_seed(predicate, seed: tuple[Point, ...]) -> bool:
+    halt, _history = run_locks(predicate, seed)
+    return halt == len(VERTICES)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Admissibility, and "
+        "Record wording; no observations or fits"
+    )
+    print("integrity_reads: this runner, its note, and the axiom memo")
+    print(
+        "construction: 32 cube-covariant complement-even predicates on the "
+        "two-cube, off-patch occupancy 0, seed (1,0,0)"
+    )
+    print("negative_scope: displayed selector only; vertex3 is not adopted")
+
+    expected_tuple = (
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")"
+    )
+    checks.check(
+        "audit-inputs",
+        "declared inputs are the required two static string literals and exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_VERTEX3_SHARED_FACE_FILL_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and expected_tuple in source
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    local_distribution = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-local-distribution",
+        "current local-distribution wording is pinned",
+        local_distribution in axiom_flat and local_distribution in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+            )
+        )
+        and formation_residual in note_flat,
+    )
+
+    cells = all_cells()
+    orbit_counts = Counter(orbit_name(cell) for cell in cells)
+    expected_counts = {
+        "empty": 1,
+        "full": 1,
+        "wt1": 6,
+        "wt5": 6,
+        "opp2": 3,
+        "adj2": 12,
+        "vertex3": 8,
+        "mixed3": 12,
+        "opp4": 3,
+        "adj4": 12,
+    }
+    checks.check(
+        "vertex-count",
+        "two-cube has twelve vertices and the seed is the shared-face site (1,0,0)",
+        len(VERTICES) == 12 == len(set(VERTICES))
+        and SEED == ((1, 0, 0),)
+        and SEED[0] in VERTICES
+        and SEED[0][0] == 1,
+    )
+    checks.check(
+        "orbit-partition",
+        "proper-cube action on six-tuples has ten orbits with derived sizes",
+        orbit_counts == expected_counts,
+        residual=dict(orbit_counts),
+    )
+    complement_pairs = {
+        (orbit_name(cell), orbit_name(complement(cell))) for cell in cells
+    }
+    checks.check(
+        "complement-action",
+        "complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3",
+        complement_pairs
+        == {
+            ("empty", "full"),
+            ("full", "empty"),
+            ("wt1", "wt5"),
+            ("wt5", "wt1"),
+            ("opp2", "opp4"),
+            ("opp4", "opp2"),
+            ("adj2", "adj4"),
+            ("adj4", "adj2"),
+            ("vertex3", "vertex3"),
+            ("mixed3", "mixed3"),
+        },
+        residual=complement_pairs,
+    )
+
+    f_cut_maps = tuple(product((0, 1), repeat=5))
+    checks.check(
+        "f-cut-cardinality",
+        "five free remaining bits give 32 F_cut maps",
+        len(f_cut_maps) == 32,
+    )
+
+    l1_bits = remaining_bits(f_L1)
+    ham_bits = remaining_bits(f_hamming)
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis is unbalanced, and evaluates to (1,0,1,1,1)",
+        l1_bits == L1_REMAINING
+        and all(f_L1(cell) == int(axis_unbalanced(cell)) for cell in cells)
+        and f_L1((0, 0, 0, 0, 0, 0)) == 0
+        and f_L1((1, 1, 1, 1, 1, 1)) == 0
+        and all(f_L1(cell) == f_L1(complement(cell)) for cell in cells),
+        residual=l1_bits,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        ham_bits == (1, 0, 0, 1, 1)
+        and ham_bits != l1_bits
+        and any(f_L1(cell) != f_hamming(cell) for cell in cells)
+        and "sum(cell) % 2"
+        not in source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+        residual=ham_bits,
+    )
+    checks.check(
+        "thm1-vertex3",
+        "f_L1 has vertex3=1",
+        l1_bits[3] == 1,
+    )
+
+    l1_halt, l1_hist = run_locks(f_L1, SEED)
+    checks.check(
+        "thm1-fill",
+        "f_L1 fills from (1,0,0) with history (1, 5, 10, 12)",
+        l1_halt == 12
+        and l1_hist == (1, 5, 10, 12)
+        and fills_from_seed(f_L1, SEED),
+        residual=(l1_halt, l1_hist),
+    )
+
+    rows = []
+    for bits in f_cut_maps:
+        predicate = f_cut_from_bits(bits)
+        filled = fills_from_seed(predicate, SEED)
+        v3 = bits[3]
+        rows.append((bits, filled, v3))
+    n_fill = sum(1 for _bits, filled, _v3 in rows if filled)
+    n_v3 = sum(1 for _bits, _filled, v3 in rows if v3 == 1)
+    n_both = sum(1 for _bits, filled, v3 in rows if filled and v3 == 1)
+    equivalent = all(filled == (v3 == 1) for _bits, filled, v3 in rows)
+    counterexamples = [
+        (bits, filled, v3) for bits, filled, v3 in rows if filled != (v3 == 1)
+    ]
+    fillers = sorted(bits for bits, filled, _v3 in rows if filled)
+    silent_hold = all(not filled for _bits, filled, v3 in rows if v3 == 0)
+    lex_cex = min(counterexamples) if counterexamples else None
+    first_neighborhoods = {
+        orbit_name(neighborhood(site, {SEED[0]}))
+        for site in VERTICES
+        if site != SEED[0]
+    }
+
+    print(f"N_fill={n_fill}")
+    print(f"N_v3={n_v3}")
+    print(f"N_both={n_both}")
+    print(f"equivalent={equivalent}")
+    print(f"lex_counterexample_tuple={None if lex_cex is None else lex_cex[0]}")
+    print(f"fillers={fillers}")
+    print(f"first_neighborhoods={sorted(first_neighborhoods)}")
+    print(f"f_L1_remaining={l1_bits}")
+    print(f"f_L1_history={l1_hist}")
+
+    checks.check(
+        "thm2-counts",
+        "N_fill=4, N_v3=16, N_both=4",
+        n_fill == 4 and n_v3 == 16 and n_both == 4,
+        residual=(n_fill, n_v3, n_both),
+    )
+    checks.check(
+        "thm2-not-equivalent",
+        "fill-from-(1,0,0) is not equivalent to f(vertex3)=1",
+        equivalent is False and n_fill != n_v3,
+    )
+    checks.check(
+        "thm2-counterexample",
+        "lex-first counterexample is (0,0,0,1,0) with fill=0 and vertex3=1",
+        lex_cex == ((0, 0, 0, 1, 0), False, 1)
+        and len(counterexamples) == 12
+        and not fills_from_seed(f_cut_from_bits(DISPLAYED_COUNTEREXAMPLE), SEED)
+        and DISPLAYED_COUNTEREXAMPLE[3] == 1,
+        residual=lex_cex,
+    )
+    checks.check(
+        "thm2-one-way",
+        "every silent-vertex3 map still has fill=0; all four fillers have vertex3=1",
+        silent_hold
+        and n_v3 == 16
+        and all(bits[3] == 1 for bits in fillers)
+        and fillers == sorted(FILLERS),
+        residual=fillers,
+    )
+    checks.check(
+        "thm2-first-neighborhoods",
+        "first neighborhoods of (1,0,0) are only wt1 or empty, so vertex3 alone cannot grow",
+        first_neighborhoods == {"wt1", "empty"}
+        and run_locks(f_cut_from_bits(DISPLAYED_COUNTEREXAMPLE), SEED)[0] == 1,
+        residual=first_neighborhoods,
+    )
+    checks.check(
+        "thm2-conjunction",
+        "fill detects wt1=adj2=vertex3=1, not the single vertex3 bit",
+        all(bits[0] == 1 and bits[2] == 1 and bits[3] == 1 for bits in fillers)
+        and all(
+            (bits[0] == 1 and bits[2] == 1 and bits[3] == 1) == filled
+            for bits, filled, _v3 in rows
+        ),
+    )
+    checks.check(
+        "note-reports-counts",
+        "the note reports N_fill, N_v3, N_both, and the counterexample tuple",
+        "N_fill = 4" in note
+        and "N_v3 = 16" in note
+        and "N_both = 4" in note
+        and "(0, 0, 0, 1, 0)" in note
+        and "is not equivalent" in note,
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, filling "
+        "from the shared-face 1-site seed (1,0,0) is not equivalent to "
+        "f(vertex3)=1. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope states the failed equivalence and does not adopt vertex3",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness failure, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "target_claim_type: bounded_theorem" in note
+        and "trace_class: frontier_discovery" in note
+        and "reachability_to_target: advances" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "authors no audit verdict" in note
+        and "FAIL / DO NOT SHIP" in note
+        and "Theorem 1" in note
+        and "Theorem 2" in note
+        and "Theorem 3" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6448",
+        "the residual is the 32-map selector, not leftover-character of #6448",
+        "Not leftover-character of #6448" in note
+        and "New selector, not leftover of #6448" in note
+        and "that listed 1-site misses" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt vertex3",
+        "no axiom or approved primitive is added" in note
+        and "Do not adopt `vertex3`" in note
+        and "Do not write `vertex3` into Admissibility" in note,
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-hygiene",
+        "machine retained fields are the only retained lines; no cache or citation surface",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut class",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "vertex3" not in axiom,
+    )
+
+    print(
+        "per_element: checked exactly — each of the 64 neighbor 6-tuples is "
+        "assigned its axis-type orbit"
+    )
+    print(
+        "per_site: checked exactly — each of the twelve two-cube vertices "
+        "uses the same six-direction stencil"
+    )
+    print(
+        "per_mode: checked exactly — every F_cut map is scored on the "
+        "shared-face seed (1,0,0)"
+    )
+    print(
+        "per_block: checked exactly — N_fill, N_v3, and N_both are the "
+        "32-map census on this patch"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Z^3-wide formation law "
+        "or physical Admissibility selector is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 32 F_cut maps, filling from the shared-face 1-site seed (1,0,0) is not equivalent to f(vertex3)=1. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_vertex3_shared_face_fill_equivalence_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.