### PR TITLE
feat(bothmax): unique F_cut joint 2-site and 3-site maximizer is (1,1,1,1,1)

### DIFF
--- a/docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,448 @@
+---
+claim_id: f_cut_joint_two_three_site_maximizer_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, N_both maps attain both cov2=66 and cov3=220. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py
+---
+
+# Joint Two-Site And Three-Site Maximizer Inside The Three-Cut Class `F_cut`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock joint-coverage census of the 32
+cube-covariant complement-even predicates that vanish on empty and full,
+on the twelve-vertex two-cube, over all 66 unordered 2-site seeds and all
+220 unordered 3-site seeds, with off-patch occupancy `0`. The selector is
+joint coverage, not leftover of either separate ranking. The displayed
+joint maximizer is not adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py`](../scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+That static cardinality is leftover-character inventory of the three-cut
+class. The two-site coverage ranking of the same 32 maps is a different
+leftover inventory: it named a two-map leftover. The three-site coverage
+ranking is a different leftover inventory: it named a different leftover
+pair. This note asks the new ranking object: among all 32 maps, which
+maps attain both maxima at once.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered pair of vertices is
+a 2-site seed and each unordered triple is a 3-site seed. There are
+`C(12,2)=66` two-site seeds and `C(12,3)=220` three-site seeds. Off-patch
+neighbors have occupancy `0`. Each tick, every unlocked on-patch vertex
+evaluates `f` on its six-neighbor occupancy tuple and locks if `f=1`. The
+process is synchronous and stops at a fixed point in at most 12 ticks.
+Fill means `|locks_halt|=12`. Coverage is
+
+```text
+cov2(f) = |{ S : |S|=2 and f fills from S }|,
+cov3(f) = |{ S : |S|=3 and f fills from S }|.
+```
+
+Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`.
+
+**Theorem 1.** Exhaustive ranking of the 32 maps reconfirms the two-site
+and three-site leftover pairs. The two maps that attain `cov2=66` have
+remaining-bit tuples
+
+```text
+(1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+The two maps that attain `cov3=220` have remaining-bit tuples
+
+```text
+(1, 0, 1, 1, 1), (1, 1, 1, 1, 1).
+```
+
+The second of those three-site maximizers is `f_L1`.
+
+**Theorem 2.** The joint-maximizer class is
+
+```text
+N_both = |{ f in F_cut : cov2(f)=66 and cov3(f)=220 }|.
+```
+
+Enumeration gives
+
+```text
+N_both = 1
+```
+
+and the remaining-bit tuple of that one map is `(1, 1, 1, 1, 1)`.
+
+**Theorem 3.** So `N_both=1` and that map is remaining-bit
+`(1, 1, 1, 1, 1)`. Displayed, not adopted.
+
+Do not write the ranking into Admissibility.
+
+Not leftover of #6430 (that was the 2-site ranking; it named a two-map leftover).
+Not leftover of #6453 (that was the 3-site ranking; a different leftover pair).
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the exact leftover pairs cov2=66 and cov3=220, and the joint-maximizer count N_both=1 with remaining-bit tuple (1,1,1,1,1) are enumerated. The displayed joint maximizer is not adopted. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_joint_two_three_site_maximizer
+target_blocker_text: "whether a unique F_cut map attains both the 2-site and 3-site coverage maxima"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F_cut joint coverage selector; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut on this twelve-vertex patch with off-patch o=0 and all 66 two-site plus 220 three-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 66 unordered 2-site seeds;
+- the complete set of 220 unordered 3-site seeds.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm the `cov2=66` pair and the `cov3=220` pair among the
+32 members of `F_cut` on the two-cube, then count how many maps attain
+both maxima, and display the remaining-bit tuple of every such map.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)`. The displayed joint
+maximizer has remaining-bit tuple `(1, 1, 1, 1, 1)`: it equals `f_L1`
+except that `opp2` is on. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov2(f)` is the number of 2-site seeds whose halt set has cardinality
+12, `cov3(f)` is the same count on 3-site seeds, and `N_both` is the number
+of maps in `F_cut` that attain both `cov2=66` and `cov3=220`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut`. It is not Hamming parity. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive ranking of
+all 32 maps on all 66 two-site seeds and all 220 three-site seeds gives
+the leftover pairs
+
+```text
+cov2=66 : (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)
+cov3=220 : (1, 0, 1, 1, 1), (1, 1, 1, 1, 1).
+```
+
+The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`, so `f_L1` is one
+of the two 3-site maximizers and is not a 2-site maximizer.
+
+**Theorem 2.** The joint coverage selector is the intersection of those
+two leftover pairs. Exhaustive ranking gives
+
+```text
+N_both = 1
+```
+
+and the remaining-bit tuple of that one map is
+
+```text
+(1, 1, 1, 1, 1).
+```
+
+Equivalently, a map in `F_cut` attains both `cov2=66` and `cov3=220` if
+and only if its remaining-bit tuple is `(1, 1, 1, 1, 1)`.
+
+**Theorem 3.** So `N_both=1` and that map is remaining-bit
+`(1, 1, 1, 1, 1)`. It is distinct from `f_L1` (they disagree on `opp2`).
+It attains `cov2=66` and `cov3=220`. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two `cov2=66` maps | remaining-bit tuples `(1, 1, 1, 1, 0)` and `(1, 1, 1, 1, 1)` |
+| two `cov3=220` maps | remaining-bit tuples `(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 66 two-site seeds | `C(12,2)` unordered pairs |
+| 220 three-site seeds | `C(12,3)` unordered triples |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `N_both` and remaining-bit tuples | exhaustive 32-map ranking of the pair `(cov2, cov3)` |
+| uniqueness of the joint maximizer | `N_both=1`; remaining-bit tuple `(1, 1, 1, 1, 1)` is the displayed map |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming is a different `F_cut` member.
+2. Change the off-patch default away from `0`: the occupancy stencil
+   changes and the coverage ranking is a different object.
+3. Drop any of the three cuts: the class is no longer the 32-element
+   `F_cut`.
+4. Score only 2-site seeds: that leftover is #6430, a different leftover
+   pair.
+5. Score only 3-site seeds: that leftover is #6453, a different leftover
+   pair.
+6. Assert that `f_L1` is the joint maximizer: `f_L1` has `cov2=62`, so it
+   is not in the joint class.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 2-site `F_cut` ranking, and no
+  leftover-character restatement of the 3-site `F_cut` ranking, in place
+  of this joint coverage selector.
+- No list of the 66 two-site seeds or the 220 three-site seeds.
+- No blank-block or 4-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is adoption: the unique joint maximizer is
+displayed and is not written into Admissibility. The positive count
+`N_both=1` with remaining-bit tuple `(1, 1, 1, 1, 1)` is an exact
+enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `cov2` pair reconfirm | Run every `F_cut` map on all 66 two-site seeds. | Theorem 1 and check `thm1-cov2-max-pair` give the two `cov2=66` tuples. | **ATTEMPTED** |
+| `cov3` pair reconfirm | Run every `F_cut` map on all 220 three-site seeds. | Theorem 1 and check `thm1-cov3-max-pair` give the two `cov3=220` tuples. | **ATTEMPTED** |
+| joint coverage selector | Count maps that attain both maxima. | Theorem 2 / Theorem 3 and checks `thm2-n-both` / `thm3-unique-joint-maximizer`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: the displayed joint maximizer is not
+adopted. The exact count `N_both=1` and the remaining-bit tuple
+`(1, 1, 1, 1, 1)` are two certificates of the same joint class, so they
+collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_both=1` / displayed `(1, 1, 1, 1, 1)` | yes: a singleton names that tuple | yes: that tuple is the singleton | collapse into the joint class |
+| leftover of #6430 / this selector | no: that leftover scored only `cov2` | no: a joint class does not replace the 2-site ranking | different object |
+| leftover of #6453 / this selector | no: that leftover scored only `cov3` | no: a joint class does not replace the 3-site ranking | different object |
+| static `|F_cut|=32` / `N_both` | no: membership is not dynamics | no: a joint count does not replace the three-cut class | separate exact counts |
+| `f_L1` membership / joint class | no: `f_L1` attains `cov3` only | no: the joint map is not `f_L1` | different remaining-bit tuples |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| all 66 two-site and 220 three-site seeds | explicit seed classes; a single ranking is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuple `(1, 1, 1, 1, 1)` | displayed joint maximizer, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:81` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:125` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:130` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:52` | 66 two-site seeds | `C(12,2)` unordered pairs on the two-cube | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:55` | 220 three-site seeds | `C(12,3)` unordered triples on the two-cube | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:198` | `cov2(f)` and `cov3(f)` | number of 2-site or 3-site seeds a map fills | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:375` | joint class | exact `N_both` on `F_cut` | yes |
+| `scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py:69` | displayed map | remaining bits `(1, 1, 1, 1, 1)` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut` | the ranking is this class on both seed cardinalities; other classes are unclaimed |
+| per block | yes: the count `N_both` | the joint class is a singleton with remaining bits `(1, 1, 1, 1, 1)` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: one
+`F_cut` map does attain both `cov2=66` and `cov3=220`. That positive
+member does not select it as the physical rule. The remaining physical
+choice — which, if any, `F_cut` map is the Admissibility occupancy
+predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that the intersection of two already-named
+leftover pairs is leftover-character of those rankings: once the
+`cov2=66` pair and the `cov3=220` pair are listed, their set-theoretic
+meet is a bookkeeping remainder. That objection is correctly about the
+existence of the two leftover pairs. It does not overturn the stated
+theorem: among all maps in `F_cut`, the new selector is the joint class
+`{f : cov2(f)=66 and cov3(f)=220}`, and that class is a singleton whose
+remaining-bit tuple is `(1, 1, 1, 1, 1)`. The displayed map differs from
+`f_L1` on `opp2`. Joint coverage is a new selector, not leftover of
+either ranking.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, and 32-map joint ranking are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `F_cut` joint coverage selector or
+adopts remaining-bit tuple `(1, 1, 1, 1, 1)` as a physical law.
+
+No-Go Discipline disposition: **PASS** for the displayed-not-adopted joint
+maximizer and the exact count `N_both=1` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube from every 2-site seed and
+every 3-site seed, reports the `cov2=66` pair and the `cov3=220` pair,
+reports `N_both = 1` with remaining-bit tuple `(1, 1, 1, 1, 1)`, checks
+that `f_L1` is not Hamming parity, and exhibits the displayed joint
+maximizer without adopting it. Declared audit inputs are this note and
+the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_joint_two_three_site_maximizer_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_joint_two_three_site_maximizer_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_joint_two_three_site_maximizer_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py
+runner_sha256: b74873f68d8ec771dd10de37b599e0a9c7d8d394ba0f07a3ffedc6eae0b740a7
+input_fingerprint_sha256: 4da5d1ea0569faf94bacd1422d512a34eb04a853bc93d24421e3f1556e838fcc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_two_site_seeds=66
+n_three_site_seeds=220
+cov2_max=66
+cov2_maximizers=[(1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+cov3_max=220
+cov3_maximizers=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+N_both=1
+both_remaining=[(1, 1, 1, 1, 1)]
+cov2_f_L1=62
+cov3_f_L1=220
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+displayed_remaining=(1, 1, 1, 1, 1)
+displayed_cov2=66
+displayed_cov3=220
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-seed-counts the two-cube has twelve vertices, C(12,2)=66 two-site seeds, C(12,3)=220 three-site seeds
+PASS: thm1-cov2-max-pair the two cov2=66 maps are remaining-bit (1,1,1,1,0) and (1,1,1,1,1)
+PASS: thm1-cov3-max-pair the two cov3=220 maps are remaining-bit (1,0,1,1,1) and (1,1,1,1,1)
+PASS: thm2-n-both N_both=1 with remaining-bit tuples [(1, 1, 1, 1, 1)]
+PASS: thm3-unique-joint-maximizer N_both=1 and that map is remaining-bit (1,1,1,1,1); displayed, not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted joint maximizer, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-joint the note reports both ranking pairs, N_both, and the displayed joint tuple
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6430-or-6453 the residual is the joint coverage selector, not leftover of #6430 or #6453
+PASS: claim-scope-joint claim_scope states N_both maps attain both cov2=66 and cov3=220
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by both cov2 and cov3
+per_block: checked exactly — N_both is the joint-maximizer count on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py
+++ b/scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""Exact joint 2-site and 3-site maximizer census of the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov2(f) (resp. cov3(f)) is the number of unordered
+2-site (resp. 3-site) seeds from which f fills. The new selector is the
+joint-maximizer class {f : cov2(f)=66 and cov3(f)=220}, not leftover of
+either separate ranking. f_L1 is the unbalanced-axis predicate (some
+n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+COV2_MAXIMIZERS: tuple[tuple[int, ...], ...] = ((1, 1, 1, 1, 0), (1, 1, 1, 1, 1))
+COV3_MAXIMIZERS: tuple[tuple[int, ...], ...] = ((1, 0, 1, 1, 1), (1, 1, 1, 1, 1))
+DISPLAYED_JOINT: tuple[int, ...] = (1, 1, 1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f_displayed(config: Config) -> int:
+    """Displayed joint maximizer: remaining bits (1, 1, 1, 1, 1).  Not adopted."""
+    kind = axis_type(config)
+    if kind in (EMPTY_TYPE, FULL_TYPE):
+        return 0
+    return 1
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate, seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def coverage_ranking(
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, int, tuple[int, ...], tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    ranked: list[tuple[int, int, tuple[int, ...], tuple[int, ...]]] = []
+    for bits, remaining in members:
+        predicate = predicate_from_bits(bits, orbit_types, type_of)
+        cov2 = coverage(predicate, TWO_SITE_SEEDS)
+        cov3 = coverage(predicate, THREE_SITE_SEEDS)
+        ranked.append((cov2, cov3, remaining, bits))
+    return ranked
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    ranked = coverage_ranking(members, orbit_types, orbits)
+    cov2_by_remaining = {remaining: cov2 for cov2, _cov3, remaining, _bits in ranked}
+    cov3_by_remaining = {remaining: cov3 for _cov2, cov3, remaining, _bits in ranked}
+    cov2_max = max(cov2 for cov2, _cov3, _remaining, _bits in ranked)
+    cov3_max = max(cov3 for _cov2, cov3, _remaining, _bits in ranked)
+    cov2_maximizers = sorted(
+        remaining for cov2, _cov3, remaining, _bits in ranked if cov2 == cov2_max
+    )
+    cov3_maximizers = sorted(
+        remaining for _cov2, cov3, remaining, _bits in ranked if cov3 == cov3_max
+    )
+    both = sorted(
+        remaining
+        for cov2, cov3, remaining, _bits in ranked
+        if cov2 == cov2_max and cov3 == cov3_max
+    )
+    n_both = len(both)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    extra_bits = bits_from_predicate(f_displayed, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    extra_remaining = remaining_bits_from_full(extra_bits, orbit_types)
+    cov2_l1 = cov2_by_remaining[l1_remaining]
+    cov3_l1 = cov3_by_remaining[l1_remaining]
+    cov2_extra = cov2_by_remaining[extra_remaining]
+    cov3_extra = cov3_by_remaining[extra_remaining]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"cov2_max={cov2_max}")
+    print(f"cov2_maximizers={cov2_maximizers}")
+    print(f"cov3_max={cov3_max}")
+    print(f"cov3_maximizers={cov3_maximizers}")
+    print(f"N_both={n_both}")
+    print(f"both_remaining={both}")
+    print(f"cov2_f_L1={cov2_l1}")
+    print(f"cov3_f_L1={cov3_l1}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"displayed_remaining={extra_remaining}")
+    print(f"displayed_cov2={cov2_extra}")
+    print(f"displayed_cov3={cov3_extra}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_JOINT_TWO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == EMPTY_TYPE
+        and full_type == FULL_TYPE
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-seed-counts",
+        "the two-cube has twelve vertices, C(12,2)=66 two-site seeds, C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS)
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-cov2-max-pair",
+        "the two cov2=66 maps are remaining-bit (1,1,1,1,0) and (1,1,1,1,1)",
+        cov2_max == 66
+        and cov2_maximizers == list(COV2_MAXIMIZERS)
+        and all(cov2_by_remaining[tuple_] == 66 for tuple_ in COV2_MAXIMIZERS)
+        and "(1, 1, 1, 1, 0)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "cov2=66" in note,
+    )
+    checks.check(
+        "thm1-cov3-max-pair",
+        "the two cov3=220 maps are remaining-bit (1,0,1,1,1) and (1,1,1,1,1)",
+        cov3_max == 220
+        and cov3_maximizers == list(COV3_MAXIMIZERS)
+        and all(cov3_by_remaining[tuple_] == 220 for tuple_ in COV3_MAXIMIZERS)
+        and l1_remaining == L1_REMAINING
+        and cov3_l1 == 220
+        and cov3_l1 == coverage(f_L1, THREE_SITE_SEEDS)
+        and "(1, 0, 1, 1, 1)" in note
+        and "cov3=220" in note,
+    )
+    checks.check(
+        "thm2-n-both",
+        f"N_both={n_both} with remaining-bit tuples {both}",
+        n_both == 1
+        and both == [DISPLAYED_JOINT]
+        and both == sorted(set(cov2_maximizers) & set(cov3_maximizers))
+        and n_both == sum(
+            1
+            for cov2, cov3, _remaining, _bits in ranked
+            if cov2 == 66 and cov3 == 220
+        )
+        and f"N_both = {n_both}" in note
+        and "(1, 1, 1, 1, 1)" in note,
+    )
+    checks.check(
+        "thm3-unique-joint-maximizer",
+        "N_both=1 and that map is remaining-bit (1,1,1,1,1); displayed, not adopted",
+        n_both == 1
+        and extra_remaining == DISPLAYED_JOINT
+        and extra_remaining != l1_remaining
+        and extra_remaining in both
+        and cov2_extra == 66
+        and cov3_extra == 220
+        and in_f_cut(extra_bits, orbit_types, empty_type, full_type)
+        and extra_remaining == remaining_bits_from_full(extra_bits, orbit_types)
+        and l1_remaining not in both
+        and cov2_l1 == 62
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted joint maximizer, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "joint coverage" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-joint",
+        "the note reports both ranking pairs, N_both, and the displayed joint tuple",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 1, 1, 1, 0)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "N_both = 1" in note
+        and "cov2=66" in note
+        and "cov3=220" in note
+        and "joint coverage" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6430-or-6453",
+        "the residual is the joint coverage selector, not leftover of #6430 or #6453",
+        "Not leftover of #6430" in note
+        and "Not leftover of #6453" in note
+        and "joint coverage" in note
+        and "different leftover pair" in note,
+    )
+    checks.check(
+        "claim-scope-joint",
+        "claim_scope states N_both maps attain both cov2=66 and cov3=220",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "N_both maps attain both cov2=66 and cov3=220" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by both cov2 and cov3")
+    print("per_block: checked exactly — N_both is the joint-maximizer count on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, exactly one map attains both cov2=66 and cov3=220: remaining bits (1,1,1,1,1). Reconfirms the #6430 and #6453 pairs. f_L1 is n≠0. Displayed, not adopted.

## Runner

`scripts/f_cut_joint_two_three_site_maximizer_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.