### PR TITLE
feat(mix0c3): f_mix0 three-site coverage is 188 of 220

### DIFF
--- a/docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,204 @@
+---
+claim_id: f_mix0_three_site_coverage_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the F_cut map (1,0,1,1,0) fills 188 of the 220 three-site seeds. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_mix0_three_site_coverage_2026_08_15.py
+---
+
+# Three-Site Coverage Of The Mixed3-Silent Opp2=0 Twin Of L1
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-to-lock coverage of the displayed F_cut map
+`(1, 0, 1, 1, 0)` on the twelve-vertex two-cube with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_mix0_three_site_coverage_2026_08_15.py`](../scripts/f_mix0_three_site_coverage_2026_08_15.py)
+
+## Result up front
+
+On the two-cube with off-patch occupancy `0`, the F_cut remaining-bit map
+
+```text
+f_mix0 = (wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 0)
+```
+
+is L1’s `opp2=0` twin with silent mixed3. L1 itself is the remaining-bit
+map `(1, 0, 1, 1, 1)`. The two maps tie on 2-site coverage inside F0
+(`cov2 = 62`, #6434). They do **not** tie on 3-site coverage.
+
+```text
+cov3(f_L1) = 220
+cov3(f_mix0) = 188
+```
+
+The #6437 splitter `S = {(0, 0, 0), (0, 0, 1), (2, 0, 0)}` is a miss for
+`f_mix0` and is one of several 3-site misses: `220 − 188 = 32` three-site
+seeds stall unfilled. This is a new number. Not leftover-character of #6437
+(that named one seed). Not leftover-character of #6456 (that reported
+`cov3(f0)` for the different map `(1, 1, 1, 1, 0)`). Displayed, not adopted.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed occupancy
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "cov3(f_L1)=220 is reconfirmed, the #6437 splitter is a miss for f_mix0, and cov3(f_mix0)=188 is computed exactly on the declared two-cube. The map is displayed, not adopted as a physical formation law."
+trace_class: negative_route_pruning
+target_claim_id: f_mix0_three_site_coverage
+target_blocker_text: "report three-site coverage of the mixed3-silent opp2=0 twin of L1"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "keep f_mix0 displayed-only; do not promote mixed3 silence into Admissibility"
+conditional_surface_status: "exact for occupancy-to-lock coverage on the twelve-vertex two-cube with off-patch occupancy 0; no physical law selection"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations. Records form. When present, a record
+locks exactly one admissible local possibility. A readout value is determined
+by record content alone. A site with no record cannot be read. Admissibility
+does not supply the formation site, probability, or rate. Admissibility is not
+a dynamics axiom.
+
+The following are declared finite scaffolding, not measured or fitted physics
+inputs:
+
+- the six-ray neighbor stencil
+  `{+e_x,-e_x,+e_y,-e_y,+e_z,-e_z}` and the 24 proper cube rotations;
+- occupancy cells `{0,1}^6`, partitioned into ten axis-type orbits;
+- the cube-covariant class `F_cut` of maps with `f(empty)=f(full)=0` and
+  `f(c)=f(1-c)`, leaving five free remaining bits
+  `(wt1, opp2, adj2, vertex3, mixed3)`;
+- the twelve-vertex two-cube `{0,1,2} × {0,1} × {0,1}`;
+- occupancy-to-lock dynamics with off-patch occupancy `0` (a blank-block is a
+  different rule);
+- two-site seeds, of which there are `66`, and three-site seeds, of which
+  there are `220`.
+
+A seed is filled when iterated lock updates occupy all twelve vertices.
+
+## Exact target and objects
+
+**Theorem 1.** Reconfirm `cov3(f_L1) = 220`. The #6437 splitter
+`S = {(0, 0, 0), (0, 0, 1), (2, 0, 0)}` is a miss for `f_mix0`.
+
+**Theorem 2.** Report `cov3(f_mix0)`. The computed value is
+`cov3(f_mix0) = 188`. Thirty-two of the 220 three-site seeds are unfilled.
+The #6437 splitter is one of those several misses.
+
+**Theorem 3.** Display `f_mix0`. Do not adopt `f_mix0`. Do not write
+`f_mix0` into Admissibility.
+
+## Claim scope
+
+On the two-cube with off-patch o=0, the F_cut map (1,0,1,1,0) fills 188 of the 220 three-site seeds.
+Displayed, not adopted.
+
+## No-Go Discipline
+
+The negative result is only that the mixed3-silent `opp2=0` twin of L1 is not
+a 3-site maximizer. It is not a universal no-go against other F_cut maps or
+against a later derived formation law.
+
+No-Go Discipline disposition: **PASS**
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| replace `f_L1` by Hamming parity | **ATTEMPTED** | Hamming disagrees with unbalanced-axis `n_μ ≠ 0` on the six-ray cells |
+| treat `cov3(f_mix0)` as leftover-character of #6437 | **ATTEMPTED** | #6437 named one 3-site splitter seed; this note counts all 220 seeds |
+| treat `cov3(f_mix0)` as leftover-character of #6456 | **ATTEMPTED** | #6456 reported `cov3(f0)` for the different remaining-bit map `(1, 1, 1, 1, 0)` |
+| adopt `f_mix0` because it ties L1 on 2-site coverage inside F0 | **ATTEMPTED** | the 2-site tie `#6434` does not imply a 3-site tie |
+| read silent mixed3 as a physical selector | **ATTEMPTED** | mixed3 silence is a remaining-bit choice, not an Admissibility derivation |
+| replace off-patch occupancy `0` by a blank-block | **ATTEMPTED** | a blank-block is a different rule |
+
+### N2 — wall independence
+
+One type wall is claimed: `f_mix0` does not fill every three-site seed. The
+#6437 seed is one miss among 32, not a second wall. No inflated wall count
+is used.
+
+### N3 — hidden-wall scan
+
+The two-cube, off-patch occupancy `0`, remaining-bit labels, and seed families
+are all declared. No full-lattice formation law, blank-block, Hamming
+substitute, or adopted selector is imported.
+
+### N4 — residual matching
+
+The residual after #6437 and #6456 was the three-site coverage of `f_mix0`.
+This note reports that new number. It neither closes a physical formation
+law nor enlarges the axiom set.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per-site: executed — each of the twelve two-cube vertices uses the same six-direction stencil
+per-mode: executed — f_mix0 and f_L1 are scored on the 220 three-site seeds
+per-block: executed — cov3(f_mix0) is the mixed3-silent three-site coverage on this patch
+lattice-wide: not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+```
+
+### N6 — partial-closure paths
+
+A later derived formation kernel, a larger patch, or a different off-patch
+rule could change coverage counts. Those routes remain live and need not
+alter the axioms.
+
+### N7 — steelman
+
+The strongest objection is that mixed3 silence is only a display choice and
+that a physical law could still fill every three-site seed. Correct: this
+note does not adopt `f_mix0` and does not claim that every F_cut map misses
+those thirty-two seeds. It reports the coverage of this one displayed map.
+
+### N8 — cross-cycle echo
+
+#6453 named `cov3(f_L1) = 220`. #6437 named one 3-site splitter. #6456
+named `cov3(f0)` for a different map. This note agrees with those surfaces
+and adds only `cov3(f_mix0)`.
+
+## Boundaries and explicit non-claims
+
+- The theorem is conditional on the declared two-cube and off-patch occupancy
+  `0`.
+- `f_mix0` and `f_L1` are displayed maps in `F_cut`. Neither is adopted.
+- Thirty-two unfilled three-site seeds are a patch count, not a physical rate.
+- No axiom, primitive, registry, or audit verdict is edited.
+- Do not write `f_mix0` into Admissibility.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/f_mix0_three_site_coverage_2026_08_15.py
+```
+
+The runner enumerates the two-cube seeds, evolves occupancy-to-lock under
+the two displayed maps, and checks the N1–N8 packet. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_mix0_three_site_coverage_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_mix0_three_site_coverage_2026_08_15.txt
+++ b/logs/runner-cache/f_mix0_three_site_coverage_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/f_mix0_three_site_coverage_2026_08_15.py
+runner_sha256: 575e79d827cad5080945b3ea62a1ecc76d81caa361a3154d34797df7f4091ab1
+input_fingerprint_sha256: d95b8790eecc0af4cb32523ef33660ad2429cf876b52d258d1084e03b9bb83c6
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_two_site_seeds=66
+n_three_site_seeds=220
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_mix0_remaining=(1, 0, 1, 1, 0)
+cov2_L1=62
+cov2_mix0=62
+cov3_L1=220
+cov3_mix0=188
+cov3_mix0_unfilled=32
+splitter_6437_fills_mix0=False
+splitter_6437_fills_L1=True
+f_mix0_mixed3=0
+f_mix0_opp2=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-seeds the two-cube has twelve vertices and C(12,3)=220 three-site seeds
+PASS: thm1-reconfirm-cov3-L1 reconfirm cov3(f_L1)=220
+PASS: thm1-6437-splitter-is-a-miss the #6437 splitter S={(0,0,0),(0,0,1),(2,0,0)} is a miss for f_mix0
+PASS: thm2-cov3-mix0 cov3(f_mix0) = 188 of the 220 three-site seeds
+PASS: thm2-mix0-remaining-bits f_mix0 is the mixed3-silent remaining-bit tuple (1, 0, 1, 1, 0)
+PASS: thm2-two-site-tie-inside-F0 f_mix0 ties f_L1 on 2-site coverage inside F0
+PASS: thm3-display-not-adopt-mix0 f_mix0 is displayed and is not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted cov3(f_mix0), and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-cov3-mix0 the note reports cov3(f_L1), the #6437 miss, and cov3(f_mix0)
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6437-or-6456 the residual is cov3(f_mix0), not leftover-character of #6437 or #6456
+PASS: claim-scope-cov3-mix0 claim_scope reports cov3(f_mix0) on the two-cube with off-patch o=0
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f_mix0 and f_L1 are scored on the 220 three-site seeds
+per_block: checked exactly — cov3(f_mix0) is the mixed3-silent three-site coverage on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_mix0_three_site_coverage_2026_08_15.py
+++ b/scripts/f_mix0_three_site_coverage_2026_08_15.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Three-site coverage of the mixed3-silent opp2=0 twin of L1.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. f_mix0 is the remaining-bit tuple (1, 0, 1, 1, 0): L1 with
+mixed3 silent. cov3(f) counts filled unordered 3-site seeds. The new object
+is cov3(f_mix0). That is not leftover-character of #6437, which named one
+splitter seed, or of #6456, which reported cov3(f0). f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+f_mix0 is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+SPLITTER_6437: frozenset[Site] = frozenset({(0, 0, 0), (0, 0, 1), (2, 0, 0)})
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+MIX0_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 0)
+F0_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f_mix0(config: Config) -> int:
+    """Displayed opp2=0 twin of L1: remaining bits (1, 0, 1, 1, 0).  Not adopted."""
+    return remaining_value(config, MIX0_REMAINING)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate, seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    mix0_bits = bits_from_predicate(f_mix0, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    mix0_remaining = remaining_bits_from_full(mix0_bits, orbit_types)
+
+    cov2_mix0 = coverage(f_mix0, TWO_SITE_SEEDS)
+    cov2_l1 = coverage(f_L1, TWO_SITE_SEEDS)
+    cov3_l1 = coverage(f_L1, THREE_SITE_SEEDS)
+    cov3_mix0 = coverage(f_mix0, THREE_SITE_SEEDS)
+    cov3_miss = len(THREE_SITE_SEEDS) - cov3_mix0
+    splitter_fills_mix0 = fills_from_seed(f_mix0, SPLITTER_6437)
+    splitter_fills_l1 = fills_from_seed(f_L1, SPLITTER_6437)
+    mixed3_index = REMAINING_LABELS.index("mixed3")
+    opp2_index = REMAINING_LABELS.index("opp2")
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_mix0_remaining={mix0_remaining}")
+    print(f"cov2_L1={cov2_l1}")
+    print(f"cov2_mix0={cov2_mix0}")
+    print(f"cov3_L1={cov3_l1}")
+    print(f"cov3_mix0={cov3_mix0}")
+    print(f"cov3_mix0_unfilled={cov3_miss}")
+    print(f"splitter_6437_fills_mix0={splitter_fills_mix0}")
+    print(f"splitter_6437_fills_L1={splitter_fills_l1}")
+    print(f"f_mix0_mixed3={mix0_remaining[mixed3_index]}")
+    print(f"f_mix0_opp2={mix0_remaining[opp2_index]}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_MIX0_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-seeds",
+        "the two-cube has twelve vertices and C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and SPLITTER_6437 in THREE_SITE_SEEDS
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-reconfirm-cov3-L1",
+        "reconfirm cov3(f_L1)=220",
+        l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and cov3_l1 == 220
+        and cov3_l1 == coverage(f_L1, THREE_SITE_SEEDS)
+        and splitter_fills_l1
+        and f"cov3(f_L1) = {cov3_l1}" in note,
+    )
+    checks.check(
+        "thm1-6437-splitter-is-a-miss",
+        "the #6437 splitter S={(0,0,0),(0,0,1),(2,0,0)} is a miss for f_mix0",
+        SPLITTER_6437 == frozenset({(0, 0, 0), (0, 0, 1), (2, 0, 0)})
+        and not splitter_fills_mix0
+        and splitter_fills_l1
+        and "{(0, 0, 0), (0, 0, 1), (2, 0, 0)}" in note
+        and "one of several" in note,
+    )
+    checks.check(
+        "thm2-cov3-mix0",
+        f"cov3(f_mix0) = {cov3_mix0} of the 220 three-site seeds",
+        cov3_mix0 == coverage(f_mix0, THREE_SITE_SEEDS)
+        and cov3_mix0 < 220
+        and cov3_miss > 1
+        and cov3_mix0 + cov3_miss == 220
+        and mix0_remaining != L1_REMAINING
+        and mix0_remaining != F0_REMAINING
+        and f"cov3(f_mix0) = {cov3_mix0}" in note,
+    )
+    checks.check(
+        "thm2-mix0-remaining-bits",
+        "f_mix0 is the mixed3-silent remaining-bit tuple (1, 0, 1, 1, 0)",
+        mix0_remaining == MIX0_REMAINING
+        and mix0_remaining[mixed3_index] == 0
+        and mix0_remaining[opp2_index] == 0
+        and l1_remaining[mixed3_index] == 1
+        and l1_remaining[opp2_index] == 0
+        and in_f_cut(mix0_bits, orbit_types, empty_type, full_type)
+        and "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 0, 1, 1, 0)" in note,
+    )
+    checks.check(
+        "thm2-two-site-tie-inside-F0",
+        "f_mix0 ties f_L1 on 2-site coverage inside F0",
+        cov2_mix0 == cov2_l1
+        and cov2_mix0 == 62
+        and mix0_remaining[opp2_index] == 0
+        and l1_remaining[opp2_index] == 0
+        and "cov2 = 62" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt-mix0",
+        "f_mix0 is displayed and is not adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt `f_mix0`" in note
+        and "Do not write `f_mix0` into Admissibility" in note
+        and mix0_remaining != l1_remaining,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted cov3(f_mix0), and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-cov3-mix0",
+        "the note reports cov3(f_L1), the #6437 miss, and cov3(f_mix0)",
+        "(1, 0, 1, 1, 0)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and f"cov3(f_L1) = {cov3_l1}" in note
+        and f"cov3(f_mix0) = {cov3_mix0}" in note
+        and f"{cov3_miss}" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write `f_mix0` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6437-or-6456",
+        "the residual is cov3(f_mix0), not leftover-character of #6437 or #6456",
+        "Not leftover-character of #6437" in note
+        and "that named one seed" in note
+        and "Not leftover-character of #6456" in note
+        and "cov3(f0)" in note
+        and "new number" in note_flat,
+    )
+    checks.check(
+        "claim-scope-cov3-mix0",
+        "claim_scope reports cov3(f_mix0) on the two-cube with off-patch o=0",
+        f"On the two-cube with off-patch o=0, the F_cut map (1,0,1,1,0) fills {cov3_mix0} of the 220 three-site seeds."
+        in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f_mix0 and f_L1 are scored on the 220 three-site seeds")
+    print("per_block: checked exactly — cov3(f_mix0) is the mixed3-silent three-site coverage on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, F_cut (1,0,1,1,0) fills 188 of 220 three-site seeds. The #6437 splitter is a miss. Displayed, not adopted.

## Runner

`scripts/f_mix0_three_site_coverage_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.