### PR TITLE
feat(cut4cover): unique 4-site F_cut maximizer is f1 not f_L1

### DIFF
--- a/docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,446 @@
+---
+claim_id: f_cut_four_site_coverage_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, the maximum number of 4-site seeds filled is 495, attained by 1 map. f_L1 is not the unique maximizer. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_four_site_coverage_2026_08_15.py
+---
+
+# Four-Site Fill Coverage Ranking Inside The Three-Cut Class `F_cut`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock coverage ranking of the 32 cube-covariant
+complement-even predicates that vanish on empty and full, on the
+twelve-vertex two-cube, over all 495 unordered 4-site seeds, with
+off-patch occupancy `0`. The unbalanced-axis map `f_L1` and the remaining-bit
+tuple `f1=(1,1,1,1,1)` are displayed as scored members. Neither is adopted
+as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_four_site_coverage_2026_08_15.py`](../scripts/f_cut_four_site_coverage_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+That static cardinality is leftover-character inventory of the three-cut
+class. The 2-site coverage ranking of the same 32 maps (#6429) is a
+different leftover inventory: it used a different seed cardinality `|S|`.
+The 3-site coverage ranking (#6453) is again a different leftover: also a
+different `|S|`, and it found two maximizers, `f_L1` and `f1`. The joint
+2+3 maximizer identity (#6457) names a pair of coverage scores, not this
+`|S|=4` ranking. This note is not a seed-table of two named maps. It asks
+the new ranking object: among all 32 maps, how many of the 495 four-site
+seeds does each fill, and is `f_L1` the unique maximizer.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 4-set of vertices is
+a 4-site seed. There are `C(12,4)=495` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov4(f) = |{ S : |S|=4 and f fills from S }|.
+```
+
+Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `f1` for the remaining-bit tuple `(1, 1, 1, 1, 1)`.
+
+**Theorem 1.** `f_L1 ∈ F_cut`, `f1 ∈ F_cut`, and
+
+```text
+cov4(f_L1) = 489
+cov4(f1) = 495.
+```
+
+The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`. The remaining-bit
+tuple of `f1` is `(1, 1, 1, 1, 1)`.
+
+**Theorem 2.** Exhaustive enumeration of the 32 maps gives
+
+```text
+m4 = 495
+N_max4 = 1.
+```
+
+So the 4-site maximum is the full seed count, attained by one map.
+
+**Theorem 3.** So `N_max4=1`, but that unique maximizer is not `f_L1`.
+The displayed maximizer is the remaining-bit tuple `(1, 1, 1, 1, 1)`,
+which is `f1`, with `cov4=495`. The map `f_L1` attains `489 < 495`.
+Displayed, not adopted.
+
+Do not write the ranking into Admissibility.
+
+Not leftover-character of #6429 (that was the 2-site ranking; different |S|).
+Not leftover-character of #6453 (that was the 3-site ranking; different |S|;
+`f_L1` and `f1` both attained the 3-site maximum).
+Not leftover-character of #6457 (that was the joint 2+3 maximizer identity,
+not this `|S|=4` ranking). This note is not a seed-table of two named maps.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, membership of f_L1 and f1, the exact integers cov4(f_L1)=489 and cov4(f1)=495, and the 4-site coverage-ranking pair (m4,N_max4)=(495,1) are enumerated. Uniqueness of f_L1 as an F_cut 4-site coverage maximizer is false on this patch. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_four_site_coverage
+target_blocker_text: "whether f_L1 uniquely maximizes 4-site fill coverage among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F_cut 4-site coverage ranking; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut on this twelve-vertex patch with off-patch o=0 and all 495 four-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 495 unordered 4-site seeds.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Rank the 32 members of `F_cut` by four-site fill coverage on
+the two-cube, report `cov4(f_L1)` and `cov4(f1)`, and decide uniqueness of
+`f_L1` as a 4-site maximizer.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+f1(c)       = 1  iff  c is neither empty nor full,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and `f1` has
+remaining-bit tuple `(1, 1, 1, 1, 1)`. The displayed maximizer is `f1`.
+Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov4(f)` is the number of 4-site seeds whose halt set has cardinality
+12, `m4` is the maximum of `cov4` over `F_cut`, and `N_max4` is the number
+of maps attaining `m4`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut`. It is not Hamming parity. The map
+`f1` is the complementary remaining-bit tuple with `opp2` on. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive run of all
+495 four-site seeds gives
+
+```text
+cov4(f_L1) = 489
+cov4(f1) = 495.
+```
+
+**Theorem 2.** Exhaustive ranking of the 32 maps on all 495 four-site
+seeds gives
+
+```text
+m4 = 495
+N_max4 = 1.
+```
+
+The unique remaining-bit tuple that attains `m4` is
+
+```text
+(1, 1, 1, 1, 1).
+```
+
+Equivalently, a map in `F_cut` fills every 4-site seed if and only if it
+is `f1`.
+
+**Theorem 3.** So `N_max4=1`, but that map is not `f_L1`. The map `f_L1`
+fills 489 of the 495 four-site seeds, so it is not a maximizer. The
+displayed maximizer is the remaining-bit tuple `(1, 1, 1, 1, 1)`. It is
+distinct from `f_L1` (they disagree on `opp2`) and has `cov4=495`.
+Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f1` is in `F_cut` | vanish on empty and full, and complement-even on every remaining orbit |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| `cov4(f_L1)=489` | exhaustive 495-seed fill census of `f_L1` |
+| `cov4(f1)=495` | exhaustive 495-seed fill census of `f1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 495 four-site seeds | `C(12,4)` unordered 4-sets |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `m4`, `N_max4` | exhaustive 32-map ranking of `cov4` |
+| uniqueness of `f_L1` as maximizer | false; remaining-bit tuple `(1, 1, 1, 1, 1)` is the unique maximizer with `cov4=495` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming is a different `F_cut` member.
+2. Change the off-patch default away from `0`: the occupancy stencil
+   changes and the coverage ranking is a different object.
+3. Drop any of the three cuts: the class is no longer the 32-element
+   `F_cut`.
+4. Score only 2-site seeds: that leftover is #6429, a different `|S|`.
+5. Score only 3-site seeds: that leftover is #6453, a different `|S|`.
+6. Identify the unique joint 2+3 maximizer and stop: that leftover is
+   #6457, not the `|S|=4` ranking.
+7. Assert that `f_L1` uniquely maximizes `cov4`: the explicit remaining-bit
+   tuple `(1, 1, 1, 1, 1)` with `cov4=495` and `cov4(f_L1)=489` refute
+   uniqueness of `f_L1`.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 2-site `F_cut` ranking, the
+  3-site `F_cut` ranking, or the joint 2+3 maximizer identity, in place
+  of this 32-map 4-site coverage ranking.
+- No list of the 495 four-site seeds, and not a seed-table of two named
+  maps.
+- No blank-block or 5-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness of the maximizer: `f_L1` is not the
+unique `F_cut` maximizer of four-site coverage on this patch. The positive
+triple `(m4, N_max4, cov4(f_L1))=(495, 1, 489)` is an exact enumeration,
+not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `cov4` of the two named maps | Run `f_L1` and `f1` on all 495 four-site seeds. | Theorem 1 and check `thm1-cov4-L1-and-f1` give `cov4(f_L1)=489` and `cov4(f1)=495`. | **ATTEMPTED** |
+| `F_cut` 4-site coverage ranking | Score every map in `F_cut` by `cov4`. | Theorem 2 and check `thm2-m4-and-n-max4` give `m4 = 495` and `N_max4 = 1`. | **ATTEMPTED** |
+| uniqueness of `f_L1` as maximizer | Ask whether the maximizer class is the singleton `{f_L1}`. | Theorem 3 and checks `thm3-not-unique-l1-maximizer` / `thm3-displayed-other-maximizer`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness of `f_L1` as maximizer fails.
+The unique maximizer being `f1` and the score `cov4(f_L1)=489 < m4` are
+two certificates of the same non-uniqueness of `f_L1`, so they collapse
+rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_max4=1` with maximizer `f1` / `cov4(f_L1)=489` | yes: the unique maximizer is not `f_L1` | yes: a strictly smaller score is non-uniqueness of `f_L1` | collapse into the uniqueness failure |
+| `cov4(f1)=495` / `m4=495` | no: a score does not name the multiplicity | no: the max does not name uniqueness of `f_L1` | independent positive integers versus uniqueness |
+| static `|F_cut|=32` / ranking pair `(m4, N_max4)` | no: membership is not dynamics | no: a ranking does not replace the three-cut class | separate exact counts |
+| leftover of #6429 / this ranking | no: that leftover scored `|S|=2` | no: a 4-site ranking does not replace the 2-site ranking | different object |
+| leftover of #6453 / this ranking | no: that leftover scored `|S|=3` | no: a 4-site ranking does not replace the 3-site ranking | different object |
+| leftover of #6457 / this ranking | no: that leftover named the joint 2+3 maximizer | no: a 4-site ranking does not replace a joint-score identity | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| all 495 four-site seeds | explicit seed class; a 2-site or 3-site ranking is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuple `(1, 1, 1, 1, 1)` | displayed witness against uniqueness of `f_L1`, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:76` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:120` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:125` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:129` | `f1` definition | remaining bits `(1, 1, 1, 1, 1)` | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:49` | 495 four-site seeds | `C(12,4)` unordered 4-sets on the two-cube | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:193` | `cov4(f)` | number of 4-site seeds a map fills | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:296` | ranking | exact `(m4, N_max4)` on `F_cut` | yes |
+| `scripts/f_cut_four_site_coverage_2026_08_15.py:62` | uniqueness | displayed maximizer, remaining bits `(1, 1, 1, 1, 1)` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut` | the ranking is this class on all 495 seeds; other classes are unclaimed |
+| per block | yes: the pair `(m4, N_max4)` | uniqueness of `f_L1` fails because the unique maximizer is `f1` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does lie in `F_cut` and does fill 489 of the 495 four-site seeds. That
+positive member does not make `f_L1` a maximizer and does not select it
+as the physical rule. The remaining physical choice — which, if any,
+`F_cut` map is the Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f1` was already the unique joint 2+3
+maximizer (#6457) and already a 3-site maximizer (#6453), so four-site
+coverage might be called a leftover decoration of those two named maps,
+or a seed-table that only scores `f_L1` against `f1`. That objection is
+correctly about the existence of a two-map comparison at other
+cardinalities. It does not overturn the stated theorem: among all 32
+maps in `F_cut`, four-site coverage selects the singleton `{f1}` and
+excludes `f_L1` (`489 < 495`). That is a ranking failure for uniqueness
+of `f_L1` at `|S|=4`, not leftover-character of #6429, #6453, or #6457,
+and not a seed-table of two named maps.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, and 32-map 495-seed ranking are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `F_cut` 4-site coverage ranking or
+restores uniqueness of `f_L1` as a maximizer inside the 32-map class.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact triple `(m4, N_max4, cov4(f_L1))` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube from every 4-site seed,
+reports `cov4(f_L1) = 489` and `cov4(f1) = 495`, reports `m4 = 495` and
+`N_max4 = 1`, checks that `f_L1` is not Hamming parity, and exhibits the
+displayed maximizer by remaining-bit tuple `(1, 1, 1, 1, 1)` with
+`cov4=495`. Declared audit inputs are this note and the axiom memo.
+No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_four_site_coverage_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_four_site_coverage_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_four_site_coverage_2026_08_15.txt
@@ -1,0 +1,65 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_four_site_coverage_2026_08_15.py
+runner_sha256: f86eb155722e8d14615dc4055309a483b3815ffa200d619e0771f9576445447e
+input_fingerprint_sha256: db53f2d720f976ff7185fdf50bb4db36045459cd3d8b1c95a8d2af61a7891f0b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.27
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_four_site_seeds=495
+cov4_f_L1=489
+cov4_f1=495
+m4=495
+N_max4=1
+maximizer_remaining=[(1, 1, 1, 1, 1)]
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f1_bits=(0, 1, 1, 0, 1, 1, 1, 1, 1, 1)
+f1_remaining=(1, 1, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+displayed_remaining=(1, 1, 1, 1, 1)
+displayed_cov4=495
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-four-site-seeds the two-cube has twelve vertices and C(12,4)=495 four-site seeds
+PASS: thm1-cov4-L1-and-f1 cov4(f_L1)=489 and cov4(f1)=495 among the 495 four-site seeds
+PASS: thm2-m4-and-n-max4 max 4-site coverage is m4=495 attained by N_max4=1 maps
+PASS: thm3-not-unique-l1-maximizer N_max4=1 but the unique maximizer is not f_L1
+PASS: thm3-displayed-other-maximizer displayed remaining-bit tuple (1, 1, 1, 1, 1) is the unique maximizer and is not f_L1
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness failure, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-ranking the note reports m4, N_max4, cov4(f_L1), cov4(f1), and a displayed maximizer tuple
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6429-6453-6457 the residual is the F_cut 4-site coverage ranking, not leftover-character of #6429, #6453, or #6457
+PASS: claim-scope-ranking claim_scope states m4, N_max4, and that f_L1 is not the unique maximizer
+PASS: seeds-not-listed the note does not list 4-site seeds
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by how many of the 495 four-site seeds it fills
+per_block: checked exactly — m4 and N_max4 are the F_cut 4-site coverage-ranking pair on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_four_site_coverage_2026_08_15.py
+++ b/scripts/f_cut_four_site_coverage_2026_08_15.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Exact 4-site fill-coverage ranking of the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov4(f) is the number of unordered 4-site seeds from
+which f fills. The new object is the |S|=4 ranking, not a seed-table of
+two named maps. f_L1 is the unbalanced-axis predicate (some n_mu != 0),
+never Hamming |c|_1 mod 2. f1 is remaining bits (1,1,1,1,1).
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+FOUR_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(quad) for quad in combinations(TWO_CUBE, 4)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F1_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 1)
+DISPLAYED_MAXIMIZER: tuple[int, ...] = (1, 1, 1, 1, 1)
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f1(config: Config) -> int:
+    """f1 remaining bits (1, 1, 1, 1, 1): on except empty and full.  Not adopted."""
+    kind = axis_type(config)
+    if kind in (EMPTY_TYPE, FULL_TYPE):
+        return 0
+    return 1
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate, seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def coverage_ranking(
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, tuple[int, ...], tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    ranked: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = []
+    for bits, remaining in members:
+        predicate = predicate_from_bits(bits, orbit_types, type_of)
+        cov4 = coverage(predicate, FOUR_SITE_SEEDS)
+        ranked.append((cov4, remaining, bits))
+    return ranked
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, orbits, empty_type, full_type)
+    ranked = coverage_ranking(members, orbit_types, orbits)
+    cov4_by_remaining = {remaining: cov4 for cov4, remaining, _bits in ranked}
+    m4 = max(cov4 for cov4, _remaining, _bits in ranked)
+    maximizers = sorted(remaining for cov4, remaining, _bits in ranked if cov4 == m4)
+    n_max4 = len(maximizers)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    f1_bits = bits_from_predicate(f1, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f1_remaining = remaining_bits_from_full(f1_bits, orbit_types)
+    cov4_l1 = cov4_by_remaining[l1_remaining]
+    cov4_f1 = cov4_by_remaining[f1_remaining]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_four_site_seeds={len(FOUR_SITE_SEEDS)}")
+    print(f"cov4_f_L1={cov4_l1}")
+    print(f"cov4_f1={cov4_f1}")
+    print(f"m4={m4}")
+    print(f"N_max4={n_max4}")
+    print(f"maximizer_remaining={maximizers}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f1_bits={f1_bits}")
+    print(f"f1_remaining={f1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"displayed_remaining={f1_remaining}")
+    print(f"displayed_cov4={cov4_f1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-four-site-seeds",
+        "the two-cube has twelve vertices and C(12,4)=495 four-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(FOUR_SITE_SEEDS) == 495
+        and len(set(FOUR_SITE_SEEDS)) == 495
+        and all(seed <= set(TWO_CUBE) and len(seed) == 4 for seed in FOUR_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-cov4-L1-and-f1",
+        "cov4(f_L1)=489 and cov4(f1)=495 among the 495 four-site seeds",
+        in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type)
+        and l1_remaining == L1_REMAINING
+        and f1_remaining == F1_REMAINING
+        and cov4_l1 == 489
+        and cov4_f1 == 495
+        and cov4_l1 == coverage(f_L1, FOUR_SITE_SEEDS)
+        and cov4_f1 == coverage(f1, FOUR_SITE_SEEDS)
+        and f"cov4(f_L1) = {cov4_l1}" in note
+        and f"cov4(f1) = {cov4_f1}" in note,
+    )
+    checks.check(
+        "thm2-m4-and-n-max4",
+        f"max 4-site coverage is m4={m4} attained by N_max4={n_max4} maps",
+        m4 == 495
+        and n_max4 == 1
+        and m4 == max(cov4_by_remaining.values())
+        and n_max4 == sum(1 for cov4 in cov4_by_remaining.values() if cov4 == m4)
+        and f"m4 = {m4}" in note
+        and f"N_max4 = {n_max4}" in note,
+    )
+    checks.check(
+        "thm3-not-unique-l1-maximizer",
+        "N_max4=1 but the unique maximizer is not f_L1",
+        n_max4 == 1
+        and l1_remaining not in maximizers
+        and cov4_l1 < m4
+        and l1_remaining == (1, 0, 1, 1, 1),
+    )
+    checks.check(
+        "thm3-displayed-other-maximizer",
+        "displayed remaining-bit tuple (1, 1, 1, 1, 1) is the unique maximizer and is not f_L1",
+        f1_remaining == DISPLAYED_MAXIMIZER
+        and f1_remaining != l1_remaining
+        and f1_remaining in maximizers
+        and maximizers == [DISPLAYED_MAXIMIZER]
+        and cov4_f1 == m4
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness failure, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "f_L1 is not the unique maximizer" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-ranking",
+        "the note reports m4, N_max4, cov4(f_L1), cov4(f1), and a displayed maximizer tuple",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "f_L1 is not the unique maximizer" in note
+        and "m4 = 495" in note
+        and "N_max4 = 1" in note
+        and "cov4(f_L1) = 489" in note
+        and "cov4(f1) = 495" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6429-6453-6457",
+        "the residual is the F_cut 4-site coverage ranking, not leftover-character of #6429, #6453, or #6457",
+        "Not leftover-character of #6429" in note
+        and "Not leftover-character of #6453" in note
+        and "Not leftover-character of #6457" in note
+        and "different |S|" in note
+        and "not a seed-table of two named maps" in note,
+    )
+    checks.check(
+        "claim-scope-ranking",
+        "claim_scope states m4, N_max4, and that f_L1 is not the unique maximizer",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "maximum number of 4-site seeds filled is 495" in note
+        and "attained by 1 map" in note
+        and "f_L1 is not the unique maximizer" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "seeds-not-listed",
+        "the note does not list 4-site seeds",
+        "Do not list the seeds" in note
+        and "combinations(TWO_CUBE" not in note
+        and "{(0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0)}" not in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by how many of the 495 four-site seeds it fills")
+    print("per_block: checked exactly — m4 and N_max4 are the F_cut 4-site coverage-ranking pair on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 32 F_cut maps on the two-cube, m4=495 attained by 1 map (f1). cov4(f_L1)=489. f_L1 is not the unique maximizer. Displayed, not adopted.

## Runner

`scripts/f_cut_four_site_coverage_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.