### PR TITLE
feat(cminmix3): cutmin mixed3 pair splits on the mix0/L1 seed

### DIFF
--- a/docs/F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,337 @@
+---
+claim_id: f_cut_cutmin_mixed3_split_seed_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0 and seed {(0,0,0),(0,0,1),(2,0,0)}, the F_cut maps (1,0,1,0,0) and (1,0,1,0,1) do not have the same lock history. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py
+---
+
+# Mix0/L1 Splitter Seed Distinguishes The Cutmin Mixed3 Pair
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock histories of the two cutmin mixed3 maps
+`(1,0,1,0,0)` and `(1,0,1,0,1)` on the twelve-vertex two-cube with off-patch
+occupancy `0`, from the displayed seed
+`S={(0,0,0),(0,0,1),(2,0,0)}`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py`](../scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6454: the maps `(1,0,1,0,0)` and `(1,0,1,0,1)` agree on the
+1-site seed `(0,0,0)` with lock history `(1,4,8,10,11,12)` (cutmin already
+so at #6418). Investment #6437: the three-site seed
+`S={(0,0,0),(0,0,1),(2,0,0)}` splits the `mix0`/`L1` pair. Investment
+#6452: the same `S` splits the `vertex3=0` k=4 pair `(1,1,1,0,0)` versus
+`(1,1,1,0,1)`. This note asks whether that same `S` splits the cutmin
+mixed3 pair `(1,0,1,0,0)` versus `(1,0,1,0,1)`.
+New uniqueness, not leftover of #6454 (that seed agreed) or #6452
+(different pair).
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+The map `f_mix0` is the remaining-bit tuple `(1, 0, 1, 1, 0)`.
+
+Write `f00` for remaining bits `(1,0,1,0,0)` and `f01` for `(1,0,1,0,1)`.
+Independent occupancy-to-lock runs, off-patch occupancy `0`:
+
+- Theorem 1. Both maps fill from `{(0,0,0)}` with history
+  `(1, 4, 8, 10, 11, 12)`. The same `S` splits `mix0`/`L1`: `f_L1` fills
+  with `(3, 8, 11, 12)` and `f_mix0` halts unfilled at `(3, 8, 10)`. The
+  same `S` splits the `vertex3=0` k=4 pair: `(1,1,1,0,0)` fills with
+  `(3, 9, 11, 12)` and `(1,1,1,0,1)` fills with `(3, 9, 12)`.
+- Theorem 2. From `S`, `f00` halts unfilled with history `(3, 8, 10)` and
+  `f01` fills with history `(3, 8, 11, 12)`.
+- Theorem 3. The two histories differ. The displayed equality bit is `0`.
+  This is not a `|S|` census. Do not adopt `mixed3`.
+
+On this seed the pair is dynamically distinct: one map fills and the other
+does not. Displayed, not adopted.
+
+Do not write `mixed3` into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Independent occupancy-to-lock runs of two named F_cut maps from one displayed seed yield exact lock histories. The equality bit is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cutmin_mixed3_split_seed
+target_blocker_text: "whether the mix0/L1 splitter seed S splits the cutmin mixed3 pair"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed history inequality; do not adopt mixed3"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- the one-site seed `{(0,0,0)}` and the three-site seed
+  `S={(0,0,0),(0,0,1),(2,0,0)}`;
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** On the two-cube with off-patch occupancy `0`, decide whether
+`f00` and `f01` have the same lock history from the displayed seed `S`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The lock history is the nondecreasing sequence of
+`|L|` after each nonempty wave, starting from the seed cardinality. The map
+`f` fills from a seed if iterating this rule from `L_0` reaches `L = T` in
+at most 13 ticks. Runs of distinct maps are independent: each starts from
+the same seed and never shares an intermediate locked set.
+
+The equality bit is `1` if the two histories are identical as tuples and
+`0` otherwise. It is not a count of seeds.
+
+## Theorems
+
+### Theorem 1 — 1-site agreement and the displayed splits on `S`
+
+`f00` and `f01` are the `F_cut` maps with remaining-bit tuples
+`(1, 0, 1, 0, 0)` and `(1, 0, 1, 0, 1)`. Direct evolution from
+`{(0,0,0)}` reaches all twelve vertices for both maps, with the same lock
+history `(1, 4, 8, 10, 11, 12)`.
+
+`f_L1` is the unbalanced-axis predicate. This is **not** Hamming parity.
+Its remaining bits are `(1, 0, 1, 1, 1)`. The map `f_mix0` is
+`(1, 0, 1, 1, 0)`. From `S`, `f_L1` fills with history `(3, 8, 11, 12)`
+and `f_mix0` halts unfilled with history `(3, 8, 10)`. So `S` splits
+`mix0`/`L1`.
+
+From the same `S`, the `vertex3=0` k=4 maps `(1,1,1,0,0)` and
+`(1,1,1,0,1)` fill with histories `(3, 9, 11, 12)` and `(3, 9, 12)`.
+So `S` splits that pair as well.
+
+### Theorem 2 — lock histories of the pair from `S`
+
+Independent runs from `S`:
+
+```text
+f00 = (1, 0, 1, 0, 0): history (3, 8, 10), does not fill
+f01 = (1, 0, 1, 0, 1): history (3, 8, 11, 12), fills
+```
+
+The histories are not the same tuple. Only `f01` fills.
+
+### Theorem 3 — equality bit `0`; do not adopt `mixed3`
+
+The displayed equality bit is `0`. The two maps do not have the same lock
+history on this seed. This is not a `|S|` census: no other seed is scored,
+and no count of splitting seeds is reported.
+
+After the shared first wave from `S`, the neighborhood of `(1,0,0)` is the
+`mixed3` orbit. The map `f01` fires that orbit and then fills; `f00` refuses
+it and halts at ten sites. That mechanism is displayed only. Do not adopt
+`mixed3`. Do not write `mixed3` into Admissibility. `f_L1` remains the
+unbalanced-axis predicate `n≠0` rather than Hamming parity.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` remaining bits of `f00` and `f01` | enumerated |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, seed `S`, off-patch 0 | declared finite patch |
+| 1-site histories agree at `(1, 4, 8, 10, 11, 12)` | proved by evolution |
+| `S` splits `mix0`/`L1` | proved by evolution |
+| `S` splits the `vertex3=0` k=4 pair | proved by evolution |
+| `S`-histories of `f00` and `f01` | proved by independent runs |
+| equality bit | `0`; displayed, not adopted |
+| leftover-character of #6454 or #6452 | refused; new uniqueness |
+| physical Admissibility selector | open |
+
+## Current premise boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility identifies the six-neighbor condition domain and covariance
+under proper cubic rotations; it does not supply the formation site, probability, or rate.
+The boolean occupancy predicates and the lock-update rule are explicit
+bounded mathematical input, not axiom text.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Permanence of a lock once formed is used only as the declared update rule on
+this finite patch. No physical readout, content map, or formation rate is
+identified.
+
+## Boundary and imports
+
+Not leftover-character of #6454: that displayed 1-site agreement of this
+pair from `(0,0,0)`. The present object is the pair of lock histories from
+a different seed.
+
+Not leftover-character of #6452: that displayed a split of the different
+`vertex3=0` k=4 pair, and of `mix0`/`L1`, on this seed. The present object
+is the same seed on the cutmin mixed3 pair.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write `mixed3` into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the mix0/L1 splitter seed `S` splits the cutmin mixed3 pair. |
+| V2 | Current main has the 1-site agreement (#6454) and the mix0/L1 and k=4 splits on `S` (#6437, #6452), but no landed history comparison of this pair on `S`. |
+| V3 | The two maps, one seed, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it separates 1-site agreement from history-agreement on `S`. |
+| V5 | It is not a physical selector: the equality bit is displayed, and `mixed3` is not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: on this patch and pair, the lock histories
+from `S` are unequal. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover #6454 | treat the `S`-histories as leftover-character of the 1-site agreement | **ATTEMPTED** |
+| leftover #6452 | treat this pair as leftover-character of the `vertex3=0` k=4 split | **ATTEMPTED** |
+| adopt `mixed3` | write the bit into Admissibility | **ATTEMPTED** |
+| `|S|` census | replace the equality bit by a count of splitting seeds | **ATTEMPTED** |
+| lattice-wide formation | lift the patch histories to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The history-inequality extra, the Hamming contrast, and the off-patch
+convention are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the seed `S`, off-patch occupancy `0`, occupancy-to-lock
+ticks, independent runs, and the `F_cut` remaining-bit order are declared.
+Equality of the two `S`-histories is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the history comparison
+of this pair on `S`, not leftover-character of #6454 or #6452.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | independent runs of the two maps from `(0,0,0)` and from `S` | no physical law selection |
+| per block | equality bit of the two lock histories on this seed | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed, a different off-patch rule, a selector
+other than this equality bit, and any independently derived physical map
+from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** Because the pair agrees from `(0,0,0)`, mixed3 is dynamically
+free on the cutmin pair, so the maps remain the same on every displayed seed.
+
+**Answer:** Fill-agreement on one seed is not history-agreement on another.
+From `S` the histories are `(3, 8, 10)` (unfilled) and `(3, 8, 11, 12)`
+(filled). The equality bit is `0`. That is a new uniqueness on this pair,
+not a leftover of the 1-site agreement.
+
+### N8 — cross-cycle echo
+
+Investment #6454 already displayed the 1-site agreement. Investment #6452
+already displayed a split of different maps on `S`. Echoing either is not a
+substitute for the pair of independent `S`-histories of this pair.
+
+No-Go Discipline disposition: **PASS** for the finite history inequality and
+the displayed equality bit. FAIL / DO NOT SHIP for “`mixed3` is selected by
+this seed” or “`mixed3` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner reconfirms the 1-site agreement
+`(1, 4, 8, 10, 11, 12)`, reconfirms that `S` splits `mix0`/`L1` and the
+`vertex3=0` k=4 pair, runs each of `f00` and `f01` independently from `S`,
+reports both histories and both fill bits, and checks that the displayed
+equality bit is `0`. Declared audit inputs are this note and the axiom
+memo; the runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cutmin_mixed3_split_seed_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cutmin_mixed3_split_seed_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cutmin_mixed3_split_seed_2026_08_15.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py
+runner_sha256: 3b34d099b9c08d7ca830e002a22f4470ce3e931f1ae5de6365802c4b6bf14253
+input_fingerprint_sha256: 63c82ee5a30480fc6b372d3d85d4a00411a78bc87da5e3583765b60ac24f78f8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo
+construction: independent occupancy-to-lock runs of F_cut maps (1,0,1,0,0) and (1,0,1,0,1) on the two-cube, off-patch occupancy 0, from (0,0,0) and from S={(0,0,0),(0,0,1),(2,0,0)}
+negative_scope: displayed equality bit only; mixed3 is not adopted
+PASS: audit-inputs declared inputs are the required two static string literals and exist
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-local-distribution current local-distribution wording is pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: vertex-count two-cube has twelve vertices and S is the displayed three-site seed
+PASS: orbit-partition proper-cube action on six-tuples has ten orbits with derived sizes
+PASS: complement-action complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis is unbalanced, and evaluates to (1,0,1,1,1)
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-one-site-agree both cutmin mixed3 maps fill from (0,0,0) with history (1, 4, 8, 10, 11, 12)
+PASS: thm1-S-splits-mix0-L1 S splits mix0/L1: L1 fills with (3, 8, 11, 12) and mix0 halts unfilled at (3, 8, 10)
+PASS: thm1-S-splits-v30-k4 S splits the vertex3=0 k=4 pair: (3, 9, 11, 12) versus (3, 9, 12)
+f00_one_site_history=(1, 4, 8, 10, 11, 12)
+f01_one_site_history=(1, 4, 8, 10, 11, 12)
+mix0_S_history=(3, 8, 10) fill=False
+L1_S_history=(3, 8, 11, 12) fill=True
+k4_f00_S_history=(3, 9, 11, 12) fill=True
+k4_f01_S_history=(3, 9, 12) fill=True
+f00_S_history=(3, 8, 10) fill=False
+f01_S_history=(3, 8, 11, 12) fill=True
+equality_bit=0
+PASS: thm2-f00-from-S f00=(1,0,1,0,0) halts unfilled from S with history (3, 8, 10)
+PASS: thm2-f01-from-S f01=(1,0,1,0,1) fills from S with history (3, 8, 11, 12)
+PASS: thm3-histories-differ the two S-histories differ; equality bit is 0, not a seed census
+PASS: note-reports-histories the note reports both S-histories, both fill bits, and equality bit 0
+PASS: claim-scope claim_scope states the failed history equality and does not adopt mixed3
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6454-6452 the residual is a new uniqueness on this pair and seed, not leftover of #6454 or #6452
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt mixed3
+PASS: note-hygiene machine retained fields are the only retained lines; no cache or citation surface
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut class
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — independent runs of the two maps from (0,0,0) and from S
+per_block: checked exactly — the displayed equality bit compares the two lock histories on this seed
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py
+++ b/scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Exact lock histories of the cutmin mixed3 pair from the mix0/L1 seed.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The scored maps are remaining bits (1,0,1,0,0) and (1,0,1,0,1).
+The scored seed is S={(0,0,0),(0,0,1),(2,0,0)}. f_L1 is the unbalanced-axis
+predicate (some n_mu != 0), never Hamming |c|_1 mod 2. The equality bit of
+the two lock histories is displayed; mixed3 is not adopted.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Cell = tuple[int, int, int, int, int, int]
+Bits = tuple[int, int, int, int, int]
+
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+FREE_ORBITS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+VERTICES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+ONE_SITE: tuple[Point, ...] = ((0, 0, 0),)
+SEED_S: tuple[Point, ...] = ((0, 0, 0), (0, 0, 1), (2, 0, 0))
+F00_BITS: Bits = (1, 0, 1, 0, 0)
+F01_BITS: Bits = (1, 0, 1, 0, 1)
+MIX0_BITS: Bits = (1, 0, 1, 1, 0)
+L1_REMAINING: Bits = (1, 0, 1, 1, 1)
+K4_F00_BITS: Bits = (1, 1, 1, 0, 0)
+K4_F01_BITS: Bits = (1, 1, 1, 0, 1)
+ONE_SITE_HISTORY: tuple[int, ...] = (1, 4, 8, 10, 11, 12)
+F00_S_HISTORY: tuple[int, ...] = (3, 8, 10)
+F01_S_HISTORY: tuple[int, ...] = (3, 8, 11, 12)
+L1_S_HISTORY: tuple[int, ...] = (3, 8, 11, 12)
+MIX0_S_HISTORY: tuple[int, ...] = (3, 8, 10)
+K4_F00_S_HISTORY: tuple[int, ...] = (3, 9, 11, 12)
+K4_F01_S_HISTORY: tuple[int, ...] = (3, 9, 12)
+EQUALITY_BIT = 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def orbit_name(cell: Cell) -> str:
+    weight = sum(cell)
+    n_full = sum(1 for i, j in AXES if cell[i] == 1 and cell[j] == 1)
+    if weight == 0:
+        return "empty"
+    if weight == 6:
+        return "full"
+    if weight == 1:
+        return "wt1"
+    if weight == 5:
+        return "wt5"
+    if weight == 2:
+        return "opp2" if n_full == 1 else "adj2"
+    if weight == 4:
+        return "opp4" if n_full == 2 else "adj4"
+    if weight == 3:
+        return "mixed3" if n_full == 1 else "vertex3"
+    raise ValueError(cell)
+
+
+def all_cells() -> tuple[Cell, ...]:
+    return tuple(product((0, 1), repeat=6))  # type: ignore[return-value]
+
+
+def complement(cell: Cell) -> Cell:
+    return tuple(1 - bit for bit in cell)  # type: ignore[return-value]
+
+
+def axis_unbalanced(cell: Cell) -> bool:
+    return any(cell[i] != cell[j] for i, j in AXES)
+
+
+def f_L1(cell: Cell) -> int:
+    """Formation on a 6-tuple iff some axis is unbalanced (n != 0)."""
+    return int(axis_unbalanced(cell))
+
+
+def f_hamming(cell: Cell) -> int:
+    return sum(cell) % 2
+
+
+def f_cut_from_bits(bits: Bits):
+    wt1, opp2, adj2, vertex3, mixed3 = bits
+    table = {
+        "empty": 0,
+        "full": 0,
+        "wt1": wt1,
+        "wt5": wt1,
+        "opp2": opp2,
+        "opp4": opp2,
+        "adj2": adj2,
+        "adj4": adj2,
+        "vertex3": vertex3,
+        "mixed3": mixed3,
+    }
+    return lambda cell: table[orbit_name(cell)]
+
+
+def remaining_bits(predicate) -> Bits:
+    reps: dict[str, Cell] = {}
+    for cell in all_cells():
+        name = orbit_name(cell)
+        if name not in reps:
+            reps[name] = cell
+    return tuple(int(predicate(reps[name])) for name in FREE_ORBITS)  # type: ignore[return-value]
+
+
+def neighborhood(site: Point, locked: set[Point]) -> Cell:
+    bits = []
+    for shift in SHIFTS:
+        neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        bits.append(1 if neighbor in locked else 0)
+    return tuple(bits)  # type: ignore[return-value]
+
+
+def run_locks(predicate, seed: tuple[Point, ...]) -> tuple[int, tuple[int, ...]]:
+    locked: set[Point] = set(seed)
+    history = [len(locked)]
+    for _tick in range(13):
+        fresh = {
+            site
+            for site in VERTICES
+            if site not in locked and predicate(neighborhood(site, locked))
+        }
+        if not fresh:
+            break
+        locked |= fresh
+        history.append(len(locked))
+    return len(locked), tuple(history)
+
+
+def fills_from_seed(predicate, seed: tuple[Point, ...]) -> bool:
+    halt, _history = run_locks(predicate, seed)
+    return halt == len(VERTICES)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Admissibility, and "
+        "Record wording; no observations or fits"
+    )
+    print("integrity_reads: this runner, its note, and the axiom memo")
+    print(
+        "construction: independent occupancy-to-lock runs of F_cut maps "
+        "(1,0,1,0,0) and (1,0,1,0,1) on the two-cube, off-patch occupancy 0, "
+        "from (0,0,0) and from S={(0,0,0),(0,0,1),(2,0,0)}"
+    )
+    print("negative_scope: displayed equality bit only; mixed3 is not adopted")
+
+    expected_tuple = (
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")"
+    )
+    checks.check(
+        "audit-inputs",
+        "declared inputs are the required two static string literals and exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_CUTMIN_MIXED3_SPLIT_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and expected_tuple in source
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    local_distribution = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-local-distribution",
+        "current local-distribution wording is pinned",
+        local_distribution in axiom_flat and local_distribution in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+            )
+        )
+        and formation_residual in note_flat,
+    )
+
+    cells = all_cells()
+    orbit_counts = Counter(orbit_name(cell) for cell in cells)
+    expected_counts = {
+        "empty": 1,
+        "full": 1,
+        "wt1": 6,
+        "wt5": 6,
+        "opp2": 3,
+        "adj2": 12,
+        "vertex3": 8,
+        "mixed3": 12,
+        "opp4": 3,
+        "adj4": 12,
+    }
+    checks.check(
+        "vertex-count",
+        "two-cube has twelve vertices and S is the displayed three-site seed",
+        len(VERTICES) == 12 == len(set(VERTICES))
+        and SEED_S == ((0, 0, 0), (0, 0, 1), (2, 0, 0))
+        and set(SEED_S).issubset(set(VERTICES))
+        and ONE_SITE == ((0, 0, 0),),
+    )
+    checks.check(
+        "orbit-partition",
+        "proper-cube action on six-tuples has ten orbits with derived sizes",
+        orbit_counts == expected_counts,
+        residual=dict(orbit_counts),
+    )
+    complement_pairs = {
+        (orbit_name(cell), orbit_name(complement(cell))) for cell in cells
+    }
+    checks.check(
+        "complement-action",
+        "complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3",
+        complement_pairs
+        == {
+            ("empty", "full"),
+            ("full", "empty"),
+            ("wt1", "wt5"),
+            ("wt5", "wt1"),
+            ("opp2", "opp4"),
+            ("opp4", "opp2"),
+            ("adj2", "adj4"),
+            ("adj4", "adj2"),
+            ("vertex3", "vertex3"),
+            ("mixed3", "mixed3"),
+        },
+        residual=complement_pairs,
+    )
+
+    f00 = f_cut_from_bits(F00_BITS)
+    f01 = f_cut_from_bits(F01_BITS)
+    mix0 = f_cut_from_bits(MIX0_BITS)
+    k4_f00 = f_cut_from_bits(K4_F00_BITS)
+    k4_f01 = f_cut_from_bits(K4_F01_BITS)
+    l1_bits = remaining_bits(f_L1)
+    ham_bits = remaining_bits(f_hamming)
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis is unbalanced, and evaluates to (1,0,1,1,1)",
+        l1_bits == L1_REMAINING
+        and remaining_bits(mix0) == MIX0_BITS
+        and remaining_bits(f00) == F00_BITS
+        and remaining_bits(f01) == F01_BITS
+        and remaining_bits(k4_f00) == K4_F00_BITS
+        and remaining_bits(k4_f01) == K4_F01_BITS
+        and all(f_L1(cell) == int(axis_unbalanced(cell)) for cell in cells)
+        and f_L1((0, 0, 0, 0, 0, 0)) == 0
+        and f_L1((1, 1, 1, 1, 1, 1)) == 0
+        and all(f_L1(cell) == f_L1(complement(cell)) for cell in cells),
+        residual=l1_bits,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        ham_bits == (1, 0, 0, 1, 1)
+        and ham_bits != l1_bits
+        and any(f_L1(cell) != f_hamming(cell) for cell in cells)
+        and "sum(cell) % 2"
+        not in source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+        residual=ham_bits,
+    )
+
+    f00_one_halt, f00_one_hist = run_locks(f00, ONE_SITE)
+    f01_one_halt, f01_one_hist = run_locks(f01, ONE_SITE)
+    checks.check(
+        "thm1-one-site-agree",
+        "both cutmin mixed3 maps fill from (0,0,0) with history (1, 4, 8, 10, 11, 12)",
+        f00_one_halt == 12
+        and f01_one_halt == 12
+        and f00_one_hist == ONE_SITE_HISTORY
+        and f01_one_hist == ONE_SITE_HISTORY
+        and f00_one_hist == f01_one_hist
+        and fills_from_seed(f00, ONE_SITE)
+        and fills_from_seed(f01, ONE_SITE),
+        residual=(f00_one_hist, f01_one_hist),
+    )
+
+    mix0_s_halt, mix0_s_hist = run_locks(mix0, SEED_S)
+    l1_s_halt, l1_s_hist = run_locks(f_L1, SEED_S)
+    checks.check(
+        "thm1-S-splits-mix0-L1",
+        "S splits mix0/L1: L1 fills with (3, 8, 11, 12) and mix0 halts unfilled at (3, 8, 10)",
+        l1_s_halt == 12
+        and mix0_s_halt == 10
+        and l1_s_hist == L1_S_HISTORY
+        and mix0_s_hist == MIX0_S_HISTORY
+        and fills_from_seed(f_L1, SEED_S)
+        and not fills_from_seed(mix0, SEED_S)
+        and mix0_s_hist != l1_s_hist,
+        residual=(mix0_s_hist, l1_s_hist),
+    )
+
+    k4_f00_s_halt, k4_f00_s_hist = run_locks(k4_f00, SEED_S)
+    k4_f01_s_halt, k4_f01_s_hist = run_locks(k4_f01, SEED_S)
+    checks.check(
+        "thm1-S-splits-v30-k4",
+        "S splits the vertex3=0 k=4 pair: (3, 9, 11, 12) versus (3, 9, 12)",
+        k4_f00_s_halt == 12
+        and k4_f01_s_halt == 12
+        and k4_f00_s_hist == K4_F00_S_HISTORY
+        and k4_f01_s_hist == K4_F01_S_HISTORY
+        and k4_f00_s_hist != k4_f01_s_hist
+        and fills_from_seed(k4_f00, SEED_S)
+        and fills_from_seed(k4_f01, SEED_S),
+        residual=(k4_f00_s_hist, k4_f01_s_hist),
+    )
+
+    f00_s_halt, f00_s_hist = run_locks(f00, SEED_S)
+    f01_s_halt, f01_s_hist = run_locks(f01, SEED_S)
+    equality_bit = int(f00_s_hist == f01_s_hist)
+    print(f"f00_one_site_history={f00_one_hist}")
+    print(f"f01_one_site_history={f01_one_hist}")
+    print(f"mix0_S_history={mix0_s_hist} fill={mix0_s_halt == 12}")
+    print(f"L1_S_history={l1_s_hist} fill={l1_s_halt == 12}")
+    print(f"k4_f00_S_history={k4_f00_s_hist} fill={k4_f00_s_halt == 12}")
+    print(f"k4_f01_S_history={k4_f01_s_hist} fill={k4_f01_s_halt == 12}")
+    print(f"f00_S_history={f00_s_hist} fill={f00_s_halt == 12}")
+    print(f"f01_S_history={f01_s_hist} fill={f01_s_halt == 12}")
+    print(f"equality_bit={equality_bit}")
+
+    checks.check(
+        "thm2-f00-from-S",
+        "f00=(1,0,1,0,0) halts unfilled from S with history (3, 8, 10)",
+        f00_s_halt == 10
+        and f00_s_hist == F00_S_HISTORY
+        and not fills_from_seed(f00, SEED_S),
+        residual=(f00_s_halt, f00_s_hist),
+    )
+    checks.check(
+        "thm2-f01-from-S",
+        "f01=(1,0,1,0,1) fills from S with history (3, 8, 11, 12)",
+        f01_s_halt == 12
+        and f01_s_hist == F01_S_HISTORY
+        and fills_from_seed(f01, SEED_S),
+        residual=(f01_s_halt, f01_s_hist),
+    )
+    checks.check(
+        "thm3-histories-differ",
+        "the two S-histories differ; equality bit is 0, not a seed census",
+        f00_s_hist != f01_s_hist
+        and equality_bit == EQUALITY_BIT == 0
+        and f00_s_halt == 10
+        and f01_s_halt == 12,
+        residual=(f00_s_hist, f01_s_hist, equality_bit),
+    )
+    checks.check(
+        "note-reports-histories",
+        "the note reports both S-histories, both fill bits, and equality bit 0",
+        "(3, 8, 10)" in note
+        and "(3, 8, 11, 12)" in note
+        and "(1, 4, 8, 10, 11, 12)" in note
+        and "equality bit is `0`" in note
+        and "do not have the same lock history" in note,
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0 and seed "
+        "{(0,0,0),(0,0,1),(2,0,0)}, the F_cut maps (1,0,1,0,0) and "
+        "(1,0,1,0,1) do not have the same lock history. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope states the failed history equality and does not adopt mixed3",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "target_claim_type: bounded_theorem" in note
+        and "trace_class: frontier_discovery" in note
+        and "reachability_to_target: advances" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "authors no audit verdict" in note
+        and "FAIL / DO NOT SHIP" in note
+        and "Theorem 1" in note
+        and "Theorem 2" in note
+        and "Theorem 3" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6454-6452",
+        "the residual is a new uniqueness on this pair and seed, not leftover of #6454 or #6452",
+        "Not leftover-character of #6454" in note
+        and "Not leftover-character of #6452" in note
+        and "New uniqueness" in note
+        and "not a `|S|` census" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt mixed3",
+        "no axiom or approved primitive is added" in note
+        and "Do not adopt `mixed3`" in note
+        and "Do not write `mixed3` into Admissibility" in note,
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-hygiene",
+        "machine retained fields are the only retained lines; no cache or citation surface",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut class",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "mixed3" not in axiom,
+    )
+
+    print(
+        "per_element: checked exactly — each of the 64 neighbor 6-tuples is "
+        "assigned its axis-type orbit"
+    )
+    print(
+        "per_site: checked exactly — each of the twelve two-cube vertices "
+        "uses the same six-direction stencil"
+    )
+    print(
+        "per_mode: checked exactly — independent runs of the two maps from "
+        "(0,0,0) and from S"
+    )
+    print(
+        "per_block: checked exactly — the displayed equality bit compares the "
+        "two lock histories on this seed"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Z^3-wide formation law "
+        "or physical Admissibility selector is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, seed S={(0,0,0),(0,0,1),(2,0,0)} splits F_cut (1,0,1,0,0) from (1,0,1,0,1): f00 halts unfilled (3,8,10) and f01 fills (3,8,11,12). Same S already splits mix0/L1 and the v3=0 k=4 pair. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_cutmin_mixed3_split_seed_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.