### PR TITLE
feat(cutkuniq): coverage is unique only at k=4,6,8 and the maximizer is f1

### DIFF
--- a/docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,455 @@
+---
+claim_id: f_cut_k_site_uniqueness_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, the seed sizes k in {1,5,6,7,8,9,10,11} at which coverage has a unique maximizer are reported, and that maximizer is named as f_L1 or f1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_k_site_uniqueness_2026_08_15.py
+---
+
+# For Which Seed Sizes Is `F_cut` Coverage Unique
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock coverage uniqueness set of the 32
+cube-covariant complement-even predicates that vanish on empty and full, on
+the twelve-vertex two-cube, over all k-site seeds for each
+`k ∈ {1,5,6,7,8,9,10,11}`, with off-patch occupancy `0`. Seed sizes 2, 3,
+and 4 are cited from #6429, #6453, and #6460 and are not re-censused. The
+unbalanced-axis map `f_L1` and the remaining-bit tuple `f1=(1,1,1,1,1)` are
+displayed as named members. Neither is adopted as the physical
+Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_k_site_uniqueness_2026_08_15.py`](../scripts/f_cut_k_site_uniqueness_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+That static cardinality is leftover-character inventory of the three-cut
+class. A single-k coverage ranking of the same 32 maps is also leftover
+inventory of one seed cardinality. New selector, not leftover of one k.
+This note asks the new ranking object: among all 32 maps, for each census
+seed size, how many k-site seeds does each fill, at which k is the
+maximizer unique, and is that unique maximizer `f_L1` or `f1`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered k-set of vertices is
+a k-site seed. Off-patch neighbors have occupancy `0`. Each tick, every
+unlocked on-patch vertex evaluates `f` on its six-neighbor occupancy tuple
+and locks if `f=1`. The process is synchronous and stops at a fixed point
+in at most 12 ticks. Fill means `|locks_halt|=12`. Coverage is
+
+```text
+cov_k(f) = |{ S : |S|=k and f fills from S }|.
+```
+
+Do not list the seeds. Do not re-census k=2,3,4.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `f1` for the remaining-bit tuple `(1, 1, 1, 1, 1)`.
+The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+**Theorem 1.** Exhaustive ranking of the 32 maps on every k-site seed for
+each census size gives
+
+```text
+m_1 = 12
+N_max_1 = 4
+m_5 = 792
+N_max_5 = 2
+m_6 = 924
+N_max_6 = 1
+m_7 = 792
+N_max_7 = 2
+m_8 = 495
+N_max_8 = 1
+m_9 = 220
+N_max_9 = 4
+m_10 = 66
+N_max_10 = 4
+m_11 = 12
+N_max_11 = 8.
+```
+
+**Theorem 2.** Write `K_unique = {k ∈ 1..11 : N_max_k = 1}`. Citing #6429
+(`N_max_2 = 2`), #6453 (`N_max_3 = 2`), and #6460 (`N_max_4 = 1` is `f1`)
+without recomputing those three as the claim,
+
+```text
+K_unique = {4, 6, 8}.
+```
+
+**Theorem 3.** For each `k ∈ K_unique` the unique maximizer is `f1`, not
+`f_L1`. At the two newly ranked members, `cov_6(f1)=924=m_6` while
+`cov_6(f_L1)=920`, and `cov_8(f1)=495=m_8` while `cov_8(f_L1)=494`. The
+k=4 member is the cited #6460 identity. Displayed, not adopted.
+
+Do not write the ranking into Admissibility.
+
+Not leftover-character of #6429 (that was the 2-site ranking; different |S|).
+Not leftover-character of #6453 (that was the 3-site ranking; different |S|).
+Not leftover-character of #6460 (that was the 4-site ranking; different |S|;
+one of the three members of `K_unique`, not the uniqueness set). New
+selector, not leftover of one k.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, membership of f_L1 and f1, the eight census pairs (m_k,N_max_k), the cited N_max values at k=2,3,4, the uniqueness set K_unique={4,6,8}, and the name f1 of each unique maximizer are enumerated. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_k_site_uniqueness
+target_blocker_text: "for which seed sizes other than 2, 3, 4 does F_cut coverage select one map, and is that map f_L1 or f1"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F_cut k-site uniqueness set; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut on this twelve-vertex patch with off-patch o=0 and the eight census seed sizes, citing #6429/#6453/#6460 for k=2,3,4; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of k-site seeds for each census `k`;
+- the cited ranking pairs `N_max_2=2` (#6429), `N_max_3=2` (#6453), and
+  `N_max_4=1` with unique maximizer `f1` (#6460).
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Rank the 32 members of `F_cut` by k-site fill coverage on the
+two-cube for each `k ∈ {1,5,6,7,8,9,10,11}`, form
+`K_unique = {k ∈ 1..11 : N_max_k = 1}` by adjoining the cited values at
+k=2,3,4, and name each unique maximizer as `f_L1` or `f1`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+f1(c)       = 1  iff  c is neither empty nor full,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and `f1` has
+remaining-bit tuple `(1, 1, 1, 1, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov_k(f)` is the number of k-site seeds whose halt set has
+cardinality 12, `m_k` is the maximum of `cov_k` over `F_cut`, and
+`N_max_k` is the number of maps attaining `m_k`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut`. It is not Hamming parity. The map
+`f1` is the complementary remaining-bit tuple with `opp2` on. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive ranking of
+all 32 maps on every census seed size gives the eight pairs
+
+```text
+(m_1, N_max_1) = (12, 4)
+(m_5, N_max_5) = (792, 2)
+(m_6, N_max_6) = (924, 1)
+(m_7, N_max_7) = (792, 2)
+(m_8, N_max_8) = (495, 1)
+(m_9, N_max_9) = (220, 4)
+(m_10, N_max_10) = (66, 4)
+(m_11, N_max_11) = (12, 8).
+```
+
+**Theorem 2.** The uniqueness set, using the cited values `N_max_2=2`
+(#6429), `N_max_3=2` (#6453), and `N_max_4=1` (#6460) and the eight
+computed `N_max_k`, is
+
+```text
+K_unique = {4, 6, 8}.
+```
+
+Those three cited cardinalities are not recomputed here.
+
+**Theorem 3.** For each `k ∈ K_unique` the unique maximizer is `f1`, not
+`f_L1`. At k=6 the unique remaining-bit tuple is `(1, 1, 1, 1, 1)` with
+`cov_6=924`. At k=8 the unique remaining-bit tuple is again
+`(1, 1, 1, 1, 1)` with `cov_8=495`. The k=4 member is the cited #6460
+identity that `N_max_4=1` is `f1`. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f1` is in `F_cut` | vanish on empty and full, and complement-even on every remaining orbit |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| eight census seed counts | `C(12,k)` for `k ∈ {1,5,6,7,8,9,10,11}` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| eight pairs `(m_k, N_max_k)` | exhaustive 32-map ranking of `cov_k` on each census size |
+| cited `N_max_2,N_max_3,N_max_4` | #6429, #6453, #6460; not recomputed |
+| `K_unique={4,6,8}` | `{k ∈ 1..11 : N_max_k=1}` |
+| unique maximizer name | `f1` at each of 4, 6, 8; not `f_L1` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming is a different `F_cut` member.
+2. Change the off-patch default away from `0`: the occupancy stencil
+   changes and the uniqueness set is a different object.
+3. Drop any of the three cuts: the class is no longer the 32-element
+   `F_cut`.
+4. Score only 2-site seeds: that leftover is #6429, a different `|S|`.
+5. Score only 3-site seeds: that leftover is #6453, a different `|S|`.
+6. Score only 4-site seeds: that leftover is #6460, a different `|S|`.
+7. Assert that `f_L1` is the unique maximizer at some `k ∈ K_unique`: at
+   each such k the unique maximizer is `f1`.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 2-site, 3-site, or 4-site
+  `F_cut` ranking in place of this multi-k uniqueness set.
+- No list of the k-site seeds, and not a recensus of k=2,3,4.
+- No blank-block variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness of `f_L1` as the unique-k maximizer:
+on this patch, whenever coverage has a unique maximizer in `1..11`, that
+map is `f1`, not `f_L1`. The positive set `K_unique={4,6,8}` and the eight
+census pairs are an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| eight-k coverage ranking | Score every map in `F_cut` by `cov_k` for each census k. | Theorem 1 and check `thm1-m-and-n-max-census`. | **ATTEMPTED** |
+| uniqueness set | Form `{k ∈ 1..11 : N_max_k=1}` from the census and the three citations. | Theorem 2 and checks `thm2-k-unique-set` / `thm2-cites-without-recensus`. | **ATTEMPTED** |
+| unique maximizer name | Ask whether each unique maximizer is `f_L1` or `f1`. | Theorem 3 and check `thm3-unique-maximizers-are-f1`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness of `f_L1` as the unique-k
+maximizer fails. The three identities “unique maximizer at 4, 6, 8 is
+`f1`” are three certificates of the same non-uniqueness of `f_L1` on
+`K_unique`, so they collapse rather than count as three walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| unique maximizer is `f1` at k=6 / `cov_6(f_L1)=920` | yes: the unique maximizer is not `f_L1` | yes: a strictly smaller score is non-uniqueness of `f_L1` | collapse into the uniqueness failure |
+| unique maximizer is `f1` at k=8 / unique maximizer is `f1` at k=6 | yes: both name `f1` on `K_unique` | yes: both name `f1` on `K_unique` | collapse into the uniqueness failure |
+| static `|F_cut|=32` / `K_unique` | no: membership is not dynamics | no: a uniqueness set does not replace the three-cut class | separate exact counts |
+| leftover of #6429 / this set | no: that leftover scored `|S|=2` | no: a multi-k set does not replace the 2-site ranking | different object |
+| leftover of #6453 / this set | no: that leftover scored `|S|=3` | no: a multi-k set does not replace the 3-site ranking | different object |
+| leftover of #6460 / this set | no: that leftover scored `|S|=4` | no: a uniqueness set does not replace the 4-site ranking | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| census seed sizes `{1,5,6,7,8,9,10,11}` | explicit seed class; a single-k ranking is a different residual |
+| cited k=2,3,4 | explicit non-recensus; those pairs are inherited, not recomputed |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuple `(1, 1, 1, 1, 1)` | displayed unique maximizer on `K_unique`, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:77` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:121` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:126` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:130` | `f1` definition | remaining bits `(1, 1, 1, 1, 1)` | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:51` | census seed sizes | `k ∈ {1,5,6,7,8,9,10,11}` | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:52` | cited `N_max` at 2,3,4 | #6429, #6453, #6460; not recomputed | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:321` | `cov_k(f)` | number of k-site seeds a map fills | yes |
+| `scripts/f_cut_k_site_uniqueness_2026_08_15.py:329` | unique maximizer name | `f1` or `f_L1` from remaining bits | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut` | the ranking is this class on each census seed size; other classes are unclaimed |
+| per block | yes: the set `K_unique` | uniqueness of `f_L1` fails because each unique maximizer is `f1` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does lie in `F_cut` and does attain the coverage maximum at several
+non-unique seed sizes. That positive member does not make `f_L1` a unique
+maximizer at any `k ∈ 1..11` and does not select it as the physical rule.
+The remaining physical choice — which, if any, `F_cut` map is the
+Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f1` was already the unique 4-site
+maximizer (#6460), so adjoining k=6 and k=8 might be called leftover
+decoration of that one k, or a seed-table that only scores `f_L1` against
+`f1`. That objection is correctly about the existence of a unique
+maximizer at `|S|=4`. It does not overturn the stated theorem: among all
+32 maps in `F_cut`, the set of seed sizes in `1..11` at which coverage
+has a unique maximizer is `{4,6,8}`, and that maximizer is `f1` at each
+member. That is a new multi-k selector, not leftover-character of #6429,
+#6453, or #6460, and not leftover of one k.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, and eight-k 32-map ranking are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `F_cut` k-site uniqueness set or restores
+uniqueness of `f_L1` as a maximizer inside the 32-map class.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure of
+`f_L1` on `K_unique` and the exact set `{4, 6, 8}` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube from every k-site seed for
+each `k ∈ {1,5,6,7,8,9,10,11}`, reports each `(m_k, N_max_k)`, forms
+`K_unique = {4, 6, 8}` by citing #6429/#6453/#6460 for k=2,3,4 without
+recensing those three, checks that `f_L1` is not Hamming parity, and
+names the unique maximizer at each member of `K_unique` as `f1`.
+Declared audit inputs are this note and the axiom memo. No runner cache
+is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_k_site_uniqueness_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_k_site_uniqueness_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_k_site_uniqueness_2026_08_15.txt
@@ -1,0 +1,71 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_k_site_uniqueness_2026_08_15.py
+runner_sha256: 3499529389adae0659eb48a75682824a733a0be572223bddaf96e014ce1630a6
+input_fingerprint_sha256: 6ecaa4c7fab233082ebdd0c5806fa0ff2b170cfa8d5ba5a7e0faa3a334c1e5dc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.50
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+census_ks=(1, 5, 6, 7, 8, 9, 10, 11)
+k=1 n_seeds=12 m_1=12 N_max_1=4 cov_L1=12 cov_f1=12
+k=5 n_seeds=792 m_5=792 N_max_5=2 cov_L1=792 cov_f1=792
+k=6 n_seeds=924 m_6=924 N_max_6=1 cov_L1=920 cov_f1=924
+unique_maximizer_6=f1 remaining=(1, 1, 1, 1, 1)
+k=7 n_seeds=792 m_7=792 N_max_7=2 cov_L1=792 cov_f1=792
+k=8 n_seeds=495 m_8=495 N_max_8=1 cov_L1=494 cov_f1=495
+unique_maximizer_8=f1 remaining=(1, 1, 1, 1, 1)
+k=9 n_seeds=220 m_9=220 N_max_9=4 cov_L1=220 cov_f1=220
+k=10 n_seeds=66 m_10=66 N_max_10=4 cov_L1=66 cov_f1=66
+k=11 n_seeds=12 m_11=12 N_max_11=8 cov_L1=12 cov_f1=12
+cited_N_max={2: 2, 3: 2, 4: 1}
+K_unique=[4, 6, 8]
+unique_names={4: 'f1', 6: 'f1', 8: 'f1'}
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f1_bits=(0, 1, 1, 0, 1, 1, 1, 1, 1, 1)
+f1_remaining=(1, 1, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-census-seeds the two-cube has twelve vertices and the eight census k-site seed counts
+PASS: thm1-m-and-n-max-census each census k reports its computed (m_k, N_max_k) pair
+PASS: thm2-k-unique-set K_unique is the seed sizes in 1..11 with N_max_k=1
+PASS: thm2-cites-without-recensus k=2,3,4 enter K_unique only as cited N_max values, not a recensus
+PASS: thm3-unique-maximizers-are-f1 for each k in K_unique the unique maximizer is f1, not f_L1
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness set, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-ranking the note reports every census pair, K_unique, and names f1 not f_L1
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-one-k the residual is the multi-k uniqueness set, not leftover-character of one k
+PASS: claim-scope-ranking claim_scope reports unique-maximizer seed sizes and names f_L1 or f1
+PASS: seeds-not-listed the note does not list k-site seeds and does not recensus 2,3,4
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on each census seed size
+per_block: checked exactly — K_unique is the set of k in 1..11 with a unique coverage maximizer
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_k_site_uniqueness_2026_08_15.py
+++ b/scripts/f_cut_k_site_uniqueness_2026_08_15.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+"""Exact F_cut k-site coverage uniqueness set on the two-cube.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. For each k in {1,5,6,7,8,9,10,11}, cov_k(f) is the number of
+unordered k-site seeds from which f fills. The new object is the set of
+seed sizes whose coverage ranking has a unique maximizer, not leftover of
+one k. Do not re-census k=2,3,4: cite #6429 N_max2=2, #6453 N_max3=2,
+#6460 N_max4=1 is f1. f_L1 is the unbalanced-axis predicate (some n_mu !=
+0), never Hamming |c|_1 mod 2. f1 is remaining bits (1,1,1,1,1).
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+CENSUS_KS: tuple[int, ...] = (1, 5, 6, 7, 8, 9, 10, 11)
+CITED_N_MAX: dict[int, int] = {2: 2, 3: 2, 4: 1}
+CITED_UNIQUE_NAME: dict[int, str] = {4: "f1"}
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F1_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 1)
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f1(config: Config) -> int:
+    """f1 remaining bits (1, 1, 1, 1, 1): on except empty and full.  Not adopted."""
+    kind = axis_type(config)
+    if kind in (EMPTY_TYPE, FULL_TYPE):
+        return 0
+    return 1
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config: Config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def name_unique_maximizer(remaining: tuple[int, ...]) -> str:
+    if remaining == F1_REMAINING:
+        return "f1"
+    if remaining == L1_REMAINING:
+        return "f_L1"
+    raise RuntimeError(f"unique maximizer {remaining} is neither f1 nor f_L1")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    neighbors = neighbor_indices()
+    seed_masks = {k: seed_masks_for(k) for k in CENSUS_KS}
+
+    ranked: dict[int, list[tuple[int, tuple[int, ...]]]] = {k: [] for k in CENSUS_KS}
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        for k in CENSUS_KS:
+            cov = coverage_from_masks(table, seed_masks[k], neighbors)
+            ranked[k].append((cov, remaining))
+
+    m_of: dict[int, int] = {}
+    n_max_of: dict[int, int] = {}
+    maximizers_of: dict[int, list[tuple[int, ...]]] = {}
+    cov_l1_of: dict[int, int] = {}
+    cov_f1_of: dict[int, int] = {}
+    for k in CENSUS_KS:
+        scores = ranked[k]
+        m_k = max(cov for cov, _remaining in scores)
+        maximizers = sorted(remaining for cov, remaining in scores if cov == m_k)
+        m_of[k] = m_k
+        n_max_of[k] = len(maximizers)
+        maximizers_of[k] = maximizers
+        cov_l1_of[k] = next(cov for cov, remaining in scores if remaining == L1_REMAINING)
+        cov_f1_of[k] = next(cov for cov, remaining in scores if remaining == F1_REMAINING)
+
+    n_max_all = dict(CITED_N_MAX)
+    n_max_all.update(n_max_of)
+    k_unique = tuple(k for k in range(1, 12) if n_max_all[k] == 1)
+    unique_name: dict[int, str] = dict(CITED_UNIQUE_NAME)
+    for k in k_unique:
+        if k in CENSUS_KS:
+            unique_name[k] = name_unique_maximizer(maximizers_of[k][0])
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    f1_bits = bits_from_predicate(f1, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f1_remaining = remaining_bits_from_full(f1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"census_ks={CENSUS_KS}")
+    for k in CENSUS_KS:
+        print(
+            f"k={k} n_seeds={len(seed_masks[k])} m_{k}={m_of[k]} "
+            f"N_max_{k}={n_max_of[k]} cov_L1={cov_l1_of[k]} cov_f1={cov_f1_of[k]}"
+        )
+        if n_max_of[k] == 1:
+            print(f"unique_maximizer_{k}={unique_name[k]} remaining={maximizers_of[k][0]}")
+    print(f"cited_N_max={CITED_N_MAX}")
+    print(f"K_unique={list(k_unique)}")
+    print(f"unique_names={ {k: unique_name[k] for k in k_unique} }")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f1_bits={f1_bits}")
+    print(f"f1_remaining={f1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_K_SITE_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    expected_seed_counts = {1: 12, 5: 792, 6: 924, 7: 792, 8: 495, 9: 220, 10: 66, 11: 12}
+    checks.check(
+        "thm1-two-cube-and-census-seeds",
+        "the two-cube has twelve vertices and the eight census k-site seed counts",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and CENSUS_KS == (1, 5, 6, 7, 8, 9, 10, 11)
+        and all(len(seed_masks[k]) == expected_seed_counts[k] for k in CENSUS_KS)
+        and all(len(set(seed_masks[k])) == expected_seed_counts[k] for k in CENSUS_KS),
+    )
+    expected_m = {1: 12, 5: 792, 6: 924, 7: 792, 8: 495, 9: 220, 10: 66, 11: 12}
+    expected_n_max = {1: 4, 5: 2, 6: 1, 7: 2, 8: 1, 9: 4, 10: 4, 11: 8}
+    checks.check(
+        "thm1-m-and-n-max-census",
+        "each census k reports its computed (m_k, N_max_k) pair",
+        m_of == expected_m
+        and n_max_of == expected_n_max
+        and all(f"m_{k} = {m_of[k]}" in note for k in CENSUS_KS)
+        and all(f"N_max_{k} = {n_max_of[k]}" in note for k in CENSUS_KS),
+    )
+    checks.check(
+        "thm2-k-unique-set",
+        "K_unique is the seed sizes in 1..11 with N_max_k=1",
+        k_unique == (4, 6, 8)
+        and n_max_all[2] == 2
+        and n_max_all[3] == 2
+        and n_max_all[4] == 1
+        and "K_unique = {4, 6, 8}" in note,
+    )
+    checks.check(
+        "thm2-cites-without-recensus",
+        "k=2,3,4 enter K_unique only as cited N_max values, not a recensus",
+        CITED_N_MAX == {2: 2, 3: 2, 4: 1}
+        and 2 not in CENSUS_KS
+        and 3 not in CENSUS_KS
+        and 4 not in CENSUS_KS
+        and "combinations(TWO_CUBE, " + "2)" not in self_source
+        and "combinations(TWO_CUBE, " + "3)" not in self_source
+        and "combinations(TWO_CUBE, " + "4)" not in self_source
+        and "#6429" in note
+        and "#6453" in note
+        and "#6460" in note
+        and "Do not re-census k=2,3,4" in note,
+    )
+    checks.check(
+        "thm3-unique-maximizers-are-f1",
+        "for each k in K_unique the unique maximizer is f1, not f_L1",
+        unique_name[4] == "f1"
+        and unique_name[6] == "f1"
+        and unique_name[8] == "f1"
+        and maximizers_of[6] == [F1_REMAINING]
+        and maximizers_of[8] == [F1_REMAINING]
+        and l1_remaining == L1_REMAINING
+        and f1_remaining == F1_REMAINING
+        and l1_remaining != f1_remaining
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type)
+        and cov_l1_of[6] < m_of[6]
+        and cov_l1_of[8] < m_of[8]
+        and cov_f1_of[6] == m_of[6]
+        and cov_f1_of[8] == m_of[8]
+        and "unique maximizer is `f1`" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness set, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-ranking",
+        "the note reports every census pair, K_unique, and names f1 not f_L1",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "K_unique = {4, 6, 8}" in note
+        and "f1=(1,1,1,1,1)" in note.replace(" ", ""),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-one-k",
+        "the residual is the multi-k uniqueness set, not leftover-character of one k",
+        "New selector, not leftover of one k" in note
+        and "Not leftover-character of #6429" in note
+        and "Not leftover-character of #6453" in note
+        and "Not leftover-character of #6460" in note
+        and "different |S|" in note,
+    )
+    checks.check(
+        "claim-scope-ranking",
+        "claim_scope reports unique-maximizer seed sizes and names f_L1 or f1",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "k in {1,5,6,7,8,9,10,11}" in note
+        and "unique maximizer" in note
+        and "f_L1 or f1" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "seeds-not-listed",
+        "the note does not list k-site seeds and does not recensus 2,3,4",
+        "Do not list the seeds" in note
+        and "Do not re-census k=2,3,4" in note
+        and "combinations(TWO_CUBE" not in note
+        and "{(0, 0, 0), (0, 0, 1)}" not in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on each census seed size")
+    print("per_block: checked exactly — K_unique is the set of k in 1..11 with a unique coverage maximizer")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 32 F_cut maps, K_unique={k in 1..11 : N_max_k=1} is {4,6,8}. At each of those k the unique maximizer is f1=(1,1,1,1,1), not f_L1. New k=1,5..11 ranking; k=2,3,4 cited not recensed. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_k_site_uniqueness_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.