### PR TITLE
feat(c4share): L1 and f0 do not miss the same 4-site seeds

### DIFF
--- a/docs/F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,240 @@
+---
+claim_id: f_cut_l1_f0_four_site_miss_set_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the 4-site miss set of f_L1 is not equal to the 4-site miss set of F_cut (1,1,1,1,0). Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py
+---
+
+# Four-Site Miss Sets of `f_L1` and `F_cut` `(1,1,1,1,0)` Are Not Equal
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock census of all four-site seeds on the
+twelve-vertex two-cube with off-patch occupancy `0`, comparing the miss
+set of `f_L1` with the miss set of the `F_cut` map `(1,1,1,1,0)`. No
+seed is listed. No map is adopted. No Admissibility selector is written.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py`](../scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The two-cube is the twelve-site block `{0,1,2} × {0,1} × {0,1}`. The
+off-patch occupancy is the explicit default `0`; a blank-block is a different rule.
+There are exactly `C(12,4) = 495` unordered four-site seeds.
+
+The map `f_L1` fires at a site if and only if some cubic axis of its
+nearest-neighbor occupancy is unbalanced: `n_unbalanced ≠ 0`, equivalently
+`n_μ ≠ 0` on at least one axis. In the five remaining `F_cut` bits
+`(wt1, opp2, adj2, vertex3, mixed3)` this is the tuple `(1,0,1,1,1)`.
+This is not Hamming parity of the six neighbor bits.
+
+The compared `F_cut` map is `f0 = (1,1,1,1,0)`: it fires on every remaining
+orbit except `mixed3`. The bit `mixed3 = 0` is the only difference between
+`f0` and the all-ones remaining map `f1 = (1,1,1,1,1)`. Neither map is
+adopted.
+
+Starting from a seed as the locked set and iterating occupancy-to-lock with
+off-patch occupancy `0`, `f_L1` fills from `489` seeds, so `|M_L1| = 6`.
+That reconfirms the `#6460` count; the object here is not that count.
+Independently, `f0` fills from `459` seeds, so `|M_f0| = 36`. The
+intersection has `|M_L1 ∩ M_f0| = 4`. Therefore `M_L1 ≠ M_f0`. The
+equality bit is `0`.
+
+These cardinals and the equality bit are displayed, not adopted. Do not
+list the seeds. Do not adopt a map. They are not written into
+Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exhaustive four-site census determines |M_f0|=36, |M_L1 ∩ M_f0|=4, and equality bit 0."
+trace_class: frontier_discovery
+target_claim_id: f_cut_l1_f0_four_site_miss_set
+target_blocker_text: "is L1’s 4-site miss set a theorem of mixed3=0, or a different set than f0’s?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the two-cube with off-patch occupancy 0; no seed or map is adopted"
+hypothetical_axiom_status: "none; f_L1, f0, and the miss-set cardinals are displayed occupancy data, not axiom content"
+admitted_observation_status: null
+next_trace_action: "independent audit of the two miss-set cardinals and the equality bit"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice, Admissibility, and Record
+  sentences quoted below supply cubic nearest-neighbor wording and the lock
+  rule. They are quoted without rewrite.
+- **Explicit theorem-domain condition:** the two-cube, off-patch occupancy
+  `0`, the unbalanced-axis predicate `f_L1`, and the remaining-bit map
+  `f0 = (1,1,1,1,0)` are supplied finite data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selection of a seed or of either map by
+  Admissibility or Record remains a separate, open obligation.
+
+## Exact Objects
+
+Sites are points of `Z^3`. The two-cube is
+
+```text
+V = {0,1,2} × {0,1} × {0,1},    |V| = 12.
+```
+
+On-patch occupancy of a site is the lock bit. Off-patch occupancy is `0`.
+For a locked set `L ⊂ V` and a site `x ∈ V`, each cubic axis `μ` contributes
+one pair `(c_{μ+}, c_{μ-})` of neighbor occupancies. Write
+
+```text
+n_unbalanced = |{μ : c_{μ+} ≠ c_{μ-}}|,
+n_both       = |{μ : c_{μ+} = c_{μ-} = 1}|,
+n_empty      = |{μ : c_{μ+} = c_{μ-} = 0}|.
+```
+
+The pair `(n_unbalanced, n_both, n_empty)` is the axis type. Empty
+`(0,0,3)` and full `(0,3,0)` never fire in `F_cut`. The five remaining
+types, with complement identification `f(c) = f(1-c)`, are
+
+```text
+wt1=(1,0,2), opp2=(0,1,2), adj2=(2,0,1), vertex3=(3,0,0), mixed3=(1,1,1).
+```
+
+Then `f_L1(x; L) = 1` if and only if `n_unbalanced ≠ 0`, which is the
+remaining tuple `(1,0,1,1,1)`. Hamming parity of the six neighbor bits is
+a different map: `opp2` has Hamming weight `2` and `n_unbalanced = 0`, so
+`f_L1` refuses it; `mixed3` has Hamming weight `3` and `n_unbalanced = 1`,
+so Hamming fires it while `f0` refuses it.
+
+A four-site seed is an unordered 4-subset of `V`. Occupancy-to-lock starts
+from `L_0 = S` and at each tick adds every unlocked two-cube site at which
+the displayed map fires. The seed fills when some `L_t = V`. The miss sets
+are
+
+```text
+M_L1 = {S ⊂ V : |S| = 4 and S does not fill under f_L1},
+M_f0 = {S ⊂ V : |S| = 4 and S does not fill under f0}.
+```
+
+The claimed object is the pair of cardinals `|M_f0|` and `|M_L1 ∩ M_f0|`
+together with the equality bit of `M_L1` against `M_f0`. It is not `N_orb`.
+It is not a 6-row leftover table. Not leftover-character of
+`#6460`, which named only the counts `cov4(L1) = 489` and unique-max
+`cov4(f1) = 495`.
+
+## Exact Target And Proof Obligations
+
+The exact target is `|M_f0|`, the intersection cardinal, and whether the
+two miss sets are equal.
+
+1. enumerate all `495` four-site seeds and reconfirm `|M_L1| = 6`;
+2. compute `|M_f0|` by independent occupancy-to-lock runs under `f0`;
+3. compute `|M_L1 ∩ M_f0|` and the equality bit, display that bit, and
+   refuse to list seeds or adopt a map.
+
+All three obligations are closed below and in the runner. There is no
+missing lemma for this bounded census. Listing the seeds, writing a
+selector into Admissibility, or promoting the count `#6460` to a leftover
+table would be a different claim.
+
+## Theorem 1 — `|M_f0| = 36`
+
+There are exactly `495` four-site seeds. Independent occupancy-to-lock
+runs with off-patch occupancy `0` give `|M_L1| = 6`, reconfirming
+`cov4(L1) = 489`. The same seed list under `f0` gives `cov4(f0) = 459`.
+Therefore `|M_f0| = 36`.
+
+The all-ones remaining map `f1` fills every four-site seed, so
+`cov4(f1) = 495`. The `36` misses of `f0` are therefore exactly the
+four-site seeds that require the `mixed3` bit. That supporting split is
+not a seed list.
+
+## Theorem 2 — `|M_L1 ∩ M_f0| = 4` and `M_L1 ≠ M_f0`
+
+The two independently computed miss sets satisfy
+
+```text
+|M_L1 ∩ M_f0| = 4.
+```
+
+Since `|M_L1| = 6` and `|M_f0| = 36`, the intersection being strictly
+smaller than both sides implies `M_L1 ≠ M_f0`. Equivalently, two of the
+six `f_L1` misses fill under `f0`, and thirty-two of the thirty-six `f0`
+misses fill under `f_L1`. The 4-site miss set of `f_L1` is therefore not
+a theorem of `mixed3 = 0`.
+
+## Theorem 3 — display the equality bit
+
+The equality bit of the two miss sets is `0`. Displayed, not adopted.
+Do not list the seeds. Do not adopt a map. Do not adopt `f_L1` or `f0`.
+Do not write either map, either miss set, or the equality bit into
+Admissibility.
+
+## Physical-Interpretation Boundary
+
+The proved output is the displayed inequality of two finite miss sets on a
+supplied two-cube. This note neither assigns those seeds a physical label
+nor changes the Lattice, Qubit, Admissibility, or Record sentences.
+`f_L1` and `f0` are displayed occupancy data, not axiom content, and no
+additional axiom is proposed.
+
+## Mutation Checks
+
+Three non-equivalences guard the load-bearing conclusions:
+
+1. `f_L1` is not Hamming parity of the six neighbor bits;
+2. `f0` is not Hamming parity: `mixed3` has odd Hamming weight and is
+   refused by `f0`;
+3. the claimed object is not `N_orb` and not a 6-row leftover table of
+   `M_L1`.
+
+## What This Does Not Claim
+
+- Neither `f_L1` nor `f0` is selected by Admissibility or Record.
+- No four-site seed is a preferred physical initial condition.
+- Coverage on other patches, other occupancy defaults, or other maps in
+  `F_cut` is not computed here except the supporting `f1` census that
+  fills all `495` seeds.
+- The common halt patterns of either miss set are not promoted to a
+  dynamics law.
+- Independent class-`C` leftovers are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A readout value is determined by record content alone.
+
+> A site with no record cannot be read.
+
+> does not supply the formation site, probability, or rate
+
+Their dependency role is limited to cubic nearest-neighbor vocabulary and
+the lock rule. This theorem separately supplies the two-cube, the
+off-patch default `0`, the unbalanced-axis predicate, and the remaining-bit
+tuple `(1,1,1,1,0)`.
+
+## Runner Contract
+
+The companion runner re-enumerates all `495` four-site seeds, recomputes
+`M_L1` and `M_f0` by independent occupancy-to-lock runs, and reports
+`|M_f0|`, `|M_L1 ∩ M_f0|`, and the equality bit. It does not print the
+seeds. It checks the three mutations, quotes the live axiom sentences, and
+records the import boundary. Declared review inputs are this note and the
+axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_l1_f0_four_site_miss_set_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_l1_f0_four_site_miss_set_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_l1_f0_four_site_miss_set_2026_08_15.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py
+runner_sha256: bc64ec09e8dd4f46a9353ddd5d5ff726aaf96876324657cb5ae0b5dad0e6dbd0
+input_fingerprint_sha256: d658a6ee04ad41ec666cacf7c72408c4658019370c7974b0779d43ddd87a5e4a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: exhaustive four-site lock-step census under f_L1 and f0; set cardinals only
+negative_scope: |M_f0|, |M_L1 ∩ M_f0|, and the equality bit are displayed; no seed is listed and no map is adopted
+cache_write: false
+PASS: audit-inputs the two declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: two-cube-cardinality the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}
+PASS: four-seed-count there are C(12,4)=495 unordered four-site seeds
+census: |M_L1|=6 |M_f0|=36 |intersection|=4 equality_bit=0 cov4(L1)=489 cov4(f0)=459 cov4(f1)=495
+PASS: theorem-1-reconfirm-m-l1 |M_L1|=6 and cov4(L1)=489 among the 495 four-site seeds
+PASS: theorem-1-abs-m-f0 |M_f0|=36 and cov4(f0)=459 among the 495 four-site seeds
+PASS: theorem-1-f1-fills-all f1 fills every four-site seed, so the f0 misses are exactly mixed3-required seeds
+PASS: theorem-2-intersection |M_L1 ∩ M_f0|=4
+PASS: theorem-2-sets-unequal M_L1 is not equal to M_f0
+PASS: identity-l1-not-hamming opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire
+PASS: identity-f0-not-hamming mixed3 has Hamming weight 3, so Hamming fires it and f0 refuses it
+PASS: l1-remaining-tuple n!=0 is exactly the remaining tuple (1,0,1,1,1)
+PASS: theorem-3-equality-bit the note displays equality bit 0 and does not adopt a map
+PASS: theorem-3-no-seed-list the note and this runner do not list four-site seeds
+PASS: not-n-orb-not-leftover the claimed object is the miss-set comparison, not N_orb and not a leftover table
+PASS: forbidden-phrases the note and runner avoid the dispatch-forbidden phrases
+PASS: claim-scope the YAML claim_scope states the miss-set inequality
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py
+++ b/scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Compare the four-site miss sets of f_L1 and F_cut (1,1,1,1,0).
+
+Recomputes every unordered 4-subset of the twelve two-cube sites with
+off-patch occupancy 0. M_L1 (resp. M_f0) is the set of those seeds from
+which f_L1 (resp. f0) does not fill. The claimed object is |M_f0|,
+|M_L1 ∩ M_f0|, and the equality bit of the two sets. Seeds are not
+listed. No map is adopted. f_L1 is the some-axis-unbalanced (n != 0)
+map, not Hamming weight.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+AXES: tuple[Point, ...] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SITES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1)
+)
+SITE_SET = frozenset(SITES)
+N_FOUR_SEEDS = 495
+N_MISS_L1 = 6
+N_MISS_F0 = 36
+N_INTER = 4
+EQUALITY_BIT = 0
+F0_BITS: tuple[int, ...] = (1, 1, 1, 1, 0)
+F1_BITS: tuple[int, ...] = (1, 1, 1, 1, 1)
+L1_BITS: tuple[int, ...] = (1, 0, 1, 1, 1)
+REMAINING_INDEX: dict[tuple[int, int, int], int] = {
+    (1, 0, 2): 0,
+    (1, 2, 0): 0,
+    (0, 1, 2): 1,
+    (0, 2, 1): 1,
+    (2, 0, 1): 2,
+    (2, 1, 0): 2,
+    (3, 0, 0): 3,
+    (1, 1, 1): 4,
+}
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locked: frozenset[Point]) -> int:
+    """On-patch occupancy is the lock bit; off-patch occupancy is 0."""
+    if site not in SITE_SET:
+        return 0
+    return 1 if site in locked else 0
+
+
+def axis_type(site: Point, locked: frozenset[Point]) -> tuple[int, int, int]:
+    """Return (n_unbalanced, n_both, n_empty) for the three cubic axes."""
+    n_unbalanced = n_both = n_empty = 0
+    for axis in AXES:
+        plus = occupancy(add(site, axis), locked)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+        if plus == minus == 0:
+            n_empty += 1
+        elif plus == minus == 1:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fire_l1(counts: tuple[int, int, int]) -> bool:
+    """f_L1: some axis is unbalanced (n != 0). Not Hamming weight."""
+    n_unbalanced, _n_both, _n_empty = counts
+    return n_unbalanced != 0
+
+
+def fire_bits(counts: tuple[int, int, int], bits: tuple[int, ...]) -> bool:
+    """F_cut remaining-bit evaluation. Empty and full never fire."""
+    if counts in ((0, 0, 3), (0, 3, 0)):
+        return False
+    index = REMAINING_INDEX.get(counts)
+    if index is None:
+        raise RuntimeError(f"axis type {counts} is outside F_cut remaining types")
+    return bits[index] == 1
+
+
+def fire_hamming(site: Point, locked: frozenset[Point]) -> bool:
+    weight = 0
+    for axis in AXES:
+        weight += occupancy(add(site, axis), locked)
+        weight += occupancy(add(site, (-axis[0], -axis[1], -axis[2])), locked)
+    return weight % 2 == 1
+
+
+def run_map(
+    seed: frozenset[Point], predicate
+) -> tuple[tuple[int, ...], bool]:
+    locked = frozenset(seed)
+    history = [len(locked)]
+    for _tick in range(len(SITES)):
+        ready = [
+            site
+            for site in SITES
+            if site not in locked and predicate(axis_type(site, locked))
+        ]
+        if not ready:
+            break
+        locked = locked.union(ready)
+        history.append(len(locked))
+    return (tuple(history), len(locked) == len(SITES))
+
+
+def miss_set(predicate) -> tuple[int, frozenset[frozenset[Point]]]:
+    seeds = tuple(frozenset(combo) for combo in combinations(SITES, 4))
+    misses = [
+        seed for seed in seeds if not run_map(seed, predicate)[1]
+    ]
+    return (len(seeds) - len(misses), frozenset(misses))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: exhaustive four-site lock-step census under f_L1 and f0; set cardinals only")
+    print("negative_scope: |M_f0|, |M_L1 ∩ M_f0|, and the equality bit are displayed; no seed is listed and no map is adopted")
+    print("cache_write: false")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_L1_F0_FOUR_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    checks.check(
+        "two-cube-cardinality",
+        "the two-cube is exactly the twelve sites {0,1,2} x {0,1} x {0,1}",
+        len(SITES) == 12 and len(SITE_SET) == 12 and SITES[0] == (0, 0, 0) and SITES[-1] == (2, 1, 1),
+    )
+    checks.check(
+        "four-seed-count",
+        "there are C(12,4)=495 unordered four-site seeds",
+        len(tuple(combinations(SITES, 4))) == N_FOUR_SEEDS,
+    )
+
+    cov_l1, misses_l1 = miss_set(fire_l1)
+    cov_f0, misses_f0 = miss_set(lambda counts: fire_bits(counts, F0_BITS))
+    cov_f1, misses_f1 = miss_set(lambda counts: fire_bits(counts, F1_BITS))
+    intersection = misses_l1 & misses_f0
+    equality_bit = int(misses_l1 == misses_f0)
+
+    print(
+        f"census: |M_L1|={len(misses_l1)} |M_f0|={len(misses_f0)} "
+        f"|intersection|={len(intersection)} equality_bit={equality_bit} "
+        f"cov4(L1)={cov_l1} cov4(f0)={cov_f0} cov4(f1)={cov_f1}"
+    )
+
+    checks.check(
+        "theorem-1-reconfirm-m-l1",
+        "|M_L1|=6 and cov4(L1)=489 among the 495 four-site seeds",
+        cov_l1 + len(misses_l1) == N_FOUR_SEEDS
+        and len(misses_l1) == N_MISS_L1
+        and cov_l1 == N_FOUR_SEEDS - N_MISS_L1
+        and "|M_L1| = 6" in note,
+        residual=(cov_l1, len(misses_l1)),
+    )
+    checks.check(
+        "theorem-1-abs-m-f0",
+        "|M_f0|=36 and cov4(f0)=459 among the 495 four-site seeds",
+        cov_f0 + len(misses_f0) == N_FOUR_SEEDS
+        and len(misses_f0) == N_MISS_F0
+        and cov_f0 == N_FOUR_SEEDS - N_MISS_F0
+        and "|M_f0| = 36" in note
+        and "cov4(f0) = 459" in note,
+        residual=(cov_f0, len(misses_f0)),
+    )
+    checks.check(
+        "theorem-1-f1-fills-all",
+        "f1 fills every four-site seed, so the f0 misses are exactly mixed3-required seeds",
+        cov_f1 == N_FOUR_SEEDS
+        and len(misses_f1) == 0
+        and "cov4(f1) = 495" in note,
+        residual=(cov_f1, len(misses_f1)),
+    )
+
+    checks.check(
+        "theorem-2-intersection",
+        "|M_L1 ∩ M_f0|=4",
+        len(intersection) == N_INTER
+        and len(misses_l1 - misses_f0) == N_MISS_L1 - N_INTER
+        and len(misses_f0 - misses_l1) == N_MISS_F0 - N_INTER
+        and "|M_L1 ∩ M_f0| = 4" in note,
+        residual=len(intersection),
+    )
+    checks.check(
+        "theorem-2-sets-unequal",
+        "M_L1 is not equal to M_f0",
+        misses_l1 != misses_f0
+        and equality_bit == EQUALITY_BIT
+        and "M_L1 ≠ M_f0" in note
+        and "not a theorem of `mixed3 = 0`" in normalized_note,
+    )
+
+    locked_opp = frozenset(((0, 0, 0), (2, 0, 0)))
+    opp2 = axis_type((1, 0, 0), locked_opp)
+    hamming_opp = sum(
+        occupancy(add((1, 0, 0), shift), locked_opp)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    locked_mixed = frozenset(((0, 0, 0), (2, 0, 0), (1, 1, 0)))
+    mixed3 = axis_type((1, 0, 0), locked_mixed)
+    hamming_mixed = sum(
+        occupancy(add((1, 0, 0), shift), locked_mixed)
+        for shift in AXES + tuple((-a, -b, -c) for a, b, c in AXES)
+    )
+    checks.check(
+        "identity-l1-not-hamming",
+        "opp2 has Hamming weight 2 but n_unbalanced=0, so f_L1 does not fire",
+        opp2 == (0, 1, 2)
+        and hamming_opp == 2
+        and not fire_l1(opp2)
+        and fire_bits(opp2, F0_BITS)
+        and fire_hamming((1, 0, 0), locked_opp) is False
+        and "sum(config) % 2" not in self_source.split("def fire_l1", 1)[1].split("def fire_bits", 1)[0],
+    )
+    checks.check(
+        "identity-f0-not-hamming",
+        "mixed3 has Hamming weight 3, so Hamming fires it and f0 refuses it",
+        mixed3 == (1, 1, 1)
+        and hamming_mixed == 3
+        and fire_l1(mixed3)
+        and not fire_bits(mixed3, F0_BITS)
+        and fire_hamming((1, 0, 0), locked_mixed)
+        and fire_bits(mixed3, F1_BITS),
+    )
+    remaining_l1 = tuple(
+        int(fire_l1(kind))
+        for kind in ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1))
+    )
+    checks.check(
+        "l1-remaining-tuple",
+        "n!=0 is exactly the remaining tuple (1,0,1,1,1)",
+        remaining_l1 == L1_BITS
+        and F0_BITS == (1, 1, 1, 1, 0)
+        and "n_unbalanced ≠ 0" in note
+        and "(1,0,1,1,1)" in note.replace(" ", ""),
+    )
+
+    checks.check(
+        "theorem-3-equality-bit",
+        "the note displays equality bit 0 and does not adopt a map",
+        equality_bit == 0
+        and "equality bit is `0`" in normalized_note
+        and "displayed, not adopted" in normalized_note.lower()
+        and "Do not adopt a map" in note
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "theorem-3-no-seed-list",
+        "the note and this runner do not list four-site seeds",
+        "{(" not in note
+        and "R_adj" not in note
+        and "Do not list the seeds" in note
+        and "does not print the seeds" in normalized_note
+        and "lex representative" not in normalized_note,
+    )
+    checks.check(
+        "not-n-orb-not-leftover",
+        "the claimed object is the miss-set comparison, not N_orb and not a leftover table",
+        "It is not `N_orb`" in note
+        and "not a 6-row leftover table" in normalized_note
+        and "Not leftover-character of `#6460`" in normalized_note
+        and "unique-max" in normalized_note,
+    )
+
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note and runner avoid the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "claim-scope",
+        "the YAML claim_scope states the miss-set inequality",
+        "On the two-cube with off-patch o=0, the 4-site miss set of f_L1 is not equal to the 4-site miss set of F_cut (1,1,1,1,0). Displayed, not adopted."
+        in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy is the explicit default `0`" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "n_unbalanced ≠ 0" in note
+        and "not Hamming" in normalized_note
+        and "some cubic axis" in normalized_note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, |M_f0|=36, |M_L1 ∩ M_f0|=4, so L1 4-site misses are not a theorem of mixed3=0. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_l1_f0_four_site_miss_set_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.