### PR TITLE
feat(l1c8why): first f_L1 eight-site miss refuses on opp2

### DIFF
--- a/docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,414 @@
+---
+claim_id: f_l1_eight_site_miss_mechanism_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the first neighborhood at which f_L1 refuses and f1 fires, on the unique 8-site seed f_L1 does not fill, is reported by tick, site, and axis type. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py
+---
+
+# First Refused Neighborhood On The Unique `f_L1` Eight-Site Miss Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one independent occupancy-to-lock pair of runs from the unique
+unordered 8-site seed that `f_L1` does not fill, on the twelve-vertex
+two-cube `{0,1,2}×{0,1}×{0,1}` with off-patch occupancy `0`. The
+`F_cut` map `f1` with remaining-bit tuple `(1, 1, 1, 1, 1)` fills that
+seed. The first neighborhood at which `f_L1=0` and `f1=1` is reported
+by tick, site, and axis type. That type is `opp2`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py`](../scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut| = 32`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 8-subset of vertices
+is an 8-site seed. There are `C(12,8)=495` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Eight-site coverage is
+
+```text
+cov8(f) = |{ S : |S|=8 and f fills from S }|.
+```
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is
+`(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 1)`.
+
+Write `f1` for the `F_cut` map with remaining-bit tuple `(1, 1, 1, 1, 1)`.
+That map is the unique `cov8=495` coverage maximizer. It is displayed,
+not adopted.
+
+New |S|. The residual is an 8-site seed, `|S|=8`, not leftover of the 2-site or 4-site miss lists. Those leftovers name different cardinalities.
+
+**Theorem 1.** Independent recomputation of every 8-site seed reconfirms
+exactly one miss for `f_L1`, and `f1` fills it. So `|M|=1`. The unique
+miss, in lexicographic order of the sorted 8-tuple, is
+
+```text
+{(0,0,0),(0,0,1),(0,1,0),(0,1,1),(2,0,0),(2,0,1),(2,1,0),(2,1,1)}
+```
+
+On that seed, `f_L1` halts unfilled with lock-count history `(8,)` and
+`f1` fills with history `(8, 12)`. Equivalently
+`cov8(f_L1) = 494` and `cov8(f1) = 495`.
+
+**Theorem 2.** On the unique miss
+`{(0,0,0),(0,0,1),(0,1,0),(0,1,1),(2,0,0),(2,0,1),(2,1,0),(2,1,1)}`,
+the first neighborhood at which `f_L1` refuses and `f1` fires is
+
+```text
+t = 1
+x = (1, 0, 0)
+axis type = opp2 = (0, 1, 2)
+```
+
+The six-neighbor occupancy is `(1, 1, 0, 0, 0, 0)`: both ends of the
+long `x` axis are occupied and the other two axes are empty. That is a
+filled axis. An extra `f_L1` refuses. The same first event is seen on
+the independent `f_L1` run and on the independent `f1` run. Four unlocked
+middle-layer sites fire the same type at the same tick; the first site
+in two-cube order is `(1, 0, 0)`.
+
+**Theorem 3.** That first axis type is `opp2`. Display. Do not adopt opp2.
+Do not write it into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The unique f_L1 8-site miss, the independent f1 fill, and the first refused neighborhood (tick, site, axis type) are enumerated. opp2 is displayed, not written into Admissibility."
+trace_class: frontier_discovery
+target_claim_id: f_l1_eight_site_miss_mechanism
+target_blocker_text: "the first neighborhood at which f_L1 refuses and f1 fires, on the unique 8-site miss, remains unnamed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed first refused neighborhood; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for f_L1 and f1 on this twelve-vertex patch with off-patch o=0 and the unique 8-site miss; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws. Admissibility does not supply the formation site, probability, or rate.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 495 unordered 8-site seeds;
+- independent lock-step runs of `f_L1` and of `f1` from the unique miss.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+New |S|. Not leftover of the 2-site or 4-site miss lists: those leftovers
+name `|S|=2` and `|S|=4`. This residual is the first refused neighborhood
+on the unique seed of cardinality `|S|=8`.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm the unique 8-site miss of `f_L1` and that `f1`
+fills it by an independent run, then name the first
+`(tick, site, axis type)` at which `f_L1` refuses and `f1` fires.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The remaining-bit tuple is those five free bits in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c) = 1  iff  u(c) ≥ 1,
+f1(c)   = remaining-value of (1, 1, 1, 1, 1).
+```
+
+So `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and `f1` has
+`(1, 1, 1, 1, 1)`. They differ on `opp2` and on its complement
+`(0, 2, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+An independent run of `f` from a seed is that iteration started at the
+seed and continued to a fixed point. A miss is an 8-site seed whose
+`f_L1` halt set has cardinality strictly less than 12. The first refused
+neighborhood on a run is the lexicographically first unlocked site, at
+the earliest tick, whose neighborhood has `f_L1=0` and `f1=1`. Tick
+`t = 1` is the first evaluation on the seed occupancy.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The unbalanced-axis map `f_L1` is one element of
+`F_cut`. It is not Hamming parity. On the twelve-vertex two-cube with
+off-patch occupancy `0`, exhaustive fill census of all 495 eight-site
+seeds reconfirms exactly one `f_L1` miss, listed above. So `|M|=1`. The
+`F_cut` map `f1` with remaining-bit tuple `(1, 1, 1, 1, 1)` fills that
+seed on an independent run. The lock-count histories are `(8,)` for
+`f_L1` and `(8, 12)` for `f1`.
+
+**Theorem 2.** On the unique miss
+`{(0,0,0),(0,0,1),(0,1,0),(0,1,1),(2,0,0),(2,0,1),(2,1,0),(2,1,1)}`,
+the first neighborhood with `f_L1(nbhd)=0` and `f1(nbhd)=1` is tick
+`t = 1`, site `(1, 0, 0)`, axis type `opp2` `= (0, 1, 2)`. Coverage
+maximizers that fire `opp2` form on that filled axis; an extra `f_L1`
+refuses.
+
+**Theorem 3.** That type is `opp2`. Display. Do not adopt opp2. Do not
+write it into Admissibility. The first refused neighborhood is a
+displayed census output, not a selected occupancy law.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| unique `f_L1` miss | exhaustive 495-seed fill census; `|M|=1`; lex list as above |
+| `f1` fills the miss | independent run from the unique seed fills with history `(8, 12)` |
+| `cov8(f_L1)=494`, `cov8(f1)=495` | 495 minus one miss; `f1` fills every 8-site seed |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 495 eight-site seeds | `C(12,8)` unordered 8-subsets |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| first refused neighborhood | `t = 1`, site `(1, 0, 0)`, axis type `opp2` on the unique miss |
+| that type is `opp2` | displayed; not adopted |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit) and is not this
+   miss-set residual.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave
+   candidates become undefined; that is a different census.
+3. Start from a complementary 4-site seed such as the middle layer
+   `{(1,0,0),(1,0,1),(1,1,0),(1,1,1)}`: that is a different cardinality
+   and a different leftover.
+4. Report only `cov8(f_L1)=494`: that leftover names the miss count, not
+   the first refused neighborhood.
+5. Adopt `opp2` as the physical rule: the note displays the first axis
+   type and writes nothing into Admissibility.
+6. Score only the `f1` run: the theorem requires independent runs of
+   both maps from the unique miss.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover restatement of the 2-site or 4-site miss lists.
+- No adoption of `opp2`.
+- No blank-block or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is that `f_L1` refuses a filled-axis
+neighborhood that `f1` fires, on the unique 8-site miss. The first
+refused neighborhood is an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| unique-miss reconfirm | Score every 8-site seed under `f_L1` and under `f1`. | Theorem 1 and check `thm1-unique-miss-and-f1-fills`. | **ATTEMPTED** |
+| unique-seed refusal | Name the first `(t, x, axis type)` on the unique miss. | Theorem 2 and check `thm2-first-refusal`. | **ATTEMPTED** |
+| type identity | State whether that first axis type is `opp2`. | Theorem 3 and check `thm3-type-is-opp2`. | **ATTEMPTED** |
+| display, do not adopt | Ask whether `opp2` is written into Admissibility. | Theorem 3 and check `thm3-display-not-adopt-opp2`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: `f_L1` refuses `opp2` on this unique
+miss while `f1` fires it. Naming the first refused neighborhood and
+stating that the type is `opp2` are two certificates of the same
+filled-axis refusal, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| unique miss / first `opp2` refusal | no: a miss list does not name a neighborhood | no: one neighborhood does not list the miss set | independent exact objects |
+| first `(t,x,type)` / type is `opp2` | yes: the type is the named mechanism | no: a type does not name the site | collapse into the refused-axis type |
+| `cov8(f_L1)=494` / unique named miss | yes: one miss gives the count | yes: the count is the size of the one-set | collapse into the miss set |
+| 2-site or 4-site leftover / this first refusal | no: those leftovers have different `|S|` | no: an 8-site neighborhood does not replace those lists | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| unique 8-site miss | explicit seed class; a smaller-cardinality leftover is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| first axis type `opp2` | displayed mechanism, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:92` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:136` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:141` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:155` | `f1` definition | remaining-bit tuple `(1, 1, 1, 1, 1)` | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:52` | 495 eight-site seeds | `C(12,8)` unordered 8-subsets on the two-cube | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:206` | independent runs | lock-step evolution from the unique miss seed | yes |
+| `scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py:274` | first refused neighborhood | earliest `(tick, site, axis type)` with `f_L1=0` and `f1=1` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---:|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: `f_L1` and `f1` from the unique miss | independent runs; `f1` fills; `f_L1` misses |
+| per block | yes: the first refused neighborhood | tick, site, and axis type on the unique miss; type is `opp2` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f_L1`
+does lie in `F_cut` and does fill 494 of the 495 eight-site seeds. That
+positive member does not make `f_L1` a maximizer and does not write
+`opp2` into Admissibility. The remaining physical choice — which, if any,
+`F_cut` map is the Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f_L1` is already known to miss one
+8-site seed because its remaining bit `opp2` is `0`, so naming the
+first refused neighborhood might be called leftover-character of the
+coverage ranking or of the miss-set list. That objection is correctly
+about the miss count and the remaining-bit tuple. It does not overturn
+the stated theorem: the new object is the first `(tick, site, axis type)`
+on the unique `|S|=8` miss, together with the statement that the type
+is `opp2`. Displaying `opp2` names that mechanism. `opp2` is not adopted.
+
+A second steelman is that this is leftover of the 2-site or 4-site miss
+lists. Those leftovers live at different cardinalities. New |S|.
+Different object.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`f_L1`, `f1`, the unique miss, and the first refused neighborhood are
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the first refused neighborhood or writes
+`opp2` into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the unique-miss reconfirm, the
+independent `f1` fill, and the displayed first refused neighborhood
+stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, evaluates
+`f_L1` and `f1` independently from every 8-site seed, reconfirms the unique
+`f_L1` miss and that `f1` fills it, names the first refused neighborhood
+on that miss by tick, site, and axis type, checks that the type is
+`opp2`, checks that `f_L1` is not Hamming parity, and does not adopt
+`opp2`. Declared audit inputs are this note and the axiom memo. No runner
+cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_l1_eight_site_miss_mechanism_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_l1_eight_site_miss_mechanism_2026_08_15.txt
+++ b/logs/runner-cache/f_l1_eight_site_miss_mechanism_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py
+runner_sha256: 15f8b9dcff3437093887843c6fd29160f22f7a581b9fffa2c3cce3f52f3e8214
+input_fingerprint_sha256: 0af3c9d5f5c31c57975f5b81c1c60007793694eda9f7bacdfcc02e889d988b67
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: independent occupancy-to-lock runs from the unique f_L1 8-site miss
+negative_scope: opp2 is displayed, not adopted or written into Admissibility
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+n_eight_site_seeds=495
+cov8_f_L1=494
+cov8_f1=495
+f_L1_remaining=(1, 0, 1, 1, 1)
+f1_remaining=(1, 1, 1, 1, 1)
+n_l1_miss=1
+unique_miss_seed={(0,0,0),(0,0,1),(0,1,0),(0,1,1),(2,0,0),(2,0,1),(2,1,0),(2,1,1)}
+  {(0,0,0),(0,0,1),(0,1,0),(0,1,1),(2,0,0),(2,0,1),(2,1,0),(2,1,1)} hist_L1=(8,) fill_L1=False hist_f1=(8, 12) fill_f1=True first=t=1 x=(1, 0, 0) type=opp2(0, 1, 2)
+unique_miss_refusal=t=1 x=(1, 0, 0) type=opp2(0, 1, 2) cfg=(1, 1, 0, 0, 0, 0) n_events=4
+type_is_opp2=True
+adopt_opp2=false
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-four-hundred-ninety-five-seeds the two-cube has twelve vertices and C(12,8)=495 eight-site seeds
+PASS: thm1-unique-miss-and-f1-fills exactly one 8-site seed misses under f_L1, and f1 fills it independently
+PASS: thm2-first-refusal unique miss first refusal is t=1, site (1,0,0), axis type opp2
+PASS: thm3-type-is-opp2 the first refused axis type on the unique 8-site miss is opp2
+PASS: thm3-display-not-adopt-opp2 opp2 is displayed and is not adopted or written into Admissibility
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted first refusal, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-first-refusal the note reports the unique miss, f1 fill, and the first (t, x, axis type)
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: new-cardinality-eight the residual is a new |S|=8 miss, not leftover of smaller seed lists
+PASS: claim-scope claim_scope reports the first refused neighborhood on the unique 8-site miss
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f_L1 and f1 are run independently from the unique 8-site miss
+per_block: checked exactly — the first refused neighborhood is named by tick, site, and axis type
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py
+++ b/scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""First refused neighborhood on the unique 8-site seed f_L1 does not fill.
+
+Independent occupancy-to-lock runs start from the unique 8-site miss seed
+on the twelve-vertex two-cube with off-patch occupancy 0.  The unique
+miss of f_L1 is recomputed; the F_cut map f1 with remaining bits
+(1,1,1,1,1) fills it.  The first (tick, site, axis-type) with
+f_L1(nbhd)=0 and f1(nbhd)=1 is displayed, not adopted.  That type is
+opp2.  opp2 is not written into Admissibility.  f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+New |S|=8: not leftover of the 2-site or 4-site miss lists.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Seed = tuple[Site, Site, Site, Site, Site, Site, Site, Site]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+EIGHT_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(octuplet) for octuplet in combinations(TWO_CUBE, 8)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+AXIS_TYPE_NAME: dict[OrbitType, str] = {
+    (0, 0, 3): "empty",
+    (0, 3, 0): "full",
+    (1, 0, 2): "wt1",
+    (1, 2, 0): "wt1_comp",
+    (0, 1, 2): "opp2",
+    (0, 2, 1): "opp2_comp",
+    (2, 0, 1): "adj2",
+    (2, 1, 0): "adj2_comp",
+    (3, 0, 0): "vertex3",
+    (1, 1, 1): "mixed3",
+}
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F1_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 1)
+F1_LABEL = "f1"
+UNIQUE_MISS_DISPLAY = (
+    "{(0,0,0),(0,0,1),(0,1,0),(0,1,1),(2,0,0),(2,0,1),(2,1,0),(2,1,1)}"
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f1(config: Config) -> int:
+    """F_cut remaining bits (1, 1, 1, 1, 1).  Displayed 8-site maximizer.  Not adopted."""
+    return remaining_value(config, F1_REMAINING)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_from_seed(predicate, seed: frozenset[Site], halt_bound: int = 13) -> dict:
+    locked = set(seed)
+    history = [len(locked)]
+    for _tick in range(halt_bound):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            break
+        locked = nxt
+        history.append(len(locked))
+    return {
+        "fill": len(locked) == 12,
+        "history": tuple(history),
+        "locks": frozenset(locked),
+        "halt_tick": len(history) - 1,
+    }
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    return bool(run_from_seed(predicate, seed)["fill"])
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in EIGHT_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def seed_key(seed: frozenset[Site]) -> Seed:
+    ordered = tuple(sorted(seed))
+    return (
+        ordered[0],
+        ordered[1],
+        ordered[2],
+        ordered[3],
+        ordered[4],
+        ordered[5],
+        ordered[6],
+        ordered[7],
+    )
+
+
+def seed_display(seed: frozenset[Site] | Seed) -> str:
+    sites = seed_key(frozenset(seed))
+    inner = ",".join(f"({s[0]},{s[1]},{s[2]})" for s in sites)
+    return "{" + inner + "}"
+
+
+def refusal_events(locked: set[Site]) -> list[dict]:
+    rows: list[dict] = []
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        config = neighborhood(site, locked)
+        value_l1 = f_L1(config)
+        value_f1 = f1(config)
+        if value_l1 == 0 and value_f1 == 1:
+            kind = axis_type(config)
+            rows.append(
+                {
+                    "site": site,
+                    "config": config,
+                    "axis_type": kind,
+                    "axis_name": AXIS_TYPE_NAME[kind],
+                    "f_L1": value_l1,
+                    "f1": value_f1,
+                }
+            )
+    return rows
+
+
+def first_refusal(seed: frozenset[Site], predicate, halt_bound: int = 13) -> dict | None:
+    """Independent run: first (tick, site, axis-type) with f_L1=0 and f1=1."""
+    locked = set(seed)
+    for tick in range(1, halt_bound + 1):
+        events = refusal_events(locked)
+        if events:
+            first = events[0]
+            return {
+                "tick": tick,
+                "site": first["site"],
+                "config": first["config"],
+                "axis_type": first["axis_type"],
+                "axis_name": first["axis_name"],
+                "n_events": len(events),
+                "events": tuple(events),
+            }
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return None
+        locked = nxt
+    return None
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: independent occupancy-to-lock runs from the unique f_L1 8-site miss")
+    print("negative_scope: opp2 is displayed, not adopted or written into Admissibility")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    f1_bits = bits_from_predicate(f1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f1_remaining = remaining_bits_from_full(f1_bits, orbit_types)
+
+    miss_seeds = [seed for seed in EIGHT_SITE_SEEDS if not fills_from_seed(f_L1, seed)]
+    miss_seeds.sort(key=seed_key)
+    unique_seed = miss_seeds[0]
+    independent = []
+    for seed in miss_seeds:
+        run_l1 = run_from_seed(f_L1, seed)
+        run_f1 = run_from_seed(f1, seed)
+        first_on_f1 = first_refusal(seed, f1)
+        first_on_l1 = first_refusal(seed, f_L1)
+        independent.append(
+            {
+                "seed": seed_key(seed),
+                "display": seed_display(seed),
+                "l1": run_l1,
+                "f1": run_f1,
+                "first_f1": first_on_f1,
+                "first_l1": first_on_l1,
+            }
+        )
+    first_unique = independent[0]["first_f1"]
+    first_unique_l1 = independent[0]["first_l1"]
+    cov_l1 = 495 - len(miss_seeds)
+    cov_f1 = coverage(f1)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"n_eight_site_seeds={len(EIGHT_SITE_SEEDS)}")
+    print(f"cov8_f_L1={cov_l1}")
+    print(f"cov8_f1={cov_f1}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f1_remaining={f1_remaining}")
+    print(f"n_l1_miss={len(miss_seeds)}")
+    print("unique_miss_seed=" + independent[0]["display"])
+    row = independent[0]
+    print(
+        f"  {row['display']} "
+        f"hist_L1={row['l1']['history']} fill_L1={row['l1']['fill']} "
+        f"hist_f1={row['f1']['history']} fill_f1={row['f1']['fill']} "
+        f"first=t={first_unique['tick']} x={first_unique['site']} "
+        f"type={first_unique['axis_name']}{first_unique['axis_type']}"
+    )
+    print(
+        "unique_miss_refusal="
+        f"t={first_unique['tick']} x={first_unique['site']} "
+        f"type={first_unique['axis_name']}{first_unique['axis_type']} "
+        f"cfg={first_unique['config']} n_events={first_unique['n_events']}"
+    )
+    print(f"type_is_opp2={first_unique['axis_name'] == 'opp2'}")
+    print("adopt_opp2=false")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_L1_EIGHT_SITE_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-four-hundred-ninety-five-seeds",
+        "the two-cube has twelve vertices and C(12,8)=495 eight-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(EIGHT_SITE_SEEDS) == 495
+        and len(set(EIGHT_SITE_SEEDS)) == 495
+        and all(seed <= set(TWO_CUBE) and len(seed) == 8 for seed in EIGHT_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-unique-miss-and-f1-fills",
+        "exactly one 8-site seed misses under f_L1, and f1 fills it independently",
+        len(miss_seeds) == 1
+        and cov_l1 == 494
+        and cov_f1 == 495
+        and f1_remaining == F1_REMAINING
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type)
+        and not row["l1"]["fill"]
+        and row["f1"]["fill"]
+        and row["l1"]["history"] == (8,)
+        and row["f1"]["history"] == (8, 12)
+        and row["display"] == UNIQUE_MISS_DISPLAY,
+    )
+    checks.check(
+        "thm2-first-refusal",
+        "unique miss first refusal is t=1, site (1,0,0), axis type opp2",
+        first_unique is not None
+        and seed_display(unique_seed) == UNIQUE_MISS_DISPLAY
+        and first_unique["tick"] == 1
+        and first_unique["site"] == (1, 0, 0)
+        and first_unique["axis_type"] == (0, 1, 2)
+        and first_unique["axis_name"] == "opp2"
+        and first_unique["config"] == (1, 1, 0, 0, 0, 0)
+        and first_unique["n_events"] == 4
+        and first_unique_l1["tick"] == 1
+        and first_unique_l1["site"] == (1, 0, 0)
+        and first_unique_l1["axis_name"] == "opp2"
+        and first_unique_l1["config"] == (1, 1, 0, 0, 0, 0)
+        and first_unique_l1["n_events"] == 4,
+    )
+    checks.check(
+        "thm3-type-is-opp2",
+        "the first refused axis type on the unique 8-site miss is opp2",
+        first_unique["axis_name"] == "opp2"
+        and first_unique["axis_type"] == (0, 1, 2)
+        and first_unique_l1["axis_name"] == "opp2"
+        and all(event["axis_name"] == "opp2" for event in first_unique["events"])
+        and [event["site"] for event in first_unique["events"]]
+        == [(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)],
+    )
+    checks.check(
+        "thm3-display-not-adopt-opp2",
+        "opp2 is displayed and is not adopted or written into Admissibility",
+        first_unique["axis_name"] == "opp2"
+        and "Do not adopt opp2" in note
+        and "Displayed, not adopted" in note,
+    )
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_absence = "A site with no record cannot be read."
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        lattice_sentence in axiom
+        and "proper cubic rotations about each site." in axiom
+        and admissibility_sentence in axiom
+        and record_lock in axiom
+        and record_absence in axiom
+        and lattice_sentence in note
+        and record_absence in note,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted first refusal, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-first-refusal",
+        "the note reports the unique miss, f1 fill, and the first (t, x, axis type)",
+        UNIQUE_MISS_DISPLAY in note.replace(" ", "")
+        and "(1, 1, 1, 1, 1)" in note
+        and "t = 1" in note
+        and "(1, 0, 0)" in note
+        and "`opp2`" in note
+        and "(0, 1, 2)" in note
+        and "|M|=1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not adopt opp2" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "new-cardinality-eight",
+        "the residual is a new |S|=8 miss, not leftover of smaller seed lists",
+        "New |S|" in note
+        and "|S|=8" in note
+        and "not leftover of the 2-site or 4-site miss lists" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the first refused neighborhood on the unique 8-site miss",
+        "On the two-cube with off-patch o=0, the first neighborhood at which f_L1 refuses and f1 fires, on the unique 8-site seed f_L1 does not fill, is reported by tick, site, and axis type."
+        in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        "does not supply the formation site, probability, or rate" in axiom_flat
+        and "does not supply the formation site, probability, or rate" in note_flat,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f_L1 and f1 are run independently from the unique 8-site miss")
+    print("per_block: checked exactly — the first refused neighborhood is named by tick, site, and axis type")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the unique 8-site seed f_L1 (n≠0, not Hamming) misses is filled by f1. First refusal is t=1, site (1,0,0), axis type opp2. New |S|. Displayed, not adopted.

## Runner

`scripts/f_l1_eight_site_miss_mechanism_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.