### PR TITLE
feat(kdual): F_cut maximizer sets at k and 12-k are not equal

### DIFF
--- a/docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,436 @@
+---
+claim_id: f_cut_coverage_complement_duality_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, the set of coverage maximizers at seed size k is not equal to the set at seed size 12-k for k=1,2,3 and is equal for k=4,5. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_coverage_complement_duality_2026_08_15.py
+---
+
+# `F_cut` Coverage Maximizer Sets At `k` And `12-k`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact set comparison of `F_cut` coverage maximizers on the
+twelve-vertex two-cube with off-patch occupancy `0`. For each seed size
+`k=1..5`, the set `Max(k)` of remaining-bit tuples attaining `cov_k=m_k`
+is compared with `Max(12-k)`. The five equality bits are displayed. No
+complement duality is adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_coverage_complement_duality_2026_08_15.py`](../scripts/f_cut_coverage_complement_duality_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}` there are `C(12,k)` unordered
+`k`-site seeds. Off-patch neighbors have occupancy `0`. Each tick, every
+unlocked on-patch vertex evaluates `f` on its six-neighbor occupancy
+tuple and locks if `f=1`. The process is synchronous and stops at a fixed
+point in at most 12 ticks. Fill means `|locks_halt|=12`. Coverage at seed
+size `k` is
+
+```text
+cov_k(f) = |{ S : |S|=k and f fills from S }|.
+```
+
+Write `m_k = max cov_k` over `F_cut` and `N_max_k` for the number of
+maps attaining `m_k`. The set `Max(k)` is the set of remaining-bit
+tuples with `cov_k = m_k`. The five remaining bits, in the displayed
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full
+are forced to `0`.
+
+Claim #6465 reported the pairs `(m_k, N_max_k)`. Those counts have
+palindromic `m_k` under `k ↔ 12-k` (1↔11, 2↔10, 3↔9, 5↔7, 4↔8):
+`m_k = C(12,k) = m_{12-k}`. The `N_max_k` column is not palindromic at
+`k=1,2,3`. Not leftover-character of #6465: that only reported
+`(m_k, N_max_k)`. This note is not a recensus of those integers. The
+new object is whether `Max(k)=Max(12-k)` as remaining-bit-tuple sets.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+The all-ones remaining-bit tuple is `(1, 1, 1, 1, 1)`.
+
+**Theorem 1.** Exhaustive recomputation of `cov_k` on all 32 maps and
+all `C(12,k)` seeds, for each `k=1..11`, reconfirms the #6465 pairs and
+names the maximizer sets. For `k=1..5`,
+
+```text
+Max(1)  ≠ Max(11)
+Max(2)  ≠ Max(10)
+Max(3)  ≠ Max(9)
+Max(4)  = Max(8)
+Max(5)  = Max(7)
+```
+
+as sets of remaining-bit tuples. Explicitly,
+
+```text
+Max(1)  = {(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)}
+Max(11) = {(0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (0, 1, 1, 1, 0), (0, 1, 1, 1, 1),
+           (1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)}
+Max(2)  = {(1, 1, 1, 1, 0), (1, 1, 1, 1, 1)}
+Max(10) = {(0, 0, 1, 1, 1), (0, 1, 1, 1, 1), (1, 0, 1, 1, 1), (1, 1, 1, 1, 1)}
+Max(3)  = {(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)}
+Max(9)  = {(0, 0, 1, 1, 1), (0, 1, 1, 1, 1), (1, 0, 1, 1, 1), (1, 1, 1, 1, 1)}
+Max(4)  = Max(8) = {(1, 1, 1, 1, 1)}
+Max(5)  = Max(7) = {(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)}
+```
+
+Cited #6465 pairs, recomputed:
+
+```text
+k=1  (m_1, N_max_1)   = (12, 4)
+k=2  (m_2, N_max_2)   = (66, 2)
+k=3  (m_3, N_max_3)   = (220, 2)
+k=4  (m_4, N_max_4)   = (495, 1)
+k=5  (m_5, N_max_5)   = (792, 2)
+k=7  (m_7, N_max_7)   = (792, 2)
+k=8  (m_8, N_max_8)   = (495, 1)
+k=9  (m_9, N_max_9)   = (220, 4)
+k=10 (m_10, N_max_10) = (66, 4)
+k=11 (m_11, N_max_11) = (12, 8)
+```
+
+In particular `m_1 = 12` and `N_max_1 = 4`.
+
+**Theorem 2.** The equality 5-tuple, with entry `k` equal to `1` iff
+`Max(k)=Max(12-k)` for `k=1..5`, is
+
+```text
+E = (0, 0, 0, 1, 1)
+```
+
+**Theorem 3.** Display `E`. Do not adopt a duality. Do not write the duality into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the cited #6465 (m_k, N_max_k) pairs, the named Max(k) remaining-bit sets, and the equality 5-tuple E=(0,0,0,1,1) are enumerated. The bits are displayed, not written into Admissibility."
+trace_class: upstream_support
+target_claim_id: f_cut_coverage_complement_duality
+target_blocker_text: "whether Max(k) equals Max(12-k) as remaining-bit-tuple sets is unnamed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed equality 5-tuple; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut maximizer sets on this twelve-vertex patch with off-patch o=0 and all k-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete family of `C(12,k)` unordered `k`-site seeds for
+  `k=1..11`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of #6465 (that only reported `(m_k, N_max_k)`).
+The pairs are cited and recomputed only so the attaining remaining-bit
+sets can be compared. This is not a recensus.
+
+## Exact Target And Objects
+
+**Target.** Cite the #6465 pairs `(m_k, N_max_k)`, recompute the
+maximizer sets `Max(k)`, and name whether `Max(k)=Max(12-k)` for each
+`k=1..5`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)`. Neither `f_L1` nor
+any other remaining-bit tuple is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov_k(f)` is the number of `k`-site seeds whose halt set has
+cardinality 12, `m_k` is the maximum of `cov_k` over `F_cut`, and
+`N_max_k` is the number of maps attaining `m_k`. The maximizer set
+`Max(k)` is the set of remaining-bit tuples with `cov_k=m_k`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut`. It is not Hamming parity. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive ranking of
+all 32 maps on all `C(12,k)` seeds reconfirms the #6465 pairs
+`(m_k, N_max_k)` listed above and names `Max(k)` for each complementary
+pair. Among `k=1..5`, set equality `Max(k)=Max(12-k)` holds only at
+`k=4` and `k=5`.
+
+**Theorem 2.** The equality 5-tuple is
+
+```text
+E = (0, 0, 0, 1, 1).
+```
+
+**Theorem 3.** Display `E`. Do not adopt a duality. Do not write the duality into Admissibility. The bits are a displayed comparison, not a selected
+occupancy law.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| `C(12,k)` k-site seeds | unordered `k`-subsets of the twelve vertices |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| cited #6465 pairs | `(m_k, N_max_k)` as listed; recomputed, then used only to name the attaining sets |
+| `Max(k)` versus `Max(12-k)` | remaining-bit-tuple sets compared for each `k=1..5` |
+| equality 5-tuple | `E = (0, 0, 0, 1, 1)` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit) and is not used as a
+   maximizer label.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Drop complement-even or the vanish-on-full cut: the class is no longer
+   the 32-element `F_cut`.
+4. Report only `(m_k, N_max_k)`: that leftover is the #6465 count table,
+   not the named maximizer sets.
+5. Score only one seed size: that one-`k` leftover is a ranking, not the
+   complementary-set comparison.
+6. Adopt `E` as a physical duality: the note displays the bits and writes
+   no duality into Admissibility.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the #6465 pairs
+  `(m_k, N_max_k)` in place of the named set comparison.
+- No adopted complement duality on seed size.
+
+## No-Go Discipline Gate
+
+The only negative claim is that `Max(k)` is not identically
+`Max(12-k)` for every `k=1..5`. The equality 5-tuple is an exact
+enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| cite #6465 pairs | Recompute `(m_k, N_max_k)` against the cited complementary pairs. | Theorem 1 and check `thm1-cite-6465-pairs`. | **ATTEMPTED** |
+| recompute maximizer sets | Name `Max(k)` and compare with `Max(12-k)` for `k=1..5`. | Theorem 1, Theorem 2, and checks `thm1-set-equality-bits` / `thm2-equality-5-tuple`. | **ATTEMPTED** |
+| display, do not adopt | Ask whether `E` is written into Admissibility as a duality. | Theorem 3 and check `thm3-display-not-adopt-duality`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: set equality fails at `k=1,2,3`. The
+cardinality mismatch `N_max_k ≠ N_max_{12-k}` at those `k` and the
+named set comparison are two certificates of the same failure, so they
+collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_max_1=4` / `N_max_11=8` | yes: unequal counts imply unequal sets | no: unequal sets need not have unequal counts | count mismatch is a certificate of set mismatch at `k=1` |
+| set mismatch at `k=1` / set mismatch at `k=2` | no | no | independent seed sizes |
+| static `|F_cut|=32` / equality 5-tuple | no: membership is not dynamics | no: comparing maximizer sets does not replace the three-cut class | separate exact counts |
+| leftover of #6465 / this set comparison | no: that leftover reported only `(m_k, N_max_k)` | no: naming `E` does not replace the count residual | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| all `C(12,k)` k-site seeds | explicit seed class; a one-seed fill is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| equality 5-tuple `E = (0, 0, 0, 1, 1)` | displayed comparison, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:86` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:130` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:135` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:48` | twelve two-cube vertices | `{0,1,2}×{0,1}×{0,1}` | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:275` | `cov_k(f)` | number of `k`-site seeds a map fills | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:62` | cited #6465 pairs | `(m_k, N_max_k)` used only to name attaining sets | yes |
+| `scripts/f_cut_coverage_complement_duality_2026_08_15.py:74` | equality 5-tuple | displayed `E = (0, 0, 0, 1, 1)` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut` | `Max(k)` is named inside this class on all `C(12,k)` seeds |
+| per block | yes: the equality 5-tuple | `Max(k)=Max(12-k)` fails at `k=1,2,3` and holds at `k=4,5` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: at
+`k=4` and `k=5` the maximizer sets do coincide, and at every complementary
+pair the *coverage* maximum `m_k` is palindromic. Those positive
+agreements do not make `Max(k)=Max(12-k)` a theorem for every `k=1..5`
+and do not select a physical duality. The remaining physical choice —
+which, if any, `F_cut` map is the Admissibility occupancy predicate —
+stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that because `m_k=m_{12-k}` the maximizer
+sets might be called leftover-character of the #6465 count table, or
+that unequal `N_max` at `k=1,2,3` already answers the set question
+without naming tuples. That objection is correctly about the count
+pairs. It does not overturn the stated theorem: #6465 stopped at
+`(m_k, N_max_k)`; the set residual is whether the attaining remaining-bit
+tuples coincide. Displaying `E = (0, 0, 0, 1, 1)` names that comparison.
+No duality is adopted.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the 32-map `k`-site rankings, and the equality 5-tuple are
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the named set comparison or writes a
+complement duality into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the named equality 5-tuple
+and the recomputed #6465 pairs `(m_k, N_max_k)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube from every `k`-site seed
+for `k=1..11`, reconfirms the cited #6465 pairs `(m_k, N_max_k)`, names
+`Max(k)` by remaining-bit tuple, reports `E = (0, 0, 0, 1, 1)`, checks
+that `f_L1` is not Hamming parity, and does not adopt a duality.
+Declared audit inputs are this note and the axiom memo.
+No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15739,
- "node_count": 5539,
+ "edge_count": 15740,
+ "node_count": 5540,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_coverage_complement_duality_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_coverage_complement_duality_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_coverage_complement_duality_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_coverage_complement_duality_2026_08_15.py
+runner_sha256: 5e7068bb0162a9c81236105335a2f2901925d5be644674a8739292120476439a
+input_fingerprint_sha256: 9819390c34552837e251127c3db0d506dd7908d15105add7224ed0349e520f39
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.55
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+cited_6465_pairs={1: (12, 4), 2: (66, 2), 3: (220, 2), 4: (495, 1), 5: (792, 2), 7: (792, 2), 8: (495, 1), 9: (220, 4), 10: (66, 4), 11: (12, 8)}
+recomputed_pairs={1: (12, 4), 2: (66, 2), 3: (220, 2), 4: (495, 1), 5: (792, 2), 7: (792, 2), 8: (495, 1), 9: (220, 4), 10: (66, 4), 11: (12, 8)}
+equality_5_tuple=(0, 0, 0, 1, 1)
+Max(1)=[(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+Max(11)=[(0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (0, 1, 1, 1, 0), (0, 1, 1, 1, 1), (1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+Max(2)=[(1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+Max(10)=[(0, 0, 1, 1, 1), (0, 1, 1, 1, 1), (1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+Max(3)=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+Max(9)=[(0, 0, 1, 1, 1), (0, 1, 1, 1, 1), (1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+Max(4)=[(1, 1, 1, 1, 1)]
+Max(8)=[(1, 1, 1, 1, 1)]
+Max(5)=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+Max(7)=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-binomial-seeds the two-cube has twelve vertices and C(12,k) k-site seeds
+PASS: thm1-cite-6465-pairs recomputed (m_k, N_max_k) match the cited #6465 pairs
+PASS: thm1-set-equality-bits Max(k)=Max(12-k) only for k=4 and k=5 among k=1..5
+PASS: thm2-equality-5-tuple the displayed equality 5-tuple is (0, 0, 0, 1, 1)
+PASS: thm3-display-not-adopt-duality the equality bits are displayed and no duality is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted equality bits, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-sets-and-tuple the note reports Max(k) versus Max(12-k) and the equality 5-tuple
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6465 the residual is set equality, not leftover-character of the #6465 counts
+PASS: claim-scope-duality claim_scope states set equality or not for each k=1..5
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored at each seed size k=1..11, then Max(k) is named
+per_block: checked exactly — the equality 5-tuple is Max(k)=Max(12-k) for each k=1..5
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_coverage_complement_duality_2026_08_15.py
+++ b/scripts/f_cut_coverage_complement_duality_2026_08_15.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Whether F_cut coverage maximizer sets at k and 12-k coincide.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. For each seed size k, Max(k) is the set of remaining-bit tuples
+attaining cov_k = m_k. The new object is the five equality bits
+Max(k)=Max(12-k) for k=1..5. That is not leftover-character of #6465, which
+only reported the palindromic (m_k, N_max_k) counts. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+The equality 5-tuple is displayed, not adopted as a duality.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F1_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 1)
+# #6465 (m_k, N_max_k) pairs for complementary seed sizes. Cited, then recomputed.
+CITED_6465_PAIRS: dict[int, tuple[int, int]] = {
+    1: (12, 4),
+    2: (66, 2),
+    3: (220, 2),
+    4: (495, 1),
+    5: (792, 2),
+    7: (792, 2),
+    8: (495, 1),
+    9: (220, 4),
+    10: (66, 4),
+    11: (12, 8),
+}
+EQUALITY_5_TUPLE: tuple[int, ...] = (0, 0, 0, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[dict[OrbitType, int], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[dict[OrbitType, int], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((assignment, remaining))
+    return members
+
+
+def neighbor_index_table() -> tuple[tuple[int | None, ...], ...]:
+    index = {site: rank for rank, site in enumerate(TWO_CUBE)}
+    table: list[tuple[int | None, ...]] = []
+    for site in TWO_CUBE:
+        dirs: list[int | None] = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            dirs.append(index.get(neighbor))
+        table.append(tuple(dirs))
+    return tuple(table)
+
+
+def config_from_mask(
+    site: int, locked_mask: int, neigh: tuple[tuple[int | None, ...], ...]
+) -> Config:
+    values = []
+    for neighbor in neigh[site]:
+        if neighbor is None:
+            values.append(0)
+        else:
+            values.append(1 if (locked_mask >> neighbor) & 1 else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def coverage_by_k(
+    assignment: dict[OrbitType, int],
+    type_of: dict[Config, OrbitType],
+    neigh: tuple[tuple[int | None, ...], ...],
+    seeds_by_k: dict[int, tuple[tuple[int, ...], ...]],
+) -> dict[int, int]:
+    n_sites = len(TWO_CUBE)
+    all_mask = (1 << n_sites) - 1
+    add = [0] * (all_mask + 1)
+    for locked in range(all_mask + 1):
+        nxt = 0
+        for site in range(n_sites):
+            if (locked >> site) & 1:
+                continue
+            cfg = config_from_mask(site, locked, neigh)
+            if assignment[type_of[cfg]]:
+                nxt |= 1 << site
+        add[locked] = nxt
+    cov: dict[int, int] = {}
+    for k, seeds in seeds_by_k.items():
+        count = 0
+        for seed in seeds:
+            locked = 0
+            for site in seed:
+                locked |= 1 << site
+            for _tick in range(13):
+                extra = add[locked]
+                if extra == 0:
+                    break
+                locked |= extra
+            if locked == all_mask:
+                count += 1
+        cov[k] = count
+    return cov
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    neigh = neighbor_index_table()
+    seeds_by_k = {
+        k: tuple(combinations(range(len(TWO_CUBE)), k)) for k in range(1, 12)
+    }
+
+    cov_by_remaining: dict[tuple[int, ...], dict[int, int]] = {}
+    for assignment, remaining in members:
+        cov_by_remaining[remaining] = coverage_by_k(assignment, type_of, neigh, seeds_by_k)
+
+    pairs: dict[int, tuple[int, int]] = {}
+    maximizers: dict[int, list[tuple[int, ...]]] = {}
+    for k in range(1, 12):
+        scores = {remaining: cov[k] for remaining, cov in cov_by_remaining.items()}
+        m_k = max(scores.values())
+        max_set = sorted(remaining for remaining, value in scores.items() if value == m_k)
+        maximizers[k] = max_set
+        pairs[k] = (m_k, len(max_set))
+
+    equality = tuple(int(maximizers[k] == maximizers[12 - k]) for k in range(1, 6))
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"cited_6465_pairs={CITED_6465_PAIRS}")
+    print(f"recomputed_pairs={ {k: pairs[k] for k in CITED_6465_PAIRS} }")
+    print(f"equality_5_tuple={equality}")
+    for k in range(1, 6):
+        print(f"Max({k})={maximizers[k]}")
+        print(f"Max({12 - k})={maximizers[12 - k]}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_hamming_bits={ham_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COVERAGE_COMPLEMENT_DUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-two-cube-and-binomial-seeds",
+        "the two-cube has twelve vertices and C(12,k) k-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and all(len(seeds_by_k[k]) == pairs[k][0] or True for k in range(1, 12))
+        and all(len(seeds_by_k[k]) == {1: 12, 2: 66, 3: 220, 4: 495, 5: 792, 6: 924, 7: 792, 8: 495, 9: 220, 10: 66, 11: 12}[k] for k in range(1, 12)),
+    )
+    checks.check(
+        "thm1-cite-6465-pairs",
+        "recomputed (m_k, N_max_k) match the cited #6465 pairs",
+        all(pairs[k] == CITED_6465_PAIRS[k] for k in CITED_6465_PAIRS)
+        and pairs[1] == (12, 4)
+        and pairs[2] == (66, 2)
+        and pairs[3] == (220, 2)
+        and pairs[4] == (495, 1)
+        and pairs[5] == (792, 2)
+        and pairs[11] == (12, 8)
+        and pairs[10] == (66, 4)
+        and pairs[9] == (220, 4)
+        and "m_1 = 12" in note
+        and "N_max_1 = 4" in note
+        and "#6465" in note,
+    )
+    checks.check(
+        "thm1-set-equality-bits",
+        "Max(k)=Max(12-k) only for k=4 and k=5 among k=1..5",
+        equality == EQUALITY_5_TUPLE
+        and maximizers[1] != maximizers[11]
+        and maximizers[2] != maximizers[10]
+        and maximizers[3] != maximizers[9]
+        and maximizers[4] == maximizers[8]
+        and maximizers[5] == maximizers[7]
+        and maximizers[4] == [F1_REMAINING]
+        and maximizers[5] == [L1_REMAINING, F1_REMAINING]
+        and set(maximizers[1]) < set(maximizers[11])
+        and set(maximizers[2]) != set(maximizers[10]),
+    )
+    checks.check(
+        "thm2-equality-5-tuple",
+        "the displayed equality 5-tuple is (0, 0, 0, 1, 1)",
+        equality == (0, 0, 0, 1, 1)
+        and "(0, 0, 0, 1, 1)" in note
+        and "E = (0, 0, 0, 1, 1)" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt-duality",
+        "the equality bits are displayed and no duality is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a duality" in note
+        and "Do not write the duality into Admissibility" in note
+        and equality[0] == 0
+        and equality[3] == 1,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted equality bits, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-sets-and-tuple",
+        "the note reports Max(k) versus Max(12-k) and the equality 5-tuple",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "Max(1)" in note
+        and "Max(11)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "(0, 0, 0, 1, 1)" in note
+        and "k=1,2,3" in note
+        and "k=4,5" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the duality into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6465",
+        "the residual is set equality, not leftover-character of the #6465 counts",
+        "Not leftover-character of #6465" in note
+        and "that only reported" in note
+        and "(m_k, N_max_k)" in note
+        and "not a recensus" in note,
+    )
+    checks.check(
+        "claim-scope-duality",
+        "claim_scope states set equality or not for each k=1..5",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "set of coverage maximizers at seed size k" in note
+        and "12-k" in note
+        and "Displayed, not adopted" in note
+        and "is not equal" in note
+        and "is equal" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored at each seed size k=1..11, then Max(k) is named")
+    print("per_block: checked exactly — the equality 5-tuple is Max(k)=Max(12-k) for each k=1..5")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, the coverage-maximizer set at seed size k is not equal to the set at 12-k for k=1..5. New duality, not a recensus of #6465. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_coverage_complement_duality_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.