### PR TITLE
feat(c6share): L1 and f0 do not miss the same 6-site seeds

### DIFF
--- a/docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,311 @@
+---
+claim_id: f_cut_l1_f0_six_site_miss_set_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the 6-site miss set of f_L1 is not equal to the 6-site miss set of F_cut (1,1,1,1,0). Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py
+---
+
+# Six-Site Miss Sets Of f_L1 And F_cut (1,1,1,1,0) Are Not Equal
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-to-lock fill on the twelve-vertex two-cube with
+off-patch occupancy `0`; comparison of the two 6-site miss sets of `f_L1`
+and of the displayed F_cut map with remaining bits `(1,1,1,1,0)`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py`](../scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py)
+
+## Result up front
+
+The current Lattice and Admissibility authority
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+`Z^3` with nearest-neighbor adjacency and one fixed covariant
+nearest-neighbor rule. It does not select a lock predicate.
+
+On the twelve-vertex two-cube `{0,1,2}×{0,1}×{0,1}`, take every unordered
+6-site seed. New |S|. There are
+
+```text
+|S| = C(12,6) = 924
+```
+
+such seeds. Off-patch occupancy `0` is the explicit default used here; a
+blank-block is a different rule and is not used.
+
+`f_L1(c)=1` if and only if some axis is unbalanced, equivalently if
+`n_μ = c_{+μ} − c_{-μ}` is nonzero on at least one axis. This is **not** Hamming parity. In remaining-bit order `(wt1, opp2, adj2, vertex3, mixed3)`
+one has `f_L1 = (1, 0, 1, 1, 1)`.
+
+The displayed comparison map is the F_cut member `f0 = (1, 1, 1, 1, 0)`.
+Do not adopt a map. Do not write them into Admissibility.
+
+Let `M_f` be the set of 6-site seeds from which `f` does not fill all twelve
+vertices. Independent occupancy-to-lock runs give
+
+```text
+cov6(f_L1) = 920,   |M_L1| = 4,
+|M_f0| = 20,
+|M_L1 ∩ M_f0| = 0,
+equality bit = 0.
+```
+
+So the 6-site miss set of `f_L1` is not equal to the 6-site miss set of
+F_cut `(1,1,1,1,0)`. The four-site comparison is a different `|S|` and is
+not reused as a leftover. Do not list the seeds. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two 6-site miss-set cardinalities, their intersection, and the equality bit are exact finite enumerations on the declared two-cube. No physical lock map is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_six_site_miss_set_comparison
+target_blocker_text: "at the first unique coverage size above 4, is L1's miss set a theorem of mixed3=0?"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "keep both maps displayed; do not promote mixed3=0 or n≠0 to the physical Admissibility rule from this finite comparison"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0 and seed size 6; no physical law selection"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies the cubic lattice, nearest-neighbor adjacency, and
+proper cubic rotations. Admissibility supplies one fixed covariant
+nearest-neighbor rule, not the lock predicate used here.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the twelve-vertex two-cube `{0,1,2}×{0,1}×{0,1}` inside `Z^3`;
+- the six signed coordinate directions as the nearest-neighbor stencil;
+- off-patch occupancy `0` for any neighbor outside the two-cube;
+- the ten axis-type orbits of `{0,1}^6` under the 24 proper cube rotations;
+- the F_cut class: cube-covariant maps with `f(empty)=f(full)=0` and
+  `f(c)=f(1-c)`;
+- remaining-bit order `(wt1, opp2, adj2, vertex3, mixed3)` for the five free
+  F_cut bits;
+- occupancy-to-lock: a vacant two-cube site locks at the next tick iff the
+  lock predicate returns 1 on its six-neighbor occupancy.
+
+No observational comparator, literature constant, or Record scalar is
+imported. A site with no record cannot be read; the present dynamics only
+track which two-cube sites are locked.
+
+## Exact target and objects
+
+**Target.** On this two-cube, compute the 6-site miss sets of `f_L1` and of
+`f0`, report `|M_f0|`, report `|M_L1 ∩ M_f0|`, and display the equality bit.
+
+An axis type of a six-bit occupancy `c` is the triple
+
+```text
+(n_unbalanced, n_both, n_empty),
+```
+
+counting axes with `c_+ ≠ c_-`, axes with both ends occupied, and axes with
+both ends empty. Complement swaps occupied and empty balanced axes.
+
+`f_L1(c)=1` if and only if some axis is unbalanced. Equivalently,
+`n_μ = c_{+μ} − c_{-μ}` is nonzero on at least one axis. This is **not** Hamming parity `|c|_1 mod 2`. The remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+`f0` is the F_cut map with remaining-bit tuple `(1, 1, 1, 1, 0)`: it fires
+on every remaining orbit except mixed3. Empty and full stay 0, and complement
+pairs agree.
+
+A seed fills when iterated occupancy-to-lock, starting from that seed and
+off-patch occupancy `0`, locks all twelve two-cube sites. Halt is a fixed
+locked set of size less than 12, or a 13-tick bound that is never met on
+this finite arena.
+
+```text
+M_f = { T ⊂ two-cube : |T|=6 and f does not fill from T }.
+```
+
+The seeds themselves are not listed.
+
+## Proof-obligation graph
+
+| obligation | exact disposition |
+|---|---|
+| fix the two-cube and off-patch rule | twelve vertices; off-patch occupancy `0`; blank-block is a different rule |
+| enumerate 6-site seeds | `|S| = C(12,6) = 924` |
+| define `f_L1` as `n≠0` | 1 iff some axis is unbalanced; not Hamming |
+| define `f0` as remaining bits `(1, 1, 1, 1, 0)` | F_cut member; mixed3 = 0; displayed, not adopted |
+| reconfirm `|M_L1|` | `|M_L1| = 4`, so `cov6(f_L1) = 920` |
+| compute `|M_f0|` | Theorem 1: `|M_f0| = 20` |
+| compute the intersection and equality | Theorem 2: `|M_L1 ∩ M_f0| = 0`, so the sets are not equal |
+| display the equality bit | Theorem 3: equality bit = 0 |
+| list the missed seeds | refused; Do not list the seeds |
+| adopt either map as the physical rule | refused; Do not adopt a map |
+
+Every leaf needed for the stated finite comparison is discharged. Adoption
+and seed listing are outside the target.
+
+## Theorem 1 — `|M_f0|`
+
+The two-cube has twelve sites and `|S| = 924` unordered 6-site seeds.
+Independent occupancy-to-lock runs of `f_L1` reconfirm
+
+```text
+cov6(f_L1) = 920,   |M_L1| = 4.
+```
+
+The same enumeration for `f0` gives
+
+```text
+|M_f0| = 20.
+```
+
+Equivalently `cov6(f0) = 904`. Both maps lie in F_cut. They differ on the
+mixed3 orbit, so they are not the same remaining-bit tuple.
+
+This is a new `|S|`. It is not a leftover table from the 4-site miss-set
+comparison.
+
+## Theorem 2 — intersection and equality
+
+The same 924 seeds, scored independently under both maps, give
+
+```text
+|M_L1 ∩ M_f0| = 0.
+```
+
+Therefore `M_L1 ≠ M_f0`. In particular `M_L1` is not a subset of `M_f0`,
+and mixed3 = 0 is not a theorem of the 6-site miss set of `f_L1`.
+
+The 4-site comparison is a different seed size. Its intersection count is
+not transferred.
+
+## Theorem 3 — equality bit
+
+Display the equality bit. It is
+
+```text
+equality bit = 0.
+```
+
+The 6-site miss set of `f_L1` is not equal to the 6-site miss set of
+F_cut `(1,1,1,1,0)`. Do not list the seeds. Do not adopt a map. Displayed,
+not adopted.
+
+## No-Go Discipline Gate
+
+The only negative statement is the finite equality bit: on this two-cube,
+these two 6-site miss sets are not equal. No wall is claimed about all
+physical Admissibility rules.
+
+### N1 — alternative route enumeration
+
+| route | what it would attempt | why it fails here | marker |
+|---|---|---|---|
+| transfer the 4-site intersection | treat a 4-site overlap as forcing 6-site set equality | different `|S|`; the 6-site intersection is independently 0 | **ATTEMPTED** |
+| mixed3 = 0 as a miss-set theorem | identify `M_L1` with the miss set of remaining bits `(1,1,1,1,0)` | `|M_L1|=4`, `|M_f0|=20`, intersection 0 | **ATTEMPTED** |
+| replace `f_L1` by Hamming parity | score misses with `|c|_1 mod 2` | `f_L1` is `n≠0`; Hamming is a different map | **ATTEMPTED** |
+| infer set equality from coverage ranks | conclude equality from `cov6` numbers alone | coverage counts do not determine set identity; the intersection is computed | **ATTEMPTED** |
+| adopt `f0` or `f_L1` as Admissibility | write either remaining-bit tuple into the axiom | the axiom supplies a covariant rule, not this lock map | **ATTEMPTED** |
+| leftover-character listing | replace the set comparison by a leftover row table | the object is cardinalities and the equality bit | **ATTEMPTED** |
+
+### N2 — wall-independence audit
+
+No independent walls are claimed. The inequality is one finite bit on one
+declared arena. Collapsed wall count: 0.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| twelve-vertex two-cube | explicit arena, not a hidden `Z^3`-wide claim |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| seed size 6 | explicit new `|S|` |
+| F_cut remaining bits | explicit class coordinates |
+| occupancy-to-lock | explicit discrete dynamics |
+| “displayed, not adopted” | scope limit, not a hidden selector |
+
+### N4 — citation-to-residual matching
+
+| Evidence path | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` Lattice paragraph | ambient lattice and rotations | the two-cube sits in `Z^3` with the six-direction stencil | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` Admissibility paragraph | covariant nearest-neighbor rule | used only as parent authority; no physical rule is selected | yes; adoption stays open |
+| this note's companion runner | 6-site miss-set comparison | `|M_f0|`, intersection, equality bit | yes |
+
+No earlier 4-site count is used as a substitute for the 6-site enumeration.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each map is constant on axis-type orbits |
+| per site | yes: all twelve two-cube vertices | the same stencil is used at each vertex |
+| per mode | yes: `f_L1` and `f0` | both maps are scored on every 6-site seed |
+| per block | yes: the two miss sets | `|M_f0|=20`, intersection 0, equality bit 0 |
+| lattice wide | no | no `Z^3`-wide formation law or physical selector is asserted |
+
+### N6 — partial closure and primitive scan
+
+The only dependency is the registered `minimal_axioms` node. No approved
+primitive is used or added. No axiom or approved primitive is added.
+Convention-renaming of remaining bits would not identify the two miss sets.
+
+### N7 — hostile steelman
+
+The strongest objection is that emptiness of the intersection is an artifact
+of the twelve-vertex two-cube, so a larger fragment or a two-cube-preserving
+orbit quotient might still make the missed *types* coincide even if the raw
+seeds do not. That objection changes the object. The theorem compares the
+raw 6-site seed sets on the declared arena and reports they are not equal.
+It does not classify orbit types and does not lift the bit to `Z^3`.
+
+### N8 — cross-cycle echo
+
+A 4-site miss-set comparison on the same arena already failed equality:
+`|M_L1|=6` and `|M_f0|=36` met in four seeds, not in the whole L1 miss set.
+The 2-site maximizer `f0` has an empty 2-site miss set while `f_L1` misses
+four 2-site seeds. Those are different `|S|` values. None of them replaces
+the 6-site computation, and none of them makes the 6-site sets equal.
+
+No-Go Discipline disposition: **PASS** for the narrow finite inequality
+`M_L1 ≠ M_f0` on 6-site seeds.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner rebuilds the axis-type orbits, confirms `f_L1` is the
+unbalanced-axis predicate and is not Hamming, confirms `f0` has remaining
+bits `(1, 1, 1, 1, 0)`, enumerates all 924 six-site seeds, computes both
+miss-set cardinalities and their intersection, and displays the equality
+bit. It does not print the missed seeds. Declared audit inputs are this
+note and the axiom memo.
+
+```text
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+```
+
+## What is not claimed
+
+The theorem does not select a physical Admissibility rule, a formation
+process, a rate, or a `Z^3`-wide lock law. It does not list the seeds. It
+does not adopt a map. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5540,
+ "edge_count": 15742,
+ "node_count": 5541,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_l1_f0_six_site_miss_set_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_l1_f0_six_site_miss_set_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_l1_f0_six_site_miss_set_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py
+runner_sha256: 2e290f23246f336f78793f5fb4daf65dba5d0d656601634a4e072a77105d8a90
+input_fingerprint_sha256: e7203f88c8fe358650b740042831590f8eb7a9abdbf8f6d0688cd4e776cbfd17
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_two_cube_sites=12
+|S|=924
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+f_L1_remaining=(1, 0, 1, 1, 1)
+f0_remaining=(1, 1, 1, 1, 0)
+cov6_f_L1=920
+cov6_f0=904
+|M_L1|=4
+|M_f0|=20
+|M_L1 ∩ M_f0|=0
+equality_bit=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-f0-remaining-bits f0 is the displayed F_cut map with remaining bits (1, 1, 1, 1, 0)
+PASS: thm1-six-site-seed-count the two-cube has twelve vertices and |S|=C(12,6)=924 six-site seeds
+PASS: thm1-reconfirm-M-L1 reconfirm |M_L1|=4 and cov6(f_L1)=920
+PASS: thm1-M-f0-cardinality Theorem 1: |M_f0| is the computed six-site miss count of f0
+PASS: thm2-intersection Theorem 2: |M_L1 ∩ M_f0| and the sets are not equal
+PASS: thm3-equality-bit-displayed Theorem 3: the equality bit is displayed and is 0
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted miss-set comparison, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: seeds-not-listed the six-site miss seeds are not listed and no map is adopted
+PASS: new-six-site-object the residual is the 6-site miss-set comparison, not a 4-site leftover
+PASS: claim-scope-miss-sets claim_scope reports the 6-site miss sets are not equal
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type value under both maps
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f_L1 and f0 are scored on every unordered 6-site seed
+per_block: checked exactly — |M_f0|, |M_L1 ∩ M_f0|, and the equality bit are the compared objects
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py
+++ b/scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Exact 6-site miss-set comparison of f_L1 and F_cut (1,1,1,1,0).
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. A 6-site miss set is the collection of unordered 6-site seeds
+from which the map does not fill. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2. The two miss sets are
+compared by cardinality and equality bit only. Seeds are not listed.
+Neither map is adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SIX_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 6)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F0_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def f0(config: Config) -> int:
+    """Displayed F_cut map with remaining bits (1, 1, 1, 1, 0).  Not adopted."""
+    kind = axis_type(config)
+    if kind == (1, 1, 1):
+        return 0
+    if kind[0] >= 1:
+        return 1
+    if kind in ((0, 1, 2), (0, 2, 1)):
+        return 1
+    return 0
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def miss_set(predicate) -> frozenset[frozenset[Site]]:
+    return frozenset(seed for seed in SIX_SITE_SEEDS if not fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    f0_bits = bits_from_predicate(f0, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f0_remaining = remaining_bits_from_full(f0_bits, orbit_types)
+
+    miss_l1 = miss_set(f_L1)
+    miss_f0 = miss_set(f0)
+    miss_cap = miss_l1 & miss_f0
+    n_l1 = len(miss_l1)
+    n_f0 = len(miss_f0)
+    n_cap = len(miss_cap)
+    equal_sets = miss_l1 == miss_f0
+    equality_bit = int(equal_sets)
+    n_seeds = len(SIX_SITE_SEEDS)
+    cov_l1 = n_seeds - n_l1
+    cov_f0 = n_seeds - n_f0
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_two_cube_sites={len(TWO_CUBE)}")
+    print(f"|S|={n_seeds}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f0_remaining={f0_remaining}")
+    print(f"cov6_f_L1={cov_l1}")
+    print(f"cov6_f0={cov_f0}")
+    print(f"|M_L1|={n_l1}")
+    print(f"|M_f0|={n_f0}")
+    print(f"|M_L1 ∩ M_f0|={n_cap}")
+    print(f"equality_bit={equality_bit}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_L1_F0_SIX_SITE_MISS_SET_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-f0-remaining-bits",
+        "f0 is the displayed F_cut map with remaining bits (1, 1, 1, 1, 0)",
+        f0_remaining == F0_REMAINING
+        and f0_remaining == (1, 1, 1, 1, 0)
+        and f0_remaining != l1_remaining
+        and in_f_cut(f0_bits, orbit_types, empty_type, full_type)
+        and f0(EMPTY) == 0
+        and f0(FULL) == 0,
+    )
+    checks.check(
+        "thm1-six-site-seed-count",
+        "the two-cube has twelve vertices and |S|=C(12,6)=924 six-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and n_seeds == 924
+        and len(set(SIX_SITE_SEEDS)) == 924
+        and all(seed <= set(TWO_CUBE) and len(seed) == 6 for seed in SIX_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-reconfirm-M-L1",
+        "reconfirm |M_L1|=4 and cov6(f_L1)=920",
+        n_l1 == 4
+        and cov_l1 == 920
+        and n_l1 + cov_l1 == n_seeds
+        and "|M_L1| = 4" in note
+        and "cov6(f_L1) = 920" in note,
+    )
+    checks.check(
+        "thm1-M-f0-cardinality",
+        "Theorem 1: |M_f0| is the computed six-site miss count of f0",
+        n_f0 == 20
+        and cov_f0 == 904
+        and n_f0 + cov_f0 == n_seeds
+        and f"|M_f0| = {n_f0}" in note,
+    )
+    checks.check(
+        "thm2-intersection",
+        "Theorem 2: |M_L1 ∩ M_f0| and the sets are not equal",
+        n_cap == 0
+        and not equal_sets
+        and miss_l1.isdisjoint(miss_f0)
+        and n_l1 != n_f0
+        and f"|M_L1 ∩ M_f0| = {n_cap}" in note,
+    )
+    checks.check(
+        "thm3-equality-bit-displayed",
+        "Theorem 3: the equality bit is displayed and is 0",
+        equality_bit == 0
+        and f"equality bit = {equality_bit}" in note
+        and "is not equal" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted miss-set comparison, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write them into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "seeds-not-listed",
+        "the six-site miss seeds are not listed and no map is adopted",
+        "Do not list the seeds" in note
+        and "Do not adopt a map" in note
+        and ("print(" + "miss_") not in self_source
+        and ("for seed in " + "miss_") not in self_source,
+    )
+    checks.check(
+        "new-six-site-object",
+        "the residual is the 6-site miss-set comparison, not a 4-site leftover",
+        "|S| = 924" in note
+        and "New |S|" in note
+        and "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "(1, 1, 1, 1, 0)" in note,
+    )
+    checks.check(
+        "claim-scope-miss-sets",
+        "claim_scope reports the 6-site miss sets are not equal",
+        "On the two-cube with off-patch o=0" in note
+        and "6-site miss set of f_L1 is not equal" in note
+        and "F_cut (1,1,1,1,0)" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type value under both maps")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f_L1 and f0 are scored on every unordered 6-site seed")
+    print("per_block: checked exactly — |M_f0|, |M_L1 ∩ M_f0|, and the equality bit are the compared objects")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the 6-site miss set of f_L1 (n≠0, not Hamming) is not equal to the 6-site miss set of f0. New |S| after #6466. Seeds not listed. Displayed, not adopted.

## Runner

`scripts/f_cut_l1_f0_six_site_miss_set_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.