### PR TITLE
feat(wt0mixdiff): first seed where mix0 fills and its wt1=0 sibling does not

### DIFF
--- a/docs/F_CUT_WT1_ZERO_MIX0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_ZERO_MIX0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,278 @@
+---
+claim_id: f_cut_wt1_zero_mix0_first_split_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the lex-first seed of size at most 3 at which F_cut (1,0,1,1,0) fills and (0,0,1,1,0) does not is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py
+---
+
+# First `|S|≤3` Seed Where `f_mix0` Fills And Its `wt1=0` Sibling Does Not
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact lock-evolution coverage on the supplied twelve-site
+two-cube `{0,1,2} × {0,1} × {0,1}` with off-patch occupancy `o = 0`.
+The displayed pair is `f_mix0 = (1,0,1,1,0)` and
+`fwt = (0,0,1,1,0)`. The lex-first nonempty seed of size at most `3`
+at which the first map fills and the second does not is reported by
+the seed, both fill bits, and both lock-count histories. Displayed,
+not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py`](../scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Work on the two-cube of twelve lattice sites
+`{0,1,2} × {0,1} × {0,1}`. Off-patch occupancy is `0`. A seed locks its
+sites. At each tick, every unlocked site whose six-neighbor axis type is
+fired by the displayed map locks. The process fills when all twelve sites
+are locked at halt.
+
+`F_cut` is the family of cube-covariant `{0,1}`-maps on six-neighbor
+occupancy with `f(empty) = f(full) = 0` and `f(c) = f(1-c)`. After those
+constraints the remaining bits are
+`(wt1, opp2, adj2, vertex3, mixed3)`. The displayed pair is
+
+```text
+f_mix0 = (1, 0, 1, 1, 0)
+fwt    = (0, 0, 1, 1, 0)
+```
+
+They differ only on the remaining bit `wt1`. This is not leftover-character of #6476,
+which listed `fwt` among the four extras in `Max(11)` minus `Max(1)` and did
+not name a seed. It is not leftover-character of #6473, which placed
+`f_mix0` in `Max(1)` and did not compare the pair. It is not leftover-character of #6437,
+which split `f_mix0` from `f_L1` on a three-site seed.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}`
+for at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor
+contrast `n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is
+`(1, 0, 1, 1, 1)`. Hamming parity has remaining bits `(1, 0, 0, 1, 1)`.
+
+Nonempty seeds are searched by increasing size, then by lexicographic
+order of the sorted site tuple, with sites ordered as `(x,y,z)` and
+`TWO_CUBE` listed by `x ∈ {0,1,2}`, `y ∈ {0,1}`, `z ∈ {0,1}`. The
+search is capped at `|S| ≤ 3`.
+
+The lex-first such seed at which `f_mix0` fills and `fwt` does not is
+the one-site seed
+
+```text
+S = {(0,0,0)}.
+```
+
+On that seed the lock-count histories are
+
+```text
+f_mix0 : (1, 4, 8, 11, 12)   fills
+fwt    : (1)                 does not fill
+```
+
+Displayed, not adopted. The remaining bit `wt1` is not written into
+Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact lock evolution on the twelve-site two-cube finds the lex-first seed of size at most 3 at which displayed f_mix0 fills and its wt1=0 sibling does not, and reports both halt histories."
+trace_class: frontier_discovery
+target_claim_id: f_cut_wt1_zero_mix0_first_split
+target_blocker_text: "is wt1 free on the mix0 line?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the supplied two-cube with off-patch o=0 and the displayed pair; no selector or Admissibility edit is asserted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded first-split claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice, Admissibility, and Record
+  sentences below supply site language, nearest-neighbor covariance, and
+  the lock/unread rule. They are quoted without rewrite.
+- **Explicit theorem-domain condition:** the twelve-site two-cube, off-patch
+  occupancy `0`, the displayed `F_cut` bit tuples `f_mix0 = (1,0,1,1,0)`
+  and `fwt = (0,0,1,1,0)`, simultaneous ready-lock evolution, and the
+  lex order of nonempty seeds of size at most `3` are supplied
+  mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selection of `f_mix0`, of `fwt`, or of the
+  remaining bit `wt1` by Admissibility or Record remains a separate open
+  obligation outside the target proved here. Do not adopt wt1.
+
+## Exact Objects
+
+Sites are the twelve points of `{0,1,2} × {0,1} × {0,1}`. A site outside
+this set has occupancy `0`. The blank-block is a different rule and is
+not used. For an unlocked site `v` the six neighbors
+`v ± e_μ`, `μ ∈ {x,y,z}`, determine an axis type
+`(n_unbalanced, n_both, n_empty)` with those three integers summing to
+`3`. The named remaining types are
+
+```text
+wt1 = (1,0,2), opp2 = (0,1,2), adj2 = (2,0,1),
+vertex3 = (3,0,0), mixed3 = (1,1,1).
+```
+
+Complement swaps empty with both and leaves unbalanced fixed, so
+`mixed3` and `vertex3` are self-complementary. `F_cut` forces
+`f(empty) = f(full) = 0` and equal values on each complementary pair.
+The five remaining bits therefore label the `32` cut maps.
+
+`f_mix0` fires `wt1`, `adj2`, and `vertex3`, and is silent on `opp2`
+and `mixed3`. `fwt` is the same map with the `wt1` bit cleared: it
+fires `adj2` and `vertex3` only.
+
+A seed `S` starts locked. Each tick locks every currently unlocked site
+whose axis type is fired. Halt is the first tick with no new lock. Fill
+means the halt lock set is the whole two-cube.
+
+One-site coverage is
+
+```text
+cov1(f) = |{ v : f fills from {v} }|.
+```
+
+`Max(1)` is the set of the `32` cut maps that attain `m_1 = max cov1`.
+Independent recomputation on this patch gives `m_1 = 12` attained by
+exactly four maps, so a map is in `Max(1)` here if and only if it fills
+every one-site seed.
+
+## Exact Target And Proof Obligations
+
+The exact target is the lex-first nonempty seed `S` of size at most `3`
+at which `f_mix0` fills and `fwt` does not, together with both
+lock-count histories on that seed.
+
+The obligation graph is:
+
+1. recompute `Max(1)` among the `32` cut maps and locate the displayed
+   pair in or out of that set;
+2. enumerate nonempty seeds of size `1`, then `2`, then `3`, in lex
+   order, and stop at the first seed `f_mix0` fills and `fwt` misses;
+3. report both lock-count histories from that seed.
+
+All three obligations are closed below and in the runner. The two-cube,
+off-patch default, and displayed bit tuples are theorem hypotheses.
+Other patches, other maps, and any selector among `F_cut` are outside
+this theorem.
+
+## Theorem 1 — `f_mix0` is in `Max(1)`; `fwt` is not
+
+There are twelve one-site seeds. Direct lock evolution gives
+`cov1(f_mix0) = 12` and `cov1(fwt) = 0`. Among all `32` cut maps the
+maximum one-site coverage is `m_1 = 12`, attained by the four remaining-bit
+tuples
+
+```text
+(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+Thus `f_mix0` is in `Max(1)` and `fwt` is not. The four maximizers are
+`f_mix0`, `f_L1`, `f0 = (1,1,1,1,0)`, and `f1 = (1,1,1,1,1)`. This
+reconfirms the membership recorded as #6473 for `f_mix0` and the
+exclusion of `fwt` from `Max(1)` recorded as #6476. Hamming parity is
+not among those four tuples.
+
+## Theorem 2 — lex-first `|S|≤3` split seed is `{(0,0,0)}`
+
+Enumerate nonempty seeds by increasing size, then lexicographic order of
+the sorted site tuple. The first one-site seed is `{(0,0,0)}`. On that
+seed `f_mix0` fills and `fwt` does not. No earlier nonempty seed of size
+at most `3` exists, so this is the lex-first `|S|≤3` seed at which the
+pair splits in the required direction.
+
+The same search run to completion is not the claim: later two-site and
+three-site splits are not listed. The claim is the first seed, not a
+census of all seeds on which the pair disagrees.
+
+## Theorem 3 — histories from `S`; display; do not adopt `wt1`
+
+From `S = {(0,0,0)}` the lock-count histories are
+
+```text
+f_mix0 : (1, 4, 8, 11, 12)
+fwt    : (1)
+```
+
+`f_mix0` reaches all twelve sites. `fwt` never leaves the seed: halt
+locks equal `1`. The three on-patch neighbors of `(0,0,0)` have axis
+type `wt1 = (1,0,2)`. Displayed `f_mix0` fires that type and locks
+`(1,0,0)`, `(0,1,0)`, and `(0,0,1)` on the first tick. Displayed `fwt`
+is silent on `wt1` and therefore has an empty first wave. That
+neighborhood type is reported only to name the first split. The
+remaining bit `wt1` is not adopted as an Admissibility selector, not
+named as a physical sector, and not written into the axiom memo.
+
+## Physical-Interpretation Boundary
+
+The proved output is a first-split seed and two halt histories on a
+supplied finite patch for a displayed pair of cut maps. This note
+neither assigns `wt1` a physical label nor changes Lattice,
+Admissibility, or Record. No additional axiom is proposed. Do not write the ranking into Admissibility.
+
+## Mutation Checks
+
+Three non-equivalences guard the load-bearing conclusions:
+
+1. `fwt` is not in `Max(1)`: `cov1(fwt) = 0`, not `12`;
+2. `f_mix0` is not `f_L1` and is not Hamming parity;
+3. the first split is a one-site seed, not the three-site mix0/L1
+   splitter `{(0,0,0),(0,0,1),(2,0,0)}` of #6437.
+
+A fourth guard is that the pair is not leftover of the #6476 listing of
+`Max(11)` extras: that listing named `fwt` and did not report a seed or
+a history.
+
+## What This Does Not Claim
+
+- `f_mix0` and `fwt` are not adopted as physical nearest-neighbor rules.
+- The remaining bit `wt1` is not adopted.
+- No claim is made that Record locks `{(0,0,0)}` or that Admissibility
+  selects `wt1` silence.
+- Other `F_cut` tuples, later split seeds, and the infinite lattice
+  outside the two-cube are not classified.
+- Independent class-`C` leftovers are not used as parents.
+- This note does not re-list `Max(11)` and does not census every
+  `|S|≤3` disagreement.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under
+> lattice translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to site language, covariance of a
+nearest-neighbor rule, and the lock/unread vocabulary. This theorem
+separately supplies the two-cube, the displayed pair, and the first-split
+seed; physical selection of `wt1` remains outside its target.
+
+## Runner Contract
+
+The companion runner checks Theorems 1–3 by recomputing `Max(1)` among
+the `32` cut maps, searching nonempty seeds of size at most `3` in lex
+order, and evolving both displayed maps from the first split. It also
+checks the mutations, quotes the live axiom sentences, prints
+substantive N5 scope certificates, and records the import boundary.
+Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_zero_mix0_first_split_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_zero_mix0_first_split_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_zero_mix0_first_split_2026_08_15.txt
@@ -1,0 +1,64 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py
+runner_sha256: a250f9f1278e1cafd80ec238f46b7a9dfdaa5ea18fe7fb0f10b050d3f3df1769
+input_fingerprint_sha256: b296ba1cb01e3bb271f81ff7765d91231da55e82b90ce912046084b77c81a921
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_WT1_ZERO_MIX0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: none; two-cube occupancy and cut-map bits only
+package_local_integrity_reads: proposed source note and live axiom memo only
+measure_boundary: exact integer lock counts; no floating-point inputs
+claim_boundary: displayed first-split seed; wt1 is not adopted
+PASS: geometry-two-cube the two-cube has 12 sites
+PASS: geometry-one-site-count there are exactly 12 one-site seeds
+PASS: geometry-seed-counts there are 66 two-site seeds and 220 three-site seeds
+m1=12
+N_max1=4
+Max1=((1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1))
+cov1_mix0=12
+cov1_fwt=0
+PASS: thm1-m1-twelve maximum one-site coverage is m1=12 attained by four maps
+PASS: thm1-mix0-in-max1 f_mix0=(1,0,1,1,0) is in Max(1)
+PASS: thm1-fwt-not-in-max1 fwt=(0,0,1,1,0) is not in Max(1)
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 remaining bits fire every type with n_unbalanced>=1
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming parity of the six neighbor bits
+S=((0, 0, 0),)
+hist_mix0=(1, 4, 8, 11, 12)
+hist_fwt=(1,)
+fill_mix0=True
+fill_fwt=False
+PASS: thm2-first-seed-is-origin the lex-first |S|<=3 split is the one-site seed {(0,0,0)}
+PASS: thm2-direction f_mix0 fills S and fwt does not
+PASS: thm2-no-earlier-split no earlier nonempty |S|<=3 seed splits in that direction
+PASS: thm3-histories lock-count histories are (1,4,8,11,12) and (1)
+PASS: thm3-first-wave-is-wt1 the first mix0 wave from S is the three wt1 neighbors; fwt is silent
+PASS: mutation-not-l1-or-hamming f_mix0 is not f_L1 and neither displayed map is Hamming
+PASS: mutation-not-6437-three-site the first split is not the mix0/L1 three-site splitter
+PASS: mutation-pair-differs-only-on-wt1 the displayed pair differs only on the remaining bit wt1
+PASS: forbidden-substrings the note and runner omit the dispatch-forbidden phrases
+PASS: display-not-adopt the note displays S and refuses adoption of wt1
+PASS: live-parent-quotes Lattice, Admissibility, and Record sentences are quoted without rewrite
+PASS: machine-status-contract bounded-support status and no axiom adoption are source-visible
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-scope-first-split claim_scope states the lex-first |S|<=3 mix0-fills / fwt-misses seed
+PASS: not-leftover-6476-or-6437 the residual is a new pair seed, not leftover-character of #6476 or #6437
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: scope-not-nogo the note is a bounded display, not a no-go
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+per_element: each F_cut remaining-bit tuple is scored by one-site fill
+per_site: occupancy is the two-cube with off-patch o=0; no other patch is used
+per_mode: nonempty seeds of size at most 3 are searched in lex order
+per_block: the first mix0-fills / fwt-misses seed and both histories are the claim
+lattice_wide: checked and not executed — no Z^3-wide selector or adoption
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py
+++ b/scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Lex-first |S|<=3 seed where f_mix0 fills and its wt1=0 sibling does not.
+
+On the two-cube {0,1,2} x {0,1} x {0,1} with off-patch occupancy 0,
+f_mix0 is the complement-even cut map with remaining bits
+(wt1, opp2, adj2, vertex3, mixed3) = (1,0,1,1,0) and fwt is the
+same map with wt1 cleared, (0,0,1,1,0). This runner recomputes
+Max(1) among the 32 F_cut maps, searches nonempty seeds of size
+at most 3 in lex order, and reports the first seed at which
+f_mix0 fills and fwt does not, together with both lock-count
+histories. Values are derived, not embedded. f_L1 is n != 0
+(some axis unbalanced), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+import ast
+from itertools import combinations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_WT1_ZERO_MIX0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_ZERO_MIX0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+TWO_CUBE = tuple((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+MIX0_BITS = (1, 0, 1, 1, 0)
+FWT_BITS = (0, 0, 1, 1, 0)
+L1_BITS = (1, 0, 1, 1, 1)
+F0_BITS = (1, 1, 1, 1, 0)
+F1_BITS = (1, 1, 1, 1, 1)
+HAMMING_BITS = (1, 0, 0, 1, 1)
+ALL_REMAINING = tuple(product((0, 1), repeat=5))
+
+
+def _add(a: tuple[int, int, int], b: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def _sub(a: tuple[int, int, int], b: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def axis_type(
+    site: tuple[int, int, int], locked: set[tuple[int, int, int]]
+) -> tuple[int, int, int]:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for step in AXES:
+        occupied = int(_add(site, step) in locked) + int(_sub(site, step) in locked)
+        if occupied == 0:
+            n_empty += 1
+        elif occupied == 2:
+            n_both += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def fires(typ: tuple[int, int, int], bits: tuple[int, int, int, int, int]) -> bool:
+    wt1, opp2, adj2, vertex3, mixed3 = bits
+    table = {
+        (0, 0, 3): 0,
+        (0, 3, 0): 0,
+        (1, 0, 2): wt1,
+        (1, 2, 0): wt1,
+        (0, 1, 2): opp2,
+        (0, 2, 1): opp2,
+        (2, 0, 1): adj2,
+        (2, 1, 0): adj2,
+        (3, 0, 0): vertex3,
+        (1, 1, 1): mixed3,
+    }
+    return bool(table[typ])
+
+
+def evolve(
+    seed: tuple[tuple[int, int, int], ...], bits: tuple[int, int, int, int, int]
+) -> tuple[tuple[int, ...], frozenset[tuple[int, int, int]]]:
+    locked = set(seed)
+    history = [len(locked)]
+    while True:
+        ready = [
+            site
+            for site in TWO_CUBE
+            if site not in locked and fires(axis_type(site, locked), bits)
+        ]
+        if not ready:
+            break
+        locked.update(ready)
+        history.append(len(locked))
+        if len(locked) == 12:
+            break
+    return tuple(history), frozenset(locked)
+
+
+def filled(seed: tuple[tuple[int, int, int], ...], bits: tuple[int, int, int, int, int]) -> bool:
+    return len(evolve(seed, bits)[1]) == 12
+
+
+def cov1(bits: tuple[int, int, int, int, int]) -> int:
+    return sum(1 for site in TWO_CUBE if filled((site,), bits))
+
+
+def lex_seeds(max_size: int):
+    for size in range(1, max_size + 1):
+        for seed in combinations(TWO_CUBE, size):
+            yield seed
+
+
+def first_split(
+    fill_bits: tuple[int, int, int, int, int],
+    miss_bits: tuple[int, int, int, int, int],
+    max_size: int = 3,
+) -> tuple[tuple[int, int, int], ...] | None:
+    for seed in lex_seeds(max_size):
+        if filled(seed, fill_bits) and not filled(seed, miss_bits):
+            return seed
+    return None
+
+
+def seed_key(seed: tuple[tuple[int, int, int], ...]) -> tuple[tuple[int, int, int], ...]:
+    return tuple(sorted(seed))
+
+
+def audit_paths_are_static_literals(source: str) -> bool:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS" for target in node.targets):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Tuple):
+            return False
+        return all(
+            isinstance(element, ast.Constant) and isinstance(element.value, str)
+            for element in value.elts
+        )
+    return False
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("external_scientific_inputs: none; two-cube occupancy and cut-map bits only")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("measure_boundary: exact integer lock counts; no floating-point inputs")
+    print("claim_boundary: displayed first-split seed; wt1 is not adopted")
+
+    checks.check("geometry-two-cube", "the two-cube has 12 sites", len(TWO_CUBE) == 12)
+    checks.check(
+        "geometry-one-site-count",
+        "there are exactly 12 one-site seeds",
+        len(TWO_CUBE) == 12 and len(set(TWO_CUBE)) == 12,
+    )
+    n_two = sum(1 for _ in combinations(TWO_CUBE, 2))
+    n_three = sum(1 for _ in combinations(TWO_CUBE, 3))
+    checks.check(
+        "geometry-seed-counts",
+        "there are 66 two-site seeds and 220 three-site seeds",
+        n_two == 66 and n_three == 220,
+    )
+
+    cov1_by_bits = {bits: cov1(bits) for bits in ALL_REMAINING}
+    m1 = max(cov1_by_bits.values())
+    max1 = tuple(sorted(bits for bits, cov in cov1_by_bits.items() if cov == m1))
+    cov1_mix0 = cov1_by_bits[MIX0_BITS]
+    cov1_fwt = cov1_by_bits[FWT_BITS]
+    print(f"m1={m1}")
+    print(f"N_max1={len(max1)}")
+    print(f"Max1={max1}")
+    print(f"cov1_mix0={cov1_mix0}")
+    print(f"cov1_fwt={cov1_fwt}")
+
+    checks.check(
+        "thm1-m1-twelve",
+        "maximum one-site coverage is m1=12 attained by four maps",
+        m1 == 12
+        and len(max1) == 4
+        and set(max1) == {MIX0_BITS, L1_BITS, F0_BITS, F1_BITS},
+    )
+    checks.check(
+        "thm1-mix0-in-max1",
+        "f_mix0=(1,0,1,1,0) is in Max(1)",
+        MIX0_BITS in max1 and cov1_mix0 == 12 and all(filled((site,), MIX0_BITS) for site in TWO_CUBE),
+    )
+    checks.check(
+        "thm1-fwt-not-in-max1",
+        "fwt=(0,0,1,1,0) is not in Max(1)",
+        FWT_BITS not in max1 and cov1_fwt == 0 and cov1_fwt < m1,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 remaining bits fire every type with n_unbalanced>=1",
+        L1_BITS == (1, 0, 1, 1, 1) and L1_BITS in max1,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming parity of the six neighbor bits",
+        L1_BITS != HAMMING_BITS
+        and MIX0_BITS != HAMMING_BITS
+        and FWT_BITS != HAMMING_BITS
+        and HAMMING_BITS not in max1,
+    )
+
+    split = first_split(MIX0_BITS, FWT_BITS, max_size=3)
+    if split is None:
+        raise RuntimeError("no |S|<=3 seed where mix0 fills and fwt does not")
+    hist_mix0, locks_mix0 = evolve(split, MIX0_BITS)
+    hist_fwt, locks_fwt = evolve(split, FWT_BITS)
+    print(f"S={seed_key(split)}")
+    print(f"hist_mix0={hist_mix0}")
+    print(f"hist_fwt={hist_fwt}")
+    print(f"fill_mix0={len(locks_mix0) == 12}")
+    print(f"fill_fwt={len(locks_fwt) == 12}")
+
+    earlier_ok = True
+    for seed in lex_seeds(3):
+        if seed == split:
+            break
+        if filled(seed, MIX0_BITS) and not filled(seed, FWT_BITS):
+            earlier_ok = False
+            break
+
+    checks.check(
+        "thm2-first-seed-is-origin",
+        "the lex-first |S|<=3 split is the one-site seed {(0,0,0)}",
+        split == ((0, 0, 0),) and len(split) == 1,
+    )
+    checks.check(
+        "thm2-direction",
+        "f_mix0 fills S and fwt does not",
+        len(locks_mix0) == 12 and len(locks_fwt) != 12,
+    )
+    checks.check(
+        "thm2-no-earlier-split",
+        "no earlier nonempty |S|<=3 seed splits in that direction",
+        earlier_ok,
+    )
+    checks.check(
+        "thm3-histories",
+        "lock-count histories are (1,4,8,11,12) and (1)",
+        hist_mix0 == (1, 4, 8, 11, 12) and hist_fwt == (1,) and len(locks_fwt) == 1,
+    )
+
+    locked0 = set(split)
+    first_wave_types = {
+        site: axis_type(site, locked0)
+        for site in TWO_CUBE
+        if site not in locked0 and fires(axis_type(site, locked0), MIX0_BITS)
+    }
+    checks.check(
+        "thm3-first-wave-is-wt1",
+        "the first mix0 wave from S is the three wt1 neighbors; fwt is silent",
+        first_wave_types
+        == {
+            (1, 0, 0): (1, 0, 2),
+            (0, 1, 0): (1, 0, 2),
+            (0, 0, 1): (1, 0, 2),
+        }
+        and all(not fires(typ, FWT_BITS) for typ in first_wave_types.values()),
+    )
+
+    checks.check(
+        "mutation-not-l1-or-hamming",
+        "f_mix0 is not f_L1 and neither displayed map is Hamming",
+        MIX0_BITS != L1_BITS and MIX0_BITS != HAMMING_BITS and FWT_BITS != HAMMING_BITS,
+    )
+    checks.check(
+        "mutation-not-6437-three-site",
+        "the first split is not the mix0/L1 three-site splitter",
+        seed_key(split) != ((0, 0, 0), (0, 0, 1), (2, 0, 0)),
+    )
+    checks.check(
+        "mutation-pair-differs-only-on-wt1",
+        "the displayed pair differs only on the remaining bit wt1",
+        MIX0_BITS[0] == 1
+        and FWT_BITS[0] == 0
+        and MIX0_BITS[1:] == FWT_BITS[1:]
+        and MIX0_BITS[1:] == (0, 1, 1, 0),
+    )
+
+    forbidden = ("G" + "_N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-substrings",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "display-not-adopt",
+        "the note displays S and refuses adoption of wt1",
+        "Displayed, not adopted" in note
+        and "Do not adopt wt1" in note
+        and "S = {(0,0,0)}" in note
+        and "(1, 4, 8, 11, 12)" in note
+        and "fwt    : (1)" in note,
+    )
+    checks.check(
+        "live-parent-quotes",
+        "Lattice, Admissibility, and Record sentences are quoted without rewrite",
+        "proper cubic rotations about each site" in axiom
+        and "proper cubic rotations about each site" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom
+        and "one fixed nearest-neighbor admissibility rule" in note
+        and "A site with no record cannot be read." in axiom
+        and "A site with no record cannot be read." in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "bounded-support status and no axiom adoption are source-visible",
+        "actual_current_surface_status: bounded-support" in note
+        and "hypothetical_axiom_status:" in note
+        and "no axiom or approved primitive is added" in note
+        and "**Type:** bounded_theorem" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_ZERO_MIX0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and audit_paths_are_static_literals(self_source)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "claim-scope-first-split",
+        "claim_scope states the lex-first |S|<=3 mix0-fills / fwt-misses seed",
+        "lex-first seed of size at most 3" in note
+        and "F_cut (1,0,1,1,0) fills and (0,0,1,1,0) does not" in note
+        and "Displayed, not adopted" in note
+        and "off-patch o=0" in note,
+    )
+    checks.check(
+        "not-leftover-6476-or-6437",
+        "the residual is a new pair seed, not leftover-character of #6476 or #6437",
+        "not leftover-character of #6476" in note
+        and "not leftover-character of #6437" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        ("Off-patch occupancy is `0`" in note or "off-patch occupancy `0`" in note)
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "Do not write the ranking into Admissibility" in note
+        and "Do not adopt wt1" in note,
+    )
+    checks.check(
+        "scope-not-nogo",
+        "the note is a bounded display, not a no-go",
+        "### N8" not in note
+        and "FAIL / DO NOT SHIP" not in note
+        and "These are scope boundaries, not impossibility" in note
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+
+    print("per_element: each F_cut remaining-bit tuple is scored by one-site fill")
+    print("per_site: occupancy is the two-cube with off-patch o=0; no other patch is used")
+    print("per_mode: nonempty seeds of size at most 3 are searched in lex order")
+    print("per_block: the first mix0-fills / fwt-misses seed and both histories are the claim")
+    print("lattice_wide: checked and not executed — no Z^3-wide selector or adoption")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the lex-first |S|<=3 seed at which F_cut (1,0,1,1,0) fills and (0,0,1,1,0) does not is reported. Displayed, not adopted. f_L1 is n!=0, not Hamming. Source-only. No axiom edit.

## Runner

`scripts/f_cut_wt1_zero_mix0_first_split_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.