### PR TITLE
feat(wt0f1diff): first seed where f1 fills and its wt1=0 sibling does not

### DIFF
--- a/docs/F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,338 @@
+---
+claim_id: f_cut_wt1_zero_f1_first_split_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the lex-first seed of size at most 3 at which F_cut (1,1,1,1,1) fills and (0,1,1,1,1) does not is S={(0,0,0)}. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py
+---
+
+# First Seed Of Size At Most Three Where `f1` Fills And Its `wt1=0` Sibling Does Not
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** displayed occupancy-to-lock dynamics of two cube-covariant
+`F_cut` maps on the twelve-vertex two-cube `{0,1,2}×{0,1}×{0,1}`,
+started from every nonempty seed of size at most three, with off-patch
+occupancy identically `0`. The lex-first seed at which `f1` fills and
+the `wt1=0` sibling does not is displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py`](../scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve sites `{0,1,2}×{0,1}×{0,1}`. A site
+locks when a displayed predicate of its six-neighbor occupancy tuple
+returns `1`. Off-patch neighbors contribute occupancy `0`. A run is the
+tuple of lock-set cardinalities from the seed through halt, together
+with the fill bit `|locks_halt|=12`.
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Remaining bits are ordered
+`(wt1, opp2, adj2, vertex3, mixed3)`. Write
+
+- `f1 = (1,1,1,1,1)`,
+- `fwt = (0,1,1,1,1)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced (`n≠0`,
+not Hamming parity). That map has remaining bits `(1,0,1,1,1)` and is
+not this pair.
+
+Enumerate nonempty seeds `S` by increasing `|S|`, then lexicographic
+site order, through `|S|≤3` (`12+66+220=298` seeds).
+
+**Theorem 1.** `f1` fills every 2-site seed (`cov2(f1)=66`). `fwt` is
+not in `Max(2)`: `cov2(fwt)=0`, while `Max(2)` is the class attaining
+`66`.
+
+**Theorem 2.** The lex-first seed of size at most 3 at which `f1`
+fills and `fwt` does not is `S={(0,0,0)}`, so `|S|=1`.
+
+**Theorem 3.** From that `S`, `f1` has lock history `(1, 4, 8, 11, 12)`
+and fills. `fwt` has lock history `(1,)` and does not fill. Display
+the first split. Do not adopt `wt1`.
+
+Displayed, not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of those sentences is to name the cubic nearest-neighbor
+graph and to keep formation outside the axiom. The axiom memo says the
+distribution concerns which possibility a forming record locks,
+conditional on formation; it does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The maps `f1` and `fwt` are supplied displayed members, not
+axiom content. A seed is likewise displayed data, not an admissibility
+rule: no axiom or approved primitive is added.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact seed census of two displayed F_cut occupancy-to-lock maps on a twelve-vertex two-cube through size 3."
+trace_class: frontier_discovery
+target_claim_id: f_cut_wt1_zero_f1_first_split
+target_blocker_text: "lex-first two-cube seed of size at most 3 at which F_cut (1,1,1,1,1) fills and (0,1,1,1,1) does not"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded first-split claim; do not adopt wt1 or the seed"
+conditional_surface_status: "exact on the two-cube with off-patch o=0 for |S|<=3; both maps remain displayed members"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Sites of the two-cube, in lexicographic order:
+
+`(0,0,0)`, `(0,0,1)`, `(0,1,0)`, `(0,1,1)`,
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`,
+`(2,0,0)`, `(2,0,1)`, `(2,1,0)`, `(2,1,1)`.
+
+The six-neighbor tuple at a site is ordered
+`(+x,-x,+y,-y,+z,-z)`. Each coordinate is the occupancy of that
+neighbor: `1` if the neighbor is an on-patch lock, else `0`. Every
+off-patch neighbor is `0`. Off-patch occupancy `0` is the explicit
+default; a blank-block is a different rule.
+
+For each axis, the pair of opposite bits is
+
+- unbalanced if the bits are `{0,1}`,
+- both if the bits are `{1,1}`,
+- empty if the bits are `{0,0}`.
+
+Write `(n_unbalanced, n_both, n_empty)` with sum `3`. Remaining-bit
+orbits used below:
+
+| name | type | representative |
+|---|---|---|
+| empty | `(0,0,3)` | `(0,0,0,0,0,0)` |
+| wt1 | `(1,0,2)` | `(1,0,0,0,0,0)` |
+| opp2 | `(0,1,2)` | `(1,1,0,0,0,0)` |
+| adj2 | `(2,0,1)` | `(1,0,1,0,0,0)` |
+| type120 | `(1,2,0)` | `(1,0,1,1,1,1)` |
+| vertex3 | `(3,0,0)` | `(1,0,1,0,1,0)` |
+| mixed3 | `(1,1,1)` | `(1,0,1,1,0,0)` |
+| full | `(0,3,0)` | `(1,1,1,1,1,1)` |
+
+`f_L1(c)=1` if and only if some axis is unbalanced. Hamming parity of
+`|c|_1` is a different predicate: `adj2` is even and `f_L1(adj2)=1`.
+
+On those representatives the remaining bits are
+
+| map | wt1 | opp2 | adj2 | vertex3 | mixed3 |
+|---|---|---|---|---|---|
+| `f1` | 1 | 1 | 1 | 1 | 1 |
+| `fwt` | 0 | 1 | 1 | 1 | 1 |
+| `f_L1` | 1 | 0 | 1 | 1 | 1 |
+
+Complement-even assignment sends type `(1,2,0)` with `wt1`. So `f1`
+fires on every nonempty nonfull six-tuple, and `fwt` is silent on
+`wt1` and on its complement.
+
+One tick locks every currently unlocked on-patch site whose neighbor
+tuple has `f=1`. The process starts with `locks_0=S` and halts at the
+first fixed point, or at tick `12`. Lock history is the sequence of
+cardinalities from `t=0` through halt. Fill means `|locks_halt|=12`.
+`Max(k)` is the set of `F_cut` maps attaining the maximum number of
+filling `k`-site seeds.
+
+Seeds are enumerated by increasing cardinality, then as combinations
+of the lexicographic site list. That census is `12+66+220=298` nonempty
+seeds of size at most three.
+
+## Theorem 1 — `f1` fills every 2-site seed; `fwt` is not in `Max(2)`
+
+There are `C(12,2)=66` two-site seeds. Independent runs from each seed
+give `cov2(f1)=66`: `f1` fills every 2-site seed. The same census gives
+`cov2(fwt)=0`. Therefore `fwt` does not attain the two-site maximum
+and is not in `Max(2)`. The two-site maximum `66` is attained (in
+particular) by `f1` and by `f0=(1,1,1,1,0)`.
+
+This is the 2-site coverage comparison of the pair, not a recensus of
+`Max(11)`.
+
+## Theorem 2 — lex-first seed of size at most 3
+
+The lex-first seed of size at most 3 at which `f1` fills and `fwt`
+does not is
+
+`S={(0, 0, 0)}`.
+
+It is the first 1-site seed in lexicographic site order. Every later
+1-site seed is likewise a fill for `f1` and a miss for `fwt`, but the
+lex-first witness is the corner singleton. So a distinguishing seed
+exists inside the `|S|≤3` cap, and it has `|S|=1`.
+
+Not leftover of the `opp2=0` first-split pair (that pair is `f_L1`
+versus `(0,0,1,1,1)`). The present pair differs only in the `wt1` bit
+of `f1`.
+
+## Theorem 3 — histories from `S`; display, not adoption
+
+Start with `S={(0,0,0)}`, so `|locks_0|=1`.
+
+The three on-patch nearest neighbors `(1,0,0)`, `(0,1,0)`, `(0,0,1)`
+each see a single occupied nearest neighbor, type `wt1`. Then `f1=1`
+and `fwt=0`. Every other unlocked site sees the empty tuple.
+
+Therefore `f1` locks those three sites at tick `1` and continues:
+
+`T=4`, `|locks_halt|=12`, history `(1, 4, 8, 11, 12)`, fill bit `1`.
+
+`fwt` locks nothing further. The first wave is empty:
+
+`T=0`, `|locks_halt|=1`, history `(1,)`, fill bit `0`.
+
+The executed split is the `wt1` orbit. Display the first split. Do not
+adopt `wt1`. Do not adopt `f1`. Do not adopt `fwt`. Do not write a
+seed into Admissibility. The seed is not written into Admissibility.
+
+A displayed filler or seed is not axiom content. Admissibility is not
+a dynamics axiom and does not supply this predicate or this seed.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, lex seed order, `|S|≤3` | declared finite data |
+| `f1` fills every 2-site seed | recomputed; `cov2=66` |
+| `fwt` not in `Max(2)` | recomputed; `cov2=0` |
+| lex-first seed | `{(0, 0, 0)}` |
+| both histories | `(1, 4, 8, 11, 12)` and `(1,)` |
+| both fill bits | `f1` fills; `fwt` does not |
+| adoption of `wt1` or either map | refused |
+| formation site / rate from the axioms | open |
+
+## Boundary And Imports
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. The two-cube, the two predicates, and the
+seed order are supplied mathematical data for this note. Record lock
+language is quoted only as the existing lock/content/absence boundary;
+it does not select either map or any seed.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers which first `|S|≤3` seed, if any, is a fill for `f1` and a miss for `fwt`. |
+| V2 | Current main has the axiom memo and no landed first-split census of this `wt1` pair. |
+| V3 | The 298-seed twelve-vertex process is independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it executes two supplied predicates the axiom does not name. |
+| V5 | Neither map nor the seed is an admissibility rule, and none is adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: a first distinguishing seed is not
+predicate identity, and a displayed filler or seed is not axiom
+content.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| 2-site census | every pair seed | `f1` fills all `66`; `fwt` fills none |
+| `Max(2)` membership | compare `cov2` to `66` | `fwt` is not in `Max(2)` |
+| lex census through size 3 | 298 seeds | first split at `{(0,0,0)}` |
+| `f1` from that `S` | remaining bits `(1,1,1,1,1)` | fills; history `(1, 4, 8, 11, 12)` |
+| `fwt` from that `S` | remaining bits `(0,1,1,1,1)` | does not fill; history `(1,)` |
+| `wt1` distinction | evaluate both maps on `(1,0,2)` | they disagree; first wave splits |
+| Hamming parity | `|c|_1 mod 2` | different predicate; `adj2` even |
+| write a seed or `wt1` into Admissibility | treat either as the local rule | refused; axiom is not a dynamics axiom |
+
+### N2 — wall independence
+
+The missing formation-site selector, the missing axiom-level
+occupancy rule, and the choice among displayed members are distinct
+open items. This note claims no complete wall and no compiler no-go.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch `o=0`, lex site order, size cap 3,
+six-neighbor order, and both remaining-bit tuples are declared. Cube
+covariance is used only as the axis-type reading of a six-tuple. No
+continuum, Hamming, or admissibility rewrite is assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor graph and states
+that Admissibility is not a dynamics axiom and does not supply the
+formation site, probability, or rate. The residual therefore matches
+those sources: a displayed lock predicate and a displayed seed are
+extra data.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | remaining-bit representatives and off-patch `0` | no alphabet classification |
+| per site | every two-cube vertex against both predicates | no derived kernel values |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | all 66 two-site seeds and the lex `|S|≤3` search | no physical compiler |
+| lattice wide | checked and not executed | neither map nor the seed adopted as a rule |
+
+### N6 — live partial-closure paths
+
+Live routes include an independent reason to select or reject either
+map, a larger-`k` coverage comparison, and a formation mechanism
+supplied by something other than a displayed predicate.
+
+### N7 — hostile steelman
+
+**Steelman:** `fwt` sits in `Max(11)`, so the `wt1` bit is dynamically
+free on small seeds and the pair may be treated as one object.
+
+**Answer:** The lex-first seed `{(0, 0, 0)}` already splits fill.
+`f1` fills every 2-site seed and `fwt` fills none of them. `Max(11)`
+membership is a different ranking. Admissibility does not name either
+map or this seed.
+
+### N8 — cross-cycle echo
+
+A 2-site fill census of `f1` and a `Max(11)` listing of `fwt` are
+different claims. This note executes the first seed of size at most 3
+at which the pair disagrees on fill.
+
+No-Go Discipline disposition: **PASS**
+
+**Gate disposition:** PASS for the finite first-seed statement and the
+displayed histories. FAIL / DO NOT SHIP for “adopt `wt1`,” “adopt
+`f1`,” “write a seed into Admissibility,” or “the maps are the same
+dynamics on every two-cube seed.”
+
+## Primary Runner
+
+The primary runner rebuilds the two-cube, both remaining-bit
+predicates, the 66-seed two-site coverage comparison, the lex
+`|S|≤3` first-split search, both histories and both fill bits from
+`{(0,0,0)}`, the `wt1` first-wave mechanism, the current premise
+boundary, and the non-adoption wording. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_zero_f1_first_split_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_zero_f1_first_split_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_zero_f1_first_split_2026_08_15.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py
+runner_sha256: 2343b7ecaa166e6daeca8cd193a5a70c87e0371377d6e50ff08b144e5061ff47
+input_fingerprint_sha256: 837f2dedf58e7f159ce6781c1aee2e31ea937306983748cef94f108bd9117e7f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+negative_scope: neither map nor the first seed is adopted
+PASS: audit-inputs declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site, probability, and rate remain outside Admissibility
+PASS: source-record-and-non-dynamics Record lock wording and the non-dynamics Admissibility boundary are pinned
+PASS: two-cube-and-lex-order the two-cube has twelve lexicographically ordered vertices
+PASS: off-patch-zero every off-patch neighbor contributes occupancy 0
+PASS: remaining-bits-and-maps f1 and fwt are the declared remaining-bit F_cut maps
+PASS: f1-not-l1-not-hamming f1 is not f_L1 and neither is Hamming parity
+cov2_f1=66 cov2_fwt=0 cov2_f0=66
+PASS: thm1-f1-fills-every-2-site f1 fills every 2-site seed
+PASS: thm1-fwt-not-in-max2 fwt is not in Max(2), because cov2(fwt) is strictly below cov2(f1)
+first_split seed=((0, 0, 0),) hist_f1=(1, 4, 8, 11, 12) fill_f1=True hist_fwt=(1,) fill_fwt=False
+PASS: thm2-lex-first-seed the lex-first |S|<=3 seed where f1 fills and fwt does not is {(0,0,0)}
+PASS: thm3-histories from {(0,0,0)} f1 has history (1, 4, 8, 11, 12) and fills; fwt has (1,) and does not
+PASS: split-mechanism the first wave from {(0,0,0)} is type wt1; f1 locks it and fwt is silent
+PASS: theorem-3-display-not-adopt the note displays the seed and refuses adoption of wt1
+PASS: note-contract machine fields, first-seed statement, and forbidden-phrase hygiene hold
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-opp2-zero the pair is new, not leftover of the opp2=0 wt1=0 split
+PASS: no-axiom-edit the theorem proposes no axiom change
+per_element: remaining-bit representatives and off-patch occupancy 0 are enumerated
+per_site: each two-cube vertex is tested against both displayed lock predicates
+per_mode: checked and not executed — no spectral claim occurs
+per_block: every 2-site seed and the lex |S|<=3 search are executed to a fixed point
+lattice_wide: checked and not executed — neither map nor the seed is adopted
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py
+++ b/scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Lex-first |S|<=3 seed where F_cut f1 fills and its wt1=0 sibling does not.
+
+Two-cube {0,1,2}x{0,1}x{0,1}, off-patch occupancy 0. Remaining-bit order
+is (wt1, opp2, adj2, vertex3, mixed3). f1=(1,1,1,1,1) and
+fwt=(0,1,1,1,1). Seeds are enumerated by increasing size, then
+lexicographic site order. f_L1 is the some-axis-unbalanced (n!=0) map,
+not Hamming parity. The first split is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+OrbitType = tuple[int, int, int]
+
+SITES: tuple[Point, ...] = tuple(
+    sorted((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+)
+TWO_CUBE_SET = frozenset(SITES)
+AXIS_SHIFTS: tuple[tuple[Point, Point], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+F1_BITS: tuple[int, ...] = (1, 1, 1, 1, 1)
+FWT_BITS: tuple[int, ...] = (0, 1, 1, 1, 1)
+F0_BITS: tuple[int, ...] = (1, 1, 1, 1, 0)
+L1_BITS: tuple[int, ...] = (1, 0, 1, 1, 1)
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+WT1_TYPE: OrbitType = (1, 0, 2)
+WT1_COMPLEMENT: OrbitType = (1, 2, 0)
+MAX_SEED = 3
+TWO_SITE_COUNT = 66
+
+ORBIT_REPS: dict[str, Config] = {
+    "empty": (0, 0, 0, 0, 0, 0),
+    "wt1": (1, 0, 0, 0, 0, 0),
+    "opp2": (1, 1, 0, 0, 0, 0),
+    "adj2": (1, 0, 1, 0, 0, 0),
+    "vertex3": (1, 0, 1, 0, 1, 0),
+    "mixed3": (1, 0, 1, 1, 0, 0),
+    "type120": (1, 0, 1, 1, 1, 1),
+    "full": (1, 1, 1, 1, 1, 1),
+}
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locks: frozenset[Point]) -> int:
+    if site not in TWO_CUBE_SET:
+        return 0
+    return 1 if site in locks else 0
+
+
+def neighbor_config(site: Point, locks: frozenset[Point]) -> Config:
+    bits: list[int] = []
+    for plus, minus in AXIS_SHIFTS:
+        bits.append(occupancy(add(site, plus), locks))
+        bits.append(occupancy(add(site, minus), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for index in (0, 2, 4):
+        plus, minus = config[index], config[index + 1]
+        if plus == 1 and minus == 1:
+            n_both += 1
+        elif plus == 0 and minus == 0:
+            n_empty += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def remaining_value(bits: tuple[int, ...], kind: OrbitType) -> int:
+    if kind in (EMPTY_TYPE, FULL_TYPE):
+        return 0
+    lookup = {
+        (1, 0, 2): bits[0],
+        (1, 2, 0): bits[0],
+        (0, 1, 2): bits[1],
+        (0, 2, 1): bits[1],
+        (2, 0, 1): bits[2],
+        (2, 1, 0): bits[2],
+        (3, 0, 0): bits[3],
+        (1, 1, 1): bits[4],
+    }
+    return lookup[kind]
+
+
+def predicate_from_remaining(bits: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(bits, axis_type(config))
+
+    return predicate
+
+
+f1 = predicate_from_remaining(F1_BITS)
+fwt = predicate_from_remaining(FWT_BITS)
+f0 = predicate_from_remaining(F0_BITS)
+f_l1 = predicate_from_remaining(L1_BITS)
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def step(locks: frozenset[Point], predicate) -> frozenset[Point]:
+    newcomers = {
+        site
+        for site in SITES
+        if site not in locks and predicate(neighbor_config(site, locks)) == 1
+    }
+    return locks | newcomers
+
+
+def run_from_seed(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    history = [len(locks)]
+    tick = 0
+    while tick < halt_bound:
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+        history.append(len(locks))
+    return tick, frozenset(locks), tuple(history)
+
+
+def fills(seed: frozenset[Point], predicate) -> bool:
+    _tick, locks, _history = run_from_seed(seed, predicate)
+    return len(locks) == 12
+
+
+def seed_family():
+    for size in range(1, MAX_SEED + 1):
+        for combo in combinations(SITES, size):
+            yield combo
+
+
+def first_split():
+    for combo in seed_family():
+        seed = frozenset(combo)
+        if fills(seed, f1) and not fills(seed, fwt):
+            t1, locks1, hist1 = run_from_seed(seed, f1)
+            tw, locksw, histw = run_from_seed(seed, fwt)
+            return {
+                "seed": combo,
+                "hist_f1": hist1,
+                "fill_f1": len(locks1) == 12,
+                "locks_f1": locks1,
+                "tick_f1": t1,
+                "hist_fwt": histw,
+                "fill_fwt": len(locksw) == 12,
+                "locks_fwt": locksw,
+                "tick_fwt": tw,
+            }
+    return None
+
+
+def coverage_two_site(predicate) -> int:
+    return sum(1 for pair in combinations(SITES, 2) if fills(frozenset(pair), predicate))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Admissibility, and Record "
+        "boundaries; no observations or fits"
+    )
+    print("negative_scope: neither map nor the first seed is adopted")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_WT1_ZERO_F1_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    unread = "A site with no record cannot be read."
+    not_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site, probability, and rate remain outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in note_flat,
+    )
+    checks.check(
+        "source-record-and-non-dynamics",
+        "Record lock wording and the non-dynamics Admissibility boundary are pinned",
+        record_lock in normalize(axiom)
+        and record_lock in note
+        and unread in axiom
+        and unread in note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-and-lex-order",
+        "the two-cube has twelve lexicographically ordered vertices",
+        len(SITES) == 12
+        and SITES == tuple(sorted(SITES))
+        and SITES[0] == (0, 0, 0)
+        and SITES[-1] == (2, 1, 1)
+        and len(list(combinations(SITES, 2))) == TWO_SITE_COUNT
+        and len(list(combinations(SITES, 3))) == 220,
+    )
+    checks.check(
+        "off-patch-zero",
+        "every off-patch neighbor contributes occupancy 0",
+        occupancy((-1, 0, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((0, -1, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((3, 0, 0), frozenset({(2, 0, 0)})) == 0,
+    )
+    checks.check(
+        "remaining-bits-and-maps",
+        "f1 and fwt are the declared remaining-bit F_cut maps",
+        axis_type(ORBIT_REPS["wt1"]) == (1, 0, 2)
+        and axis_type(ORBIT_REPS["opp2"]) == (0, 1, 2)
+        and axis_type(ORBIT_REPS["adj2"]) == (2, 0, 1)
+        and axis_type(ORBIT_REPS["vertex3"]) == (3, 0, 0)
+        and axis_type(ORBIT_REPS["mixed3"]) == (1, 1, 1)
+        and axis_type(ORBIT_REPS["type120"]) == (1, 2, 0)
+        and remaining_value(F1_BITS, WT1_TYPE) == 1
+        and remaining_value(FWT_BITS, WT1_TYPE) == 0
+        and remaining_value(FWT_BITS, WT1_COMPLEMENT) == 0
+        and remaining_value(F1_BITS, (0, 1, 2)) == 1
+        and remaining_value(FWT_BITS, (0, 1, 2)) == 1
+        and f1(ORBIT_REPS["empty"]) == 0
+        and f1(ORBIT_REPS["full"]) == 0
+        and fwt(ORBIT_REPS["empty"]) == 0
+        and fwt(ORBIT_REPS["full"]) == 0
+        and f1(ORBIT_REPS["wt1"]) == 1
+        and fwt(ORBIT_REPS["wt1"]) == 0
+        and f_l1(ORBIT_REPS["opp2"]) == 0
+        and f1(ORBIT_REPS["opp2"]) == 1,
+    )
+    checks.check(
+        "f1-not-l1-not-hamming",
+        "f1 is not f_L1 and neither is Hamming parity",
+        F1_BITS != L1_BITS
+        and FWT_BITS != L1_BITS
+        and f1(ORBIT_REPS["opp2"]) != f_l1(ORBIT_REPS["opp2"])
+        and f1(ORBIT_REPS["adj2"]) != f_hamming(ORBIT_REPS["adj2"])
+        and f_l1(ORBIT_REPS["wt1"]) == 1
+        and f_l1(ORBIT_REPS["opp2"]) == 0
+        and "sum(config) % 2"
+        not in self_source.split("def remaining_value", 1)[0],
+    )
+
+    cov2_f1 = coverage_two_site(f1)
+    cov2_fwt = coverage_two_site(fwt)
+    cov2_f0 = coverage_two_site(f0)
+    print(f"cov2_f1={cov2_f1} cov2_fwt={cov2_fwt} cov2_f0={cov2_f0}")
+
+    checks.check(
+        "thm1-f1-fills-every-2-site",
+        "f1 fills every 2-site seed",
+        cov2_f1 == TWO_SITE_COUNT,
+        residual=cov2_f1,
+    )
+    checks.check(
+        "thm1-fwt-not-in-max2",
+        "fwt is not in Max(2), because cov2(fwt) is strictly below cov2(f1)",
+        cov2_fwt < cov2_f1
+        and cov2_f1 == TWO_SITE_COUNT
+        and cov2_f0 == TWO_SITE_COUNT
+        and FWT_BITS != F0_BITS
+        and FWT_BITS != F1_BITS,
+        residual=cov2_fwt,
+    )
+
+    first = first_split()
+    if first is None:
+        print("first_split: none")
+    else:
+        print(
+            f"first_split seed={first['seed']} "
+            f"hist_f1={first['hist_f1']} fill_f1={first['fill_f1']} "
+            f"hist_fwt={first['hist_fwt']} fill_fwt={first['fill_fwt']}"
+        )
+
+    checks.check(
+        "thm2-lex-first-seed",
+        "the lex-first |S|<=3 seed where f1 fills and fwt does not is {(0,0,0)}",
+        first is not None
+        and first["seed"] == ((0, 0, 0),)
+        and "{(0,0,0)}" in note.replace(" ", ""),
+        residual=None if first is None else first["seed"],
+    )
+
+    seed0 = frozenset({(0, 0, 0)})
+    wave_f1 = step(seed0, f1) - seed0
+    wave_fwt = step(seed0, fwt) - seed0
+    expected_wave = frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)})
+    checks.check(
+        "thm3-histories",
+        "from {(0,0,0)} f1 has history (1, 4, 8, 11, 12) and fills; fwt has (1,) and does not",
+        first is not None
+        and first["hist_f1"] == (1, 4, 8, 11, 12)
+        and first["fill_f1"]
+        and first["locks_f1"] == TWO_CUBE_SET
+        and first["hist_fwt"] == (1,)
+        and not first["fill_fwt"]
+        and first["locks_fwt"] == seed0
+        and "(1, 4, 8, 11, 12)" in note
+        and "(1,)" in note,
+        residual=None
+        if first is None
+        else (first["hist_f1"], first["hist_fwt"], first["fill_f1"], first["fill_fwt"]),
+    )
+    checks.check(
+        "split-mechanism",
+        "the first wave from {(0,0,0)} is type wt1; f1 locks it and fwt is silent",
+        wave_f1 == expected_wave
+        and wave_fwt == frozenset()
+        and all(
+            axis_type(neighbor_config(site, seed0)) == WT1_TYPE
+            for site in expected_wave
+        )
+        and f1(ORBIT_REPS["wt1"]) == 1
+        and fwt(ORBIT_REPS["wt1"]) == 0,
+        residual=(sorted(wave_f1), sorted(wave_fwt)),
+    )
+    checks.check(
+        "theorem-3-display-not-adopt",
+        "the note displays the seed and refuses adoption of wt1",
+        first is not None
+        and "Displayed, not adopted" in note
+        and "Do not adopt" in note
+        and "not written into Admissibility" in note_flat
+        and "wt1" in note,
+    )
+
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "No-Go Discipline disposition: **PASS**",
+        "(1, 4, 8, 11, 12)",
+        "lex-first seed",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, first-seed statement, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and all(phrase not in note and phrase not in self_source for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "new axiom" not in note
+        and "Block 12" not in note
+        and "toe-lphys" not in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "not Hamming" in note
+        and "n≠0" in note,
+    )
+    checks.check(
+        "not-leftover-opp2-zero",
+        "the pair is new, not leftover of the opp2=0 wt1=0 split",
+        "Not leftover" in note
+        and "opp2=0" in note
+        and "(0,1,1,1,1)" in note.replace(" ", ""),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "no axiom or approved primitive is added" in note,
+    )
+
+    print("per_element: remaining-bit representatives and off-patch occupancy 0 are enumerated")
+    print("per_site: each two-cube vertex is tested against both displayed lock predicates")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: every 2-site seed and the lex |S|<=3 search are executed to a fixed point")
+    print("lattice_wide: checked and not executed — neither map nor the seed is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the lex-first |S|<=3 seed at which F_cut (1,1,1,1,1) fills and (0,1,1,1,1) does not is reported. Displayed, not adopted. f_L1 is n!=0, not Hamming. Source-only. No axiom edit.

## Runner

`scripts/f_cut_wt1_zero_f1_first_split_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.