### PR TITLE
feat(wt0f0diff): first seed where f0 fills and its wt1=0 sibling does not

### DIFF
--- a/docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,314 @@
+---
+claim_id: f_cut_wt1_zero_f0_first_split_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the lex-first seed of size at most 3 at which F_cut (1,1,1,1,0) fills and (0,1,1,1,0) does not is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py
+---
+
+# First |S|≤3 Seed Where F_cut (1,1,1,1,0) Fills and Its wt1=0 Sibling Does Not
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** occupancy-to-lock dynamics on the twelve-vertex two-cube with
+off-patch occupancy `0`. The displayed pair is the mixed3-silent F_cut map
+`(1, 1, 1, 1, 0)` and its wt1=0 sibling `(0, 1, 1, 1, 0)`. The first split
+seed of size at most 3 is reported. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py`](../scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+`F_cut` is the cube-covariant class of occupancy predicates with
+`f(empty)=f(full)=0` and `f(c)=f(1-c)`. Its five free remaining bits are
+ordered as `(wt1, opp2, adj2, vertex3, mixed3)`. Write `f0 = (1, 1, 1, 1, 0)`
+for the mixed3-silent maximizer and `fwt = (0, 1, 1, 1, 0)` for the same
+tuple with the wt1 bit cleared.
+
+On the two-cube, `Max(k)` is the set of `F_cut` maps that maximize the number
+of unordered `k`-site seeds from which the map fills all twelve vertices.
+
+- `f0` is in `Max(1)` and `Max(2)`.
+- `fwt` is in neither Max(1) nor Max(2). Independently, `fwt` attains
+  `Max(11)` (twelve of the twelve eleven-site seeds fill).
+- Searching seeds in size-then-lex order with `|S| ≤ 3`, the first seed at
+  which `f0` fills and `fwt` does not is the singleton `S = {(0, 0, 0)}`,
+  so `|S| = 1`.
+- From that seed, `f0` reaches the full twelve-site halt lock set in four
+  ticks. `fwt` never leaves `{(0, 0, 0)}`.
+
+The pair and the seed are displayed. Do not adopt wt1. Do not write them
+into Admissibility.
+
+Not leftover-character of the Max(11) listing: that listing only placed
+`(0, 1, 1, 1, 0)` among the four extras that attain `Max(11)` and miss
+`Max(1)`. The new object is the first dynamical split of the mixed3-silent
+line from its wt1=0 sibling.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact occupancy-to-lock enumeration on the two-cube names the lex-first |S|<=3 seed at which F_cut (1,1,1,1,0) fills and (0,1,1,1,0) does not."
+trace_class: frontier_discovery
+target_claim_id: f_cut_wt1_zero_f0_first_split
+target_blocker_text: "is wt1 free on the mixed3-silent line?"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the twelve-vertex two-cube with off-patch occupancy 0; no physical selector is asserted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded algebraic claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice, Admissibility, and Record
+  sentences quoted below supply the repository's `Z^3` vocabulary, covariant
+  nearest-neighbor rule, and unread-absence lock rule. They are quoted
+  without rewrite.
+- **Explicit theorem-domain condition:** the two-cube
+  `{0,1,2} × {0,1} × {0,1}`, off-patch occupancy `0` (a blank-block is a
+  different rule), and the five remaining-bit coordinates of `F_cut` are
+  supplied mathematical data.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selecting `f0`, `fwt`, or the wt1 bit as a
+  physical Admissibility rule remains a separate, open obligation.
+
+## Exact Objects
+
+A neighbor configuration is a 6-tuple `c ∈ {0,1}^6` indexed by the ordered
+directions `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced when
+`c_{+μ} ≠ c_{-μ}`, both-occupied when both bits are 1, and empty when both
+are 0. Complement swaps `n_both` with `n_empty`. Cube-covariance forces a
+constant value on each of the ten axis-type orbits. The `F_cut` conditions
+`f(empty)=f(full)=0` and `f(c)=f(1-c)` leave five free bits.
+
+Those bits, in remaining order, are:
+
+| bit | axis type | complement |
+|---|---|---|
+| wt1 | `(1,0,2)` | `(1,2,0)` |
+| opp2 | `(0,1,2)` | `(0,2,1)` |
+| adj2 | `(2,0,1)` | `(2,1,0)` |
+| vertex3 | `(3,0,0)` | self |
+| mixed3 | `(1,1,1)` | self |
+
+`f_L1(c)=1` if and only if some axis is unbalanced: equivalently,
+`n_μ = c_{+μ} − c_{-μ}` is nonzero for some axis `μ`. This is **not** Hamming parity `|c|_1 mod 2`. The L1 remaining-bit tuple is
+`(1, 0, 1, 1, 1)`. It is used only as a contrast predicate, not as a
+selector.
+
+The two-cube has the twelve vertices
+`(x,y,z)` with `x ∈ {0,1,2}` and `y,z ∈ {0,1}`. Sites are ordered
+lexicographically. Seeds of size at most 3 are searched size-first, then
+in that site order. Off-patch occupancy `0` means a neighbor outside the
+twelve vertices contributes 0. At each tick every unlocked ready site locks
+simultaneously. Fill means the halt lock set has cardinality 12.
+
+## Exact Target And Proof Obligations
+
+The exact target is the lex-first seed of size at most 3 at which `f0`
+fills and `fwt` does not, together with both lock histories from that seed.
+
+The obligation graph is:
+
+1. rebuild the 24 proper cube rotations and the 10 axis-type orbits;
+2. confirm `f0 ∈ Max(1) ∩ Max(2)` and `fwt` in neither;
+3. enumerate `|S| ≤ 3` seeds in size-then-lex order and report the first
+   split;
+4. display both occupancy-to-lock histories from that seed.
+
+All four obligations are closed below and in the runner. Larger patches,
+other remaining-bit pairs, and any physical adoption of wt1 are outside
+this theorem.
+
+## Theorem 1 — Membership in Max(1) and Max(2)
+
+There are 24 proper cube rotations and 10 axis-type orbits partitioning the
+64 cells of `{0,1}^6`. `|F_cut| = 32`. The two-cube has 12 vertices, so
+there are 12 one-site seeds and `C(12,2) = 66` two-site seeds.
+
+Scoring every `F_cut` map:
+
+- `Max(1)` has `m = 12` and `N_max = 4`. The maximizers are
+  `(1, 0, 1, 1, 0)`, `(1, 0, 1, 1, 1)`, `(1, 1, 1, 1, 0)`, and
+  `(1, 1, 1, 1, 1)`. Thus `f0` is in `Max(1)`, with coverage 12.
+- `Max(2)` has `m = 66` and `N_max = 2`. The maximizers are
+  `(1, 1, 1, 1, 0)` and `(1, 1, 1, 1, 1)`. Thus `f0` is in `Max(2)`,
+  with coverage 66.
+- `fwt = (0, 1, 1, 1, 0)` has one-site coverage 0 and two-site coverage 0,
+  so it is in neither `Max(1)` nor `Max(2)`.
+- For completeness of the parent listing: `fwt` has eleven-site coverage 12,
+  so it is in `Max(11)`.
+
+Every one-site first wave on the two-cube is a wt1 neighborhood: a neighbor
+of the unique locked site sees exactly one occupied opposite pair. Clearing
+the wt1 bit therefore freezes every one-site seed, and every two-site seed
+whose first wave is still only wt1. That is the membership split.
+
+## Theorem 2 — Lex-first |S|≤3 split seed
+
+Search all unordered seeds with `|S| ≤ 3` in size-then-lex order of their
+sorted site tuples. The first seed at which `f0` fills and `fwt` does not
+is
+
+```text
+S = {(0, 0, 0)},    |S| = 1.
+```
+
+No earlier seed exists: the search begins at the lex-first one-site seed,
+and that seed already splits. Independently, all 12 one-site seeds split
+the same way (`f0` fills each; `fwt` fills none). The theorem reports the
+lex-first representative, not a census.
+
+## Theorem 3 — Histories from S
+
+Write `L_t` for the lock set after `t` simultaneous ticks.
+
+For `f0` from `S`:
+
+```text
+L_0 = {(0, 0, 0)}
+L_1 = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0)}
+L_2 = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0)}
+L_3 = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1), (2, 1, 0)}
+L_4 = the twelve-vertex two-cube
+```
+
+The halt lock set of `f0` is the full two-cube, so `f0` fills. Halt tick
+`T = 4`.
+
+For `fwt` from the same `S`:
+
+```text
+L_0 = {(0, 0, 0)}
+```
+
+already a fixed point. The first wave is empty because every neighbor of
+`(0, 0, 0)` presents a wt1 configuration and `fwt` has wt1 `= 0`. The halt
+lock set has cardinality 1, so `fwt` does not fill.
+
+These histories are displayed. Do not adopt wt1.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's lattice vocabulary,
+covariant nearest-neighbor rule, and unread-absence lock rule. This theorem
+separately supplies the two-cube, the `F_cut` pair, and the occupancy ticks.
+Off-patch occupancy `0` is an explicit default; a blank-block is a different
+rule.
+
+## No-Go Discipline
+
+The result is a finite split on one displayed pair. It is not a universal
+selector theorem and not a no-go against other remaining-bit lines.
+
+No-Go Discipline disposition: **PASS**
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| adopt Hamming parity in place of `f_L1` | **ATTEMPTED** | Hamming differs from unbalanced-axis `n_μ ≠ 0` on `{0,1}^6` and is not the remaining-bit coordinate used here |
+| treat `Max(11)` membership as 1-site filling | **ATTEMPTED** | `fwt` attains `Max(11)` and has one-site coverage 0 |
+| take any 3-site seed as the first split | **ATTEMPTED** | size-then-lex search returns the one-site seed `{(0, 0, 0)}` |
+| identify the pair with `f_L1` | **ATTEMPTED** | `f_L1` is `(1, 0, 1, 1, 1)`, not `(1, 1, 1, 1, 0)` |
+| write the wt1 bit into Admissibility | **ATTEMPTED** | the bit is displayed; no axiom or approved primitive is added |
+| replace off-patch `0` by a blank-block | **ATTEMPTED** | a blank-block is a different rule and is outside the theorem domain |
+
+### N2 — wall independence
+
+One dynamical wall is claimed: on this pair, the first `|S| ≤ 3` seed that
+splits fill is the lex-first one-site seed. Membership of `fwt` in `Max(11)`
+is a separate coverage fact, not a second impossibility wall.
+
+### N3 — hidden-wall scan
+
+The two-cube, the off-patch default, the remaining-bit coordinates, and the
+size-then-lex seed order are all declared. No full-lattice formation law,
+physical Admissibility selector, Hamming substitute for `f_L1`, or other
+`F_cut` pair is imported.
+
+### N4 — residual matching
+
+The residual after the `Max(11)` listing was whether wt1 is dynamically free
+on the mixed3-silent line. This note answers that residual by a first split
+seed. It neither closes a physical selector nor enlarges the axiom set.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — each neighbor 6-tuple is scored by axis type
+per-site: executed — each of the twelve two-cube vertices uses the same stencil
+per-mode: executed — Max(1) and Max(2) are scored over all 32 F_cut maps
+per-block: executed — lex search of |S|<=3 seeds reports the first split
+lattice-wide: not executed — no Z^3-wide formation law is claimed
+```
+
+### N6 — partial-closure paths
+
+A physical rule could still adopt a different remaining-bit tuple, a
+different seed class, or a derived dynamics on a larger patch. Every such
+route remains live and need not alter the axioms if derived from separately
+supported structure.
+
+### N7 — steelman
+
+The strongest objection is that a later seed, or a different lex convention,
+might be the intended first split. Correct that convention is part of the
+hypothesis: size-then-lex on the declared site order. Under that order the
+first split is uniquely `{(0, 0, 0)}`. Another order would be another
+theorem.
+
+### N8 — cross-cycle echo
+
+Earlier coverage work named `f0` as a two-site maximizer and placed `fwt`
+in `Max(11)` minus `Max(1)`. This note agrees with those listings and
+contributes only the first dynamical split of that mixed3-silent pair.
+
+## Boundaries and explicit non-claims
+
+- The theorem is conditional on the two-cube and off-patch occupancy `0`.
+- It does not classify all `|S| ≤ 3` split seeds; it reports the lex-first
+  one.
+- It does not adopt `f0`, `fwt`, or the wt1 bit as a physical rule.
+- Hamming parity is not a substitute for `f_L1`.
+- No axiom, primitive, registry, or audit verdict is edited.
+- Do not write them into Admissibility.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py
+```
+
+The runner rebuilds the orbits, scores `Max(1)` and `Max(2)` over all 32
+`F_cut` maps, searches `|S| ≤ 3` seeds in size-then-lex order, and checks
+both lock histories from the reported seed. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_zero_f0_first_split_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_zero_f0_first_split_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_zero_f0_first_split_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py
+runner_sha256: 1ef586ae93778141958bf36fbb3658fd4808b96022e764f2622b3d9e9521c096
+input_fingerprint_sha256: 9692eb339a2b5258f17e734eccac24ad462ea9151d09c645436aaff500c6e63d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_sites=12
+Max(1): m=12 N_max=4 maximizers=[(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+Max(2): m=66 N_max=2 maximizers=[(1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+cov1_f0=12 cov1_fwt=0
+cov2_f0=66 cov2_fwt=0
+cov11_f0=12 cov11_fwt=12
+|S|=1 S=((0, 0, 0),)
+f0_history=[((0, 0, 0),), ((0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0)), ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0)), ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1), (2, 1, 0)), ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1))]
+fwt_history=[((0, 0, 0),)]
+f0_fills=True fwt_fills=False
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-f-L1-not-hamming f_L1 is n != 0 on an axis and is not Hamming parity
+PASS: thm1-f0-in-max1-and-max2 f0=(1,1,1,1,0) attains Max(1) and Max(2)
+PASS: thm1-fwt-in-neither fwt=(0,1,1,1,0) is in neither Max(1) nor Max(2)
+PASS: thm2-lex-first-seed the lex-first |S|<=3 split seed is the singleton {(0, 0, 0)}
+PASS: thm2-f0-fills-fwt-misses on that seed f0 fills and fwt does not
+PASS: thm3-histories histories from S are computed and displayed; wt1 is not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted first split, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: claim-scope-first-split claim_scope reports the lex-first |S|<=3 f0-versus-fwt split
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt wt1
+PASS: not-leftover-max11-listing the residual is the first split seed, not leftover-character of the Max(11) listing
+per_element: checked exactly — each neighbor 6-tuple is scored by axis type
+per_site: checked exactly — each of the twelve two-cube vertices uses the same stencil
+per_mode: checked exactly — Max(1) and Max(2) are scored over all 32 F_cut maps
+per_block: checked exactly — lex search of |S|<=3 seeds reports the first split
+lattice_wide: checked and not executed — no Z^3-wide formation law is claimed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py
+++ b/scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Lex-first |S|<=3 seed that splits F_cut (1,1,1,1,0) from its wt1=0 sibling.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Remaining bits are (wt1, opp2, adj2, vertex3, mixed3). The
+displayed map is f0=(1,1,1,1,0); its wt1=0 sibling is fwt=(0,1,1,1,0).
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. The first split seed and both lock histories are displayed,
+not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F0_REMAINING: tuple[int, ...] = (1, 1, 1, 1, 0)
+FWT_REMAINING: tuple[int, ...] = (0, 1, 1, 1, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def predicate_from_remaining(remaining: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(config, remaining)
+
+    return predicate
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def lock_history(predicate, seed: frozenset[Site]) -> list[frozenset[Site]]:
+    locked = set(seed)
+    history = [frozenset(locked)]
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return history
+        locked = nxt
+        history.append(frozenset(locked))
+    return history
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    return len(lock_history(predicate, seed)[-1]) == 12
+
+
+def k_site_seeds(k: int) -> tuple[frozenset[Site], ...]:
+    return tuple(frozenset(combo) for combo in combinations(TWO_CUBE, k))
+
+
+def seeds_size_at_most(max_size: int) -> tuple[frozenset[Site], ...]:
+    return tuple(
+        frozenset(combo)
+        for size in range(1, max_size + 1)
+        for combo in combinations(TWO_CUBE, size)
+    )
+
+
+def coverage_k(predicate, k: int) -> int:
+    return sum(1 for seed in k_site_seeds(k) if fills_from_seed(predicate, seed))
+
+
+def enumerate_remaining() -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple((mask >> index) & 1 for index in range(5)) for mask in range(32))
+
+
+def maximizers_k(k: int) -> tuple[int, tuple[tuple[int, ...], ...], dict[tuple[int, ...], int]]:
+    scores: dict[tuple[int, ...], int] = {}
+    for remaining in enumerate_remaining():
+        scores[remaining] = coverage_k(predicate_from_remaining(remaining), k)
+    maximum = max(scores.values())
+    winners = tuple(sorted(remaining for remaining, score in scores.items() if score == maximum))
+    return maximum, winners, scores
+
+
+def first_split_seed(
+    pred_fill, pred_miss, max_size: int
+) -> frozenset[Site] | None:
+    for seed in seeds_size_at_most(max_size):
+        if fills_from_seed(pred_fill, seed) and not fills_from_seed(pred_miss, seed):
+            return seed
+    return None
+
+
+def seed_key(seed: frozenset[Site]) -> tuple[Site, ...]:
+    return tuple(sorted(seed))
+
+
+def history_key(history: list[frozenset[Site]]) -> list[tuple[Site, ...]]:
+    return [tuple(sorted(step)) for step in history]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    pred_f0 = predicate_from_remaining(F0_REMAINING)
+    pred_fwt = predicate_from_remaining(FWT_REMAINING)
+    pred_l1 = f_L1
+
+    m1, max1, cov1 = maximizers_k(1)
+    m2, max2, cov2 = maximizers_k(2)
+    cov11_fwt = coverage_k(pred_fwt, 11)
+    cov11_f0 = coverage_k(pred_f0, 11)
+
+    seed = first_split_seed(pred_f0, pred_fwt, 3)
+    if seed is None:
+        raise RuntimeError("no |S|<=3 seed splits f0 from fwt")
+    hist_f0 = lock_history(pred_f0, seed)
+    hist_fwt = lock_history(pred_fwt, seed)
+    seed_tuple = seed_key(seed)
+    hist_f0_tuples = history_key(hist_f0)
+    hist_fwt_tuples = history_key(hist_fwt)
+
+    l1_sample = next(iter(orbits[(1, 0, 2)]))
+    ham_differs = any(
+        f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6)
+    )
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|=32")
+    print(f"n_sites={len(TWO_CUBE)}")
+    print(f"Max(1): m={m1} N_max={len(max1)} maximizers={list(max1)}")
+    print(f"Max(2): m={m2} N_max={len(max2)} maximizers={list(max2)}")
+    print(f"cov1_f0={cov1[F0_REMAINING]} cov1_fwt={cov1[FWT_REMAINING]}")
+    print(f"cov2_f0={cov2[F0_REMAINING]} cov2_fwt={cov2[FWT_REMAINING]}")
+    print(f"cov11_f0={cov11_f0} cov11_fwt={cov11_fwt}")
+    print(f"|S|={len(seed)} S={seed_tuple}")
+    print(f"f0_history={hist_f0_tuples}")
+    print(f"fwt_history={hist_fwt_tuples}")
+    print(f"f0_fills={len(hist_f0[-1]) == 12} fwt_fills={len(hist_fwt[-1]) == 12}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_WT1_ZERO_F0_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and orbit_sizes == expected_sizes
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n != 0 on an axis and is not Hamming parity",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and ham_differs
+        and f_L1(l1_sample) == 1
+        and L1_REMAINING != F0_REMAINING
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-f0-in-max1-and-max2",
+        "f0=(1,1,1,1,0) attains Max(1) and Max(2)",
+        F0_REMAINING in max1
+        and F0_REMAINING in max2
+        and cov1[F0_REMAINING] == m1 == 12
+        and cov2[F0_REMAINING] == m2 == 66
+        and len(max1) == 4
+        and len(max2) == 2
+        and "Max(1)" in note
+        and "Max(2)" in note
+        and "(1, 1, 1, 1, 0)" in note,
+    )
+    checks.check(
+        "thm1-fwt-in-neither",
+        "fwt=(0,1,1,1,0) is in neither Max(1) nor Max(2)",
+        FWT_REMAINING not in max1
+        and FWT_REMAINING not in max2
+        and cov1[FWT_REMAINING] == 0
+        and cov2[FWT_REMAINING] == 0
+        and cov11_fwt == 12
+        and "(0, 1, 1, 1, 0)" in note
+        and "neither Max(1) nor Max(2)" in note,
+    )
+    checks.check(
+        "thm2-lex-first-seed",
+        "the lex-first |S|<=3 split seed is the singleton {(0, 0, 0)}",
+        seed == frozenset({(0, 0, 0)})
+        and len(seed) == 1
+        and seed_tuple == ((0, 0, 0),)
+        and seed == first_split_seed(pred_f0, pred_fwt, 3)
+        and "{(0, 0, 0)}" in note
+        and "|S| = 1" in note,
+    )
+    checks.check(
+        "thm2-f0-fills-fwt-misses",
+        "on that seed f0 fills and fwt does not",
+        fills_from_seed(pred_f0, seed)
+        and not fills_from_seed(pred_fwt, seed)
+        and len(hist_f0[-1]) == 12
+        and len(hist_fwt[-1]) == 1
+        and fills_from_seed(pred_l1, seed),
+    )
+    expected_f0 = [
+        ((0, 0, 0),),
+        ((0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0)),
+        ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0)),
+        (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, 0),
+            (1, 1, 1),
+            (2, 0, 0),
+            (2, 0, 1),
+            (2, 1, 0),
+        ),
+        (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, 0),
+            (1, 1, 1),
+            (2, 0, 0),
+            (2, 0, 1),
+            (2, 1, 0),
+            (2, 1, 1),
+        ),
+    ]
+    checks.check(
+        "thm3-histories",
+        "histories from S are computed and displayed; wt1 is not adopted",
+        hist_f0_tuples == expected_f0
+        and hist_fwt_tuples == [((0, 0, 0),)]
+        and len(hist_f0) == 5
+        and len(hist_fwt) == 1
+        and "halt lock set" in note
+        and "Do not adopt wt1" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted first split, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "claim-scope-first-split",
+        "claim_scope reports the lex-first |S|<=3 f0-versus-fwt split",
+        "lex-first seed of size at most 3" in note
+        and "off-patch o=0" in note
+        and "F_cut (1,1,1,1,0) fills and (0,1,1,1,0) does not" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt wt1",
+        "no axiom or approved primitive is added" in note
+        and "Do not write them into Admissibility" in note
+        and "Do not adopt wt1" in note
+        and "off-patch occupancy `0`" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-max11-listing",
+        "the residual is the first split seed, not leftover-character of the Max(11) listing",
+        "Not leftover-character of the Max(11) listing" in note
+        and "mixed3-silent" in note
+        and "(wt1, opp2, adj2, vertex3, mixed3)" in note,
+    )
+
+    print("per_element: checked exactly — each neighbor 6-tuple is scored by axis type")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same stencil")
+    print("per_mode: checked exactly — Max(1) and Max(2) are scored over all 32 F_cut maps")
+    print("per_block: checked exactly — lex search of |S|<=3 seeds reports the first split")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the lex-first |S|<=3 seed at which F_cut (1,1,1,1,0) fills and (0,1,1,1,0) does not is reported. Displayed, not adopted. f_L1 is n!=0, not Hamming. Source-only. No axiom edit.

## Runner

`scripts/f_cut_wt1_zero_f0_first_split_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.