### PR TITLE
feat(wt0c2max): unique 2-site maximizer among wt1=0 F_cut maps

### DIFF
--- a/docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,443 @@
+---
+claim_id: f_cut_wt1_zero_two_site_maximizer_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 16 F_cut maps with remaining bit wt1=0 on the two-cube with off-patch o=0, the maximum 2-site coverage is 0, attained by 16 maps. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py
+---
+
+# Wt1-Silent Two-Site Coverage Ranking Inside The Three-Cut Class `F_cut`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock coverage ranking of those cube-covariant
+complement-even predicates that vanish on empty and full *and* vanish on
+the weight-one orbit `wt1`, on the twelve-vertex two-cube, over all
+66 unordered 2-site seeds, with off-patch occupancy `0`. The
+unbalanced-axis map `f_L1` is displayed only as a contrast: it has
+`wt1=1` and is not a member of the subclass. No map is adopted as the
+physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py`](../scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+That static cardinality is leftover-character inventory of the three-cut
+class. The 32-map two-site coverage ranking is a different leftover
+inventory (#6429). This note asks a new ranking object on a new subclass:
+among the maps in `F_cut` that already vanish on `wt1`, how many of the
+66 two-site seeds does each fill, and is the maximizer unique.
+
+`wt1` is the orbit of a cell with exactly one unbalanced axis and two
+empty axes. A representative is
+`(c_{+x},c_{-x},c_{+y},c_{-y},c_{+z},c_{-z})=(1,0,0,0,0,0)`. The axis type
+is `(u,b,e)=(1,0,2)`. The orbit has size `6`. Equivalently, `wt1` is the
+orbit of a cell with exactly one occupied neighbor. `f(wt1)=0` means a
+single occupied neighbor does not form.
+
+Write
+
+```text
+F_W0 = { f ∈ F_cut : f(wt1) = 0 }.
+```
+
+The `wt1` bit is one of the five free remaining bits, so
+
+```text
+|F_W0| = 16.
+```
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered pair of vertices is
+a 2-site seed. There are `C(12,2)=66` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov2(f) = |{ S : |S|=2 and f fills from S }|.
+```
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. f_L1 has remaining-bit tuple `(1, 0, 1, 1, 1)`, so
+`wt1=1` and `f_L1 ∉ F_W0`.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Membership in `F_W0` is exactly the remaining-bit condition
+`wt1=0`.
+
+**Theorem 1.** Exhaustive ranking of the 16 maps in `F_W0` gives
+
+```text
+|F_W0| = 16
+m2 = 0
+N_max = 16.
+```
+
+Every map in `F_W0` fills none of the 66 two-site seeds. The maximum
+halt size on this subclass, even for the remaining-bit tuple
+`(0, 1, 1, 1, 1)` that turns every other free bit on, is `4`.
+
+**Theorem 2.** So N_max is not 1. There is no unique maximizer tuple.
+Two-site coverage does not select a unique member inside `F_W0`.
+The same fact in the claim voice: two-site coverage does not select a unique member.
+
+**Theorem 3.** Display the pair `(m2, N_max)=(0, 16)` and the
+classification: every remaining-bit tuple with `wt1=0` attains `m2`.
+Displayed, not adopted. Do not re-list Max(2) of the full 32.
+
+Do not write the ranking into Admissibility.
+
+Not leftover-character of #6429 (that ranked all 32). This is a new
+selector question on a new subclass.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the 16-element F_W0, the exact integer pair (m2,N_max)=(0,16), and the uniqueness failure N_max≠1 are enumerated. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_wt1_zero_two_site_maximizer
+target_blocker_text: "whether 2-site coverage selects a unique member inside the unnamed wt1=0 half of F_cut"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F_W0 2-site coverage ranking; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_W0 on this twelve-vertex patch with off-patch o=0 and all 66 two-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 66 unordered 2-site seeds;
+- the weight-one orbit `wt1` and the subclass `F_W0`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+Not leftover-character of #6429 (that ranked all 32). Do not re-list Max(2)
+of the full 32.
+
+## Exact Target And Objects
+
+**Target.** Restrict the 32-member class `F_cut` to the independently
+motivated extra `f(wt1)=0`, rank that new subclass `F_W0` by two-site fill
+coverage on the two-cube, report the pair `(m2, N_max)`, and decide
+whether `N_max=1`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`. The subclass `F_W0` freezes the
+`wt1` bit at `0` and leaves the other four bits free, so `|F_W0|=16`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and does not lie in
+`F_W0`. It is displayed only as the contrast that the unbalanced-axis
+predicate uses `wt1=1`. It is not adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov2(f)` is the number of 2-site seeds whose halt set has
+cardinality 12, `m2` is the maximum of `cov2` over `F_W0`, and `N_max`
+is the number of maps in `F_W0` attaining `m2`.
+
+From a 2-site seed, a third vertex is adjacent to at most two locked
+sites. The first wave can therefore use only `empty` (never forms),
+`wt1` (one locked neighbor), `opp2` (opposite pair; long-axis seeds),
+or `adj2` (two non-opposite neighbors; face-diagonal seeds). With
+`f(wt1)=0`, long-axis seeds halt at size `3` when `opp2=1` and
+face-diagonal seeds halt at size `4` when `adj2=1`. Neither is a fill.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut` and is not Hamming parity. It is not
+an element of `F_W0`. On the twelve-vertex two-cube with off-patch
+occupancy `0`, exhaustive ranking of all 16 maps in `F_W0` on all 66
+two-site seeds gives
+
+```text
+|F_W0| = 16
+m2 = 0
+N_max = 16.
+```
+
+**Theorem 2.** So N_max is not 1. There is no unique remaining-bit
+tuple attaining `m2`. Two-site coverage does not select a unique member
+inside the unnamed `wt1=0` half.
+
+**Theorem 3.** Display: every remaining-bit tuple with `wt1=0` attains
+`m2 = 0`. A displayed certificate is that the generous tuple
+`(0, 1, 1, 1, 1)` has maximum halt size `4` on the 66 seeds. Displayed,
+not adopted. Do not re-list Max(2) of the full 32.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `|F_W0|=16` | the `wt1` remaining bit is frozen at `0`; four free bits remain |
+| `f_L1` is not in `F_W0` | remaining-bit tuple `(1, 0, 1, 1, 1)` has `wt1=1` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 66 two-site seeds | `C(12,2)` unordered pairs |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `m2` and `N_max` | exhaustive 16-map ranking of `cov2` on `F_W0` |
+| uniqueness of a maximizer | false; `N_max = 16` and every `wt1=0` tuple attains `m2 = 0` |
+| no 2-site fill without `wt1` | even `(0, 1, 1, 1, 1)` has maximum halt size `4` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit). Hamming is not used
+   as a member of `F_W0`.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave candidates
+   become undefined; that is a different census.
+3. Drop complement-even or the vanish-on-full cut: the class is no longer
+   the 32-element `F_cut`, so `F_W0` is no longer this 16-element subclass.
+4. Rank all 32 maps of `F_cut` by `cov2`: that leftover is #6429, not the
+   `F_W0` restriction. Do not re-list Max(2) of the full 32.
+5. Unfreeze `wt1`: the 16 maps with `wt1=1` are a different subclass and
+   are the only maps that can fire a one-neighbor first wave.
+6. Assert that two-site coverage selects a unique member of `F_W0`: the
+   exact count `N_max = 16` refutes uniqueness.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 32-map coverage ranking
+  (#6429) in place of this `F_W0` coverage ranking.
+- No re-list of Max(2) of the full 32.
+- No blank-block or 3-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness of the maximizer: two-site
+coverage does not select a unique member of `F_W0`. The positive
+triple `(|F_W0|, m2, N_max)=(16, 0, 16)` is an exact enumeration, not
+a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class and `F_W0` | Force vanish-on-empty, vanish-on-full, `f(c)=f(1-c)`, and `f(wt1)=0`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`; Theorem 1 gives `|F_W0|=16`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `f_L1` outside `F_W0` | Read the `wt1` remaining bit of `f_L1`. | Remaining-bit tuple `(1, 0, 1, 1, 1)` has `wt1=1`. | **ATTEMPTED** |
+| `F_W0` coverage ranking | Score every map in `F_W0` by `cov2`. | Theorem 1 and check `thm1-m2-n-max` give `m2 = 0` and `N_max = 16`. | **ATTEMPTED** |
+| uniqueness of a maximizer | Ask whether `N_max=1`. | Theorem 2 and checks `thm2-not-unique` / `thm3-all-sixteen-attain-m2`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness of the maximizer fails. The
+count `N_max=16` and the statement that every `wt1=0` tuple attains
+`m2` are two certificates of the same non-uniqueness, so they collapse
+rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_max=16` / all sixteen attain `m2` | yes: a count larger than one is non-uniqueness | yes: a full-class tie is non-uniqueness | collapse into the uniqueness failure |
+| `m2=0` / max halt size `4` | no: a coverage score does not name the halt histogram | no: a halt bound does not name uniqueness | independent of uniqueness |
+| static `|F_W0|=16` / ranking pair `(m2, N_max)` | no: membership is not dynamics | no: a ranking does not replace the `wt1=0` cut | separate exact counts |
+| leftover of #6429 / this ranking | no: that leftover ranked all 32 maps | no: an `F_W0` ranking does not replace the 32-map ranking | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| `F_W0` | explicit `wt1=0` subclass of `F_cut` |
+| all 66 two-site seeds | explicit seed class; a one-seed fill is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuple `(0, 1, 1, 1, 1)` | displayed halt-size certificate, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:74` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:118` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:123` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:49` | 66 two-site seeds | `C(12,2)` unordered pairs on the two-cube | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:187` | `cov2(f)` | number of 2-site seeds a map fills | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:351` | ranking | exact `(m2, N_max)` on `F_W0` | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:60` | `wt1` orbit | axis type `(1,0,2)` | yes |
+| `scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py:173` | halt size | no `F_W0` 2-site seed fills | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_W0` | the ranking is this subclass on all 66 seeds; other classes are unclaimed |
+| per block | yes: the pair `(m2, N_max)` | uniqueness fails because `N_max=16` and every `wt1=0` map attains `m2` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed:
+`wt1=0` is an independently named remaining bit, and the 16-map subclass
+it cuts out is closed under the three displayed cuts. That static cut
+does not make two-site coverage a selector inside the subclass. The
+remaining physical choice — which, if any, `F_cut` map is the
+Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that `m2=0` for every `wt1=0` map is “obvious”
+once one-neighbor formation is silenced, so the ranking might be called
+a leftover decoration of the already-known 32-map ranking, or a restatement
+of #6476 that no `wt1=0` map lies in Max(2) of all 32. That objection is
+correctly about first-wave local types. It does not overturn the stated
+theorem: among maps in `F_cut` that already silence `wt1`, two-site
+coverage selects the entire 16-element class equally at `cov2=0`. Coverage
+therefore does not select a member inside the unnamed `wt1=0` half. The
+32-map maximizer set is a different object and is not re-listed here.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, `F_W0`, and 16-map 66-seed ranking are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `F_W0` 2-site coverage ranking or
+restores uniqueness of a maximizer inside the 16-map subclass.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact triple `(|F_W0|, m2, N_max)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, restricts to `F_W0`, evaluates all 16 maps on the two-cube from
+every 2-site seed, reports `|F_W0| = 16`, `m2 = 0` and `N_max = 16`,
+checks that `f_L1` is not Hamming parity and is not in `F_W0`, and
+exhibits that every `wt1=0` remaining-bit tuple attains `m2`. Declared
+audit inputs are this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_zero_two_site_maximizer_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_zero_two_site_maximizer_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_zero_two_site_maximizer_2026_08_15.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py
+runner_sha256: 9336d0abda8b393e7fc19ea761b7890260fc388a19fdf36c76c5aa8e9895d024
+input_fingerprint_sha256: e87bc8b7d32aed00f2963d1ae1a4c166f31492355b7cee906a381efc703588ba
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+|F_W0|=16
+n_two_site_seeds=66
+m2=0
+N_max=16
+unique_maximizer=False
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_wt1=1
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+max_halt_F_W0=4
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-sixty-six-seeds the two-cube has twelve vertices and C(12,2)=66 two-site seeds
+PASS: thm1-m2-n-max max coverage on F_W0 is m2=0 attained by N_max=16 of |F_W0|=16 maps
+PASS: thm2-not-unique N_max is not 1; two-site coverage does not select a unique F_W0 map
+PASS: thm3-all-sixteen-attain-m2 every remaining-bit tuple with wt1=0 attains m2; none is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted uniqueness failure, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-ranking the note reports m2, N_max, |F_W0|, and the uniqueness failure
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6429-or-6476-list the residual is the F_W0 coverage ranking, not leftover of #6429 or a re-list of Max(2)
+PASS: claim-scope-ranking claim_scope states m2, N_max, and displayed-not-adopted
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_W0 map is scored by how many of the 66 two-site seeds it fills
+per_block: checked exactly — m2 and N_max are the F_W0 coverage-ranking pair on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py
+++ b/scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Exact 2-site fill-coverage ranking of F_cut maps with f(wt1)=0.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+F_W0 is the subclass with f(wt1)=0: a single occupied neighbor does not
+form. Dynamics are occupancy-to-lock on the twelve-vertex two-cube with
+off-patch occupancy 0. Coverage cov2(f) is the number of unordered 2-site
+seeds from which f fills. f_L1 is the unbalanced-axis predicate (some
+n_mu != 0), never Hamming |c|_1 mod 2. f_L1 has wt1=1 and is not in F_W0.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+WT1_TYPE: OrbitType = (1, 0, 2)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+GENEROUS_WT0: tuple[int, ...] = (0, 1, 1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def halt_size(predicate, seed: frozenset[Site]) -> int:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked)
+        locked = nxt
+    return len(locked)
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    return halt_size(predicate, seed) == 12
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def coverage_ranking(
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, tuple[int, ...], tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    ranked: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = []
+    for bits, remaining in members:
+        cov = coverage(predicate_from_bits(bits, orbit_types, type_of))
+        ranked.append((cov, remaining, bits))
+    return ranked
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    wt0_members = [(bits, remaining) for bits, remaining in members if remaining[0] == 0]
+    ranked = coverage_ranking(wt0_members, orbit_types, orbits)
+    cov_by_remaining = {remaining: cov for cov, remaining, _bits in ranked}
+    n_wt0 = len(wt0_members)
+    m2 = max(cov for cov, _remaining, _bits in ranked)
+    maximizers = sorted(remaining for cov, remaining, _bits in ranked if cov == m2)
+    n_max = len(maximizers)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    wt1_index = REMAINING_LABELS.index("wt1")
+    generous_pred = predicate_from_bits(
+        next(bits for bits, remaining in wt0_members if remaining == GENEROUS_WT0),
+        orbit_types,
+        type_of,
+    )
+    generous_halts = [halt_size(generous_pred, seed) for seed in TWO_SITE_SEEDS]
+    max_halt_wt0 = max(generous_halts)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"|F_W0|={n_wt0}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"m2={m2}")
+    print(f"N_max={n_max}")
+    print(f"unique_maximizer={n_max == 1}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_L1_wt1={l1_remaining[wt1_index]}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"max_halt_F_W0={max_halt_wt0}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_WT1_ZERO_TWO_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-sixty-six-seeds",
+        "the two-cube has twelve vertices and C(12,2)=66 two-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-m2-n-max",
+        f"max coverage on F_W0 is m2={m2} attained by N_max={n_max} of |F_W0|={n_wt0} maps",
+        n_wt0 == 16
+        and m2 == 0
+        and n_max == 16
+        and n_wt0 == sum(1 for _bits, remaining in members if remaining[wt1_index] == 0)
+        and m2 == max(cov_by_remaining.values())
+        and n_max == sum(1 for cov in cov_by_remaining.values() if cov == m2)
+        and set(cov_by_remaining.values()) == {0}
+        and f"m2 = {m2}" in note
+        and f"N_max = {n_max}" in note
+        and f"|F_W0| = {n_wt0}" in note,
+    )
+    checks.check(
+        "thm2-not-unique",
+        "N_max is not 1; two-site coverage does not select a unique F_W0 map",
+        n_max != 1
+        and n_max == n_wt0
+        and l1_remaining[wt1_index] == 1
+        and l1_remaining == L1_REMAINING
+        and l1_remaining not in maximizers
+        and "N_max is not 1" in note,
+    )
+    checks.check(
+        "thm3-all-sixteen-attain-m2",
+        "every remaining-bit tuple with wt1=0 attains m2; none is adopted",
+        n_max == 16
+        and maximizers == sorted(remaining for _bits, remaining in wt0_members)
+        and all(remaining[wt1_index] == 0 for remaining in maximizers)
+        and max_halt_wt0 < 12
+        and max_halt_wt0 == 4
+        and GENEROUS_WT0 in maximizers
+        and "Displayed, not adopted" in note
+        and "Do not re-list Max(2) of the full 32" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted uniqueness failure, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "two-site coverage does not select a unique member" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note
+        and "f_L1 has remaining-bit tuple `(1, 0, 1, 1, 1)`" in note,
+    )
+    checks.check(
+        "note-reports-ranking",
+        "the note reports m2, N_max, |F_W0|, and the uniqueness failure",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "m2 = 0" in note
+        and "N_max = 16" in note
+        and "|F_W0| = 16" in note
+        and "N_max is not 1" in note
+        and "wt1=0" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6429-or-6476-list",
+        "the residual is the F_W0 coverage ranking, not leftover of #6429 or a re-list of Max(2)",
+        "Not leftover-character of #6429" in note
+        and "that ranked all 32" in note
+        and "Do not re-list Max(2) of the full 32" in note
+        and "new subclass" in note,
+    )
+    checks.check(
+        "claim-scope-ranking",
+        "claim_scope states m2, N_max, and displayed-not-adopted",
+        "Among the 16 F_cut maps with remaining bit wt1=0" in note
+        and "off-patch o=0" in note
+        and "maximum 2-site coverage is 0" in note
+        and "attained by 16 maps" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_W0 map is scored by how many of the 66 two-site seeds it fills")
+    print("per_block: checked exactly — m2 and N_max are the F_W0 coverage-ranking pair on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 16 F_cut maps with remaining bit wt1=0 on the two-cube with off-patch o=0, the maximum 2-site coverage is reported. Displayed, not adopted. f_L1 is n!=0, not Hamming. Source-only. No axiom edit.

## Runner

`scripts/f_cut_wt1_zero_two_site_maximizer_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.