### PR TITLE
feat(wt0c3max): unique 3-site maximizer among wt1=0 F_cut maps

### DIFF
--- a/docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,407 @@
+---
+claim_id: f_cut_wt1_zero_three_site_maximizer_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 16 F_cut maps with remaining bit wt1=0 on the two-cube with off-patch o=0, the maximum 3-site coverage is 44, attained by 2 maps. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py
+---
+
+# Three-Site Fill-Coverage Maximizer Among The Sixteen `wt1=0` Maps In `F_cut`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock coverage ranking of the 16 cube-covariant
+complement-even predicates that vanish on empty and full and have remaining
+bit `wt1=0`, on the twelve-vertex two-cube, over all 220 unordered 3-site
+seeds, with off-patch occupancy `0`. The attaining remaining-bit tuples are
+displayed. No map is adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py`](../scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Exactly one of those bits is `wt1`. The subclass scored here
+is the 16 maps with remaining bit `wt1=0`.
+
+That static split of `F_cut` is leftover-character inventory. The 32-map
+3-site ranking of the same two-cube is a different leftover inventory: it
+asked which maps attain the global `Max(3)` of all 32, and both of those
+global maximizers have `wt1=1`. This note asks the new coverage object on the subclass:
+among the 16 maps with `wt1=0`, what is the maximum number of
+the 220 three-site seeds each fills, and is that maximum attained uniquely.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered triple of vertices is
+a 3-site seed. There are `C(12,3)=220` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov3(f) = |{ S : |S|=3 and f fills from S }|.
+```
+
+Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The unbalanced-axis map has remaining-bit tuple
+`(1, 0, 1, 1, 1)`, so remaining bit `wt1=1`. It is outside the scored
+subclass and is not a candidate for the subclass maximizer.
+
+**Theorem 1.** Exhaustive enumeration of the 16 maps with remaining bit
+`wt1=0` on all 220 three-site seeds gives
+
+```text
+m3 = 44
+N_max = 2
+```
+
+so the subclass maximum 3-site coverage is 44, attained by 2 maps.
+
+**Theorem 2.** So `N_max > 1`: the `wt1=0` subclass does not have a
+unique 3-site maximizer. There is no single remaining-bit tuple that
+alone attains `m3`.
+
+**Theorem 3.** The two attaining remaining-bit tuples, displayed and not
+adopted, are
+
+```text
+(0, 1, 1, 1, 0), (0, 1, 1, 1, 1).
+```
+
+Do not write the ranking into Admissibility.
+
+Not leftover-character of the 32-map 3-site ranking (that leftover named
+the global `Max(3)` pair, both with `wt1=1`). The present object is a new
+coverage object on the subclass.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the 16-element wt1=0 subclass, and the 3-site coverage-ranking pair (m3,N_max)=(44,2) with displayed remaining-bit tuples (0,1,1,1,0) and (0,1,1,1,1) are enumerated. Uniqueness of a 3-site maximizer inside the subclass is false on this patch. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_wt1_zero_three_site_maximizer
+target_blocker_text: "whether 3-site coverage selects a unique member inside the wt1=0 half of F_cut"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the wt1=0 3-site coverage ranking; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for the wt1=0 half of F_cut on this twelve-vertex patch with off-patch o=0 and all 220 three-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 220 unordered 3-site seeds;
+- the remaining-bit filter `wt1=0`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Rank the 16 members of `F_cut` with remaining bit `wt1=0` by
+three-site fill coverage on the two-cube, report the pair `(m3, N_max)`,
+decide whether `N_max` equals one, and display the attaining remaining-bit
+tuples without adopting a map.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`. The scored subclass is the 16
+tuples whose first coordinate is `0`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and lies outside the
+subclass. Neither `f_L1` nor either displayed maximizer is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov3(f)` is the number of 3-site seeds whose halt set has cardinality
+12, `m3` is the maximum of `cov3` over the 16 maps with `wt1=0`, and
+`N_max` is the number of those maps attaining `m3`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. Exactly 16 of
+those maps have remaining bit `wt1=0`. The unbalanced-axis map `f_L1` is
+one element of `F_cut` and is not Hamming parity; its remaining bit
+`wt1` is `1`, so it is not among the 16. On the twelve-vertex two-cube
+with off-patch occupancy `0`, exhaustive ranking of the 16 maps on all
+220 three-site seeds gives
+
+```text
+m3 = 44
+N_max = 2
+```
+
+**Theorem 2.** Because `N_max > 1`, 3-site coverage does not select a
+unique member inside the `wt1=0` half. There is not a unique 3-site
+maximizer on this subclass, and there is no single remaining-bit tuple
+to report as the unique maximizer.
+
+**Theorem 3.** The two maps that attain `m3` have remaining-bit tuples
+
+```text
+(0, 1, 1, 1, 0), (0, 1, 1, 1, 1).
+```
+
+They differ only on the complement-fixed orbit `mixed3`. Both are
+displayed. Neither is adopted as the physical Admissibility rule.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after empty/full are forced to `0` |
+| 16 maps with `wt1=0` | the remaining bit on orbit `(1,0,2)` and its complement `(1,2,0)` is fixed to `0`; the other four free bits vary |
+| 220 three-site seeds | `C(12,3)` unordered triples on the two-cube |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` and has remaining bits `(1, 0, 1, 1, 1)` |
+| pair `(m3, N_max)` | exhaustive `cov3` on the 16 maps yields `(44, 2)` |
+| uniqueness | fails: `N_max > 1` |
+| displayed tuples | `(0, 1, 1, 1, 0)` and `(0, 1, 1, 1, 1)`, not adopted |
+
+## What This Does Not Claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No ranking of the complementary 16 maps with `wt1=1`.
+- No reopening of the 32-map global `Max(3)` pair.
+- No blank-block or 4-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is uniqueness of the maximizer: the `wt1=0`
+subclass of `F_cut` does not have a unique 3-site coverage maximizer on
+this patch. The positive pair `(m3, N_max)=(44, 2)` is an exact
+enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-and-wt1-zero-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| `wt1=0` subclass | Fix remaining bit `wt1` to `0` and count the remaining 16 maps. | Theorem 1 and the same cardinality check. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| subclass 3-site ranking | Score every `wt1=0` map by `cov3`. | Theorem 1 and check `thm1-m3-and-n-max` give `m3 = 44` and `N_max = 2`. | **ATTEMPTED** |
+| uniqueness of a maximizer | Ask whether the maximizer class is a singleton. | Theorem 2 and checks `thm2-not-unique-maximizer` / `thm3-displayed-maximizers`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: uniqueness of the maximizer fails. The
+explicit two-tuple display and the cardinality `N_max=2` are two
+certificates of the same non-uniqueness, so they collapse rather than
+count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `N_max=2` / displayed pair | yes: a count larger than one is non-uniqueness | yes: two displayed maximizers are non-uniqueness | collapse into the uniqueness failure |
+| `m3=44` / uniqueness failure | no: a score does not name the multiplicity | no: non-uniqueness does not name the score | independent positive integer versus uniqueness |
+| static 16-map subclass / ranking pair `(m3, N_max)` | no: membership is not dynamics | no: a ranking does not replace the remaining-bit filter | separate exact counts |
+| leftover 32-map `Max(3)` / this ranking | no: that leftover scored all 32 maps | no: a subclass ranking does not replace the global pair | different object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| remaining bit `wt1=0` | explicit subclass filter; the complementary 16 maps are excluded |
+| all 220 three-site seeds | explicit seed class; a 2-site ranking is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuples `(0, 1, 1, 1, 0)` and `(0, 1, 1, 1, 1)` | displayed witnesses against uniqueness, not selected laws |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:74` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:118` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:123` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:49` | 220 three-site seeds | `C(12,3)` unordered triples on the two-cube | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:183` | `cov3(f)` | number of 3-site seeds a map fills | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:285` | subclass ranking | `wt1=0` filter and `cov3` on those 16 maps | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:347` | pair `(m3, N_max)` | exact maximum and multiplicity on the subclass | yes |
+| `scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py:60` | `f_L1` remaining bits | `(1, 0, 1, 1, 1)` lies outside `wt1=0` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in the `wt1=0` half of `F_cut` | the ranking is this subclass on all 220 seeds; other classes are unclaimed |
+| per block | yes: the pair `(m3, N_max)` | uniqueness fails because `N_max=2` |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: the
+subclass does have a well-defined 3-site maximum `m3=44`, attained by two
+explicit remaining-bit tuples. That positive pair does not make either
+tuple the unique maximizer and does not select either as the physical
+rule. The remaining physical choice — which, if any, `F_cut` map is the
+Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that the 32-map 3-site ranking already showed
+no `wt1=0` map lies in the global maximizer pair, so a ranking inside the
+16 might be called leftover decoration of that split. That objection is
+correctly about exclusion from the global `Max(3)`. It does not overturn
+the stated theorem: among the 16 maps with `wt1=0`, three-site coverage
+selects a two-element class `{(0, 1, 1, 1, 0), (0, 1, 1, 1, 1)}` with
+score `44`, not a singleton. Exclusion from the global pair does not name
+the subclass maximum or its multiplicity. This is a new coverage object on the subclass.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the `wt1=0` filter, and the 16-map 220-seed ranking are
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `wt1=0` 3-site coverage ranking or
+restores uniqueness of a maximizer inside the 16-map subclass.
+
+No-Go Discipline disposition: **PASS** for the uniqueness failure and the
+exact pair `(m3, N_max)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, restricts to the 16 maps with remaining bit `wt1=0`, evaluates
+those maps on the two-cube from every 3-site seed, reports `m3 = 44` and
+`N_max = 2`, checks that `f_L1` is not Hamming parity and lies outside
+the subclass, and exhibits the displayed maximizers by remaining-bit
+tuples `(0, 1, 1, 1, 0)` and `(0, 1, 1, 1, 1)`. Declared audit inputs are
+this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_zero_three_site_maximizer_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_zero_three_site_maximizer_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_zero_three_site_maximizer_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py
+runner_sha256: d8d5a9b06b66495932a0fcfbe5e922625bc2e066a413576342e3fddaa5db6dd8
+input_fingerprint_sha256: 5e5959cf5dea13399b99c7bedecf60be707ef12f167e17826a5c116135cde9ee
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_wt1_zero=16
+n_three_site_seeds=220
+m3=44
+N_max=2
+maximizer_remaining=[(0, 1, 1, 1, 0), (0, 1, 1, 1, 1)]
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_remaining=(1, 0, 0, 1, 1)
+unique_maximizer=False
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-and-wt1-zero-cardinality F_cut has size 32 and exactly 16 members have remaining bit wt1=0
+PASS: thm1-three-site-seed-count the two-cube has twelve vertices and C(12,3)=220 three-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-m3-and-n-max max 3-site coverage on the wt1=0 subclass is m3=44 attained by N_max=2 maps
+PASS: thm2-not-unique-maximizer N_max is not 1: the wt1=0 subclass has no unique 3-site maximizer
+PASS: thm3-displayed-maximizers the attaining remaining-bit tuples are displayed and not adopted
+PASS: thm3-l1-outside-subclass f_L1 has remaining bit wt1=1, so it is outside the scored subclass
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-ranking the note reports m3, N_max, and the displayed remaining-bit tuples
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-scope-ranking claim_scope states the 16-map 3-site maximum and N_max, displayed not adopted
+PASS: new-subclass-object the residual is the 3-site ranking on the wt1=0 subclass, not leftover of the 32-map Max(3)
+PASS: seeds-not-listed the note does not list 3-site seeds
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the 16 wt1=0 F_cut maps is scored on all 220 three-site seeds
+per_block: checked exactly — m3 and N_max are the 3-site coverage-ranking pair on this subclass
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py
+++ b/scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Exact 3-site fill-coverage maximizer among the 16 F_cut maps with wt1=0.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+The remaining-bit tuple is (wt1, opp2, adj2, vertex3, mixed3). This runner
+restricts to the 16 members with remaining bit wt1=0 and ranks them by
+cov3 on all 220 unordered 3-site seeds of the twelve-vertex two-cube with
+off-patch occupancy 0. f_L1 is the unbalanced-axis predicate (some n_mu
+!= 0), never Hamming |c|_1 mod 2. No map is adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate, seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def subclass_ranking(
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, tuple[int, ...], tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    ranked: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = []
+    for bits, remaining in members:
+        if remaining[0] != 0:
+            continue
+        predicate = predicate_from_bits(bits, orbit_types, type_of)
+        cov3 = coverage(predicate, THREE_SITE_SEEDS)
+        ranked.append((cov3, remaining, bits))
+    return ranked
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    ranked = subclass_ranking(members, orbit_types, orbits)
+    cov3_by_remaining = {remaining: cov3 for cov3, remaining, _bits in ranked}
+    m3 = max(cov3 for cov3, _remaining, _bits in ranked)
+    maximizers = sorted(remaining for cov3, remaining, _bits in ranked if cov3 == m3)
+    n_max = len(maximizers)
+    n_wt0 = len(ranked)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    ham_remaining = remaining_bits_from_full(ham_bits, orbit_types)
+
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    displayed = []
+    for remaining in maximizers:
+        bits = next(full_bits for full_bits, rem in members if rem == remaining)
+        recomputed = coverage(predicate_from_bits(bits, orbit_types, type_of), THREE_SITE_SEEDS)
+        displayed.append((remaining, recomputed, bits))
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_wt1_zero={n_wt0}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"m3={m3}")
+    print(f"N_max={n_max}")
+    print(f"maximizer_remaining={maximizers}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_remaining={ham_remaining}")
+    print(f"unique_maximizer={n_max == 1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_WT1_ZERO_THREE_SITE_MAXIMIZER_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-and-wt1-zero-cardinality",
+        "F_cut has size 32 and exactly 16 members have remaining bit wt1=0",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and n_wt0 == 16
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == EMPTY_TYPE
+        and full_type == FULL_TYPE
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1))
+        and all(remaining[0] == 0 for _cov3, remaining, _bits in ranked)
+        and {rem for _bits, rem in members if rem[0] == 0}
+        == {remaining for _cov3, remaining, _bits in ranked},
+    )
+    checks.check(
+        "thm1-three-site-seed-count",
+        "the two-cube has twelve vertices and C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and l1_remaining != ham_remaining
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-m3-and-n-max",
+        f"max 3-site coverage on the wt1=0 subclass is m3={m3} attained by N_max={n_max} maps",
+        n_wt0 == 16
+        and m3 == max(cov3_by_remaining.values())
+        and n_max == sum(1 for cov3 in cov3_by_remaining.values() if cov3 == m3)
+        and n_max == len(maximizers)
+        and all(0 <= cov3 <= 220 for cov3 in cov3_by_remaining.values())
+        and f"m3 = {m3}" in note
+        and f"N_max = {n_max}" in note,
+    )
+    checks.check(
+        "thm2-not-unique-maximizer",
+        "N_max is not 1: the wt1=0 subclass has no unique 3-site maximizer",
+        n_max != 1
+        and n_max == 2
+        and "N_max = 1" not in note
+        and "not a unique" in note_flat
+        and "unique 3-site maximizer" in note_flat,
+    )
+    displayed_ok = (
+        len(displayed) == n_max
+        and all(recomputed == m3 for _remaining, recomputed, _bits in displayed)
+        and all(in_f_cut(bits, orbit_types, empty_type, full_type) for _r, _c, bits in displayed)
+        and all(remaining[0] == 0 for remaining, _c, _bits in displayed)
+        and all(f"{remaining}" in note for remaining, _c, _bits in displayed)
+    )
+    checks.check(
+        "thm3-displayed-maximizers",
+        "the attaining remaining-bit tuples are displayed and not adopted",
+        displayed_ok
+        and "Displayed, not adopted" in note
+        and "Do not write the ranking into Admissibility" in note
+        and all(tuple_ != L1_REMAINING for tuple_, _c, _bits in displayed),
+    )
+    checks.check(
+        "thm3-l1-outside-subclass",
+        "f_L1 has remaining bit wt1=1, so it is outside the scored subclass",
+        l1_remaining[0] == 1
+        and l1_remaining not in cov3_by_remaining
+        and ham_remaining[0] == 1,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-ranking",
+        "the note reports m3, N_max, and the displayed remaining-bit tuples",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and f"m3 = {m3}" in note
+        and f"N_max = {n_max}" in note
+        and all(f"{remaining}" in note for remaining in maximizers),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-scope-ranking",
+        "claim_scope states the 16-map 3-site maximum and N_max, displayed not adopted",
+        "Among the 16 F_cut maps with remaining bit wt1=0" in note
+        and "off-patch o=0" in note
+        and f"maximum 3-site coverage is {m3}" in note
+        and f"attained by {n_max} maps" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "new-subclass-object",
+        "the residual is the 3-site ranking on the wt1=0 subclass, not leftover of the 32-map Max(3)",
+        "Not leftover-character of the 32-map 3-site ranking" in note
+        and "new coverage object on the subclass" in note
+        and "wt1=0" in note,
+    )
+    checks.check(
+        "seeds-not-listed",
+        "the note does not list 3-site seeds",
+        "Do not list the seeds" in note
+        and "{(0, 0, 0), (1, 0, 1), (2, 0, 0)}" not in note
+        and "combinations(TWO_CUBE" not in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the 16 wt1=0 F_cut maps is scored on all 220 three-site seeds")
+    print("per_block: checked exactly — m3 and N_max are the 3-site coverage-ranking pair on this subclass")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 16 F_cut maps with remaining bit wt1=0 on the two-cube with off-patch o=0, the maximum 3-site coverage is reported. Displayed, not adopted. f_L1 is n!=0, not Hamming. Source-only. No axiom edit.

## Runner

`scripts/f_cut_wt1_zero_three_site_maximizer_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.