### PR TITLE
feat(max11split): first seed that splits the four extra Max(11) maps

### DIFF
--- a/docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,456 @@
+---
+claim_id: f_cut_max11_extra_first_split_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the lex-first seed of size at most 3 at which the four F_cut maps in Max(11) minus Max(1) do not all fill or all miss is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_max11_extra_first_split_2026_08_15.py
+---
+
+# First Bounded Seed That Splits The Four `Max(11)` Extra Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock census of the 32 cube-covariant
+complement-even predicates that vanish on empty and full, on the
+twelve-vertex two-cube, with off-patch occupancy `0`. The four
+`F_cut` maps that attain maximum 11-site coverage and miss maximum
+1-site coverage are reconfirmed. The lex-first seed of size at most
+3 on which those four fill-bits are not all equal is displayed. No
+map is adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_max11_extra_first_split_2026_08_15.py`](../scripts/f_cut_max11_extra_first_split_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+That static cardinality is leftover-character inventory of the three-cut
+class. The set `Max(11) \ Max(1)` is leftover-character inventory of two
+coverage rankings: #6476 named the set. This note asks a new uniqueness
+of the set: on which lex-first seed of size at most 3 the four extras
+do not all fill or all miss.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered `k`-set of vertices
+is a `k`-site seed. There are `C(12,1)=12` one-site seeds and
+`C(12,11)=12` eleven-site seeds. Off-patch neighbors have occupancy `0`.
+Each tick, every unlocked on-patch vertex evaluates `f` on its
+six-neighbor occupancy tuple and locks if `f=1`. The process is
+synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov_k(f) = |{ S : |S|=k and f fills from S }|.
+```
+
+`Max(k)` is the set of maps in `F_cut` that attain `m_k = max cov_k`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`.
+
+**Theorem 1.** Exhaustive ranking of the 32 maps gives
+
+```text
+m1 = 12
+N_max1 = 4
+m11 = 12
+N_max11 = 8.
+```
+
+The four remaining-bit tuples
+
+```text
+(0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (0, 1, 1, 1, 0), (0, 1, 1, 1, 1)
+```
+
+all lie in `Max(11)` and none lie in `Max(1)`. Each has `cov11=12` and
+`cov1=0`. These are exactly the members of `Max(11) \ Max(1)`. The map
+`f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)` and lies in `Max(1)`,
+so it is not one of the four extras.
+
+**Theorem 2.** Among all seeds of size at most 3, ordered by increasing
+cardinality and then by the lexicographic order of the sorted vertex
+tuple, the first seed on which the four fill-bits are not all equal is
+the 3-site seed
+
+```text
+((0, 0, 0), (0, 1, 1), (2, 0, 0)).
+```
+
+No empty, 1-site, or 2-site seed splits the four extras: all 1 + 12 + 66
+of those seeds give fill-bits `(0, 0, 0, 0)`.
+
+**Theorem 3.** On that displayed seed the four fill-bits, in the Theorem 1
+order, are
+
+```text
+(0, 0, 1, 1).
+```
+
+So the two extras with `opp2=0` miss and the two extras with `opp2=1`
+fill. Displayed, not adopted. Do not write the seed into Admissibility.
+Do not adopt a map.
+
+Not leftover-character of #6476 (that named the set). This is a new
+uniqueness of the set: the first bounded seed that dynamizes the four
+extras into two pairs.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the pair (m1,N_max1)=(12,4), the pair (m11,N_max11)=(12,8), membership of the four named extras in Max(11) minus Max(1), and the lex-first |S|<=3 split seed with fill-bits (0,0,1,1) are enumerated. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_max11_extra_first_split
+target_blocker_text: "whether the four Max(11) minus Max(1) extras are dynamically one object on some |S|<=3 seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the first bounded split of the four extras; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut on this twelve-vertex patch with off-patch o=0 and all seeds of size at most 3; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 12 one-site seeds and 12 eleven-site seeds;
+- the complete set of seeds of size at most 3 (`1+12+66+220=299`).
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm that the four remaining-bit tuples named above are
+exactly `Max(11) \ Max(1)`, and report the lex-first seed of size at
+most 3 on which their four fill-bits are not all equal.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+```
+
+so `f_L1` has remaining-bit tuple `(1, 0, 1, 1, 1)`. It is not one of the
+four extras. Neither the extras nor `f_L1` is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov_k(f)` is the number of `k`-site seeds whose halt set has
+cardinality 12, `m_k` is the maximum of `cov_k` over `F_cut`, and
+`Max(k)` is the set of maps attaining `m_k`. The four extras are the
+remaining-bit members of `Max(11) \ Max(1)`. The fill-bits of a seed `S`
+are the four Booleans that say whether each extra fills from `S`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut`. It is not Hamming parity. Exhaustive
+ranking of the 32 maps on all 12 one-site seeds and all 12 eleven-site
+seeds gives
+
+```text
+m1 = 12
+N_max1 = 4
+m11 = 12
+N_max11 = 8.
+```
+
+The four remaining-bit tuples `(0, 0, 1, 1, 0)`, `(0, 0, 1, 1, 1)`,
+`(0, 1, 1, 1, 0)`, and `(0, 1, 1, 1, 1)` each have `cov11=12` and
+`cov1=0`. They are exactly `Max(11) \ Max(1)`.
+
+**Theorem 2.** Exhaustive search of the 299 seeds of size at most 3, in
+lex order by increasing `|S|` and then by the sorted vertex tuple, finds
+a first split at
+
+```text
+S = ((0, 0, 0), (0, 1, 1), (2, 0, 0)).
+```
+
+Every strictly earlier seed in that order, including every seed of size
+at most 2, gives identical fill-bits on the four extras.
+
+**Theorem 3.** The four fill-bits on `S` are `(0, 0, 1, 1)`. The extras
+are therefore not dynamically one object: two miss and two fill. The
+split is exactly the `opp2` bit. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| 12 one-site and 12 eleven-site seeds | `C(12,1)` and `C(12,11)` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `(m1, N_max1)` and `(m11, N_max11)` | exhaustive 32-map ranking of `cov1` and `cov11` |
+| four extras in `Max(11) \ Max(1)` | the four named remaining-bit tuples, each with `cov11=12` and `cov1=0` |
+| lex-first `|S|≤3` split | seed `((0, 0, 0), (0, 1, 1), (2, 0, 0))` |
+| fill-bits on that seed | `(0, 0, 1, 1)` |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming is a different `F_cut` member.
+2. Change the off-patch default away from `0`: the occupancy stencil
+   changes and the fill-bits are a different object.
+3. Drop any of the three cuts: the class is no longer the 32-element
+   `F_cut`.
+4. Score only the listing of `Max(11) \ Max(1)`: that leftover is #6476,
+   which named the set and did not dynamize it.
+5. Restrict the search to `|S|≤2`: every such seed gives fill-bits
+   `(0, 0, 0, 0)`, so the four extras remain one miss-class.
+6. Assert that the four extras fill or miss together on every `|S|≤3`
+   seed: the displayed 3-site seed with fill-bits `(0, 0, 1, 1)` refutes
+   that they are dynamically one object.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the #6476 listing of
+  `Max(11) \ Max(1)` in place of this first bounded split.
+- No adoption of the displayed seed or of either fill-pair.
+- No blank-block or 4-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is that the four extras are not dynamically one
+object on every seed of size at most 3. The positive pair
+`(S, fill-bits)=(((0, 0, 0), (0, 1, 1), (2, 0, 0)), (0, 0, 1, 1))` is an
+exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `Max(11)` and `Max(1)` reconfirm | Score every `F_cut` map on all 12 one-site and all 12 eleven-site seeds. | Theorem 1 and checks `thm1-max11-contains-four-extras` / `thm1-max1-excludes-four-extras`. | **ATTEMPTED** |
+| lex-first `|S|≤3` split | Search all 299 bounded seeds in lex order. | Theorem 2 and checks `thm2-first-split-seed` / `thm2-no-smaller-split`. | **ATTEMPTED** |
+| fill-bits on the displayed seed | Evaluate the four extras on `S`. | Theorem 3 and check `thm3-displayed-fill-bits` give `(0, 0, 1, 1)`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: the four extras are not dynamically one
+object. The displayed seed and the fill-bit tuple are two certificates of
+the same split, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| displayed seed / fill-bits `(0, 0, 1, 1)` | yes: a split seed is a split | yes: unequal fill-bits name a split | collapse into the one-object failure |
+| `m11=12` / four extras in `Max(11)` | no: a max does not name the extras | no: membership does not replace the max | independent positive integers versus the set |
+| leftover of #6476 / this split | no: that leftover named the set | no: a first seed does not replace the listing | different object |
+| static `|F_cut|=32` / the split seed | no: membership is not dynamics | no: a seed does not replace the three-cut class | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| seeds of size at most 3 | explicit search bound; a larger seed is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit extras | displayed #6476 set, not a selected law |
+| fill-bits `(0, 0, 1, 1)` | displayed witness against one-object dynamics, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:89` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:133` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:138` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:51` | 12 one-site seeds | `C(12,1)` unordered singles on the two-cube | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:54` | 12 eleven-site seeds | `C(12,11)` unordered 11-sets on the two-cube | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:69` | four extras | remaining-bit tuples of `Max(11) \ Max(1)` | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:75` | displayed seed | lex-first `|S|≤3` split | yes |
+| `scripts/f_cut_max11_extra_first_split_2026_08_15.py:326` | first-split search | increasing `|S|` then lex of the sorted tuple | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut` | `cov1` and `cov11` are this class; other classes are unclaimed |
+| per block | yes: the four extras and one seed | the extras split on `S`; they are not dynamically one object |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: the
+four extras do share `cov11=12` and `cov1=0`, and they do miss together
+on every seed of size at most 2. That common miss-class does not make
+them dynamically one object on every `|S|≤3` seed and does not select
+any of them as the physical rule. The remaining physical choice — which,
+if any, `F_cut` map is the Admissibility occupancy predicate — stays
+explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that #6476 already named the four extras, so
+a first split seed might be called leftover decoration of that listing,
+or of the fact that the four tuples differ already on `opp2` and
+`mixed3`. That objection is correctly about the static bit-tuples. It
+does not overturn the stated theorem: among all seeds of size at most 3,
+the four extras first disagree dynamically on the displayed 3-site seed,
+with fill-bits `(0, 0, 1, 1)`. The split is a dynamics fact, not a
+leftover of listing the set.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the two coverage rankings, and the 299-seed search are
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the first bounded split of the four extras
+or restores the claim that they are dynamically one object on every
+seed of size at most 3.
+
+No-Go Discipline disposition: **PASS** for the one-object failure and the
+exact pair `(S, fill-bits)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube from every 1-site seed and
+every 11-site seed, reports `m1 = 12`, `N_max1 = 4`, `m11 = 12`, and
+`N_max11 = 8`, reconfirms that the four named extras are exactly
+`Max(11) \ Max(1)`, searches all seeds of size at most 3 in lex order,
+reports the first split seed `((0, 0, 0), (0, 1, 1), (2, 0, 0))` with
+fill-bits `(0, 0, 1, 1)`, checks that `f_L1` is not Hamming parity, and
+does not adopt a map. Declared audit inputs are this note and the axiom
+memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_max11_extra_first_split_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_max11_extra_first_split_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_max11_extra_first_split_2026_08_15.txt
@@ -1,0 +1,71 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_max11_extra_first_split_2026_08_15.py
+runner_sha256: bf21ec42d9b142c9058bb022c779ea9a943743318915c1b10143bbbea4b4d8b3
+input_fingerprint_sha256: 4461f0da265314a7b6f0e0826dc33ee2fc119b8f6dab84968b6229c524c9fb33
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_one_site_seeds=12
+n_eleven_site_seeds=12
+n_bounded_seeds=299
+m1=12
+N_max1=4
+Max1=[(1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+m11=12
+N_max11=8
+Max11=[(0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (0, 1, 1, 1, 0), (0, 1, 1, 1, 1), (1, 0, 1, 1, 0), (1, 0, 1, 1, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1)]
+named_extras=[(0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (0, 1, 1, 1, 0), (0, 1, 1, 1, 1)]
+extras_computed=[(0, 0, 1, 1, 0), (0, 0, 1, 1, 1), (0, 1, 1, 1, 0), (0, 1, 1, 1, 1)]
+extra_cov1=[0, 0, 0, 0]
+extra_cov11=[12, 12, 12, 12]
+split_seed=((0, 0, 0), (0, 1, 1), (2, 0, 0))
+split_fill_bits=(0, 0, 1, 1)
+n_split_bounded=20
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-seed-counts the two-cube has twelve vertices, C(12,1)=12 one-site seeds, C(12,11)=12 eleven-site seeds
+PASS: thm1-max11-contains-four-extras all four named extras lie in Max(11) and attain cov11=12
+PASS: thm1-max1-excludes-four-extras none of the four named extras lie in Max(1); each has cov1=0
+PASS: thm2-first-split-seed lex-first |S|<=3 seed that splits the four extras is the displayed 3-site seed
+PASS: thm2-no-smaller-split no empty, 1-site, or 2-site seed splits the four extras
+PASS: thm3-displayed-fill-bits on the displayed seed the four fill-bits are (0, 0, 1, 1)
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted first split, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-split the note reports Max(11), Max(1), the four extras, the first seed, and the fill-bits
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6476 the residual is the first split seed, not leftover-character of listing Max(11) minus Max(1)
+PASS: claim-scope-split claim_scope reports the lex-first |S|<=3 split of the four extras
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on all 1-site and 11-site seeds
+per_block: checked exactly — the four extras and the lex-first |S|<=3 split seed are enumerated
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_max11_extra_first_split_2026_08_15.py
+++ b/scripts/f_cut_max11_extra_first_split_2026_08_15.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""First |S|<=3 seed that splits the four Max(11)\\Max(1) F_cut extras.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov_k(f) is the number of unordered k-site seeds from
+which f fills. Max(k) is the set of F_cut maps attaining the maximum of
+cov_k. The four remaining-bit extras in Max(11) minus Max(1) are named, not
+adopted. f_L1 is the unbalanced-axis predicate (some n_mu != 0), never
+Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+ONE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(single) for single in combinations(TWO_CUBE, 1)
+)
+ELEVEN_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 11)
+)
+BOUNDED_SEEDS: tuple[tuple[Site, ...], ...] = tuple(
+    combo for size in range(0, 4) for combo in combinations(TWO_CUBE, size)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+NAMED_EXTRAS: tuple[Remaining, ...] = (
+    (0, 0, 1, 1, 0),
+    (0, 0, 1, 1, 1),
+    (0, 1, 1, 1, 0),
+    (0, 1, 1, 1, 1),
+)
+DISPLAYED_SEED: tuple[Site, ...] = ((0, 0, 0), (0, 1, 1), (2, 0, 0))
+DISPLAYED_FILL_BITS: tuple[int, ...] = (0, 0, 1, 1)
+FULL_MASK = (1 << 12) - 1
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[dict[OrbitType, int], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[dict[OrbitType, int], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((assignment, remaining))
+    return members
+
+
+def neighbor_index_table() -> tuple[tuple[int, ...], ...]:
+    site_index = {site: index for index, site in enumerate(TWO_CUBE)}
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(site_index.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+NEIGHBOR_INDEX: tuple[tuple[int, ...], ...] = neighbor_index_table()
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def seed_mask(seed: frozenset[Site] | tuple[Site, ...]) -> int:
+    return sum(1 << SITE_INDEX[site] for site in seed)
+
+
+def predicate_table(
+    assignment: dict[OrbitType, int], type_of: dict[Config, OrbitType]
+) -> tuple[int, ...]:
+    table = [0] * 64
+    for bits in range(64):
+        config: Config = (
+            bits & 1,
+            (bits >> 1) & 1,
+            (bits >> 2) & 1,
+            (bits >> 3) & 1,
+            (bits >> 4) & 1,
+            (bits >> 5) & 1,
+        )
+        table[bits] = assignment[type_of[config]]
+    return tuple(table)
+
+
+def evolve(locked: int, table: tuple[int, ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction_index, neighbor in enumerate(NEIGHBOR_INDEX[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction_index
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills(seed: int, table: tuple[int, ...]) -> bool:
+    locked = seed
+    for _tick in range(13):
+        nxt = evolve(locked, table)
+        if nxt == locked:
+            return locked == FULL_MASK
+        locked = nxt
+    return False
+
+
+def coverage(table: tuple[int, ...], seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills(seed_mask(seed), table))
+
+
+def fill_bits_on_seed(
+    seed: tuple[Site, ...], extra_tables: tuple[tuple[int, ...], ...]
+) -> tuple[int, ...]:
+    mask = seed_mask(seed)
+    return tuple(int(fills(mask, table)) for table in extra_tables)
+
+
+def first_split_seed(
+    extra_tables: tuple[tuple[int, ...], ...]
+) -> tuple[tuple[Site, ...], tuple[int, ...]]:
+    for seed in BOUNDED_SEEDS:
+        bits = fill_bits_on_seed(seed, extra_tables)
+        if len(set(bits)) > 1:
+            return seed, bits
+    raise RuntimeError("no |S|<=3 seed splits the four extras")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    tables = {
+        remaining: predicate_table(assignment, type_of) for assignment, remaining in members
+    }
+    cov1 = {remaining: coverage(table, ONE_SITE_SEEDS) for remaining, table in tables.items()}
+    cov11 = {remaining: coverage(table, ELEVEN_SITE_SEEDS) for remaining, table in tables.items()}
+    m1 = max(cov1.values())
+    m11 = max(cov11.values())
+    max1 = tuple(sorted(remaining for remaining, value in cov1.items() if value == m1))
+    max11 = tuple(sorted(remaining for remaining, value in cov11.items() if value == m11))
+    extras_computed = tuple(remaining for remaining in max11 if remaining not in max1)
+
+    extra_tables = tuple(tables[remaining] for remaining in NAMED_EXTRAS)
+    split_seed, split_bits = first_split_seed(extra_tables)
+    n_split_bounded = sum(
+        1 for seed in BOUNDED_SEEDS if len(set(fill_bits_on_seed(seed, extra_tables))) > 1
+    )
+    two_site_bits = [
+        fill_bits_on_seed(seed, extra_tables)
+        for seed in BOUNDED_SEEDS
+        if len(seed) == 2
+    ]
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_one_site_seeds={len(ONE_SITE_SEEDS)}")
+    print(f"n_eleven_site_seeds={len(ELEVEN_SITE_SEEDS)}")
+    print(f"n_bounded_seeds={len(BOUNDED_SEEDS)}")
+    print(f"m1={m1}")
+    print(f"N_max1={len(max1)}")
+    print(f"Max1={list(max1)}")
+    print(f"m11={m11}")
+    print(f"N_max11={len(max11)}")
+    print(f"Max11={list(max11)}")
+    print(f"named_extras={list(NAMED_EXTRAS)}")
+    print(f"extras_computed={list(extras_computed)}")
+    print(f"extra_cov1={[cov1[remaining] for remaining in NAMED_EXTRAS]}")
+    print(f"extra_cov11={[cov11[remaining] for remaining in NAMED_EXTRAS]}")
+    print(f"split_seed={split_seed}")
+    print(f"split_fill_bits={split_bits}")
+    print(f"n_split_bounded={n_split_bounded}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_hamming_bits={ham_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_MAX11_EXTRA_FIRST_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-seed-counts",
+        "the two-cube has twelve vertices, C(12,1)=12 one-site seeds, C(12,11)=12 eleven-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(ONE_SITE_SEEDS) == 12
+        and len(set(ONE_SITE_SEEDS)) == 12
+        and len(ELEVEN_SITE_SEEDS) == 12
+        and len(set(ELEVEN_SITE_SEEDS)) == 12
+        and len(BOUNDED_SEEDS) == 1 + 12 + 66 + 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 1 for seed in ONE_SITE_SEEDS)
+        and all(seed <= set(TWO_CUBE) and len(seed) == 11 for seed in ELEVEN_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-max11-contains-four-extras",
+        "all four named extras lie in Max(11) and attain cov11=12",
+        m11 == 12
+        and len(max11) == 8
+        and all(remaining in max11 for remaining in NAMED_EXTRAS)
+        and all(cov11[remaining] == 12 for remaining in NAMED_EXTRAS)
+        and extras_computed == NAMED_EXTRAS,
+    )
+    checks.check(
+        "thm1-max1-excludes-four-extras",
+        "none of the four named extras lie in Max(1); each has cov1=0",
+        m1 == 12
+        and len(max1) == 4
+        and all(remaining not in max1 for remaining in NAMED_EXTRAS)
+        and all(cov1[remaining] == 0 for remaining in NAMED_EXTRAS)
+        and L1_REMAINING in max1
+        and L1_REMAINING not in NAMED_EXTRAS,
+    )
+    checks.check(
+        "thm2-first-split-seed",
+        "lex-first |S|<=3 seed that splits the four extras is the displayed 3-site seed",
+        split_seed == DISPLAYED_SEED
+        and len(split_seed) == 3
+        and len(set(split_bits)) > 1
+        and all(
+            len(set(fill_bits_on_seed(seed, extra_tables))) == 1
+            for seed in BOUNDED_SEEDS
+            if seed < DISPLAYED_SEED or len(seed) < 3
+        ),
+    )
+    checks.check(
+        "thm2-no-smaller-split",
+        "no empty, 1-site, or 2-site seed splits the four extras",
+        all(bits == (0, 0, 0, 0) for bits in two_site_bits)
+        and len(two_site_bits) == 66
+        and fill_bits_on_seed((), extra_tables) == (0, 0, 0, 0)
+        and all(
+            fill_bits_on_seed((site,), extra_tables) == (0, 0, 0, 0) for site in TWO_CUBE
+        ),
+    )
+    checks.check(
+        "thm3-displayed-fill-bits",
+        "on the displayed seed the four fill-bits are (0, 0, 1, 1)",
+        split_bits == DISPLAYED_FILL_BITS
+        and split_bits == fill_bits_on_seed(DISPLAYED_SEED, extra_tables)
+        and n_split_bounded == 20,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted first split, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-split",
+        "the note reports Max(11), Max(1), the four extras, the first seed, and the fill-bits",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(0, 0, 1, 1, 0)" in note
+        and "(0, 0, 1, 1, 1)" in note
+        and "(0, 1, 1, 1, 0)" in note
+        and "(0, 1, 1, 1, 1)" in note
+        and "((0, 0, 0), (0, 1, 1), (2, 0, 0))" in note
+        and "(0, 0, 1, 1)" in note
+        and "m11 = 12" in note
+        and "N_max11 = 8" in note
+        and "m1 = 12" in note
+        and "N_max1 = 4" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the seed into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6476",
+        "the residual is the first split seed, not leftover-character of listing Max(11) minus Max(1)",
+        "Not leftover-character of #6476" in note
+        and "named the set" in note
+        and "new uniqueness of the set" in note_flat,
+    )
+    checks.check(
+        "claim-scope-split",
+        "claim_scope reports the lex-first |S|<=3 split of the four extras",
+        "On the two-cube with off-patch o=0" in note
+        and "lex-first seed of size at most 3" in note
+        and "Max(11) minus Max(1)" in note
+        and "do not all fill or all miss" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on all 1-site and 11-site seeds")
+    print("per_block: checked exactly — the four extras and the lex-first |S|<=3 split seed are enumerated")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the lex-first |S|<=3 seed at which the four F_cut maps in Max(11) minus Max(1) do not all fill or all miss is reported. Displayed, not adopted. f_L1 is n!=0, not Hamming. Source-only. No axiom edit.

## Runner

`scripts/f_cut_max11_extra_first_split_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.