### PR TITLE
physics: classify the global dressing space and the positivity split

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block109-global-dressing-involution-positivity-20260815/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block109-global-dressing-involution-positivity-20260815/NO_GO_LEDGER.md
@@ -1,0 +1,28 @@
+# Block 109 No-Go Ledger
+
+Scope: one narrow class-scoped wall inside a positive global-feasibility
+packet. `W1` says involution and positivity are exactly disjoint on the
+displayed classes: the anti-diagonal reflection-pairing class reduces
+exactly to the one-parameter family lambda A-star with involution variety
+exactly {+A-star, -A-star} (Groebner {lambda^2 - 1}), both branches of
+exact inertia (8,8,0) at both fixtures; and the searched structured
+families of the full 132-dimensional space (Hermitian-subspace pairs,
+full-space pairs, gamma-identity extensions, the positive-fiber
+representative with rank(A^2 - I) = 32) contain no joint element. This is
+not a transporter impossibility: the joint variety on the full space is
+open and named, with the modular/transfer selection live.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the global class is infeasible like the seam-local one | `ATTEMPTED` | false: exact rank 380 / dimension 132 at both fixtures | none needed |
+| the undressed reflection is already in the space | `ATTEMPTED` | false: A = I fails Hermiticity by the pinned Block 108 defect | dress globally |
+| no exact involution exists globally | `ATTEMPTED` | false: A-star is a certified exact dressed reflection | none needed |
+| A-star is positive | `ATTEMPTED` | false: exact inertia (8,8,0), displayed negative minors at both fixtures | the joint variety |
+| positivity is unreachable globally | `ATTEMPTED` | false: the K = I fiber has exact real dimension 72 | none needed |
+| the positive fiber contains an involution trivially | `ATTEMPTED` | false: the displayed representative has rank(A^2 - I) = 32; pair scans find only +-A-star | the joint variety |
+| the anti-diagonal class hides more solutions | `ATTEMPTED` | false: complete classification — dimension 1, variety {+-A-star} | widen the support class |
+| central-window methods would have found A-star | `ATTEMPTED` | false: its central window block is identically zero — window-invisible | global constructions only |
+| these results settle the transporter | `ATTEMPTED` | false: the joint variety on 132 dimensions is open and named | Block 110 |
+| these results amend an axiom or retire a TOE obligation | `ATTEMPTED` | false: representation/action-interface results only | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; only class-scoped `W1` ships.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_GLOBAL_DRESSING_INVOLUTION_POSITIVITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_GLOBAL_DRESSING_INVOLUTION_POSITIVITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,765 @@
+---
+claim_id: admissibility_dirac_kahler_global_dressing_involution_positivity_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the Block 107/108 seam carrier, the globally supported x-covariant dressing class (512 real parameters over all eight torus slices) jointly satisfying reflection-reality and full-span two-history Hermiticity has exact dimension 132 (rank 380: reality is a fixed-point-free signed involution of the parameter basis contributing rank 256, Hermiticity adds exact rank 124) at both displayed shear fixtures, and the undressed identity is excluded; the class contains the displayed exact involution A_star--anti-diagonal reflection-pairing of slices with alternating signs times the x-parity sign field--which makes the dressed reflection a genuine antilinear involution with an exactly Hermitian full-span Gram of exact inertia (8,8,0) (displayed negative minors at both fixtures), occupies every slice at magnitude one with a vanishing central-window block (invisible to every central-window search), and within the anti-diagonal class the joint linear system is exactly one-dimensional with involution variety exactly {+/-A_star} (Groebner basis lambda^2-1), both branches exactly indefinite; separately the positive fiber K_A=I is feasible with exact real dimension 72 and a displayed representative that is exactly non-involutive (rank(A^2-I)=32); hence involution and positivity each hold globally but are exactly disjoint on the displayed classes, and the joint variety on the full 132-dimensional space, curved OS positivity, the completed ADM/history transporter, joint gravity, the gravity constraint quotient, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_involution_seam_dressing_locality_bounded_theorem_note_2026-08-15
+runner: scripts/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_involution_seam_dressing_locality_bounded_theorem_note_2026-08-15
+target_blocker_text: "Construct the globally supported transfer/modular seam dressing; verify involution quadric, full-span Hermiticity, positivity"
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Solve the joint involution-positivity variety on the full 132-dimensional global space (structured decompositions and the modular selection); carry any positive dressed reflection to the OS package and the gravity constraint quotient."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-108 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact finite operator identities, exact rational linear algebra, exact inertia, and an exact one-variable polynomial classification on the declared d=2 carrier; dependencies are content-bound unaudited, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Global Dressing Space, The Exact Reflection Involution, And The Positivity Split
+
+**Date:** 2026-08-15
+
+**Campaign block:** 109
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.py`](../scripts/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.py)
+
+## 1. Result Up Front
+
+[Block 108](ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md)
+closed onto the following handoff next gate, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:629-645`:
+
+> Construct the globally supported transfer/modular seam dressing; verify
+> involution quadric, full-span Hermiticity, positivity.
+
+Three exact theorems sharpen that gate.
+
+First, the globally supported `x`-covariant dressing ansatz has 512 real
+parameters. Reflection-reality is a fixed-point-free signed involution of
+that parameter basis and contributes exact rank 256. Full-span two-history
+Hermiticity contributes a further exact rank 124. Hence at each fixture,
+
+\[
+ \dim_{\mathbb R}\mathscr L_{5/13}
+ =\dim_{\mathbb R}\mathscr L_{3/5}
+ =512-(256+124)=132.                            \tag{1}
+\]
+
+The combined rank is 380 at both fixtures. The identity does not lie in
+either space: its surviving Hermiticity residual is exactly the Block 108
+non-decay defect.
+
+Second, each 132-dimensional space contains the same displayed exact
+involution `A_star`. It pairs the eight time slices anti-diagonally, with
+alternating reflection-pair signs, and multiplies by the Block 106
+shear-flip `x`-parity sign field. Its eight nonzero blocks are
+
+\[
+\begin{array}{c|rrrrrrrr}
+ (t,t')&(-4,3)&(-3,2)&(-2,1)&(-1,0)&(0,-1)&(1,-2)&(2,-3)&(3,-4)\\
+\hline
+ A_{\star;t,t'}&D_x&-D_x&D_x&-D_x&-D_x&D_x&-D_x&D_x,
+\end{array}                                      \tag{2}
+\]
+
+with every other time block zero and
+`D_x=diag(1,-1,1,-1)` in the ordered `x`-character basis. Thus every time
+slice has magnitude-one support. Exact multiplication gives
+
+\[
+ P\overline {A_\star}P=A_\star,
+ \qquad A_\star^2=I_{32}.                       \tag{3}
+\]
+
+The dressed reflection is therefore a genuine antilinear involution. Its
+full-span Gram is exactly Hermitian at both fixtures, but its exact inertia
+is `(8,8,0)`. Section 5 displays an exact negative principal-minor witness
+at each fixture.
+
+Third, involution and positivity split on the displayed classes. The exact
+64-real anti-diagonal class has joint linear rank 63 and hence is
+one-dimensional, `A(lambda)=lambda A_star`. Its involution ideal has reduced
+Groebner basis `{lambda^2-1}`, so its real variety is exactly
+`{+A_star,-A_star}`. Both branches have inertia `(8,8,0)`. Separately, the
+positive identity-Gram fiber
+
+\[
+ \mathscr P_c=\{A:P\overline A P=A,
+                  \quad\mathcal K_+(A;c)=I_{16}\} \tag{4}
+\]
+
+is nonempty and has exact real dimension 72 at both fixtures. The displayed
+canonical representative has
+`rank(A^2-I_32)=32`, so it is exactly non-involutive.
+
+Thus involution and positivity each occur globally, but they are exactly
+disjoint on the classes just displayed. This does not decide their joint
+existence on the full 132-dimensional space. That remaining problem has
+132 real dressing variables, with 37 coordinates in the `A`-Hermitian
+subfamily; it is the live next mechanism, not a transporter impossibility.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) at
+`origin/main b8d9f4c40125e45415d6dd240a7ef806e773a278`, with axiom blob
+`bc23300becfe4e4db57153c0e94cfcdf2338da71` and registry blob
+`b93959cca4f7e26c673cdccbe601e50c3cb93daa`, recomputed when this draft was
+written.
+
+The exact stacked parent is [Block 108](ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md)
+commit `8afe8dff5ccf531208238af0aaaec1f547d73874`, content-bound through note
+blob `21128ab10b32d4f99190ce7107ef9fb790a05781`. Its direct parent is
+[Block 107](ADMISSIBILITY_DIRAC_KAHLER_ADM_SEAM_TWO_HISTORY_GRAM_BOUNDED_THEOREM_NOTE_2026-08-15.md)
+commit `d41a05e153d4cb77eee125b82fc0b0bd767bf32e`, note blob
+`cefc3be28430a9069ef572eb992f2605e58fccd5`. The local shear-flip source is
+[Block 106](ADMISSIBILITY_DIRAC_KAHLER_LOCAL_DUAL_PATCH_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-15.md)
+commit `22d6d90ec2279e5868c9c825149b2a20beea3797`, note blob
+`a08c8d5381e5bfac52f23d28fa6ffd05adf81697`. No audit verdict is imported.
+
+The executed contract is:
+
+1. the Block 107/108 `d=2` one-fine-mode carrier on
+   `Z8_t x Z4_x`, ordered time first with representatives `-4,...,3`;
+2. antiperiodic time closure and the antilinear link-centered reflection
+   `theta(t)=-1-t`;
+3. the step-shear history `(-c,-c,-c,0,c,c,c,0)`, with `m=9/20`, `v=1`,
+   and the two exact fixtures `c=5/13` and `c=3/5`;
+4. the full positive span `Lambda_+={0,1,2,3} x Z4`, the central positive
+   span `Lambda_cen={0,1} x Z4`, and the reflection-symmetric four-slice
+   window `W4={-2,-1,0,1} x Z4`;
+5. the globally supported `x`-covariant class: an `8 x 8` array of
+   `4 x 4` spatial-circulant complex blocks, hence `8*8*4` complex or 512
+   real coordinates, ordered lexicographically by target time, source time,
+   spatial offset, and real then imaginary part; and
+6. exact antilinear identities, exact rational row reduction and rank,
+   exact principal-minor/inertia certification, and exact polynomial
+   reduction only. Decimal values are never proof inputs.
+
+No OS reconstruction theorem is used. No modular or transfer selection is
+constructed. The joint variety on all 132 variables, curved positivity,
+ADM/history transport, and gravity terminals are outside the executed
+contract.
+
+## 3. Global Feasibility
+
+Let `X_x` be the 512-real-dimensional globally supported `x`-covariant
+coordinate space in Section 2. In its ordered real parameter basis,
+reflection-reality acts as
+
+\[
+ \rho(e_\alpha)=\epsilon_\alpha e_{\sigma(\alpha)},
+ \qquad \epsilon_\alpha\epsilon_{\sigma(\alpha)}=1,
+ \qquad \sigma(\alpha)\ne\alpha.                \tag{5}
+\]
+
+Thus `rho` is a signed involution whose underlying permutation is
+fixed-point-free. Its 512 basis elements form 256 two-cycles. Each cycle
+contributes one independent fixed coordinate and one independent reality
+row, so
+
+\[
+ \dim\operatorname{Fix}(\rho)=256,
+ \qquad \operatorname{rank}(I-\rho)=256.        \tag{6}
+\]
+
+This count includes the diagonal-reality rows. It is a basis permutation
+mechanism, not a floating-point rank observation.
+
+Let `S_+` embed the ordered sixteen-dimensional positive span, put
+`G_c=Q_c^(-1)`, and define the dressed full-span Gram by the Block 108
+target-arm convention,
+
+\[
+ \mathcal K_+(A;c)
+ =\overline{S_+^\dagger A G_c P S_+}.           \tag{7}
+\]
+
+On `Fix(rho)`, impose the exact real-linear equations
+
+\[
+ \mathcal H_c(A)
+ :=\mathcal K_+(A;c)-\mathcal K_+(A;c)^\dagger=0. \tag{8}
+\]
+
+Fraction-free elimination gives
+
+\[
+ \begin{array}{c|ccc}
+ c&\operatorname{rank}(I-\rho)&
+   \operatorname{rank}(\mathcal H_c\mid\operatorname{Fix}\rho)&
+   &\operatorname{rank}_{\rm stacked}\\
+ \hline
+ 5/13&256&124&380\\
+ 3/5 &256&124&380.
+ \end{array}                                    \tag{9}
+\]
+
+Therefore
+
+\[
+ \mathscr L_c
+ :=\{A\in\mathscr X_x:P\overline A P=A,
+                  \ \mathcal H_c(A)=0\}
+\]
+
+is a real vector space of exact dimension 132 at each fixture.
+
+The undressed identity is reflection-real, but it is not in `L_c`.
+Indeed,
+
+\[
+ \mathcal H_{5/13}(I)\ne0,
+ \qquad \mathcal H_{3/5}(I)\ne0.               \tag{10}
+\]
+
+These are exactly the nonzero undressed far-block constants and independent
+rank inconsistency displayed in
+[Block 108 Sections 6.1--6.3](ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md),
+`docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:283-406`.
+Global support makes the Hermiticity equations feasible; it does not make
+the identity a solution.
+
+## 4. The Exact Involution
+
+Index time slices by `tau_i=i-4`, `i=0,...,7`, and set `r(i)=7-i`. Let
+
+\[
+ D_x=\operatorname{diag}(1,-1,1,-1),
+ \qquad D_x^2=I_4,                              \tag{11}
+\]
+
+in the ordered four-mode `x`-character basis. This is the spatial
+`x`-parity sign field in the Block 106 shear-flip channel, whose signed time
+lift and action-derived seam link are anchored at
+[Block 106 Section 8](ADMISSIBILITY_DIRAC_KAHLER_LOCAL_DUAL_PATCH_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-15.md),
+`docs/ADMISSIBILITY_DIRAC_KAHLER_LOCAL_DUAL_PATCH_DESCENT_BOUNDED_THEOREM_NOTE_2026-08-15.md:410-509`.
+The associated real-space operator is `x`-covariant.
+
+Define the symmetric alternating sign vector
+
+\[
+ (s_0,s_1,s_2,s_3,s_4,s_5,s_6,s_7)
+ =(1,-1,1,-1,-1,1,-1,1),                       \tag{12}
+\]
+
+and define `A_star` by
+
+\[
+ (A_\star)_{ij}=\delta_{j,r(i)}s_iD_x.          \tag{13}
+\]
+
+For completeness, its full list of eight nonzero time blocks is
+
+\[
+\begin{aligned}
+ (A_\star)_{-4,3}&= D_x,&
+ (A_\star)_{-3,2}&=-D_x,&
+ (A_\star)_{-2,1}&= D_x,&
+ (A_\star)_{-1,0}&=-D_x,\\
+ (A_\star)_{0,-1}&=-D_x,&
+ (A_\star)_{1,-2}&= D_x,&
+ (A_\star)_{2,-3}&=-D_x,&
+ (A_\star)_{3,-4}&= D_x.
+                                                        \tag{14}
+\end{aligned}
+\]
+
+There are two separate exact mechanisms. First,
+
+\[
+ s_i=s_{r(i)}                                   \tag{15}
+\]
+
+makes reflection-reality hold after `P` exchanges each anti-diagonal pair.
+Second,
+
+\[
+ s_i s_{r(i)}=1,
+ \qquad D_x^2=I_4                              \tag{16}
+\]
+
+gives `A_star^2=I_32` block by block. Combining (15)--(16) with the Block
+108 reduction
+`(Theta compose A)^2=A^2`, anchored at
+[Block 108 Section 3](ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md),
+`docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:128-179`,
+gives
+
+\[
+ (\Theta\mathbin\circ A_\star)^2=I_{32}.       \tag{17}
+\]
+
+This is a genuine antilinear reflection involution, not merely a Hermitian
+dressing.
+
+The support mechanism is equally sharp. Every row slice has one nonzero
+reflection partner and every nonzero entry of that partner has magnitude
+one. Hence `A_star` occupies all eight torus slices. On the other hand,
+
+\[
+ S_{\rm cen}^\dagger A_\star S_{\rm cen}=0,     \tag{18}
+\]
+
+because `r` sends each central positive slice into its negative-time mate.
+Thus its central positive-to-positive window block vanishes. Block 107's
+central target-arm search, anchored at
+[Block 107 Section 7](ADMISSIBILITY_DIRAC_KAHLER_ADM_SEAM_TWO_HISTORY_GRAM_BOUNDED_THEOREM_NOTE_2026-08-15.md),
+`docs/ADMISSIBILITY_DIRAC_KAHLER_ADM_SEAM_TWO_HISTORY_GRAM_BOUNDED_THEOREM_NOTE_2026-08-15.md:462-490`,
+could not identify it through that block. Block 108's affine search instead
+required identity continuation outside `W4`, while `A_star` is supported on
+every slice. The two central-window searches therefore excluded this
+candidate by their declared premises; they did not test and reject it. In
+this exact sense, `A_star` is window-invisible.
+
+This realizes Block 108's global-support forcing exactly. It does not yet
+realize positivity.
+
+## 5. The Positivity Split
+
+Put
+
+\[
+ \mathcal K_\star(c)=\mathcal K_+(A_\star;c).   \tag{19}
+\]
+
+Exact conjugate-transpose comparison gives
+
+\[
+ \mathcal K_\star(c)=\mathcal K_\star(c)^\dagger
+ \quad(c=5/13,3/5).                             \tag{20}
+\]
+
+Exact fraction-free Hermitian elimination, including zero-pivot principal
+reordering rather than a numerical eigensolve, gives
+
+\[
+ \operatorname{inertia}\mathcal K_\star(5/13)
+ =\operatorname{inertia}\mathcal K_\star(3/5)
+ =(8,8,0).                                      \tag{21}
+\]
+
+Here are exact negative principal-minor witnesses at both fixtures:
+
+\[
+ \begin{aligned}
+ \Delta_{\star,1}(5/13)
+  &=-{33333963283450197824471164187210075293672388640
+       \over
+       61391349876435377016600254323619839508354485363}<0,\\
+ \bigl(\mathcal K_\star(3/5)\bigr)_{8,8}
+  &=-{30292616102306685544040740640984160
+       \over
+       68872508036021339265532585819028911}<0.
+                                                        \tag{22}
+ \end{aligned}
+\]
+
+Their signs are certified by positive integer numerators and denominators.
+They independently exclude positive semidefiniteness, while (21) gives the
+stronger complete inertia.
+
+Positivity is nevertheless globally feasible. Let
+
+\[
+ \mathscr P_c
+ =\{A\in\mathscr X_x:P\overline A P=A,
+                  \ \mathcal K_+(A;c)=I_{16}\}. \tag{23}
+\]
+
+After the rank-256 reality reduction, the exact affine system has
+`rank[M]=rank[M|b]=184` at both fixtures. Equivalently, the combined stack
+has rank `256+184=440` in 512 real coordinates. Therefore
+
+\[
+ \dim_{\mathbb R}\mathscr P_{5/13}
+ =\dim_{\mathbb R}\mathscr P_{3/5}=512-440=72. \tag{24}
+\]
+
+To display a reproducible exact representative, order the 512 coordinates
+as in Section 3, row-reduce the reality-plus-`K=I` system over `Q`, and set
+all 72 free coordinates to zero. If `R_c a=b_c` denotes that exact reduced
+system, write
+
+\[
+ A_+^{(c)}
+ :=\operatorname{unvec}_x\!\left(
+      a_{\rm free}=0,\ a_{\rm piv}=R_{c,{\rm piv}}^{-1}b_c
+    \right).                                    \tag{25}
+\]
+
+This definition displays the canonical zero-free-coordinate rational
+member without decimal fitting. Direct exact substitution gives
+
+\[
+ \mathcal K_+(A_+^{(c)};c)=I_{16}>0,
+ \qquad
+ \operatorname{rank}\bigl((A_+^{(c)})^2-I_{32}\bigr)=32
+ \quad(c=5/13,3/5).                             \tag{26}
+\]
+
+Thus the positive representative is exactly non-involutive. Conversely,
+the displayed exact involutions are indefinite. Involution and positivity
+are therefore disjoint on these displayed classes, but (26) does not prove
+that the entire 72-dimensional positive fiber misses the involution
+quadric.
+
+## 6. The Anti-Diagonal Classification
+
+The anti-diagonal class is not merely sampled. It can be closed exactly.
+Let
+
+\[
+ \mathscr A_{\rm ad}
+ =\{A:(A)_{ij}=\delta_{j,r(i)}C_i,
+       \ C_i\text{ is a complex }4\mathbin\times4
+          \text{ spatial-circulant block}\}.   \tag{27}
+\]
+
+Each `C_i` has four complex, hence eight real, coordinates, so (27) is a
+64-real anti-diagonal class. Stacking reflection-reality with full-span
+Hermiticity gives, at each fixture,
+
+\[
+ \operatorname{rank}M_{\rm ad}(c)=63,
+ \qquad
+ \dim\bigl(\mathscr A_{\rm ad}\cap\mathscr L_c\bigr)=1,
+ \qquad C_i=\lambda s_iD_x.                     \tag{28}
+\]
+
+Hence every reflection-real, full-span-Hermitian member of this complete
+anti-diagonal class is
+
+\[
+ A(\lambda)=\lambda A_\star.                    \tag{29}
+\]
+
+Substitution into the involution equations gives
+
+\[
+ A(\lambda)^2-I_{32}=(\lambda^2-1)I_{32}.       \tag{30}
+\]
+
+With the monomial order `lambda`, the reduced Groebner basis is exactly
+
+\[
+ \{\lambda^2-1\},                               \tag{31}
+\]
+
+and the real involution variety is exactly
+
+\[
+ V_{\rm ad}(\mathbb R)=\{-A_\star,+A_\star\}.  \tag{32}
+\]
+
+There are no missed nonlinear branches in this class. Since the Gram is
+linear in `A`,
+
+\[
+ \mathcal K_+(-A_\star;c)=-\mathcal K_+(A_\star;c). \tag{33}
+\]
+
+Negation interchanges the positive and negative inertia counts. Because
+both counts are eight, both branches have exact inertia `(8,8,0)` at both
+fixtures. Each branch therefore has an exact negative principal minor and
+is indefinite. Equations (27)--(33) close the anti-diagonal class
+completely; they do not classify the full 132-dimensional solution space.
+
+## 7. The Surviving Joint Question
+
+Choose an exact real basis `B_1(c),...,B_132(c)` for `L_c` and write
+
+\[
+ A_c(u)=\sum_{j=1}^{132}u_jB_j(c),
+ \qquad u\in\mathbb R^{132}.                    \tag{34}
+\]
+
+The unresolved semialgebraic set is
+
+\[
+ \mathscr V_c^+
+ =\{u\in\mathbb R^{132}:A_c(u)^2=I_{32},
+               \ \mathcal K_+(A_c(u);c)>0\}.   \tag{35}
+\]
+
+This is an honest 132-real-variable quadratic involution problem followed
+by positivity of an exactly Hermitian `16 x 16` Gram. The linear subfamily
+in which the dressing itself is Hermitian,
+
+\[
+ \mathscr L_c^{\rm h}
+ =\{A\in\mathscr L_c:A=A^\dagger\},             \tag{36}
+\]
+
+has exactly 37 real coordinates. Thus the 666-pair scan in Section 8 is
+the complete set of coordinate pairs in the 37-dimensional
+`A`-Hermitian subfamily, whereas the 8,646-pair scan is the complete set of
+coordinate pairs in the 132-dimensional full linear space. Neither pair
+scan is the full quadratic variety (35).
+
+Three structured routes remain live:
+
+1. mixed diagonal-plus-anti-diagonal time supports, allowing the positive
+   fiber to bend toward the closed anti-diagonal involution branches;
+2. wider spatial classes beyond the declared `x`-covariant ansatz, if the
+   full `x`-covariant variety is exhausted without a positive branch; and
+3. the modular/transfer selection derived from `Q_seam`, which can select a
+   nonlinear point of (35) without being sparse in the displayed basis.
+
+The first and third routes attack the 132-dimensional problem without
+changing the carrier. The second explicitly widens the representation
+premise. None requires a new primitive.
+
+The current split is therefore not a transporter impossibility. A positive
+involution may exist away from the anti-diagonal line, away from all tested
+coordinate two-planes, and away from the canonical positive-fiber
+representative. Solving (35), then applying the modular/transfer selection,
+is the exact surviving question.
+
+## 8. No-Go Discipline Gate
+
+There is exactly one narrow finite-carrier wall.
+
+- `W1`: on the displayed classes, involution and positivity are disjoint.
+  The anti-diagonal class is closed exactly: its only involutions are
+  `+/-A_star`, and both are indefinite at both fixtures. The searched
+  structured families of the full 132-dimensional space add no other
+  involution, while the displayed identity-Gram representative is positive
+  and has `rank(A^2-I)=32`.
+
+The scope is exactly the declared carrier, two fixtures, complete
+anti-diagonal class, coordinate-pair families, identity extension, and
+displayed positive-fiber representative. The full joint variety (35) is
+not closed. Mixed supports and the modular/transfer selection are the named
+live repairs. No statement about a completed transporter, transporter
+impossibility, or curved OS positivity follows.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by `(object, mechanism, terminal)`. The complete
+class closure is distinguished from finite structured scans, and the
+premise-widening live route is not counted as an attempted repair.
+
+1. **ATTEMPTED — anti-diagonal class / complete exact classification /
+   involution plus positivity.** The 64-real starting class has joint
+   linear rank 63 and dimension one, its reduced involution basis is
+   `{lambda^2-1}`, and its variety is exactly `{+A_star,-A_star}`. Both
+   points have inertia `(8,8,0)` at both fixtures. This anti-diagonal
+   complete classification is the strongest row.
+2. **ATTEMPTED — `A`-Hermitian subfamily / all coordinate-pair planes /
+   involution plus positivity.** The exact 37-coordinate basis has
+   `binomial(37,2)=666` unordered pairs. Exact pairwise polynomial solves
+   return only the already classified `+/-A_star` solutions and hence no
+   positive involution. This is the Hermitian-subfamily pair scan.
+3. **ATTEMPTED — full global linear space / all coordinate-pair planes /
+   involution plus positivity.** The exact 132-coordinate basis has
+   `binomial(132,2)=8646` unordered pairs. Exact pairwise solves again
+   return only `+/-A_star`. This exhausts coordinate two-planes, not their
+   nonlinear mixtures. This is the full-space pair scan.
+4. **ATTEMPTED — `gamma*I` extensions / diagonal-plus-anti-diagonal line /
+   full Hermiticity and involution.** In
+   `A=lambda A_star+gamma I`, full-span Hermiticity forces `gamma=0` at
+   both fixtures. The surviving involution equation is `lambda^2-1=0`, so
+   no positive branch is added.
+5. **ATTEMPTED — positive identity-Gram fiber / canonical exact
+   representative / involution.** The representative (25) has
+   `K_A=I_16>0` and exact `rank(A^2-I_32)=32` at both fixtures. It proves
+   positivity feasibility, not joint feasibility. This is the
+   positive-fiber representative involution test.
+6. **UNTESTED — LIVE — full joint variety and modular selection /
+   nonlinear action/representation construction / positive involution.**
+   This `UNTESTED-LIVE` premise-widening route goes beyond every finite pair
+   scan and is not counted as an attempted route against `W1`.
+
+### N2 — Wall-Independence Audit
+
+There is one current wall, so no pairwise current-wall table is needed. It
+is independent of Block 108's `W1`, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:442-457`.
+
+The Block 108 residual is locality: identity continuation outside `W4`
+leaves parameter-free nonzero far-block Hermiticity rows. Current `W1` is a
+positivity split after that locality premise has been removed and global
+Hermiticity has become feasible. `A_star` is a globally supported exact
+involution with a Hermitian but indefinite Gram; `A_+` has a positive Gram
+but is non-involutive. Repairing the Block 108 residual therefore does not
+repair the current residual. Conversely, a positive involution in (35)
+would not change Block 108's theorem about identity continuation. The two
+walls have different residuals: locality vs positivity.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required scope-certificate phrase scan is classified explicitly.
+
+| lowercase hit | classification |
+|---|---|
+| `globally supported x-covariant dressing class` | the declared 512-real-parameter ansatz, not every global operator |
+| `fixed-point-free signed involution` | exact reality-basis mechanism giving rank 256 |
+| `hermiticity adds exact rank 124` | exact incremental rank at both fixtures |
+| `dimension 132` | global reflection-real, full-span-Hermitian linear space |
+| `undressed identity is excluded` | inherited exact non-decay residual, not nonexistence of global solutions |
+| `exact involution a_star` | displayed member of the global space, not a positive member |
+| `every slice at magnitude one` | global-support certificate on this eight-slice torus |
+| `vanishing central-window block` | equation (18), explaining central-search invisibility |
+| `inertia (8,8,0)` | exact indefiniteness of both anti-diagonal branches |
+| `anti-diagonal dimension one` | complete class closure, not closure of the full space |
+| `groebner basis lambda^2-1` | exact involution ideal inside the anti-diagonal line |
+| `positive fiber dimension 72` | exact feasibility of `K_A=I`, not joint feasibility |
+| `rank(a^2-i)=32` | exact non-involution of the displayed positive representative |
+| `666 pairs` | exhaustive coordinate pairs only in the 37-coordinate `A`-Hermitian subfamily |
+| `8646 pairs` | exhaustive coordinate pairs only in the 132-coordinate global space |
+| `gamma = 0 forced` | identity extension collapses to the anti-diagonal line |
+| `joint variety untested-live` | the surviving 132-variable nonlinear problem |
+| `not a transporter impossibility` | scope firewall for `w1` |
+| `no axiom amendment is justified` | constitutional firewall |
+| `zero obligation retirement` | TOE accounting firewall |
+| `no toe percentage moves` | TOE accounting firewall |
+| `retained-positive end-to-end theory count remains zero` | audit-status accounting |
+| `actual adm/history transporter remains unexecuted` | partial-closure statement only |
+| `n1 n2 n3 n4 n5 n6 n7 n8` | every discipline gate is present |
+| `w1` | the wall set has exactly one member |
+| `per_element per_site per_mode per_block lattice_wide` | the five N5 resolution keys |
+
+The bounded note preserves the `N1`--`N8`, `W1`, N5, ADM, gravity, audit,
+and TOE walls. No phrase upgrades a structured-family split into a theorem
+about the full joint variety.
+
+### N4 — Residual Matching
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 108 Next Decision](ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:629-645` | construct the global transfer/modular dressing; verify involution, full-span Hermiticity, and positivity; then form the gravity quotient | equations (5)--(10) construct the full global Hermitian space, (11)--(18) give an exact involution, and (19)--(33) isolate the positivity split; their joint full-space solution remains open |
+| [Block 107 certificate section](ADMISSIBILITY_DIRAC_KAHLER_ADM_SEAM_TWO_HISTORY_GRAM_BOUNDED_THEOREM_NOTE_2026-08-15.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_ADM_SEAM_TWO_HISTORY_GRAM_BOUNDED_THEOREM_NOTE_2026-08-15.md:462-490` | the eight-dimensional local space contains an exact central positive certificate but lacks involution, action selection, and full-span extension | equation (18) explains why `A_star` is invisible to the central positive-to-positive block, while (9) supplies full-span Hermiticity and (21) shows that this involution is not positive |
+| [Block 105 Section 12](ADMISSIBILITY_DIRAC_KAHLER_SHIFTED_ORIGIN_FRAME_GAUGE_NONUNIFORM_HODGE_OVERLAP_BOUNDED_THEOREM_NOTE_2026-08-14.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_SHIFTED_ORIGIN_FRAME_GAUGE_NONUNIFORM_HODGE_OVERLAP_BOUNDED_THEOREM_NOTE_2026-08-14.md:630-643` | the action-derived ADM seam and both-eigenline Gram are required, and an uncancelled contact residual marks an action defect | the exact global linear space and involution are now present, but the modular/action selection of a positive involution remains the matching repair |
+
+Every cited residual reaches its stated interface. No citation is used as an
+audit verdict.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “Within the complete anti-diagonal
+class, and within every searched coordinate-pair or identity-extension
+family of the displayed 132-dimensional global space, the only exact
+involutions are `+/-A_star`, whose full-span Hermitian Grams have inertia
+`(8,8,0)` at both fixtures; the displayed positive identity-Gram
+representative is exactly non-involutive.”
+
+Forbidden upgrades include “the transporter exists,” “the transporter
+cannot exist,” “curved OS is closed,” “the full 132-dimensional joint
+variety is empty,” “ADM/history transport is finished,” “the gravity
+quotient has been executed,” “an axiom amendment is required,” and “a TOE
+obligation is retired.”
+
+The five resolution lines from the runner specification are reproduced
+verbatim:
+
+```text
+per_element: exact feasibility, involution, classification, fiber, and invisibility identities are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: both shear fixtures certify the same dimensions, variety, and inertia
+per_block: the exact involution occupies every slice at magnitude one while its central window block vanishes
+lattice_wide: checked and not executed — the joint involution-positivity variety on the full 132-dimensional space, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The full joint variety and its
+modular/transfer selection are action/representation constructions from the
+existing seam kernel.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| global reflection-reality plus full-span Hermiticity | exact dimension 132 at both fixtures by (5)--(10) | intersect with the involution quadric and positive cone |
+| exact global involution | `A_star` obeys (17) and occupies every slice | replace its exact inertia `(8,8,0)` by positivity |
+| complete anti-diagonal class | exactly `{+/-A_star}` on the involution variety, both indefinite | leave the anti-diagonal class |
+| positive identity-Gram fiber | exact dimension 72, with the displayed member positive and non-involutive | solve the involution equations within or beyond that fiber |
+| full joint variety | live 132-variable action/representation problem | structured decomposition, then modular selection |
+| modular/transfer selection | live and axiom-free | carry any selected positive involution to the OS package |
+
+The scan finds no axiom-amendment route. Solving the quadratic representation
+problem changes neither the carrier axioms nor the registered primitives.
+
+### N7 — Steelman
+
+**Hostile steelman against the wall.** The split may dissolve on the full
+132-dimensional variety. A nonlinear combination of three or more basis
+directions could be involutive and positive even though every coordinate
+pair returns only `+/-A_star`; likewise, another point of the
+72-dimensional identity-Gram fiber could lie on the involution quadric even
+though its displayed canonical representative does not.
+
+That objection is correct and fixes the scope of `W1`. The anti-diagonal
+classification is complete, but the coordinate-pair scans are not a
+Groebner decomposition of (35), and a rank-32 result for one positive point
+does not classify its entire fiber. This is exactly why the full joint
+variety, structured decompositions, and modular selection are the named
+next mechanisms. The shipped wall is class-scoped; it is not widened to a
+full-space no-go.
+
+### N8 — Cross-Cycle Echo
+
+| earlier exact boundary | echo here |
+|---|---|
+| Block 107's two-history and dressing-space walls, `docs/ADMISSIBILITY_DIRAC_KAHLER_ADM_SEAM_TWO_HISTORY_GRAM_BOUNDED_THEOREM_NOTE_2026-08-15.md:462-490` | its central positive certificate is preserved, while the globally supported involution is shown to have a vanishing central positive-to-positive block |
+| Block 108's seam-locality wall, `docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:442-457` | its forced global-support escape is realized by the 132-dimensional space and every-slice `A_star`, after which positivity becomes the distinct residual |
+| Block 108's discipline echo, `docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md:600-615` | the anti-diagonal class is closed completely before widening to mixed supports or the modular selection |
+
+The repeated discipline is to close a stated class completely, preserve its
+exact witness, and only then widen the representation premise. Blocks 107
+and 108 did not turn their local walls into transporter no-go statements;
+the present note does not turn its positivity split into one either.
+
+**No-Go Discipline verdict:** **PASS** only for narrow `W1` on the
+displayed classes and fixtures. **FAIL** for the full 132-dimensional joint
+variety, transporter existence or impossibility, curved OS positivity,
+gravity, axiom necessity, or TOE.
+
+## 9. Axiom And TOE Disposition
+
+No axiom amendment is justified. The global rank calculation, exact
+involution, inertia split, anti-diagonal classification, and positive fiber
+are finite consequences of the displayed carrier and pairing; no new
+primitive is assumed.
+
+This is bounded route progress, not an audit-grade assignment. It retires no
+end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 10. Next Decision
+
+The shortest high-value sequence is:
+
+1. solve the joint involution-positivity variety on the full
+   132-dimensional global space, beginning with mixed
+   diagonal-plus-anti-diagonal decompositions and then wider spatial
+   classes if required;
+2. impose the modular/transfer selection derived from `Q_seam` on any
+   surviving positive involution; and
+3. only then carry the selected dressed reflection to the OS package and
+   the gravity constraint quotient.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed global feasibility, exact anti-diagonal involution, and positivity-split certificates.
+
+Reflection positivity on the curved carrier remains unexecuted.
+
+The gravity constraint quotient remains unexecuted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15919,
- "node_count": 5537,
+ "edge_count": 15924,
+ "node_count": 5538,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -425,6 +425,10 @@
   "admissibility_dirac_kahler_cochain_hodge_quadratic_ward_shell_locality_os_reentry_bounded_theorem_note_2026-08-14": {
    "deps_hash": "e20317fe93b4",
    "out_degree": 6
+  },
+  "admissibility_dirac_kahler_global_dressing_involution_positivity_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "767fbba8a59e",
+   "out_degree": 5
   },
   "admissibility_dirac_kahler_involution_seam_dressing_locality_bounded_theorem_note_2026-08-15": {
    "deps_hash": "81f646aa8f71",

--- a/logs/runner-cache/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.py
+runner_sha256: de5668e1043e8cc76c376131d622f72b91cd6309fb4abecc4db95bef6f315a31
+input_fingerprint_sha256: abe09cb7dedab6fcb6ee861ab99a8bca500fe36bc236166ecc029046385b399a
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 64.78
+status: ok
+----- stdout -----
+[PASS] A-authority-and-Block108-parent: current axioms, registries, ancestry, and the Block108 parent triple are content-bound
+[PASS] B-global-feasibility: the fixed-point-free reality permutation gives rank 256 and both fixtures give rank 380
+       reality/H/joint/dim=256/124/380/132 at c=5/13 and c=3/5
+[PASS] C-undressed-exclusion: A=I obeys reality but its pinned Block108 defect excludes it from the joint space
+[PASS] D-exact-involution-A-star: A* is an exact real dressed reflection with Hermitian Gram and inertia (8,8,0)
+       Delta1=-33333963283450197824471164187210075293672388640/61391349876435377016600254323619839508354485363; inertia=(8, 8, 0); sign changes=8
+[PASS] E-anti-diagonal-classification: the 64-real anti-diagonal class is lambda A* with variety {+A*,-A*}, both indefinite
+       rank/dim=63/1; Groebner=(lambda**2 - 1,); both fixtures and branches have inertia (8,8,0)
+[PASS] F-positive-fiber: K_A=I16 has exact rank 184 and a 72-dimensional real fiber with a pinned non-involution
+       rank[M]=rank[M|b]=184; dim=72; rank(A^2-I)=32
+[PASS] G-window-invisibility: A* has zero central {0,1} window block, the zero Block107 homogeneous solution
+[PASS] H-structure-and-support: A* occupies all eight anti-diagonal slice-blocks at magnitude one with x-parity structure
+[PASS] I-scope: the note preserves the bounded joint-variety, N1--N8, W1, N5, ADM, gravity, audit, and T...
+EXACT_WITNESSES: undressed_defect=2100468154772736499016437760573154473873400000/61391349876435377016600254323619839508354485363; primary_Delta1=-33333963283450197824471164187210075293672388640/61391349876435377016600254323619839508354485363; second_K88=-30292616102306685544040740640984160/68872508036021339265532585819028911
+AXIOM_AUTHORITY: origin/main=b8d9f4c40125e45415d6dd240a7ef806e773a278 axiom=bc23300becfe4e4db57153c0e94cfcdf2338da71 registry=b93959cca4f7e26c673cdccbe601e50c3cb93daa; Block108 parent=8afe8dff5ccf531208238af0aaaec1f547d73874
+per_element: exact feasibility, involution, classification, fiber, and invisibility identities are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: both shear fixtures certify the same dimensions, variety, and inertia
+per_block: the exact involution occupies every slice at magnitude one while its central window block vanishes
+lattice_wide: checked and not executed — the joint involution-positivity variety on the full 132-dimensional space, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+RESULT: the global dressing space is richly feasible and contains an exact window-invisible dressed-reflection involution and a positive fiber, but on the anti-diagonal class involution and positivity are exactly disjoint
+DECISION_CUT: advance the joint variety on the full global space and the modular selection; reject undressed, seam-local, and anti-diagonal-only routes
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=9 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.py
+++ b/scripts/admissibility_dirac_kahler_global_dressing_involution_positivity_2026_08_15.py
@@ -1,0 +1,1466 @@
+#!/usr/bin/env python3
+"""Block 109: global dressing, involution, and positivity boundary.
+
+On the exact Block 108 antiperiodic reflection torus, the full globally
+supported translation-covariant dressing space is feasible.  It contains a
+window-invisible dressed-reflection involution and a separate positive fiber.
+Within the exact anti-diagonal class, however, involution leaves only the two
+indefinite branches ``+A*`` and ``-A*``.  This is a bounded classification,
+not a transporter impossibility or an ADM/history completion.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+import sympy as sp
+from sympy.polys.matrices import DomainMatrix
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_GLOBAL_DRESSING_INVOLUTION_POSITIVITY_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_involution_seam_dressing_locality_"
+    "2026_08_15.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_involution_seam_dressing_"
+    "locality_2026_08_15.txt"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_GLOBAL_DRESSING_INVOLUTION_POSITIVITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_INVOLUTION_SEAM_DRESSING_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "scripts/admissibility_dirac_kahler_involution_seam_dressing_locality_2026_08_15.py",
+    "logs/runner-cache/admissibility_dirac_kahler_involution_seam_dressing_locality_2026_08_15.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "b8d9f4c40125e45415d6dd240a7ef806e773a278"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block108-involution-seam-dressing-20260815"
+)
+PARENT_COMMIT = "8afe8dff5ccf531208238af0aaaec1f547d73874"
+PARENT_NOTE_BLOB = "21128ab10b32d4f99190ce7107ef9fb790a05781"
+PARENT_RUNNER_BLOB = "57c7a81317b455912571a703a3933043248ce70f"
+PARENT_CACHE_BLOB = "e0bc41e3d44d67a22dc327acd2c0d8ce77c83d30"
+ANCESTOR_107 = "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"
+ANCESTOR_106 = "22d6d90ec2279e5868c9c825149b2a20beea3797"
+ANCESTOR_105 = "d06066c2b908aaca0779625d831dfb10620cf34d"
+ANCESTOR_104 = "7fe07db6c03fad1191893c942f708c5cb9a54c43"
+ANCESTOR_103 = "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition, detail: str = "") -> None:
+        ok = bool(condition)
+        short = statement if len(statement) <= 91 else statement[:88] + "..."
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {short}")
+        if detail:
+            clipped = detail if len(detail) <= 190 else detail[:187] + "..."
+            print(f"       {clipped}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args, cwd=ROOT, text=True, timeout=AUDIT_TIMEOUT_SEC
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        "ancestor_107": is_ancestor(ANCESTOR_107, "HEAD"),
+        "ancestor_106": is_ancestor(ANCESTOR_106, "HEAD"),
+        "ancestor_105": is_ancestor(ANCESTOR_105, "HEAD"),
+        "ancestor_104": is_ancestor(ANCESTOR_104, "HEAD"),
+        "ancestor_103": is_ancestor(ANCESTOR_103, "HEAD"),
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+    }
+
+
+I = sp.I
+LX = 4
+TT = 4
+SIZE = 2 * TT * LX
+WINDOW_TIMES = (-2, -1, 0, 1)
+POSITIVE_TIMES = (0, 1, 2, 3)
+OFFSETS = ((0, 0), (0, 1), (1, 0), (1, 1))
+
+
+def parity(integer: int) -> sp.Integer:
+    """Return the staggered sign without unsafe negative exponentiation."""
+    return sp.Integer(-1 if integer % 2 else 1)
+
+
+def matrix_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    if left.shape != right.shape:
+        return False
+    return all(sp.expand(entry) == 0 for entry in left - right)
+
+
+def exact_rank(matrix: sp.Matrix) -> int:
+    return DomainMatrix.from_Matrix(matrix).rank()
+
+
+def max_abs_entry(matrix: sp.Matrix) -> sp.Expr:
+    return max((sp.Abs(sp.factor(value)) for value in matrix), default=sp.Integer(0))
+
+
+def h_site(shear: sp.Expr, volume: sp.Expr) -> sp.Matrix:
+    metric = sp.Matrix([[1, shear], [shear, 1]])
+    return sp.diag(volume, volume * metric.inv(), 1 / volume)
+
+
+def torus_objects(
+    mass: sp.Expr,
+    field_c: dict[int, sp.Expr],
+    volume: sp.Expr,
+    half_time: int,
+    boundary_sign: int,
+    spatial_extent: int = LX,
+) -> tuple[sp.Matrix, sp.Matrix, object]:
+    """Build the exact Dirac--Kahler Q, reflection P, and torus site map."""
+    size = 2 * half_time * spatial_extent
+
+    def site_index(time_value: int, space: int) -> int:
+        return ((time_value + half_time) % (2 * half_time)) * spatial_extent + (
+            space % spatial_extent
+        )
+
+    def temporal_hop_sign(target_time_raw: int) -> sp.Integer:
+        return sp.Integer(
+            boundary_sign
+            if target_time_raw >= half_time or target_time_raw < -half_time
+            else 1
+        )
+
+    staggered = sp.zeros(size, size)
+    for time_value in range(-half_time, half_time):
+        for space in range(spatial_extent):
+            index = site_index(time_value, space)
+            staggered[index, index] += mass
+            staggered[index, site_index(time_value + 1, space)] += (
+                sp.Rational(1, 2) * temporal_hop_sign(time_value + 1)
+            )
+            staggered[index, site_index(time_value - 1, space)] += (
+                -sp.Rational(1, 2) * temporal_hop_sign(time_value - 1)
+            )
+            staggered[index, site_index(time_value, space + 1)] += (
+                parity(time_value) * sp.Rational(1, 2)
+            )
+            staggered[index, site_index(time_value, space - 1)] += (
+                -parity(time_value) * sp.Rational(1, 2)
+            )
+
+    degrees = {
+        site_index(time_value, space): (time_value % 2) + (space % 2)
+        for time_value in range(-half_time, half_time)
+        for space in range(spatial_extent)
+    }
+    kernel = staggered - mass * sp.eye(size)
+    raising_kernel = sp.zeros(size, size)
+    for row in range(size):
+        for column in range(size):
+            if kernel[row, column] != 0 and degrees[row] == degrees[column] + 1:
+                raising_kernel[row, column] = kernel[row, column]
+    differential = -I * raising_kernel
+
+    hodge = sp.zeros(size, size)
+    for anchor_time in range(-half_time, half_time):
+        for anchor_space in range(spatial_extent):
+            block = h_site(field_c[anchor_time], volume)
+            for row_offset, (row_time, row_space) in enumerate(OFFSETS):
+                for column_offset, (column_time, column_space) in enumerate(OFFSETS):
+                    if block[row_offset, column_offset] == 0:
+                        continue
+                    hodge[
+                        site_index(anchor_time + row_time, anchor_space + row_space),
+                        site_index(
+                            anchor_time + column_time, anchor_space + column_space
+                        ),
+                    ] += block[row_offset, column_offset] / 4
+
+    operator = mass * hodge + I * (
+        hodge * differential + differential.H * hodge
+    )
+    reflection = sp.zeros(size, size)
+    for time_value in range(-half_time, half_time):
+        for space in range(spatial_extent):
+            reflection[
+                site_index(-1 - time_value, space), site_index(time_value, space)
+            ] = 1
+    return operator, reflection, site_index
+
+
+def step_profile(half_time: int, shear: sp.Expr) -> dict[int, sp.Expr]:
+    return {
+        time_value: (
+            sp.Integer(0)
+            if time_value in (-1, half_time - 1)
+            else (shear if time_value >= 0 else -shear)
+        )
+        for time_value in range(-half_time, half_time)
+    }
+
+
+def spatial_factors() -> tuple[sp.Matrix, ...]:
+    cyclic_shift = sp.zeros(LX, LX)
+    for space in range(LX):
+        cyclic_shift[(space + 1) % LX, space] = 1
+    return (
+        sp.eye(LX),
+        sp.diag(*(parity(space) for space in range(LX))),
+        cyclic_shift + cyclic_shift.T,
+        cyclic_shift - cyclic_shift.T,
+    )
+
+
+@dataclass(frozen=True)
+class Fixture:
+    shear: sp.Rational
+    propagator: sp.Matrix
+    reflection: sp.Matrix
+    site_index: object
+    window: tuple[int, ...]
+    positive: tuple[int, ...]
+    reflected: tuple[int, ...]
+    raw_gram: sp.Matrix
+
+
+def history_gram(
+    propagator: sp.Matrix,
+    positive: tuple[int, ...] | list[int],
+    reflected: tuple[int, ...] | list[int],
+) -> sp.Matrix:
+    return sp.Matrix(
+        len(positive),
+        len(reflected),
+        lambda row, column: sp.conjugate(
+            propagator[positive[row], reflected[column]]
+        ),
+    )
+
+
+def fixture_data(shear: sp.Rational) -> Fixture:
+    operator, reflection, site_index = torus_objects(
+        sp.Rational(9, 20),
+        step_profile(TT, shear),
+        sp.Integer(1),
+        TT,
+        -1,
+    )
+    propagator = operator.inv(method="DM")
+    window = tuple(
+        site_index(time_value, space)
+        for time_value in WINDOW_TIMES
+        for space in range(LX)
+    )
+    positive = tuple(
+        site_index(time_value, space)
+        for time_value in POSITIVE_TIMES
+        for space in range(LX)
+    )
+    reflected = tuple(
+        site_index(-1 - time_value, space)
+        for time_value in POSITIVE_TIMES
+        for space in range(LX)
+    )
+    raw_gram = history_gram(propagator, positive, reflected)
+    return Fixture(
+        shear,
+        propagator,
+        reflection,
+        site_index,
+        window,
+        positive,
+        reflected,
+        raw_gram,
+    )
+
+
+def parameter_index(
+    slice_i: int, slice_j: int, factor_index: int, imaginary: int
+) -> int:
+    """Factor/block/real-imag order on all eight torus slices."""
+    return 2 * (4 * (8 * slice_i + slice_j) + factor_index) + imaginary
+
+
+def global_labels() -> tuple[tuple[int, int, int, str], ...]:
+    return tuple(
+        (slice_i, slice_j, factor_index, part)
+        for slice_i in range(8)
+        for slice_j in range(8)
+        for factor_index in range(4)
+        for part in ("re", "im")
+    )
+
+
+def reality_permutation_certificate(mutation: str) -> dict[str, object]:
+    labels = global_labels()
+    label_to_index = {label: index for index, label in enumerate(labels)}
+    targets: list[int] = []
+    signs: list[int] = []
+    for slice_i, slice_j, factor_index, part in labels:
+        targets.append(
+            label_to_index[(7 - slice_i, 7 - slice_j, factor_index, part)]
+        )
+        signs.append(-1 if part == "im" else 1)
+    if mutation == "break_reality_permutation":
+        targets[0] = 0
+    involutive = all(
+        targets[targets[index]] == index
+        and signs[index] * signs[targets[index]] == 1
+        for index in range(512)
+    )
+    fixed_points = tuple(
+        index for index, target in enumerate(targets) if index == target
+    )
+    return {
+        "basis_count": len(labels),
+        "signed_basis_map": len(set(targets)) == 512
+        and all(abs(sign) == 1 for sign in signs),
+        "involutive": involutive,
+        "fixed_points": fixed_points,
+        "cycle_count": len(labels) // 2,
+    }
+
+
+def reality_system() -> tuple[sp.Matrix, sp.Matrix]:
+    """Return reality equations and a 256-column exact kernel basis."""
+    rows: list[list[int]] = []
+    transform_columns: list[list[int]] = []
+    seen: set[tuple[int, int]] = set()
+    for slice_i in range(8):
+        for slice_j in range(8):
+            reflected_i, reflected_j = 7 - slice_i, 7 - slice_j
+            for factor_index in range(4):
+                real_row = [0] * 512
+                imaginary_row = [0] * 512
+                real_row[parameter_index(slice_i, slice_j, factor_index, 0)] += 1
+                real_row[
+                    parameter_index(reflected_i, reflected_j, factor_index, 0)
+                ] -= 1
+                imaginary_row[
+                    parameter_index(slice_i, slice_j, factor_index, 1)
+                ] += 1
+                imaginary_row[
+                    parameter_index(reflected_i, reflected_j, factor_index, 1)
+                ] += 1
+                rows.extend((real_row, imaginary_row))
+            if (slice_i, slice_j) in seen:
+                continue
+            seen.add((slice_i, slice_j))
+            seen.add((reflected_i, reflected_j))
+            for factor_index in range(4):
+                for imaginary, reflected_sign in ((0, 1), (1, -1)):
+                    column = [0] * 512
+                    column[
+                        parameter_index(slice_i, slice_j, factor_index, imaginary)
+                    ] = 1
+                    column[
+                        parameter_index(
+                            reflected_i, reflected_j, factor_index, imaginary
+                        )
+                    ] = reflected_sign
+                    transform_columns.append(column)
+    reality = sp.Matrix(rows)
+    transform = sp.Matrix(
+        512, 256, lambda row, column: transform_columns[column][row]
+    )
+    return reality, transform
+
+
+def global_hermiticity_matrix(fixture: Fixture) -> sp.Matrix:
+    """The 16^2 real equations for K_A=K_A^H in 512 real coordinates.
+
+    The convention is the Block 108 left placement
+    ``K_A[r,s]=conjugate((A G)[positive[r], reflected[s]])``.
+    """
+    if not all(sp.im(value) == 0 for value in fixture.propagator):
+        raise AssertionError("the exact fixture propagator must be real")
+    factors = spatial_factors()
+    base_rows: dict[tuple[int, int, int, int], tuple[sp.Expr, ...]] = {}
+    for positive_row in range(16):
+        slice_i = 4 + positive_row // 4
+        space_i = positive_row % 4
+        for slice_j in range(8):
+            for factor_index, factor in enumerate(factors):
+                values = []
+                for reflected_column in range(16):
+                    value = sum(
+                        factor[space_i, space_j]
+                        * fixture.propagator[
+                            4 * slice_j + space_j,
+                            fixture.reflected[reflected_column],
+                        ]
+                        for space_j in range(4)
+                    )
+                    values.append(sp.cancel(value))
+                base_rows[(slice_i, slice_j, factor_index, positive_row)] = tuple(
+                    values
+                )
+
+    rows: list[list[sp.Expr]] = []
+    for row in range(16):
+        diagonal_equation = [sp.Integer(0)] * 512
+        slice_i = 4 + row // 4
+        for slice_j in range(8):
+            for factor_index in range(4):
+                coordinate = parameter_index(slice_i, slice_j, factor_index, 1)
+                diagonal_equation[coordinate] = -base_rows[
+                    (slice_i, slice_j, factor_index, row)
+                ][row]
+        rows.append(diagonal_equation)
+
+        for column in range(row + 1, 16):
+            real_equation = [sp.Integer(0)] * 512
+            imaginary_equation = [sp.Integer(0)] * 512
+            row_slice = 4 + row // 4
+            column_slice = 4 + column // 4
+            for slice_j in range(8):
+                for factor_index in range(4):
+                    row_base = base_rows[
+                        (row_slice, slice_j, factor_index, row)
+                    ][column]
+                    column_base = base_rows[
+                        (column_slice, slice_j, factor_index, column)
+                    ][row]
+                    real_equation[
+                        parameter_index(row_slice, slice_j, factor_index, 0)
+                    ] += row_base
+                    real_equation[
+                        parameter_index(column_slice, slice_j, factor_index, 0)
+                    ] -= column_base
+                    imaginary_equation[
+                        parameter_index(row_slice, slice_j, factor_index, 1)
+                    ] -= row_base
+                    imaginary_equation[
+                        parameter_index(column_slice, slice_j, factor_index, 1)
+                    ] -= column_base
+            rows.extend((real_equation, imaginary_equation))
+    return sp.Matrix(rows)
+
+
+@dataclass(frozen=True)
+class GlobalLinearCertificate:
+    hermiticity: sp.Matrix
+    hermiticity_rank_on_reality: int
+    joint_rank: int
+    dimension: int
+
+
+def global_linear_certificate(
+    fixture: Fixture, transform: sp.Matrix
+) -> GlobalLinearCertificate:
+    hermiticity = global_hermiticity_matrix(fixture)
+    reduced = hermiticity * transform
+    reduced_rank = exact_rank(reduced)
+    return GlobalLinearCertificate(
+        hermiticity,
+        reduced_rank,
+        256 + reduced_rank,
+        256 - reduced_rank,
+    )
+
+
+def coordinates_to_matrix(coordinates: sp.Matrix) -> sp.Matrix:
+    if coordinates.shape != (512, 1):
+        raise ValueError("global coordinate vector must be 512x1")
+    factors = spatial_factors()
+    result = sp.zeros(SIZE, SIZE)
+    for slice_i in range(8):
+        for slice_j in range(8):
+            block = sp.zeros(4, 4)
+            for factor_index, factor in enumerate(factors):
+                coefficient = (
+                    coordinates[parameter_index(slice_i, slice_j, factor_index, 0)]
+                    + I
+                    * coordinates[
+                        parameter_index(slice_i, slice_j, factor_index, 1)
+                    ]
+                )
+                if coefficient != 0:
+                    block += coefficient * factor
+            result[
+                4 * slice_i : 4 * (slice_i + 1),
+                4 * slice_j : 4 * (slice_j + 1),
+            ] = block
+    return result
+
+
+ASTAR_SIGNS = (1, -1, 1, -1, -1, 1, -1, 1)
+UNDRESSED_DEFECT = sp.Rational(
+    2100468154772736499016437760573154473873400000,
+    61391349876435377016600254323619839508354485363,
+)
+PRIMARY_NEGATIVE_MINOR = sp.Rational(
+    -33333963283450197824471164187210075293672388640,
+    61391349876435377016600254323619839508354485363,
+)
+SECOND_NEGATIVE_MINOR = sp.Rational(
+    -30292616102306685544040740640984160,
+    68872508036021339265532585819028911,
+)
+
+
+def global_candidate(signs: tuple[int, ...] = ASTAR_SIGNS) -> sp.Matrix:
+    """Exact anti-diagonal dressed-reflection involution A*."""
+    dressing = sp.zeros(SIZE, SIZE)
+    spatial_parity = spatial_factors()[1]
+    for slice_i, sign in enumerate(signs):
+        slice_j = 7 - slice_i
+        dressing[
+            4 * slice_i : 4 * (slice_i + 1),
+            4 * slice_j : 4 * (slice_j + 1),
+        ] = sign * spatial_parity
+    return dressing
+
+
+def astar_ambient_coordinates(signs: tuple[int, ...] = ASTAR_SIGNS) -> sp.Matrix:
+    coordinates = sp.zeros(512, 1)
+    for slice_i, sign in enumerate(signs):
+        coordinates[parameter_index(slice_i, 7 - slice_i, 1, 0)] = sign
+    return coordinates
+
+
+def dressed_gram(dressing: sp.Matrix, fixture: Fixture) -> sp.Matrix:
+    return history_gram(
+        dressing * fixture.propagator,
+        fixture.positive,
+        fixture.reflected,
+    )
+
+
+def leading_minors(matrix: sp.Matrix) -> tuple[sp.Expr, ...]:
+    return tuple(
+        sp.factor(matrix[:size, :size].det(method="domain-ge"))
+        for size in range(1, matrix.rows + 1)
+    )
+
+
+def inertia_from_nonzero_leading_minors(
+    minors: tuple[sp.Expr, ...]
+) -> tuple[int, int, int]:
+    previous = sp.Integer(1)
+    positive = 0
+    negative = 0
+    for minor in minors:
+        if minor == 0:
+            raise AssertionError("leading-minor inertia certificate is singular")
+        pivot = sp.factor(minor / previous)
+        positive += int(bool(pivot > 0))
+        negative += int(bool(pivot < 0))
+        previous = minor
+    return positive, negative, 0
+
+
+def leading_sign_changes(minors: tuple[sp.Expr, ...]) -> int:
+    signs = [1] + [1 if minor > 0 else -1 for minor in minors]
+    return sum(left != right for left, right in zip(signs, signs[1:]))
+
+
+@dataclass(frozen=True)
+class AstarCertificate:
+    matrix: sp.Matrix
+    gram: sp.Matrix
+    leading: tuple[sp.Expr, ...]
+    inertia: tuple[int, int, int]
+    selected_reality: bool
+    selected_hermiticity: bool
+    selected_involution: bool
+    sign_symmetry: bool
+    sign_products: bool
+    expected_inertia: tuple[int, int, int]
+
+
+def astar_certificate(fixture: Fixture, mutation: str) -> AstarCertificate:
+    canonical = global_candidate()
+    gram = dressed_gram(canonical, fixture)
+    leading = leading_minors(gram)
+    inertia = inertia_from_nonzero_leading_minors(leading)
+
+    selected_signs = list(ASTAR_SIGNS)
+    if mutation == "break_astar_signs":
+        selected_signs[0] *= -1
+    selected = global_candidate(tuple(selected_signs))
+    selected_gram = dressed_gram(selected, fixture)
+    expected_inertia = (
+        (16, 0, 0) if mutation == "claim_astar_positive" else (8, 8, 0)
+    )
+    return AstarCertificate(
+        canonical,
+        gram,
+        leading,
+        inertia,
+        matrix_equal(
+            fixture.reflection * selected.conjugate() * fixture.reflection,
+            selected,
+        ),
+        matrix_equal(selected_gram, selected_gram.H),
+        matrix_equal(selected * selected, sp.eye(SIZE)),
+        all(selected_signs[index] == selected_signs[7 - index] for index in range(8)),
+        all(
+            selected_signs[index] * selected_signs[7 - index] == 1
+            for index in range(8)
+        ),
+        expected_inertia,
+    )
+
+
+def anti_diagonal_embedding() -> sp.Matrix:
+    embedding = sp.zeros(512, 64)
+    for slice_i in range(8):
+        slice_j = 7 - slice_i
+        for factor_index in range(4):
+            for imaginary in (0, 1):
+                local = 8 * slice_i + 2 * factor_index + imaginary
+                embedding[
+                    parameter_index(slice_i, slice_j, factor_index, imaginary),
+                    local,
+                ] = 1
+    return embedding
+
+
+def matrix_block(matrix: sp.Matrix, slice_i: int, slice_j: int) -> sp.Matrix:
+    return matrix[
+        4 * slice_i : 4 * (slice_i + 1),
+        4 * slice_j : 4 * (slice_j + 1),
+    ]
+
+
+def monic_nonzero_entries(
+    matrix: sp.Matrix, variable: sp.Symbol
+) -> tuple[sp.Expr, ...]:
+    polynomials: dict[str, sp.Expr] = {}
+    for entry in matrix:
+        expanded = sp.expand(entry)
+        if expanded == 0:
+            continue
+        monic = sp.Poly(expanded, variable, domain=sp.QQ).monic().as_expr()
+        polynomials[sp.srepr(monic)] = monic
+    return tuple(polynomials.values())
+
+
+def involution_groebner_certificate(
+    generator: sp.Matrix,
+) -> tuple[tuple[sp.Expr, ...], tuple[tuple[sp.Expr], ...], bool]:
+    lam = sp.Symbol("lambda", real=True)
+    pair_bases: list[sp.Expr] = []
+    every_pair_reduces = True
+    for slice_i in range(4):
+        slice_j = 7 - slice_i
+        left = matrix_block(lam * generator, slice_i, slice_j)
+        right = matrix_block(lam * generator, slice_j, slice_i)
+        equations = monic_nonzero_entries(
+            (left * right - sp.eye(4)).col_join(right * left - sp.eye(4)),
+            lam,
+        )
+        pair_groebner = sp.groebner(equations, lam, order="lex", domain=sp.QQ)
+        basis = tuple(poly.monic().as_expr() for poly in pair_groebner.polys)
+        every_pair_reduces &= basis == (lam**2 - 1,)
+        pair_bases.extend(basis)
+    total = sp.groebner(pair_bases, lam, order="lex", domain=sp.QQ)
+    total_basis = tuple(poly.monic().as_expr() for poly in total.polys)
+    solutions = tuple(sp.solve_poly_system(total_basis, lam))
+    return total_basis, solutions, every_pair_reduces and total.is_zero_dimensional
+
+
+@dataclass(frozen=True)
+class AntiDiagonalCertificate:
+    reality_rank: int
+    primary_h_rank: int
+    second_h_rank: int
+    primary_joint_rank: int
+    second_joint_rank: int
+    generator_member_both: bool
+    parametrization_exact: bool
+    groebner_basis: tuple[sp.Expr, ...]
+    expected_groebner_basis: tuple[sp.Expr, ...]
+    solutions: tuple[tuple[sp.Expr], ...]
+    pair_reduction: bool
+    primary_minus_inertia: tuple[int, int, int]
+    second_plus_inertia: tuple[int, int, int]
+    second_minus_inertia: tuple[int, int, int]
+    pinned_negative_minors: bool
+    both_branches_indefinite: bool
+    expected_disjoint: bool
+
+
+def anti_diagonal_certificate(
+    primary: Fixture,
+    second: Fixture,
+    reality: sp.Matrix,
+    primary_linear: GlobalLinearCertificate,
+    second_linear: GlobalLinearCertificate,
+    astar: AstarCertificate,
+    mutation: str,
+) -> AntiDiagonalCertificate:
+    embedding = anti_diagonal_embedding()
+    restricted_reality = reality * embedding
+    primary_h = primary_linear.hermiticity * embedding
+    second_h = second_linear.hermiticity * embedding
+    primary_joint = restricted_reality.col_join(primary_h)
+    second_joint = restricted_reality.col_join(second_h)
+    local_generator = sp.zeros(64, 1)
+    for slice_i, sign in enumerate(ASTAR_SIGNS):
+        local_generator[8 * slice_i + 2] = sign
+    ambient_generator = embedding * local_generator
+    generator = coordinates_to_matrix(ambient_generator)
+    total_basis, solutions, pair_reduction = involution_groebner_certificate(
+        generator
+    )
+    expected_basis = (
+        (sp.Symbol("lambda", real=True) ** 2 + 1,)
+        if mutation == "break_groebner_reduction"
+        else (sp.Symbol("lambda", real=True) ** 2 - 1,)
+    )
+
+    primary_minus_leading = tuple(
+        (-1) ** size * minor for size, minor in enumerate(astar.leading, start=1)
+    )
+    primary_minus_inertia = inertia_from_nonzero_leading_minors(
+        primary_minus_leading
+    )
+    second_plus_gram = dressed_gram(generator, second)
+    second_plus_leading = leading_minors(second_plus_gram)
+    second_plus_inertia = inertia_from_nonzero_leading_minors(second_plus_leading)
+    second_minus_leading = tuple(
+        (-1) ** size * minor
+        for size, minor in enumerate(second_plus_leading, start=1)
+    )
+    second_minus_inertia = inertia_from_nonzero_leading_minors(
+        second_minus_leading
+    )
+    both_indefinite = all(
+        inertia == (8, 8, 0)
+        for inertia in (
+            astar.inertia,
+            primary_minus_inertia,
+            second_plus_inertia,
+            second_minus_inertia,
+        )
+    )
+    pinned_negative = (
+        astar.gram[0, 0] == PRIMARY_NEGATIVE_MINOR
+        and any(
+            second_plus_gram[index, index] == SECOND_NEGATIVE_MINOR
+            for index in range(16)
+        )
+        and any(-astar.gram[index, index] < 0 for index in range(16))
+        and any(-second_plus_gram[index, index] < 0 for index in range(16))
+    )
+    return AntiDiagonalCertificate(
+        exact_rank(restricted_reality),
+        exact_rank(primary_h),
+        exact_rank(second_h),
+        exact_rank(primary_joint),
+        exact_rank(second_joint),
+        matrix_equal(primary_joint * local_generator, sp.zeros(primary_joint.rows, 1))
+        and matrix_equal(
+            second_joint * local_generator, sp.zeros(second_joint.rows, 1)
+        ),
+        matrix_equal(generator, global_candidate()),
+        total_basis,
+        expected_basis,
+        solutions,
+        pair_reduction,
+        primary_minus_inertia,
+        second_plus_inertia,
+        second_minus_inertia,
+        pinned_negative,
+        both_indefinite,
+        mutation != "claim_antidiagonal_positive",
+    )
+
+
+def undressed_certificate(fixture: Fixture, mutation: str) -> dict[str, object]:
+    identity = sp.eye(SIZE)
+    gram = dressed_gram(identity, fixture)
+    excluded = not matrix_equal(gram, gram.H)
+    expected_excluded = mutation != "claim_undressed_included"
+    return {
+        "reality": matrix_equal(
+            fixture.reflection * identity.conjugate() * fixture.reflection,
+            identity,
+        ),
+        "excluded": excluded,
+        "expected_excluded": expected_excluded,
+        "defect": sp.factor(max_abs_entry(gram - gram.H)),
+    }
+
+
+# Exact real coefficients of the pinned K_A=I16 representative.  The order is
+# output-positive-slice/source-slice/spatial-factor; each coefficient's paired
+# imaginary coordinate is pinned to zero, giving a 256-real-coordinate vector.
+POSITIVE_FIBER_REAL_COEFFICIENTS = (
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(-601, 1152),
+    sp.Rational(0, 1),
+    sp.Rational(13, 512),
+    sp.Rational(-13, 512),
+    sp.Rational(601, 1280),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(601, 1152),
+    sp.Rational(601, 1152),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(-65, 1152),
+    sp.Rational(65, 1152),
+    sp.Rational(-313, 576),
+    sp.Rational(0, 1),
+    sp.Rational(13, 512),
+    sp.Rational(-13, 512),
+    sp.Rational(313, 640),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(-21, 32),
+    sp.Rational(601, 1152),
+    sp.Rational(0, 1),
+    sp.Rational(13, 512),
+    sp.Rational(13, 512),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(65, 2304),
+    sp.Rational(65, 2304),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(-313, 576),
+    sp.Rational(0, 1),
+    sp.Rational(13, 512),
+    sp.Rational(-13, 512),
+    sp.Rational(313, 640),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(313, 576),
+    sp.Rational(313, 576),
+    sp.Rational(0, 1),
+    sp.Rational(13, 512),
+    sp.Rational(13, 512),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(436809039108148887533657557, 804232781120185338452680960),
+    sp.Rational(0, 1),
+    sp.Rational(
+        -274883293329205100057146567350659375,
+        11729321357571487073092949075073000096,
+    ),
+    sp.Rational(
+        -33553212886792720271322184503961802111,
+        50472385359755030117824566557535388992,
+    ),
+    sp.Rational(313, 576),
+    sp.Rational(0, 1),
+    sp.Rational(13, 512),
+    sp.Rational(13, 512),
+    sp.Rational(250275225864092239893875, 20105819528004633461317024),
+    sp.Rational(0, 1),
+    sp.Rational(46696418743926259989987865, 482539668672111203071608576),
+    sp.Rational(23270527433258866903237225, 1447619006016333609214825728),
+    sp.Rational(540061969291618982716173449, 723809503008166804607412864),
+    sp.Rational(0, 1),
+    sp.Rational(2314083242220299018095675, 40211639056009266922634048),
+    sp.Rational(2314083242220299018095675, 40211639056009266922634048),
+    sp.Rational(-25026612019895715356918807, 25132274410005791826646280),
+    sp.Rational(0, 1),
+    sp.Rational(
+        -1093045962325603246948958346437854715,
+        11729321357571487073092949075073000096,
+    ),
+    sp.Rational(
+        19286823944372851229685807615056984221,
+        25236192679877515058912283278767694496,
+    ),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+    sp.Rational(0, 1),
+)
+POSITIVE_FIBER_PARAMETER_VECTOR = tuple(
+    coordinate
+    for real_coordinate in POSITIVE_FIBER_REAL_COEFFICIENTS
+    for coordinate in (real_coordinate, sp.Integer(0))
+)
+
+
+def positive_fiber_mapping(fixture: Fixture) -> tuple[sp.Matrix, sp.Matrix]:
+    factors = spatial_factors()
+    mapping = sp.zeros(64, 32)
+    right_hand_side = sp.zeros(64, 4)
+    for space in range(4):
+        for column, reflected_index in enumerate(fixture.reflected):
+            row = 16 * space + column
+            for output_slice in range(4):
+                right_hand_side[row, output_slice] = int(
+                    4 * output_slice + space == column
+                )
+            for slice_j in range(8):
+                for factor_index, factor in enumerate(factors):
+                    mapping[row, 4 * slice_j + factor_index] = sum(
+                        factor[space, source_space]
+                        * fixture.propagator[
+                            4 * slice_j + source_space, reflected_index
+                        ]
+                        for source_space in range(4)
+                    )
+    return mapping, right_hand_side
+
+
+@dataclass(frozen=True)
+class PositiveFiberCertificate:
+    mapping_rank: int
+    rank: int
+    augmented_rank: int
+    dimension: int
+    expected_dimension: int
+    parameter_count: int
+    reality: bool
+    representative_exact: bool
+    square_defect_rank: int
+
+
+def positive_fiber_certificate(
+    fixture: Fixture, mutation: str
+) -> PositiveFiberCertificate:
+    mapping, right_hand_side = positive_fiber_mapping(fixture)
+    mapping_rank = exact_rank(mapping)
+    local_augmented_rank = exact_rank(mapping.row_join(right_hand_side))
+    full_rank = 8 * mapping_rank
+    full_augmented_rank = (
+        full_rank if local_augmented_rank == mapping_rank else full_rank + 1
+    )
+    coefficients = list(POSITIVE_FIBER_REAL_COEFFICIENTS)
+    if mutation == "break_fiber_representative":
+        coefficients[0] += 1
+
+    factors = spatial_factors()
+    positive_half = sp.zeros(SIZE, SIZE)
+    offset = 0
+    for output_slice in range(4):
+        slice_i = 4 + output_slice
+        for slice_j in range(8):
+            block = sp.zeros(4, 4)
+            for factor in factors:
+                block += coefficients[offset] * factor
+                offset += 1
+            positive_half[
+                4 * slice_i : 4 * (slice_i + 1),
+                4 * slice_j : 4 * (slice_j + 1),
+            ] = block
+    matrix = (
+        positive_half
+        + fixture.reflection * positive_half.conjugate() * fixture.reflection
+    )
+    gram = dressed_gram(matrix, fixture)
+    return PositiveFiberCertificate(
+        mapping_rank,
+        full_rank,
+        full_augmented_rank,
+        256 - full_rank,
+        36 if mutation == "claim_fiber_dim_36" else 72,
+        len(POSITIVE_FIBER_PARAMETER_VECTOR),
+        matrix_equal(
+            fixture.reflection * matrix.conjugate() * fixture.reflection,
+            matrix,
+        ),
+        matrix_equal(gram, sp.eye(16)),
+        exact_rank(matrix * matrix - sp.eye(SIZE)),
+    )
+
+
+def block107_homogeneous_window_system(fixture: Fixture) -> sp.Matrix:
+    raw = history_gram(
+        fixture.propagator, fixture.positive[:8], fixture.reflected[:8]
+    )
+    basis: list[sp.Matrix] = []
+    for slice_i in range(2):
+        for slice_j in range(2):
+            for factor in spatial_factors():
+                for scalar in (sp.Integer(1), I):
+                    item = sp.zeros(8, 8)
+                    item[
+                        4 * slice_i : 4 * (slice_i + 1),
+                        4 * slice_j : 4 * (slice_j + 1),
+                    ] = scalar * factor
+                    basis.append(item)
+
+    rows: list[list[sp.Expr]] = []
+    for row in range(8):
+        diagonal_row: list[sp.Expr] = []
+        for item in basis:
+            _, imaginary = sp.expand_complex((item * raw)[row, row]).as_real_imag()
+            diagonal_row.append(sp.expand(imaginary))
+        rows.append(diagonal_row)
+        for column in range(row + 1, 8):
+            real_row: list[sp.Expr] = []
+            imaginary_row: list[sp.Expr] = []
+            for item in basis:
+                product = item * raw
+                difference = sp.expand(
+                    product[row, column] - sp.conjugate(product[column, row])
+                )
+                real, imaginary = sp.expand_complex(difference).as_real_imag()
+                real_row.append(sp.expand(real))
+                imaginary_row.append(sp.expand(imaginary))
+            rows.extend((real_row, imaginary_row))
+    return sp.Matrix(rows)
+
+
+def window_invisibility_certificate(
+    fixture: Fixture, dressing: sp.Matrix, mutation: str
+) -> dict[str, object]:
+    central_indices = fixture.positive[:8]
+    central_block = dressing.extract(central_indices, central_indices)
+    central_zero = matrix_equal(central_block, sp.zeros(8, 8))
+    homogeneous = block107_homogeneous_window_system(fixture)
+    zero_coordinates = sp.zeros(32, 1)
+    claimed_zero = False if mutation == "claim_window_visible" else central_zero
+    return {
+        "central_zero": claimed_zero,
+        "homogeneous_rank": exact_rank(homogeneous),
+        "homogeneous_dimension": 32 - exact_rank(homogeneous),
+        "zero_member": matrix_equal(
+            homogeneous * zero_coordinates, sp.zeros(homogeneous.rows, 1)
+        ),
+    }
+
+
+def support_certificate(mutation: str) -> dict[str, object]:
+    signs = list(ASTAR_SIGNS)
+    dressing = global_candidate()
+    if mutation == "break_astar_support":
+        dressing[0:4, 28:32] = sp.zeros(4, 4)
+        signs[0] = 0
+    occupied = tuple(
+        (slice_i, slice_j)
+        for slice_i in range(8)
+        for slice_j in range(8)
+        if not matrix_equal(
+            matrix_block(dressing, slice_i, slice_j), sp.zeros(4, 4)
+        )
+    )
+    magnitudes = {
+        sp.Abs(entry) for entry in dressing if sp.expand(entry) != 0
+    }
+    spatial_parity = spatial_factors()[1]
+    parity_blocks = all(
+        matrix_equal(
+            matrix_block(dressing, slice_i, 7 - slice_i),
+            signs[slice_i] * spatial_parity,
+        )
+        for slice_i in range(8)
+    )
+    return {
+        "occupied": occupied,
+        "row_slices": {slice_i for slice_i, _ in occupied},
+        "column_slices": {slice_j for _, slice_j in occupied},
+        "magnitudes": magnitudes,
+        "parity_blocks": parity_blocks,
+    }
+
+
+SCOPE_KEYS = (
+    "global_feasibility",
+    "involution",
+    "indefinite",
+    "positive_fiber",
+    "window_invisible",
+    "joint_variety",
+    "transporter_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity",
+    "adm",
+    "n1_n8",
+    "walls",
+    "n5_resolution",
+)
+
+
+def scope_certificate(mutation: str) -> dict[str, bool]:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return {key: False for key in SCOPE_KEYS}
+    note = " ".join(raw_note.lower().split())
+    result = {
+        "global_feasibility": "global feasibility" in note,
+        "involution": "exact involution" in note or "dressed reflection" in note,
+        "indefinite": "inertia (8,8,0)" in note or "exactly indefinite" in note,
+        "positive_fiber": "positive fiber" in note,
+        "window_invisible": (
+            "window-invisible" in note or "invisible to the central window" in note
+        ),
+        "joint_variety": (
+            "joint variety" in note or "involution and positivity" in note
+        ),
+        "transporter_boundary": "not a transporter impossibility" in note,
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": "retained-positive end-to-end theory count remains zero"
+        in note,
+        "gravity": "gravity constraint quotient remains unexecuted" in note,
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "walls": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+    if mutation == "claim_adm_link_derived":
+        result["adm"] = False
+    if mutation == "claim_curved_os_closed":
+        result["transporter_boundary"] = False
+    if mutation == "claim_axiom_amendment":
+        result["axiom"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    if mutation == "claim_obligation_retirement":
+        result["zero_retirement"] = False
+    return result
+
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "break_reality_permutation",
+    "claim_wrong_global_dim",
+    "claim_undressed_included",
+    "break_astar_signs",
+    "claim_astar_positive",
+    "break_groebner_reduction",
+    "claim_antidiagonal_positive",
+    "claim_fiber_dim_36",
+    "break_fiber_representative",
+    "claim_window_visible",
+    "break_astar_support",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_adm_link_derived",
+    "claim_curved_os_closed",
+    "claim_axiom_amendment",
+    "claim_toe_progress",
+    "claim_obligation_retirement",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    checks.check(
+        "A-authority-and-Block108-parent",
+        "current axioms, registries, ancestry, and the Block108 parent triple are content-bound",
+        authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and authority["ancestor_107"]
+        and authority["ancestor_106"]
+        and authority["ancestor_105"]
+        and authority["ancestor_104"]
+        and authority["ancestor_103"]
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB,
+    )
+
+    primary = fixture_data(sp.Rational(5, 13))
+    second = fixture_data(sp.Rational(3, 5))
+    permutation = reality_permutation_certificate(mutation)
+    reality, transform = reality_system()
+    primary_linear = global_linear_certificate(primary, transform)
+    second_linear = global_linear_certificate(second, transform)
+    expected_dimension = 66 if mutation == "claim_wrong_global_dim" else 132
+    checks.check(
+        "B-global-feasibility",
+        "the fixed-point-free reality permutation gives rank 256 and both fixtures give rank 380",
+        permutation["basis_count"] == 512
+        and permutation["signed_basis_map"]
+        and permutation["involutive"]
+        and permutation["fixed_points"] == ()
+        and permutation["cycle_count"] == 256
+        and matrix_equal(reality * transform, sp.zeros(512, 256))
+        and exact_rank(transform) == 256
+        and primary_linear.hermiticity_rank_on_reality == 124
+        and second_linear.hermiticity_rank_on_reality == 124
+        and primary_linear.joint_rank == second_linear.joint_rank == 380
+        and primary_linear.dimension
+        == second_linear.dimension
+        == expected_dimension,
+        f"reality/H/joint/dim=256/124/380/{primary_linear.dimension} at c=5/13 and c=3/5",
+    )
+
+    undressed = undressed_certificate(primary, mutation)
+    checks.check(
+        "C-undressed-exclusion",
+        "A=I obeys reality but its pinned Block108 defect excludes it from the joint space",
+        undressed["reality"]
+        and undressed["excluded"] == undressed["expected_excluded"]
+        and undressed["defect"] == UNDRESSED_DEFECT,
+    )
+
+    astar = astar_certificate(primary, mutation)
+    checks.check(
+        "D-exact-involution-A-star",
+        "A* is an exact real dressed reflection with Hermitian Gram and inertia (8,8,0)",
+        astar.selected_reality
+        and astar.selected_hermiticity
+        and astar.selected_involution
+        and astar.sign_symmetry
+        and astar.sign_products
+        and len(astar.leading) == 16
+        and all(minor != 0 for minor in astar.leading)
+        and astar.inertia == astar.expected_inertia
+        and leading_sign_changes(astar.leading) == 8
+        and astar.leading[0] == PRIMARY_NEGATIVE_MINOR,
+        f"Delta1={astar.leading[0]}; inertia={astar.inertia}; sign changes=8",
+    )
+
+    anti = anti_diagonal_certificate(
+        primary,
+        second,
+        reality,
+        primary_linear,
+        second_linear,
+        astar,
+        mutation,
+    )
+    checks.check(
+        "E-anti-diagonal-classification",
+        "the 64-real anti-diagonal class is lambda A* with variety {+A*,-A*}, both indefinite",
+        anti.reality_rank == 32
+        and anti.primary_h_rank == anti.second_h_rank == 31
+        and anti.primary_joint_rank == anti.second_joint_rank == 63
+        and anti.generator_member_both
+        and anti.parametrization_exact
+        and anti.groebner_basis == anti.expected_groebner_basis
+        and anti.solutions == ((sp.Integer(-1),), (sp.Integer(1),))
+        and anti.pair_reduction
+        and anti.pinned_negative_minors
+        and anti.both_branches_indefinite
+        and anti.expected_disjoint,
+        f"rank/dim=63/1; Groebner={anti.groebner_basis}; both fixtures and branches have inertia (8,8,0)",
+    )
+
+    fiber = positive_fiber_certificate(primary, mutation)
+    checks.check(
+        "F-positive-fiber",
+        "K_A=I16 has exact rank 184 and a 72-dimensional real fiber with a pinned non-involution",
+        fiber.mapping_rank == 23
+        and fiber.rank == fiber.augmented_rank == 184
+        and fiber.dimension == fiber.expected_dimension
+        and fiber.parameter_count == 256
+        and fiber.reality
+        and fiber.representative_exact
+        and fiber.square_defect_rank == 32,
+        f"rank[M]=rank[M|b]=184; dim={fiber.dimension}; rank(A^2-I)={fiber.square_defect_rank}",
+    )
+
+    window = window_invisibility_certificate(primary, astar.matrix, mutation)
+    checks.check(
+        "G-window-invisibility",
+        "A* has zero central {0,1} window block, the zero Block107 homogeneous solution",
+        window["central_zero"]
+        and window["homogeneous_rank"] == 24
+        and window["homogeneous_dimension"] == 8
+        and window["zero_member"],
+    )
+
+    support = support_certificate(mutation)
+    checks.check(
+        "H-structure-and-support",
+        "A* occupies all eight anti-diagonal slice-blocks at magnitude one with x-parity structure",
+        support["occupied"] == tuple((index, 7 - index) for index in range(8))
+        and support["row_slices"] == set(range(8))
+        and support["column_slices"] == set(range(8))
+        and support["magnitudes"] == {sp.Integer(1)}
+        and support["parity_blocks"],
+    )
+
+    scope = scope_certificate(mutation)
+    checks.check(
+        "I-scope",
+        "the note preserves the bounded joint-variety, N1--N8, W1, N5, ADM, gravity, audit, and TOE walls",
+        all(scope.values()),
+    )
+
+    print(
+        "EXACT_WITNESSES: "
+        f"undressed_defect={undressed['defect']}; primary_Delta1={astar.leading[0]}; "
+        f"second_K88={SECOND_NEGATIVE_MINOR}"
+    )
+    print(
+        f"AXIOM_AUTHORITY: origin/main={authority['main']} axiom={CURRENT_AXIOM_BLOB} "
+        f"registry={CURRENT_REGISTRY_BLOB}; Block108 parent={PARENT_COMMIT}"
+    )
+    print(
+        "per_element: exact feasibility, involution, classification, fiber, and invisibility identities are checked"
+    )
+    print(
+        "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus"
+    )
+    print(
+        "per_mode: both shear fixtures certify the same dimensions, variety, and inertia"
+    )
+    print(
+        "per_block: the exact involution occupies every slice at magnitude one while its central window block vanishes"
+    )
+    print(
+        "lattice_wide: checked and not executed — the joint involution-positivity variety on the full 132-dimensional space, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open"
+    )
+    print(
+        "RESULT: the global dressing space is richly feasible and contains an exact window-invisible dressed-reflection involution and a positive fiber, but on the anti-diagonal class involution and positivity are exactly disjoint"
+    )
+    print(
+        "DECISION_CUT: advance the joint variety on the full global space and the modular selection; reject undressed, seam-local, and anti-diagonal-only routes"
+    )
+    print(
+        "TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- prove global feasibility: the all-slice x-covariant dressing class jointly satisfying reflection-reality and full-span two-history Hermiticity has exact rank 380 / dimension 132 at both shear fixtures (reality acts on the 512-element parameter basis as a fixed-point-free signed permutation, contributing rank 256; Hermiticity adds exact rank 124) — completing Block 108's dichotomy: seam-local empty, global richly feasible; the undressed identity is excluded
- display the exact involution `A*`: anti-diagonal reflection-pairing of slices with alternating signs times the x-parity (shear-flip) sign field — a genuine antilinear dressed reflection (`A*² = I`, reflection-real, Hermitian full-span Gram), occupying every slice at magnitude one (the Block 108 forcing realized) with an identically-zero central window block: window-invisible, which is exactly why the Block 107/108 local searches could not see it
- certify the positivity split: `±A*`'s dressed Grams have exact inertia (8,8,0) (displayed negative minors at both fixtures), while the positive fiber `K = I` is feasible with exact real dimension 72 and a displayed representative that is exactly non-involutive (rank(A² − I) = 32)
- close the anti-diagonal class completely: reality+Hermiticity reduces it to the one-parameter family `λA*`; the involution variety is exactly `{+A*, −A*}` (Gröbner basis `{λ² − 1}`); both branches exactly indefinite at both fixtures
- ship the single class-scoped wall: involution and positivity are exactly disjoint on the displayed classes; the joint variety on the full 132-dimensional space is the named open gate (not a transporter impossibility), with structured decompositions and the modular/transfer selection as the live routes

## No-Go Discipline

The committed source note carries the complete N1-N8 packet for the class-scoped wall, with the complete anti-diagonal classification as the strongest row, the pair-scan and gamma-extension families certified, and the five-resolution N5 certificate byte-identical in note and cached runner stdout.

## Validation

- primary runner: 9/9, ~66 s, exact throughout; hostile mutations 20/20, each flipping exactly one gate
- cross-model verification: global dimensions (380/132 both fixtures, via the structural reality-permutation proof), A=I exclusion, the full A* certification (reality, membership, involution, inertia (8,8,0), the exact first minor), fiber feasibility with the non-involutive representative, and window-invisibility all confirmed by the machinery-disjoint exact-Fraction checker; the checker also corrected the fiber dimension bookkeeping (72 real, not 36 complex-counted) — shipped as 72
- the anti-diagonal classification independently solved and verified (46/46 internal checks in the focused solve)
- cache: canonical envelope, status ok; vocab lint zero; audit lint --strict no errors; citation graph +1 node (out-degree 5), manifest co-lands; pipeline terminates at the pre-existing epoch-debt gate (base-identical); reviewed delta = exactly five files

## TOE accounting

Zero obligation retirement, no percentage movement, no axiom amendment, zero retained-positive end-to-end theories. Blocks 103-108 remain content-bound unaudited dependencies; expected first audit disposition conditional (dependency_not_retained). Referral for the independent audit lane.

## Execution disclosure

Supervised workhorse split (campaign mode): supervisor formulated the global system and the anti-diagonal reduction, spec'd all lanes, reviewed line-by-line, landed; exact solves and drafts by codex (`gpt-5.6-sol`, max); refutation checking on the Claude worker tier (Opus), including the fiber-dimension correction.

## Portfolio

Next gate (Block 110): the joint involution-positivity variety on the full 132-dimensional global space — structured support decompositions (mixed diagonal/anti-diagonal), wider spatial classes, and the modular/transfer selection; any positive dressed reflection then feeds the OS package and the gravity constraint quotient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
