### PR TITLE
feat(wt0oppwhy): first refused neighborhood on the #6484 opp2 split

### DIFF
--- a/docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,416 @@
+---
+claim_id: f_cut_wt1_zero_opp2_miss_mechanism_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the first neighborhood at which F_cut (0,0,1,1,1) refuses and (0,1,1,1,1) fires, on seed {(0,0,0),(0,1,1),(2,0,0)}, is reported by tick, site, and axis type. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py
+---
+
+# First Refused Neighborhood On The wt1=0 Opp2 Split Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** independent occupancy-to-lock runs from the displayed 3-site
+seed `S = {(0,0,0),(0,1,1),(2,0,0)}` on the twelve-vertex two-cube
+`{0,1,2}×{0,1}×{0,1}` with off-patch occupancy `0`. The map `f00` with
+remaining-bit tuple `(0, 0, 1, 1, 1)` does not fill `S`. The map `f10`
+with remaining-bit tuple `(0, 1, 1, 1, 1)` fills `S`. On `S`, the first
+neighborhood at which `f00=0` and `f10=1` is reported by tick, site, and
+axis type. That type is `opp2`, the remaining bit that splits the pair.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py`](../scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so `|F_cut| = 32`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, off-patch neighbors have occupancy
+`0`. Each tick, every unlocked on-patch vertex evaluates `f` on its
+six-neighbor occupancy tuple and locks if `f=1`. The process is
+synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Tick `t = 1` is the first evaluation on the seed
+occupancy.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is
+`(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 1, 1, 1)`.
+
+Write `f00` for the `F_cut` map with remaining-bit tuple `(0, 0, 1, 1, 1)`
+and `f10` for `(0, 1, 1, 1, 1)`. Both maps have `wt1=0`. They differ only
+on `opp2`. Neither map is adopted.
+
+New mechanism. Not leftover of #6486 (fill-bit only): that leftover names
+that `f10` fills `S` and `f00` misses, a pair of fill bits. This residual
+is the first refused neighborhood on that same seed.
+
+**Theorem 1.** Independent recomputation from
+
+```text
+S = {(0,0,0),(0,1,1),(2,0,0)}
+```
+
+gives lock-count history `(3, 5)` for `f00` (halt at five locks; does not
+fill) and history `(3, 6, 8, 11, 12)` for `f10` (fills). The first wave of
+`f00` is `{(0,0,1),(0,1,0)}`. The first wave of `f10` is
+`{(0,0,1),(0,1,0),(1,0,0)}`.
+
+**Theorem 2.** On that seed `S`, the first neighborhood at which `f00`
+refuses and `f10` fires is
+
+```text
+t = 1
+x = (1, 0, 0)
+axis type = opp2 = (0, 1, 2)
+```
+
+The six-neighbor occupancy is `(1, 1, 0, 0, 0, 0)`: both ends of the `x`
+axis occupied, the `y` and `z` axes empty. That is the `opp2` orbit. The
+same first event is seen on the independent `f00` run and on the
+independent `f10` run. There is one such event at that tick.
+
+**Theorem 3.** That type is `opp2`, the remaining bit that splits `f00`
+from `f10`. Display. Do not adopt opp2.
+Do not write it into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The independent f00 miss and f10 fill of S, and the first refused neighborhood on that seed (tick, site, axis type), are enumerated. opp2 is displayed, not written into Admissibility."
+trace_class: frontier_discovery
+target_claim_id: f_cut_wt1_zero_opp2_miss_mechanism
+target_blocker_text: "the first neighborhood at which f00 refuses and f10 fires, on the #6484/#6486 split seed, remains unnamed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed first refused neighborhood; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for f00 and f10 on this twelve-vertex patch with off-patch o=0 and the displayed 3-site seed; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws. Admissibility does not supply the formation site, probability, or rate.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the displayed 3-site seed `{(0,0,0),(0,1,1),(2,0,0)}`;
+- independent lock-step runs of `f00` and of `f10` from that seed.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+New mechanism. Not leftover of #6486. That leftover is fill-bit only:
+`f10` fills and `f00` misses. This residual is the first refused
+neighborhood on the same seed. It is not an `N_orb` count. The first axis
+type being `opp2` identifies the remaining bit that splits `f00` from
+`f10` and does not adopt that bit.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm that `f10` fills `S` and `f00` does not, with the
+displayed lock-count histories. Name the first `(tick, site, axis type)`
+at which `f00` refuses and `f10` fires on `S`. Display whether that type
+is `opp2`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The remaining-bit tuple is those five free bits in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f00(c)  = remaining-value of (0, 0, 1, 1, 1),
+f10(c)  = remaining-value of (0, 1, 1, 1, 1),
+f_L1(c) = 1  iff  u(c) ≥ 1.
+```
+
+So `f00` has remaining-bit tuple `(0, 0, 1, 1, 1)`, `f10` has
+`(0, 1, 1, 1, 1)`, and `f_L1` has `(1, 0, 1, 1, 1)`. The maps `f00` and
+`f10` differ only on `opp2`. Neither map is adopted.
+
+A locked set `L` determines occupancies: a lattice neighbor in `L` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `L` by
+
+```text
+L ∪ { v in two-cube \ L : f(neighborhood_6(v; L)) = 1 }.
+```
+
+An independent run of `f` from a seed is that iteration started at the
+seed and continued to a fixed point. The first refused neighborhood on a
+run is the lexicographically first unlocked site, at the earliest tick,
+whose neighborhood has `f00=0` and `f10=1`. Tick `t = 1` is the first
+evaluation on the seed occupancy.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The opp2-silent map `f00` is one element of
+`F_cut`. The unbalanced-axis map `f_L1` is a different element; it is
+not Hamming parity. On the twelve-vertex two-cube with off-patch
+occupancy `0`, independent runs from
+`S = {(0,0,0),(0,1,1),(2,0,0)}` give history `(3, 5)` for `f00` (does
+not fill) and history `(3, 6, 8, 11, 12)` for `f10` (fills).
+
+**Theorem 2.** On that seed, the first neighborhood with
+`f00(nbhd)=0` and `f10(nbhd)=1` is tick `t = 1`, site `(1, 0, 0)`,
+axis type `opp2` `= (0, 1, 2)`. The occupancy is
+`(1, 1, 0, 0, 0, 0)`.
+
+**Theorem 3.** That type is `opp2`, the bit that splits `f00` from
+`f10`. Display. Do not adopt opp2. Do not write it into
+Admissibility. The first refused neighborhood is a displayed census
+output, not a selected occupancy law.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `f00` is in `F_cut` | remaining bits `(0, 0, 1, 1, 1)`; silent on `wt1` and `opp2` and their complements |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| `f10` fills `S` | independent run from `S` fills with history `(3, 6, 8, 11, 12)` |
+| `f00` misses `S` | independent run from `S` halts with history `(3, 5)` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| first refused neighborhood | `t = 1`, site `(1, 0, 0)`, axis type `opp2` on `S` |
+| type is opp2 | first axis type is `opp2`; displayed, not adopted |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity: Hamming is a different `F_cut` map
+   (it disagrees on the two-unbalanced-axis orbit) and is not this
+   miss-neighborhood residual.
+2. Replace off-patch occupancy `0` by a blank-block: first-wave
+   candidates become undefined; that is a different census.
+3. Report only the fill bits of `f00` and `f10` on `S`: that leftover
+   is #6486 (fill-bit only), not the first refused neighborhood.
+4. Adopt `opp2` as the physical rule: the note displays the first axis
+   type and writes nothing into Admissibility.
+5. Score only the `f10` run: the theorem requires independent runs of
+   both maps from `S`.
+6. Treat a later tick as first: on `S` the first refusal is at `t = 1`
+   on the seed occupancy itself.
+7. Identify the extra with `mixed3`: both maps fire `mixed3`, so the
+   first `f00=0` and `f10=1` neighborhood cannot be `mixed3`.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover restatement of the #6486 fill-bit pair.
+- No `N_orb` count of missed seeds.
+- No adoption of `opp2` or of `wt1`.
+- No blank-block or 2-site variant as the claimed object.
+
+## No-Go Discipline Gate
+
+The only negative claim is that `f00` refuses an `opp2` neighborhood that
+`f10` fires, on the displayed 3-site seed. The first refused neighborhood
+is an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| fill reconfirm | Run `f00` and `f10` independently from `S`. | Theorem 1 and check `thm1-f10-fills-f00-misses`. | **ATTEMPTED** |
+| first refusal | Name the first `(t, x, axis type)` on `{(0,0,0),(0,1,1),(2,0,0)}`. | Theorem 2 and check `thm2-first-refusal`. | **ATTEMPTED** |
+| opp2 versus mixed3 | Ask whether that first type is opp2 or mixed3. | Theorem 3 and check `thm3-type-is-opp2`. | **ATTEMPTED** |
+| display, do not adopt | Ask whether a remaining bit is written into Admissibility. | Theorem 3 and check `thm3-display-not-adopt-opp2`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: `f00` refuses `opp2` on `S` while
+`f10` fires it. Naming the miss history and naming the first refused
+neighborhood are two certificates of that opp2-silent refusal, so they
+collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| history `(3, 5)` / first `opp2` refusal | no: a miss history does not name a neighborhood | no: one neighborhood does not give the halt history | independent exact objects |
+| first `(t,x,type)` / type-is-opp2 | yes: the type is `opp2` | no: naming the splitter bit does not name the site | collapse into the refused-axis type |
+| `f10` fills `S` / first extra lock `(1,0,0)` | no: a fill does not name the first extra site | no: one extra lock does not fill the patch | independent exact objects |
+| #6486 fill bits / this first refusal | no: fill bits do not name a tick or a type | no: this first type is `opp2` | different extras |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| displayed 3-site seed | explicit seed; a two-site miss list is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| first axis type `opp2` | displayed mechanism, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:94` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:138` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:143` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:157` | `f00` definition | remaining-bit tuple `(0, 0, 1, 1, 1)` | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:162` | `f10` definition | remaining-bit tuple `(0, 1, 1, 1, 1)` | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:53` | displayed seed | `{(0,0,0),(0,1,1),(2,0,0)}` | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:213` | independent runs | lock-step evolution from the displayed seed | yes |
+| `scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py:256` | first refused neighborhood | earliest `(tick, site, axis type)` with `f00=0` and `f10=1` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: `f00` and `f10` from the displayed seed | independent runs; `f10` fills; `f00` misses |
+| per block | yes: the first refused neighborhood | tick, site, and axis type on the displayed seed |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+No approved primitive supplies the Boolean occupancy maps, and none is
+reclassified as an import or wall. The scale-reference, kinetic-isotropy,
+and realized-state primitives are unused.
+
+One partial-closure mechanism is displayed rather than suppressed: `f00`
+does lie in `F_cut` and does fire `adj2`, `vertex3`, and `mixed3`. That
+positive member does not make `f00` fill `S` and does not write `opp2`
+into Admissibility. The remaining physical choice — which, if any,
+`F_cut` map is the Admissibility occupancy predicate — stays explicit.
+
+### N7 — hostile steelman
+
+The strongest objection is that `f00` and `f10` differ only on the
+`opp2` remaining bit, so the first neighborhood with `f00=0` and
+`f10=1` is forced to be `opp2` by the remaining-bit tuple, and naming
+it might be called leftover-character of that tuple or of the #6486
+fill-bit pair. That objection is correctly about the bit assignment
+and the fill bits. It does not overturn the stated theorem: the new
+object is the first `(tick, site, axis type)` on the displayed 3-site
+seed `f00` does not fill. Displaying `opp2` names that mechanism. No
+bit is adopted.
+
+A second steelman is that history `(3, 5)` already encodes the miss, so
+the first refused neighborhood is leftover of the miss history. The
+miss history does not name a tick, a site, or an axis type. Those three
+coordinates were unnamed.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`f00`, `f10`, the two lock histories, and the first refused neighborhood
+are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the first refused neighborhood of `f00` on
+this seed or writes `opp2` into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the independent `f10` fill of
+`S`, the independent `f00` miss, and the displayed first refused
+neighborhood stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, evaluates
+`f00` and `f10` independently from the displayed 3-site seed, reports that
+`f10` fills and `f00` misses with the displayed histories, names the first
+refused neighborhood on that seed by tick, site, and axis type, checks that
+the type is `opp2`, checks that `f_L1` is not Hamming parity, and
+does not adopt a bit. Declared audit inputs are this note and the axiom
+memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_zero_opp2_miss_mechanism_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py
+runner_sha256: 7974e3a8574214861c2d5fc6406db4b23761ef20c4df51171176702a523f7813
+input_fingerprint_sha256: 11e161735325a2f7f6c6f0b4f0bee7eea6426a19e66d6b77dd93fc5643bed2bd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+seed={(0,0,0),(0,1,1),(2,0,0)}
+f00_remaining=(0, 0, 1, 1, 1)
+f10_remaining=(0, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+hist_f00=(3, 5) fill_f00=False
+hist_f10=(3, 6, 8, 11, 12) fill_f10=True
+wave1_f00=[(0, 0, 1), (0, 1, 0)]
+wave1_f10=[(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+first_refusal=t=1 x=(1, 0, 0) type=opp2(0, 1, 2) cfg=(1, 1, 0, 0, 0, 0)
+first_axis_type_is_opp2=True
+displayed_not_adopted_bit=opp2
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f00-opp2-silent f00 is the F_cut map with remaining bits (0,0,1,1,1)
+PASS: thm1-f-L1-not-hamming f_L1 is n != 0 and is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-seed the two-cube has twelve vertices and S is the displayed 3-site seed
+PASS: thm1-f10-fills-f00-misses f10 fills S with history (3,6,8,11,12); f00 misses with history (3,5)
+PASS: thm2-first-refusal first refusal is t=1, site (1,0,0), axis type opp2
+PASS: thm3-type-is-opp2 the first axis type is opp2, the remaining bit that splits f00 from f10
+PASS: thm3-display-not-adopt-opp2 opp2 is displayed and is not adopted or written into Admissibility
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted first refusal, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-first-refusal the note reports the independent histories and the first (t, x, axis type)
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: new-mechanism-not-leftover-6486 the residual is the first refused neighborhood, not leftover of #6486 fill-bit only
+PASS: claim-scope claim_scope reports the first refused neighborhood on the displayed seed
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f00 and f10 are run independently from the displayed 3-site seed
+per_block: checked exactly — the first refused neighborhood is named by tick, site, and axis type
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py
+++ b/scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python3
+"""First refused neighborhood on the #6484/#6486 wt1=0 opp2 split seed.
+
+Independent occupancy-to-lock runs start from
+S = {(0,0,0),(0,1,1),(2,0,0)} on the twelve-vertex two-cube with
+off-patch occupancy 0.  F_cut f00 with remaining bits (0,0,1,1,1)
+misses S; F_cut f10 with remaining bits (0,1,1,1,1) fills S.
+The first (tick, site, axis-type) with f00(nbhd)=0 and f10(nbhd)=1
+is displayed, not adopted.  That type is opp2, the remaining bit
+that splits the pair.  No bit is written into Admissibility.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never
+Hamming |c|_1 mod 2.  New mechanism: the first refused neighborhood,
+not leftover of #6486 (fill-bit only).
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED: frozenset[Site] = frozenset(((0, 0, 0), (0, 1, 1), (2, 0, 0)))
+SEED_DISPLAY = "{(0,0,0),(0,1,1),(2,0,0)}"
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+AXIS_TYPE_NAME: dict[OrbitType, str] = {
+    (0, 0, 3): "empty",
+    (0, 3, 0): "full",
+    (1, 0, 2): "wt1",
+    (1, 2, 0): "wt1_comp",
+    (0, 1, 2): "opp2",
+    (0, 2, 1): "opp2_comp",
+    (2, 0, 1): "adj2",
+    (2, 1, 0): "adj2_comp",
+    (3, 0, 0): "vertex3",
+    (1, 1, 1): "mixed3",
+}
+F00_REMAINING: tuple[int, ...] = (0, 0, 1, 1, 1)
+F10_REMAINING: tuple[int, ...] = (0, 1, 1, 1, 1)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+HIST_F00: tuple[int, ...] = (3, 5)
+HIST_F10: tuple[int, ...] = (3, 6, 8, 11, 12)
+FIRST_SITE: Site = (1, 0, 0)
+FIRST_CONFIG: Config = (1, 1, 0, 0, 0, 0)
+FIRST_TYPE: OrbitType = (0, 1, 2)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (0, 0, 1, 1, 1).  Opp2-silent.  Not adopted."""
+    return remaining_value(config, F00_REMAINING)
+
+
+def f10(config: Config) -> int:
+    """F_cut remaining bits (0, 1, 1, 1, 1).  Displayed.  Not adopted."""
+    return remaining_value(config, F10_REMAINING)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_from_seed(predicate, seed: frozenset[Site], halt_bound: int = 13) -> dict:
+    locked = set(seed)
+    history = [len(locked)]
+    waves: list[frozenset[Site]] = []
+    for _tick in range(halt_bound):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            break
+        waves.append(frozenset(nxt - locked))
+        locked = nxt
+        history.append(len(locked))
+    return {
+        "fill": len(locked) == 12,
+        "history": tuple(history),
+        "locks": frozenset(locked),
+        "waves": tuple(waves),
+        "halt_tick": len(history) - 1,
+    }
+
+
+def refusal_events(locked: set[Site]) -> list[dict]:
+    rows: list[dict] = []
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        config = neighborhood(site, locked)
+        value_f00 = f00(config)
+        value_f10 = f10(config)
+        if value_f00 == 0 and value_f10 == 1:
+            kind = axis_type(config)
+            rows.append(
+                {
+                    "site": site,
+                    "config": config,
+                    "axis_type": kind,
+                    "axis_name": AXIS_TYPE_NAME[kind],
+                    "f00": value_f00,
+                    "f10": value_f10,
+                }
+            )
+    return rows
+
+
+def first_refusal(seed: frozenset[Site], predicate, halt_bound: int = 13) -> dict | None:
+    """Independent run: first (tick, site, axis-type) with f00=0 and f10=1."""
+    locked = set(seed)
+    for tick in range(1, halt_bound + 1):
+        events = refusal_events(locked)
+        if events:
+            first = events[0]
+            return {
+                "tick": tick,
+                "site": first["site"],
+                "config": first["config"],
+                "axis_type": first["axis_type"],
+                "axis_name": first["axis_name"],
+                "n_events": len(events),
+                "events": tuple(events),
+            }
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return None
+        locked = nxt
+    return None
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+
+    f00_bits = bits_from_predicate(f00, orbit_types, orbits)
+    f10_bits = bits_from_predicate(f10, orbit_types, orbits)
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    f00_remaining = remaining_bits_from_full(f00_bits, orbit_types)
+    f10_remaining = remaining_bits_from_full(f10_bits, orbit_types)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    run_f00 = run_from_seed(f00, SEED)
+    run_f10 = run_from_seed(f10, SEED)
+    first_on_f00 = first_refusal(SEED, f00)
+    first_on_f10 = first_refusal(SEED, f10)
+    seed_nbhd = neighborhood(FIRST_SITE, set(SEED))
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"seed={SEED_DISPLAY}")
+    print(f"f00_remaining={f00_remaining}")
+    print(f"f10_remaining={f10_remaining}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"hist_f00={run_f00['history']} fill_f00={run_f00['fill']}")
+    print(f"hist_f10={run_f10['history']} fill_f10={run_f10['fill']}")
+    print(f"wave1_f00={sorted(run_f00['waves'][0]) if run_f00['waves'] else ()}")
+    print(f"wave1_f10={sorted(run_f10['waves'][0]) if run_f10['waves'] else ()}")
+    print(
+        "first_refusal="
+        f"t={first_on_f10['tick']} x={first_on_f10['site']} "
+        f"type={first_on_f10['axis_name']}{first_on_f10['axis_type']} "
+        f"cfg={first_on_f10['config']}"
+        if first_on_f10 is not None
+        else "first_refusal=None"
+    )
+    print(f"first_axis_type_is_opp2={first_on_f10 is not None and first_on_f10['axis_name'] == 'opp2'}")
+    print("displayed_not_adopted_bit=opp2")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_WT1_ZERO_OPP2_MISS_MECHANISM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f00-opp2-silent",
+        "f00 is the F_cut map with remaining bits (0,0,1,1,1)",
+        f00_remaining == F00_REMAINING
+        and in_f_cut(f00_bits, orbit_types, empty_type, full_type)
+        and all(
+            f00(config)
+            == int(
+                axis_type(config)
+                not in (
+                    (0, 0, 3),
+                    (0, 3, 0),
+                    (1, 0, 2),
+                    (1, 2, 0),
+                    (0, 1, 2),
+                    (0, 2, 1),
+                )
+            )
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n != 0 and is not Hamming |c|_1 mod 2",
+        l1_remaining == L1_REMAINING
+        and l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-seed",
+        "the two-cube has twelve vertices and S is the displayed 3-site seed",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and SEED <= set(TWO_CUBE)
+        and len(SEED) == 3
+        and SEED_DISPLAY == "{(0,0,0),(0,1,1),(2,0,0)}",
+    )
+    checks.check(
+        "thm1-f10-fills-f00-misses",
+        "f10 fills S with history (3,6,8,11,12); f00 misses with history (3,5)",
+        f10_remaining == F10_REMAINING
+        and in_f_cut(f10_bits, orbit_types, empty_type, full_type)
+        and run_f00["fill"] is False
+        and run_f10["fill"] is True
+        and run_f00["history"] == HIST_F00
+        and run_f10["history"] == HIST_F10
+        and run_f00["waves"][0] == frozenset(((0, 0, 1), (0, 1, 0)))
+        and run_f10["waves"][0] == frozenset(((0, 0, 1), (0, 1, 0), (1, 0, 0))),
+    )
+    checks.check(
+        "thm2-first-refusal",
+        "first refusal is t=1, site (1,0,0), axis type opp2",
+        first_on_f10 is not None
+        and first_on_f00 is not None
+        and first_on_f10["tick"] == 1
+        and first_on_f10["site"] == FIRST_SITE
+        and first_on_f10["axis_type"] == FIRST_TYPE
+        and first_on_f10["axis_name"] == "opp2"
+        and first_on_f10["config"] == FIRST_CONFIG
+        and first_on_f10["n_events"] == 1
+        and first_on_f00["tick"] == 1
+        and first_on_f00["site"] == FIRST_SITE
+        and first_on_f00["axis_name"] == "opp2"
+        and seed_nbhd == FIRST_CONFIG
+        and axis_type(seed_nbhd) == FIRST_TYPE,
+    )
+    checks.check(
+        "thm3-type-is-opp2",
+        "the first axis type is opp2, the remaining bit that splits f00 from f10",
+        first_on_f10 is not None
+        and first_on_f10["axis_name"] == "opp2"
+        and first_on_f10["axis_type"] == (0, 1, 2)
+        and first_on_f10["axis_name"] != "mixed3"
+        and f00_remaining[1] == 0
+        and f10_remaining[1] == 1
+        and f00_remaining[0] == 0
+        and f10_remaining[0] == 0,
+    )
+    checks.check(
+        "thm3-display-not-adopt-opp2",
+        "opp2 is displayed and is not adopted or written into Admissibility",
+        first_on_f10 is not None
+        and first_on_f10["axis_name"] == "opp2"
+        and "Do not adopt opp2" in note
+        and "Do not write it into Admissibility" in note
+        and "Displayed, not adopted" in note,
+    )
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_absence = "A site with no record cannot be read."
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        lattice_sentence in axiom
+        and "proper cubic rotations about each site." in axiom
+        and admissibility_sentence in axiom
+        and record_lock in axiom
+        and record_absence in axiom
+        and lattice_sentence in note
+        and record_absence in note,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted first refusal, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-first-refusal",
+        "the note reports the independent histories and the first (t, x, axis type)",
+        SEED_DISPLAY.replace(" ", "") in note.replace(" ", "")
+        and "(0, 0, 1, 1, 1)" in note
+        and "(0, 1, 1, 1, 1)" in note
+        and "(3, 5)" in note
+        and "(3, 6, 8, 11, 12)" in note
+        and "t = 1" in note
+        and "(1, 0, 0)" in note
+        and "`opp2`" in note
+        and "(0, 1, 2)" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write it into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "new-mechanism-not-leftover-6486",
+        "the residual is the first refused neighborhood, not leftover of #6486 fill-bit only",
+        "New mechanism" in note
+        and "Not leftover of #6486" in note
+        and "fill-bit only" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the first refused neighborhood on the displayed seed",
+        "On the two-cube with off-patch o=0, the first neighborhood at which F_cut (0,0,1,1,1) refuses and (0,1,1,1,1) fires, on seed {(0,0,0),(0,1,1),(2,0,0)}, is reported by tick, site, and axis type."
+        in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        "does not supply the formation site, probability, or rate" in axiom_flat
+        and "does not supply the formation site, probability, or rate" in note_flat,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f00 and f10 are run independently from the displayed 3-site seed")
+    print("per_block: checked exactly — the first refused neighborhood is named by tick, site, and axis type")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, seed S={(0,0,0),(0,1,1),(2,0,0)}, the first neighborhood where F_cut (0,0,1,1,1) refuses and (0,1,1,1,1) fires is t=1, site (1,0,0), type opp2. New mechanism, not leftover of #6486 fill-bit. Displayed, not adopted. f_L1 is n≠0, not Hamming.

## Runner

`scripts/f_cut_wt1_zero_opp2_miss_mechanism_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.