### PR TITLE
feat(wt1iff2): wt1 is not equivalent to positive two-site coverage

### DIFF
--- a/docs/F_CUT_WT1_TWO_SITE_FILLABLE_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_WT1_TWO_SITE_FILLABLE_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,303 @@
+---
+claim_id: f_cut_wt1_two_site_fillable_equivalence_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, having positive 2-site coverage is not equivalent to f(wt1)=1. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py
+---
+
+# F_cut Positive Two-Site Coverage Is Not The Wt1 Bit
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 32 cube-covariant complement-even formation predicates that
+vanish on empty and full, run as occupancy dynamics on the twelve-vertex
+two-cube with off-patch occupancy `0`, scored by whether they fill at least
+one of the 66 unordered 2-site seeds.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py`](../scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py)
+
+## Result Up Front
+
+Write `V={0,1,2}×{0,1}×{0,1}` for the twelve-vertex two-cube. Every unordered
+pair of vertices is a 2-site seed; there are `C(12,2)=66` such seeds.
+Off-patch neighbors have occupancy `0`. For each of the 32 `F_cut` maps,
+let
+
+`cov2(f)=|{S : |S|=2 and |locks_halt(f,S)|=12}|`.
+
+Then `cov2(f)>0` means `f` fills at least one two-site seed. The remaining
+bit `wt1` is the value of `f` on the weight-one orbit. Every map with
+`f(wt1)=0` has `cov2=0`. The converse fails: not every map with `f(wt1)=1`
+has `cov2>0`. The census is
+
+```text
+N_wt1 = 16
+N_pos = 14
+N_both = 14
+```
+
+so having positive 2-site coverage is **not** equivalent to `f(wt1)=1`.
+The lex-first counterexample remaining-bit tuple
+`(wt1, opp2, adj2, vertex3, mixed3)=(1, 0, 0, 0, 0)` has `f(wt1)=1` and
+`cov2=0`. A second witness is `(1, 1, 0, 0, 0)`.
+
+`f_L1` is the unbalanced-axis predicate (`n≠0` on the six-neighbor occupancy
+tuple; not Hamming parity). It evaluates to `(1, 0, 1, 1, 1)`, so
+`f_L1(wt1)=1`, and it has `cov2(f_L1)=62`. That positive-control map is
+not a unique selector and is not adopted.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) remains
+untouched:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+This note displays a selector on a finite predicate class. It does not write
+`wt1` into Admissibility and does not adopt any remaining-bit tuple.
+Displayed, not adopted.
+
+Not leftover-character of #6482 (that only scored the 16 maps with
+`wt1=0`). Not leftover-character of #6429 (that ranked Max(2) on the full
+32). This is a new selector question: whether the `wt1` bit is exactly the
+2-site fillability bit.
+
+## Exact Objects And The Dynamics
+
+The six-neighbor occupancy cell at a site is the `{0,1}^6` tuple of locked
+status on the ordered shifts `±e_1, ±e_2, ±e_3`. Off-patch neighbors contribute
+occupancy `0`. A cell is assigned one of ten orbits under the 24 proper cube
+rotations:
+
+| orbit | representative type | size |
+|---|---|---|
+| empty | all unoccupied | 1 |
+| wt1 | a single occupied slot | 6 |
+| opp2 | both ends of one axis occupied | 3 |
+| adj2 | two occupied slots on distinct axes | 12 |
+| vertex3 | one slot on each axis, no opposite pair | 8 |
+| mixed3 | one full axis plus one extra slot | 12 |
+| opp4 | complement of opp2 | 3 |
+| adj4 | complement of adj2 | 12 |
+| wt5 | complement of wt1 | 6 |
+| full | all occupied | 1 |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Complement-evenness identifies `wt5` with `wt1`, `opp4` with
+`opp2`, and `adj4` with `adj2`, and leaves `vertex3` and `mixed3`
+complement-fixed, so `|F_cut|=2^5=32`. Remaining-bit tuples are written in
+the order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced. That rule evaluates to
+`(1, 0, 1, 1, 1)` and is therefore one `F_cut` element. Hamming parity
+`|c|_1 mod 2` evaluates to `(1, 0, 0, 1, 1)` and is a different element.
+
+A run from a seed `S` starts with `S` locked. Each tick, every unlocked
+on-patch site evaluates `f` on its current six-neighbor occupancy tuple and
+locks if `f=1`. Halt is the first fixed point (at most twelve ticks). Fill
+means halt lock-count `12`. Coverage `cov2(f)` counts how many of the 66
+two-site seeds fill.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility identifies the six-neighbor condition domain and covariance
+under proper cubic rotations. It
+does not supply the formation site, probability, or rate.
+The boolean occupancy predicates and the lock-update rule are explicit
+bounded mathematical input, not axiom text.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Permanence of a lock once formed is used only as the declared update rule on
+this finite patch. No physical readout, content map, or formation rate is
+identified.
+
+## Theorem 1
+
+Reconfirm the one-way fact on the `wt1=0` half. There are 16 remaining-bit
+tuples with `f(wt1)=0`. Exhaustive evaluation of `cov2` on those 16 maps
+gives `cov2=0` for each of them. A single occupied neighbor never starts a
+fill from a 2-site seed when the weight-one orbit is silent, and turning on
+any combination of `opp2`, `adj2`, `vertex3`, and `mixed3` does not repair
+that silence. This is the same 16-map score as #6482, recomputed here as
+the first half of the biconditional.
+
+## Theorem 2
+
+Enumerate all 32 remaining-bit tuples. Write
+
+- `N_wt1` for the number of maps with `f(wt1)=1`,
+- `N_pos` for the number of maps with `cov2(f)>0`,
+- `N_both` for the number of maps with both.
+
+The exact integers are `N_wt1 = 16`, `N_pos = 14`, `N_both = 14`. Therefore
+`cov2(f)>0` if and only if `f(wt1)=1` is false. The two counterexample
+tuples are
+
+`(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`.
+
+Both have `f(wt1)=1` and `cov2=0`. The lex-first of these is
+`(1, 0, 0, 0, 0)`: only the weight-one (and complementary weight-five)
+orbit fires. From every 2-site seed the run stalls at halt lock-count at
+most `10`. Firing `opp2` as well, as in `(1, 1, 0, 0, 0)`, still never
+fills. Positive coverage first appears when `wt1=1` and at least one of
+`adj2`, `vertex3`, `mixed3` is on.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, is one of the 14 maps with
+`cov2>0`; its coverage is `62`. The two maps that attain `cov2=66` are
+`(1, 1, 1, 1, 0)` and `(1, 1, 1, 1, 1)`. Those ranking facts are displayed
+only as controls; this note does not re-rank Max(2).
+
+## Theorem 3
+
+The failed equivalence, the triple `(N_wt1, N_pos, N_both)=(16, 14, 14)`,
+and the counterexample tuple `(1, 0, 0, 0, 0)` are displayed. They are not
+adopted. Do not adopt `wt1`. The Admissibility sentence is not edited. In
+particular `wt1` is not written into the nearest-neighbor rule, and `f_L1`
+remains the unbalanced-axis predicate `n≠0` rather than Hamming parity.
+Do not write wt1 into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact enumeration of 32 F_cut maps on the twelve-vertex two-cube; cov2>0 versus f(wt1) is a displayed selector, not a physical law."
+trace_class: upstream_support
+target_claim_id: admissibility_formation_predicate_selection
+target_blocker_text: "select a formation predicate from the axioms rather than by a displayed finite extra"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep wt1 and the 2-site fillability bit as displayed extras; do not promote either to Admissibility."
+conditional_surface_status: "exact for the declared two-cube, off-patch o=0, and the 32 F_cut maps; no axiom selector"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Boundary And Non-Claims
+
+- The 66 seeds and the integer `cov2(f)` are constructed objects on one
+  twelve-vertex patch. They are not a lattice-wide formation law.
+- Off-patch occupancy `0` is a declared default. Blank-block (undefined
+  off-patch slots) is a different rule and is not run here.
+- `F_cut` is the three-cut subclass of cube-covariant predicates. Maps
+  outside that subclass are not ranked.
+- No remaining-bit tuple is written into Admissibility.
+- No Record readout, content alphabet, or formation rate is selected.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether positive 2-site coverage detects the single remaining bit `wt1` inside `F_cut`. |
+| V2 | Current main has the axiom memo but no landed census of this `cov2>0` versus `f(wt1)` comparison. |
+| V3 | All orbit sizes, the 32-map table, and every halt lock-count are finite and exact. |
+| V4 | The theorem is more than restating the #6482 one-way score: it separates that implication from a failed biconditional. |
+| V5 | Displayed, not adopted. The extras remain conditional. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: on this patch and class, `cov2(f)>0` does
+not characterize `f(wt1)=1`. No global formation impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| silent `wt1` | set `f(wt1)=0` | executed; every such map has `cov2=0` |
+| `wt1` alone | tuple `(1,0,0,0,0)` | executed counterexample; `cov2=0` |
+| `wt1` and `opp2` without the other three | tuple `(1,1,0,0,0)` | executed; still `cov2=0` |
+| `wt1` plus at least one of `adj2`, `vertex3`, `mixed3` | the 14 maps with `cov2>0` | executed fill of at least one seed |
+| Hamming parity | `|c|_1 mod 2` | different `F_cut` tuple `(1,0,0,1,1)` with `cov2=16` |
+| `f_L1` | remaining bits `(1,0,1,1,1)` | `cov2=62`; positive control, not a selector |
+
+### N2 — wall independence
+
+The missing axiom-level selector, physical formation rate, and Record
+content map are distinct open premises. This note claims no wall collection.
+
+### N3 — hidden-condition scan
+
+The six-neighbor order, off-patch default, simultaneous lock update, and
+`F_cut` cuts are declared. No continuum, Hamming, or fitted prefactor is
+used.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate, the
+local-distribution sentence, and the formation-site/probability/rate
+boundary used here. The residual is a displayed extra on a finite class,
+matching those sources rather than an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | all 32 remaining-bit tuples | no ranking of the 512 maps with only `f(empty)=0` |
+| per seed | all 66 two-site seeds | no claim about 1-site or k-site seeds for k>2 |
+| per tick | halt lock-counts for every map-seed pair | no physical clock |
+| lattice wide | checked and not executed | no infinite-volume formation law |
+
+### N6 — live partial-closure paths
+
+Live routes are an independent derivation of a formation predicate from
+Admissibility, a justification of the off-patch default, and a Record
+content identification. Other seeds and other cuts remain live.
+
+### N7 — hostile steelman
+
+**Steelman:** Because every `wt1=0` map has `cov2=0`, the `wt1` bit should
+be exactly the 2-site fillability bit.
+
+**Answer:** Silence of `wt1` does force `cov2=0`, but firing `wt1` is not
+enough to fill. The lex-first map with `f(wt1)=1` and every other remaining
+bit off stalls at halt lock-count at most 10 on every 2-site seed. Positive
+coverage requires an extra orbit among `adj2`, `vertex3`, and `mixed3`.
+
+### N8 — cross-cycle echo
+
+This is a new selector, not leftover-character of #6482 (that only scored
+the 16) and not leftover-character of #6429 (that ranked Max(2)). The 66
+seeds and the 32 maps are recomputed here.
+
+**Gate disposition:** PASS for the finite failed equivalence and the
+displayed counterexample. FAIL / DO NOT SHIP for “`wt1` is Admissibility”
+or “`wt1` selects 2-site fillability.”
+
+## Inputs And Dependency Roles
+
+- **Framework context:** the Lattice nearest-neighbor cubic graph and the
+  Admissibility condition-domain sentence.
+- **Explicit bounded mathematical input:** the two-cube vertex set, off-patch
+  occupancy `0`, the ten-orbit classification, the three `F_cut` cuts, and
+  the simultaneous lock-update rule.
+- **Not imported:** any unmerged census of a different seed, any Hamming
+  identity for `f_L1`, and any axiom edit.
+
+## Primary Runner
+
+The primary runner recomputes the ten orbits, the 32 `F_cut` maps, `cov2`
+on the 66 two-site seeds, the failed biconditional, the counts
+`N_wt1`, `N_pos`, `N_both`, the lex-first counterexample, the one-way
+`wt1=0` implication, and the current premise boundary. It authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_wt1_two_site_fillable_equivalence_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py
+runner_sha256: bc60c7098ec5ab92b622fda10799fdabf2106830e52d8fa64daaa6c85dccea97
+input_fingerprint_sha256: fd19191039d7cddb495033db0108dbef7c46ce79cf2ea98c1dd50e9f525d484f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo
+construction: 32 cube-covariant complement-even predicates on the two-cube, off-patch occupancy 0
+negative_scope: displayed selector only; wt1 is not written into Admissibility
+PASS: audit-inputs declared source-bound pair exists
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: vertex-count two-cube has twelve vertices
+PASS: orbit-partition proper-cube action on six-tuples has ten orbits with derived sizes
+PASS: complement-action complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3
+PASS: f-cut-cardinality five free remaining bits give 32 F_cut maps
+PASS: two-site-seeds C(12,2)=66 unordered two-site seeds
+PASS: l1-bits n≠0 evaluates to remaining-bit tuple (1,0,1,1,1) and lies in F_cut
+PASS: l1-not-hamming Hamming parity is a different F_cut tuple
+N_wt1=16
+N_pos=14
+N_both=14
+equivalent=False
+lex_counterexample_tuple: (1, 0, 0, 0, 0) cov2=0
+wt1_cov2_spectrum: {0: 2, 8: 4, 16: 2, 32: 2, 36: 2, 62: 2, 66: 2}
+counterexamples: [((1, 0, 0, 0, 0), 0), ((1, 1, 0, 0, 0), 0)]
+PASS: theorem1-wt1-zero every wt1=0 map has cov2=0
+PASS: theorem2-counts N_wt1=16, N_pos=14, N_both=14
+PASS: theorem2-not-equivalent positive 2-site coverage is not equivalent to f(wt1)=1
+PASS: theorem2-counterexample lex-first counterexample is (1, 0, 0, 0, 0) with cov2=0 and f(wt1)=1
+PASS: l1-positive-control f_L1 has wt1=1 and cov2=62
+PASS: cex-stalls lex-first counterexample never reaches halt lock-count 12; max halt is 10
+PASS: note-scope note reports the failed equivalence, displays a counterexample, and does not adopt wt1
+PASS: claim-scope claim_scope states the failed cov2>0 versus wt1 equivalence
+PASS: not-leftover new selector, not leftover of #6482 or #6429
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt wt1
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py
+++ b/scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Exact F_cut census: whether cov2>0 is equivalent to f(wt1)=1."""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_WT1_TWO_SITE_FILLABLE_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_WT1_TWO_SITE_FILLABLE_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Cell = tuple[int, int, int, int, int, int]
+Bits = tuple[int, int, int, int, int]
+
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+FREE_ORBITS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+VERTICES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = tuple(combinations(VERTICES, 2))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def orbit_name(cell: Cell) -> str:
+    weight = sum(cell)
+    n_full = sum(1 for i, j in AXES if cell[i] == 1 and cell[j] == 1)
+    if weight == 0:
+        return "empty"
+    if weight == 6:
+        return "full"
+    if weight == 1:
+        return "wt1"
+    if weight == 5:
+        return "wt5"
+    if weight == 2:
+        return "opp2" if n_full == 1 else "adj2"
+    if weight == 4:
+        return "opp4" if n_full == 2 else "adj4"
+    if weight == 3:
+        return "mixed3" if n_full == 1 else "vertex3"
+    raise ValueError(cell)
+
+
+def all_cells() -> tuple[Cell, ...]:
+    return tuple(product((0, 1), repeat=6))  # type: ignore[return-value]
+
+
+def complement(cell: Cell) -> Cell:
+    return tuple(1 - bit for bit in cell)  # type: ignore[return-value]
+
+
+def axis_unbalanced(cell: Cell) -> bool:
+    return any(cell[i] != cell[j] for i, j in AXES)
+
+
+def f_l1(cell: Cell) -> int:
+    """Formation on a 6-tuple iff some axis is unbalanced (n≠0)."""
+    return int(axis_unbalanced(cell))
+
+
+def hamming_parity(cell: Cell) -> int:
+    return sum(cell) % 2
+
+
+def f_cut_from_bits(bits: Bits):
+    wt1, opp2, adj2, vertex3, mixed3 = bits
+    table = {
+        "empty": 0,
+        "full": 0,
+        "wt1": wt1,
+        "wt5": wt1,
+        "opp2": opp2,
+        "opp4": opp2,
+        "adj2": adj2,
+        "adj4": adj2,
+        "vertex3": vertex3,
+        "mixed3": mixed3,
+    }
+    return lambda cell: table[orbit_name(cell)]
+
+
+def remaining_bits(predicate) -> Bits:
+    reps: dict[str, Cell] = {}
+    for cell in all_cells():
+        name = orbit_name(cell)
+        if name not in reps:
+            reps[name] = cell
+    return tuple(int(predicate(reps[name])) for name in FREE_ORBITS)  # type: ignore[return-value]
+
+
+def neighborhood(site: Point, locked: set[Point]) -> Cell:
+    bits = []
+    for shift in SHIFTS:
+        neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        bits.append(1 if neighbor in locked else 0)
+    return tuple(bits)  # type: ignore[return-value]
+
+
+def run_locks(predicate, seed: tuple[Point, ...]) -> tuple[int, tuple[int, ...]]:
+    locked: set[Point] = set(seed)
+    history = [len(locked)]
+    for _ in range(len(VERTICES)):
+        fresh = {
+            site
+            for site in VERTICES
+            if site not in locked and predicate(neighborhood(site, locked))
+        }
+        if not fresh:
+            break
+        locked |= fresh
+        history.append(len(locked))
+    return len(locked), tuple(history)
+
+
+def fills(predicate, seed: tuple[Point, ...]) -> bool:
+    halt, _history = run_locks(predicate, seed)
+    return halt == len(VERTICES)
+
+
+def cov2_of(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills(predicate, seed))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo")
+    print("construction: 32 cube-covariant complement-even predicates on the two-cube, off-patch occupancy 0")
+    print("negative_scope: displayed selector only; wt1 is not written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound pair exists",
+        len(AUDIT_INPUT_PATHS) == 2
+        and AUDIT_TIMEOUT_SEC == 120
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_WT1_TWO_SITE_FILLABLE_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and (
+            "AUDIT_INPUT_PATHS = (\n"
+            '    "docs/F_CUT_WT1_TWO_SITE_FILLABLE_EQUIVALENCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+            '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+            ")"
+        )
+        in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalize(axiom) for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+
+    cells = all_cells()
+    orbit_counts = Counter(orbit_name(cell) for cell in cells)
+    expected_counts = {
+        "empty": 1,
+        "full": 1,
+        "wt1": 6,
+        "wt5": 6,
+        "opp2": 3,
+        "adj2": 12,
+        "vertex3": 8,
+        "mixed3": 12,
+        "opp4": 3,
+        "adj4": 12,
+    }
+    checks.check("vertex-count", "two-cube has twelve vertices", len(VERTICES) == 12 == len(set(VERTICES)))
+    checks.check(
+        "orbit-partition",
+        "proper-cube action on six-tuples has ten orbits with derived sizes",
+        orbit_counts == expected_counts,
+        residual=dict(orbit_counts),
+    )
+    complement_pairs = {(orbit_name(cell), orbit_name(complement(cell))) for cell in cells}
+    checks.check(
+        "complement-action",
+        "complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3",
+        complement_pairs
+        == {
+            ("empty", "full"),
+            ("full", "empty"),
+            ("wt1", "wt5"),
+            ("wt5", "wt1"),
+            ("opp2", "opp4"),
+            ("opp4", "opp2"),
+            ("adj2", "adj4"),
+            ("adj4", "adj2"),
+            ("vertex3", "vertex3"),
+            ("mixed3", "mixed3"),
+        },
+        residual=complement_pairs,
+    )
+
+    f_cut_maps = tuple(product((0, 1), repeat=5))
+    checks.check("f-cut-cardinality", "five free remaining bits give 32 F_cut maps", len(f_cut_maps) == 32)
+    checks.check(
+        "two-site-seeds",
+        "C(12,2)=66 unordered two-site seeds",
+        len(TWO_SITE_SEEDS) == 66
+        and len(set(frozenset(seed) for seed in TWO_SITE_SEEDS)) == 66
+        and all(len(set(seed)) == 2 for seed in TWO_SITE_SEEDS),
+    )
+
+    l1_bits = remaining_bits(f_l1)
+    ham_bits = remaining_bits(hamming_parity)
+    checks.check(
+        "l1-bits",
+        "n≠0 evaluates to remaining-bit tuple (1,0,1,1,1) and lies in F_cut",
+        l1_bits == (1, 0, 1, 1, 1)
+        and f_l1((0, 0, 0, 0, 0, 0)) == 0
+        and f_l1((1, 1, 1, 1, 1, 1)) == 0
+        and all(f_l1(cell) == f_l1(complement(cell)) for cell in cells),
+        residual=l1_bits,
+    )
+    checks.check(
+        "l1-not-hamming",
+        "Hamming parity is a different F_cut tuple",
+        ham_bits == (1, 0, 0, 1, 1) and ham_bits != l1_bits,
+        residual=ham_bits,
+    )
+
+    rows = []
+    for bits in f_cut_maps:
+        predicate = f_cut_from_bits(bits)
+        cov = cov2_of(predicate)
+        rows.append((bits, cov, bits[0]))
+
+    n_wt1 = sum(1 for _bits, _cov, wt1 in rows if wt1 == 1)
+    n_pos = sum(1 for _bits, cov, _wt1 in rows if cov > 0)
+    n_both = sum(1 for _bits, cov, wt1 in rows if wt1 == 1 and cov > 0)
+    n_wt0 = sum(1 for _bits, _cov, wt1 in rows if wt1 == 0)
+    wt0_all_zero = all(cov == 0 for _bits, cov, wt1 in rows if wt1 == 0)
+    equivalent = n_wt1 == n_pos == n_both and wt0_all_zero
+    counterexamples = [(bits, cov) for bits, cov, wt1 in rows if (wt1 == 1) != (cov > 0)]
+    lex_cex = min(counterexamples) if counterexamples else None
+    cov_spectrum_wt1 = Counter(cov for _bits, cov, wt1 in rows if wt1 == 1)
+
+    print(f"N_wt1={n_wt1}")
+    print(f"N_pos={n_pos}")
+    print(f"N_both={n_both}")
+    print(f"equivalent={equivalent}")
+    print(f"lex_counterexample_tuple: {None if lex_cex is None else lex_cex[0]} cov2={None if lex_cex is None else lex_cex[1]}")
+    print(f"wt1_cov2_spectrum: {dict(sorted(cov_spectrum_wt1.items()))}")
+    print(f"counterexamples: {counterexamples}")
+
+    checks.check(
+        "theorem1-wt1-zero",
+        "every wt1=0 map has cov2=0",
+        n_wt0 == 16 and wt0_all_zero and all(cov == 0 for _bits, cov, wt1 in rows if wt1 == 0),
+    )
+    checks.check(
+        "theorem2-counts",
+        "N_wt1=16, N_pos=14, N_both=14",
+        n_wt1 == 16 and n_pos == 14 and n_both == 14,
+        residual=(n_wt1, n_pos, n_both),
+    )
+    checks.check(
+        "theorem2-not-equivalent",
+        "positive 2-site coverage is not equivalent to f(wt1)=1",
+        equivalent is False and len(counterexamples) == 2,
+        residual=counterexamples,
+    )
+    checks.check(
+        "theorem2-counterexample",
+        "lex-first counterexample is (1, 0, 0, 0, 0) with cov2=0 and f(wt1)=1",
+        lex_cex == ((1, 0, 0, 0, 0), 0)
+        and counterexamples == [((1, 0, 0, 0, 0), 0), ((1, 1, 0, 0, 0), 0)],
+        residual=lex_cex,
+    )
+    checks.check(
+        "l1-positive-control",
+        "f_L1 has wt1=1 and cov2=62",
+        l1_bits[0] == 1 and cov2_of(f_l1) == 62,
+    )
+    lex_max_halt = max(run_locks(f_cut_from_bits((1, 0, 0, 0, 0)), seed)[0] for seed in TWO_SITE_SEEDS)
+    checks.check(
+        "cex-stalls",
+        "lex-first counterexample never reaches halt lock-count 12; max halt is 10",
+        lex_max_halt == 10,
+        residual=lex_max_halt,
+    )
+
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-scope",
+        "note reports the failed equivalence, displays a counterexample, and does not adopt wt1",
+        "is not equivalent" in note
+        and "(1, 0, 0, 0, 0)" in note
+        and "N_wt1 = 16" in note
+        and "N_pos = 14" in note
+        and "N_both = 14" in note
+        and "Displayed, not adopted" in note
+        and "hypothetical_axiom_status: \"no edit\"" in note
+        and all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope states the failed cov2>0 versus wt1 equivalence",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "positive 2-site coverage is not equivalent to f(wt1)=1" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-leftover",
+        "new selector, not leftover of #6482 or #6429",
+        "Not leftover-character of #6482" in note
+        and "that only scored the 16" in note
+        and "Not leftover-character of #6429" in note
+        and "that ranked Max(2)" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt wt1",
+        "Do not write the ranking into Admissibility" in note
+        or "Do not write wt1 into Admissibility" in note,
+    )
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov2>0 is not equivalent to f(wt1)=1. N_wt1=16, N_pos=14, N_both=14. Two wt1=1 maps have cov2=0; lex-first counterexample (1,0,0,0,0). Theorem 1 reconfirms #6482 (all 16 wt1=0 maps have cov2=0). Displayed selector only; do not adopt wt1. f_L1 remains n≠0, not Hamming.

## Runner

`scripts/f_cut_wt1_two_site_fillable_equivalence_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.