### PR TITLE
feat(wt2closed): cov2>0 iff remaining-bit selector P

### DIFF
--- a/docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,277 @@
+---
+claim_id: f_cut_cov2_positive_closed_form_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, positive 2-site coverage is equivalent to remaining bits satisfying wt1=1 and (adj2,vertex3,mixed3) not all zero. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov2_positive_closed_form_2026_08_15.py
+---
+
+# Closed Form of Positive 2-Site Coverage Among the 32 F_cut Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill counts on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the sixty-six two-site seeds, for the
+thirty-two cube-covariant cut maps `F_cut`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov2_positive_closed_form_2026_08_15.py`](../scripts/f_cut_cov2_positive_closed_form_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6490 showed that cov2>0 is not wt1=1: the two exceptions are
+remaining-bit tuples `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`. This note
+tests a new selector on the same 32 maps, not leftover of naming those two.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov2(f) = |{S : |S|=2 and f fills from S}|`. Define
+
+`P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`.
+
+Then:
+
+- Theorem 1. The two #6490 exceptions have P=false and cov2=0.
+- Theorem 2. `cov2(f)>0 iff P(f)` for all 32 maps. The counts are
+  `N_pos = 14`, `N_P = 14`, `N_both = 14`.
+- Theorem 3. The selector `P` is displayed. Do not adopt a bit.
+
+Displayed, not adopted.
+
+Do not write the selector into Admissibility. The closed form is a
+remaining-bit predicate on this patch, not a physical law.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the sixty-six two-site seeds of the two-cube. P(f) and cov2(f)>0 are finite exact predicates. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov2_positive_closed_form
+target_blocker_text: "which remaining bits make cov2>0 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded closed form; do not adopt P as a bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil
+  `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Test whether positive 2-site coverage on `T` is equivalent to
+the remaining-bit selector `P` on `F_cut`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The two-site seeds are the sixty-six unordered pairs of distinct sites in
+`T`. Then `cov2(f)` is the number of those pairs from which `f` fills.
+
+The selector is `P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`. The
+`opp2` bit is free in `P`. New selector, not leftover of naming the two
+#6490 exceptions.
+
+## Theorems
+
+### Theorem 1 — the two #6490 exceptions have P=false and cov2=0
+
+The remaining-bit tuples `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)` are the
+two maps with `wt1=1` and `(adj2,vertex3,mixed3)=(0,0,0)`. For both,
+`P` is false because the last three remaining bits are all zero. Direct
+evolution on all 66 two-site seeds gives `cov2=0` for both. This reconfirms
+#6490: cov2>0 is not wt1=1.
+
+### Theorem 2 — `cov2(f)>0 iff P(f)` on all 32 maps
+
+Enumerate the 32 members of `F_cut` by remaining bits. For each map compute
+`cov2(f)` by occupancy-to-lock from every two-site seed, and evaluate `P`
+from the remaining bits. Then `P(f)` equals the Boolean `cov2(f)>0` on
+every map. The counts are `N_pos = 14`, `N_P = 14`, `N_both = 14`. There
+is no counterexample tuple.
+
+The fourteen maps with `P` true are exactly the maps with `wt1=1` and at
+least one of `adj2`, `vertex3`, `mixed3` equal to 1.
+
+### Theorem 3 — display; do not adopt a bit
+
+`P` is a remaining-bit closed form of the predicate `cov2>0` on this
+patch. Displayed, not adopted. Do not adopt a bit: neither `wt1` alone,
+nor `opp2`, nor any one of `adj2`, `vertex3`, `mixed3`, nor the compound
+`P`, is written into Admissibility.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, sixty-six two-site seeds, off-patch 0 | declared finite patch |
+| two #6490 exceptions have P=false and cov2=0 | proved by evolution |
+| `cov2(f)>0 iff P(f)` on all 32 maps | proved by exhaustive scoring |
+| adopt `P` or a remaining bit | refused; displayed, not adopted |
+| leftover of naming the two #6490 exceptions | refused; new selector |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover of naming those two: #6490 only exhibited the two `wt1=1`
+maps with `cov2=0`. The present object is the selector `P` on all 32 maps,
+which excludes those two by the three-bit remainder rather than by a
+two-name leftover list.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write the selector into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether `cov2>0` has a remaining-bit closed form inside `F_cut` on this patch. |
+| V2 | Current main has the #6490 exceptions but no landed closed form of `cov2>0`. |
+| V3 | The 32 maps, 66 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared finite class. |
+| V5 | It is not a physical selector: `P` is displayed and no bit is adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: `wt1=1` alone does not select positive
+2-site coverage, and the closed form `P` is not adopted as a bit. No
+global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of two names | replace `P` by the two-name leftover list from #6490 | **ATTEMPTED** |
+| leftover of `wt1=1` | treat the closed form as leftover-character of #6490 | **ATTEMPTED** |
+| adopt a bit | write `P` or one remaining bit into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch count to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed `wt1=1` identification, the Hamming contrast, and the off-patch
+convention are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the sixty-six pairs, off-patch occupancy `0`, occupancy-to-lock
+ticks, and the `F_cut` remaining-bit order are declared. Adoption of `P` as
+a physical bit is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the remaining-bit
+closed form of `cov2>0` on the declared patch, not leftover of naming the
+two #6490 exceptions.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 66 seeds | no physical law selection |
+| per block | `P` versus `cov2>0` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than `P`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** the two #6490 exceptions already name the leftover, so a
+closed form is only a two-name list.
+
+**Answer:** `P` is a three-bit remainder on `wt1=1`, not a leftover list of
+two tuples. It is checked against all 32 maps. Displayed, not adopted.
+Do not adopt a bit.
+
+### N8 — cross-cycle echo
+
+Investment #6490 already showed that cov2>0 is not wt1=1. Echoing those two
+exceptions is not a substitute for testing `P` on the whole class.
+
+No-Go Discipline disposition: **PASS** for the finite closed form and the
+refusal to adopt a bit. FAIL / DO NOT SHIP for “`P` is the physical rule”
+or “`wt1` alone selects 2-site fillability.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov2` on the
+sixty-six two-site seeds, reconfirms that the two #6490 exceptions have
+P=false and cov2=0, and checks that `cov2(f)>0 iff P(f)` on the whole
+class. Declared audit inputs are this note and the axiom memo; the runner
+writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov2_positive_closed_form_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov2_positive_closed_form_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov2_positive_closed_form_2026_08_15.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov2_positive_closed_form_2026_08_15.py
+runner_sha256: 86debed9346913bfca9dbf1f2f0bb996a321486dde6ff7bbe693bc3e7b5c3e3c
+input_fingerprint_sha256: b5f60502d6c1c87f2e5ff1047a08aa5559dd03ba009160e94926cbfbad55cebf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_two_site_seeds=66
+exceptions_6490=[((1, 0, 0, 0, 0), 0, False), ((1, 1, 0, 0, 0), 0, False)]
+N_pos=14
+N_P=14
+N_both=14
+n_mismatches=0
+f_L1_remaining=(1, 0, 1, 1, 1)
+cov2_f_L1=62
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+f_hamming_cov2=16
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-sixty-six-seeds the two-cube has twelve vertices and C(12,2)=66 two-site seeds
+PASS: thm1-exceptions-p-false-cov2-zero the two #6490 exceptions have P=false and cov2=0
+PASS: thm2-cov2-positive-iff-P cov2(f)>0 iff P(f) on all 32 F_cut maps
+PASS: thm3-display-not-adopt P is displayed as a remaining-bit selector and is not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted closed form, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-closed-form the note reports P, the two exceptions, and the equivalence counts
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6490 the residual is the closed-form selector P, not leftover of naming the two #6490 exceptions
+PASS: claim-scope-closed-form claim_scope states the displayed equivalence of cov2>0 with P
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by whether cov2>0 matches P
+per_block: checked exactly — P is the remaining-bit closed form of cov2>0 on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov2_positive_closed_form_2026_08_15.py
+++ b/scripts/f_cut_cov2_positive_closed_form_2026_08_15.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Exact closed form of positive 2-site coverage among the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov2(f) is the number of unordered 2-site seeds from
+which f fills. P(f) is the remaining-bit selector (wt1=1) and
+(adj2,vertex3,mixed3)!=(0,0,0). f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EXCEPTIONS_6490: tuple[tuple[int, ...], ...] = (
+    (1, 0, 0, 0, 0),
+    (1, 1, 0, 0, 0),
+)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def selector_P(remaining: tuple[int, ...]) -> bool:
+    """wt1=1 and (adj2, vertex3, mixed3) not all zero.  Not leftover of two names."""
+    wt1, _opp2, adj2, vertex3, mixed3 = remaining
+    return wt1 == 1 and (adj2, vertex3, mixed3) != (0, 0, 0)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in TWO_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def coverage_table(
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, tuple[int, ...], tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    rows: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = []
+    for bits, remaining in members:
+        cov = coverage(predicate_from_bits(bits, orbit_types, type_of))
+        rows.append((cov, remaining, bits))
+    return rows
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, orbits, empty_type, full_type)
+    rows = coverage_table(members, orbit_types, orbits)
+    cov_by_remaining = {remaining: cov for cov, remaining, _bits in rows}
+
+    mismatches = [
+        remaining
+        for cov, remaining, _bits in rows
+        if selector_P(remaining) != (cov > 0)
+    ]
+    n_pos = sum(1 for cov, _remaining, _bits in rows if cov > 0)
+    n_p = sum(1 for _cov, remaining, _bits in rows if selector_P(remaining))
+    n_both = sum(
+        1 for cov, remaining, _bits in rows if cov > 0 and selector_P(remaining)
+    )
+
+    exception_rows = [
+        (remaining, cov_by_remaining[remaining], selector_P(remaining))
+        for remaining in EXCEPTIONS_6490
+    ]
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_l1 = cov_by_remaining[l1_remaining]
+    cov_ham = coverage(f_hamming)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"exceptions_6490={exception_rows}")
+    print(f"N_pos={n_pos}")
+    print(f"N_P={n_p}")
+    print(f"N_both={n_both}")
+    print(f"n_mismatches={len(mismatches)}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"cov2_f_L1={cov_l1}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"f_hamming_cov2={cov_ham}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV2_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-sixty-six-seeds",
+        "the two-cube has twelve vertices and C(12,2)=66 two-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TWO_SITE_SEEDS) == 66
+        and len(set(TWO_SITE_SEEDS)) == 66
+        and all(seed <= set(TWO_CUBE) and len(seed) == 2 for seed in TWO_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-exceptions-p-false-cov2-zero",
+        "the two #6490 exceptions have P=false and cov2=0",
+        all(remaining in cov_by_remaining for remaining in EXCEPTIONS_6490)
+        and all(cov_by_remaining[remaining] == 0 for remaining in EXCEPTIONS_6490)
+        and all(selector_P(remaining) is False for remaining in EXCEPTIONS_6490)
+        and all(
+            remaining[0] == 1 and remaining[2:] == (0, 0, 0)
+            for remaining in EXCEPTIONS_6490
+        )
+        and "(1, 0, 0, 0, 0)" in note
+        and "(1, 1, 0, 0, 0)" in note
+        and "P=false" in note
+        and "cov2=0" in note,
+    )
+    checks.check(
+        "thm2-cov2-positive-iff-P",
+        "cov2(f)>0 iff P(f) on all 32 F_cut maps",
+        len(rows) == 32
+        and mismatches == []
+        and n_pos == 14
+        and n_p == 14
+        and n_both == 14
+        and n_pos == n_p == n_both
+        and f"N_pos = {n_pos}" in note
+        and f"N_P = {n_p}" in note
+        and f"N_both = {n_both}" in note
+        and "cov2(f)>0 iff P(f)" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "P is displayed as a remaining-bit selector and is not adopted",
+        selector_P(l1_remaining) is True
+        and cov_l1 > 0
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted closed form, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-closed-form",
+        "the note reports P, the two exceptions, and the equivalence counts",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)" in note
+        and "(1, 0, 0, 0, 0)" in note
+        and "(1, 1, 0, 0, 0)" in note
+        and "N_pos = 14" in note
+        and "N_P = 14" in note
+        and "N_both = 14" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the selector into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6490",
+        "the residual is the closed-form selector P, not leftover of naming the two #6490 exceptions",
+        "Not leftover of naming those two" in note
+        and "#6490" in note
+        and "New selector" in note
+        and "cov2>0 is not wt1=1" in note,
+    )
+    checks.check(
+        "claim-scope-closed-form",
+        "claim_scope states the displayed equivalence of cov2>0 with P",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "positive 2-site coverage is equivalent to remaining bits satisfying wt1=1"
+        in note
+        and "(adj2,vertex3,mixed3) not all zero" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by whether cov2>0 matches P")
+    print("per_block: checked exactly — P is the remaining-bit closed form of cov2>0 on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), cov2>0 iff wt1=1 and (adj2,vertex3,mixed3)≠(0,0,0). Census N_P=N_pos=N_both=14. New selector after #6490. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_cov2_positive_closed_form_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.