### PR TITLE
feat(c10firstfill): lex-first seed that (1,1,0,0,0) fills

### DIFF
--- a/docs/F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,368 @@
+---
+claim_id: f_cut_c10_first_fill_seed_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the lex-first seed that F_cut (1,1,0,0,0) fills is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c10_first_fill_seed_2026_08_15.py
+---
+
+# Lex-First Two-Cube Seed That `F_cut` `(1,1,0,0,0)` Fills
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** displayed occupancy-to-lock dynamics of the cube-covariant
+map `F_cut` remaining bits `(1,1,0,0,0)` on the twelve-vertex two-cube
+`{0,1,2}×{0,1}×{0,1}`, started from seeds ordered by increasing size
+then lexicographic site order, from `|S|=3` through `|S|=6`, with
+off-patch occupancy identically `0`. The lex-first fill seed is
+displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c10_first_fill_seed_2026_08_15.py`](../scripts/f_cut_c10_first_fill_seed_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve sites `{0,1,2}×{0,1}×{0,1}`. A site
+locks when a displayed predicate of its six-neighbor occupancy tuple
+returns `1`. Off-patch neighbors contribute occupancy `0`. A
+blank-block is a different rule; it is not used. A run is the tuple of
+lock-set cardinalities from the seed through halt, together with the
+fill bit `|locks_halt|=12`.
+
+Let `f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}`
+for at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor
+contrast `n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+Let `f10` be the `F_cut` remaining-bit map
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 1, 0, 0, 0)
+```
+
+with complements forced. It fires on `wt1` and `opp2` and on their
+complements `wt5` and `(0,2,1)`. It is a different map from
+`f00=(1,0,0,0,0)`, which silences `opp2`.
+
+Among the `66` two-site seeds, `cov2(f10)=0` (#6490). That scoring
+does not name a first fill. Enumerate seeds `S` by increasing `|S|`,
+then lexicographic site order, starting at `|S|=3` through `|S|=6`.
+
+**Theorem 1.** `cov2(f10)=0` among the `66` two-site seeds. This
+reconfirms the `#6490` exception for remaining bits `(1,1,0,0,0)`.
+
+**Theorem 2.** The lex-first seed that `f10` fills is the size-`3`
+seed `S={(0,0,0),(1,1,1),(2,0,0)}`. So `|S|=3`. Four of the `220`
+three-site seeds fill; this is the first in lex order.
+
+**Theorem 3.** From that `S` the lock history is `(3, 12)` and the run
+fills. The seed and the history are displayed only. Do not adopt
+`f10`. Do not adopt a seed. Do not write a seed into Admissibility.
+
+Displayed, not adopted.
+
+Not leftover-character of #6490 (that scored `cov2` only).
+Not leftover-character of the `(1,0,0,0,0)` first-fill seed (that is a
+different map; `f00` does not fill this `S`).
+New finite object: the lex-first fill of remaining bits `(1,1,0,0,0)`.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of those sentences is to name the cubic nearest-neighbor
+graph and to keep formation outside the axiom. The axiom memo says the
+distribution concerns which possibility a forming record locks,
+conditional on formation; it does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The map `f10` is a supplied displayed member, not axiom
+content. A seed is likewise displayed data, not an admissibility rule.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact seed census of one displayed F_cut occupancy-to-lock map on a twelve-vertex two-cube from size 3 through size 6."
+trace_class: frontier_discovery
+target_claim_id: f_cut_c10_first_fill_seed
+target_blocker_text: "lex-first two-cube seed from which F_cut remaining bits (1,1,0,0,0) fills"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded first-fill-seed claim; do not adopt the map or the seed"
+conditional_surface_status: "exact on the two-cube with off-patch o=0 for |S|<=6; the map and seed remain displayed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Sites of the two-cube, in lexicographic order:
+
+`(0,0,0)`, `(0,0,1)`, `(0,1,0)`, `(0,1,1)`,
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`,
+`(2,0,0)`, `(2,0,1)`, `(2,1,0)`, `(2,1,1)`.
+
+The six-neighbor tuple at a site is ordered
+`(+x,-x,+y,-y,+z,-z)`. Each coordinate is the occupancy of that
+neighbor: `1` if the neighbor is an on-patch lock, else `0`. Every
+off-patch neighbor is `0`. The off-patch occupancy `0` is the explicit
+default.
+
+For each axis, the pair of opposite bits is
+
+- unbalanced if the bits are `{0,1}`,
+- both if the bits are `{1,1}`,
+- empty if the bits are `{0,0}`.
+
+Write `(n_unbalanced, n_both, n_empty)` with sum `3`. Representative
+orbits used below:
+
+| name | type | representative |
+|---|---|---|
+| empty | `(0,0,3)` | `(0,0,0,0,0,0)` |
+| wt1 | `(1,0,2)` | `(1,0,0,0,0,0)` |
+| opp2 | `(0,1,2)` | `(1,1,0,0,0,0)` |
+| adj2 | `(2,0,1)` | `(1,0,1,0,0,0)` |
+| type210 | `(2,1,0)` | `(1,1,1,0,0,1)` |
+| vertex3 | `(3,0,0)` | `(1,0,1,0,1,0)` |
+| mixed3 | `(1,1,1)` | `(1,0,1,1,0,0)` |
+| wt5 | `(1,2,0)` | `(1,1,1,1,1,0)` |
+| opp2c | `(0,2,1)` | `(1,1,1,1,0,0)` |
+| full | `(0,3,0)` | `(1,1,1,1,1,1)` |
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Five remaining bits stay free, so `|F_cut|=32`. Those
+bits are ordered `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` iff `n_unbalanced(c)≥1`. Its remaining-bit tuple is
+`(1,0,1,1,1)`.
+`f10(c)=1` iff the axis type is `wt1=(1,0,2)`, `opp2=(0,1,2)`,
+`wt5=(1,2,0)`, or `opp2c=(0,2,1)`. Its remaining-bit tuple is
+`(1,1,0,0,0)`.
+
+On those representatives the bits are
+
+| map | wt1 | opp2 | adj2 | type210 | vertex3 | mixed3 | empty | full | wt5 | opp2c |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `f_L1` | 1 | 0 | 1 | 1 | 1 | 1 | 0 | 0 | 1 | 0 |
+| `f10` | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 1 |
+
+Hamming parity of `|c|_1` is a different predicate: `opp2` is even and
+`f_L1(opp2)=0`, while `f10(opp2)=1`.
+
+One tick locks every currently unlocked on-patch site whose neighbor
+tuple has `f=1`. The process starts with `locks_0=S` and halts at the
+first fixed point, or at tick `12`. Lock history is the sequence of
+cardinalities from `t=0` through halt. Fill means `|locks_halt|=12`.
+
+Seeds are enumerated by increasing cardinality, then as combinations
+of the lexicographic site list. The two-site census has `66` seeds.
+The search for a first fill starts at size `3` (`220` seeds) and
+continues through size `6` (`C(12,3)+…+C(12,6)=2431` seeds in the
+search window). It is a seed census on this two-cube, not a clone of
+the `(1,0,0,0,0)` first-fill map.
+
+## Theorem 1 — `cov2(f10)=0`
+
+Reconfirm the `#6490` exception for this remaining-bit tuple.
+
+There are `C(12,2)=66` unordered two-site seeds. From each of them
+`f10` fails to fill: `cov2(f10)=0`. No two-site seed is a filler.
+
+That fact scores coverage only. It does not name a first fill, a
+history, or a preferred seed.
+
+## Theorem 2 — lex-first fill seed
+
+Enumerate seeds by increasing `|S|`, then lex, starting at `3`.
+
+No seed of size `2` fills, as Theorem 1 already recorded. At size
+`3` four of the `220` seeds fill. The first in lex order is
+
+`S={(0,0,0),(1,1,1),(2,0,0)}`.
+
+So `|S|=3`. The later size-`3` fillers are the three remaining
+`x`-aligned `opp2` pairs with the opposite middle-cube vertex. They
+are not the lex-first seed.
+
+The census through size `6` is
+
+| `|S|` | `C(12,|S|)` | number that fill | lex-first filler |
+|---|---|---|---|
+| 2 | 66 | 0 | none |
+| 3 | 220 | 4 | `{(0,0,0),(1,1,1),(2,0,0)}` |
+| 4 | 495 | 7 | the `x=0` face (later than size 3) |
+| 5 | 792 | 0 | none |
+| 6 | 924 | 12 | later than size 3 |
+
+A first fill therefore exists inside the `|S|≤6` cap, and it occurs
+already at size `3`.
+
+This is not the `(1,0,0,0,0)` first-fill seed. That map first fills
+only at a size-`4` face and does not fill this size-`3` `S`.
+
+## Theorem 3 — history from that `S`
+
+Start with `S={(0,0,0),(1,1,1),(2,0,0)}`, so `|locks_0|=3`.
+
+The nine unlocked sites at tick `1` split as follows.
+
+- Eight sites see a single occupied nearest neighbor (type `wt1`):
+  `(0,0,1)`, `(0,1,0)`, `(0,1,1)`, `(1,0,1)`, `(1,1,0)`, `(2,0,1)`,
+  `(2,1,0)`, `(2,1,1)`. Both `f10` and `f00` return `1`.
+- The remaining site `(1,0,0)` sees type `opp2=(0,1,2)`: its `+x` and
+  `-x` neighbors `(2,0,0)` and `(0,0,0)` are both locked. Then
+  `f10=1` and `f00=0`.
+
+Therefore `f10` locks all nine unlocked sites in one tick:
+
+`T=1`, `|locks_halt|=12`, history `(3, 12)`, fill bit `1`.
+
+The executed new orbit is `opp2` at `(1,0,0)`. Silencing that bit
+(`f00`) leaves `(1,0,0)` unlocked and halts at eleven locks, so the
+two maps are dynamically distinct on this seed.
+
+The seed `S` and the history `(3, 12)` are displayed data. Do not
+adopt `f10`. Do not adopt a seed. Do not write a seed into
+Admissibility. The seed is not written into Admissibility.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, lex seed order, sizes `3`–`6` | declared finite data |
+| `cov2(f10)=0` | recomputed; `#6490` |
+| lex-first fill seed | `{(0,0,0),(1,1,1),(2,0,0)}`, `|S|=3` |
+| history from that `S` | `(3, 12)`; fills |
+| identity with `f00` or `f_L1` | refused; different remaining bits |
+| adoption of the map or the seed | refused |
+| formation site / rate from the axioms | open |
+
+## Boundary And Imports
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. The two-cube, the predicate `f10`, and the
+seed order are supplied mathematical data for this note. Record lock
+language is quoted only as the existing lock/content/absence boundary;
+it does not select this map or any seed.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers which first `|S|≥3` seed, if any, `f10` fills. |
+| V2 | Current main has the axiom memo and no landed first-fill-seed census of remaining bits `(1,1,0,0,0)`. |
+| V3 | The twelve-vertex process through size `6` is independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it executes a supplied predicate the axiom does not name. |
+| V5 | Neither the map nor the seed is an admissibility rule, and neither is adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: a first fill is not an axiom-level
+occupancy rule, and a displayed seed is not axiom content.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| two-site coverage | all `66` pairs | `cov2(f10)=0` |
+| lex census from size `3` | `220` three-site seeds | first fill at `{(0,0,0),(1,1,1),(2,0,0)}` |
+| `f10` from that `S` | remaining bits `(1,1,0,0,0)` | fills; history `(3, 12)` |
+| `f00` from that `S` | remaining bits `(1,0,0,0,0)` | does not fill; different map |
+| `opp2` distinction | evaluate `f10` on `(0,1,2)` | `f10=1`; `f_L1=0` |
+| Hamming parity | `|c|_1 mod 2` | different predicate; `opp2` even |
+| write a seed or map into Admissibility | treat either as the local rule | refused; axiom is not a dynamics axiom |
+
+### N2 — wall independence
+
+The missing formation-site selector, the missing axiom-level
+occupancy rule, and the choice among displayed members are distinct
+open items. This note claims no complete wall and no compiler no-go.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch `o=0`, lex site order, size window `3`–`6`,
+six-neighbor order, and the predicate `f10` are declared. Cube
+covariance is used only as the axis-type reading of a six-tuple. No
+continuum, Hamming, or admissibility rewrite is assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor graph and states
+that Admissibility is not a dynamics axiom and does not supply the
+formation site, probability, or rate. The residual therefore matches
+those sources: a displayed lock predicate and a displayed seed are
+extra data.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | axis-type representatives and off-patch `0` | no alphabet classification |
+| per site | every two-cube vertex against the displayed lock predicate | no derived kernel values |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | all seeds of size `2` through `6` | no physical compiler |
+| lattice wide | checked and not executed | neither the map nor the seed adopted as a rule |
+
+### N6 — live partial-closure paths
+
+Live routes include an independent reason to select or reject `f10`,
+a first-fill census of the remaining `cov2=0` members, and a
+formation mechanism supplied by something other than a displayed
+predicate.
+
+### N7 — hostile steelman
+
+**Steelman:** `cov2=0` already said this map cannot start, so either
+no fill exists or the first fill is the same size-`4` face that
+`(1,0,0,0,0)` uses, and the two `#6490` exceptions are one object.
+
+**Answer:** The lex-first fill of `f10` is already the size-`3` seed
+`{(0,0,0),(1,1,1),(2,0,0)}`, with history `(3, 12)`. The map `f00`
+does not fill that seed. The two remaining-bit tuples are different
+maps and produce different first-fill seeds.
+
+### N8 — cross-cycle echo
+
+A two-site coverage score of `0` (#6490) and a first-fill seed of
+remaining bits `(1,0,0,0,0)` are different claims. This note executes
+the lex-first fill of remaining bits `(1,1,0,0,0)`.
+
+**Gate disposition:** PASS for the finite first-fill statement and the
+displayed history. FAIL / DO NOT SHIP for “adopt `f10`,” “adopt this
+seed,” “write a seed into Admissibility,” or “`f10` is the same
+first-fill object as `f00`.”
+
+## Primary Runner
+
+The primary runner rebuilds the two-cube, the predicate `f10`, the
+two-site coverage `cov2(f10)=0`, the lex census from size `3` through
+size `6`, the first-fill seed with its history and fill bit, the
+`opp2` lock at `(1,0,0)`, the current premise boundary, and the
+non-adoption wording. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c10_first_fill_seed_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c10_first_fill_seed_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c10_first_fill_seed_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c10_first_fill_seed_2026_08_15.py
+runner_sha256: 143d0462a69ab7f9cba6e1001371267ba4c698d7c320b696fb1832b2e592a939
+input_fingerprint_sha256: 7cf5467d84944c00f62886bf3e075884e719c6e2b499bb38d871a01e8d9bd868
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs
+construction: displayed F_cut occupancy-to-lock map; lex first-fill seed on the twelve-vertex two-cube
+negative_scope: neither the map nor the first-fill seed is adopted or written into Admissibility
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+PASS: audit-inputs declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site, probability, and rate remain outside Admissibility
+PASS: source-record-and-non-dynamics Record lock wording and the non-dynamics Admissibility boundary are pinned
+PASS: two-cube-and-lex-order the two-cube has twelve lexicographically ordered vertices
+PASS: census-cardinality seed counts are C(12,k) for k=2..6
+PASS: off-patch-zero every off-patch neighbor contributes occupancy 0
+PASS: axis-type-reps declared orbit representatives have the stated axis types
+PASS: f10-remaining-bits f10 is the F_cut remaining-bit tuple (1,1,0,0,0)
+PASS: f-l1-is-n-unbalanced f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity
+PASS: maps-distinct-from-f00-and-l1 f10 differs from f00 on opp2 and from f_L1 on opp2 and adj2
+cov2(f10)=0 n_two=66
+size 3: n=220 nfill=4 first=((0, 0, 0), (1, 1, 1), (2, 0, 0))
+size 4: n=495 nfill=7 first=((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
+size 5: n=792 nfill=0 first=None
+size 6: n=924 nfill=12 first=((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (2, 0, 0), (2, 0, 1))
+lex_first_fill=((0, 0, 0), (1, 1, 1), (2, 0, 0))
+PASS: theorem-1-cov2-zero cov2(f10)=0 among the 66 two-site seeds
+PASS: theorem-2-lex-first-seed the lex-first fill is the size-3 seed {(0,0,0),(1,1,1),(2,0,0)}
+history=(3, 12) T=1 fill=True
+f00_on_same_seed history=(3, 11) fill=False
+PASS: theorem-3-history from that S the lock history is (3, 12) and the run fills
+PASS: fill-mechanism-opp2 one tick locks the eight wt1 sites and the opp2 site (1,0,0)
+PASS: not-the-f00-fill f00 does not fill this S, so the object is not the (1,0,0,0,0) first fill
+PASS: theorem-3-display-not-adopt the note displays the seed and refuses adoption
+PASS: claim-scope claim_scope reports the lex-first f10 fill seed and does not adopt it
+PASS: note-contract machine fields, first-fill statement, and forbidden-phrase hygiene hold
+PASS: not-leftover-6490 the residual is the first-fill seed, not leftover cov2 scoring of #6490
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-declared off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut map
+per_element: axis-type representatives and off-patch occupancy 0 are enumerated
+per_site: each two-cube vertex is tested against the displayed lock predicate
+per_mode: checked and not executed — no spectral claim occurs
+per_block: all seeds of size 2 through 6 are executed to a fixed point
+lattice_wide: checked and not executed — neither the map nor the seed is adopted
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c10_first_fill_seed_2026_08_15.py
+++ b/scripts/f_cut_c10_first_fill_seed_2026_08_15.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Lex-first two-cube seed that F_cut (1,1,0,0,0) fills.
+
+Enumerate seeds of the twelve-vertex two-cube by increasing cardinality,
+then lexicographic site order, from |S|=3 through |S|=6.  Dynamics are
+occupancy-to-lock with off-patch occupancy 0.  f10 is the F_cut remaining-bit
+map (1,1,0,0,0): fire on wt1, opp2, and their complements.  f_L1 is the
+some-axis-unbalanced (n!=0) map, not Hamming parity.  The first fill seed is
+displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+
+SITES: tuple[Point, ...] = tuple(
+    sorted((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+)
+TWO_CUBE_SET = frozenset(SITES)
+AXIS_SHIFTS: tuple[tuple[Point, Point], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+F10_TUPLE: tuple[int, ...] = (1, 1, 0, 0, 0)
+F00_TUPLE: tuple[int, ...] = (1, 0, 0, 0, 0)
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+FIRST_SEED: tuple[Point, ...] = ((0, 0, 0), (1, 1, 1), (2, 0, 0))
+FIRST_HISTORY = (3, 12)
+SEARCH_MIN = 3
+SEARCH_MAX = 6
+CENSUS_COUNTS = {2: 66, 3: 220, 4: 495, 5: 792, 6: 924}
+SIZE3_NFILL = 4
+SIZE4_NFILL = 7
+SIZE5_NFILL = 0
+SIZE6_NFILL = 12
+
+ORBIT_REPS: dict[str, Config] = {
+    "empty": (0, 0, 0, 0, 0, 0),
+    "wt1": (1, 0, 0, 0, 0, 0),
+    "opp2": (1, 1, 0, 0, 0, 0),
+    "adj2": (1, 0, 1, 0, 0, 0),
+    "vertex3": (1, 0, 1, 0, 1, 0),
+    "mixed3": (1, 0, 1, 1, 0, 0),
+    "type210": (1, 1, 1, 0, 0, 1),
+    "wt5": (1, 1, 1, 1, 1, 0),
+    "opp2c": (1, 1, 1, 1, 0, 0),
+    "full": (1, 1, 1, 1, 1, 1),
+}
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locks: frozenset[Point]) -> int:
+    if site not in TWO_CUBE_SET:
+        return 0
+    return 1 if site in locks else 0
+
+
+def neighbor_config(site: Point, locks: frozenset[Point]) -> Config:
+    bits: list[int] = []
+    for plus, minus in AXIS_SHIFTS:
+        bits.append(occupancy(add(site, plus), locks))
+        bits.append(occupancy(add(site, minus), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def axis_type(config: Config) -> tuple[int, int, int]:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for index in (0, 2, 4):
+        plus, minus = config[index], config[index + 1]
+        if plus == 1 and minus == 1:
+            n_both += 1
+        elif plus == 0 and minus == 0:
+            n_empty += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    n_unbalanced, _n_both, _n_empty = axis_type(config)
+    return 1 if n_unbalanced >= 1 else 0
+
+
+def f10(config: Config) -> int:
+    """F_cut remaining bits (1,1,0,0,0): fire on wt1, opp2, and complements."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (0, 1, 2), (1, 2, 0), (0, 2, 1)) else 0
+
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (1,0,0,0,0): fire only on wt1 and wt5."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (1, 2, 0)) else 0
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_tuple(predicate) -> tuple[int, ...]:
+    return tuple(int(predicate(ORBIT_REPS[name]) == 1) for name in BIT_NAMES)
+
+
+def step(locks: frozenset[Point], predicate) -> frozenset[Point]:
+    newcomers = {
+        site
+        for site in SITES
+        if site not in locks and predicate(neighbor_config(site, locks)) == 1
+    }
+    return locks | newcomers
+
+
+def run_from_seed(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    history = [len(locks)]
+    tick = 0
+    while tick < halt_bound:
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+        history.append(len(locks))
+    return tick, frozenset(locks), tuple(history)
+
+
+def fills(seed: tuple[Point, ...] | frozenset[Point], predicate=f10) -> bool:
+    _tick, locks, _history = run_from_seed(frozenset(seed), predicate)
+    return len(locks) == 12
+
+
+def coverage(size: int, predicate=f10) -> tuple[int, int, tuple[Point, ...] | None]:
+    n_total = 0
+    n_fill = 0
+    first: tuple[Point, ...] | None = None
+    for combo in combinations(SITES, size):
+        n_total += 1
+        if fills(combo, predicate):
+            n_fill += 1
+            if first is None:
+                first = combo
+    return n_total, n_fill, first
+
+
+def first_fill_seed(min_size: int = SEARCH_MIN, max_size: int = SEARCH_MAX):
+    per_size = {}
+    found = None
+    for size in range(min_size, max_size + 1):
+        n_total, n_fill, first = coverage(size)
+        per_size[size] = {"n_total": n_total, "n_fill": n_fill, "first": first}
+        if found is None and first is not None:
+            found = first
+    return found, per_size
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs")
+    print("construction: displayed F_cut occupancy-to-lock map; lex first-fill seed on the twelve-vertex two-cube")
+    print("negative_scope: neither the map nor the first-fill seed is adopted or written into Admissibility")
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_C10_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    not_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site, probability, and rate remain outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+    checks.check(
+        "source-record-and-non-dynamics",
+        "Record lock wording and the non-dynamics Admissibility boundary are pinned",
+        record_lock in normalize(axiom)
+        and record_lock in note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-and-lex-order",
+        "the two-cube has twelve lexicographically ordered vertices",
+        len(SITES) == 12
+        and SITES == tuple(sorted(SITES))
+        and SITES[0] == (0, 0, 0)
+        and SITES[-1] == (2, 1, 1)
+        and TWO_CUBE_SET == frozenset(SITES),
+    )
+    checks.check(
+        "census-cardinality",
+        "seed counts are C(12,k) for k=2..6",
+        all(len(list(combinations(SITES, size))) == count for size, count in CENSUS_COUNTS.items()),
+    )
+    checks.check(
+        "off-patch-zero",
+        "every off-patch neighbor contributes occupancy 0",
+        occupancy((-1, 0, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((0, -1, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((3, 0, 0), frozenset({(2, 0, 0)})) == 0,
+    )
+    checks.check(
+        "axis-type-reps",
+        "declared orbit representatives have the stated axis types",
+        axis_type(ORBIT_REPS["wt1"]) == (1, 0, 2)
+        and axis_type(ORBIT_REPS["opp2"]) == (0, 1, 2)
+        and axis_type(ORBIT_REPS["adj2"]) == (2, 0, 1)
+        and axis_type(ORBIT_REPS["vertex3"]) == (3, 0, 0)
+        and axis_type(ORBIT_REPS["mixed3"]) == (1, 1, 1)
+        and axis_type(ORBIT_REPS["type210"]) == (2, 1, 0)
+        and axis_type(ORBIT_REPS["empty"]) == (0, 0, 3)
+        and axis_type(ORBIT_REPS["wt5"]) == (1, 2, 0)
+        and axis_type(ORBIT_REPS["opp2c"]) == (0, 2, 1)
+        and axis_type(ORBIT_REPS["full"]) == (0, 3, 0),
+    )
+
+    f10_bits = remaining_tuple(f10)
+    f00_bits = remaining_tuple(f00)
+    l1_bits = remaining_tuple(f_L1)
+    checks.check(
+        "f10-remaining-bits",
+        "f10 is the F_cut remaining-bit tuple (1,1,0,0,0)",
+        f10_bits == F10_TUPLE
+        and f00_bits == F00_TUPLE
+        and l1_bits == L1_TUPLE
+        and f10(ORBIT_REPS["wt1"]) == 1
+        and f10(ORBIT_REPS["opp2"]) == 1
+        and f10(ORBIT_REPS["wt5"]) == 1
+        and f10(ORBIT_REPS["opp2c"]) == 1
+        and f10(ORBIT_REPS["adj2"]) == 0
+        and f10(ORBIT_REPS["vertex3"]) == 0
+        and f10(ORBIT_REPS["mixed3"]) == 0
+        and f10(ORBIT_REPS["type210"]) == 0
+        and f10(ORBIT_REPS["empty"]) == 0
+        and f10(ORBIT_REPS["full"]) == 0,
+    )
+    checks.check(
+        "f-l1-is-n-unbalanced",
+        "f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity",
+        f_L1(ORBIT_REPS["wt1"]) == 1
+        and f_L1(ORBIT_REPS["mixed3"]) == 1
+        and f_L1(ORBIT_REPS["type210"]) == 1
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["empty"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) != f_hamming(ORBIT_REPS["adj2"])
+        and sum(ORBIT_REPS["opp2"]) % 2 == 0
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f10", 1)[0],
+    )
+    checks.check(
+        "maps-distinct-from-f00-and-l1",
+        "f10 differs from f00 on opp2 and from f_L1 on opp2 and adj2",
+        f10(ORBIT_REPS["opp2"]) == 1
+        and f00(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f10(ORBIT_REPS["adj2"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) == 1
+        and F10_TUPLE != F00_TUPLE
+        and F10_TUPLE != L1_TUPLE,
+    )
+
+    n_two, cov2, first_two = coverage(2)
+    found, per_size = first_fill_seed()
+    print(f"cov2(f10)={cov2} n_two={n_two}")
+    for size in range(SEARCH_MIN, SEARCH_MAX + 1):
+        row = per_size[size]
+        print(f"size {size}: n={row['n_total']} nfill={row['n_fill']} first={row['first']}")
+    print(f"lex_first_fill={found}")
+
+    checks.check(
+        "theorem-1-cov2-zero",
+        "cov2(f10)=0 among the 66 two-site seeds",
+        n_two == 66
+        and cov2 == 0
+        and first_two is None
+        and "cov2(f10)=0" in note.replace(" ", "")
+        and "#6490" in note,
+        residual=(n_two, cov2, first_two),
+    )
+    checks.check(
+        "theorem-2-lex-first-seed",
+        "the lex-first fill is the size-3 seed {(0,0,0),(1,1,1),(2,0,0)}",
+        found == FIRST_SEED
+        and len(found) == 3
+        and per_size[3]["first"] == FIRST_SEED
+        and per_size[3]["n_fill"] == SIZE3_NFILL
+        and per_size[3]["n_total"] == 220
+        and per_size[4]["n_fill"] == SIZE4_NFILL
+        and per_size[4]["n_total"] == 495
+        and per_size[5]["n_fill"] == SIZE5_NFILL
+        and per_size[6]["n_fill"] == SIZE6_NFILL
+        and "{(0,0,0),(1,1,1),(2,0,0)}" in note.replace(" ", "")
+        and "|S|=3" in note.replace(" ", ""),
+        residual=found,
+    )
+
+    tick, locks, history = run_from_seed(frozenset(FIRST_SEED), f10)
+    seed0 = frozenset(FIRST_SEED)
+    after1 = step(seed0, f10)
+    wave1 = after1 - seed0
+    expected_wave1 = TWO_CUBE_SET - seed0
+    tick00, locks00, history00 = run_from_seed(seed0, f00)
+    print(f"history={history} T={tick} fill={locks == TWO_CUBE_SET}")
+    print(f"f00_on_same_seed history={history00} fill={locks00 == TWO_CUBE_SET}")
+
+    checks.check(
+        "theorem-3-history",
+        "from that S the lock history is (3, 12) and the run fills",
+        tick == 1
+        and history == FIRST_HISTORY
+        and locks == TWO_CUBE_SET
+        and fills(FIRST_SEED)
+        and "(3, 12)" in note,
+        residual=(tick, history, len(locks)),
+    )
+    checks.check(
+        "fill-mechanism-opp2",
+        "one tick locks the eight wt1 sites and the opp2 site (1,0,0)",
+        wave1 == expected_wave1
+        and after1 == TWO_CUBE_SET
+        and axis_type(neighbor_config((1, 0, 0), seed0)) == (0, 1, 2)
+        and f10(neighbor_config((1, 0, 0), seed0)) == 1
+        and f00(neighbor_config((1, 0, 0), seed0)) == 0
+        and all(
+            axis_type(neighbor_config(site, seed0)) == (1, 0, 2)
+            for site in expected_wave1
+            if site != (1, 0, 0)
+        )
+        and all(f10(neighbor_config(site, seed0)) == 1 for site in expected_wave1),
+        residual=sorted(wave1),
+    )
+    checks.check(
+        "not-the-f00-fill",
+        "f00 does not fill this S, so the object is not the (1,0,0,0,0) first fill",
+        not fills(FIRST_SEED, f00)
+        and history00 == (3, 11)
+        and tick00 == 1
+        and len(locks00) == 11
+        and (1, 0, 0) not in locks00,
+    )
+    checks.check(
+        "theorem-3-display-not-adopt",
+        "the note displays the seed and refuses adoption",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in normalize(note)
+        and "Do not adopt" in note
+        and "Do not write" in note,
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, the lex-first seed that F_cut "
+        "(1,1,0,0,0) fills is reported. Displayed, not adopted."
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "(3, 12)",
+        "(1, 1, 0, 0, 0)",
+        "lex-first seed",
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the lex-first f10 fill seed and does not adopt it",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, first-fill statement, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and all(phrase not in note and phrase not in self_source for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "new axiom" not in note
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "citation" not in note.lower()
+        and "runner-cache" not in note
+        and "retained" not in other_retained,
+    )
+    checks.check(
+        "not-leftover-6490",
+        "the residual is the first-fill seed, not leftover cov2 scoring of #6490",
+        "Not leftover-character of #6490" in note
+        and "that scored `cov2` only" in note
+        and "different map" in note
+        and "New finite object" in normalize(note).replace("new finite object", "New finite object"),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in normalize(note)
+        and "not Hamming" in note
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-declared",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut map",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "f10" not in axiom,
+    )
+
+    print("per_element: axis-type representatives and off-patch occupancy 0 are enumerated")
+    print("per_site: each two-cube vertex is tested against the displayed lock predicate")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: all seeds of size 2 through 6 are executed to a fixed point")
+    print("lattice_wide: checked and not executed — neither the map nor the seed is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the lex-first seed that F_cut (1,1,0,0,0) fills is reported. First fill of the second #6490 exception, not a counted F_W0 set. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c10_first_fill_seed_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.