### PR TITLE
feat(c00facewhy): first refuse on f00 lex-first 4-face fill

### DIFF
--- a/docs/F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,372 @@
+---
+claim_id: f_cut_c00_face_first_refuse_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the first refused neighborhood of F_cut (1,0,0,0,0) on its #6493 lex-first four-site face fill is reported, or the run refuses none. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c00_face_first_refuse_2026_08_15.py
+---
+
+# First Refused Neighborhood On The `#6493` Four-Site Face Fill Of `F_cut` `(1,0,0,0,0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** displayed occupancy-to-lock dynamics of one cube-covariant
+map on the twelve-vertex two-cube `{0,1,2}×{0,1}×{0,1}`, started from
+the `#6493` lex-first four-site face
+`S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}`, with off-patch occupancy
+identically `0`. The first remaining-bit neighborhood that `f00`
+refuses on that filling run is reported, or `N_refuse=0` if the run
+refuses none. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c00_face_first_refuse_2026_08_15.py`](../scripts/f_cut_c00_face_first_refuse_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve sites `{0,1,2}×{0,1}×{0,1}`. A site
+locks when a displayed predicate of its six-neighbor occupancy tuple
+returns `1`. Off-patch neighbors contribute occupancy `0`. A
+blank-block is a different rule; it is not used. A run is the tuple of lock-set
+cardinalities from the seed through halt, together with the fill bit
+`|locks_halt|=12`.
+
+Let `f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}`
+for at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor
+contrast `n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+Let `f00` be the `F_cut` remaining-bit map
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 0, 0, 0)
+```
+
+with complements forced. It fires only on axis types `(1,0,2)` and
+`(1,2,0)`. The seed
+
+```text
+S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}
+```
+
+is the `#6493` lex-first four-site face that this map fills. That
+naming of the face is leftover-character of `#6493`. The object of
+this note is the first remaining-bit neighborhood `f00` refuses on
+the filling run from that face.
+
+A remaining-bit neighborhood is a six-tuple whose axis type is one of
+`wt1`, `opp2`, `adj2`, `vertex3`, `mixed3`, or a complement of those.
+Empty and full are the two `F_cut` cuts, not remaining bits. A refuse
+is an unlocked on-patch site whose neighbor tuple has `f00=0` and
+whose type is remaining-bit. `N_refuse` is the number of such events
+on the run.
+
+**Theorem 1.** `f00` fills from `S`. The lock history is `(4, 8, 12)`
+and `|locks_halt|=12`. This reconfirms the `#6493` face fill.
+
+**Theorem 2.** Every remaining-bit orbit that appears on that run is
+accepted. The only remaining-bit type that appears is `wt1`. So
+`N_refuse=0`: the run refuses none. The four `x=2` sites see the
+empty tuple on the seed occupancy; empty is the `F_cut` empty cut,
+not a remaining-bit refuse.
+
+**Theorem 3.** The refuse census is displayed only. Do not adopt a
+bit. Do not write a remaining bit into Admissibility.
+
+Displayed, not adopted.
+
+Not leftover-character of #6493 (that named the lex-first fill seed).
+Not leftover-character of L1-miss-why (that named the first axis type
+where `f_L1` refuses and the cov=66 map fires on a 2-site miss).
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of those sentences is to name the cubic nearest-neighbor
+graph and to keep formation outside the axiom. The axiom memo says the
+distribution concerns which possibility a forming record locks,
+conditional on formation; it does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The map `f00` is a supplied displayed member, not axiom
+content. A remaining-bit assignment is likewise displayed data, not
+an admissibility rule.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact remaining-bit refuse census of one displayed F_cut map on the #6493 four-site face of the twelve-vertex two-cube."
+trace_class: frontier_discovery
+target_claim_id: f_cut_c00_face_first_refuse
+target_blocker_text: "first remaining-bit neighborhood that F_cut (1,0,0,0,0) refuses on its #6493 lex-first four-site face fill"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded refuse census; do not adopt a remaining bit"
+conditional_surface_status: "exact on the two-cube with off-patch o=0 for this displayed face; N_refuse remains displayed data"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Sites of the two-cube, in lexicographic order:
+
+`(0,0,0)`, `(0,0,1)`, `(0,1,0)`, `(0,1,1)`,
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`,
+`(2,0,0)`, `(2,0,1)`, `(2,1,0)`, `(2,1,1)`.
+
+The six-neighbor tuple at a site is ordered
+`(+x,-x,+y,-y,+z,-z)`. Each coordinate is the occupancy of that
+neighbor: `1` if the neighbor is an on-patch lock, else `0`. Every
+off-patch neighbor is `0`. The off-patch occupancy `0` is the explicit
+default.
+
+For each axis, the pair of opposite bits is
+
+- unbalanced if the bits are `{0,1}`,
+- both if the bits are `{1,1}`,
+- empty if the bits are `{0,0}`.
+
+Write `(n_unbalanced, n_both, n_empty)` with sum `3`. Representative
+orbits used below:
+
+| name | type | representative |
+|---|---|---|
+| empty | `(0,0,3)` | `(0,0,0,0,0,0)` |
+| wt1 | `(1,0,2)` | `(1,0,0,0,0,0)` |
+| opp2 | `(0,1,2)` | `(1,1,0,0,0,0)` |
+| adj2 | `(2,0,1)` | `(1,0,1,0,0,0)` |
+| type210 | `(2,1,0)` | `(1,1,1,0,0,1)` |
+| vertex3 | `(3,0,0)` | `(1,0,1,0,1,0)` |
+| mixed3 | `(1,1,1)` | `(1,0,1,1,0,0)` |
+| wt5 | `(1,2,0)` | `(1,1,1,1,1,0)` |
+| full | `(0,3,0)` | `(1,1,1,1,1,1)` |
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Five remaining bits stay free, so `|F_cut|=32`. Those
+bits are ordered `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` iff `n_unbalanced(c)≥1`. Its remaining-bit tuple is
+`(1,0,1,1,1)`.
+`f00(c)=1` iff the axis type is `wt1=(1,0,2)` or `wt5=(1,2,0)`. Its
+remaining-bit tuple is `(1, 0, 0, 0, 0)`.
+
+On those representatives the bits are
+
+| map | wt1 | opp2 | adj2 | type210 | vertex3 | mixed3 | empty | full |
+|---|---|---|---|---|---|---|---|---|
+| `f_L1` | 1 | 0 | 1 | 1 | 1 | 1 | 0 | 0 |
+| `f00` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+Hamming parity of `|c|_1` is a different predicate: `opp2` is even and
+`f_L1(opp2)=0`, while `adj2` is even and `f_L1(adj2)=1`.
+
+One tick locks every currently unlocked on-patch site whose neighbor
+tuple has `f=1`. The process starts with `locks_0=S` and halts at the
+first fixed point, or at tick `12`. Lock history is the sequence of
+cardinalities from `t=0` through halt. Fill means `|locks_halt|=12`.
+
+A remaining-bit refuse is recorded in lexicographic site order at each
+tick, then by increasing tick. If the list is empty, report
+`N_refuse=0`.
+
+## Theorem 1 — `f00` fills from the `#6493` face
+
+Start with
+
+`S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}`,
+
+so `|locks_0|=4`. This is the entire `x=0` face.
+
+At tick `1` the four middle-slice sites
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`
+each see a single occupied nearest neighbor along `-x` (type `wt1`),
+so `f00` returns `1`. The four `x=2` sites see the empty tuple and
+stay unlocked. After tick `1` one has `|locks_1|=8`.
+
+At tick `2` the four `x=2` sites each see a single occupied nearest
+neighbor along `-x` (type `wt1`) and lock. The run fills:
+
+`T=2`, `|locks_halt|=12`, history `(4, 8, 12)`, fill bit `1`.
+
+This reconfirms the `#6493` face fill. The seed is displayed data,
+not a newly chosen first-fill object.
+
+## Theorem 2 — first remaining-bit refuse, or `N_refuse=0`
+
+On the seed occupancy the unlocked sites evaluate as follows, in lex
+order.
+
+| site | type | `f00` |
+|---|---|---|
+| `(1,0,0)` | `wt1` | 1 |
+| `(1,0,1)` | `wt1` | 1 |
+| `(1,1,0)` | `wt1` | 1 |
+| `(1,1,1)` | `wt1` | 1 |
+| `(2,0,0)` | empty | 0 |
+| `(2,0,1)` | empty | 0 |
+| `(2,1,0)` | empty | 0 |
+| `(2,1,1)` | empty | 0 |
+
+The four empty evaluations are the `F_cut` empty cut. They are not
+remaining-bit refuses.
+
+After the middle slice locks, the four `x=2` sites each see type
+`wt1` and fire. No other remaining-bit type appears.
+
+The remaining-bit orbits that appear are `{wt1}` only, and `f00`
+accepts `wt1`. Therefore `N_refuse=0`: the run refuses none.
+
+## Theorem 3 — display, not adoption
+
+The executed firings are the `wt1` orbit only. The empty evaluations
+on the far face are forced by the `F_cut` empty cut. No remaining bit
+other than `wt1` is seen, and none is refused. Do not adopt `f00`.
+Do not adopt `wt1`. Do not adopt `N_refuse=0` as a formation rule.
+Do not write a remaining bit into Admissibility. Admissibility is not
+a dynamics axiom and does not supply this predicate or this refuse
+census. The census is not written into Admissibility.
+
+A first-fill seed is not a refuse census. The refuse census on that
+seed is a new finite object on this two-cube.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, `#6493` face `S` | declared finite data |
+| `f00` fills from `S` | recomputed; history `(4, 8, 12)` |
+| remaining-bit refuse list | empty; `N_refuse=0` |
+| empty evaluations on the far face | displayed; not remaining-bit |
+| adoption of a remaining bit or the map | refused |
+| formation site / rate from the axioms | open |
+
+## Boundary And Imports
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. The two-cube, the predicate `f00`, and the
+`#6493` face are supplied mathematical data for this note. Record lock
+language is quoted only as the existing lock/content/absence boundary;
+it does not select this map or any remaining bit.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers which first remaining-bit neighborhood, if any, `f00` refuses on the `#6493` face fill. |
+| V2 | Current main has the axiom memo and the `#6493` first-fill seed, not this refuse census. |
+| V3 | The twelve-vertex process from this face is independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it executes a supplied predicate the axiom does not name. |
+| V5 | Neither the map nor a remaining bit is an admissibility rule, and neither is adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: a first-fill seed is not a refuse
+census, and a displayed filler or remaining bit is not axiom content.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| face fill | occupancy-to-lock from `S` | **ATTEMPTED**; history `(4, 8, 12)`; fills |
+| seed neighborhoods | eight unlocked sites at `t=0` | **ATTEMPTED**; four `wt1`, four empty |
+| remaining-bit refuses | remaining-bit types with `f00=0` | **ATTEMPTED**; `N_refuse=0` |
+| after-wave neighborhoods | four `x=2` sites at `t=1` | **ATTEMPTED**; four `wt1`; all fire |
+| Hamming parity | `|c|_1 mod 2` | **ATTEMPTED**; different predicate; `adj2` even |
+| write a remaining bit into Admissibility | treat a bit as the local rule | **ATTEMPTED**; refused; axiom is not a dynamics axiom |
+
+### N2 — wall independence
+
+The missing formation-site selector, the missing axiom-level
+occupancy rule, and the choice among displayed members are distinct
+open items. This note claims no complete wall and no compiler no-go.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch `o=0`, the `#6493` face, six-neighbor order,
+remaining-bit versus empty/full, and the remaining-bit tuple
+`(1,0,0,0,0)` are declared. Cube covariance is used only as the
+axis-type reading of a six-tuple. No continuum, Hamming, or
+admissibility rewrite is assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor graph and states
+that Admissibility is not a dynamics axiom and does not supply the
+formation site, probability, or rate. The extra therefore matches
+those sources: a displayed lock predicate and a displayed refuse
+census are extra data.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | axis-type representatives and off-patch `0` | no alphabet classification |
+| per site | every two-cube vertex against `f00` | no derived kernel values |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | the `#6493` face run to a fixed point | no physical compiler |
+| lattice wide | checked and not executed | neither map nor a remaining bit adopted as a rule |
+
+### N6 — live partial-closure paths
+
+Live routes include an independent reason to select or reject `f00`,
+a refuse census of the other `#6490` exception `(1,1,0,0,0)`, and a
+formation mechanism supplied by something other than a displayed
+predicate.
+
+### N7 — hostile steelman
+
+**Steelman:** the `#6493` face already fills by two `wt1` waves, so
+either there is nothing to report or empty on the far face may be
+treated as the first refuse and written as a rule.
+
+**Answer:** empty is the `F_cut` empty cut, not a remaining bit. The
+remaining-bit refuse list is empty, so `N_refuse=0`. That is a
+displayed finite fact. Admissibility does not name `f00` or this
+census.
+
+### N8 — cross-cycle echo
+
+A first-fill seed (`#6493`) and a first axis type on an `f_L1`
+two-site miss (L1-miss-why) are different claims. This note executes
+the remaining-bit refuse census of `F_cut` `(1,0,0,0,0)` on that
+face.
+
+**Gate disposition:** PASS for the finite refuse census and the
+displayed history. FAIL / DO NOT SHIP for “adopt `f00`,” “write a
+remaining bit into Admissibility,” or “`#6493` already is the refuse
+census.”
+
+## Primary Runner
+
+The primary runner rebuilds the two-cube, the predicate `f00`, the
+`#6493` face fill with its history and fill bit, the `wt1`
+face-to-face waves, the remaining-bit refuse list (empty;
+`N_refuse=0`), the empty far-face evaluations, the current premise
+boundary, and the non-adoption wording. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c00_face_first_refuse_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c00_face_first_refuse_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c00_face_first_refuse_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c00_face_first_refuse_2026_08_15.py
+runner_sha256: 2d4d8acebb6c77b377a8ab6b8f23929c32e898057b160b3dae32072f735f6ca1
+input_fingerprint_sha256: 0a2a6b8bd2cdf48252e317a73a3ae016c852c3165eabdbb263606ff996975d4a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs
+construction: displayed F_cut occupancy-to-lock map; first remaining-bit refuse on the #6493 face
+negative_scope: neither the map nor any remaining bit is adopted or written into Admissibility
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+PASS: audit-inputs declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site, probability, and rate remain outside Admissibility
+PASS: source-record-and-non-dynamics Record lock wording and the non-dynamics Admissibility boundary are pinned
+PASS: two-cube-and-lex-order the two-cube has twelve lexicographically ordered vertices
+PASS: off-patch-zero every off-patch neighbor contributes occupancy 0
+PASS: axis-type-reps declared orbit representatives have the stated axis types
+PASS: f00-remaining-bits f00 is the F_cut remaining-bit tuple (1,0,0,0,0)
+PASS: f-l1-is-n-unbalanced f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity
+seed={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}
+history=(4, 8, 12) T=2 fill=True
+wave1=[(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+wave2=[(2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1)]
+appeared_remaining=('wt1', 'wt1', 'wt1', 'wt1', 'wt1', 'wt1', 'wt1', 'wt1')
+N_refuse=0
+first_remaining_refuse=None
+empty_refuses_n=4 sites=((2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1))
+PASS: theorem-1-f00-fills-face f00 fills the #6493 face S with history (4, 8, 12)
+PASS: fill-mechanism-waves the x=0 face locks the x=1 slice then the x=2 face, each as wt1
+PASS: theorem-2-n-refuse-zero every remaining-bit orbit that appears is accepted; N_refuse=0
+PASS: theorem-2-note-reports-n-refuse the note reports N_refuse=0 and that only wt1 appears as a remaining bit
+PASS: empty-cut-is-not-remaining-bit empty appears on the far face at tick 0 and is the F_cut empty cut, not a remaining bit
+PASS: theorem-3-display-not-adopt the note displays the refuse census and refuses adoption of a bit
+PASS: claim-scope claim_scope reports the first refused neighborhood or that the run refuses none
+PASS: note-contract machine fields, refuse census, and forbidden-phrase hygiene hold
+PASS: not-leftover-6493-or-l1-miss-why the residual is the refuse census on the face, not leftover of #6493 or L1-miss-why
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-declared off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut map
+per_element: axis-type representatives and off-patch occupancy 0 are enumerated
+per_site: each two-cube vertex is tested against the displayed lock predicate
+per_mode: checked and not executed — no spectral claim occurs
+per_block: the #6493 face run is executed to a fixed point and remaining-bit refuses are counted
+lattice_wide: checked and not executed — neither the map nor a remaining bit is adopted
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c00_face_first_refuse_2026_08_15.py
+++ b/scripts/f_cut_c00_face_first_refuse_2026_08_15.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""First refused neighborhood of F_cut (1,0,0,0,0) on its #6493 face fill.
+
+Independent occupancy-to-lock run from the lex-first four-site face
+S = {(0,0,0),(0,0,1),(0,1,0),(0,1,1)} on the twelve-vertex two-cube
+with off-patch occupancy 0.  f00 is the F_cut remaining-bit map
+(1,0,0,0,0): fire only on wt1 and its complement wt5.  The first
+remaining-bit neighborhood that f00 refuses on that filling run is
+reported, or N_refuse=0 if every remaining-bit orbit that appears is
+accepted.  Displayed, not adopted.  f_L1 is the unbalanced-axis
+predicate (some n_mu != 0), never Hamming |c|_1 mod 2.  New seed
+census: not leftover of #6493 (that named the face) and not
+L1-miss-why.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+OrbitType = tuple[int, int, int]
+
+SITES: tuple[Point, ...] = tuple(
+    sorted((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+)
+TWO_CUBE_SET = frozenset(SITES)
+AXIS_SHIFTS: tuple[tuple[Point, Point], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+F00_TUPLE: tuple[int, ...] = (1, 0, 0, 0, 0)
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+SEED: tuple[Point, ...] = ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
+SEED_DISPLAY = "{(0,0,0),(0,0,1),(0,1,0),(0,1,1)}"
+FIRST_HISTORY = (4, 8, 12)
+REMAINING_TYPES: frozenset[OrbitType] = frozenset(
+    (
+        (1, 0, 2),
+        (1, 2, 0),
+        (0, 1, 2),
+        (0, 2, 1),
+        (2, 0, 1),
+        (2, 1, 0),
+        (3, 0, 0),
+        (1, 1, 1),
+    )
+)
+AXIS_TYPE_NAME: dict[OrbitType, str] = {
+    (0, 0, 3): "empty",
+    (0, 3, 0): "full",
+    (1, 0, 2): "wt1",
+    (1, 2, 0): "wt5",
+    (0, 1, 2): "opp2",
+    (0, 2, 1): "opp2_comp",
+    (2, 0, 1): "adj2",
+    (2, 1, 0): "adj2_comp",
+    (3, 0, 0): "vertex3",
+    (1, 1, 1): "mixed3",
+}
+ORBIT_REPS: dict[str, Config] = {
+    "empty": (0, 0, 0, 0, 0, 0),
+    "wt1": (1, 0, 0, 0, 0, 0),
+    "opp2": (1, 1, 0, 0, 0, 0),
+    "adj2": (1, 0, 1, 0, 0, 0),
+    "vertex3": (1, 0, 1, 0, 1, 0),
+    "mixed3": (1, 0, 1, 1, 0, 0),
+    "type210": (1, 1, 1, 0, 0, 1),
+    "wt5": (1, 1, 1, 1, 1, 0),
+    "full": (1, 1, 1, 1, 1, 1),
+}
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locks: frozenset[Point]) -> int:
+    if site not in TWO_CUBE_SET:
+        return 0
+    return 1 if site in locks else 0
+
+
+def neighbor_config(site: Point, locks: frozenset[Point]) -> Config:
+    bits: list[int] = []
+    for plus, minus in AXIS_SHIFTS:
+        bits.append(occupancy(add(site, plus), locks))
+        bits.append(occupancy(add(site, minus), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for index in (0, 2, 4):
+        plus, minus = config[index], config[index + 1]
+        if plus == 1 and minus == 1:
+            n_both += 1
+        elif plus == 0 and minus == 0:
+            n_empty += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    n_unbalanced, _n_both, _n_empty = axis_type(config)
+    return 1 if n_unbalanced >= 1 else 0
+
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (1,0,0,0,0): fire only on wt1 and wt5."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (1, 2, 0)) else 0
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_tuple(predicate) -> tuple[int, ...]:
+    return tuple(int(predicate(ORBIT_REPS[name]) == 1) for name in BIT_NAMES)
+
+
+def step(locks: frozenset[Point], predicate) -> frozenset[Point]:
+    newcomers = {
+        site
+        for site in SITES
+        if site not in locks and predicate(neighbor_config(site, locks)) == 1
+    }
+    return locks | newcomers
+
+
+def run_from_seed(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    history = [len(locks)]
+    snapshots = [locks]
+    tick = 0
+    while tick < halt_bound:
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+        history.append(len(locks))
+        snapshots.append(locks)
+    return tick, frozenset(locks), tuple(history), tuple(snapshots)
+
+
+def refusal_census(seed: frozenset[Point], predicate=f00, halt_bound: int = 12) -> dict:
+    """Remaining-bit refuses on the independent run; empty/full are cuts, not remaining bits."""
+    locks = frozenset(seed)
+    remaining_refuses: list[dict] = []
+    empty_refuses: list[dict] = []
+    appeared_remaining: list[OrbitType] = []
+    for tick in range(halt_bound + 1):
+        for site in SITES:
+            if site in locks:
+                continue
+            config = neighbor_config(site, locks)
+            kind = axis_type(config)
+            value = predicate(config)
+            if kind in REMAINING_TYPES:
+                appeared_remaining.append(kind)
+                if value == 0:
+                    remaining_refuses.append(
+                        {
+                            "tick": tick,
+                            "site": site,
+                            "config": config,
+                            "axis_type": kind,
+                            "axis_name": AXIS_TYPE_NAME[kind],
+                        }
+                    )
+            elif value == 0:
+                empty_refuses.append(
+                    {
+                        "tick": tick,
+                        "site": site,
+                        "config": config,
+                        "axis_type": kind,
+                        "axis_name": AXIS_TYPE_NAME[kind],
+                    }
+                )
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+    first = remaining_refuses[0] if remaining_refuses else None
+    return {
+        "n_refuse": len(remaining_refuses),
+        "first": first,
+        "remaining_refuses": tuple(remaining_refuses),
+        "empty_refuses": tuple(empty_refuses),
+        "appeared_remaining": tuple(appeared_remaining),
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs")
+    print("construction: displayed F_cut occupancy-to-lock map; first remaining-bit refuse on the #6493 face")
+    print("negative_scope: neither the map nor any remaining bit is adopted or written into Admissibility")
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_C00_FACE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    not_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site, probability, and rate remain outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+    checks.check(
+        "source-record-and-non-dynamics",
+        "Record lock wording and the non-dynamics Admissibility boundary are pinned",
+        record_lock in normalize(axiom)
+        and record_lock in note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-and-lex-order",
+        "the two-cube has twelve lexicographically ordered vertices",
+        len(SITES) == 12
+        and SITES == tuple(sorted(SITES))
+        and SITES[0] == (0, 0, 0)
+        and SITES[-1] == (2, 1, 1)
+        and TWO_CUBE_SET == frozenset(SITES),
+    )
+    checks.check(
+        "off-patch-zero",
+        "every off-patch neighbor contributes occupancy 0",
+        occupancy((-1, 0, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((0, -1, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((3, 0, 0), frozenset({(2, 0, 0)})) == 0,
+    )
+    checks.check(
+        "axis-type-reps",
+        "declared orbit representatives have the stated axis types",
+        axis_type(ORBIT_REPS["wt1"]) == (1, 0, 2)
+        and axis_type(ORBIT_REPS["opp2"]) == (0, 1, 2)
+        and axis_type(ORBIT_REPS["adj2"]) == (2, 0, 1)
+        and axis_type(ORBIT_REPS["vertex3"]) == (3, 0, 0)
+        and axis_type(ORBIT_REPS["mixed3"]) == (1, 1, 1)
+        and axis_type(ORBIT_REPS["type210"]) == (2, 1, 0)
+        and axis_type(ORBIT_REPS["empty"]) == (0, 0, 3)
+        and axis_type(ORBIT_REPS["wt5"]) == (1, 2, 0)
+        and axis_type(ORBIT_REPS["full"]) == (0, 3, 0),
+    )
+
+    f00_bits = remaining_tuple(f00)
+    l1_bits = remaining_tuple(f_L1)
+    checks.check(
+        "f00-remaining-bits",
+        "f00 is the F_cut remaining-bit tuple (1,0,0,0,0)",
+        f00_bits == F00_TUPLE
+        and l1_bits == L1_TUPLE
+        and f00(ORBIT_REPS["wt1"]) == 1
+        and f00(ORBIT_REPS["wt5"]) == 1
+        and f00(ORBIT_REPS["opp2"]) == 0
+        and f00(ORBIT_REPS["adj2"]) == 0
+        and f00(ORBIT_REPS["vertex3"]) == 0
+        and f00(ORBIT_REPS["mixed3"]) == 0
+        and f00(ORBIT_REPS["type210"]) == 0
+        and f00(ORBIT_REPS["empty"]) == 0
+        and f00(ORBIT_REPS["full"]) == 0,
+    )
+    checks.check(
+        "f-l1-is-n-unbalanced",
+        "f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity",
+        f_L1(ORBIT_REPS["wt1"]) == 1
+        and f_L1(ORBIT_REPS["mixed3"]) == 1
+        and f_L1(ORBIT_REPS["type210"]) == 1
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["empty"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) != f_hamming(ORBIT_REPS["adj2"])
+        and sum(ORBIT_REPS["opp2"]) % 2 == 0
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f00", 1)[0],
+    )
+
+    tick, locks, history, snapshots = run_from_seed(frozenset(SEED), f00)
+    census = refusal_census(frozenset(SEED), f00)
+    seed0 = frozenset(SEED)
+    after1 = step(seed0, f00)
+    wave1 = after1 - seed0
+    after2 = step(after1, f00)
+    wave2 = after2 - after1
+    expected_wave1 = frozenset({(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)})
+    expected_wave2 = frozenset({(2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1)})
+    empty_sites = tuple(row["site"] for row in census["empty_refuses"])
+    appeared_names = tuple(AXIS_TYPE_NAME[kind] for kind in census["appeared_remaining"])
+
+    print(f"seed={SEED_DISPLAY}")
+    print(f"history={history} T={tick} fill={locks == TWO_CUBE_SET}")
+    print(f"wave1={sorted(wave1)}")
+    print(f"wave2={sorted(wave2)}")
+    print(f"appeared_remaining={appeared_names}")
+    print(f"N_refuse={census['n_refuse']}")
+    print(f"first_remaining_refuse={census['first']}")
+    print(f"empty_refuses_n={len(census['empty_refuses'])} sites={empty_sites}")
+
+    checks.check(
+        "theorem-1-f00-fills-face",
+        "f00 fills the #6493 face S with history (4, 8, 12)",
+        tick == 2
+        and history == FIRST_HISTORY
+        and locks == TWO_CUBE_SET
+        and len(SEED) == 4
+        and SEED_DISPLAY.replace(" ", "") in note.replace(" ", "")
+        and "(4, 8, 12)" in note
+        and "#6493" in note,
+        residual=(tick, history, len(locks)),
+    )
+    checks.check(
+        "fill-mechanism-waves",
+        "the x=0 face locks the x=1 slice then the x=2 face, each as wt1",
+        wave1 == expected_wave1
+        and wave2 == expected_wave2
+        and after2 == TWO_CUBE_SET
+        and all(axis_type(neighbor_config(site, seed0)) == (1, 0, 2) for site in wave1)
+        and all(axis_type(neighbor_config(site, after1)) == (1, 0, 2) for site in wave2)
+        and all(f00(neighbor_config(site, seed0)) == 1 for site in wave1)
+        and all(f00(neighbor_config(site, after1)) == 1 for site in wave2),
+        residual=(sorted(wave1), sorted(wave2)),
+    )
+    checks.check(
+        "theorem-2-n-refuse-zero",
+        "every remaining-bit orbit that appears is accepted; N_refuse=0",
+        census["n_refuse"] == 0
+        and census["first"] is None
+        and set(census["appeared_remaining"]) == {(1, 0, 2)}
+        and f00(ORBIT_REPS["wt1"]) == 1
+        and "N_refuse=0" in note,
+        residual=(census["n_refuse"], census["first"], appeared_names),
+    )
+    checks.check(
+        "theorem-2-note-reports-n-refuse",
+        "the note reports N_refuse=0 and that only wt1 appears as a remaining bit",
+        "N_refuse=0" in note
+        and "`wt1`" in note
+        and "remaining-bit" in note
+        and "refuses none" in note.lower(),
+    )
+    checks.check(
+        "empty-cut-is-not-remaining-bit",
+        "empty appears on the far face at tick 0 and is the F_cut empty cut, not a remaining bit",
+        len(census["empty_refuses"]) == 4
+        and empty_sites == ((2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1))
+        and all(row["tick"] == 0 and row["axis_name"] == "empty" for row in census["empty_refuses"])
+        and all(row["config"] == (0, 0, 0, 0, 0, 0) for row in census["empty_refuses"])
+        and (0, 0, 3) not in REMAINING_TYPES
+        and "empty" in note
+        and snapshots[0] == seed0
+        and snapshots[-1] == TWO_CUBE_SET,
+        residual=empty_sites,
+    )
+    checks.check(
+        "theorem-3-display-not-adopt",
+        "the note displays the refuse census and refuses adoption of a bit",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in normalize(note)
+        and "Do not adopt" in note
+        and "Do not write" in note,
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, the first refused neighborhood "
+        "of F_cut (1,0,0,0,0) on its #6493 lex-first four-site face fill is "
+        "reported, or the run refuses none. Displayed, not adopted."
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "(4, 8, 12)",
+        "(1, 0, 0, 0, 0)",
+        "N_refuse=0",
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the first refused neighborhood or that the run refuses none",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, refuse census, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and all(phrase not in note and phrase not in self_source for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "new axiom" not in note
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "citation" not in note.lower()
+        and "runner-cache" not in note
+        and "retained" not in other_retained,
+    )
+    checks.check(
+        "not-leftover-6493-or-l1-miss-why",
+        "the residual is the refuse census on the face, not leftover of #6493 or L1-miss-why",
+        "Not leftover-character of #6493" in note
+        and "that named the lex-first fill seed" in note
+        and "Not leftover-character of L1-miss-why" in note
+        and "New finite object" in normalize(note).replace("new finite object", "New finite object"),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in normalize(note)
+        and "not Hamming" in note
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-declared",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut map",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "f00" not in axiom,
+    )
+
+    print("per_element: axis-type representatives and off-patch occupancy 0 are enumerated")
+    print("per_site: each two-cube vertex is tested against the displayed lock predicate")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: the #6493 face run is executed to a fixed point and remaining-bit refuses are counted")
+    print("lattice_wide: checked and not executed — neither the map nor a remaining bit is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the first refused neighborhood of F_cut (1,0,0,0,0) on its #6493 lex-first four-site face fill is reported, or the run refuses none. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c00_face_first_refuse_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.