### PR TITLE
feat(s00oppwhy): first refuse of (1,0,0,0,0) on the #6492 seed

### DIFF
--- a/docs/F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,399 @@
+---
+claim_id: f_cut_c00_6492_seed_first_refuse_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the first refused neighborhood of F_cut (1,0,0,0,0) on the #6492 seed {(0,0,0),(1,1,1),(2,0,0)} is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py
+---
+
+# First Refused Neighborhood Of `F_cut` `(1,0,0,0,0)` On The `#6492` Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** displayed occupancy-to-lock dynamics of one cube-covariant
+map on the twelve-vertex two-cube `{0,1,2}×{0,1}×{0,1}`, started from
+the displayed three-site seed `S={(0,0,0),(1,1,1),(2,0,0)}`, with
+off-patch occupancy identically `0`. The first neighborhood that
+`F_cut (1,0,0,0,0)` refuses on that run is displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py`](../scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve sites `{0,1,2}×{0,1}×{0,1}`. A site
+locks when a displayed predicate of its six-neighbor occupancy tuple
+returns `1`. Off-patch neighbors contribute occupancy `0`. A
+blank-block is a different rule; it is not used. A run is the tuple of lock-set
+cardinalities from the seed through halt, together with the fill bit
+`|locks_halt|=12`.
+
+Let `f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}`
+for at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor
+contrast `n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+Let `f00` be the `F_cut` remaining-bit map
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 0, 0, 0)
+```
+
+with complements forced. It fires only on axis types `(1,0,2)` and
+`(1,2,0)`. The displayed seed is the `#6492` first split of the two
+`wt1=1`, `cov2=0` maps:
+
+```text
+S = {(0,0,0), (1,1,1), (2,0,0)}.
+```
+
+This is a new seed object: not L1-miss-why and not a second named-pair fill.
+`#6492` reported the fill bits of `f00` versus `f10=(1,1,0,0,0)`.
+The object of this note is the first neighborhood `f00` refuses on the
+run from that displayed seed.
+
+**Theorem 1.** From `S`, `f00` has lock history `(3, 11)` and does not
+fill. The history ends before `12`.
+
+**Theorem 2.** The run does fire a remaining-bit orbit after the seed:
+eight unlocked sites present a `wt1` cell and lock. The lex-first
+refused neighborhood, ordered by tick then site, is the `opp2` cell at
+tick `0` on site `(1,0,0)`:
+
+```text
+cell = (1,1,0,0,0,0),    axis type (0,1,2),    remaining bit opp2.
+```
+
+After that wave the leftover site sees an `adj4` cell of type `(2,1,0)`,
+the `adj2` remaining bit, which `f00` also refuses. That later refuse
+is not first.
+
+**Theorem 3.** Display. Do not adopt a bit. Do not adopt `opp2`. Do not
+write a remaining bit into Admissibility.
+
+Displayed, not adopted.
+
+Not leftover-character of L1-miss-why (that asked why `f_L1` misses four
+two-site seeds).
+Not leftover-character of `#6492` as a named-pair fill (that scored the
+fill bits of `f00` versus `f10`).
+New finite object: the first refused neighborhood of `f00` on this seed.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of those sentences is to name the cubic nearest-neighbor
+graph and to keep formation outside the axiom. The axiom memo says the
+distribution concerns which possibility a forming record locks,
+conditional on formation; it does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The map `f00` is a supplied displayed member, not axiom
+content. A seed is likewise displayed data, not an admissibility rule.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact first-refuse neighborhood of one displayed F_cut map on a twelve-vertex two-cube from the #6492 seed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_c00_6492_seed_first_refuse
+target_blocker_text: "lex-first neighborhood that F_cut (1,0,0,0,0) refuses on the #6492 seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded first-refuse claim; do not adopt a bit"
+conditional_surface_status: "exact on the two-cube with off-patch o=0 from the displayed seed; the refused bit remains displayed data"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Sites of the two-cube, in lexicographic order:
+
+`(0,0,0)`, `(0,0,1)`, `(0,1,0)`, `(0,1,1)`,
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`,
+`(2,0,0)`, `(2,0,1)`, `(2,1,0)`, `(2,1,1)`.
+
+The six-neighbor tuple at a site is ordered
+`(+x,-x,+y,-y,+z,-z)`. Each coordinate is the occupancy of that
+neighbor: `1` if the neighbor is an on-patch lock, else `0`. Every
+off-patch neighbor is `0`. The off-patch occupancy `0` is the explicit
+default.
+
+For each axis, the pair of opposite bits is
+
+- unbalanced if the bits are `{0,1}`,
+- both if the bits are `{1,1}`,
+- empty if the bits are `{0,0}`.
+
+Write `(n_unbalanced, n_both, n_empty)` with sum `3`. Representative
+orbits used below:
+
+| name | type | representative |
+|---|---|---|
+| empty | `(0,0,3)` | `(0,0,0,0,0,0)` |
+| wt1 | `(1,0,2)` | `(1,0,0,0,0,0)` |
+| opp2 | `(0,1,2)` | `(1,1,0,0,0,0)` |
+| adj2 | `(2,0,1)` | `(1,0,1,0,0,0)` |
+| type210 | `(2,1,0)` | `(1,1,1,0,0,1)` |
+| vertex3 | `(3,0,0)` | `(1,0,1,0,1,0)` |
+| mixed3 | `(1,1,1)` | `(1,0,1,1,0,0)` |
+| wt5 | `(1,2,0)` | `(1,1,1,1,1,0)` |
+| full | `(0,3,0)` | `(1,1,1,1,1,1)` |
+
+`adj4` is the complement of `adj2`: axis type `(2,1,0)`, the same
+remaining bit as `adj2`. `opp4` is the complement of `opp2`: axis type
+`(0,2,1)`, the same remaining bit as `opp2`. Empty and full are not
+remaining-bit orbits.
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Five remaining bits stay free, so `|F_cut|=32`. Those
+bits are ordered `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` iff `n_unbalanced(c)≥1`. Its remaining-bit tuple is
+`(1,0,1,1,1)`.
+`f00(c)=1` iff the axis type is `wt1=(1,0,2)` or `wt5=(1,2,0)`. Its
+remaining-bit tuple is `(1, 0, 0, 0, 0)`.
+
+On those representatives the bits are
+
+| map | wt1 | opp2 | adj2 | type210 | vertex3 | mixed3 | empty | full |
+|---|---|---|---|---|---|---|---|---|
+| `f_L1` | 1 | 0 | 1 | 1 | 1 | 1 | 0 | 0 |
+| `f00` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+Hamming parity of `|c|_1` is a different predicate: `opp2` is even and
+`f_L1(opp2)=0`, while `adj2` is even and `f_L1(adj2)=1`.
+
+One tick locks every currently unlocked on-patch site whose neighbor
+tuple has `f=1`. The process starts with `locks_0=S` and halts at the
+first fixed point, or at tick `12`. Lock history is the sequence of
+cardinalities from `t=0` through halt. Fill means `|locks_halt|=12`.
+
+A refused neighborhood on the run is an unlocked site at some tick
+whose six-neighbor cell has `f00=0`. Events are ordered by increasing
+tick, then lexicographic site. The first such event is the first
+refused neighborhood. Remaining-bit labels, axis types, and orbit
+names are the three equivalent readings of that cell.
+
+## Theorem 1 — `f00` does not fill from `S`
+
+Start with `S={(0,0,0),(1,1,1),(2,0,0)}`, so `|locks_0|=3`. One tick
+locks eight sites and leaves `(1,0,0)` unlocked. The process then
+halts: history `(3, 11)`, fill bit `0`. The history ends before `12`.
+This reconfirms the `#6492` `f00` miss on this seed.
+
+## Theorem 2 — first refused neighborhood
+
+At tick `0` the nine unlocked sites present two orbit types:
+
+- eight sites see a `wt1` cell of type `(1,0,2)` and lock, because
+  `f00` has remaining bit `wt1=1`;
+- the leftover site `(1,0,0)` sees the cell `(1,1,0,0,0,0)`, the
+  `opp2` representative of type `(0,1,2)`, and stays unlocked,
+  because `f00` has remaining bit `opp2=0`.
+
+The run therefore does fire a remaining-bit orbit after the seed
+(`wt1`). The report is not “never fires a remaining-bit orbit after
+the seed.”
+
+The unique refuse at tick `0` is already first in tick-then-site
+order: site `(1,0,0)`, orbit `opp2`, type `(0,1,2)`, remaining bit
+`opp2`.
+
+After the wave, `|locks_1|=11` and the leftover site sees
+
+```text
+(1,1,1,0,1,0),    axis type (2,1,0),    orbit adj4,    remaining bit adj2.
+```
+
+`f00` refuses that cell as well, so the process halts unfilled. The
+`adj2` refuse is later than the `opp2` refuse.
+
+## Theorem 3 — display, not adoption
+
+The first refuse is displayed data. Do not adopt a bit. Do not adopt
+`opp2`. Do not adopt `adj2`. Do not write a remaining bit into
+Admissibility. Admissibility is not a dynamics axiom and does not
+supply this predicate, this seed, or this refuse. The refused
+neighborhood is not written into Admissibility.
+
+A named-pair fill bit is not a first refused neighborhood. The first
+refuse is a new finite object on this two-cube.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, seed `S` | declared finite data |
+| `f00` history from `S` | `(3, 11)`; no fill |
+| first refuse, or “never fires a remaining-bit orbit after the seed” | `opp2` at tick `0` on `(1,0,0)` |
+| later refuse on the leftover site | `adj4` / `adj2`; not first |
+| adoption of a remaining bit | refused |
+| formation site / rate from the axioms | open |
+
+## Boundary And Imports
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. The two-cube, the predicate `f00`, and the
+seed `S` are supplied mathematical data for this note. Record lock
+language is quoted only as the existing lock/content/absence boundary;
+it does not select this map or any remaining bit.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers which first neighborhood, if any, `f00` refuses on the `#6492` seed. |
+| V2 | Current main has the axiom memo and the `#6492` fill-bit split, not this first refuse. |
+| V3 | The twelve-vertex process from one displayed seed is independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it executes a supplied predicate the axiom does not name. |
+| V5 | Neither the map nor a remaining bit is an admissibility rule, and neither is adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: a named-pair fill bit is not a first
+refuse, and a displayed refuse or remaining bit is not axiom content.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| history from `S` | occupancy-to-lock under `f00` | `(3, 11)`; no fill |
+| remaining-bit fire after the seed | unlocked cells at tick `0` | eight `wt1` cells fire |
+| first refuse, tick then site | unlocked cells with `f00=0` | `opp2` at `(1,0,0)` |
+| later leftover cell | tick `1` on `(1,0,0)` | `adj4` / `adj2`; not first |
+| Hamming parity | `|c|_1 mod 2` | different predicate; `adj2` even |
+| write a bit into Admissibility | treat `opp2` as the local rule | refused; axiom is not a dynamics axiom |
+
+### N2 — wall independence
+
+The missing formation-site selector, the missing axiom-level
+occupancy rule, and the choice among displayed remaining bits are
+distinct open items. This note claims no complete wall and no compiler
+no-go.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch `o=0`, the displayed seed
+`S={(0,0,0),(1,1,1),(2,0,0)}`, six-neighbor order, and the
+remaining-bit tuple `(1,0,0,0,0)` are declared. Cube covariance is
+used only as the axis-type reading of a six-tuple. No continuum,
+Hamming, or admissibility rewrite is assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor graph and states
+that Admissibility is not a dynamics axiom and does not supply the
+formation site, probability, or rate. The extra therefore matches
+those sources: a displayed lock predicate and a displayed refuse are
+extra data.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | axis-type representatives and off-patch `0` | no alphabet classification |
+| per site | every two-cube vertex against `f00` | no derived kernel values |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | the displayed seed through halt | no physical compiler |
+| lattice wide | checked and not executed | neither map nor a bit adopted as a rule |
+
+### N6 — live partial-closure paths
+
+Live routes include an independent reason to select or reject `f00`,
+the first refuse of the sibling map `f10` on the same seed, and a
+formation mechanism supplied by something other than a displayed
+predicate.
+
+### N7 — hostile steelman
+
+**Steelman:** `#6492` already said `f00` misses this seed because it
+lacks the `opp2` bit, so the first refuse is just that fill-bit score
+and may be written as a rule.
+
+**Answer:** The fill bit is a halt cardinality. The first refuse is a
+tick, a site, an orbit, an axis type, and a remaining-bit label on a
+concrete six-neighbor cell. That is a displayed finite fact.
+Admissibility does not name `f00` or `opp2`.
+
+### N8 — cross-cycle echo
+
+A two-site miss mechanism for `f_L1` (L1-miss-why) and a named-pair
+fill split of `f00` versus `f10` (`#6492`) are different claims. This
+note executes the first refused neighborhood of `F_cut` `(1,0,0,0,0)`
+on the displayed `#6492` seed.
+
+**Gate disposition:** PASS for the finite first-refuse statement and the
+displayed history. FAIL / DO NOT SHIP for “adopt `opp2`,” “write a bit
+into Admissibility,” or “the `#6492` fill bit already is the first
+refuse.”
+
+## Primary Runner
+
+The primary runner rebuilds the two-cube, the predicate `f00`, the
+history from `S`, the first-refuse event, the later `adj4` leftover
+cell, the current premise boundary, and the non-adoption wording. It
+authors no audit verdict.
+
+## What This Does Not Claim
+
+- The two-cube is not claimed to be a physically derived finite world.
+- The `opp2` bit is not adopted, and `f00` is not selected as a physical law.
+- No claim is made that Record locks, or refuses, on `opp2` cells.
+- The later `adj4` refuse is not the first refuse.
+- Independent class leftovers are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site, nearest-neighbor,
+and lock vocabulary. This theorem separately supplies the two-cube, the
+`F_cut` coding, and the refuse census; physical interpretation of `opp2`
+remains outside its target.
+
+On the two-cube with off-patch o=0, the first refused neighborhood of F_cut (1,0,0,0,0) on the #6492 seed {(0,0,0),(1,1,1),(2,0,0)} is reported. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c00_6492_seed_first_refuse_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c00_6492_seed_first_refuse_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c00_6492_seed_first_refuse_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py
+runner_sha256: ef785173568ae9e75ec685ef52f72aca7a7b591c52bf3b096f3d17476531ad7e
+input_fingerprint_sha256: f0df89c17f47b4362c9f231f95ca5a7bfa41df4ca4f2a9d636c779a40e8bf5c9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs
+construction: displayed F_cut occupancy-to-lock map; first refuse on the #6492 seed
+negative_scope: neither the map nor the refused remaining bit is adopted or written into Admissibility
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+PASS: audit-inputs declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site, probability, and rate remain outside Admissibility
+PASS: source-record-and-non-dynamics Record lock wording and the non-dynamics Admissibility boundary are pinned
+PASS: two-cube-and-lex-order the two-cube has twelve lexicographically ordered vertices
+PASS: off-patch-zero every off-patch neighbor contributes occupancy 0
+PASS: axis-type-reps declared orbit representatives have the stated axis types
+PASS: f00-remaining-bits f00 is the F_cut remaining-bit tuple (1,0,0,0,0)
+PASS: f-l1-is-n-unbalanced f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity
+history=(3, 11) T=1 fill=False
+first_refuse=(0, (1, 0, 0), 'opp2', (0, 1, 2), 'opp2', (1, 1, 0, 0, 0, 0))
+n_refuse=2 n_fire=8 tick0_fires=8
+PASS: theorem-1-no-fill f00 has history (3, 11) from S and does not fill
+PASS: theorem-2-fires-remaining-bit the run fires the wt1 remaining-bit orbit after the seed
+PASS: theorem-2-first-refuse the lex-first refuse is opp2 at tick 0 on (1,0,0)
+PASS: theorem-2-later-adj4 the leftover site later sees adj4 / adj2, which is not first
+PASS: theorem-3-display-not-adopt the note displays the refuse and refuses adoption of a bit
+PASS: mutation-hamming-is-not-l1 Hamming parity is a different predicate from n!=0 and from f00
+PASS: mutation-swap-fill-fails the swapped claim that f00 fills S is false
+PASS: claim-scope claim_scope reports the first refuse on the #6492 seed and does not adopt it
+PASS: note-contract machine fields, first-refuse statement, and forbidden-phrase hygiene hold
+PASS: not-leftover the residual is the first refuse, not L1-miss-why or a named-pair fill
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-declared off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut map
+per_element: axis-type representatives and off-patch occupancy 0 are enumerated
+per_site: each two-cube vertex is tested against the displayed lock predicate
+per_mode: checked and not executed — no spectral claim occurs
+per_block: the displayed seed is executed to a fixed point
+lattice_wide: checked and not executed — neither the map nor a bit is adopted
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py
+++ b/scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""First refused neighborhood of F_cut (1,0,0,0,0) on the #6492 seed.
+
+Two-cube, off-patch occupancy 0. Seed S={(0,0,0),(1,1,1),(2,0,0)}.
+f00 is the F_cut remaining-bit map (1,0,0,0,0): fire only on wt1 and wt5.
+f_L1 is the some-axis-unbalanced (n!=0) map, not Hamming parity.
+The first refuse is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+
+SITES: tuple[Point, ...] = tuple(
+    sorted((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+)
+TWO_CUBE_SET = frozenset(SITES)
+AXIS_SHIFTS: tuple[tuple[Point, Point], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+F00_TUPLE: tuple[int, ...] = (1, 0, 0, 0, 0)
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+SEED: tuple[Point, ...] = ((0, 0, 0), (1, 1, 1), (2, 0, 0))
+SEED_HISTORY = (3, 11)
+LEFTOVER: Point = (1, 0, 0)
+OPP2_CELL: Config = (1, 1, 0, 0, 0, 0)
+ADJ4_CELL: Config = (1, 1, 1, 0, 1, 0)
+
+ORBIT_REPS: dict[str, Config] = {
+    "empty": (0, 0, 0, 0, 0, 0),
+    "wt1": (1, 0, 0, 0, 0, 0),
+    "opp2": (1, 1, 0, 0, 0, 0),
+    "adj2": (1, 0, 1, 0, 0, 0),
+    "vertex3": (1, 0, 1, 0, 1, 0),
+    "mixed3": (1, 0, 1, 1, 0, 0),
+    "type210": (1, 1, 1, 0, 0, 1),
+    "wt5": (1, 1, 1, 1, 1, 0),
+    "full": (1, 1, 1, 1, 1, 1),
+}
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+CLAIM_SCOPE = (
+    "On the two-cube with off-patch o=0, the first refused neighborhood of "
+    "F_cut (1,0,0,0,0) on the #6492 seed {(0,0,0),(1,1,1),(2,0,0)} is "
+    "reported. Displayed, not adopted."
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locks: frozenset[Point]) -> int:
+    if site not in TWO_CUBE_SET:
+        return 0
+    return 1 if site in locks else 0
+
+
+def neighbor_config(site: Point, locks: frozenset[Point]) -> Config:
+    bits: list[int] = []
+    for plus, minus in AXIS_SHIFTS:
+        bits.append(occupancy(add(site, plus), locks))
+        bits.append(occupancy(add(site, minus), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def axis_type(config: Config) -> tuple[int, int, int]:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for index in (0, 2, 4):
+        plus, minus = config[index], config[index + 1]
+        if plus == 1 and minus == 1:
+            n_both += 1
+        elif plus == 0 and minus == 0:
+            n_empty += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def orbit_name(config: Config) -> str:
+    kind = axis_type(config)
+    names = {
+        (0, 0, 3): "empty",
+        (1, 0, 2): "wt1",
+        (0, 1, 2): "opp2",
+        (2, 0, 1): "adj2",
+        (3, 0, 0): "vertex3",
+        (1, 1, 1): "mixed3",
+        (2, 1, 0): "adj4",
+        (0, 2, 1): "opp4",
+        (1, 2, 0): "wt5",
+        (0, 3, 0): "full",
+    }
+    return names[kind]
+
+
+def remaining_bit(config: Config) -> str | None:
+    name = orbit_name(config)
+    pairing = {
+        "wt1": "wt1",
+        "wt5": "wt1",
+        "opp2": "opp2",
+        "opp4": "opp2",
+        "adj2": "adj2",
+        "adj4": "adj2",
+        "vertex3": "vertex3",
+        "mixed3": "mixed3",
+    }
+    return pairing.get(name)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    n_unbalanced, _n_both, _n_empty = axis_type(config)
+    return 1 if n_unbalanced >= 1 else 0
+
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (1,0,0,0,0): fire only on wt1 and wt5."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (1, 2, 0)) else 0
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_tuple(predicate) -> tuple[int, ...]:
+    return tuple(int(predicate(ORBIT_REPS[name]) == 1) for name in BIT_NAMES)
+
+
+def step(locks: frozenset[Point], predicate) -> frozenset[Point]:
+    newcomers = {
+        site
+        for site in SITES
+        if site not in locks and predicate(neighbor_config(site, locks)) == 1
+    }
+    return locks | newcomers
+
+
+def run_from_seed(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    history = [len(locks)]
+    layers = [locks]
+    tick = 0
+    while tick < halt_bound:
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+        history.append(len(locks))
+        layers.append(locks)
+    return tick, frozenset(locks), tuple(history), tuple(layers)
+
+
+def refuse_events(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    events = []
+    fires = []
+    tick = 0
+    while True:
+        for site in SITES:
+            if site in locks:
+                continue
+            config = neighbor_config(site, locks)
+            bit = remaining_bit(config)
+            record = (
+                tick,
+                site,
+                orbit_name(config),
+                axis_type(config),
+                bit,
+                config,
+            )
+            if predicate(config) == 1:
+                fires.append(record)
+            else:
+                events.append(record)
+        if tick >= halt_bound:
+            break
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+    return tuple(events), tuple(fires)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    compact_note = note.replace(" ", "")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs")
+    print("construction: displayed F_cut occupancy-to-lock map; first refuse on the #6492 seed")
+    print("negative_scope: neither the map nor the refused remaining bit is adopted or written into Admissibility")
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_C00_6492_SEED_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    not_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site, probability, and rate remain outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+    checks.check(
+        "source-record-and-non-dynamics",
+        "Record lock wording and the non-dynamics Admissibility boundary are pinned",
+        record_lock in normalize(axiom)
+        and record_lock in note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-and-lex-order",
+        "the two-cube has twelve lexicographically ordered vertices",
+        len(SITES) == 12
+        and SITES == tuple(sorted(SITES))
+        and SITES[0] == (0, 0, 0)
+        and SITES[-1] == (2, 1, 1)
+        and TWO_CUBE_SET == frozenset(SITES),
+    )
+    checks.check(
+        "off-patch-zero",
+        "every off-patch neighbor contributes occupancy 0",
+        occupancy((-1, 0, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((0, -1, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((3, 0, 0), frozenset({(2, 0, 0)})) == 0,
+    )
+    checks.check(
+        "axis-type-reps",
+        "declared orbit representatives have the stated axis types",
+        axis_type(ORBIT_REPS["wt1"]) == (1, 0, 2)
+        and axis_type(ORBIT_REPS["opp2"]) == (0, 1, 2)
+        and axis_type(ORBIT_REPS["adj2"]) == (2, 0, 1)
+        and axis_type(ORBIT_REPS["vertex3"]) == (3, 0, 0)
+        and axis_type(ORBIT_REPS["mixed3"]) == (1, 1, 1)
+        and axis_type(ORBIT_REPS["type210"]) == (2, 1, 0)
+        and axis_type(ORBIT_REPS["empty"]) == (0, 0, 3)
+        and axis_type(ORBIT_REPS["wt5"]) == (1, 2, 0)
+        and axis_type(ORBIT_REPS["full"]) == (0, 3, 0)
+        and orbit_name(OPP2_CELL) == "opp2"
+        and orbit_name(ADJ4_CELL) == "adj4"
+        and remaining_bit(OPP2_CELL) == "opp2"
+        and remaining_bit(ADJ4_CELL) == "adj2",
+    )
+
+    f00_bits = remaining_tuple(f00)
+    l1_bits = remaining_tuple(f_L1)
+    checks.check(
+        "f00-remaining-bits",
+        "f00 is the F_cut remaining-bit tuple (1,0,0,0,0)",
+        f00_bits == F00_TUPLE
+        and l1_bits == L1_TUPLE
+        and f00(ORBIT_REPS["wt1"]) == 1
+        and f00(ORBIT_REPS["wt5"]) == 1
+        and f00(ORBIT_REPS["opp2"]) == 0
+        and f00(ORBIT_REPS["adj2"]) == 0
+        and f00(ORBIT_REPS["vertex3"]) == 0
+        and f00(ORBIT_REPS["mixed3"]) == 0
+        and f00(ORBIT_REPS["type210"]) == 0
+        and f00(ORBIT_REPS["empty"]) == 0
+        and f00(ORBIT_REPS["full"]) == 0,
+    )
+    checks.check(
+        "f-l1-is-n-unbalanced",
+        "f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity",
+        f_L1(ORBIT_REPS["wt1"]) == 1
+        and f_L1(ORBIT_REPS["mixed3"]) == 1
+        and f_L1(ORBIT_REPS["type210"]) == 1
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["empty"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) != f_hamming(ORBIT_REPS["adj2"])
+        and sum(ORBIT_REPS["opp2"]) % 2 == 0
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f00", 1)[0],
+    )
+
+    seed0 = frozenset(SEED)
+    tick, locks, history, layers = run_from_seed(seed0, f00)
+    refuses, fires = refuse_events(seed0, f00)
+    first = refuses[0] if refuses else None
+    tick0_fires = tuple(event for event in fires if event[0] == 0)
+    tick0_refuses = tuple(event for event in refuses if event[0] == 0)
+    later_adj4 = tuple(
+        event
+        for event in refuses
+        if event[0] == 1 and event[1] == LEFTOVER and event[2] == "adj4"
+    )
+    print(f"history={history} T={tick} fill={locks == TWO_CUBE_SET}")
+    print(f"first_refuse={first}")
+    print(f"n_refuse={len(refuses)} n_fire={len(fires)} tick0_fires={len(tick0_fires)}")
+
+    checks.check(
+        "theorem-1-no-fill",
+        "f00 has history (3, 11) from S and does not fill",
+        tick == 1
+        and history == SEED_HISTORY
+        and locks == TWO_CUBE_SET - {LEFTOVER}
+        and locks != TWO_CUBE_SET
+        and history[-1] < 12
+        and "(3, 11)" in note
+        and "{(0,0,0),(1,1,1),(2,0,0)}" in compact_note
+        and "does not fill" in note,
+        residual=(tick, history, len(locks)),
+    )
+    checks.check(
+        "theorem-2-fires-remaining-bit",
+        "the run fires the wt1 remaining-bit orbit after the seed",
+        len(tick0_fires) == 8
+        and all(event[2] == "wt1" and event[4] == "wt1" for event in tick0_fires)
+        and all(event[3] == (1, 0, 2) for event in tick0_fires)
+        and "does fire a remaining-bit orbit after the seed" in note
+        and "never fires a remaining-bit orbit after the seed" in note,
+    )
+    checks.check(
+        "theorem-2-first-refuse",
+        "the lex-first refuse is opp2 at tick 0 on (1,0,0)",
+        first is not None
+        and first[0] == 0
+        and first[1] == LEFTOVER
+        and first[2] == "opp2"
+        and first[3] == (0, 1, 2)
+        and first[4] == "opp2"
+        and first[5] == OPP2_CELL
+        and len(tick0_refuses) == 1
+        and tick0_refuses[0] == first
+        and neighbor_config(LEFTOVER, seed0) == OPP2_CELL
+        and f00(OPP2_CELL) == 0
+        and "`opp2`" in note
+        and "(1,0,0)" in compact_note
+        and "(1,1,0,0,0,0)" in compact_note
+        and "(0,1,2)" in compact_note,
+        residual=first,
+    )
+    checks.check(
+        "theorem-2-later-adj4",
+        "the leftover site later sees adj4 / adj2, which is not first",
+        later_adj4 != ()
+        and later_adj4[0][5] == ADJ4_CELL
+        and later_adj4[0][3] == (2, 1, 0)
+        and later_adj4[0][4] == "adj2"
+        and neighbor_config(LEFTOVER, layers[1]) == ADJ4_CELL
+        and f00(ADJ4_CELL) == 0
+        and "adj4" in note
+        and "not first" in note,
+    )
+    checks.check(
+        "theorem-3-display-not-adopt",
+        "the note displays the refuse and refuses adoption of a bit",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not adopt `opp2`" in note
+        and "not written into Admissibility" in normalize(note)
+        and "Do not write" in note,
+    )
+
+    checks.check(
+        "mutation-hamming-is-not-l1",
+        "Hamming parity is a different predicate from n!=0 and from f00",
+        remaining_tuple(f_hamming) != L1_TUPLE
+        and remaining_tuple(f_hamming) != F00_TUPLE
+        and f_hamming(ORBIT_REPS["adj2"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) == 1,
+    )
+    checks.check(
+        "mutation-swap-fill-fails",
+        "the swapped claim that f00 fills S is false",
+        history != (3, 12) and len(locks) != 12,
+    )
+
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "(3, 11)",
+        "(1, 0, 0, 0, 0)",
+        "first refused neighborhood",
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the first refuse on the #6492 seed and does not adopt it",
+        CLAIM_SCOPE in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, first-refuse statement, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and all(phrase not in note and phrase not in self_source for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "new axiom" not in note
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "citation" not in note.lower()
+        and "runner-cache" not in note
+        and "retained" not in other_retained,
+    )
+    checks.check(
+        "not-leftover",
+        "the residual is the first refuse, not L1-miss-why or a named-pair fill",
+        "Not leftover-character of L1-miss-why" in note
+        and "Not leftover-character of `#6492`" in note
+        and "not a second named-pair fill" in note
+        and "New finite object" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in normalize(note)
+        and "not Hamming" in note
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-declared",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut map",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "f00" not in axiom,
+    )
+
+    print("per_element: axis-type representatives and off-patch occupancy 0 are enumerated")
+    print("per_site: each two-cube vertex is tested against the displayed lock predicate")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: the displayed seed is executed to a fixed point")
+    print("lattice_wide: checked and not executed — neither the map nor a bit is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the first refused neighborhood of F_cut (1,0,0,0,0) on the #6492 seed {(0,0,0),(1,1,1),(2,0,0)} is reported. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c00_6492_seed_first_refuse_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.