### PR TITLE
feat(c00c3): 3-site coverage of the two #6490 exceptions

### DIFF
--- a/docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,393 @@
+---
+claim_id: f_cut_c00_c10_three_site_coverage_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the 3-site coverage of F_cut (1,0,0,0,0) and (1,1,0,0,0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py
+---
+
+# Three-Site Coverage Of The Two `#6490` `F_cut` Exceptions
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 3-site coverage of the two cube-covariant
+complement-even maps in `F_cut` with remaining-bit tuples
+`(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`, on the twelve-vertex two-cube,
+over all 220 unordered 3-site seeds, with off-patch occupancy `0`. Those
+two maps are the `#6490` exceptions (`wt1=1` and `cov2=0`). The pair of
+coverages is displayed. Neither map is adopted as the physical
+Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py`](../scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `f00` for remaining bits `(1, 0, 0, 0, 0)` and `f10`
+for remaining bits `(1, 1, 0, 0, 0)`. Both have `wt1=1`. Both have
+`cov2=0`. They are the two `#6490` exceptions to the failed equivalence
+`cov2>0` iff `wt1=1`.
+
+Not leftover-character of #6490: that scored only cov2. The present object
+is three-site coverage of the same two maps. New |S|.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered triple of vertices is
+a 3-site seed. There are `C(12,3)=220` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov3(f) = |{ S : |S|=3 and f fills from S }|.
+```
+
+The comparison ceiling `m3=220` is that seed count: a map attains `m3`
+exactly when it fills every 3-site seed. Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+That map is a control, not a scored exception.
+
+**Theorem 1.** Exhaustive evaluation of the two exception maps on all 220
+three-site seeds gives
+
+```text
+cov3(f00) = 0
+cov3(f10) = 4.
+```
+
+**Theorem 2.** Neither attains m3=220.
+
+**Theorem 3.** The pair `(cov3(f00), cov3(f10)) = (0, 4)` is displayed.
+Neither `f00` nor `f10` is adopted as the physical Admissibility rule.
+
+Do not write the ranking into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, membership of f00=(1,0,0,0,0) and f10=(1,1,0,0,0), and the exact pair cov3(f00)=0, cov3(f10)=4 against m3=220 are enumerated. Neither exception fills every 3-site seed. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_c00_c10_three_site_coverage
+target_blocker_text: "do the cov2=0 wt1=1 maps fill any 3-site seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the two-exception 3-site coverage pair; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for f00 and f10 on this twelve-vertex patch with off-patch o=0 and all 220 three-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 220 unordered 3-site seeds;
+- the two remaining-bit tuples `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Report `cov3` of the two `#6490` exception maps `f00` and `f10`
+on the two-cube, and decide whether either attains `m3=220`. Display the
+pair. Do not adopt a map.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f00(c)      = 1  iff  the remaining-bit assignment is (1, 0, 0, 0, 0),
+f10(c)      = 1  iff  the remaining-bit assignment is (1, 1, 0, 0, 0),
+f_L1(c)     = 1  iff  u(c) ≥ 1.
+```
+
+So `f00` fires only on the `wt1` orbit and its complement, `f10` fires on
+`wt1` and `opp2` (and their complements), and `f_L1` has remaining bits
+`(1, 0, 1, 1, 1)`. None of these maps is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov3(f)` is the number of 3-site seeds whose halt set has cardinality
+12. Write `m3=220` for the number of 3-site seeds. A map attains `m3` if
+and only if it fills every such seed.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The maps `f00` and
+`f10` are two of those 32 members. Both have remaining bit `wt1=1`. Both
+have `cov2=0`, which is the `#6490` exception pair. The unbalanced-axis
+map `f_L1` is one element of `F_cut` and is not Hamming parity. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive evaluation
+of the two exception maps on all 220 three-site seeds gives
+
+```text
+cov3(f00) = 0
+cov3(f10) = 4.
+```
+
+So `f00` fills no 3-site seed, and `f10` fills four of the 220.
+
+**Theorem 2.** Because `cov3(f00)=0 < 220` and `cov3(f10)=4 < 220`,
+neither attains `m3=220`. The `#6490` exceptions do not fill the 3-site
+seed class. Neither attains m3=220.
+
+**Theorem 3.** The pair
+
+```text
+(cov3(f00), cov3(f10)) = (0, 4)
+```
+
+is displayed. Neither remaining-bit tuple is adopted as the physical
+Admissibility rule.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after empty/full are forced to `0` |
+| `f00` and `f10` in `F_cut` | remaining-bit tuples `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)` |
+| 220 three-site seeds | `C(12,3)` unordered triples on the two-cube; `m3=220` |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` and has remaining bits `(1, 0, 1, 1, 1)` |
+| pair `(cov3(f00), cov3(f10))` | exhaustive `cov3` yields `(0, 4)` |
+| attain `m3` | fails for both maps |
+| displayed tuples | `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`, not adopted |
+
+## What This Does Not Claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No ranking of the other 30 maps in `F_cut`.
+- No reopening of the 32-map global `Max(3)` pair.
+- No blank-block or 4-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is attainment of `m3`: neither `#6490` exception
+fills every 3-site seed on this patch. The positive pair
+`(cov3(f00), cov3(f10))=(0, 4)` is an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| two-exception 3-site score | Score `f00` and `f10` by `cov3` on all 220 seeds. | Theorem 1 and check `thm1-cov3-f00-and-f10` give `0` and `4`. | **ATTEMPTED** |
+| attain `m3=220` | Ask whether either exception fills every 3-site seed. | Theorem 2 and check `thm2-neither-attains-m3`. | **ATTEMPTED** |
+| adopt a map | Write `f00` or `f10` into Admissibility. | Theorem 3 and check `thm3-displayed-not-adopted`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: neither exception attains `m3=220`. The
+two separate inequalities `0<220` and `4<220` are two certificates of the
+same non-attainment, so they collapse rather than count as two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `cov3(f00)=0` / `cov3(f10)=4` | no: one map's score does not name the other | no: four fills do not force zero fills | independent positive integers |
+| pair `(0, 4)` / non-attainment of `m3` | yes: both scores are below 220 | no: non-attainment does not name the scores | independent scores versus the ceiling test |
+| static `#6490` pair / this `cov3` pair | no: `cov2=0` is not 3-site dynamics | no: a 3-site score does not replace the 2-site exception | different `|S|` |
+| leftover `#6490` / this ranking | no: that leftover scored only `cov2` | no: a 3-site pair does not replace the 2-site census | New \|S\| |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| remaining bits `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)` | explicit scored pair; the other 30 maps are unclaimed |
+| all 220 three-site seeds | explicit seed class; a 2-site ranking is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuples `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)` | displayed witnesses, not selected laws |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:81` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:125` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:130` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:53` | 220 three-site seeds | `C(12,3)` unordered triples on the two-cube | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:144` | `f00` remaining bits | `(1, 0, 0, 0, 0)` | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:149` | `f10` remaining bits | `(1, 1, 0, 0, 0)` | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:210` | `cov3(f)` | number of 3-site seeds a map fills | yes |
+| `scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py:67` | `m3=220` | seed-count ceiling | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: `f00` and `f10` | the score is these two maps on all 220 seeds; other classes are unclaimed |
+| per block | yes: the pair `(0, 4)` against `m3=220` | neither exception attains the ceiling |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: `f10`
+does fill four of the 220 three-site seeds, while `f00` fills none. That
+positive pair does not make either tuple a unique maximizer and does not
+select either as the physical rule. The remaining physical choice —
+which, if any, `F_cut` map is the Admissibility occupancy predicate —
+stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that `#6490` already showed these two maps
+never fill a 2-site seed, so a 3-site score might be called leftover
+decoration of that silence. That objection is correctly about `cov2=0`.
+It does not overturn the stated theorem: on the 220 three-site seeds,
+`f00` still fills none, while `f10` fills four. Two-site silence does
+not name the 3-site pair. This is a new `|S|`.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the two exception maps, and the 220-seed scores are recomputed
+here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the two-exception 3-site coverage pair or
+restores attainment of `m3=220` for `f00` or `f10`.
+
+No-Go Discipline disposition: **PASS** for the non-attainment of `m3` and
+the exact pair `(cov3(f00), cov3(f10))` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates `f00=(1,0,0,0,0)` and `f10=(1,1,0,0,0)` on the
+two-cube from every 3-site seed, reports `cov3(f00) = 0` and
+`cov3(f10) = 4`, checks that neither attains `m3=220`, checks that
+`f_L1` is not Hamming parity, and exhibits the two remaining-bit tuples
+as displayed, not adopted. Declared audit inputs are this note and the
+axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5541,
+ "edge_count": 15742,
+ "node_count": 5542,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c00_c10_three_site_coverage_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c00_c10_three_site_coverage_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c00_c10_three_site_coverage_2026_08_15.txt
@@ -1,0 +1,67 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py
+runner_sha256: 1885153f7ecc27090706f4087c0cc1a3a09539d8766834941f6cada43ef54389
+input_fingerprint_sha256: 7d45c03edffb36467d3000e029ca3173f6dc46e734564fee2614c030a8963b78
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_two_site_seeds=66
+n_three_site_seeds=220
+m3=220
+f00_remaining=(1, 0, 0, 0, 0)
+f10_remaining=(1, 1, 0, 0, 0)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_remaining=(1, 0, 0, 1, 1)
+cov2_f00=0
+cov2_f10=0
+cov3_f00=0
+cov3_f10=4
+attains_m3_f00=False
+attains_m3_f10=False
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-three-site-seeds the two-cube has twelve vertices and C(12,3)=220 three-site seeds
+PASS: thm1-exception-membership f00 and f10 are the remaining-bit tuples (1,0,0,0,0) and (1,1,0,0,0) in F_cut
+PASS: thm1-cov2-zero-exceptions both maps have cov2=0 on the 66 two-site seeds
+PASS: thm1-cov3-f00-and-f10 cov3(f00)=0 and cov3(f10)=4 on the 220 three-site seeds
+PASS: thm2-neither-attains-m3 neither exception attains m3=220
+PASS: thm3-displayed-not-adopted the pair (0, 4) is displayed and neither map is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted pair, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-coverage the note reports cov3 of both exceptions against m3=220
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-scope-coverage claim_scope reports 3-site coverage of the two exceptions and does not adopt them
+PASS: not-leftover-6490 the residual is 3-site coverage of the two exceptions, not leftover cov2 scoring of #6490
+PASS: seeds-not-listed the note does not list 3-site seeds
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut map
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f00 and f10 are scored on all 220 three-site seeds
+per_block: checked exactly — the pair (0, 4) is tested against m3=220
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py
+++ b/scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Exact 3-site fill coverage of the two #6490 F_cut exceptions.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+The remaining-bit tuple is (wt1, opp2, adj2, vertex3, mixed3). This runner
+scores f00=(1,0,0,0,0) and f10=(1,1,0,0,0) by cov3 on all 220 unordered
+3-site seeds of the twelve-vertex two-cube with off-patch occupancy 0.
+Those two maps are the #6490 exceptions (wt1=1 and cov2=0). f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+No map is adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(pair) for pair in combinations(TWO_CUBE, 2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+F00_REMAINING: tuple[int, ...] = (1, 0, 0, 0, 0)
+F10_REMAINING: tuple[int, ...] = (1, 1, 0, 0, 0)
+M3 = 220
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+# Remaining-bit witnesses of the two #6490 exceptions. Complements are
+# forced by the F_cut cut f(c)=f(1-c). These predicates are displayed
+# occupancy-to-lock maps on the two-cube. Neither is adopted.
+# The remaining-bit order is (wt1, opp2, adj2, vertex3, mixed3).
+# f00 keeps only wt1. f10 keeps wt1 and opp2.
+# Empty and full stay 0. Mixed3, vertex3, and adj2 stay 0 on both maps.
+# The 3-site score is new |S|; the 2-site score is leftover of #6490.
+# Do not write either remaining-bit tuple into Admissibility.
+# Displayed, not adopted.
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (1, 0, 0, 0, 0): fire only on wt1 and wt5."""
+    return int(axis_type(config) in ((1, 0, 2), (1, 2, 0)))
+
+
+def f10(config: Config) -> int:
+    """F_cut remaining bits (1, 1, 0, 0, 0): fire on wt1/wt5 and opp2 pair."""
+    return int(axis_type(config) in ((1, 0, 2), (1, 2, 0), (0, 1, 2), (0, 2, 1)))
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate, seeds: tuple[frozenset[Site], ...]) -> int:
+    return sum(1 for seed in seeds if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    remaining_set = {remaining for _bits, remaining in members}
+
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    f00_bits = bits_from_predicate(f00, orbit_types, orbits)
+    f10_bits = bits_from_predicate(f10, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    ham_remaining = remaining_bits_from_full(ham_bits, orbit_types)
+    f00_remaining = remaining_bits_from_full(f00_bits, orbit_types)
+    f10_remaining = remaining_bits_from_full(f10_bits, orbit_types)
+
+    cov2_f00 = coverage(f00, TWO_SITE_SEEDS)
+    cov2_f10 = coverage(f10, TWO_SITE_SEEDS)
+    cov3_f00 = coverage(f00, THREE_SITE_SEEDS)
+    cov3_f10 = coverage(f10, THREE_SITE_SEEDS)
+    cov3_f00_from_bits = coverage(
+        predicate_from_bits(f00_bits, orbit_types, type_of), THREE_SITE_SEEDS
+    )
+    cov3_f10_from_bits = coverage(
+        predicate_from_bits(f10_bits, orbit_types, type_of), THREE_SITE_SEEDS
+    )
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_two_site_seeds={len(TWO_SITE_SEEDS)}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"m3={M3}")
+    print(f"f00_remaining={f00_remaining}")
+    print(f"f10_remaining={f10_remaining}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_remaining={ham_remaining}")
+    print(f"cov2_f00={cov2_f00}")
+    print(f"cov2_f10={cov2_f10}")
+    print(f"cov3_f00={cov3_f00}")
+    print(f"cov3_f10={cov3_f10}")
+    print(f"attains_m3_f00={cov3_f00 == M3}")
+    print(f"attains_m3_f10={cov3_f10 == M3}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_C00_C10_THREE_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(remaining_set) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == EMPTY_TYPE
+        and full_type == FULL_TYPE
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and l1_remaining != ham_remaining
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-three-site-seeds",
+        "the two-cube has twelve vertices and C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and M3 == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-exception-membership",
+        "f00 and f10 are the remaining-bit tuples (1,0,0,0,0) and (1,1,0,0,0) in F_cut",
+        f00_remaining == F00_REMAINING
+        and f10_remaining == F10_REMAINING
+        and f00_remaining in remaining_set
+        and f10_remaining in remaining_set
+        and in_f_cut(f00_bits, orbit_types, empty_type, full_type)
+        and in_f_cut(f10_bits, orbit_types, empty_type, full_type)
+        and f00_remaining[0] == 1
+        and f10_remaining[0] == 1
+        and f00_remaining != f10_remaining,
+    )
+    checks.check(
+        "thm1-cov2-zero-exceptions",
+        "both maps have cov2=0 on the 66 two-site seeds",
+        len(TWO_SITE_SEEDS) == 66
+        and cov2_f00 == 0
+        and cov2_f10 == 0,
+    )
+    checks.check(
+        "thm1-cov3-f00-and-f10",
+        "cov3(f00)=0 and cov3(f10)=4 on the 220 three-site seeds",
+        cov3_f00 == 0
+        and cov3_f10 == 4
+        and cov3_f00 == cov3_f00_from_bits
+        and cov3_f10 == cov3_f10_from_bits
+        and "cov3(f00) = 0" in note
+        and "cov3(f10) = 4" in note,
+    )
+    checks.check(
+        "thm2-neither-attains-m3",
+        "neither exception attains m3=220",
+        cov3_f00 < M3
+        and cov3_f10 < M3
+        and M3 == 220
+        and cov3_f00 != M3
+        and cov3_f10 != M3
+        and "Neither attains m3=220" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the pair (0, 4) is displayed and neither map is adopted",
+        "(cov3(f00), cov3(f10)) = (0, 4)" in note
+        and "Displayed, not adopted" in note
+        and "Do not write the ranking into Admissibility" in note
+        and "Do not adopt a map" in note
+        and f00_remaining != L1_REMAINING
+        and f10_remaining != L1_REMAINING,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted pair, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-coverage",
+        "the note reports cov3 of both exceptions against m3=220",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 0, 0, 0, 0)" in note
+        and "(1, 1, 0, 0, 0)" in note
+        and "cov3(f00) = 0" in note
+        and "cov3(f10) = 4" in note
+        and "m3=220" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note
+        and "F_cut" not in axiom
+        and "f00" not in axiom
+        and "f10" not in axiom,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-scope-coverage",
+        "claim_scope reports 3-site coverage of the two exceptions and does not adopt them",
+        "On the two-cube with off-patch o=0, the 3-site coverage of F_cut (1,0,0,0,0) and (1,1,0,0,0) is reported. Displayed, not adopted."
+        in note,
+    )
+    checks.check(
+        "not-leftover-6490",
+        "the residual is 3-site coverage of the two exceptions, not leftover cov2 scoring of #6490",
+        "Not leftover-character of #6490" in note
+        and "that scored only cov2" in note
+        and "New |S|" in note,
+    )
+    checks.check(
+        "seeds-not-listed",
+        "the note does not list 3-site seeds",
+        "Do not list the seeds" in note
+        and "{(0, 0, 0), (1, 1, 1), (2, 0, 0)}" not in note
+        and "combinations(TWO_CUBE" not in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut map",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "f_L1" not in axiom,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f00 and f10 are scored on all 220 three-site seeds")
+    print("per_block: checked exactly — the pair (0, 4) is tested against m3=220")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, 3-site coverage of F_cut (1,0,0,0,0) and (1,1,0,0,0) is reported. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c00_c10_three_site_coverage_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.