### PR TITLE
feat(p3closed): cov3>0 is not equivalent to selector P

### DIFF
--- a/docs/F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,322 @@
+---
+claim_id: f_cut_cov3_positive_closed_form_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, positive 3-site coverage is not equivalent to P. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov3_positive_closed_form_2026_08_15.py
+---
+
+# F_cut Positive Three-Site Coverage Is Not The Selector P
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 32 cube-covariant complement-even formation predicates that
+vanish on empty and full, run as occupancy dynamics on the twelve-vertex
+two-cube with off-patch occupancy `0`, scored by whether they fill at least
+one of the 220 unordered 3-site seeds.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov3_positive_closed_form_2026_08_15.py`](../scripts/f_cut_cov3_positive_closed_form_2026_08_15.py)
+
+## Result Up Front
+
+Write `V={0,1,2}×{0,1}×{0,1}` for the twelve-vertex two-cube. Every unordered
+triple of vertices is a 3-site seed; there are `C(12,3)=220` such seeds.
+Off-patch neighbors have occupancy `0`. For each of the 32 `F_cut` maps,
+let
+
+`cov3(f)=|{S : |S|=3 and |locks_halt(f,S)|=12}|`.
+
+Then `cov3(f)>0` means `f` fills at least one three-site seed. Remaining-bit
+tuples are written in the order `(wt1, opp2, adj2, vertex3, mixed3)`. Define
+the displayed selector
+
+`P(f) := (wt1=1) and (adj2, vertex3, mixed3) ≠ (0, 0, 0)`.
+
+Investment #6494 established that `cov2(f)>0` if and only if `P(f)` on this
+same class and patch. This note asks a new selector question at a new seed
+size `k=3`: whether `cov3(f)>0` is the same bit. It is not a Max(3) rename
+and not leftover-character of #6494.
+
+The exact census is
+
+```text
+N_P = 14
+N_pos = 20
+N_both = 13
+```
+
+so `cov3(f)>0` is **not** equivalent to `P(f)`. The lex-first counterexample
+remaining-bit tuple is
+
+`(wt1, opp2, adj2, vertex3, mixed3)=(0, 0, 1, 1, 0)`,
+
+which has `P=0` and `cov3=24`. One witness in the other direction is
+`(1, 0, 0, 0, 1)`, which has `P=1` and `cov3=0` (while `cov2=8`).
+
+`f_L1` is the unbalanced-axis predicate (`n≠0` on the six-neighbor occupancy
+tuple; not Hamming parity). It evaluates to `(1, 0, 1, 1, 1)`, so `P(f_L1)=1`,
+and it has `cov3(f_L1)=220`. That positive-control map is not a unique
+selector and is not adopted.
+
+The current Admissibility sentence in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) remains
+untouched:
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+This note displays a selector comparison on a finite predicate class. It does
+not write `P` into Admissibility and does not adopt any remaining-bit tuple.
+Displayed, not adopted.
+
+Not leftover-character of #6494 (that was `cov2>0` iff `P`). Not a Max(3)
+rename of the 3-site coverage ranking. New `k`, new selector question.
+
+## Exact Objects And The Dynamics
+
+The six-neighbor occupancy cell at a site is the `{0,1}^6` tuple of locked
+status on the ordered shifts `±e_1, ±e_2, ±e_3`. Off-patch neighbors contribute
+occupancy `0`. A cell is assigned one of ten orbits under the 24 proper cube
+rotations:
+
+| orbit | representative type | size |
+|---|---|---|
+| empty | all unoccupied | 1 |
+| wt1 | a single occupied slot | 6 |
+| opp2 | both ends of one axis occupied | 3 |
+| adj2 | two occupied slots on distinct axes | 12 |
+| vertex3 | one slot on each axis, no opposite pair | 8 |
+| mixed3 | one full axis plus one extra slot | 12 |
+| opp4 | complement of opp2 | 3 |
+| adj4 | complement of adj2 | 12 |
+| wt5 | complement of wt1 | 6 |
+| full | all occupied | 1 |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Complement-evenness identifies `wt5` with `wt1`, `opp4` with
+`opp2`, and `adj4` with `adj2`, and leaves `vertex3` and `mixed3`
+complement-fixed, so `|F_cut|=2^5=32`. Remaining-bit tuples are written in
+the order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. That rule evaluates to `(1, 0, 1, 1, 1)` and is therefore one
+`F_cut` element. Hamming parity evaluates to `(1, 0, 0, 1, 1)` and is a
+different element.
+
+A run from a seed `S` starts with `S` locked. Each tick, every unlocked
+on-patch site evaluates `f` on its current six-neighbor occupancy tuple and
+locks if `f=1`. Halt is the first fixed point (at most twelve ticks). Fill
+means halt lock-count `12`. Coverage `cov3(f)` counts how many of the 220
+three-site seeds fill.
+
+`P` is a boolean on remaining bits, not a formation law: it is the
+conjunction of `wt1=1` with the statement that at least one of `adj2`,
+`vertex3`, `mixed3` fires. The bit `opp2` is free in `P`. Exactly 14 of the
+32 maps satisfy `P`.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility identifies the six-neighbor condition domain and covariance
+under proper cubic rotations. It
+does not supply the formation site, probability, or rate.
+The boolean occupancy predicates and the lock-update rule are explicit
+bounded mathematical input, not axiom text.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Permanence of a lock once formed is used only as the declared update rule on
+this finite patch. No physical readout, content map, or formation rate is
+identified.
+
+## Theorem 1
+
+Whether `cov3(f)>0` if and only if `P(f)`, for all 32 maps. The biconditional
+is false. One counterexample remaining-bit tuple is
+`(0, 0, 1, 1, 0)`: `P=0` and `cov3=24`. The same enumeration also produces
+the opposite-direction witness `(1, 0, 0, 0, 1)` (`P=1`, `cov3=0`). Either
+tuple already kills the claimed equivalence.
+
+The control `#6494` recomputes on the same 32 maps: `cov2(f)>0` if and only
+if `P(f)`. That 2-site fact is not the 3-site fact.
+
+## Theorem 2
+
+Enumerate all 32 remaining-bit tuples. Write
+
+- `N_P` for the number of maps with `P(f)=1`,
+- `N_pos` for the number of maps with `cov3(f)>0`,
+- `N_both` for the number of maps with both.
+
+The exact integers are `N_P = 14`, `N_pos = 20`, `N_both = 13`. Therefore
+`N_P ≠ N_pos` and `N_both` is strictly smaller than both, so the two
+predicates are distinct.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, is one of the 13 maps in the
+intersection; its 3-site coverage is `220`. Those ranking facts are displayed
+only as controls; this note does not re-rank Max(3).
+
+## Theorem 3
+
+The failed equivalence, the triple `(N_P, N_pos, N_both)=(14, 20, 13)`, and
+the counterexample tuple `(0, 0, 1, 1, 0)` are displayed. They are not
+adopted. Do not adopt `P`. The Admissibility sentence is not edited. In
+particular `P` is not written into the nearest-neighbor rule, and `f_L1`
+remains the unbalanced-axis predicate `n≠0` rather than Hamming parity.
+Do not write P into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact enumeration of 32 F_cut maps on the twelve-vertex two-cube; cov3>0 versus P is a displayed selector comparison, not a physical law."
+trace_class: upstream_support
+target_claim_id: admissibility_formation_predicate_selection
+target_blocker_text: "select a formation predicate from the axioms rather than by a displayed finite extra"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep P and the 3-site fillability bit as displayed extras; do not promote either to Admissibility."
+conditional_surface_status: "exact for the declared two-cube, off-patch o=0, and the 32 F_cut maps; no axiom selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Boundary And Non-Claims
+
+- The 220 seeds and the integer `cov3(f)` are constructed objects on one
+  twelve-vertex patch. They are not a lattice-wide formation law.
+- Off-patch occupancy `0` is a declared default. A blank-block is a different rule and is not run here.
+- `F_cut` is the three-cut subclass of cube-covariant predicates. Maps
+  outside that subclass are not ranked.
+- No remaining-bit tuple is written into Admissibility.
+- `P` is displayed, not adopted.
+- No Record readout, content alphabet, or formation rate is selected.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether positive 3-site coverage detects the displayed selector `P` inside `F_cut`. |
+| V2 | Current main has the axiom memo but no landed census of this `cov3>0` versus `P` comparison. |
+| V3 | All orbit sizes, the 32-map table, and every halt lock-count are finite and exact. |
+| V4 | The theorem is more than restating #6494: it tests a new seed size rather than renaming Max(3). |
+| V5 | Displayed, not adopted. The extras remain conditional. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: on this patch and class, `cov3(f)>0` does
+not characterize `P(f)`. No global formation impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| adopt `P` | write `P` into Admissibility | **ATTEMPTED** |
+| leftover `#6494` | treat `cov3>0` iff `P` as leftover of `cov2>0` iff `P` | **ATTEMPTED** |
+| Max(3) rename | replace the selector question by a 3-site coverage ranking | **ATTEMPTED** |
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch count to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The missing axiom-level selector, physical formation rate, and Record
+content map are distinct open premises. This note claims no wall collection.
+
+### N3 — hidden-condition scan
+
+The six-neighbor order, off-patch default, simultaneous lock update, and
+`F_cut` cuts are declared. No continuum, Hamming, or fitted prefactor is
+used. Unique selection of `f_L1` is not silently assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate, the
+local-distribution sentence, and the formation-site/probability/rate
+boundary used here. The residual is a displayed extra on a finite class,
+matching those sources rather than an axiom edit. The residual is not
+leftover-character of #6494 and is not a Max(3) rename.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | all 32 remaining-bit tuples | no ranking of the 512 maps with only `f(empty)=0` |
+| per seed | all 220 three-site seeds | no claim that the Max(3) ranking is this selector |
+| per tick | halt lock-counts for every map-seed pair | no physical clock |
+| per block | `N_P`, `N_pos`, `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no infinite-volume formation law |
+
+### N6 — live partial-closure paths
+
+Live routes are an independent derivation of a formation predicate from
+Admissibility, a justification of the off-patch default, and a Record
+content identification. Other seeds and other cuts remain live.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `P` is exactly the 2-site fillability bit (#6494), the
+same `P` should be the 3-site fillability bit.
+
+**Answer:** The 2-site and 3-site positive-coverage bits are different. Seven
+maps with `P=0` still fill at least one 3-site seed, and the map
+`(1, 0, 0, 0, 1)` satisfies `P` and has `cov2=8` but `cov3=0`. Lex-first
+counterexample `(0, 0, 1, 1, 0)` has `P=0` and `cov3=24`.
+
+### N8 — cross-cycle echo
+
+This is a new selector at a new `k`, not leftover-character of #6494 and
+not a Max(3) rename. The 220 seeds and the 32 maps are recomputed here.
+
+No-Go Discipline disposition: **PASS** for the finite failed equivalence and
+the displayed counterexample. FAIL / DO NOT SHIP for “`P` is Admissibility”
+or “`P` selects 3-site fillability.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Inputs And Dependency Roles
+
+- **Framework context:** the Lattice nearest-neighbor cubic graph and the
+  Admissibility condition-domain sentence.
+- **Explicit bounded mathematical input:** the two-cube vertex set, off-patch
+  occupancy `0`, the ten-orbit classification, the three `F_cut` cuts, and
+  the simultaneous lock-update rule.
+- **Not imported:** any unmerged Max(3) ranking as a substitute for this
+  selector, any Hamming identity for `f_L1`, and any axiom edit.
+
+## Primary Runner
+
+The primary runner recomputes the ten orbits, the 32 `F_cut` maps, `cov3`
+on the 220 three-site seeds, the failed biconditional against `P`, the
+counts `N_P`, `N_pos`, `N_both`, the lex-first counterexample, the #6494
+`cov2` control, and the current premise boundary. It authors no audit
+verdict. Declared audit inputs are this note and the axiom memo; the runner
+writes no cache.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov3_positive_closed_form_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov3_positive_closed_form_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov3_positive_closed_form_2026_08_15.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov3_positive_closed_form_2026_08_15.py
+runner_sha256: 070a154301850709db304ed5219be6d819ad9f67d63d762b9a10fdec6d0fa538
+input_fingerprint_sha256: 1f6b6fcf44f25f212344805b846e552c0a7fcbcdbbcb4e15370a58a707aaba4f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits
+construction: 32 F_cut maps on the two-cube, off-patch occupancy 0, 3-site seeds
+negative_scope: displayed selector only; P is not written into Admissibility
+PASS: audit-inputs declared source-bound pair exists
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: vertex-count two-cube has twelve vertices
+PASS: orbit-partition six-tuples partition into ten orbits with derived sizes
+PASS: complement-action complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3
+PASS: f-cut-cardinality five free remaining bits give 32 F_cut maps
+PASS: three-site-seeds C(12,3)=220 unordered three-site seeds
+PASS: two-site-seeds-control C(12,2)=66 two-site seeds for the #6494 control
+PASS: l1-bits n≠0 evaluates to remaining-bit tuple (1,0,1,1,1) and lies in F_cut
+PASS: l1-not-hamming Hamming parity is a different F_cut tuple
+N_P=14
+N_pos=20
+N_both=13
+equivalent=False
+lex_counterexample_tuple: (0, 0, 1, 1, 0) cov3=24 P=0
+n_counterexamples=8
+cov2_iff_P=True N_pos2=14 N_both2=14
+f_L1 remaining=(1, 0, 1, 1, 1) cov2=62 cov3=220 P=1
+PASS: p-cardinality P holds on exactly 14 maps: wt1=1 and (adj2,vertex3,mixed3)!=(0,0,0)
+PASS: control-6494 on the same 32 maps, cov2>0 iff P (investment #6494)
+PASS: theorem1-not-equivalent cov3>0 is not equivalent to P among the 32
+PASS: theorem1-counterexample lex-first counterexample is (0, 0, 1, 1, 0) with cov3=24 and P=0
+PASS: theorem2-counts N_P=14, N_pos=20, N_both=13
+PASS: l1-positive-control f_L1 has P=1 and fills every 3-site seed
+PASS: note-scope note reports the failed equivalence, displays a counterexample, and does not adopt P
+PASS: claim-scope claim_scope states the failed cov3>0 versus P equivalence
+PASS: not-leftover new k, new selector, not leftover of #6494 and not a Max(3) rename
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt P
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+per_element: checked exactly — each of the 32 remaining-bit tuples is scored
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — cov3>0 is compared with P on every F_cut map
+per_block: checked exactly — N_P, N_pos, N_both are the F_cut selector-census triple on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov3_positive_closed_form_2026_08_15.py
+++ b/scripts/f_cut_cov3_positive_closed_form_2026_08_15.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Exact F_cut census: whether cov3>0 is equivalent to P.
+
+P(f) := (wt1=1) and (adj2, vertex3, mixed3) != (0, 0, 0).
+New k=3 selector question, not a Max(3) rename. f_L1 is n!=0, not Hamming.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Cell = tuple[int, int, int, int, int, int]
+Bits = tuple[int, int, int, int, int]
+
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+FREE_ORBITS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+VERTICES: tuple[Point, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = tuple(combinations(VERTICES, 2))
+THREE_SITE_SEEDS: tuple[tuple[Point, Point, Point], ...] = tuple(combinations(VERTICES, 3))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def orbit_name(cell: Cell) -> str:
+    weight = sum(cell)
+    n_full = sum(1 for i, j in AXES if cell[i] == 1 and cell[j] == 1)
+    if weight == 0:
+        return "empty"
+    if weight == 6:
+        return "full"
+    if weight == 1:
+        return "wt1"
+    if weight == 5:
+        return "wt5"
+    if weight == 2:
+        return "opp2" if n_full == 1 else "adj2"
+    if weight == 4:
+        return "opp4" if n_full == 2 else "adj4"
+    if weight == 3:
+        return "mixed3" if n_full == 1 else "vertex3"
+    raise ValueError(cell)
+
+
+def all_cells() -> tuple[Cell, ...]:
+    return tuple(product((0, 1), repeat=6))  # type: ignore[return-value]
+
+
+def complement(cell: Cell) -> Cell:
+    return tuple(1 - bit for bit in cell)  # type: ignore[return-value]
+
+
+def axis_unbalanced(cell: Cell) -> bool:
+    return any(cell[i] != cell[j] for i, j in AXES)
+
+
+def f_l1(cell: Cell) -> int:
+    """Formation on a 6-tuple iff some axis is unbalanced (n≠0)."""
+    return int(axis_unbalanced(cell))
+
+
+def hamming_parity(cell: Cell) -> int:
+    return sum(cell) % 2
+
+
+def f_cut_from_bits(bits: Bits):
+    wt1, opp2, adj2, vertex3, mixed3 = bits
+    table = {
+        "empty": 0,
+        "full": 0,
+        "wt1": wt1,
+        "wt5": wt1,
+        "opp2": opp2,
+        "opp4": opp2,
+        "adj2": adj2,
+        "adj4": adj2,
+        "vertex3": vertex3,
+        "mixed3": mixed3,
+    }
+    return lambda cell: table[orbit_name(cell)]
+
+
+def remaining_bits(predicate) -> Bits:
+    reps: dict[str, Cell] = {}
+    for cell in all_cells():
+        name = orbit_name(cell)
+        if name not in reps:
+            reps[name] = cell
+    return tuple(int(predicate(reps[name])) for name in FREE_ORBITS)  # type: ignore[return-value]
+
+
+def selector_p(bits: Bits) -> bool:
+    wt1, _opp2, adj2, vertex3, mixed3 = bits
+    return wt1 == 1 and (adj2, vertex3, mixed3) != (0, 0, 0)
+
+
+def neighborhood(site: Point, locked: set[Point]) -> Cell:
+    bits = []
+    for shift in SHIFTS:
+        neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        bits.append(1 if neighbor in locked else 0)
+    return tuple(bits)  # type: ignore[return-value]
+
+
+def run_locks(predicate, seed: tuple[Point, ...]) -> tuple[int, tuple[int, ...]]:
+    locked: set[Point] = set(seed)
+    history = [len(locked)]
+    for _ in range(len(VERTICES)):
+        fresh = {
+            site
+            for site in VERTICES
+            if site not in locked and predicate(neighborhood(site, locked))
+        }
+        if not fresh:
+            break
+        locked |= fresh
+        history.append(len(locked))
+    return len(locked), tuple(history)
+
+
+def fills(predicate, seed: tuple[Point, ...]) -> bool:
+    halt, _history = run_locks(predicate, seed)
+    return halt == len(VERTICES)
+
+
+def coverage_of(predicate, seeds) -> int:
+    return sum(1 for seed in seeds if fills(predicate, seed))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observations or fits")
+    print("construction: 32 F_cut maps on the two-cube, off-patch occupancy 0, 3-site seeds")
+    print("negative_scope: displayed selector only; P is not written into Admissibility")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound pair exists",
+        len(AUDIT_INPUT_PATHS) == 2
+        and AUDIT_TIMEOUT_SEC == 120
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and (
+            "AUDIT_INPUT_PATHS = (\n"
+            '    "docs/F_CUT_COV3_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+            '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+            ")"
+        )
+        in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalize(axiom) for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+
+    cells = all_cells()
+    orbit_counts = Counter(orbit_name(cell) for cell in cells)
+    expected_counts = {
+        "empty": 1,
+        "full": 1,
+        "wt1": 6,
+        "wt5": 6,
+        "opp2": 3,
+        "adj2": 12,
+        "vertex3": 8,
+        "mixed3": 12,
+        "opp4": 3,
+        "adj4": 12,
+    }
+    checks.check("vertex-count", "two-cube has twelve vertices", len(VERTICES) == 12 == len(set(VERTICES)))
+    checks.check(
+        "orbit-partition",
+        "six-tuples partition into ten orbits with derived sizes",
+        orbit_counts == expected_counts,
+        residual=dict(orbit_counts),
+    )
+    complement_pairs = {(orbit_name(cell), orbit_name(complement(cell))) for cell in cells}
+    checks.check(
+        "complement-action",
+        "complement pairs empty/full, wt1/wt5, opp2/opp4, adj2/adj4 and fixes vertex3, mixed3",
+        complement_pairs
+        == {
+            ("empty", "full"),
+            ("full", "empty"),
+            ("wt1", "wt5"),
+            ("wt5", "wt1"),
+            ("opp2", "opp4"),
+            ("opp4", "opp2"),
+            ("adj2", "adj4"),
+            ("adj4", "adj2"),
+            ("vertex3", "vertex3"),
+            ("mixed3", "mixed3"),
+        },
+        residual=complement_pairs,
+    )
+
+    f_cut_maps = tuple(product((0, 1), repeat=5))
+    checks.check("f-cut-cardinality", "five free remaining bits give 32 F_cut maps", len(f_cut_maps) == 32)
+    checks.check(
+        "three-site-seeds",
+        "C(12,3)=220 unordered three-site seeds",
+        len(THREE_SITE_SEEDS) == 220
+        and len(set(frozenset(seed) for seed in THREE_SITE_SEEDS)) == 220
+        and all(len(set(seed)) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "two-site-seeds-control",
+        "C(12,2)=66 two-site seeds for the #6494 control",
+        len(TWO_SITE_SEEDS) == 66
+        and len(set(frozenset(seed) for seed in TWO_SITE_SEEDS)) == 66,
+    )
+
+    l1_bits = remaining_bits(f_l1)
+    ham_bits = remaining_bits(hamming_parity)
+    checks.check(
+        "l1-bits",
+        "n≠0 evaluates to remaining-bit tuple (1,0,1,1,1) and lies in F_cut",
+        l1_bits == (1, 0, 1, 1, 1)
+        and f_l1((0, 0, 0, 0, 0, 0)) == 0
+        and f_l1((1, 1, 1, 1, 1, 1)) == 0
+        and all(f_l1(cell) == f_l1(complement(cell)) for cell in cells)
+        and "sum(cell) % 2"
+        not in self_source.split("def f_l1", 1)[1].split("def hamming_parity", 1)[0],
+        residual=l1_bits,
+    )
+    checks.check(
+        "l1-not-hamming",
+        "Hamming parity is a different F_cut tuple",
+        ham_bits == (1, 0, 0, 1, 1) and ham_bits != l1_bits,
+        residual=ham_bits,
+    )
+
+    rows = []
+    for bits in f_cut_maps:
+        predicate = f_cut_from_bits(bits)
+        cov3 = coverage_of(predicate, THREE_SITE_SEEDS)
+        cov2 = coverage_of(predicate, TWO_SITE_SEEDS)
+        rows.append((bits, cov2, cov3, selector_p(bits)))
+
+    n_p = sum(1 for _bits, _c2, _c3, flag in rows if flag)
+    n_pos = sum(1 for _bits, _c2, cov3, _flag in rows if cov3 > 0)
+    n_both = sum(1 for _bits, _c2, cov3, flag in rows if flag and cov3 > 0)
+    equivalent = all((cov3 > 0) == flag for _bits, _c2, cov3, flag in rows)
+    counterexamples = [(bits, cov3, flag) for bits, _c2, cov3, flag in rows if (cov3 > 0) != flag]
+    lex_cex = min(counterexamples) if counterexamples else None
+    cov2_matches_p = all((cov2 > 0) == flag for _bits, cov2, _c3, flag in rows)
+    n_pos2 = sum(1 for _bits, cov2, _c3, _flag in rows if cov2 > 0)
+    n_both2 = sum(1 for _bits, cov2, _c3, flag in rows if flag and cov2 > 0)
+    l1_row = next(row for row in rows if row[0] == l1_bits)
+
+    print(f"N_P={n_p}")
+    print(f"N_pos={n_pos}")
+    print(f"N_both={n_both}")
+    print(f"equivalent={equivalent}")
+    print(
+        "lex_counterexample_tuple: "
+        f"{None if lex_cex is None else lex_cex[0]} "
+        f"cov3={None if lex_cex is None else lex_cex[1]} "
+        f"P={None if lex_cex is None else int(lex_cex[2])}"
+    )
+    print(f"n_counterexamples={len(counterexamples)}")
+    print(f"cov2_iff_P={cov2_matches_p} N_pos2={n_pos2} N_both2={n_both2}")
+    print(f"f_L1 remaining={l1_bits} cov2={l1_row[1]} cov3={l1_row[2]} P={int(l1_row[3])}")
+
+    checks.check(
+        "p-cardinality",
+        "P holds on exactly 14 maps: wt1=1 and (adj2,vertex3,mixed3)!=(0,0,0)",
+        n_p == 14
+        and n_p == sum(1 for bits in f_cut_maps if selector_p(bits))
+        and all(selector_p(bits) == (bits[0] == 1 and bits[2:] != (0, 0, 0)) for bits in f_cut_maps),
+        residual=n_p,
+    )
+    checks.check(
+        "control-6494",
+        "on the same 32 maps, cov2>0 iff P (investment #6494)",
+        cov2_matches_p and n_p == 14 and n_pos2 == 14 and n_both2 == 14,
+        residual=(n_pos2, n_both2),
+    )
+    checks.check(
+        "theorem1-not-equivalent",
+        "cov3>0 is not equivalent to P among the 32",
+        equivalent is False and len(counterexamples) >= 1,
+        residual=len(counterexamples),
+    )
+    checks.check(
+        "theorem1-counterexample",
+        "lex-first counterexample is (0, 0, 1, 1, 0) with cov3=24 and P=0",
+        lex_cex == ((0, 0, 1, 1, 0), 24, False),
+        residual=lex_cex,
+    )
+    checks.check(
+        "theorem2-counts",
+        "N_P=14, N_pos=20, N_both=13",
+        n_p == 14 and n_pos == 20 and n_both == 13,
+        residual=(n_p, n_pos, n_both),
+    )
+    checks.check(
+        "l1-positive-control",
+        "f_L1 has P=1 and fills every 3-site seed",
+        l1_bits[0] == 1
+        and selector_p(l1_bits)
+        and l1_row[2] == 220
+        and l1_row[1] == 62,
+    )
+
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-scope",
+        "note reports the failed equivalence, displays a counterexample, and does not adopt P",
+        "is not equivalent" in note
+        and "(0, 0, 1, 1, 0)" in note
+        and "N_P = 14" in note
+        and "N_pos = 20" in note
+        and "N_both = 13" in note
+        and "Displayed, not adopted" in note
+        and "Do not adopt `P`" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope states the failed cov3>0 versus P equivalence",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "positive 3-site coverage is not equivalent to P" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-leftover",
+        "new k, new selector, not leftover of #6494 and not a Max(3) rename",
+        "Not leftover-character of #6494" in note
+        and "Not a Max(3)" in note
+        and "New `k`" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt P",
+        "Do not write P into Admissibility" in note
+        and "no axiom or approved primitive is added" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in normalize(note)
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    print("per_element: checked exactly — each of the 32 remaining-bit tuples is scored")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — cov3>0 is compared with P on every F_cut map")
+    print("per_block: checked exactly — N_P, N_pos, N_both are the F_cut selector-census triple on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), positive 3-site coverage is not equivalent to P (wt1=1 and (adj2,vertex3,mixed3)≠(0,0,0)). f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_cov3_positive_closed_form_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.