### PR TITLE
feat(p1closed): whether cov1>0 is equivalent to selector P

### DIFF
--- a/docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,384 @@
+---
+claim_id: f_cut_cov1_positive_closed_form_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether positive 1-site coverage is equivalent to P is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov1_positive_closed_form_2026_08_15.py
+---
+
+# Whether Positive 1-Site `F_cut` Coverage Is The Selector `P`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 1-site coverage of the 32 cube-covariant
+complement-even predicates that vanish on empty and full, on the
+twelve-vertex two-cube, with off-patch occupancy `0`. The remaining-bit
+predicate `P` is displayed as a candidate selector for `cov_1(f)>0`.
+Neither `P` nor any map is adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov1_positive_closed_form_2026_08_15.py`](../scripts/f_cut_cov1_positive_closed_form_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+That static cardinality is leftover-character inventory of the three-cut
+class. The 2-site selector `P` for positive coverage is leftover inventory
+of a different seed cardinality. New k, not leftover of the cov2 selector.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each singleton vertex is a 1-site
+seed. Off-patch neighbors have occupancy `0`. A blank-block is a different
+rule; it is not used. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process is
+synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov_1(f) = |{ S : |S|=1 and f fills from S }|.
+```
+
+Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+The five remaining bits of an `F_cut` map, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+Write
+
+```text
+P(f) := (wt1=1) and (adj2,vertex3,mixed3) ≠ (0,0,0).
+```
+
+`P` is a predicate on remaining bits. It is displayed only.
+
+**Theorem 1.** Among the 32 maps, `cov_1(f)>0` if and only if `P(f)` is
+not equivalent. One counterexample remaining-bit tuple is
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 0, 0, 1)
+```
+
+for which `P` holds and `cov_1 = 0`. This is the lexicographically first
+remaining-bit counterexample.
+
+**Theorem 2.** The 32-map census of the displayed predicate and of
+positive 1-site coverage is
+
+```text
+N_P = 14
+N_pos = 8
+N_both = 8.
+```
+
+Every map with `cov_1(f)>0` satisfies `P`. Six maps satisfy `P` and have
+`cov_1(f)=0`.
+
+**Theorem 3.** The failure of the equivalence, the counterexample tuple,
+and the three counts are displayed only. Do not adopt `P`. Do not write `P` into Admissibility.
+
+Displayed, not adopted.
+
+Not leftover-character of #6494 (that was `P` for `cov_2`; different |S|).
+Not leftover-character of #6495 (that was that both exceptions have
+`cov_1=0`; not the 32-map equivalence). New k.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, membership of f_L1, the predicate P, the 1-site coverage of every map, the failure of cov1>0 iff P, one remaining-bit counterexample, and the triple (N_P, N_pos, N_both) are enumerated. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_cov1_positive_closed_form
+target_blocker_text: "whether cov1>0 is the same selector P among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the F_cut 1-site positive-coverage comparison with P; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for F_cut on this twelve-vertex patch with off-patch o=0 and 1-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 1-site seeds;
+- the remaining-bit predicate `P`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** For every member of `F_cut`, compute `cov_1(f)` on the
+two-cube and evaluate `P(f)` on its remaining bits. Report whether
+`cov_1(f)>0` if and only if `P(f)`. If the biconditional fails, display
+one remaining-bit counterexample. Report `N_P`, `N_pos`, and `N_both`.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+The remaining-bit order is
+
+```text
+wt1 = (1,0,2), opp2 = (0,1,2), adj2 = (2,0,1),
+vertex3 = (3,0,0), mixed3 = (1,1,1).
+```
+
+`P` ignores `opp2` and requires `wt1=1` together with a nonzero triple
+`(adj2,vertex3,mixed3)`.
+
+**Theorem 1.** Exhaustive evaluation of all 32 maps on the twelve 1-site
+seeds shows that `cov_1>0` iff `P` is not equivalent. The
+lexicographically first remaining-bit counterexample is `(1, 0, 0, 0, 1)`:
+`wt1=1`, `opp2=0`, `adj2=0`, `vertex3=0`, `mixed3=1`, so `P` holds, and
+that map fills from none of the twelve singletons.
+
+**Theorem 2.** Counting the 32 remaining-bit assignments gives
+`N_P = 14`, `N_pos = 8`, `N_both = 8`.
+
+**Theorem 3.** Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after the vanish cuts |
+| `f_L1` is in `F_cut` | `u` is rotation- and complement-invariant and `u(empty)=u(full)=0` |
+| `f_L1` is not Hamming | the two-unbalanced-axis orbit has even weight and `f_L1=1` |
+| two-cube has twelve vertices | `{0,1,2}×{0,1}×{0,1}` |
+| twelve 1-site seeds | `C(12,1)=12` |
+| off-patch occupancy `0` | declared stencil default; not a blank-block |
+| `P` on remaining bits | `(wt1=1)` and `(adj2,vertex3,mixed3)≠(0,0,0)` |
+| `cov_1>0` iff `P` | not equivalent; first counterexample `(1, 0, 0, 0, 1)` |
+| `(N_P, N_pos, N_both)` | `(14, 8, 8)` from the 32-map census |
+
+## Counterfactual And Mutation Table
+
+1. Replace `f_L1` by Hamming parity `|c|_1 mod 2`: the maps disagree on the
+   two-unbalanced-axis orbit, and Hamming is a different `F_cut` member.
+2. Change the off-patch default away from `0`: the occupancy stencil
+   changes and the coverage counts are a different object.
+3. Drop any of the three cuts: the class is no longer the 32-element
+   `F_cut`.
+4. Score 2-site seeds: that leftover is #6494, a different `|S|`.
+5. Restrict to the two #6495 exceptions: that leftover reports
+   `cov_1=0` on a pair, not the 32-map biconditional.
+6. Adopt `P` as the Admissibility rule: Theorem 3 forbids the adoption;
+   `P` is displayed only.
+
+## What This Does Not Claim
+
+- No physical Admissibility selector and no adopted occupancy law.
+- No Qubit rewrite and no `M_2(C)`-valued conditional probability.
+- No `Z^3`-wide formation, rate, or generator.
+- No identification of `f_L1` with Hamming parity.
+- No leftover-character restatement of the 2-site selector `P` in place
+  of this 1-site equivalence.
+- No list of the 1-site seeds.
+- No blank-block variant.
+- No adoption of `P`.
+
+## No-Go Discipline Gate
+
+The only negative claim is the biconditional itself: on this patch,
+`cov_1(f)>0` is not equivalent to `P(f)` among the 32 maps. The counts
+`N_P=14`, `N_pos=8`, `N_both=8` and the counterexample tuple are an exact
+enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| 1-site coverage census | Score every map in `F_cut` by `cov_1` on the twelve singletons. | Theorem 1 and check `thm1-two-cube-and-one-site-seeds`. | **ATTEMPTED** |
+| remaining-bit predicate `P` | Evaluate `(wt1=1)` and `(adj2,vertex3,mixed3)≠(0,0,0)` on each map. | Theorem 2 and check `thm2-counts`. | **ATTEMPTED** |
+| biconditional | Ask whether `cov_1>0` iff `P` on all 32 maps. | Theorem 1 and checks `thm1-equivalence-fails` / `thm1-counterexample-tuple`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: the biconditional `cov_1>0` iff `P`
+fails. The counterexample tuple and the gap `N_P−N_both=6` are two
+certificates of the same failure, so they collapse rather than count as
+two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| counterexample `(1, 0, 0, 0, 1)` / `N_P≠N_pos` | yes: one witness falsifies iff | yes: unequal counts falsify iff | collapse into the biconditional failure |
+| leftover of #6494 / this census | no: that leftover scored `|S|=2` | no: a 1-site census does not replace the 2-site selector | different object |
+| leftover of #6495 / this census | no: that leftover reported `cov_1=0` on two exceptions | no: the 32-map biconditional is not a pair of zeros | different object |
+| static `|F_cut|=32` / the counts | no: membership is not dynamics | no: a coverage census does not replace the three-cut class | separate exact counts |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| 1-site seeds | explicit seed class; a 2-site selector is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit predicate `P` | displayed candidate selector, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_cov1_positive_closed_form_2026_08_15.py:73` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_cov1_positive_closed_form_2026_08_15.py:117` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_cov1_positive_closed_form_2026_08_15.py:122` | Hamming mutation | `|c|_1 mod 2` is a different `F_cut` map | yes |
+| `scripts/f_cut_cov1_positive_closed_form_2026_08_15.py:50` | 1-site seed size | `SEED_K = 1` | yes |
+| `scripts/f_cut_cov1_positive_closed_form_2026_08_15.py:309` | `cov_1(f)` | number of 1-site seeds a map fills | yes |
+| `scripts/f_cut_cov1_positive_closed_form_2026_08_15.py:317` | predicate `P` | `(wt1=1)` and `(adj2,vertex3,mixed3)≠(0,0,0)` | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: every map in `F_cut` | the comparison is this class on 1-site seeds; other classes are unclaimed |
+| per block | yes: the biconditional on the 32 | `cov_1>0` iff `P` fails; one remaining-bit witness is displayed |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: every
+map with `cov_1>0` does satisfy `P`, so `P` is necessary for positive
+1-site coverage on this patch. Necessity is not sufficiency: six maps in
+`P` have `cov_1=0`. The remaining physical choice — which, if any,
+`F_cut` map is the Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that #6494 already named `P` as the selector
+for positive 2-site coverage, and that #6495 already recorded `cov_1=0`
+on two exceptions, so a 1-site census of the same 32 maps might be called
+leftover decoration of those two surfaces. That objection is correctly
+about the 2-site selector and about a pair of zeros. It does not overturn
+the stated theorem: among all 32 maps in `F_cut`, `cov_1>0` is not
+equivalent to `P`, with `N_P=14`, `N_pos=8`, `N_both=8`, and first
+counterexample `(1, 0, 0, 0, 1)`. That is a new k, not leftover-character
+of #6494 or #6495.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the 1-site coverage of all 32 maps, and the predicate `P` are
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the 1-site biconditional or restores
+`cov_1>0` iff `P` inside the 32-map class.
+
+No-Go Discipline disposition: **PASS** for the failure of `cov_1>0` iff
+`P` and the exact triple `(N_P, N_pos, N_both)=(14, 8, 8)` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates all 32 maps on the two-cube from every 1-site seed,
+evaluates `P` on remaining bits, reports that `cov_1>0` iff `P` fails,
+displays the lexicographically first remaining-bit counterexample
+`(1, 0, 0, 0, 1)`, reports `N_P=14`, `N_pos=8`, `N_both=8`, and checks
+that `f_L1` is not Hamming parity. Declared audit inputs are this note
+and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov1_positive_closed_form_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov1_positive_closed_form_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov1_positive_closed_form_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov1_positive_closed_form_2026_08_15.py
+runner_sha256: 8acdce5eee3df0b54ae0ef6a7dc99926c729af660ad2e0b988ff3054048144a9
+input_fingerprint_sha256: 34349ed579c0d9edeb40c95e3cff1ccc5442d1303422d7930321e7b3627633a5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+resolution: per element, per site, per mode, per block, not lattice wide
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+seed_k=1 n_seeds=12
+N_P=14
+N_pos=8
+N_both=8
+equivalent=False
+n_exceptions=6
+counterexample=(1, 0, 0, 0, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-one-site-seeds the two-cube has twelve vertices and twelve 1-site seeds
+PASS: thm1-equivalence-fails cov1>0 is not equivalent to P on the 32 maps
+PASS: thm1-counterexample-tuple the lexicographically first counterexample remaining-bit tuple is displayed
+PASS: thm2-counts N_P, N_pos, and N_both are the computed 32-map census
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted P, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt P
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-cov2 the residual is whether cov1>0 is P, not leftover of the cov2 selector
+PASS: claim-scope-equivalence claim_scope reports whether positive 1-site coverage is equivalent to P
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov1_positive_closed_form_2026_08_15.py
+++ b/scripts/f_cut_cov1_positive_closed_form_2026_08_15.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+"""Exact test of whether cov1>0 is the selector P on F_cut.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. For each of the 32 maps, cov1(f) is the number of 1-site seeds
+from which f fills. P(f) is the remaining-bit predicate (wt1=1) and
+(adj2,vertex3,mixed3)!=(0,0,0). The new object is whether cov1(f)>0 if and
+only if P(f), not leftover of the cov2 selector. f_L1 is the unbalanced-axis
+predicate (some n_mu != 0), never Hamming |c|_1 mod 2. Do not adopt P.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SEED_K = 1
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config: Config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_P(remaining: tuple[int, ...]) -> bool:
+    wt1, _opp2, adj2, vertex3, mixed3 = remaining
+    return wt1 == 1 and (adj2, vertex3, mixed3) != (0, 0, 0)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("resolution: per element, per site, per mode, per block, not lattice wide")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(SEED_K)
+
+    rows: list[tuple[tuple[int, ...], int, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_P(remaining)))
+
+    n_p = sum(1 for _remaining, _cov, flag in rows if flag)
+    n_pos = sum(1 for _remaining, cov, _flag in rows if cov > 0)
+    n_both = sum(1 for _remaining, cov, flag in rows if flag and cov > 0)
+    exceptions = sorted(
+        remaining for remaining, cov, flag in rows if flag != (cov > 0)
+    )
+    equivalent = len(exceptions) == 0
+    counterexample = exceptions[0] if exceptions else None
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"seed_k={SEED_K} n_seeds={len(seeds)}")
+    print(f"N_P={n_p}")
+    print(f"N_pos={n_pos}")
+    print(f"N_both={n_both}")
+    print(f"equivalent={equivalent}")
+    print(f"n_exceptions={len(exceptions)}")
+    print(f"counterexample={counterexample}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_COV1_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(rows) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-one-site-seeds",
+        "the two-cube has twelve vertices and twelve 1-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and SEED_K == 1
+        and len(seeds) == 12
+        and len(set(seeds)) == 12,
+    )
+    checks.check(
+        "thm1-equivalence-fails",
+        "cov1>0 is not equivalent to P on the 32 maps",
+        equivalent is False
+        and counterexample is not None
+        and any(flag != (cov > 0) for _remaining, cov, flag in rows)
+        and "not equivalent" in note_flat
+        and "iff" in note,
+    )
+    checks.check(
+        "thm1-counterexample-tuple",
+        "the lexicographically first counterexample remaining-bit tuple is displayed",
+        counterexample == (1, 0, 0, 0, 1)
+        and any(remaining == (1, 0, 0, 0, 1) and cov == 0 and flag for remaining, cov, flag in rows)
+        and "(1, 0, 0, 0, 1)" in note
+        and "cov_1 = 0" in note.replace("cov1", "cov_1").replace("cov_1(f)=0", "cov_1 = 0"),
+    )
+    checks.check(
+        "thm2-counts",
+        "N_P, N_pos, and N_both are the computed 32-map census",
+        n_p == 14
+        and n_pos == 8
+        and n_both == 8
+        and n_p == sum(1 for _remaining, _cov, flag in rows if flag)
+        and n_pos == sum(1 for _remaining, cov, _flag in rows if cov > 0)
+        and n_both == sum(1 for _remaining, cov, flag in rows if flag and cov > 0)
+        and "N_P = 14" in note
+        and "N_pos = 8" in note
+        and "N_both = 8" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted P, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt P",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not adopt `P`" in note
+        and "Do not write `P` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-cov2",
+        "the residual is whether cov1>0 is P, not leftover of the cov2 selector",
+        "New k" in note
+        and "Not leftover-character of #6494" in note
+        and "Not leftover-character of #6495" in note
+        and "different |S|" in note
+        and SEED_K == 1
+        and "combinations(TWO_CUBE, " + "2)" not in self_source,
+    )
+    checks.check(
+        "claim-scope-equivalence",
+        "claim_scope reports whether positive 1-site coverage is equivalent to P",
+        "Among the 32 F_cut maps on the two-cube"
+        in note
+        and "whether positive 1-site coverage is equivalent to P is reported"
+        in note_flat
+        and "Displayed, not adopted" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), whether positive 1-site coverage is equivalent to P is reported. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_cov1_positive_closed_form_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.