### PR TITLE
feat(c00c4orb): orbit type of f00 seven 4-site fills

### DIFF
--- a/docs/F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,361 @@
+---
+claim_id: f_cut_c00_four_site_fill_orbit_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the seven 4-site seeds that F_cut (1,0,0,0,0) fills form N_orb orbits under two-cube-preserving rotations. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py
+---
+
+# Orbit Type Of The Seven Four-Site Seeds `F_cut` `(1,0,0,0,0)` Fills
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** orbit count of the seven four-site seeds on the twelve-vertex
+two-cube `{0,1,2}×{0,1}×{0,1}` that the displayed `F_cut` remaining-bit
+map `(1,0,0,0,0)` fills, under the proper cube rotations about the box
+center `(1, 1/2, 1/2)` that permute those twelve sites, with off-patch
+occupancy identically `0`. The integer `N_orb` and one lexicographic
+representative per orbit are displayed, not adopted. The seven seeds
+are not listed.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py`](../scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve sites `{0,1,2}×{0,1}×{0,1}`. A site
+locks when a displayed predicate of its six-neighbor occupancy tuple
+returns `1`. Off-patch neighbors contribute occupancy `0`. A
+blank-block is a different rule; it is not used. A run is the tuple of
+lock-set cardinalities from the seed through halt. Fill means
+`|locks_halt|=12`.
+
+Let `f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}`
+for at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor
+contrast `n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+Let `f00` be the `F_cut` remaining-bit map
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 0, 0, 0)
+```
+
+with complements forced. It fires only on axis types `(1,0,2)` and
+`(1,2,0)`.
+
+Let `M` be the set of unordered four-site seeds that `f00` fills on
+this two-cube. Let `G` be the group of two-cube-preserving rotations:
+those proper cube rotations about `(1, 1/2, 1/2)` that permute the
+twelve sites. Sixteen of the twenty-four ambient proper cubic matrices
+send at least one site off the two-cube and are not used. The remaining
+eight induce `G`. `N_orb` is the number of `G`-orbits in `M`. One lex
+representative is kept per orbit.
+
+**Theorem 1.** `|M|=7` among the `495` four-site seeds. The `#6493`
+face
+
+`S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}`
+
+is in `M`.
+
+**Theorem 2.** `N_orb = 3`. The three orbits have sizes `2`, `4`, and
+`1`. One lex representative per orbit is
+
+- size `2`: `{(0,0,0),(0,0,1),(0,1,0),(0,1,1)}` (the `#6493` face);
+- size `4`: `{(0,0,0),(0,0,1),(2,1,0),(2,1,1)}`;
+- size `1`: `{(1,0,0),(1,0,1),(1,1,0),(1,1,1)}`.
+
+**Theorem 3.** Display `N_orb = 3`. Do not list all seven. Do not adopt
+an orbit. Do not write an orbit into Admissibility.
+
+Displayed, not adopted.
+
+This is new geometry of the fill set `M`. It is not leftover-character
+of `#6493` (that named the lex-first face and the fill count `7`). It
+is not `N_orb` of a miss set.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of those sentences is to name the cubic nearest-neighbor
+graph and to keep formation outside the axiom. The axiom memo says the
+distribution concerns which possibility a forming record locks,
+conditional on formation; it does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The map `f00` is a supplied displayed member, not axiom
+content. A seed, an orbit, and the integer `N_orb` are likewise
+displayed data, not an admissibility rule. The seed is not written into
+Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact orbit count of the seven four-site seeds that one displayed F_cut map fills on a twelve-vertex two-cube under two-cube-preserving rotations."
+trace_class: frontier_discovery
+target_claim_id: f_cut_c00_four_site_fill_orbit
+target_blocker_text: "N_orb of the seven four-site seeds that F_cut (1,0,0,0,0) fills under two-cube-preserving rotations"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded fill-set orbit count; do not adopt an orbit"
+conditional_surface_status: "exact on the two-cube with off-patch o=0; N_orb remains displayed data"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Sites of the two-cube, in lexicographic order:
+
+`(0,0,0)`, `(0,0,1)`, `(0,1,0)`, `(0,1,1)`,
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`,
+`(2,0,0)`, `(2,0,1)`, `(2,1,0)`, `(2,1,1)`.
+
+The six-neighbor tuple at a site is ordered
+`(+x,-x,+y,-y,+z,-z)`. Each coordinate is the occupancy of that
+neighbor: `1` if the neighbor is an on-patch lock, else `0`. Every
+off-patch neighbor is `0`. The off-patch occupancy `0` is the explicit
+default.
+
+For each axis, the pair of opposite bits is
+
+- unbalanced if the bits are `{0,1}`,
+- both if the bits are `{1,1}`,
+- empty if the bits are `{0,0}`.
+
+Write `(n_unbalanced, n_both, n_empty)` with sum `3`. Representative
+orbits used below:
+
+| name | type | representative |
+|---|---|---|
+| empty | `(0,0,3)` | `(0,0,0,0,0,0)` |
+| wt1 | `(1,0,2)` | `(1,0,0,0,0,0)` |
+| opp2 | `(0,1,2)` | `(1,1,0,0,0,0)` |
+| adj2 | `(2,0,1)` | `(1,0,1,0,0,0)` |
+| type210 | `(2,1,0)` | `(1,1,1,0,0,1)` |
+| vertex3 | `(3,0,0)` | `(1,0,1,0,1,0)` |
+| mixed3 | `(1,1,1)` | `(1,0,1,1,0,0)` |
+| wt5 | `(1,2,0)` | `(1,1,1,1,1,0)` |
+| full | `(0,3,0)` | `(1,1,1,1,1,1)` |
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Five remaining bits stay free, so `|F_cut|=32`. Those
+bits are ordered `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` iff `n_unbalanced(c)≥1`. Its remaining-bit tuple is
+`(1,0,1,1,1)`.
+`f00(c)=1` iff the axis type is `wt1=(1,0,2)` or `wt5=(1,2,0)`. Its
+remaining-bit tuple is `(1, 0, 0, 0, 0)`.
+
+On those representatives the bits are
+
+| map | wt1 | opp2 | adj2 | type210 | vertex3 | mixed3 | empty | full |
+|---|---|---|---|---|---|---|---|---|
+| `f_L1` | 1 | 0 | 1 | 1 | 1 | 1 | 0 | 0 |
+| `f00` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+Hamming parity of `|c|_1` is a different predicate: `opp2` is even and
+`f_L1(opp2)=0`, while `adj2` is even and `f_L1(adj2)=1`.
+
+One tick locks every currently unlocked on-patch site whose neighbor
+tuple has `f=1`. The process starts with `locks_0=S` and halts at the
+first fixed point, or at tick `12`. Fill means `|locks_halt|=12`.
+
+`M` is the set of four-site combinations that fill under `f00`. Seeds
+in `M` are compared as unordered four-sets. The ambient proper cubic
+group about the box center `(1, 1/2, 1/2)` is the `24` signed
+permutations of the three axes with determinant `+1`. A matrix is kept
+in `G` only when it permutes the twelve sites. If a rotation does not
+preserve the twelve-set, it is not used.
+
+An orbit representative is the lexicographically least four-tuple in
+that orbit, using the lexicographic site order above.
+
+## Theorem 1 — `|M|=7` and the `#6493` face
+
+Among the `C(12,4)=495` unordered four-site seeds, `f00` fills exactly
+seven. That reconfirms the `#6493` fill count.
+
+The `#6493` face `S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}` is one of those
+seven. From that seed the lock history is `(4, 8, 12)` and the run
+fills. The face is therefore in `M`.
+
+## Theorem 2 — `N_orb` and one lex representative per orbit
+
+Act with `G` on `M`. The action partitions `M` into three orbits:
+
+`N_orb = 3`
+
+The orbit of the `#6493` face has size `2`. Its lex representative is
+that face itself. The second orbit has size `4`; its lex representative
+is `{(0,0,0),(0,0,1),(2,1,0),(2,1,1)}`. The third orbit is a singleton;
+its lex representative is the middle slice
+`{(1,0,0),(1,0,1),(1,1,0),(1,1,1)}`.
+
+Those three representatives are the displayed orbit type of the fill
+set. They are not a listing of `M`.
+
+## Theorem 3 — display `N_orb`; do not list the seven
+
+The integer to report is `N_orb = 3`. The seven members of `M` are not
+listed. The three lex representatives name orbit type, not a census of
+every filler.
+
+Do not adopt `f00`. Do not adopt an orbit. Do not write an orbit into
+Admissibility. Admissibility is not a dynamics axiom and does not
+supply this predicate, this fill set, or this orbit count.
+
+A fill count of `7` is not an orbit type. The orbit type of `M` is a
+new finite object on this two-cube. It is not `N_orb` of a miss set.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, four-site seeds | declared finite data |
+| `|M|=7` and `#6493` face in `M` | recomputed |
+| `N_orb` under two-cube-preserving rotations | `3` |
+| one lex representative per orbit | three displayed |
+| listing of all seven members of `M` | refused |
+| adoption of the orbit or the map | refused |
+| formation site / rate from the axioms | open |
+
+## Boundary And Imports
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. The two-cube, the predicate `f00`, the
+fill-set `M`, and the two-cube-preserving rotation group are supplied
+mathematical data for this note. Record lock language is quoted only
+as the existing lock/content/absence boundary; it does not select this
+map or any orbit.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers how many `G`-orbits the seven four-site `f00` fillers form. |
+| V2 | Current main has the axiom memo and the `#6493` face/count, not this fill-set orbit type. |
+| V3 | The twelve-vertex fill census and the eight-element group action are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it executes a supplied predicate and a supplied group the axiom does not name. |
+| V5 | Neither the map nor the orbit is an admissibility rule, and neither is adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: a fill count of `7` is not an orbit
+type, an orbit type of a fill set is not an orbit type of a miss set,
+and a displayed orbit is not axiom content.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| four-site census | all `495` seeds | `|M|=7` |
+| `#6493` face membership | run from `{(0,0,0),(0,0,1),(0,1,0),(0,1,1)}` | fills; in `M` |
+| ambient proper cubes | `24` signed permutations, `det=+1` | sixteen discarded |
+| two-cube-preserving `G` | keep only twelve-set permutations | `|G|=8` |
+| orbit partition of `M` | `G` acting on the seven fillers | `N_orb = 3` |
+| lex representatives | least four-tuple per orbit | three displayed |
+| list all seven | write every member of `M` | refused |
+| Hamming parity | `|c|_1 mod 2` | different predicate; `adj2` even |
+| write an orbit into Admissibility | treat `N_orb` as the local rule | refused; axiom is not a dynamics axiom |
+
+### N2 — wall independence
+
+The missing formation-site selector, the missing axiom-level
+occupancy rule, and the choice among displayed members are distinct
+open items. This note claims no complete wall and no compiler no-go.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch `o=0`, six-neighbor order, the remaining-bit
+tuple `(1,0,0,0,0)`, and the restriction to two-cube-preserving
+rotations are declared. Cube covariance is used only as the axis-type
+reading of a six-tuple and as the ambient cubic group. No continuum,
+Hamming, miss-set orbit, or admissibility rewrite is assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor graph and states
+that Admissibility is not a dynamics axiom and does not supply the
+formation site, probability, or rate. The extra therefore matches
+those sources: a displayed lock predicate, a displayed fill set, and a
+displayed orbit count are extra data.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | axis-type representatives and off-patch `0` | no alphabet classification |
+| per site | every two-cube vertex against `f00` | no derived kernel values |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | all `495` four-site seeds and the `G`-action on `M` | no physical compiler |
+| lattice wide | checked and not executed | neither map nor orbit adopted as a rule |
+
+### N6 — live partial-closure paths
+
+Live routes include an independent reason to select or reject `f00`,
+the orbit type of the other `#6490` exception `(1,1,0,0,0)`, and a
+formation mechanism supplied by something other than a displayed
+predicate.
+
+### N7 — hostile steelman
+
+**Steelman:** `#6493` already counted seven four-site fillers and named
+the lex-first face, so either those seven are one face-type orbit or
+the miss-set orbit count of a different map already names the geometry.
+
+**Answer:** The seven fillers form `N_orb = 3` orbits under
+two-cube-preserving rotations, with lex representatives the `#6493`
+face, a size-`4` mixed pair, and the middle slice. That is a displayed
+finite fact about the fill set `M`, not about a miss set.
+Admissibility does not name `f00` or this orbit type.
+
+### N8 — cross-cycle echo
+
+A lex-first four-site face (`#6493`) and a fill count of `7` are
+different claims from the orbit type of that fill set. This note
+executes `N_orb` of the seven four-site seeds that `F_cut` `(1,0,0,0,0)`
+fills. It is not leftover-character of `#6493`. New finite object: the
+fill-set orbit type.
+
+**Gate disposition:** PASS for the finite fill-set orbit statement and
+the displayed `N_orb`. FAIL / DO NOT SHIP for “adopt `f00`,” “write an
+orbit into Admissibility,” “list all seven,” or “this is `N_orb` of a
+miss set.”
+
+## Primary Runner
+
+The primary runner rebuilds the two-cube, the predicate `f00`, the
+four-site fill set `M`, membership of the `#6493` face, the
+two-cube-preserving rotation group, the orbit count `N_orb`, one lex
+representative per orbit, the current premise boundary, and the
+non-adoption wording. It does not list all seven in the note contract.
+It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c00_four_site_fill_orbit_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c00_four_site_fill_orbit_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c00_four_site_fill_orbit_2026_08_15.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py
+runner_sha256: 753c1b79bb785f538ebacf48b63626fe1a5516214985d74d1836885ef1214921
+input_fingerprint_sha256: 5728b9ee89e9a826bb39acb5699ade9f11e8fbfab792681d47d41ba094524b09
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs
+construction: displayed F_cut occupancy-to-lock map; G-orbits of the four-site fill set on the twelve-vertex two-cube
+negative_scope: neither the map nor the fill-set orbit type is adopted or written into Admissibility
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+PASS: audit-inputs declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site, probability, and rate remain outside Admissibility
+PASS: source-record-and-non-dynamics Record lock wording and the non-dynamics Admissibility boundary are pinned
+PASS: two-cube-and-lex-order the two-cube has twelve lexicographically ordered vertices
+PASS: census-cardinality four-site seed count is C(12,4)=495
+PASS: off-patch-zero every off-patch neighbor contributes occupancy 0
+PASS: axis-type-reps declared orbit representatives have the stated axis types
+PASS: f00-remaining-bits f00 is the F_cut remaining-bit tuple (1,0,0,0,0)
+PASS: f-l1-is-n-unbalanced f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity
+|M|=7 n_four=495
+face_in_M=True history=(4, 8, 12) T=2
+orbit: N_ambient=24 |G|=8 N_orb=3 sizes=(2, 4, 1) lex=(((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1)), ((0, 0, 0), (0, 0, 1), (2, 1, 0), (2, 1, 1)), ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)))
+PASS: theorem-1-fill-set |M|=7 among the 495 four-site seeds and the #6493 face is in M
+PASS: group-preserves-twelve only site-permutations of the two-cube induced by proper cube rotations are used
+PASS: theorem-2-n-orb N_orb=3 with one lex representative per orbit
+PASS: theorem-3-display-not-list the note displays N_orb and does not list all seven
+PASS: claim-scope claim_scope reports the fill-set orbit type and does not adopt it
+PASS: note-contract machine fields, orbit statement, and forbidden-phrase hygiene hold
+PASS: not-leftover-6493 the residual is the fill-set orbit type, not leftover #6493 scoring or a miss-set N_orb
+PASS: not-miss-set-orbit the residual is new fill-set geometry, not N_orb of a miss set
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-declared off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut map
+per_element: axis-type representatives and off-patch occupancy 0 are enumerated
+per_site: each two-cube vertex is tested against the displayed lock predicate
+per_mode: checked and not executed — no spectral claim occurs
+per_block: all 495 four-site seeds and the G-action on M are executed
+lattice_wide: checked and not executed — neither the map nor the orbit is adopted
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py
+++ b/scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Orbit type of the seven four-site seeds F_cut (1,0,0,0,0) fills.
+
+Reconfirm |M|=7 on the twelve-vertex two-cube with off-patch occupancy 0,
+and that the #6493 face is in M.  Count G-orbits of M under the proper
+cube rotations about the box center that permute those twelve sites.
+Display N_orb and one lex representative per orbit.  Do not list the
+seven.  f_L1 is the some-axis-unbalanced (n!=0) map, not Hamming parity.
+The orbit type is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+SITES: tuple[Point, ...] = tuple(
+    sorted((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+)
+TWO_CUBE_SET = frozenset(SITES)
+AXIS_SHIFTS: tuple[tuple[Point, Point], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+F00_TUPLE: tuple[int, ...] = (1, 0, 0, 0, 0)
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+FACE_6493: tuple[Point, ...] = ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
+N_FOUR = 495
+N_FILL = 7
+N_ORB = 3
+ORBIT_SIZES: tuple[int, ...] = (2, 4, 1)
+LEX_REPS: tuple[tuple[Point, ...], ...] = (
+    ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1)),
+    ((0, 0, 0), (0, 0, 1), (2, 1, 0), (2, 1, 1)),
+    ((1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)),
+)
+
+ORBIT_REPS: dict[str, Config] = {
+    "empty": (0, 0, 0, 0, 0, 0),
+    "wt1": (1, 0, 0, 0, 0, 0),
+    "opp2": (1, 1, 0, 0, 0, 0),
+    "adj2": (1, 0, 1, 0, 0, 0),
+    "vertex3": (1, 0, 1, 0, 1, 0),
+    "mixed3": (1, 0, 1, 1, 0, 0),
+    "type210": (1, 1, 1, 0, 0, 1),
+    "wt5": (1, 1, 1, 1, 1, 0),
+    "full": (1, 1, 1, 1, 1, 1),
+}
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def compact(text: str) -> str:
+    return text.replace(" ", "")
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locks: frozenset[Point]) -> int:
+    if site not in TWO_CUBE_SET:
+        return 0
+    return 1 if site in locks else 0
+
+
+def neighbor_config(site: Point, locks: frozenset[Point]) -> Config:
+    bits: list[int] = []
+    for plus, minus in AXIS_SHIFTS:
+        bits.append(occupancy(add(site, plus), locks))
+        bits.append(occupancy(add(site, minus), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def axis_type(config: Config) -> tuple[int, int, int]:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for index in (0, 2, 4):
+        plus, minus = config[index], config[index + 1]
+        if plus == 1 and minus == 1:
+            n_both += 1
+        elif plus == 0 and minus == 0:
+            n_empty += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    n_unbalanced, _n_both, _n_empty = axis_type(config)
+    return 1 if n_unbalanced >= 1 else 0
+
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (1,0,0,0,0): fire only on wt1 and wt5."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (1, 2, 0)) else 0
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_tuple(predicate) -> tuple[int, ...]:
+    return tuple(int(predicate(ORBIT_REPS[name]) == 1) for name in BIT_NAMES)
+
+
+def step(locks: frozenset[Point], predicate) -> frozenset[Point]:
+    newcomers = {
+        site
+        for site in SITES
+        if site not in locks and predicate(neighbor_config(site, locks)) == 1
+    }
+    return locks | newcomers
+
+
+def run_from_seed(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    history = [len(locks)]
+    tick = 0
+    while tick < halt_bound:
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+        history.append(len(locks))
+    return tick, frozenset(locks), tuple(history)
+
+
+def fills(seed: tuple[Point, ...] | frozenset[Point], predicate=f00) -> bool:
+    _tick, locks, _history = run_from_seed(frozenset(seed), predicate)
+    return len(locks) == 12
+
+
+def fill_set(size: int = 4, predicate=f00) -> tuple[tuple[Point, ...], ...]:
+    return tuple(combo for combo in combinations(SITES, size) if fills(combo, predicate))
+
+
+def det3(matrix: Matrix) -> int:
+    a, b, c = matrix
+    return (
+        a[0] * (b[1] * c[2] - b[2] * c[1])
+        - a[1] * (b[0] * c[2] - b[2] * c[0])
+        + a[2] * (b[0] * c[1] - b[1] * c[0])
+    )
+
+
+def proper_cube_rotations() -> tuple[Matrix, ...]:
+    """The 24 proper cubic matrices: signed permutations with det +1."""
+    mats: list[Matrix] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for i in range(3):
+                rows[i][perm[i]] = signs[i]
+            matrix = (tuple(rows[0]), tuple(rows[1]), tuple(rows[2]))
+            if det3(matrix) == 1:
+                mats.append(matrix)
+    return tuple(mats)
+
+
+def apply_about_center(matrix: Matrix, point: Point) -> Point | None:
+    """Apply R about the box center (1, 1/2, 1/2) in doubled integer coordinates."""
+    delta = (2 * point[0] - 2, 2 * point[1] - 1, 2 * point[2] - 1)
+    image = tuple(sum(matrix[i][j] * delta[j] for j in range(3)) for i in range(3))
+    if (image[0] + 2) % 2 != 0 or (image[1] + 1) % 2 != 0 or (image[2] + 1) % 2 != 0:
+        return None
+    return ((image[0] + 2) // 2, (image[1] + 1) // 2, (image[2] + 1) // 2)
+
+
+def two_cube_preserving_rotations() -> tuple[Matrix, ...]:
+    """Keep only proper cube rotations that permute the twelve sites."""
+    kept: list[Matrix] = []
+    for matrix in proper_cube_rotations():
+        images = [apply_about_center(matrix, site) for site in SITES]
+        if all(image in TWO_CUBE_SET for image in images) and set(images) == TWO_CUBE_SET:
+            kept.append(matrix)
+    return tuple(kept)
+
+
+def act_on_seed(matrix: Matrix, seed: frozenset[Point]) -> frozenset[Point] | None:
+    images = [apply_about_center(matrix, site) for site in seed]
+    if any(image is None or image not in TWO_CUBE_SET for image in images):
+        return None
+    return frozenset(images)  # type: ignore[arg-type]
+
+
+def orbit_partition(
+    seeds: tuple[frozenset[Point], ...], group: tuple[Matrix, ...]
+) -> tuple[tuple[frozenset[Point], ...], ...]:
+    unused = set(range(len(seeds)))
+    orbits: list[tuple[frozenset[Point], ...]] = []
+    while unused:
+        start = min(unused)
+        unused.remove(start)
+        stack = [start]
+        members = {start}
+        while stack:
+            index = stack.pop()
+            for matrix in group:
+                image = act_on_seed(matrix, seeds[index])
+                if image is None:
+                    continue
+                for other, seed in enumerate(seeds):
+                    if seed == image and other in unused:
+                        unused.remove(other)
+                        stack.append(other)
+                        members.add(other)
+        orbits.append(tuple(seeds[i] for i in sorted(members)))
+    return tuple(orbits)
+
+
+def lex_key(seed: frozenset[Point]) -> tuple[Point, ...]:
+    return tuple(sorted(seed))
+
+
+def seed_as_set_text(seed: tuple[Point, ...]) -> str:
+    inner = ",".join(f"({p[0]},{p[1]},{p[2]})" for p in seed)
+    return "{" + inner + "}"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    compact_note = compact(note)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs")
+    print("construction: displayed F_cut occupancy-to-lock map; G-orbits of the four-site fill set on the twelve-vertex two-cube")
+    print("negative_scope: neither the map nor the fill-set orbit type is adopted or written into Admissibility")
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_C00_FOUR_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    not_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site, probability, and rate remain outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+    checks.check(
+        "source-record-and-non-dynamics",
+        "Record lock wording and the non-dynamics Admissibility boundary are pinned",
+        record_lock in normalize(axiom)
+        and record_lock in note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-and-lex-order",
+        "the two-cube has twelve lexicographically ordered vertices",
+        len(SITES) == 12
+        and SITES == tuple(sorted(SITES))
+        and SITES[0] == (0, 0, 0)
+        and SITES[-1] == (2, 1, 1)
+        and TWO_CUBE_SET == frozenset(SITES),
+    )
+    checks.check(
+        "census-cardinality",
+        "four-site seed count is C(12,4)=495",
+        len(list(combinations(SITES, 4))) == N_FOUR,
+    )
+    checks.check(
+        "off-patch-zero",
+        "every off-patch neighbor contributes occupancy 0",
+        occupancy((-1, 0, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((0, -1, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((3, 0, 0), frozenset({(2, 0, 0)})) == 0,
+    )
+    checks.check(
+        "axis-type-reps",
+        "declared orbit representatives have the stated axis types",
+        axis_type(ORBIT_REPS["wt1"]) == (1, 0, 2)
+        and axis_type(ORBIT_REPS["opp2"]) == (0, 1, 2)
+        and axis_type(ORBIT_REPS["adj2"]) == (2, 0, 1)
+        and axis_type(ORBIT_REPS["vertex3"]) == (3, 0, 0)
+        and axis_type(ORBIT_REPS["mixed3"]) == (1, 1, 1)
+        and axis_type(ORBIT_REPS["type210"]) == (2, 1, 0)
+        and axis_type(ORBIT_REPS["empty"]) == (0, 0, 3)
+        and axis_type(ORBIT_REPS["wt5"]) == (1, 2, 0)
+        and axis_type(ORBIT_REPS["full"]) == (0, 3, 0),
+    )
+
+    f00_bits = remaining_tuple(f00)
+    l1_bits = remaining_tuple(f_L1)
+    checks.check(
+        "f00-remaining-bits",
+        "f00 is the F_cut remaining-bit tuple (1,0,0,0,0)",
+        f00_bits == F00_TUPLE
+        and l1_bits == L1_TUPLE
+        and f00(ORBIT_REPS["wt1"]) == 1
+        and f00(ORBIT_REPS["wt5"]) == 1
+        and f00(ORBIT_REPS["opp2"]) == 0
+        and f00(ORBIT_REPS["adj2"]) == 0
+        and f00(ORBIT_REPS["vertex3"]) == 0
+        and f00(ORBIT_REPS["mixed3"]) == 0
+        and f00(ORBIT_REPS["type210"]) == 0
+        and f00(ORBIT_REPS["empty"]) == 0
+        and f00(ORBIT_REPS["full"]) == 0,
+    )
+    checks.check(
+        "f-l1-is-n-unbalanced",
+        "f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity",
+        f_L1(ORBIT_REPS["wt1"]) == 1
+        and f_L1(ORBIT_REPS["mixed3"]) == 1
+        and f_L1(ORBIT_REPS["type210"]) == 1
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["empty"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) != f_hamming(ORBIT_REPS["adj2"])
+        and sum(ORBIT_REPS["opp2"]) % 2 == 0
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f00", 1)[0],
+    )
+
+    members = fill_set()
+    fill_frozens = tuple(frozenset(seed) for seed in members)
+    ambient = proper_cube_rotations()
+    group = two_cube_preserving_rotations()
+    orbits = orbit_partition(fill_frozens, group)
+    n_orb = len(orbits)
+    lex_reps = tuple(min(lex_key(seed) for seed in orbit) for orbit in orbits)
+    orbit_sizes = tuple(len(orbit) for orbit in orbits)
+    face_tick, face_locks, face_history = run_from_seed(frozenset(FACE_6493), f00)
+    print(f"|M|={len(members)} n_four={N_FOUR}")
+    print(f"face_in_M={FACE_6493 in members} history={face_history} T={face_tick}")
+    print(
+        "orbit: "
+        f"N_ambient={len(ambient)} |G|={len(group)} N_orb={n_orb} "
+        f"sizes={orbit_sizes} lex={lex_reps}"
+    )
+
+    checks.check(
+        "theorem-1-fill-set",
+        "|M|=7 among the 495 four-site seeds and the #6493 face is in M",
+        len(members) == N_FILL
+        and FACE_6493 in members
+        and fills(FACE_6493)
+        and face_history == (4, 8, 12)
+        and face_locks == TWO_CUBE_SET
+        and "#6493" in note
+        and "|M|=7" in compact_note
+        and seed_as_set_text(FACE_6493) in compact_note,
+        residual=(len(members), FACE_6493 in members, face_history),
+    )
+    checks.check(
+        "group-preserves-twelve",
+        "only site-permutations of the two-cube induced by proper cube rotations are used",
+        len(ambient) == 24
+        and len(group) == 8
+        and all(det3(matrix) == 1 for matrix in group)
+        and all(
+            {apply_about_center(matrix, site) for site in SITES} == TWO_CUBE_SET
+            for matrix in group
+        ),
+        residual=len(group),
+    )
+    checks.check(
+        "theorem-2-n-orb",
+        "N_orb=3 with one lex representative per orbit",
+        n_orb == N_ORB
+        and orbit_sizes == ORBIT_SIZES
+        and lex_reps == LEX_REPS
+        and "N_orb = 3" in note
+        and all(seed_as_set_text(rep) in compact_note for rep in LEX_REPS)
+        and "one lex representative per orbit" in note.lower(),
+        residual=(n_orb, orbit_sizes, lex_reps),
+    )
+
+    non_reps = [seed for seed in members if seed not in LEX_REPS]
+    listed_non_reps = [seed for seed in non_reps if seed_as_set_text(seed) in compact_note]
+    checks.check(
+        "theorem-3-display-not-list",
+        "the note displays N_orb and does not list all seven",
+        "N_orb = 3" in note
+        and "Do not list all seven" in note
+        and len(non_reps) == 4
+        and listed_non_reps == []
+        and "Displayed, not adopted" in note
+        and "not written into Admissibility" in normalize(note)
+        and "Do not adopt" in note
+        and "Do not write" in note,
+        residual=listed_non_reps,
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, the "
+        "seven 4-site seeds that F_cut (1,0,0,0,0) fills form "
+        "N_orb orbits under two-cube-preserving rotations. "
+        "Displayed, not adopted."
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "N_orb = 3",
+        "(1, 0, 0, 0, 0)",
+        "#6493",
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the fill-set orbit type and does not adopt it",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, orbit statement, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and all(phrase not in note and phrase not in self_source for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "new axiom" not in note
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "citation" not in note.lower()
+        and "runner-cache" not in note
+        and "retained" not in other_retained,
+    )
+    checks.check(
+        "not-leftover-6493",
+        "the residual is the fill-set orbit type, not leftover #6493 scoring or a miss-set N_orb",
+        "Not leftover-character of #6493" in note
+        or "not leftover-character of `#6493`" in note.lower()
+        or "It is not leftover-character of `#6493`" in note
+        or "not leftover-character of `#6493`" in normalize(note).lower(),
+    )
+    leftover_ok = (
+        "not leftover-character of `#6493`" in normalize(note).lower()
+        or "It is not leftover-character of `#6493`" in note
+        or "not leftover-character of #6493" in note
+    )
+    miss_ok = "not `N_orb` of a miss set" in note or "not N_orb of a miss set" in note
+    new_ok = "new finite object" in note.lower() or "new geometry" in note.lower()
+    checks.check(
+        "not-miss-set-orbit",
+        "the residual is new fill-set geometry, not N_orb of a miss set",
+        leftover_ok and miss_ok and new_ok,
+        residual=(leftover_ok, miss_ok, new_ok),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in normalize(note)
+        and "not Hamming" in note
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-declared",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut map",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "f00" not in axiom,
+    )
+
+    print("per_element: axis-type representatives and off-patch occupancy 0 are enumerated")
+    print("per_site: each two-cube vertex is tested against the displayed lock predicate")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: all 495 four-site seeds and the G-action on M are executed")
+    print("lattice_wide: checked and not executed — neither the map nor the orbit is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the seven 4-site seeds that F_cut (1,0,0,0,0) fills form N_orb orbits under two-cube-preserving rotations. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c00_four_site_fill_orbit_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.