### PR TITLE
feat(f10c4n): 4-site coverage of (1,1,0,0,0)

### DIFF
--- a/docs/F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,351 @@
+---
+claim_id: f_cut_c10_four_site_coverage_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the 4-site coverage of F_cut (1,1,0,0,0) is reported, and whether it fills the #6493 face. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c10_four_site_coverage_2026_08_15.py
+---
+
+# Four-Site Coverage Of `F_cut` `(1,1,0,0,0)` On The Two-Cube
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** displayed occupancy-to-lock dynamics of the cube-covariant
+map `F_cut` remaining bits `(1,1,0,0,0)` on the twelve-vertex two-cube
+`{0,1,2}×{0,1}×{0,1}`, scored on all `495` four-site seeds, with
+off-patch occupancy identically `0`. The 4-site coverage and whether
+the `#6493` face fills are displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c10_four_site_coverage_2026_08_15.py`](../scripts/f_cut_c10_four_site_coverage_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write the two-cube as the twelve sites `{0,1,2}×{0,1}×{0,1}`. A site
+locks when a displayed predicate of its six-neighbor occupancy tuple
+returns `1`. Off-patch neighbors contribute occupancy `0`. A
+blank-block is a different rule; it is not used. A run is the tuple of
+lock-set cardinalities from the seed through halt, together with the
+fill bit `|locks_halt|=12`.
+
+Let `f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}`
+for at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor
+contrast `n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming.
+
+Let `f10` be the `F_cut` remaining-bit map
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (1, 1, 0, 0, 0)
+```
+
+with complements forced. It fires on `wt1` and `opp2` and on their
+complements `wt5` and `(0,2,1)`. It is a different map from
+`f00=(1,0,0,0,0)`, which silences `opp2`, and from `f_L1=(1,0,1,1,1)`.
+
+`#6496` already named the first fill of `f10`: four of the `220`
+three-site seeds fill. `#6493` named the first fill of `f00`: seven of
+the `495` four-site seeds fill, and the lex-first of those is the
+`x=0` face. The object of this note is the 4-site score of the second
+`#6490` exception `f10`, and whether that `#6493` face is among the
+fillers.
+
+**Theorem 1.** `cov4(f10) = 7` among the `495` four-site seeds.
+
+**Theorem 2.** The `#6493` face
+
+`S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}`
+
+is among the fillers. From that `S` the lock history is `(4, 8, 12)`
+and the run fills.
+
+**Theorem 3.** The score `7` and the face-membership bit are displayed
+only. Do not adopt a bit. Do not adopt `f10`. Do not write a remaining
+bit into Admissibility.
+
+Displayed, not adopted.
+
+Not leftover-character of #6496 (that named a size-`3` first fill).
+Not leftover-character of #6493 (that scored `f00` and named its
+lex-first face).
+New score of the second exception: `cov4` of remaining bits
+`(1,1,0,0,0)`.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom.
+
+The only use of those sentences is to name the cubic nearest-neighbor
+graph and to keep formation outside the axiom. The axiom memo says the
+distribution concerns which possibility a forming record locks,
+conditional on formation; it does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The map `f10` is a supplied displayed member, not axiom
+content. A remaining-bit tuple is likewise displayed data, not an
+admissibility rule.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact 4-site fill census of one displayed F_cut occupancy-to-lock map on a twelve-vertex two-cube."
+trace_class: frontier_discovery
+target_claim_id: f_cut_c10_four_site_coverage
+target_blocker_text: "4-site coverage of F_cut remaining bits (1,1,0,0,0) and whether the #6493 face fills"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 4-site coverage claim; do not adopt the map or a remaining bit"
+conditional_surface_status: "exact on the two-cube with off-patch o=0 for |S|=4; the map and bits remain displayed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Sites of the two-cube, in lexicographic order:
+
+`(0,0,0)`, `(0,0,1)`, `(0,1,0)`, `(0,1,1)`,
+`(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)`,
+`(2,0,0)`, `(2,0,1)`, `(2,1,0)`, `(2,1,1)`.
+
+The six-neighbor tuple at a site is ordered
+`(+x,-x,+y,-y,+z,-z)`. Each coordinate is the occupancy of that
+neighbor: `1` if the neighbor is an on-patch lock, else `0`. Every
+off-patch neighbor is `0`. The off-patch occupancy `0` is the explicit
+default.
+
+For each axis, the pair of opposite bits is
+
+- unbalanced if the bits are `{0,1}`,
+- both if the bits are `{1,1}`,
+- empty if the bits are `{0,0}`.
+
+Write `(n_unbalanced, n_both, n_empty)` with sum `3`. Representative
+orbits used below:
+
+| name | type | representative |
+|---|---|---|
+| empty | `(0,0,3)` | `(0,0,0,0,0,0)` |
+| wt1 | `(1,0,2)` | `(1,0,0,0,0,0)` |
+| opp2 | `(0,1,2)` | `(1,1,0,0,0,0)` |
+| adj2 | `(2,0,1)` | `(1,0,1,0,0,0)` |
+| type210 | `(2,1,0)` | `(1,1,1,0,0,1)` |
+| vertex3 | `(3,0,0)` | `(1,0,1,0,1,0)` |
+| mixed3 | `(1,1,1)` | `(1,0,1,1,0,0)` |
+| wt5 | `(1,2,0)` | `(1,1,1,1,1,0)` |
+| opp2c | `(0,2,1)` | `(1,1,1,1,0,0)` |
+| full | `(0,3,0)` | `(1,1,1,1,1,1)` |
+
+`F_cut` is the cube-covariant class with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. Five remaining bits stay free, so `|F_cut|=32`. Those
+bits are ordered `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` iff `n_unbalanced(c)≥1`. Its remaining-bit tuple is
+`(1,0,1,1,1)`.
+`f10(c)=1` iff the axis type is `wt1=(1,0,2)`, `opp2=(0,1,2)`,
+`wt5=(1,2,0)`, or `opp2c=(0,2,1)`. Its remaining-bit tuple is
+`(1,1,0,0,0)`.
+
+On those representatives the bits are
+
+| map | wt1 | opp2 | adj2 | type210 | vertex3 | mixed3 | empty | full | wt5 | opp2c |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `f_L1` | 1 | 0 | 1 | 1 | 1 | 1 | 0 | 0 | 1 | 0 |
+| `f10` | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 1 |
+| `f00` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 0 |
+
+Hamming parity of `|c|_1` is a different predicate: `opp2` is even and
+`f_L1(opp2)=0`, while `f10(opp2)=1`.
+
+One tick locks every currently unlocked on-patch site whose neighbor
+tuple has `f=1`. The process starts with `locks_0=S` and halts at the
+first fixed point, or at tick `12`. Lock history is the sequence of
+cardinalities from `t=0` through halt. Fill means `|locks_halt|=12`.
+
+Seeds of size `4` are the `C(12,4)=495` unordered 4-subsets of the
+two-cube. Coverage `cov4(f)` is the number of those seeds from which
+`f` fills. The `#6493` face is the entire `x=0` slice
+`{(0,0,0),(0,0,1),(0,1,0),(0,1,1)}`. The seven fillers are not listed.
+
+## Theorem 1 — `cov4(f10) = 7`
+
+Among the `495` four-site seeds, exactly seven fill under `f10`.
+
+So `cov4(f10) = 7`. This is a coverage score of one displayed map. It
+does not rank the other thirty-one `F_cut` members and does not adopt
+any remaining bit.
+
+The same integer `7` already appears as `cov4(f00)` in `#6493`. That
+coincidence of scores is not an identification of the two maps:
+`f10` and `f00` disagree on `opp2`. The new object is the score of
+the second exception, not a reuse of the `f00` first-fill census.
+
+## Theorem 2 — the `#6493` face is among the fillers
+
+The face
+
+`S={(0,0,0),(0,0,1),(0,1,0),(0,1,1)}`
+
+is one of the seven four-site seeds that `f10` fills.
+
+Start with that `S`, so `|locks_0|=4`. At tick `1` the four
+middle-slice sites `(1,0,0)`, `(1,0,1)`, `(1,1,0)`, `(1,1,1)` each see
+a single occupied nearest neighbor along `-x` (type `wt1`), so `f10`
+returns `1`. The four `x=2` sites see the empty tuple and stay
+unlocked. After tick `1` one has `|locks_1|=8`. At tick `2` the four
+`x=2` sites each see a single occupied nearest neighbor along `-x`
+(type `wt1`) and lock.
+
+`T=2`, `|locks_halt|=12`, history `(4, 8, 12)`, fill bit `1`.
+
+The executed firings on this face are the `wt1` orbit only, so the
+`opp2` bit that distinguishes `f10` from `f00` is not needed on this
+particular seed. Face membership is therefore not a new named-pair
+fill; it is a yes/no against a previously displayed face.
+
+## Theorem 3 — display; do not adopt a bit
+
+The integers `cov4(f10) = 7` and the yes-bit that the `#6493` face
+fills are displayed data. Do not adopt a bit. Do not adopt `f10`. Do
+not write a remaining bit into Admissibility. The remaining-bit tuple
+`(1, 1, 0, 0, 0)` is not written into Admissibility.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| two-cube, off-patch `o=0`, all `495` four-site seeds | declared finite data |
+| `cov4(f10)` | `7` |
+| `#6493` face among the fillers | yes; history `(4, 8, 12)` |
+| identity with `f00` or `f_L1` | refused; different remaining bits |
+| adoption of the map or a remaining bit | refused |
+| formation site / rate from the axioms | open |
+
+## Boundary And Imports
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. The two-cube, the predicate `f10`, and the
+four-site seed list are supplied mathematical data for this note.
+Record lock language is quoted only as the existing lock/content/absence
+boundary; it does not select this map or any remaining bit.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers `cov4` of remaining bits `(1,1,0,0,0)` and whether the `#6493` face fills. |
+| V2 | Current main has the axiom memo and no landed 4-site coverage score of this map. |
+| V3 | The twelve-vertex process on `495` seeds is independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it executes a supplied predicate the axiom does not name. |
+| V5 | Neither the map nor a remaining bit is an admissibility rule, and neither is adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: a 4-site coverage score is not an
+axiom-level occupancy rule, and a displayed remaining bit is not axiom
+content.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| four-site coverage | all `495` 4-subsets | `cov4(f10) = 7` |
+| `#6493` face | `{(0,0,0),(0,0,1),(0,1,0),(0,1,1)}` | among the fillers; history `(4, 8, 12)` |
+| `f00` on that face | remaining bits `(1,0,0,0,0)` | also fills; different map |
+| `opp2` distinction | evaluate `f10` on `(0,1,2)` | `f10=1`; `f_L1=0` |
+| Hamming parity | `|c|_1 mod 2` | different predicate; `opp2` even |
+| write a bit or map into Admissibility | treat either as the local rule | refused; axiom is not a dynamics axiom |
+
+### N2 — wall independence
+
+The missing formation-site selector, the missing axiom-level
+occupancy rule, and the choice among displayed members are distinct
+open items. This note claims no complete wall and no compiler no-go.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch `o=0`, six-neighbor order, the predicate
+`f10`, and the `#6493` face are declared. Cube covariance is used only
+as the axis-type reading of a six-tuple. No continuum, Hamming, or
+admissibility rewrite is assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor graph and states
+that Admissibility is not a dynamics axiom and does not supply the
+formation site, probability, or rate. The residual therefore matches
+those sources: a displayed lock predicate and a displayed remaining
+bit are extra data.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | axis-type representatives and off-patch `0` | no alphabet classification |
+| per site | every two-cube vertex against the displayed lock predicate | no derived kernel values |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | all `495` four-site seeds | no physical compiler |
+| lattice wide | checked and not executed | neither the map nor a remaining bit adopted as a rule |
+
+### N6 — live partial-closure paths
+
+Live routes include an independent reason to select or reject `f10`,
+a 4-site ranking of the remaining `F_cut` members, and a formation
+mechanism supplied by something other than a displayed predicate.
+
+### N7 — hostile steelman
+
+**Steelman:** `#6496` already said `f10` fills at size `3`, and
+`#6493` already said seven 4-site seeds fill for `f00`, so either
+`cov4(f10)` is leftover of those notes or the `#6493` face is a new
+named-pair fill that should be adopted.
+
+**Answer:** `#6496` scored three-site first-fill (`4` of `220`). This
+note scores four-site coverage of the same map: `cov4(f10) = 7`. The
+`#6493` face is among those seven fillers, with history `(4, 8, 12)`.
+The score and the membership bit are displayed. Do not adopt a bit.
+
+### N8 — cross-cycle echo
+
+A size-`3` first-fill seed (#6496) and a size-`4` first-fill face of
+a different map (#6493) are different claims. This note executes the
+4-site coverage of remaining bits `(1,1,0,0,0)` and tests that
+previously displayed face.
+
+**Gate disposition:** PASS for the finite coverage statement and the
+face-membership bit. FAIL / DO NOT SHIP for “adopt `f10`,” “adopt a
+remaining bit,” “write a bit into Admissibility,” or “this is leftover
+character of #6496 or #6493.”
+
+## Primary Runner
+
+The primary runner rebuilds the two-cube, the predicate `f10`, the
+4-site coverage `cov4(f10) = 7`, membership of the `#6493` face, the
+face history `(4, 8, 12)`, the current premise boundary, and the
+non-adoption wording. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c10_four_site_coverage_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c10_four_site_coverage_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c10_four_site_coverage_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c10_four_site_coverage_2026_08_15.py
+runner_sha256: ab642f809c4c57532588c5b3cd72ff98d1f023df2e9c72de851e5e6a2a2b0003
+input_fingerprint_sha256: 3b440dac35a5b96e14068cda01252eee787dc4a7e710ca6b6059ccb1b663456b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits
+integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs
+construction: displayed F_cut occupancy-to-lock map; 4-site coverage on the twelve-vertex two-cube
+negative_scope: neither the map nor a remaining bit is adopted or written into Admissibility
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+PASS: audit-inputs declared source-bound inputs exist as static literals
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site, probability, and rate remain outside Admissibility
+PASS: source-record-and-non-dynamics Record lock wording and the non-dynamics Admissibility boundary are pinned
+PASS: two-cube-and-four-site-seeds the two-cube has twelve vertices and C(12,4)=495 four-site seeds
+PASS: off-patch-zero every off-patch neighbor contributes occupancy 0
+PASS: axis-type-reps declared orbit representatives have the stated axis types
+PASS: f10-remaining-bits f10 is the F_cut remaining-bit tuple (1,1,0,0,0)
+PASS: f-l1-is-n-unbalanced f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity
+PASS: maps-distinct-from-f00-and-l1 f10 differs from f00 on opp2 and from f_L1 on opp2 and adj2
+n_four_site_seeds=495
+cov4(f10)=7
+cov4(f00)=7
+face_6493_in_f10_fillers=True
+face_6493_in_f00_fillers=True
+face_6493=((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
+face_history_f10=(4, 8, 12) T=2 fill=True
+PASS: theorem-1-cov4 cov4(f10)=7 among the 495 four-site seeds
+PASS: theorem-2-6493-face the #6493 face is among the f10 four-site fillers
+PASS: theorem-2-face-history from the #6493 face the lock history is (4, 8, 12) and the run fills
+PASS: theorem-3-display-not-adopt the note displays the coverage score and refuses to adopt a bit
+PASS: claim-scope claim_scope reports cov4(f10) and whether the #6493 face fills
+PASS: note-contract machine fields, coverage statement, and forbidden-phrase hygiene hold
+PASS: not-leftover-6496-6493 the residual is the 4-site score of f10, not leftover first-fill of #6496 or #6493
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: off-patch-declared off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: axiom-unedited the axiom memo still carries the four named premises and no F_cut map
+per_element: axis-type representatives and off-patch occupancy 0 are enumerated
+per_site: each two-cube vertex is tested against the displayed lock predicate
+per_mode: checked and not executed — no spectral claim occurs
+per_block: all 495 four-site seeds are executed to a fixed point
+lattice_wide: checked and not executed — neither the map nor a remaining bit is adopted
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c10_four_site_coverage_2026_08_15.py
+++ b/scripts/f_cut_c10_four_site_coverage_2026_08_15.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""4-site fill coverage of F_cut (1,1,0,0,0) on the two-cube.
+
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. f10 is the F_cut remaining-bit map (1,1,0,0,0). Coverage
+cov4(f10) is the number of unordered 4-site seeds from which f10 fills.
+The #6493 face is the lex-first 4-site fill of remaining bits (1,0,0,0,0).
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. The coverage score is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+
+SITES: tuple[Point, ...] = tuple(
+    sorted((x, y, z) for x in (0, 1, 2) for y in (0, 1) for z in (0, 1))
+)
+TWO_CUBE_SET = frozenset(SITES)
+AXIS_SHIFTS: tuple[tuple[Point, Point], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+F10_TUPLE: tuple[int, ...] = (1, 1, 0, 0, 0)
+F00_TUPLE: tuple[int, ...] = (1, 0, 0, 0, 0)
+L1_TUPLE: tuple[int, ...] = (1, 0, 1, 1, 1)
+FACE_6493: tuple[Point, ...] = ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
+FACE_HISTORY = (4, 8, 12)
+
+ORBIT_REPS: dict[str, Config] = {
+    "empty": (0, 0, 0, 0, 0, 0),
+    "wt1": (1, 0, 0, 0, 0, 0),
+    "opp2": (1, 1, 0, 0, 0, 0),
+    "adj2": (1, 0, 1, 0, 0, 0),
+    "vertex3": (1, 0, 1, 0, 1, 0),
+    "mixed3": (1, 0, 1, 1, 0, 0),
+    "type210": (1, 1, 1, 0, 0, 1),
+    "wt5": (1, 1, 1, 1, 1, 0),
+    "opp2c": (1, 1, 1, 1, 0, 0),
+    "full": (1, 1, 1, 1, 1, 1),
+}
+BIT_NAMES: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def occupancy(site: Point, locks: frozenset[Point]) -> int:
+    if site not in TWO_CUBE_SET:
+        return 0
+    return 1 if site in locks else 0
+
+
+def neighbor_config(site: Point, locks: frozenset[Point]) -> Config:
+    bits: list[int] = []
+    for plus, minus in AXIS_SHIFTS:
+        bits.append(occupancy(add(site, plus), locks))
+        bits.append(occupancy(add(site, minus), locks))
+    return (bits[0], bits[1], bits[2], bits[3], bits[4], bits[5])
+
+
+def axis_type(config: Config) -> tuple[int, int, int]:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for index in (0, 2, 4):
+        plus, minus = config[index], config[index + 1]
+        if plus == 1 and minus == 1:
+            n_both += 1
+        elif plus == 0 and minus == 0:
+            n_empty += 1
+        else:
+            n_unbalanced += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    n_unbalanced, _n_both, _n_empty = axis_type(config)
+    return 1 if n_unbalanced >= 1 else 0
+
+
+def f10(config: Config) -> int:
+    """F_cut remaining bits (1,1,0,0,0): fire on wt1, opp2, and complements."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (0, 1, 2), (1, 2, 0), (0, 2, 1)) else 0
+
+
+def f00(config: Config) -> int:
+    """F_cut remaining bits (1,0,0,0,0): fire only on wt1 and wt5."""
+    kind = axis_type(config)
+    return 1 if kind in ((1, 0, 2), (1, 2, 0)) else 0
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_tuple(predicate) -> tuple[int, ...]:
+    return tuple(int(predicate(ORBIT_REPS[name]) == 1) for name in BIT_NAMES)
+
+
+def step(locks: frozenset[Point], predicate) -> frozenset[Point]:
+    newcomers = {
+        site
+        for site in SITES
+        if site not in locks and predicate(neighbor_config(site, locks)) == 1
+    }
+    return locks | newcomers
+
+
+def run_from_seed(seed: frozenset[Point], predicate, halt_bound: int = 12):
+    locks = frozenset(seed)
+    history = [len(locks)]
+    tick = 0
+    while tick < halt_bound:
+        nxt = step(locks, predicate)
+        if nxt == locks:
+            break
+        locks = nxt
+        tick += 1
+        history.append(len(locks))
+    return tick, frozenset(locks), tuple(history)
+
+
+def fills(seed: tuple[Point, ...] | frozenset[Point], predicate=f10) -> bool:
+    _tick, locks, _history = run_from_seed(frozenset(seed), predicate)
+    return len(locks) == 12
+
+
+def four_site_coverage(predicate=f10) -> tuple[int, int, bool]:
+    n_total = 0
+    n_fill = 0
+    face_fills = False
+    face = frozenset(FACE_6493)
+    for combo in combinations(SITES, 4):
+        n_total += 1
+        if fills(combo, predicate):
+            n_fill += 1
+            if frozenset(combo) == face:
+                face_fills = True
+    return n_total, n_fill, face_fills
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries; no observations or fits")
+    print("integrity_reads: this runner, its note, and the live axiom memo; no other scientific inputs")
+    print("construction: displayed F_cut occupancy-to-lock map; 4-site coverage on the twelve-vertex two-cube")
+    print("negative_scope: neither the map nor a remaining bit is adopted or written into Admissibility")
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as static literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/F_CUT_C10_FOUR_SITE_COVERAGE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    not_dynamics = "Admissibility is not a dynamics axiom."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalize(axiom) and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalize(axiom) and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site, probability, and rate remain outside Admissibility",
+        formation_boundary in normalize(axiom) and formation_boundary in normalize(note),
+    )
+    checks.check(
+        "source-record-and-non-dynamics",
+        "Record lock wording and the non-dynamics Admissibility boundary are pinned",
+        record_lock in normalize(axiom)
+        and record_lock in note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+
+    checks.check(
+        "two-cube-and-four-site-seeds",
+        "the two-cube has twelve vertices and C(12,4)=495 four-site seeds",
+        len(SITES) == 12
+        and SITES == tuple(sorted(SITES))
+        and len(set(SITES)) == 12
+        and SITES[0] == (0, 0, 0)
+        and SITES[-1] == (2, 1, 1)
+        and TWO_CUBE_SET == frozenset(SITES)
+        and FACE_6493 == tuple(sorted(FACE_6493)),
+    )
+    checks.check(
+        "off-patch-zero",
+        "every off-patch neighbor contributes occupancy 0",
+        occupancy((-1, 0, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((0, -1, 0), frozenset({(0, 0, 0)})) == 0
+        and occupancy((3, 0, 0), frozenset({(2, 0, 0)})) == 0,
+    )
+    checks.check(
+        "axis-type-reps",
+        "declared orbit representatives have the stated axis types",
+        axis_type(ORBIT_REPS["wt1"]) == (1, 0, 2)
+        and axis_type(ORBIT_REPS["opp2"]) == (0, 1, 2)
+        and axis_type(ORBIT_REPS["adj2"]) == (2, 0, 1)
+        and axis_type(ORBIT_REPS["vertex3"]) == (3, 0, 0)
+        and axis_type(ORBIT_REPS["mixed3"]) == (1, 1, 1)
+        and axis_type(ORBIT_REPS["type210"]) == (2, 1, 0)
+        and axis_type(ORBIT_REPS["empty"]) == (0, 0, 3)
+        and axis_type(ORBIT_REPS["wt5"]) == (1, 2, 0)
+        and axis_type(ORBIT_REPS["opp2c"]) == (0, 2, 1)
+        and axis_type(ORBIT_REPS["full"]) == (0, 3, 0),
+    )
+
+    f10_bits = remaining_tuple(f10)
+    f00_bits = remaining_tuple(f00)
+    l1_bits = remaining_tuple(f_L1)
+    checks.check(
+        "f10-remaining-bits",
+        "f10 is the F_cut remaining-bit tuple (1,1,0,0,0)",
+        f10_bits == F10_TUPLE
+        and f00_bits == F00_TUPLE
+        and l1_bits == L1_TUPLE
+        and f10(ORBIT_REPS["wt1"]) == 1
+        and f10(ORBIT_REPS["opp2"]) == 1
+        and f10(ORBIT_REPS["wt5"]) == 1
+        and f10(ORBIT_REPS["opp2c"]) == 1
+        and f10(ORBIT_REPS["adj2"]) == 0
+        and f10(ORBIT_REPS["vertex3"]) == 0
+        and f10(ORBIT_REPS["mixed3"]) == 0
+        and f10(ORBIT_REPS["type210"]) == 0
+        and f10(ORBIT_REPS["empty"]) == 0
+        and f10(ORBIT_REPS["full"]) == 0,
+    )
+    checks.check(
+        "f-l1-is-n-unbalanced",
+        "f_L1 is the n!=0 (some-axis-unbalanced) map, not Hamming parity",
+        f_L1(ORBIT_REPS["wt1"]) == 1
+        and f_L1(ORBIT_REPS["mixed3"]) == 1
+        and f_L1(ORBIT_REPS["type210"]) == 1
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["empty"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) != f_hamming(ORBIT_REPS["adj2"])
+        and sum(ORBIT_REPS["opp2"]) % 2 == 0
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f10", 1)[0],
+    )
+    checks.check(
+        "maps-distinct-from-f00-and-l1",
+        "f10 differs from f00 on opp2 and from f_L1 on opp2 and adj2",
+        f10(ORBIT_REPS["opp2"]) == 1
+        and f00(ORBIT_REPS["opp2"]) == 0
+        and f_L1(ORBIT_REPS["opp2"]) == 0
+        and f10(ORBIT_REPS["adj2"]) == 0
+        and f_L1(ORBIT_REPS["adj2"]) == 1
+        and F10_TUPLE != F00_TUPLE
+        and F10_TUPLE != L1_TUPLE,
+    )
+
+    n_total, cov4, face_in_fillers = four_site_coverage(f10)
+    _n00, cov4_f00, face_in_f00 = four_site_coverage(f00)
+    tick, locks, history = run_from_seed(frozenset(FACE_6493), f10)
+    print(f"n_four_site_seeds={n_total}")
+    print(f"cov4(f10)={cov4}")
+    print(f"cov4(f00)={cov4_f00}")
+    print(f"face_6493_in_f10_fillers={face_in_fillers}")
+    print(f"face_6493_in_f00_fillers={face_in_f00}")
+    print(f"face_6493={FACE_6493}")
+    print(f"face_history_f10={history} T={tick} fill={locks == TWO_CUBE_SET}")
+
+    checks.check(
+        "theorem-1-cov4",
+        "cov4(f10)=7 among the 495 four-site seeds",
+        n_total == 495
+        and cov4 == 7
+        and f"cov4(f10) = {cov4}" in note
+        and "495" in note
+        and remaining_tuple(f10) == (1, 1, 0, 0, 0),
+        residual=(n_total, cov4),
+    )
+    checks.check(
+        "theorem-2-6493-face",
+        "the #6493 face is among the f10 four-site fillers",
+        face_in_fillers
+        and fills(FACE_6493, f10)
+        and fills(FACE_6493, f00)
+        and FACE_6493 == ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
+        and "{(0,0,0),(0,0,1),(0,1,0),(0,1,1)}" in note.replace(" ", "")
+        and "#6493" in note
+        and "among the fillers" in note,
+        residual=FACE_6493,
+    )
+    checks.check(
+        "theorem-2-face-history",
+        "from the #6493 face the lock history is (4, 8, 12) and the run fills",
+        tick == 2
+        and history == FACE_HISTORY
+        and locks == TWO_CUBE_SET
+        and "(4, 8, 12)" in note,
+        residual=(tick, history, len(locks)),
+    )
+    checks.check(
+        "theorem-3-display-not-adopt",
+        "the note displays the coverage score and refuses to adopt a bit",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "not written into Admissibility" in normalize(note)
+        and "Do not write" in note,
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, the 4-site coverage of F_cut "
+        "(1,1,0,0,0) is reported, and whether it fills the #6493 face. "
+        "Displayed, not adopted."
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "cov4(f10) = 7",
+        "(1, 1, 0, 0, 0)",
+        "#6493",
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+
+    checks.check(
+        "claim-scope",
+        "claim_scope reports cov4(f10) and whether the #6493 face fills",
+        claim_scope in note
+        and "Displayed, not adopted" in note
+        and "do not adopt" in note.lower(),
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, coverage statement, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and all(phrase not in note and phrase not in self_source for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "new axiom" not in note
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "citation" not in note.lower()
+        and "runner-cache" not in note
+        and "retained" not in other_retained,
+    )
+    checks.check(
+        "not-leftover-6496-6493",
+        "the residual is the 4-site score of f10, not leftover first-fill of #6496 or #6493",
+        "Not leftover-character of #6496" in note
+        and "Not leftover-character of #6493" in note
+        and "New score" in note
+        and "second exception" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in normalize(note)
+        and "not Hamming" in note
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "off-patch-declared",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo still carries the four named premises and no F_cut map",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "f10" not in axiom,
+    )
+
+    print("per_element: axis-type representatives and off-patch occupancy 0 are enumerated")
+    print("per_site: each two-cube vertex is tested against the displayed lock predicate")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: all 495 four-site seeds are executed to a fixed point")
+    print("lattice_wide: checked and not executed — neither the map nor a remaining bit is adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the 4-site coverage of F_cut (1,1,0,0,0) is reported, and whether it fills the #6493 face. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c10_four_site_coverage_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.