### PR TITLE
feat(p4closed): whether cov4>0 is equivalent to selector P

### DIFF
--- a/docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,297 @@
+---
+claim_id: f_cut_cov4_positive_closed_form_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether positive 4-site coverage is equivalent to P is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov4_positive_closed_form_2026_08_15.py
+---
+
+# Whether Positive 4-Site Coverage Equals P Among the 32 F_cut Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill positivity on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the 495 four-site seeds, for the
+thirty-two cube-covariant cut maps `F_cut`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov4_positive_closed_form_2026_08_15.py`](../scripts/f_cut_cov4_positive_closed_form_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6494 closed the 2-site positivity question: `cov2(f) > 0` if and
+only if the remaining-bit predicate
+`P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`.
+Investment #6502 showed that `cov3>0` is not `P`. Investment #6503 showed
+that `cov1>0` is not `P`. This note repeats the same displayed predicate on a
+new seed cardinality: four-site seeds. New k, not leftover-character of those
+three investments and not a Max(4) rename.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov4(f) = |{S : |S|=4 and f fills from S}|`. Then:
+
+- Theorem 1. cov4(f) > 0 is not equivalent to P(f) among the 32 maps.
+  The lex-first remaining-bit counterexample is `(0, 0, 1, 0, 0)`, which has
+  `P = 0` and `cov4 = 52`.
+- Theorem 2. `N_P = 14`, `N_pos = 24`, `N_both = 14`.
+- Theorem 3. `P` is displayed. Displayed, not adopted.
+
+Do not write P into Admissibility. The extra that would have made 4-site
+positivity the same selector as 2-site positivity is not present.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 495 four-site seeds of the two-cube. Whether cov4>0 equals P, and the counts N_P, N_pos, N_both, are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov4_positive_closed_form
+target_blocker_text: "whether cov4>0 is the same selector P among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 4-site positivity-versus-P comparison; do not adopt the displayed predicate P"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil
+  `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Decide whether `cov4(f) > 0` if and only if `P(f)`, for every
+member of `F_cut` on `T`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The four-site seeds are the `C(12,4) = 495` unordered 4-subsets of `T`. Then
+`cov4(f)` is the number of those subsets from which `f` fills.
+
+The displayed remaining-bit predicate is
+
+`P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`.
+
+Opp2 is free in `P`. The two remaining-bit tuples with `wt1=1` and
+`(adj2, vertex3, mixed3) = (0, 0, 0)` are `(1, 0, 0, 0, 0)` and
+`(1, 1, 0, 0, 0)`; both have `P` false. Displayed, not adopted.
+
+## Theorems
+
+### Theorem 1 — `cov4>0` is not `P`; lex-first witness
+
+Enumerate all 32 remaining-bit tuples of `F_cut` and score `cov4` on the 495
+four-site seeds. Then `cov4(f) > 0` is not equivalent to `P(f)`.
+
+The lex-first remaining-bit counterexample, in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`, is `(0, 0, 1, 0, 0)`. That map has
+`wt1 = 0`, so `P` is false, and `cov4 = 52 > 0`.
+
+### Theorem 2 — `N_P`, `N_pos`, `N_both`
+
+Among the 32 maps:
+
+- `N_P = 14` maps satisfy `P`;
+- `N_pos = 24` maps have `cov4 > 0`;
+- `N_both = 14` maps satisfy both.
+
+Every `P`-true map has `cov4 > 0`. Equivalence fails only in the other
+direction: ten `P`-false maps still have positive 4-site coverage. Those ten
+are the eight maps with `wt1 = 0` and `adj2 = 1`, together with the two
+tuples `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`.
+
+### Theorem 3 — display; do not adopt `P`
+
+`P` is the same remaining-bit predicate that #6494 found equivalent to
+`cov2>0`. On four-site seeds it is not the positivity selector. Displayed,
+not adopted. Do not write P into Admissibility.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, satisfies `P` and has
+positive `cov4`. That is consistent with Theorem 2 and does not restore
+equivalence.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, 495 four-site seeds, off-patch 0 | declared finite patch |
+| `P` as `(wt1=1)` and `(adj2,vertex3,mixed3)≠(0,0,0)` | displayed, not adopted |
+| `cov4>0` iff `P` | fails; lex-first witness `(0, 0, 1, 0, 0)` |
+| `N_P = 14`, `N_pos = 24`, `N_both = 14` | proved by exhaustive scoring |
+| leftover-character of #6494, #6502, #6503 | refused; new k |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6494: that closed `cov2>0` iff `P` on two-site
+seeds. The present count is `cov4` on 495 four-site seeds, a different seed
+family.
+
+Not leftover-character of #6502: that showed `cov3>0` is not `P` on
+three-site seeds. New k.
+
+Not leftover-character of #6503: that showed `cov1>0` is not `P` on
+one-site seeds. New k.
+
+The note is not a Max(4) ranking and not a seed-table: maximizers of `cov4`
+are not selected, and no seed census of a named map is compiled.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write P into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether 4-site positivity is the same selector as `P` inside `F_cut` on this patch. |
+| V2 | Current main has no landed 4-site positivity-versus-`P` comparison for `F_cut`. |
+| V3 | The 32 maps, 495 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared finite class. |
+| V5 | It is not a physical selector: equivalence fails, and displayed `P` is not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: `cov4>0` is not equivalent to `P` among the
+32 `F_cut` maps on this patch. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover 2-site closed form | treat the 4-site comparison as leftover-character of #6494 | **ATTEMPTED** |
+| leftover 3-site or 1-site | treat the count as leftover-character of #6502 or #6503 | **ATTEMPTED** |
+| Max(4) rename | replace positivity-versus-`P` by a 4-site maximizer ranking | **ATTEMPTED** |
+| adopt `P` | write `P` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed equivalence, the Hamming contrast, and the off-patch convention
+are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 495 four-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the displayed
+predicate `P` are declared. Equivalence of `cov4>0` with `P` is not silently
+assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is whether 4-site
+positivity equals `P` on the declared patch, not leftover-character of
+#6494, #6502, or #6503, and not a Max(4) ranking.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 495 seeds | no physical law selection |
+| per block | `N_P`, `N_pos`, `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than `P` or `cov4>0`, and any independently derived physical
+map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** #6494 already showed that positivity is `P`, so every later
+`k` inherits the same selector.
+
+**Answer:** Inheritance fails at `k=4`. Fourteen maps satisfy `P` and all
+of them have `cov4>0`, but twenty-four maps have `cov4>0`. The lex-first
+witness `(0, 0, 1, 0, 0)` has `P` false and `cov4 = 52`. Displayed `P` is
+not adopted.
+
+### N8 — cross-cycle echo
+
+Investments #6502 and #6503 already showed that `cov3>0` and `cov1>0` are
+not `P`. Echoing those failures is not a substitute for the four-site count:
+`k=4` is a new seed family, and the lex-first witness and the triple
+`(N_P, N_pos, N_both)` are four-site facts.
+
+No-Go Discipline disposition: **PASS** for the finite comparison and the
+narrow equivalence failure. FAIL / DO NOT SHIP for “`cov4>0` is `P`” or
+“displayed `P` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov4` on the
+495 four-site seeds, compares positivity with displayed `P`, reports the
+lex-first remaining-bit counterexample `(0, 0, 1, 0, 0)`, and reports
+`N_P = 14`, `N_pos = 24`, and `N_both = 14`. Declared audit inputs are this
+note and the axiom memo; the runner writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov4_positive_closed_form_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov4_positive_closed_form_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov4_positive_closed_form_2026_08_15.txt
@@ -1,0 +1,67 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov4_positive_closed_form_2026_08_15.py
+runner_sha256: ebec3754b53773feedf60c43a5d027e02d9f5fbd872e34aaac42ccd841f37c83
+input_fingerprint_sha256: 0cb5fdccc00cd16ebff2a97ad8a05f04ceab9d1bd61cfb3726f83d600bf43c74
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.30
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_four_site_seeds=495
+N_P=14
+N_pos=24
+N_both=14
+n_mismatch=10
+lex_first_counterexample=(0, 0, 1, 0, 0)
+lex_first_cov4=52
+lex_first_P=0
+cov4_f_L1=489
+f_L1_bits=(0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+f_hamming_cov4=273
+P_of_f_L1=1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-four-site-seeds the two-cube has twelve vertices and C(12,4)=495 four-site seeds
+PASS: thm1-not-equivalent cov4>0 is not equivalent to P among the 32 F_cut maps
+PASS: thm1-lex-first-counterexample lex-first counterexample remaining-bit tuple is (0, 0, 1, 0, 0)
+PASS: thm2-counts N_P=14, N_pos=24, N_both=14
+PASS: thm2-p-implies-positive every P-true map has cov4>0; ten P-false maps have cov4>0
+PASS: thm3-display-not-adopt P is displayed and is not adopted as an Admissibility selector
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted P, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-equivalence-failure the note reports the failed equivalence, the lex-first witness, and the three counts
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6494-6502-6503 the residual is 4-site positivity versus P, not leftover-character of #6494, #6502, or #6503
+PASS: claim-scope-closed-form claim_scope reports whether positive 4-site coverage is equivalent to P
+PASS: p-definition-and-l1-in-class P is the remaining-bit predicate on F_cut and f_L1 satisfies P
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by whether any of the 495 four-site seeds fills
+per_block: checked exactly — N_P, N_pos, and N_both are the F_cut positivity-versus-P counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov4_positive_closed_form_2026_08_15.py
+++ b/scripts/f_cut_cov4_positive_closed_form_2026_08_15.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""Whether cov4>0 equals P among the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov4(f) is the number of unordered 4-site seeds from
+which f fills. P(f) is the displayed remaining-bit predicate
+(wt1=1) and (adj2, vertex3, mixed3) != (0, 0, 0). Displayed, not adopted.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+FOUR_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(quad) for quad in combinations(TWO_CUBE, 4)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_COUNTEREXAMPLE: Remaining = (0, 0, 1, 0, 0)
+COUNTEREXAMPLE_COV4 = 52
+N_P = 14
+N_POS = 24
+N_BOTH = 14
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def selector_P(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, vertex3, mixed3 = remaining
+    return wt1 == 1 and (adj2, vertex3, mixed3) != (0, 0, 0)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in FOUR_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def coverage_ranking(
+    members: list[tuple[tuple[int, ...], Remaining]],
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> list[tuple[int, Remaining, tuple[int, ...]]]:
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    ranked: list[tuple[int, Remaining, tuple[int, ...]]] = []
+    for bits, remaining in members:
+        cov = coverage(predicate_from_bits(bits, orbit_types, type_of))
+        ranked.append((cov, remaining, bits))
+    return ranked
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, orbits, empty_type, full_type)
+    ranked = coverage_ranking(members, orbit_types, orbits)
+    cov_by_remaining = {remaining: cov for cov, remaining, _bits in ranked}
+    rows = sorted(
+        (remaining, cov_by_remaining[remaining], selector_P(remaining))
+        for remaining in cov_by_remaining
+    )
+    n_p = sum(1 for _remaining, _cov, flag in rows if flag)
+    n_pos = sum(1 for _remaining, cov, _flag in rows if cov > 0)
+    n_both = sum(1 for _remaining, cov, flag in rows if cov > 0 and flag)
+    mismatches = [
+        (remaining, cov, flag) for remaining, cov, flag in rows if (cov > 0) != flag
+    ]
+    lex_first = mismatches[0] if mismatches else None
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_l1 = cov_by_remaining[l1_remaining]
+    cov_ham = coverage(f_hamming)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_four_site_seeds={len(FOUR_SITE_SEEDS)}")
+    print(f"N_P={n_p}")
+    print(f"N_pos={n_pos}")
+    print(f"N_both={n_both}")
+    print(f"n_mismatch={len(mismatches)}")
+    print(f"lex_first_counterexample={None if lex_first is None else lex_first[0]}")
+    if lex_first is not None:
+        print(f"lex_first_cov4={lex_first[1]}")
+        print(f"lex_first_P={int(lex_first[2])}")
+    print(f"cov4_f_L1={cov_l1}")
+    print(f"f_L1_bits={l1_bits}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"f_hamming_cov4={cov_ham}")
+    print(f"P_of_f_L1={int(selector_P(l1_remaining))}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV4_POSITIVE_CLOSED_FORM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-four-site-seeds",
+        "the two-cube has twelve vertices and C(12,4)=495 four-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(FOUR_SITE_SEEDS) == 495
+        and len(set(FOUR_SITE_SEEDS)) == 495
+        and all(seed <= set(TWO_CUBE) and len(seed) == 4 for seed in FOUR_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "cov4>0 is not equivalent to P among the 32 F_cut maps",
+        len(mismatches) > 0
+        and n_pos != n_p
+        and n_both == n_p
+        and all(selector_P(remaining) == (cov > 0) for remaining, cov, _flag in rows) is False
+        and "cov4(f) > 0 is not equivalent to P(f)" in note_flat,
+    )
+    checks.check(
+        "thm1-lex-first-counterexample",
+        "lex-first counterexample remaining-bit tuple is (0, 0, 1, 0, 0)",
+        lex_first is not None
+        and lex_first[0] == LEX_FIRST_COUNTEREXAMPLE
+        and lex_first[1] == COUNTEREXAMPLE_COV4
+        and lex_first[2] is False
+        and cov_by_remaining[LEX_FIRST_COUNTEREXAMPLE] == 52
+        and selector_P(LEX_FIRST_COUNTEREXAMPLE) is False
+        and "(0, 0, 1, 0, 0)" in note
+        and "cov4 = 52" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_P={n_p}, N_pos={n_pos}, N_both={n_both}",
+        n_p == N_P
+        and n_pos == N_POS
+        and n_both == N_BOTH
+        and n_p == 14
+        and n_pos == 24
+        and n_both == 14
+        and f"N_P = {n_p}" in note
+        and f"N_pos = {n_pos}" in note
+        and f"N_both = {n_both}" in note,
+    )
+    checks.check(
+        "thm2-p-implies-positive",
+        "every P-true map has cov4>0; ten P-false maps have cov4>0",
+        n_both == n_p
+        and len(mismatches) == 10
+        and all(flag is False and cov > 0 for _remaining, cov, flag in mismatches)
+        and selector_P(L1_REMAINING)
+        and cov_l1 > 0
+        and l1_remaining == L1_REMAINING,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "P is displayed and is not adopted as an Admissibility selector",
+        "P(f)" in note
+        and "wt1=1" in note
+        and "(adj2,vertex3,mixed3)" in note
+        and "Displayed, not adopted" in note
+        and "Do not write P into Admissibility" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted P, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-equivalence-failure",
+        "the note reports the failed equivalence, the lex-first witness, and the three counts",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(0, 0, 1, 0, 0)" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "N_P = 14" in note
+        and "N_pos = 24" in note
+        and "N_both = 14" in note
+        and "cov4(f) > 0 is not equivalent to P(f)" in note_flat,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write P into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6494-6502-6503",
+        "the residual is 4-site positivity versus P, not leftover-character of #6494, #6502, or #6503",
+        "Not leftover-character of #6494" in note
+        and "Not leftover-character of #6502" in note
+        and "Not leftover-character of #6503" in note
+        and "New k" in note,
+    )
+    checks.check(
+        "claim-scope-closed-form",
+        "claim_scope reports whether positive 4-site coverage is equivalent to P",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "whether positive 4-site coverage is equivalent to P is reported" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "p-definition-and-l1-in-class",
+        "P is the remaining-bit predicate on F_cut and f_L1 satisfies P",
+        selector_P((1, 0, 1, 1, 1))
+        and not selector_P((1, 0, 0, 0, 0))
+        and not selector_P((1, 1, 0, 0, 0))
+        and not selector_P((0, 0, 1, 0, 0))
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and cov_l1 == cov_by_remaining[(1, 0, 1, 1, 1)],
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by whether any of the 495 four-site seeds fills")
+    print("per_block: checked exactly — N_P, N_pos, and N_both are the F_cut positivity-versus-P counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), whether positive 4-site coverage is equivalent to P is reported. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_cov4_positive_closed_form_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.