### PR TITLE
feat(f10c3orb): orbit type of f10 four 3-site fills

### DIFF
--- a/docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,417 @@
+---
+claim_id: f_cut_c10_three_site_fill_orbit_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the four 3-site seeds that F_cut (1,1,0,0,0) fills form N_orb=1 orbits under two-cube-preserving rotations. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py
+---
+
+# Orbit Type Of The Four Three-Site Fills Of `F_cut` `(1,1,0,0,0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 3-site fill set of the cube-covariant
+complement-even map in `F_cut` with remaining-bit tuple `(1, 1, 0, 0, 0)`,
+on the twelve-vertex two-cube, with off-patch occupancy `0`, together with
+the number of orbits of that fill set under two-cube-preserving proper
+cube rotations about the box center. The orbit count and one lex
+representative are displayed. The map is not adopted as the physical
+Admissibility rule. Do not list all four.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py`](../scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `f10` for remaining bits `(1, 1, 0, 0, 0)`. This map
+has `wt1=1` and is the second `#6490` exception (`cov2=0` with `wt1=1`).
+
+Not leftover-character of #6496: that counted `|M|=4`. The present object
+is the orbit type of that already-counted fill set under two-cube
+rotations. New geometry of a counted fill set of the second exception.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered triple of vertices is
+a 3-site seed. There are `C(12,3)=220` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Write `M` for the set of 3-site seeds that `f10` fills.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+That map is a control, not a scored exception.
+
+The group `G` is the set of proper cube rotations about the box center
+`(1, 1/2, 1/2)` that permute the twelve vertices. Rotations that do not
+preserve the 12-set are discarded. That group has order 8: it is the
+square-prism rotation group that keeps the long axis of the two-cube.
+
+**Theorem 1.** Exhaustive evaluation of `f10` on all 220 three-site seeds
+gives
+
+```text
+|M| = 4.
+```
+
+The `#6492` seed `{(0,0,0),(1,1,1),(2,0,0)}` is an element of `M`.
+
+**Theorem 2.** The fill set `M` is a single `G`-orbit. There is one lex
+representative:
+
+```text
+N_orb = 1
+lex representative = {(0,0,0),(1,1,1),(2,0,0)}.
+```
+
+That representative is the `#6492` seed. Do not list all four.
+
+**Theorem 3.** The integer `N_orb = 1` is displayed. The orbit is not
+adopted as the physical Admissibility rule.
+
+Do not write the orbit into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, membership of f10=(1,1,0,0,0), the exact fill count |M|=4, membership of the #6492 seed, and the orbit count N_orb=1 under the order-8 two-cube-preserving rotation group are enumerated. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_c10_three_site_fill_orbit
+target_blocker_text: "what is the orbit type of the four 3-site seeds that f10 fills"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the f10 3-site fill-orbit count; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for f10 on this twelve-vertex patch with off-patch o=0 and the order-8 two-cube-preserving rotation group; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 220 unordered 3-site seeds;
+- the remaining-bit tuple `(1, 1, 0, 0, 0)`;
+- the `#6492` seed `{(0,0,0),(1,1,1),(2,0,0)}`;
+- proper cube rotations about the box center that preserve the 12-set.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Reconfirm that `f10` fills exactly four 3-site seeds and that
+the `#6492` seed is among them. Report `N_orb` of that fill set under
+two-cube-preserving rotations, with one lex representative per orbit.
+Display `N_orb`. Do not list all four. Do not adopt a seed.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+f10(c)      = 1  iff  the remaining-bit assignment is (1, 1, 0, 0, 0),
+f_L1(c)     = 1  iff  u(c) ≥ 1.
+```
+
+So `f10` fires on `wt1` and `opp2` (and their complements), and `f_L1`
+has remaining bits `(1, 0, 1, 1, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `M` is the set of 3-site seeds whose halt set has cardinality 12.
+
+The group `G` is obtained from the 24 proper cube rotations by acting
+about the box center `(1, 1/2, 1/2)` and retaining only those maps that
+permute the twelve vertices. If a rotation does not preserve the 12-set,
+it is not used. The surviving group has order 8. Two seeds lie in the
+same `G`-orbit when a surviving rotation carries one unordered triple
+onto the other. `N_orb` is the number of such orbits in `M`. The lex
+representative of an orbit is the unique seed whose sorted triple of
+sites is minimal in dictionary order.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The map `f10` is
+one of those 32 members. The unbalanced-axis map `f_L1` is one element of
+`F_cut` and is not Hamming parity. On the twelve-vertex two-cube with
+off-patch occupancy `0`, exhaustive evaluation of `f10` on all 220
+three-site seeds gives
+
+```text
+|M| = 4.
+```
+
+The `#6492` seed `{(0,0,0),(1,1,1),(2,0,0)}` belongs to `M`.
+
+**Theorem 2.** Exactly eight of the 24 proper cube rotations about the
+box center permute the twelve vertices. The fill set `M` is closed under
+that group and forms a single orbit:
+
+```text
+N_orb = 1.
+```
+
+The unique lex representative is the `#6492` seed
+`{(0,0,0),(1,1,1),(2,0,0)}`. Do not list all four.
+
+**Theorem 3.** The integer
+
+```text
+N_orb = 1
+```
+
+is displayed. The orbit is not adopted as the physical Admissibility
+rule.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after empty/full are forced to `0` |
+| `f10` in `F_cut` | remaining-bit tuple `(1, 1, 0, 0, 0)` |
+| 220 three-site seeds | `C(12,3)` unordered triples on the two-cube |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` and has remaining bits `(1, 0, 1, 1, 1)` |
+| `|M|=4` with `#6492` in `M` | exhaustive fill census; the displayed seed fills |
+| `|G|=8` | two-cube-preserving proper rotations about the box center |
+| `N_orb=1` | `M` is one `G`-orbit; lex representative is the `#6492` seed |
+| displayed integer | `N_orb=1`, not adopted |
+
+## What This Does Not Claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No listing of the four seeds as independent extras.
+- No ranking of the other 31 maps in `F_cut`.
+- No blank-block or 4-site variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is adoption: the orbit of the four fills is not
+written into Admissibility. The positive pair `|M|=4` and `N_orb=1` is
+an exact enumeration, not a wall.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-and-f10` place `f10` in `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| fill census | Score `f10` on all 220 three-site seeds and test the `#6492` seed. | Theorem 1 and check `thm1-fill-count-and-6492` give `|M|=4` with that seed in `M`. | **ATTEMPTED** |
+| two-cube group and `N_orb` | Restrict to rotations that preserve the 12-set and orbit `M`. | Theorem 2 and checks `thm2-preserving-group` / `thm2-n-orb-and-lex-rep` give `|G|=8` and `N_orb=1`. | **ATTEMPTED** |
+| adopt an orbit | Write the orbit or the `#6492` seed into Admissibility. | Theorem 3 and check `thm3-display-not-list-four`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: the displayed orbit is not adopted.
+The count `|M|=4` and the orbit type `N_orb=1` are two certificates of
+the same fill set, not two walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| `|M|=4` / `N_orb=1` | no: a raw count does not name the group action | no: one orbit does not name the seed cardinality without `|G|` | independent positive integers |
+| `#6492` membership / `N_orb=1` | no: one seed in `M` does not force a single orbit | no: a single orbit does not name which seed is lex-first without the order | membership versus orbit type |
+| leftover `#6496` count / this `N_orb` | no: `|M|=4` is not an orbit type | no: `N_orb=1` does not replace the seed count | New geometry |
+| static `#6490` pair / this fill orbit | no: `cov2=0` is not 3-site dynamics | no: a 3-site orbit does not replace the 2-site exception | different `|S|` |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| remaining bits `(1, 1, 0, 0, 0)` | explicit scored map; the other 31 maps are unclaimed |
+| all 220 three-site seeds | explicit seed class; a 2-site ranking is a different residual |
+| two-cube-preserving rotations | explicit restriction of the 24 cube rotations to the 12-set |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuple `(1, 1, 0, 0, 0)` and the `#6492` seed | displayed witnesses, not selected laws |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:75` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:122` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:127` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:50` | 220 three-site seeds | `C(12,3)` unordered triples on the two-cube | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:60` | `f10` remaining bits | `(1, 1, 0, 0, 0)` | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:62` | `#6492` seed | `{(0,0,0),(1,1,1),(2,0,0)}` | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:231` | fill predicate | halt set of cardinality 12 | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:263` | two-cube-preserving group | proper rotations about the box center that permute the 12-set | yes |
+| `scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py:294` | orbit of a seed | `G`-images of an unordered triple | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: `f10` on all 220 seeds | the score is this one map; other classes are unclaimed |
+| per block | yes: `N_orb=1` of the four-element fill set | the four fills are one geometric type, not adopted |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-orbit count, or an Admissibility
+selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: the
+four 3-site fills of `f10` are a single geometric type under two-cube
+rotations, with lex representative the `#6492` seed. That orbit type
+does not make `f10` a unique maximizer and does not select it as the
+physical rule. The remaining physical choice — which, if any, `F_cut`
+map is the Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage or fill-orbit target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that `#6496` already counted four 3-site
+fills of `f10`, so an orbit type of that same set might be called leftover
+decoration of a known cardinality. That objection is correctly about
+`|M|=4`. It does not overturn the stated theorem: the four fills are one
+orbit under the order-8 two-cube-preserving rotation group, not four
+independent extras. A raw count does not name `N_orb`. This is new
+geometry of a counted fill set of the second exception.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the map `f10`, the fill set `M`, and `N_orb` are recomputed
+here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the orbit type of the four 3-site fills of
+`f10` or writes that orbit into Admissibility.
+
+No-Go Discipline disposition: **PASS** for the displayed `N_orb=1` of
+the four 3-site fills of `f10` stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates `f10=(1,1,0,0,0)` on the two-cube from every 3-site
+seed, reports `|M| = 4` with the `#6492` seed in `M`, restricts to the
+eight two-cube-preserving proper rotations about the box center, reports
+`N_orb = 1` with that seed as the unique lex representative, checks that
+`f_L1` is not Hamming parity, and exhibits `N_orb` as displayed, not
+adopted. Declared audit inputs are this note and the axiom memo. No
+runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_c10_three_site_fill_orbit_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_c10_three_site_fill_orbit_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_c10_three_site_fill_orbit_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py
+runner_sha256: 1abd65dff458a61ed07eca652354e7c8f54161e44f4cd6f06a49e45338303b7e
+input_fingerprint_sha256: f6f109455316334819e370157c543a9ad91e188a34db3abe7c8b747115fd47f5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_preserving=8
+n_config_orbits=10
+|F_cut|_free_check=32
+n_three_site_seeds=220
+f10_remaining=(1, 1, 0, 0, 0)
+f_L1_remaining=(1, 0, 1, 1, 1)
+|M|=4
+seed_6492_in_M=True
+N_orb=1
+lex_rep=((0, 0, 0), (1, 1, 1), (2, 0, 0))
+M_closed_under_G=True
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-f-cut-and-f10 F_cut has size 32 and f10=(1,1,0,0,0) is a member
+PASS: thm1-f-L1-not-hamming f_L1 is unbalanced-axis n_mu != 0, not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-220-seeds the two-cube has twelve vertices and C(12,3)=220 three-site seeds
+PASS: thm1-fill-count-and-6492 |M|=4 and the #6492 seed is in M
+PASS: thm2-preserving-group two-cube-preserving proper rotations about the box center form a group of order 8
+PASS: thm2-n-orb-and-lex-rep N_orb=1 and the unique lex representative is the #6492 seed
+PASS: thm3-display-not-list-four the note displays N_orb and does not list all four seeds
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted orbit type, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-count the residual is the orbit type of the counted fill set, not leftover of the |M|=4 count
+PASS: claim-scope-orbit claim_scope states the four 3-site fills of f10 form N_orb orbits
+PASS: cache-and-timeout audit timeout is 120s and no runner cache is written
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f10 is scored on all 220 three-site seeds; G acts on M
+per_block: checked exactly — N_orb is the orbit count of the four-element fill set
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py
+++ b/scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Orbit type of the four 3-site seeds filled by F_cut (1,1,0,0,0).
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. f10 is the remaining-bit map (1,1,0,0,0). M is the set of
+unordered 3-site seeds that f10 fills. N_orb is the number of orbits of M
+under two-cube-preserving proper cube rotations about the box center.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+F10_REMAINING: tuple[int, ...] = (1, 1, 0, 0, 0)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+SEED_6492: frozenset[Site] = frozenset(((0, 0, 0), (1, 1, 1), (2, 0, 0)))
+BOX_CENTER: tuple[float, float, float] = (1.0, 0.5, 0.5)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: tuple[float, float, float]) -> tuple[float, float, float]:
+    permutation, signs = rotation
+    result = [0.0, 0.0, 0.0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {
+        direction: tuple(int(component) for component in rotate_vector(rotation, direction))
+        for direction in DIRECTIONS
+    }
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def predicate_from_remaining(bits: tuple[int, ...]):
+    assignment = {
+        (0, 0, 3): 0,
+        (0, 3, 0): 0,
+        (1, 0, 2): bits[0],
+        (1, 2, 0): bits[0],
+        (0, 1, 2): bits[1],
+        (0, 2, 1): bits[1],
+        (2, 0, 1): bits[2],
+        (2, 1, 0): bits[2],
+        (3, 0, 0): bits[3],
+        (1, 1, 1): bits[4],
+    }
+
+    def predicate(config: Config) -> int:
+        return assignment[axis_type(config)]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def bits_from_predicate(
+    predicate,
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def rotate_site(rotation: Rotation, site: Site) -> Site | None:
+    relative = (
+        site[0] - BOX_CENTER[0],
+        site[1] - BOX_CENTER[1],
+        site[2] - BOX_CENTER[2],
+    )
+    image = rotate_vector(rotation, relative)
+    absolute = (
+        image[0] + BOX_CENTER[0],
+        image[1] + BOX_CENTER[1],
+        image[2] + BOX_CENTER[2],
+    )
+    rounded = (
+        int(round(absolute[0])),
+        int(round(absolute[1])),
+        int(round(absolute[2])),
+    )
+    if any(abs(absolute[index] - rounded[index]) > 1e-9 for index in range(3)):
+        return None
+    return rounded
+
+
+def two_cube_preserving(rotations: tuple[Rotation, ...]) -> tuple[Rotation, ...]:
+    preserved: list[Rotation] = []
+    two_cube_set = set(TWO_CUBE)
+    for rotation in rotations:
+        images = []
+        ok = True
+        for site in TWO_CUBE:
+            image = rotate_site(rotation, site)
+            if image is None or image not in two_cube_set:
+                ok = False
+                break
+            images.append(image)
+        if ok and set(images) == two_cube_set:
+            preserved.append(rotation)
+    return tuple(preserved)
+
+
+def rotate_seed(seed: frozenset[Site], rotation: Rotation) -> frozenset[Site]:
+    images = []
+    for site in seed:
+        image = rotate_site(rotation, site)
+        if image is None:
+            raise RuntimeError("rotation left the integer lattice")
+        images.append(image)
+    return frozenset(images)
+
+
+def lex_key(seed: frozenset[Site]) -> tuple[Site, ...]:
+    return tuple(sorted(seed))
+
+
+def orbit_of(seed: frozenset[Site], group: tuple[Rotation, ...]) -> frozenset[frozenset[Site]]:
+    orbit: set[frozenset[Site]] = set()
+    stack = [seed]
+    while stack:
+        current = stack.pop()
+        if current in orbit:
+            continue
+        orbit.add(current)
+        for rotation in group:
+            stack.append(rotate_seed(current, rotation))
+    return frozenset(orbit)
+
+
+def orbits_of(
+    seeds: tuple[frozenset[Site], ...], group: tuple[Rotation, ...]
+) -> list[frozenset[frozenset[Site]]]:
+    remaining = set(seeds)
+    orbits: list[frozenset[frozenset[Site]]] = []
+    while remaining:
+        seed = min(remaining, key=lex_key)
+        orbit = orbit_of(seed, group)
+        orbits.append(orbit)
+        remaining -= set(orbit)
+    return orbits
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    type_of = {config: orbit_type for orbit_type, members in orbits.items() for config in members}
+    all_configs = tuple(product((0, 1), repeat=6))
+
+    f10 = predicate_from_remaining(F10_REMAINING)
+    f10_bits = bits_from_predicate(f10, orbit_types, orbits)
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    f10_remaining = remaining_bits_from_assignment(
+        {orbit_type: f10(next(iter(orbits[orbit_type]))) for orbit_type in orbit_types}
+    )
+    l1_remaining = remaining_bits_from_assignment(
+        {orbit_type: f_L1(next(iter(orbits[orbit_type]))) for orbit_type in orbit_types}
+    )
+
+    fill_set = tuple(seed for seed in THREE_SITE_SEEDS if fills_from_seed(f10, seed))
+    m_count = len(fill_set)
+    seed_6492_in_m = SEED_6492 in set(fill_set)
+
+    group = two_cube_preserving(ROTATIONS)
+    fill_orbits = orbits_of(fill_set, group)
+    n_orb = len(fill_orbits)
+    lex_reps = tuple(sorted(min(orbit, key=lex_key) for orbit in fill_orbits))
+    unique_lex = lex_reps[0] if n_orb == 1 else None
+    closed = all(rotate_seed(seed, rotation) in set(fill_set) for seed in fill_set for rotation in group)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_preserving={len(group)}")
+    print(f"n_config_orbits={len(orbit_types)}")
+    print(f"|F_cut|_free_check={1 << 5}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"f10_remaining={f10_remaining}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"|M|={m_count}")
+    print(f"seed_6492_in_M={seed_6492_in_m}")
+    print(f"N_orb={n_orb}")
+    print(f"lex_rep={tuple(sorted(unique_lex)) if unique_lex is not None else None}")
+    print(f"M_closed_under_G={closed}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_C10_THREE_SITE_FILL_ORBIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    checks.check(
+        "thm1-f-cut-and-f10",
+        "F_cut has size 32 and f10=(1,1,0,0,0) is a member",
+        empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and in_f_cut(f10_bits, orbit_types, empty_type, full_type)
+        and f10_remaining == F10_REMAINING
+        and all(int(f10(config)) == int(f10(tuple(1 - bit for bit in config))) for config in all_configs)  # type: ignore[arg-type]
+        and f10(EMPTY) == 0
+        and f10(FULL) == 0,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is unbalanced-axis n_mu != 0, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and l1_remaining == L1_REMAINING
+        and any(f_L1(config) != f_hamming(config) for config in all_configs)
+        and all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)  # type: ignore[arg-type]
+            for config in all_configs
+        )
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-220-seeds",
+        "the two-cube has twelve vertices and C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-fill-count-and-6492",
+        "|M|=4 and the #6492 seed is in M",
+        m_count == 4
+        and seed_6492_in_m
+        and SEED_6492 <= set(TWO_CUBE)
+        and len(SEED_6492) == 3
+        and fills_from_seed(f10, SEED_6492)
+        and f"|M| = {m_count}" in note
+        and "#6492" in note
+        and "{(0,0,0),(1,1,1),(2,0,0)}" in note.replace(" ", ""),
+    )
+    checks.check(
+        "thm2-preserving-group",
+        "two-cube-preserving proper rotations about the box center form a group of order 8",
+        len(group) == 8
+        and len(set(group)) == 8
+        and all(rotate_site(rotation, site) in set(TWO_CUBE) for rotation in group for site in TWO_CUBE)
+        and all(axis[0] == 0 for axis, _signs in group),
+    )
+    checks.check(
+        "thm2-n-orb-and-lex-rep",
+        "N_orb=1 and the unique lex representative is the #6492 seed",
+        n_orb == 1
+        and closed
+        and unique_lex == SEED_6492
+        and len(fill_orbits[0]) == 4
+        and set(fill_orbits[0]) == set(fill_set)
+        and f"N_orb = {n_orb}" in note
+        and "one lex representative" in note,
+    )
+    checks.check(
+        "thm3-display-not-list-four",
+        "the note displays N_orb and does not list all four seeds",
+        f"N_orb = {n_orb}" in note
+        and note.count("(0, 0, 1)") == 0
+        and note.count("(0, 1, 0)") == 0
+        and note.count("(0, 1, 1)") == 0
+        and "Do not list all four" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted orbit type, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the orbit into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-count",
+        "the residual is the orbit type of the counted fill set, not leftover of the |M|=4 count",
+        "Not leftover-character of #6496" in note
+        and "that counted `|M|=4`" in note
+        and "New geometry" in note
+        and "second exception" in note,
+    )
+    checks.check(
+        "claim-scope-orbit",
+        "claim_scope states the four 3-site fills of f10 form N_orb orbits",
+        "On the two-cube with off-patch o=0" in note
+        and "four 3-site seeds that F_cut (1,1,0,0,0) fills form" in note
+        and "N_orb=1" in note
+        and "two-cube-preserving rotations" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "cache-and-timeout",
+        "audit timeout is 120s and no runner cache is written",
+        AUDIT_TIMEOUT_SEC == 120
+        and "cache_write: false" in self_source
+        and ("logs/" + "runner-cache") not in self_source,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f10 is scored on all 220 three-site seeds; G acts on M")
+    print("per_block: checked exactly — N_orb is the orbit count of the four-element fill set")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the four 3-site seeds that F_cut (1,1,0,0,0) fills form N_orb orbits under two-cube-preserving rotations. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_c10_three_site_fill_orbit_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.