### PR TITLE
feat(p3sel): remaining-bit search for a cov3>0 selector

### DIFF
--- a/docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,310 @@
+---
+claim_id: f_cut_cov3_positive_selector_search_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether any displayed remaining-bit candidate equals cov3>0 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov3_positive_selector_search_2026_08_15.py
+---
+
+# Remaining-Bit Selector Search For Positive 3-Site Coverage
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 3-site fillability on the twelve-vertex
+two-cube with off-patch occupancy `0`, for the thirty-two cube-covariant
+cut maps `F_cut`, tested against a displayed list of remaining-bit
+predicates `Q`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov3_positive_selector_search_2026_08_15.py`](../scripts/f_cut_cov3_positive_selector_search_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6502 showed that cov3>0 is not P, with `N_pos = 20` and
+`N_both = 13`. That residual asked whether positive 3-site coverage is the
+same selector as `P(f) := (wt1=1)` and `(adj2,vertex3,mixed3)≠(0,0,0)`.
+New selector search: this note is a remaining-bit search, not a Max(3) rename and not leftover-
+character of #6502: that was whether cov3>0 iff P. The present object
+is whether any displayed remaining-bit predicate `Q` satisfies
+`cov3>0` iff `Q`.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov3(f)` for the number of unordered 3-site seeds from which `f` fills.
+The displayed candidates are: each remaining bit; `wt1` AND each other
+bit; and `(adj2,vertex3,mixed3)≠(0,0,0)` alone.
+
+- Theorem 1. For each displayed `Q`, `cov3>0` iff `Q` fails. `N_pos = 20`.
+  Reconfirm: `cov3>0` is not `P`, with `N_both = 13`.
+- Theorem 2. No candidate matches. There is no displayed `Q` with
+  `N_Q = N_pos = N_both`.
+- Theorem 3. Display. Do not adopt a bit.
+
+Do not write the search into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly by whether any of the 220 three-site seeds fills. Each displayed remaining-bit Q is tested for cov3>0 iff Q. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov3_positive_selector_search
+target_blocker_text: "whether a displayed remaining-bit predicate equals cov3>0 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the remaining-bit selector search; do not adopt a displayed bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil
+  `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the displayed remaining-bit candidate list named in Theorem 1.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Among the 32 members of `F_cut`, decide whether any displayed
+remaining-bit predicate `Q` equals the fillability predicate `cov3>0`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The three-site seeds are the `C(12,3)=220` unordered triples of vertices of
+`T`. Then `cov3(f)` is the number of those triples from which `f` fills, and
+`cov3>0` is the Boolean fillability predicate.
+
+The displayed candidates `Q` are:
+
+1. each remaining bit: `wt1`, `opp2`, `adj2`, `vertex3`, `mixed3`;
+2. `wt1 AND opp2`, `wt1 AND adj2`, `wt1 AND vertex3`, `wt1 AND mixed3`;
+3. `(adj2,vertex3,mixed3)≠(0,0,0)` alone.
+
+`P` is not on this list. It is the #6502 control
+`(wt1=1)` and `(adj2,vertex3,mixed3)≠(0,0,0)`.
+
+## Theorems
+
+### Theorem 1 — each displayed `Q` versus `cov3>0`
+
+There are exactly 24 proper cube rotations and exactly 10 orbits on
+`{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis map
+`f_L1` is one element of `F_cut` and is not Hamming parity.
+
+Exhaustive evaluation of all 32 maps on all 220 three-site seeds gives
+`N_pos = 20` maps with `cov3>0`. For the #6502 control, `N_P = 14` and
+`N_both = 13`, so `cov3>0` is not `P`.
+
+For each displayed `Q`, write `N_Q` for the number of maps with `Q` true
+and `N_both` for the number with both `Q` and `cov3>0`. Then
+`cov3>0` iff `Q` if and only if those three counts agree.
+
+| `Q` | `N_Q` | `N_pos` | `N_both` | `cov3>0` iff `Q` |
+|---|---:|---:|---:|---|
+| `wt1` | `N_Q = 16` | 20 | 14 | no |
+| `opp2` | `N_Q = 16` | 20 | 12 | no |
+| `adj2` | `N_Q = 16` | 20 | 14 | no |
+| `vertex3` | `N_Q = 16` | 20 | 12 | no |
+| `mixed3` | `N_Q = 16` | 20 | 10 | no |
+| `wt1 AND opp2` | `N_Q = 8` | 20 | 8 | no |
+| `wt1 AND adj2` | `N_Q = 8` | 20 | 8 | no |
+| `wt1 AND vertex3` | `N_Q = 8` | 20 | 8 | no |
+| `wt1 AND mixed3` | `N_Q = 8` | 20 | 7 | no |
+| `(adj2,vertex3,mixed3)≠(0,0,0)` | `N_Q = 28` | 20 | 19 | no |
+
+Witnesses include: remaining-bit `(0,0,1,1,0)` has `cov3=24>0` but `wt1=0`;
+`(1,0,0,0,0)` has `wt1=1` but `cov3=0`; `(1,1,0,0,0)` has `cov3=4>0` but
+`(adj2,vertex3,mixed3)=(0,0,0)`. No single remaining bit, no `wt1` AND
+another bit, and not the three-bit-or alone, equals `cov3>0`.
+
+### Theorem 2 — no candidate matches
+
+None of the ten displayed predicates satisfies `cov3>0` iff `Q`. In
+particular no displayed `Q` has `N_Q = N_pos = N_both`. There is therefore
+no candidate matches among the five remaining bits, their pairwise ANDs
+with `wt1`, and `(adj2,vertex3,mixed3)≠(0,0,0)` alone. So
+no displayed remaining-bit candidate equals `cov3>0`.
+
+### Theorem 3 — display; do not adopt a bit
+
+The table is displayed. Do not adopt a bit. None of the ten predicates is
+written into Admissibility. The search is a displayed census of named
+Boolean combinations of remaining bits, not a selected physical rule and
+not a Max(3) rename.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, 220 three-site seeds, off-patch 0 | declared finite patch |
+| `N_pos = 20` and #6502 `N_both = 13` | proved by exhaustive `cov3` |
+| each displayed `Q` versus `cov3>0` | all ten fail iff |
+| no candidate matches | proved; displayed, not adopted |
+| leftover-character of #6502 | refused; new selector search |
+| Max(3) rename | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6502: that was whether cov3>0 iff P. The
+present count tests a different displayed list of remaining-bit predicates.
+The note is not a Max(3) rename: no maximum of `cov3` is reported as a
+selector, and `f_L1` is used only as the unbalanced-axis control.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write the search into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether any displayed remaining-bit `Q` equals `cov3>0` inside `F_cut` on this patch. |
+| V2 | Current main has the failed `P` comparison (#6502) but no landed remaining-bit search for `cov3>0`. |
+| V3 | The 32 maps, 220 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared finite class. |
+| V5 | It is not a physical selector: no candidate matches, and no bit is adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: none of the ten displayed remaining-bit
+predicates equals `cov3>0` among the 32 `F_cut` maps on this patch. No
+global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover #6502 | treat the search as leftover-character of whether `cov3>0` iff `P` | **ATTEMPTED** |
+| Max(3) rename | replace the fillability search by a maximum-`cov3` ranking | **ATTEMPTED** |
+| adopt a bit | write a remaining bit into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch census to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed `P` equivalence, the ten failed `Q` tests, the Hamming contrast,
+and the off-patch convention are distinct. This note claims no complete
+wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 220 triples, off-patch occupancy `0`, occupancy-to-lock
+ticks, the `F_cut` remaining-bit order, and the displayed candidate list
+are declared. No silent extra bit combination is treated as matching.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the remaining-bit
+selector search for `cov3>0` on the declared patch, not leftover-character
+of #6502 and not a Max(3) rename.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 220 seeds | no physical law selection |
+| per block | each displayed `Q` tested for `cov3>0` iff `Q` | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different Boolean combination of remaining bits, a
+different seed family, a different off-patch rule, and any independently
+derived physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** `P` already failed, and the remaining bits are five bits, so
+a bit or a `wt1` AND must recover `cov3>0`.
+
+**Answer:** Every single remaining bit has `N_Q = 16 ≠ 20`. Every `wt1` AND
+another bit has `N_Q = 8 ≠ 20`. The three-bit-or alone has `N_Q = 28 ≠ 20`.
+No candidate matches.
+
+### N8 — cross-cycle echo
+
+Investment #6502 already showed that `cov3>0` is not `P`. Echoing that
+failure is not a substitute for testing the displayed remaining-bit list.
+The present search is a new selector residual.
+
+No-Go Discipline disposition: **PASS** for the finite search and the
+narrow no-match verdict. FAIL / DO NOT SHIP for “a remaining bit selects
+`cov3>0`” or “a displayed `Q` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov3` on the
+220 three-site seeds, tests each displayed remaining-bit `Q` for
+`cov3>0` iff `Q`, reconfirms `N_pos = 20` and the #6502 pair
+`N_P = 14`, `N_both = 13`, and reports that no candidate matches.
+Declared audit inputs are this note and the axiom memo; the runner writes
+no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov3_positive_selector_search_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov3_positive_selector_search_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov3_positive_selector_search_2026_08_15.txt
@@ -1,0 +1,101 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov3_positive_selector_search_2026_08_15.py
+runner_sha256: 0066835637a2eaa78512f82fd56f2a72660c136a1a6900210eb24df1c8585afe
+input_fingerprint_sha256: 548167aad6ebf1b5f4c422f4c9c078ca664defe00913aee1faff29eca804dfbf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+remaining=(0, 0, 0, 0, 0) cov3=0 pos=0
+remaining=(0, 0, 0, 0, 1) cov3=0 pos=0
+remaining=(0, 0, 0, 1, 0) cov3=0 pos=0
+remaining=(0, 0, 0, 1, 1) cov3=0 pos=0
+remaining=(0, 0, 1, 0, 0) cov3=0 pos=0
+remaining=(0, 0, 1, 0, 1) cov3=0 pos=0
+remaining=(0, 0, 1, 1, 0) cov3=24 pos=1
+remaining=(0, 0, 1, 1, 1) cov3=24 pos=1
+remaining=(0, 1, 0, 0, 0) cov3=0 pos=0
+remaining=(0, 1, 0, 0, 1) cov3=0 pos=0
+remaining=(0, 1, 0, 1, 0) cov3=0 pos=0
+remaining=(0, 1, 0, 1, 1) cov3=0 pos=0
+remaining=(0, 1, 1, 0, 0) cov3=16 pos=1
+remaining=(0, 1, 1, 0, 1) cov3=16 pos=1
+remaining=(0, 1, 1, 1, 0) cov3=44 pos=1
+remaining=(0, 1, 1, 1, 1) cov3=44 pos=1
+remaining=(1, 0, 0, 0, 0) cov3=0 pos=0
+remaining=(1, 0, 0, 0, 1) cov3=0 pos=0
+remaining=(1, 0, 0, 1, 0) cov3=56 pos=1
+remaining=(1, 0, 0, 1, 1) cov3=72 pos=1
+remaining=(1, 0, 1, 0, 0) cov3=80 pos=1
+remaining=(1, 0, 1, 0, 1) cov3=96 pos=1
+remaining=(1, 0, 1, 1, 0) cov3=188 pos=1
+remaining=(1, 0, 1, 1, 1) cov3=220 pos=1
+remaining=(1, 1, 0, 0, 0) cov3=4 pos=1
+remaining=(1, 1, 0, 0, 1) cov3=4 pos=1
+remaining=(1, 1, 0, 1, 0) cov3=68 pos=1
+remaining=(1, 1, 0, 1, 1) cov3=84 pos=1
+remaining=(1, 1, 1, 0, 0) cov3=96 pos=1
+remaining=(1, 1, 1, 0, 1) cov3=96 pos=1
+remaining=(1, 1, 1, 1, 0) cov3=212 pos=1
+remaining=(1, 1, 1, 1, 1) cov3=220 pos=1
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_three_site_seeds=220
+N_pos=20
+N_P=14
+N_both_P=13
+P_iff_pos=False
+f_L1_remaining=(1, 0, 1, 1, 1)
+cov3_f_L1=220
+n_candidates=10
+Q=wt1 N_Q=16 N_pos=20 N_both=14 iff=False
+Q=opp2 N_Q=16 N_pos=20 N_both=12 iff=False
+Q=adj2 N_Q=16 N_pos=20 N_both=14 iff=False
+Q=vertex3 N_Q=16 N_pos=20 N_both=12 iff=False
+Q=mixed3 N_Q=16 N_pos=20 N_both=10 iff=False
+Q=wt1 AND opp2 N_Q=8 N_pos=20 N_both=8 iff=False
+Q=wt1 AND adj2 N_Q=8 N_pos=20 N_both=8 iff=False
+Q=wt1 AND vertex3 N_Q=8 N_pos=20 N_both=8 iff=False
+Q=wt1 AND mixed3 N_Q=8 N_pos=20 N_both=7 iff=False
+Q=(adj2,vertex3,mixed3)!=(0,0,0) N_Q=28 N_pos=20 N_both=19 iff=False
+matching_Q=[]
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-three-site-seeds the two-cube has twelve vertices and C(12,3)=220 three-site seeds
+PASS: thm1-each-candidate-iff for each displayed remaining-bit Q, cov3>0 iff Q is decided and all fail
+PASS: thm1-p-not-equivalent reconfirm #6502: cov3>0 is not P, with N_pos=20 and N_both=13
+PASS: thm2-no-candidate-matches no displayed remaining-bit candidate equals cov3>0
+PASS: thm3-displayed-not-adopted the search is displayed and no remaining bit is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted selector search, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-search the note reports each candidate Q, N_pos=20, and the no-match verdict
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-max3-or-leftover-p the residual is a remaining-bit selector search, not Max(3) and not leftover P
+PASS: claim-scope-search claim_scope reports whether any displayed remaining-bit candidate equals cov3>0
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by whether any of the 220 three-site seeds fills
+per_block: checked exactly — each displayed remaining-bit Q is tested for cov3>0 iff Q
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov3_positive_selector_search_2026_08_15.py
+++ b/scripts/f_cut_cov3_positive_selector_search_2026_08_15.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""Search displayed remaining-bit predicates Q with cov3>0 iff Q.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov3(f) is the number of unordered 3-site seeds from
+which f fills. The search is a new selector residual, not a Max(3) rename
+and not leftover-character of the failed P-equivalence (#6502). f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+No candidate is adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+EXPECTED_N_POS = 20
+EXPECTED_P_N_BOTH = 13
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Remaining) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+NEIGHBOR_INDEX: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+
+
+def fills_from_mask(fire: tuple[int, ...], seed_mask: int) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            bits = 0
+            for axis, neighbor in enumerate(NEIGHBOR_INDEX[site_index]):
+                occupied = neighbor is not None and ((locked >> neighbor) & 1)
+                if occupied:
+                    bits |= 1 << axis
+            if fire[bits]:
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def seed_mask(seed: frozenset[Site]) -> int:
+    mask = 0
+    for site in seed:
+        mask |= 1 << SITE_INDEX[site]
+    return mask
+
+
+SEED_MASKS: tuple[int, ...] = tuple(seed_mask(seed) for seed in THREE_SITE_SEEDS)
+
+
+def fire_table(remaining: Remaining) -> tuple[int, ...]:
+    table = [0] * 64
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        index = (
+            raw[0]
+            | (raw[1] << 1)
+            | (raw[2] << 2)
+            | (raw[3] << 3)
+            | (raw[4] << 4)
+            | (raw[5] << 5)
+        )
+        table[index] = remaining_value(config, remaining)
+    return tuple(table)
+
+
+def coverage3(remaining: Remaining) -> int:
+    fire = fire_table(remaining)
+    return sum(1 for mask in SEED_MASKS if fills_from_mask(fire, mask))
+
+
+def predicate_P(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, vertex3, mixed3 = remaining
+    return wt1 == 1 and (adj2, vertex3, mixed3) != (0, 0, 0)
+
+
+CANDIDATES: tuple[tuple[str, object], ...] = (
+    ("wt1", lambda rem: rem[0] == 1),
+    ("opp2", lambda rem: rem[1] == 1),
+    ("adj2", lambda rem: rem[2] == 1),
+    ("vertex3", lambda rem: rem[3] == 1),
+    ("mixed3", lambda rem: rem[4] == 1),
+    ("wt1 AND opp2", lambda rem: rem[0] == 1 and rem[1] == 1),
+    ("wt1 AND adj2", lambda rem: rem[0] == 1 and rem[2] == 1),
+    ("wt1 AND vertex3", lambda rem: rem[0] == 1 and rem[3] == 1),
+    ("wt1 AND mixed3", lambda rem: rem[0] == 1 and rem[4] == 1),
+    (
+        "(adj2,vertex3,mixed3)!=(0,0,0)",
+        lambda rem: (rem[2], rem[3], rem[4]) != (0, 0, 0),
+    ),
+)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut_remaining() -> list[Remaining]:
+    return [tuple(bits) for bits in product((0, 1), repeat=5)]  # type: ignore[misc]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def score_candidate(
+    name: str,
+    predicate,
+    rows: list[tuple[Remaining, int, int]],
+) -> dict[str, object]:
+    flags = [int(bool(predicate(remaining))) for remaining, _cov, _pos in rows]
+    n_q = sum(flags)
+    n_pos = sum(pos for _remaining, _cov, pos in rows)
+    n_both = sum(flag and pos for flag, (_remaining, _cov, pos) in zip(flags, rows))
+    iff = all(flag == pos for flag, (_remaining, _cov, pos) in zip(flags, rows))
+    return {
+        "name": name,
+        "N_Q": n_q,
+        "N_pos": n_pos,
+        "N_both": n_both,
+        "iff": iff,
+    }
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    members = enumerate_f_cut_remaining()
+
+    rows: list[tuple[Remaining, int, int]] = []
+    for remaining in members:
+        cov = coverage3(remaining)
+        rows.append((remaining, cov, int(cov > 0)))
+        print(f"remaining={remaining} cov3={cov} pos={int(cov > 0)}")
+
+    n_pos = sum(pos for _remaining, _cov, pos in rows)
+    n_p = sum(1 for remaining, _cov, _pos in rows if predicate_P(remaining))
+    n_both_p = sum(
+        1 for remaining, _cov, pos in rows if predicate_P(remaining) and pos
+    )
+    p_iff = all(int(predicate_P(remaining)) == pos for remaining, _cov, pos in rows)
+
+    scored = [score_candidate(name, pred, rows) for name, pred in CANDIDATES]
+    matches = [item["name"] for item in scored if item["iff"]]
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_l1 = next(cov for remaining, cov, _pos in rows if remaining == l1_remaining)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_P={n_p}")
+    print(f"N_both_P={n_both_p}")
+    print(f"P_iff_pos={p_iff}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"cov3_f_L1={cov_l1}")
+    print(f"n_candidates={len(scored)}")
+    for item in scored:
+        print(
+            "Q={name} N_Q={N_Q} N_pos={N_pos} N_both={N_both} iff={iff}".format(
+                **item
+            )
+        )
+    print(f"matching_Q={matches}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV3_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-three-site-seeds",
+        "the two-cube has twelve vertices and C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    expected_scores = {
+        "wt1": (16, 20, 14, False),
+        "opp2": (16, 20, 12, False),
+        "adj2": (16, 20, 14, False),
+        "vertex3": (16, 20, 12, False),
+        "mixed3": (16, 20, 10, False),
+        "wt1 AND opp2": (8, 20, 8, False),
+        "wt1 AND adj2": (8, 20, 8, False),
+        "wt1 AND vertex3": (8, 20, 8, False),
+        "wt1 AND mixed3": (8, 20, 7, False),
+        "(adj2,vertex3,mixed3)!=(0,0,0)": (28, 20, 19, False),
+    }
+    computed_scores = {
+        item["name"]: (item["N_Q"], item["N_pos"], item["N_both"], item["iff"])
+        for item in scored
+    }
+    checks.check(
+        "thm1-each-candidate-iff",
+        "for each displayed remaining-bit Q, cov3>0 iff Q is decided and all fail",
+        list(item["name"] for item in scored) == list(expected_scores)
+        and computed_scores == expected_scores
+        and n_pos == EXPECTED_N_POS
+        and all(item["N_pos"] == EXPECTED_N_POS for item in scored)
+        and not any(item["iff"] for item in scored),
+    )
+    checks.check(
+        "thm1-p-not-equivalent",
+        "reconfirm #6502: cov3>0 is not P, with N_pos=20 and N_both=13",
+        n_pos == EXPECTED_N_POS
+        and n_p == 14
+        and n_both_p == EXPECTED_P_N_BOTH
+        and not p_iff
+        and "N_pos = 20" in note
+        and "N_both = 13" in note
+        and "cov3>0 is not P" in note,
+    )
+    checks.check(
+        "thm2-no-candidate-matches",
+        "no displayed remaining-bit candidate equals cov3>0",
+        matches == []
+        and all(item["N_Q"] != item["N_pos"] or item["N_both"] != item["N_pos"] for item in scored)
+        and "no candidate matches" in note
+        and "no displayed remaining-bit candidate" in note_flat,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the search is displayed and no remaining bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write the search into Admissibility" in note
+        and "not a Max(3) rename" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted selector search, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-search",
+        "the note reports each candidate Q, N_pos=20, and the no-match verdict",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "wt1 AND opp2" in note
+        and "wt1 AND adj2" in note
+        and "wt1 AND vertex3" in note
+        and "wt1 AND mixed3" in note
+        and "(adj2,vertex3,mixed3)≠(0,0,0)" in note
+        and "N_pos = 20" in note
+        and "no candidate matches" in note
+        and all(f"N_Q = {item['N_Q']}" in note for item in scored),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the search into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-max3-or-leftover-p",
+        "the residual is a remaining-bit selector search, not Max(3) and not leftover P",
+        "not a Max(3) rename" in note
+        and "Not leftover-character of #6502" in note
+        and "that was whether cov3>0 iff P" in note
+        and "New selector search" in note,
+    )
+    checks.check(
+        "claim-scope-search",
+        "claim_scope reports whether any displayed remaining-bit candidate equals cov3>0",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "whether any displayed remaining-bit candidate equals cov3>0 is reported"
+        in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by whether any of the 220 three-site seeds fills")
+    print("per_block: checked exactly — each displayed remaining-bit Q is tested for cov3>0 iff Q")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), whether any displayed remaining-bit candidate equals cov3>0 is reported. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_cov3_positive_selector_search_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.