### PR TITLE
feat(ex0first): lex-first seed that (0,0,1,1,0) fills

### DIFF
--- a/docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,292 @@
+---
+claim_id: f_cut_ex0_first_fill_seed_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the lex-first seed that F_cut (0,0,1,1,0) fills is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_ex0_first_fill_seed_2026_08_15.py
+---
+
+# Lex-First Seed that `F_cut` `(0,0,1,1,0)` Fills
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock first fill of one named cube-covariant cut
+map on the twelve-vertex two-cube with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_ex0_first_fill_seed_2026_08_15.py`](../scripts/f_cut_ex0_first_fill_seed_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6511/#6502 named the map `f_ex0` with remaining bits
+`(0,0,1,1,0)`, recorded `P=0` and `cov3=24`, and recorded that the origin
+singleton dies at history (1). This note is the first fill of that newly
+named map: the lex-first seed it fills. New first fill of a newly named
+map, not leftover of the P=0 / cov3=24 counts.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+`f_ex0` is the `F_cut` map with remaining-bit tuple
+`(wt1, opp2, adj2, vertex3, mixed3) = (0, 0, 1, 1, 0)`.
+
+On the two-cube with off-patch occupancy `0`:
+
+- Theorem 1. `P=0` and `cov3 = 24`. The origin singleton dies at history (1).
+  The 2-site coverage is `cov2 = 0`.
+- Theorem 2. The lex-first seed that `f_ex0` fills has `|S| = 3` and sites
+  `(0, 0, 0), (1, 0, 1), (2, 1, 0)`.
+- Theorem 3. The history sizes (3, 5, 7, 10, 12) are displayed. Displayed,
+  not adopted.
+
+Do not write the seed or the remaining bits into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "P, cov2, cov3, and the lex-first filling seed of one named F_cut map are finite exact counts on the two-cube. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_ex0_first_fill_seed
+target_blocker_text: "when can the named P=0 map f_ex0=(0,0,1,1,0) fill at all"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded first-fill seed; do not adopt the displayed seed or remaining bits"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil
+  `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Report the lex-first seed that `f_ex0` fills on `T`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+Seeds are searched by increasing size, then by lexicographic order of
+sorted site tuples in the product order on `T`. Write `P=0` when the origin
+singleton `{(0,0,0)}` is already a fixed point (history (1)). Write
+`cov_k(f)` for the number of unordered k-site seeds from which `f` fills.
+
+## Theorems
+
+### Theorem 1 — `P=0`, `cov3 = 24`, and `cov2 = 0`
+
+The origin singleton has neighborhood type `(1,0,2)` at the unique locked
+site's `+x` neighbor and empty otherwise. That type is the `wt1` remaining
+bit of `f_ex0`, which is 0. No unlocked site therefore locks, so the
+process dies at history (1). In particular `P=0` and `f_ex0` fills no
+1-site seed.
+
+Exhaustive scoring of the `C(12,2)=66` two-site seeds and the
+`C(12,3)=220` three-site seeds gives
+
+```text
+cov2 = 0,   cov3 = 24.
+```
+
+This reconfirms the #6511/#6502 coverage pair and reports the 2-site
+control.
+
+### Theorem 2 — lex-first filling seed
+
+Because `cov1 = 0` and `cov2 = 0`, no seed of size 1 or 2 fills. Among the
+220 three-site seeds, in lex order of combinations of `T`, the first seed
+that fills is
+
+```text
+S = {(0, 0, 0), (1, 0, 1), (2, 1, 0)},   |S| = 3.
+```
+
+No earlier three-site combination fills.
+
+### Theorem 3 — displayed history; not adopted
+
+From that seed the locked-set sizes are history sizes (3, 5, 7, 10, 12):
+
+```text
+t0  (0, 0, 0), (1, 0, 1), (2, 1, 0)
+t1  (0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1), (2, 1, 0)
+t2  (0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0), (2, 1, 0)
+t3  (0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1), (2, 1, 0)
+t4  all twelve vertices of T
+```
+
+The seed and the remaining-bit tuple `(0, 0, 1, 1, 0)` are displayed, not
+adopted. Neither is written into Admissibility.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | remaining-bit class recalled |
+| `f_ex0` as remaining bits `(0,0,1,1,0)` | defined |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, off-patch 0 | declared finite patch |
+| `P=0` and origin history (1) | proved by evolution |
+| `cov2 = 0`, `cov3 = 24` | proved by exhaustive scoring |
+| lex-first fill `|S| = 3` at the displayed sites | proved by lex search |
+| displayed history, not adopted | stated |
+| leftover of #6511/#6502 coverage counts | refused; new first-fill object |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+New first fill of a newly named map. The #6511/#6502 scores `P=0` and
+`cov3=24` are reconfirmed as controls; they do not already name a filling
+seed. The note is not leftover of the P=0 / cov3=24 counts.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write the seed or the
+remaining bits into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers when the named map `f_ex0` can fill at all, by exhibiting the lex-first seed. |
+| V2 | Current main has no landed first-fill seed for remaining bits `(0,0,1,1,0)`. |
+| V3 | The two-cube, the occupancy-to-lock rule, and the lex search are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores one declared finite map. |
+| V5 | It is not a physical selector: the seed and remaining bits are displayed, not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: this named map does not fill from the
+origin or from any 2-site seed, and the first fill is a displayed size-3
+seed. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_ex0` or `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover coverage | treat the seed as leftover-character of the P=0 / cov3=24 counts | **ATTEMPTED** |
+| identify with `f_L1` | replace `f_ex0` by the unbalanced-axis map | **ATTEMPTED** |
+| adopt the seed | write the size-3 seed into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch fill to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed origin fill, the Hamming contrast, and the off-patch convention
+are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, off-patch occupancy `0`, occupancy-to-lock ticks, the
+remaining-bit order, and the lex seed order are declared. Unique selection
+of `f_L1` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the lex-first filling
+seed of the newly named map `f_ex0`, not leftover of the P=0 / cov3=24
+counts.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by remaining-bit assignment | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | P, cov2, cov3, and the lex-first seed of this map | no physical law selection |
+| per block | displayed size-3 seed and its history | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than first fill of this named map, and any independently
+derived physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** `P=0` and `cov2 = 0` already say the map never fills, so a
+first-fill seed is empty work.
+
+**Answer:** `cov3 = 24` already says some three-site seeds fill. The new
+object is which seed is lex-first, together with its displayed history.
+That seed is displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6511/#6502 already scored `P=0` and `cov3=24`. Echoing those
+counts is not a substitute for naming the lex-first filling seed.
+
+No-Go Discipline disposition: **PASS** for the finite first-fill report.
+FAIL / DO NOT SHIP for “the displayed seed is the physical formation seed”
+or “remaining bits `(0,0,1,1,0)` are written into Admissibility.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner evaluates `f_ex0` on the two-cube with off-patch
+occupancy `0`, reconfirms `P=0` and origin history (1), reports `cov2 = 0`
+and `cov3 = 24`, and exhibits the lex-first filling seed together with its
+history. Declared audit inputs are this note and the axiom memo; the
+runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_ex0_first_fill_seed_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_ex0_first_fill_seed_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_ex0_first_fill_seed_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_ex0_first_fill_seed_2026_08_15.py
+runner_sha256: 4d3fa3d1a8440aff4a77dfed359aab87e88cce0b631eeb0cac0eacf789351859
+input_fingerprint_sha256: 57e1ff109130cfa0b1f1db3383ef1a0bb69d60b834efef372606df1e08e39adf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_two_cube=12
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+f_ex0_remaining=(0, 0, 1, 1, 0)
+f_L1_remaining=(1, 0, 1, 1, 1)
+origin_history_sizes=[1]
+origin_halt=[(0, 0, 0)]
+P=0
+cov2=0
+cov3=24
+lex_first_k=3
+lex_first_seed=((0, 0, 0), (1, 0, 1), (2, 1, 0))
+lex_hist_sizes=[3, 5, 7, 10, 12]
+  t0=[(0, 0, 0), (1, 0, 1), (2, 1, 0)]
+  t1=[(0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1), (2, 1, 0)]
+  t2=[(0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0), (2, 1, 0)]
+  t3=[(0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1), (2, 1, 0)]
+  t4=[(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1), (2, 1, 0), (2, 1, 1)]
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations-and-two-cube exactly 24 proper cube rotations and twelve two-cube vertices
+PASS: thm1-f-ex0-remaining-bits f_ex0 is F_cut remaining bits (0,0,1,1,0) and not f_L1
+PASS: thm1-f-L1-not-hamming f_L1 is unbalanced-axis n_mu != 0 and is not Hamming parity
+PASS: thm1-P-zero-origin-history P=0: origin seed dies at history (1)
+PASS: thm1-cov2-and-cov3 cov2(f_ex0)=0 and cov3(f_ex0)=24
+PASS: thm2-lex-first-size-and-sites lex-first filling seed has size 3 and sites ((0,0,0),(1,0,1),(2,1,0))
+PASS: thm2-no-smaller-fill no 1-site or 2-site seed fills, so the size-3 seed is first
+PASS: thm3-displayed-history the displayed seed fills in four ticks along the reported history
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted seed, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: claim-scope-first-fill claim_scope states the lex-first seed that F_cut (0,0,1,1,0) fills
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: new-first-fill-not-leftover-coverage the residual is the first fill of the newly named map, not leftover of the coverage counts
+per_element: checked exactly — each neighbor 6-tuple is scored by the remaining-bit assignment of f_ex0
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — P, cov2, cov3, and the lex-first filling seed of this one F_cut map
+per_block: checked exactly — the displayed size-3 seed fills and no smaller seed does
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_ex0_first_fill_seed_2026_08_15.py
+++ b/scripts/f_cut_ex0_first_fill_seed_2026_08_15.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Lex-first seed that F_cut remaining bits (0,0,1,1,0) fill.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. f_ex0 is the remaining-bit tuple (wt1, opp2, adj2, vertex3,
+mixed3)=(0,0,1,1,0). f_L1 is the unbalanced-axis predicate (some n_mu != 0),
+never Hamming |c|_1 mod 2. The lex-first filling seed is displayed, not
+adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+ORIGIN: Site = (0, 0, 0)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EX0_REMAINING: tuple[int, ...] = (0, 0, 1, 1, 0)
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+DISPLAYED_SEED: tuple[Site, ...] = ((0, 0, 0), (1, 0, 1), (2, 1, 0))
+DISPLAYED_HISTORY: tuple[tuple[Site, ...], ...] = (
+    ((0, 0, 0), (1, 0, 1), (2, 1, 0)),
+    ((0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1), (2, 1, 0)),
+    ((0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0), (2, 1, 0)),
+    (
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 0, 0),
+        (2, 0, 1),
+        (2, 1, 0),
+    ),
+    tuple(TWO_CUBE),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f_ex0(config: Config) -> int:
+    """F_cut remaining bits (0, 0, 1, 1, 0). Displayed, not adopted."""
+    return remaining_value(config, EX0_REMAINING)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def history(predicate, seed: frozenset[Site]) -> tuple[list[int], list[frozenset[Site]], set[Site]]:
+    locked = set(seed)
+    sizes = [len(locked)]
+    snapshots = [frozenset(locked)]
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return sizes, snapshots, locked
+        locked = nxt
+        sizes.append(len(locked))
+        snapshots.append(frozenset(locked))
+    return sizes, snapshots, locked
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    _sizes, _snapshots, locked = history(predicate, seed)
+    return len(locked) == 12
+
+
+def coverage(predicate, k: int) -> int:
+    return sum(
+        1
+        for seed in combinations(TWO_CUBE, k)
+        if fills_from_seed(predicate, frozenset(seed))
+    )
+
+
+def lex_first_fill(predicate, max_k: int = 6) -> tuple[int, tuple[Site, ...], list[int], list[frozenset[Site]]]:
+    for k in range(1, max_k + 1):
+        for seed in combinations(TWO_CUBE, k):
+            s = frozenset(seed)
+            if fills_from_seed(predicate, s):
+                sizes, snapshots, _halt = history(predicate, s)
+                return k, tuple(sorted(seed)), sizes, snapshots
+    raise RuntimeError("no filling seed through the declared search bound")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    origin_sizes, origin_snaps, origin_halt = history(f_ex0, frozenset([ORIGIN]))
+    p_ex0 = 0 if origin_sizes == [1] and len(origin_halt) == 1 else 1
+    cov2 = coverage(f_ex0, 2)
+    cov3 = coverage(f_ex0, 3)
+    lex_k, lex_seed, lex_sizes, lex_snaps = lex_first_fill(f_ex0)
+    lex_sites = tuple(sorted(lex_snaps[i]) for i in range(len(lex_snaps)))
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_two_cube={len(TWO_CUBE)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"f_ex0_remaining={EX0_REMAINING}")
+    print(f"f_L1_remaining={L1_REMAINING}")
+    print(f"origin_history_sizes={origin_sizes}")
+    print(f"origin_halt={sorted(origin_halt)}")
+    print(f"P={p_ex0}")
+    print(f"cov2={cov2}")
+    print(f"cov3={cov3}")
+    print(f"lex_first_k={lex_k}")
+    print(f"lex_first_seed={lex_seed}")
+    print(f"lex_hist_sizes={lex_sizes}")
+    for tick, snap in enumerate(lex_sites):
+        print(f"  t{tick}={snap}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_EX0_FIRST_FILL_SEED_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations-and-two-cube",
+        "exactly 24 proper cube rotations and twelve two-cube vertices",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and ORIGIN in TWO_CUBE
+        and TWO_CUBE == tuple(sorted(TWO_CUBE)),
+    )
+    checks.check(
+        "thm1-f-ex0-remaining-bits",
+        "f_ex0 is F_cut remaining bits (0,0,1,1,0) and not f_L1",
+        EX0_REMAINING == (0, 0, 1, 1, 0)
+        and EX0_REMAINING != L1_REMAINING
+        and all(f_ex0(EMPTY) == 0 and f_ex0(FULL) == 0 for _ in (0,))
+        and all(
+            f_ex0(config) == f_ex0(tuple(1 - bit for bit in config))  # type: ignore[arg-type]
+            for config in product((0, 1), repeat=6)
+        )
+        and remaining_value(EMPTY, EX0_REMAINING) == 0
+        and remaining_value((1, 0, 0, 0, 0, 0), EX0_REMAINING) == 0
+        and remaining_value((1, 0, 1, 0, 0, 0), EX0_REMAINING) == 1
+        and remaining_value((1, 0, 1, 0, 1, 0), EX0_REMAINING) == 1
+        and remaining_value((1, 0, 1, 1, 0, 0), EX0_REMAINING) == 0,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is unbalanced-axis n_mu != 0 and is not Hamming parity",
+        L1_REMAINING == (1, 0, 1, 1, 1)
+        and all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-P-zero-origin-history",
+        "P=0: origin seed dies at history (1)",
+        p_ex0 == 0
+        and origin_sizes == [1]
+        and origin_halt == {ORIGIN}
+        and origin_snaps == [frozenset([ORIGIN])]
+        and not fills_from_seed(f_ex0, frozenset([ORIGIN]))
+        and coverage(f_ex0, 1) == 0
+        and "P=0" in note
+        and "dies at history (1)" in note,
+    )
+    checks.check(
+        "thm1-cov2-and-cov3",
+        "cov2(f_ex0)=0 and cov3(f_ex0)=24",
+        cov2 == 0
+        and cov3 == 24
+        and "cov2 = 0" in note
+        and "cov3 = 24" in note,
+    )
+    checks.check(
+        "thm2-lex-first-size-and-sites",
+        "lex-first filling seed has size 3 and sites ((0,0,0),(1,0,1),(2,1,0))",
+        lex_k == 3
+        and lex_seed == DISPLAYED_SEED
+        and lex_seed == ((0, 0, 0), (1, 0, 1), (2, 1, 0))
+        and fills_from_seed(f_ex0, frozenset(lex_seed))
+        and "|S| = 3" in note
+        and "(0, 0, 0), (1, 0, 1), (2, 1, 0)" in note,
+    )
+    checks.check(
+        "thm2-no-smaller-fill",
+        "no 1-site or 2-site seed fills, so the size-3 seed is first",
+        coverage(f_ex0, 1) == 0
+        and cov2 == 0
+        and all(
+            not fills_from_seed(f_ex0, frozenset(seed))
+            for seed in combinations(TWO_CUBE, 3)
+            if tuple(sorted(seed)) < lex_seed
+        ),
+    )
+    checks.check(
+        "thm3-displayed-history",
+        "the displayed seed fills in four ticks along the reported history",
+        lex_sizes == [3, 5, 7, 10, 12]
+        and len(lex_snaps) == 5
+        and tuple(tuple(sorted(snap)) for snap in lex_snaps) == DISPLAYED_HISTORY
+        and len(lex_snaps[-1]) == 12
+        and set(lex_snaps[-1]) == set(TWO_CUBE)
+        and "history sizes (3, 5, 7, 10, 12)" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted seed, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "claim-scope-first-fill",
+        "claim_scope states the lex-first seed that F_cut (0,0,1,1,0) fills",
+        "On the two-cube with off-patch o=0, the" in note
+        and "lex-first seed that F_cut (0,0,1,1,0) fills is reported" in note
+        and "Displayed, not adopted" in note
+        and "Do not write the seed or the remaining bits into Admissibility" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the seed or the remaining bits into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "new-first-fill-not-leftover-coverage",
+        "the residual is the first fill of the newly named map, not leftover of the coverage counts",
+        "New first fill of a newly named map" in note
+        and "#6511" in note
+        and "#6502" in note
+        and "not leftover of the P=0 / cov3=24 counts" in note,
+    )
+
+    print("per_element: checked exactly — each neighbor 6-tuple is scored by the remaining-bit assignment of f_ex0")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — P, cov2, cov3, and the lex-first filling seed of this one F_cut map")
+    print("per_block: checked exactly — the displayed size-3 seed fills and no smaller seed does")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, the lex-first seed that F_cut (0,0,1,1,0) fills is the size-3 seed {(0,0,0),(1,0,1),(2,1,0)} with history (3,5,7,10,12). New first fill of a newly named map. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_ex0_first_fill_seed_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.