### PR TITLE
feat(p4sel): cov4>0 iff wt1=1 or adj2=1

### DIFF
--- a/docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,351 @@
+---
+claim_id: f_cut_cov4_positive_selector_search_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether any displayed remaining-bit candidate equals cov4>0 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov4_positive_selector_search_2026_08_15.py
+---
+
+# Remaining-Bit Search For A Selector Equal To `cov4>0`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 4-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+thirty-two cube-covariant cut maps `F_cut`, against a displayed menu of
+remaining-bit candidates.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov4_positive_selector_search_2026_08_15.py`](../scripts/f_cut_cov4_positive_selector_search_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6509 showed that `cov4>0` is not `P`. Every `P`-true map has
+`cov4>0` (`N_both = 14`), but positivity is larger (`N_pos = 24`). The ten
+extras are the two `#6490` exceptions together with the eight maps that have
+`wt1 = 0` and `adj2 = 1`. This note searches a displayed remaining-bit
+predicate `Q` such that `cov4>0` if and only if `Q`, on the same 32 maps.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+The selector `P` is the remaining-bit predicate
+
+```text
+P := (wt1 = 1) and (adj2, vertex3, mixed3) ≠ (0, 0, 0).
+```
+
+The displayed candidate menu is:
+
+- each remaining bit, as a standalone `{0,1}` predicate;
+- `wt1` AND each other remaining bit;
+- `P` itself;
+- `adj2` alone;
+- `wt1` OR `adj2`.
+
+**Theorem 1.** For each candidate `Q` in that menu, whether
+`cov4(f)>0` if and only if `Q(f)` holds on all 32 maps is decided by
+exhaustive scoring. Exactly one candidate succeeds.
+
+**Theorem 2.** The unique matching candidate is
+
+```text
+Q_* := (wt1 = 1) or (adj2 = 1).
+```
+
+No other menu entry equals `cov4>0`. In particular `P` fails: ten
+`P`-false maps have `cov4>0`.
+
+**Theorem 3.** The matching bit formula is displayed only. Do not adopt a
+bit. Do not write `Q_*` into Admissibility.
+
+Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 495 four-site seeds. Each displayed remaining-bit candidate is compared to cov4>0. The unique match is a finite Boolean identity on this patch, not a physical Admissibility selector."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov4_positive_selector_search
+target_blocker_text: "whether any displayed remaining-bit candidate equals cov4>0 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded selector search; do not adopt the matching bit formula"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The candidates below are displayed remaining-bit formulas, not
+axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The four-site seeds are the `C(12,4) = 495` subsets of size 4 in `T`. Then
+`cov4(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov4(f)>0`.
+
+`P` and the menu candidates are functions of the remaining-bit tuple only.
+
+## Theorem 1 — each candidate versus `cov4>0`
+
+Direct evolution on the 495 four-site seeds scores every `F_cut` map.
+`N_pos = 24`, `N_P = 14`, and `N_both = 14`. Every `P`-true map has
+`cov4>0`. The eight maps with `wt1 = 0` and `adj2 = 0` are exactly the
+maps with `cov4 = 0`. The ten extras (`P` false, `cov4>0`) are:
+
+- the two `#6490` exceptions `(1, 0, 0, 0, 0)` and `(1, 1, 0, 0, 0)`,
+  each with `cov4 = 7`;
+- the eight maps with `wt1 = 0` and `adj2 = 1`.
+
+Thus `cov4>0` properly contains `P`. `f_L1` itself has `cov4 = 489`.
+
+For each displayed candidate `Q`, the identity `cov4>0 ⇔ Q` on all 32
+maps is:
+
+| candidate `Q` | `cov4>0` iff `Q` | mismatch |
+|---|---|---|
+| `wt1` | no | eight `wt1=0`, `adj2=1` maps have `cov4>0` |
+| `opp2` | no | both false positives and false negatives |
+| `adj2` | no | eight `adj2=0` maps with `wt1=1` have `cov4>0` |
+| `vertex3` | no | both false positives and false negatives |
+| `mixed3` | no | both false positives and false negatives |
+| `wt1` AND `opp2` | no | sixteen false negatives |
+| `wt1` AND `adj2` | no | sixteen false negatives |
+| `wt1` AND `vertex3` | no | sixteen false negatives |
+| `wt1` AND `mixed3` | no | sixteen false negatives |
+| `P` | no | ten extras; `P` fails |
+| `adj2` alone | no | same eight `adj2=0`, `wt1=1` extras as standalone `adj2` |
+| `wt1` OR `adj2` | yes | none; twenty-four true, eight false |
+
+`P` fails. Standalone bits fail. Every `wt1` AND other-bit product fails.
+`adj2` alone fails.
+
+## Theorem 2 — the unique matching candidate
+
+Exactly one menu entry works. Name it:
+
+```text
+Q_* = (wt1 = 1) ∨ (adj2 = 1).
+```
+
+It holds on precisely the twenty-four maps with `cov4>0` and on no other
+`F_cut` map. Equivalently, on this patch a four-site seed can fill only
+when the displayed remaining bits turn on the weight-1 orbit or the
+adjacent-pair orbit (or both).
+
+If the menu had contained no match, the report would have been that no
+candidate matches. That counterfactual is false: one candidate matches,
+and it is `wt1` OR `adj2`.
+
+## Theorem 3 — display, not adoption
+
+`Q_*` is displayed data. Do not adopt a bit. Do not adopt `P`. Do not
+adopt `f_L1`. Do not write `Q_*` into Admissibility. Admissibility does
+not name this remaining-bit formula.
+
+The identity `cov4>0 ⇔ (wt1 ∨ adj2)` is a finite fact about occupancy-to-lock
+on this two-cube with off-patch `o=0`. It is not a physical formation-site
+selector and not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 495 four-site seeds, off-patch `o=0` | declared finite patch |
+| each remaining bit versus `cov4>0` | none matches |
+| `wt1` AND each other bit versus `cov4>0` | none matches |
+| `P` versus `cov4>0` | fails; ten extras |
+| `adj2` alone | does not match |
+| unique matching name | `Q_* = wt1 ∨ adj2` |
+| leftover-character of #6509 | refused; that was `cov4>0` is not `P` |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6509: that note showed `cov4>0` is not `P`.
+The present object is a search among remaining-bit formulas for a
+replacement that *does* equal positivity.
+
+The two `#6490` exceptions enter only as two of the ten extras already
+counted by that positivity census. They are not a second seed-family
+ranking.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether any displayed remaining-bit candidate equals `cov4>0` on the 32 `F_cut` maps. |
+| V2 | Current main has the axiom memo and the #6509 fact that positivity is not `P`, but no landed remaining-bit search for a matching `Q`. |
+| V3 | The 32 maps, 495 seeds, and Boolean candidates are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a declared candidate menu. |
+| V5 | The matching formula is displayed, not adopted, and is not written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: `P` is not `cov4>0`, standalone remaining
+bits are not `cov4>0`, and a displayed match is not axiom content. No
+global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of #6509 | treat the search as restating that `cov4>0` is not `P` | **ATTEMPTED** |
+| rename `P` | identify `Q_*` with `P` | **ATTEMPTED** |
+| adopt the matching bit | write `wt1 ∨ adj2` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch identity to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed `P` extra, the Hamming contrast, the `#6490` pair, and the
+off-patch convention are distinct. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 495 four-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the
+candidate menu are declared. Unique selection of `f_L1` is not silently
+assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether any
+displayed remaining-bit candidate equals `cov4>0` on this patch, not
+leftover-character of #6509.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 495 seeds and the displayed menu | no physical law selection |
+| per block | the unique matching formula on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule,
+a selector outside the displayed remaining-bit menu, and any
+independently derived physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** Every `P`-true map already has `cov4>0`, so positivity is
+just `P`, or else just `adj2`, and no new selector exists.
+
+**Answer:** Ten `P`-false maps have `cov4>0`, so positivity is not `P`.
+Eight maps have `adj2 = 0` and still `cov4>0`, so positivity is not
+`adj2` alone. The remaining-bit formula `wt1 ∨ adj2` equals positivity
+exactly, and it is displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6509 already showed that `cov4>0` is not `P`. Investment
+#6490 named the two `wt1=1`, `cov2=0` exceptions. Echoing either fact is
+not a substitute for testing the remaining-bit menu against 4-site
+positivity.
+
+No-Go Discipline disposition: **PASS** for the finite candidate census
+and the unique matching name. FAIL / DO NOT SHIP for “adopt a bit,”
+“`P` equals `cov4>0`,” or “`Q_*` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov4` on the
+495 four-site seeds, tests every displayed remaining-bit candidate
+against `cov4>0`, reconfirms that `P` fails, names `wt1` OR `adj2` as the
+unique match, and checks that no bit is adopted. Declared
+audit inputs are this note and the axiom memo; the runner writes no cache
+and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov4_positive_selector_search_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov4_positive_selector_search_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov4_positive_selector_search_2026_08_15.txt
@@ -1,0 +1,68 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov4_positive_selector_search_2026_08_15.py
+runner_sha256: 78b3c066ad382f457708e0f02470634d491891d391dc426c3f5ffb05c0139a17
+input_fingerprint_sha256: e3c550ed53df35ae9e7bfe3dfb303b427925f7ce03c51704c17eb4c48da97b1f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed remaining-bit candidates versus cov4>0; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_four_site_seeds=495
+N_pos=24
+N_P=14
+N_both=14
+N_P_not_pos=0
+N_pos_not_P=10
+cov4(f_L1)=489
+matching_candidates=['wt1 OR adj2']
+candidate wt1: equiv=0 tp=16 tn=8 fp=0 fn=8
+candidate opp2: equiv=0 tp=12 tn=4 fp=4 fn=12
+candidate adj2: equiv=0 tp=16 tn=8 fp=0 fn=8
+candidate vertex3: equiv=0 tp=12 tn=4 fp=4 fn=12
+candidate mixed3: equiv=0 tp=12 tn=4 fp=4 fn=12
+candidate wt1 AND opp2: equiv=0 tp=8 tn=8 fp=0 fn=16
+candidate wt1 AND adj2: equiv=0 tp=8 tn=8 fp=0 fn=16
+candidate wt1 AND vertex3: equiv=0 tp=8 tn=8 fp=0 fn=16
+candidate wt1 AND mixed3: equiv=0 tp=8 tn=8 fp=0 fn=16
+candidate P: equiv=0 tp=14 tn=8 fp=0 fn=10
+candidate adj2 alone: equiv=0 tp=16 tn=8 fp=0 fn=8
+candidate wt1 OR adj2: equiv=1 tp=24 tn=8 fp=0 fn=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 495 four-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-positivity-census N_pos=24, N_P=14, N_both=14, and every P-true map has cov4>0
+PASS: thm1-standalone-bits-fail no standalone remaining bit equals cov4>0
+PASS: thm1-wt1-and-other-bits no wt1 AND other remaining bit equals cov4>0
+PASS: thm1-P-reconfirm-fail P fails: ten extras, including the two #6490 exceptions
+PASS: thm1-adj2-alone-fails adj2 alone is not cov4>0
+PASS: thm1-wt1-or-adj2-matches wt1 OR adj2 equals cov4>0 on all 32 maps
+PASS: thm2-unique-match the unique matching candidate is wt1 OR adj2
+PASS: thm3-display-not-adopted the matching formula is displayed and no bit is adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the remaining-bit search and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 495 four-site seeds against the displayed candidate menu
+per_block: checked exactly — the unique matching remaining-bit formula is named and not adopted
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov4_positive_selector_search_2026_08_15.py
+++ b/scripts/f_cut_cov4_positive_selector_search_2026_08_15.py
@@ -1,0 +1,689 @@
+#!/usr/bin/env python3
+"""Search remaining-bit candidates for cov4>0 on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov4(f) is the number of four-site seeds from which f
+fills. Candidates are each remaining bit, wt1 AND each other bit, P, adj2
+alone, and wt1 OR adj2. The matching formula, if any, is displayed; the
+runner does not adopt a bit. f_L1 is the unbalanced-axis predicate (some
+n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+EXCEPTIONS_6490: tuple[Remaining, ...] = (
+    (1, 0, 0, 0, 0),
+    (1, 1, 0, 0, 0),
+)
+ZERO_EIGHT: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 0, 0, 0, 1),
+    (0, 0, 0, 1, 0),
+    (0, 0, 0, 1, 1),
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+    (0, 1, 0, 1, 0),
+    (0, 1, 0, 1, 1),
+)
+WT0_ADJ2_EIGHT: tuple[Remaining, ...] = (
+    (0, 0, 1, 0, 0),
+    (0, 0, 1, 0, 1),
+    (0, 0, 1, 1, 0),
+    (0, 0, 1, 1, 1),
+    (0, 1, 1, 0, 0),
+    (0, 1, 1, 0, 1),
+    (0, 1, 1, 1, 0),
+    (0, 1, 1, 1, 1),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_P(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, vertex3, mixed3 = remaining
+    return wt1 == 1 and (adj2, vertex3, mixed3) != (0, 0, 0)
+
+
+def selector_adj2_alone(remaining: Remaining) -> bool:
+    return remaining[2] == 1
+
+
+def selector_wt1_or_adj2(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[2] == 1
+
+
+def candidate_menu() -> list[tuple[str, object]]:
+    bits = [
+        (label, (lambda rem, index=index: rem[index] == 1))
+        for index, label in enumerate(REMAINING_LABELS)
+    ]
+    ands = [
+        (f"wt1 AND {label}", (lambda rem, index=index: rem[0] == 1 and rem[index] == 1))
+        for index, label in enumerate(REMAINING_LABELS)
+        if index != 0
+    ]
+    return bits + ands + [
+        ("P", selector_P),
+        ("adj2 alone", selector_adj2_alone),
+        ("wt1 OR adj2", selector_wt1_or_adj2),
+    ]
+
+
+def score_candidate(rows: list[tuple[Remaining, int, bool]], predicate) -> dict[str, int]:
+    tp = tn = fp = fn = 0
+    for remaining, cov, _p in rows:
+        q = bool(predicate(remaining))
+        pos = cov > 0
+        if pos and q:
+            tp += 1
+        elif (not pos) and (not q):
+            tn += 1
+        elif (not pos) and q:
+            fp += 1
+        else:
+            fn += 1
+    return {"tp": tp, "tn": tn, "fp": fp, "fn": fn, "equiv": int(fp == 0 and fn == 0)}
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed remaining-bit candidates versus cov4>0; "
+        "does not adopt a bit"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(4)
+    rows: list[tuple[Remaining, int, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_P(remaining)))
+
+    scores = {name: score_candidate(rows, pred) for name, pred in candidate_menu()}
+    matching = [name for name, score in scores.items() if score["equiv"] == 1]
+    n_pos = sum(1 for _remaining, cov, _p in rows if cov > 0)
+    n_p = sum(1 for _remaining, _cov, p in rows if p)
+    n_both = sum(1 for _remaining, cov, p in rows if cov > 0 and p)
+    n_p_not_pos = sum(1 for remaining, cov, p in rows if p and cov == 0)
+    n_pos_not_p = sum(1 for _remaining, cov, p in rows if cov > 0 and not p)
+    pos_set = frozenset(remaining for remaining, cov, _p in rows if cov > 0)
+    zero_set = frozenset(remaining for remaining, cov, _p in rows if cov == 0)
+    extras = frozenset(remaining for remaining, cov, p in rows if cov > 0 and not p)
+    q_set = frozenset(remaining for remaining, _cov, _p in rows if selector_wt1_or_adj2(remaining))
+    cov_l1 = next(cov for remaining, cov, _p in rows if remaining == L1_REMAINING)
+    cov_6490 = {
+        remaining: next(cov for rem, cov, _p in rows if rem == remaining)
+        for remaining in EXCEPTIONS_6490
+    }
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_four_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_P={n_p}")
+    print(f"N_both={n_both}")
+    print(f"N_P_not_pos={n_p_not_pos}")
+    print(f"N_pos_not_P={n_pos_not_p}")
+    print(f"cov4(f_L1)={cov_l1}")
+    print(f"matching_candidates={matching}")
+    for name, score in scores.items():
+        print(
+            f"candidate {name}: equiv={score['equiv']} "
+            f"tp={score['tp']} tn={score['tn']} fp={score['fp']} fn={score['fn']}"
+        )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV4_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 495 four-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(seeds) == 495
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and L1_REMAINING in pos_set
+        and cov_l1 == 489,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-positivity-census",
+        "N_pos=24, N_P=14, N_both=14, and every P-true map has cov4>0",
+        n_pos == 24
+        and n_p == 14
+        and n_both == 14
+        and n_p_not_pos == 0
+        and n_pos_not_p == 10
+        and zero_set == frozenset(ZERO_EIGHT)
+        and extras == frozenset(EXCEPTIONS_6490) | frozenset(WT0_ADJ2_EIGHT),
+    )
+    bit_fail = all(scores[label]["equiv"] == 0 for label in REMAINING_LABELS)
+    and_names = [f"wt1 AND {label}" for label in REMAINING_LABELS if label != "wt1"]
+    and_fail = all(scores[name]["equiv"] == 0 for name in and_names)
+    checks.check(
+        "thm1-standalone-bits-fail",
+        "no standalone remaining bit equals cov4>0",
+        bit_fail
+        and scores["wt1"]["fn"] == 8
+        and scores["adj2"]["fn"] == 8,
+    )
+    checks.check(
+        "thm1-wt1-and-other-bits",
+        "no wt1 AND other remaining bit equals cov4>0",
+        and_fail
+        and all(scores[name]["fn"] == 16 for name in and_names),
+    )
+    checks.check(
+        "thm1-P-reconfirm-fail",
+        "P fails: ten extras, including the two #6490 exceptions",
+        scores["P"]["equiv"] == 0
+        and scores["P"]["fn"] == 10
+        and scores["P"]["fp"] == 0
+        and extras == frozenset(EXCEPTIONS_6490) | frozenset(WT0_ADJ2_EIGHT)
+        and cov_6490 == {(1, 0, 0, 0, 0): 7, (1, 1, 0, 0, 0): 7}
+        and "#6490" in note
+        and ("`P` fails" in note or "P fails" in note_flat),
+    )
+    checks.check(
+        "thm1-adj2-alone-fails",
+        "adj2 alone is not cov4>0",
+        scores["adj2 alone"]["equiv"] == 0
+        and scores["adj2 alone"] == scores["adj2"]
+        and scores["adj2 alone"]["fn"] == 8,
+    )
+    checks.check(
+        "thm1-wt1-or-adj2-matches",
+        "wt1 OR adj2 equals cov4>0 on all 32 maps",
+        scores["wt1 OR adj2"] == {"tp": 24, "tn": 8, "fp": 0, "fn": 0, "equiv": 1}
+        and q_set == pos_set
+        and q_set == frozenset(remaining for remaining in (product((0, 1), repeat=5)) if remaining[0] == 1 or remaining[2] == 1),
+    )
+    checks.check(
+        "thm2-unique-match",
+        "the unique matching candidate is wt1 OR adj2",
+        matching == ["wt1 OR adj2"]
+        and "Q_* := (wt1 = 1) or (adj2 = 1)" in note
+        and "unique matching candidate" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopted",
+        "the matching formula is displayed and no bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write `Q_*` into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "any displayed remaining-bit candidate equals cov4>0 is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the remaining-bit search and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 495 four-site seeds against the displayed candidate menu")
+    print("per_block: checked exactly — the unique matching remaining-bit formula is named and not adopted")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube (off-patch o=0), positive 4-site coverage is equivalent to (wt1=1) or (adj2=1). New selector after P failed at k=4. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_cov4_positive_selector_search_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.