### PR TITLE
feat(qstarwhy): first refuse of (1,0,0,0,1) from the origin is adj2

### DIFF
--- a/docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,307 @@
+---
+claim_id: f_cut_mix1_onesite_first_refuse_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the first refused neighborhood of F_cut (1,0,0,0,1) from the origin 1-site seed is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py
+---
+
+# First Remaining-Bit Refuse of F_cut (1,0,0,0,1) on the Origin 1-Site Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock evolution of one named cube-covariant cut
+map on the twelve-vertex two-cube with off-patch occupancy `0`, started from
+the lex-first one-site seed, reporting the first remaining-bit neighborhood
+the map refuses.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py`](../scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6516 asked why the displayed class `Q_*` of `F_cut` maps with
+`wt1=1` and `adj2=1` is exactly the subclass that can have `cov1>0`. This
+note answers on one named map and one named seed. It is the refuse mechanism
+on that run, not a coverage ranking and not a seed-table of `f_min`.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+Write `f_mix1` for the `F_cut` map with remaining-bit tuple
+`(wt1, opp2, adj2, vertex3, mixed3) = (1, 0, 0, 0, 1)`. In particular
+`wt1=1` and `adj2=0`. Let `S` be the lex-first one-site seed `{(0,0,0)}`.
+On the two-cube with off-patch occupancy `0`:
+
+- Theorem 1. `f_mix1` does not fill `S`. The halt set has size 9. The
+  one-site coverage is `cov1(f_mix1) = 0`.
+- Theorem 2. The first remaining-bit refuse on that run is the `adj2`
+  neighborhood `(0, 0, 0, 1, 0, 1)` at site `(0,1,1)`, at tick 2.
+- Theorem 3. That refuse is displayed. Do not adopt `adj2`.
+
+`Q_*` is the displayed subclass `{f ∈ F_cut : wt1=1 and adj2=1}`. It is
+not written into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One named F_cut map is evolved exactly from the origin 1-site seed on the twelve-vertex two-cube. The first remaining-bit refuse, the halt size, and cov1(f_mix1)=0 are finite exact counts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_mix1_onesite_first_refuse
+target_blocker_text: "first remaining-bit neighborhood that f_mix1 refuses from the origin 1-site seed, as the mechanism that Q_* needs adj2=1 for cov1>0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the origin-run refuse; do not adopt adj2"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil
+  `{±e_x, ±e_y, ±e_z}` at every site, in order
+  `(+x,-x,+y,-y,+z,-z)`;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the named map `f_mix1` with remaining bits `(1, 0, 0, 0, 1)`;
+- the lex-first one-site seed `S = {(0,0,0)}`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** On the origin one-site run of `f_mix1`, report the first
+remaining-bit neighborhood the map refuses, and reconfirm that the run does
+not fill.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks. Then
+`cov1(f)` is the number of one-site seeds from which `f` fills.
+
+A neighborhood is a remaining-bit neighborhood when its axis type is one of
+the five remaining types or a complement partner of one of them. Empty and
+full are not remaining bits. The first remaining-bit refuse on a run is the
+first remaining-bit neighborhood, in tick order and then two-cube lex order
+of sites, at which `f` returns 0.
+
+## Theorems
+
+### Theorem 1 — `f_mix1` does not fill `S`; `cov1=0`
+
+`f_mix1` is the `F_cut` map with remaining-bit tuple `(1, 0, 0, 0, 1)`.
+Direct evolution from `S = {(0,0,0)}` halts after 4 growth ticks at the
+nine-site set
+
+```text
+{(0,0,0), (0,0,1), (0,1,0), (1,0,0), (1,0,1), (1,1,0), (2,0,0), (2,0,1), (2,1,0)}.
+```
+
+The three unlocked sites are the line `y=1`, `z=1`. In particular `f_mix1`
+does not fill `S`. Scoring every one-site seed gives `cov1(f_mix1) = 0`.
+
+### Theorem 2 — first remaining-bit refuse
+
+On the same origin run, tick 1 accepts three `wt1` neighborhoods and refuses
+only empty neighborhoods. Empty is not a remaining bit.
+
+Tick 2 is the first tick at which a remaining-bit neighborhood is refused.
+The three simultaneous remaining-bit refuses, in two-cube lex order, are
+
+```text
+site (0,1,1), neighborhood (0, 0, 0, 1, 0, 1), axis type (2, 0, 1) = adj2
+site (1,0,1), neighborhood (0, 1, 0, 0, 0, 1), axis type (2, 0, 1) = adj2
+site (1,1,0), neighborhood (0, 1, 0, 1, 0, 0), axis type (2, 0, 1) = adj2
+```
+
+The first remaining-bit refuse is therefore the `adj2` neighborhood
+`(0, 0, 0, 1, 0, 1)` at site `(0,1,1)`. No `opp2` or `vertex3` neighborhood
+appears before that refuse. Later ticks accept some `mixed3` neighborhoods
+and continue to refuse `adj2`; the run still cannot fill.
+
+### Theorem 3 — display; do not adopt `adj2`
+
+The first refuse is an `adj2` neighborhood, and `f_mix1` has `adj2=0`.
+That is the mechanism of `Q_*` on this seed: every `F_cut` map with
+`wt1=1` and `adj2=0` has `cov1=0`, and the origin run of `f_mix1` is
+blocked at the first `adj2` neighborhood.
+
+The contrast map with remaining bits `(1, 0, 1, 0, 1)` (the same bits as
+`f_mix1` except `adj2=1`) fills from `S` and has `cov1=8`. Displayed, not
+adopted. Do not adopt `adj2`. Do not write `Q_*` or `adj2=1` into
+Admissibility.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| `f_mix1` remaining bits `(1, 0, 0, 0, 1)` | defined |
+| two-cube, origin 1-site seed, off-patch 0 | declared finite patch |
+| `f_mix1` does not fill `S`; halt size 9 | proved by evolution |
+| `cov1(f_mix1) = 0` | proved by exhaustive 1-site scoring |
+| first remaining-bit refuse is `adj2` at `(0,1,1)` | proved by the origin run |
+| adopt `adj2` or write `Q_*` into Admissibility | refused; displayed, not adopted |
+| leftover-character of a coverage ranking | refused; this is a refuse mechanism |
+| seed-table of `f_min` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of a 1-site coverage ranking: that ranking reports
+`cov1` numbers. The present theorem reports the first remaining-bit
+neighborhood refused on the origin run of one named map. The note is not a
+seed-table of `f_min`: no `f_min` seed census is compiled, and `f_L1` is not
+identified with Hamming or with a minimum-support table.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not adopt `adj2`. Do not write
+the displayed refuse, the contrast map, or `Q_*` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers which remaining-bit neighborhood `f_mix1` first refuses from the origin 1-site seed. |
+| V2 | Current main has no landed origin-run refuse for remaining bits `(1, 0, 0, 0, 1)`. |
+| V3 | The 32 maps, the origin seed, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a named map on a declared run. |
+| V5 | It is not a physical selector: the `adj2` refuse is displayed, not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: on this patch, `f_mix1` refuses its first
+remaining-bit neighborhood in the `adj2` class, and that refuse is not a
+reason to write `adj2=1` into Admissibility. No global compiler impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover coverage ranking | treat the refuse as leftover-character of a `cov1` table | **ATTEMPTED** |
+| `f_min` seed table | replace the origin run by a seed-table of `f_min` | **ATTEMPTED** |
+| adopt `adj2` | write `adj2=1` or `Q_*` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| empty as remaining-bit | count the tick-1 empty refuse as the first remaining-bit refuse | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The `adj2` refuse, the Hamming contrast, and the off-patch convention are
+distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the origin singleton, off-patch occupancy `0`, occupancy-to-lock
+ticks, two-cube lex site order, and the `F_cut` remaining-bit order are
+declared. Adoption of `adj2` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the first remaining-bit
+refuse of `f_mix1` from `S`, not leftover-character of a coverage ranking
+and not a seed-table of `f_min`.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | `f_mix1` evolved from the origin seed; `cov1` scored on 12 seeds | no physical law selection |
+| per block | first remaining-bit refuse and halt size on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed, a different off-patch rule, a selector
+other than a remaining-bit refuse, and any independently derived physical map
+from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** `f_mix1` has `wt1=1`, so a 1-site seed should fill, and the
+only way to restore fill is to adopt `adj2=1`.
+
+**Answer:** `wt1=1` accepts the first growth step. The first remaining-bit
+refuse is `adj2`, and that is why `cov1(f_mix1)=0`. The contrast with
+`adj2=1` is displayed, not adopted. The extra that would write `adj2` into
+Admissibility is not present.
+
+### N8 — cross-cycle echo
+
+Investment #6516 already named `Q_*` as the `wt1=1` and `adj2=1` subclass
+needed for `cov1>0`. Echoing that class membership is not a substitute for
+the origin-run refuse. This note reports the first refused neighborhood.
+
+No-Go Discipline disposition: **PASS** for the finite origin-run refuse and
+the narrow non-adoption of `adj2`. FAIL / DO NOT SHIP for “`adj2` is the
+physical rule” or “`Q_*` is written into Admissibility.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner builds `f_mix1` from remaining bits `(1, 0, 0, 0, 1)`,
+evolves occupancy-to-lock from `{(0,0,0)}`, reconfirms that the run does not
+fill and that `cov1(f_mix1)=0`, and reports the first remaining-bit refuse
+as the `adj2` neighborhood `(0, 0, 0, 1, 0, 1)` at `(0,1,1)`. The contrast
+map `(1, 0, 1, 0, 1)` is displayed, not adopted. Declared audit inputs are
+this note and the axiom memo; the runner writes no cache and authors no
+audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_mix1_onesite_first_refuse_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_mix1_onesite_first_refuse_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_mix1_onesite_first_refuse_2026_08_15.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py
+runner_sha256: 1941821e4cc1f828ed1d77d476af33f9d7bf15c0d70b203364be5ebc57f9aaeb
+input_fingerprint_sha256: 3741bee307acd69232d7c755de07ed854e9a7ffe2518575e48ad3b9a40dc1a8d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+f_mix1_remaining=(1, 0, 0, 0, 1)
+origin_halt_size=9
+origin_fills=False
+cov1_f_mix1=0
+first_refuse=(2, (0, 1, 1), (0, 0, 0, 1, 0, 1), (2, 0, 1), 'adj2')
+contrast_remaining=(1, 0, 1, 0, 1)
+contrast_fills_origin=True
+cov1_contrast=8
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits_neq_L1=True
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-not-hamming f_L1 is unbalanced-axis n!=0 and is not Hamming |c|_1 mod 2
+PASS: thm1-mix1-in-f-cut f_mix1 is the F_cut map with remaining bits (1, 0, 0, 0, 1)
+PASS: thm1-mix1-does-not-fill-S f_mix1 does not fill the origin 1-site seed; halt size is 9
+PASS: thm1-cov1-zero cov1(f_mix1)=0 on the twelve one-site seeds
+PASS: thm2-first-remaining-bit-refuse-adj2 first remaining-bit refuse on the origin run is adj2 at tick 2
+PASS: thm2-first-refused-neighborhood lex-first refused remaining-bit neighborhood is (0,0,0,1,0,1) at (0,1,1)
+PASS: thm3-display-not-adopt-adj2 adj2 refuse and adj2-flipped contrast are displayed, not adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted adj2 refuse, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: no-axiom-edit the theorem proposes no axiom change and does not adopt adj2
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: claim-scope-refuse claim_scope reports the first refused neighborhood of F_cut (1,0,0,0,1) from the origin 1-site seed
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — f_mix1 is evolved from the origin seed and scored on all 12 one-site seeds
+per_block: checked exactly — first remaining-bit refuse, halt size, and cov1 are exact on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py
+++ b/scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""First remaining-bit refuse of F_cut (1,0,0,0,1) on the origin 1-site seed.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. f_mix1 is the remaining-bit tuple (1, 0, 0, 0, 1). f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+adj2 is displayed as the first remaining-bit refuse, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+ONE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset([site]) for site in TWO_CUBE
+)
+ORIGIN: Site = (0, 0, 0)
+ORIGIN_SEED: frozenset[Site] = frozenset([ORIGIN])
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+MIX1_REMAINING: tuple[int, ...] = (1, 0, 0, 0, 1)
+CONTRAST_REMAINING: tuple[int, ...] = (1, 0, 1, 0, 1)
+EXPECTED_HALT: frozenset[Site] = frozenset(
+    {
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (2, 0, 0),
+        (2, 0, 1),
+        (2, 1, 0),
+    }
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def f_mix1(config: Config) -> int:
+    return remaining_value(config, MIX1_REMAINING)
+
+
+def f_contrast(config: Config) -> int:
+    """Displayed adj2-flipped contrast (1, 0, 1, 0, 1).  Not adopted."""
+    return remaining_value(config, CONTRAST_REMAINING)
+
+
+def remaining_label(kind: OrbitType) -> str | None:
+    if kind in REMAINING_ORDER:
+        return REMAINING_LABELS[REMAINING_ORDER.index(kind)]
+    partner = complement_type(kind)
+    if partner in REMAINING_ORDER:
+        return REMAINING_LABELS[REMAINING_ORDER.index(partner)]
+    return None
+
+
+def is_remaining_bit_type(kind: OrbitType) -> bool:
+    return remaining_label(kind) is not None
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def halt_set(predicate, seed: frozenset[Site]) -> frozenset[Site]:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return frozenset(locked)
+        locked = nxt
+    return frozenset(locked)
+
+
+def coverage(predicate) -> int:
+    return sum(1 for seed in ONE_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def first_remaining_bit_refuse(
+    predicate, seed: frozenset[Site]
+) -> tuple[int, Site, Config, OrbitType, str] | None:
+    locked = set(seed)
+    for tick in range(1, 14):
+        events: list[tuple[Site, Config, OrbitType, int]] = []
+        nxt = set(locked)
+        for site in TWO_CUBE:
+            if site in locked:
+                continue
+            config = neighborhood(site, locked)
+            kind = axis_type(config)
+            value = int(predicate(config))
+            events.append((site, config, kind, value))
+            if value:
+                nxt.add(site)
+        for site, config, kind, value in events:
+            label = remaining_label(kind)
+            if value == 0 and label is not None:
+                return (tick, site, config, kind, label)
+        if nxt == locked:
+            return None
+        locked = nxt
+    return None
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+
+    mix1_bits = bits_from_predicate(f_mix1, orbit_types, orbits)
+    mix1_remaining = remaining_bits_from_full(mix1_bits, orbit_types)
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    contrast_bits = bits_from_predicate(f_contrast, orbit_types, orbits)
+    contrast_remaining = remaining_bits_from_full(contrast_bits, orbit_types)
+
+    origin_halt = halt_set(f_mix1, ORIGIN_SEED)
+    origin_fills = fills_from_seed(f_mix1, ORIGIN_SEED)
+    cov1_mix1 = coverage(f_mix1)
+    refuse = first_remaining_bit_refuse(f_mix1, ORIGIN_SEED)
+    contrast_fills = fills_from_seed(f_contrast, ORIGIN_SEED)
+    cov1_contrast = coverage(f_contrast)
+
+    wt1_adj2_off = [
+        remaining
+        for _bits, remaining in members
+        if remaining[0] == 1 and remaining[2] == 0
+    ]
+    cov1_adj2_off = [
+        coverage(predicate_from_bits(bits, orbit_types, type_of))
+        for bits, remaining in members
+        if remaining[0] == 1 and remaining[2] == 0
+    ]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"f_mix1_remaining={mix1_remaining}")
+    print(f"origin_halt_size={len(origin_halt)}")
+    print(f"origin_fills={origin_fills}")
+    print(f"cov1_f_mix1={cov1_mix1}")
+    print(f"first_refuse={refuse}")
+    print(f"contrast_remaining={contrast_remaining}")
+    print(f"contrast_fills_origin={contrast_fills}")
+    print(f"cov1_contrast={cov1_contrast}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits_neq_L1={ham_bits != l1_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_MIX1_ONESITE_FIRST_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is unbalanced-axis n!=0 and is not Hamming |c|_1 mod 2",
+        l1_remaining == L1_REMAINING
+        and l1_bits != ham_bits
+        and all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-mix1-in-f-cut",
+        "f_mix1 is the F_cut map with remaining bits (1, 0, 0, 0, 1)",
+        mix1_remaining == MIX1_REMAINING
+        and in_f_cut(mix1_bits, orbit_types, empty_type, full_type)
+        and mix1_remaining[0] == 1
+        and mix1_remaining[2] == 0
+        and ORIGIN == TWO_CUBE[0]
+        and ORIGIN_SEED == frozenset([(0, 0, 0)]),
+    )
+    checks.check(
+        "thm1-mix1-does-not-fill-S",
+        "f_mix1 does not fill the origin 1-site seed; halt size is 9",
+        origin_fills is False
+        and len(origin_halt) == 9
+        and origin_halt == EXPECTED_HALT
+        and len(origin_halt) != 12,
+    )
+    checks.check(
+        "thm1-cov1-zero",
+        "cov1(f_mix1)=0 on the twelve one-site seeds",
+        cov1_mix1 == 0
+        and len(ONE_SITE_SEEDS) == 12
+        and all(not fills_from_seed(f_mix1, seed) for seed in ONE_SITE_SEEDS)
+        and f"cov1(f_mix1) = {cov1_mix1}" in note,
+    )
+    assert refuse is not None
+    refuse_tick, refuse_site, refuse_config, refuse_kind, refuse_label = refuse
+    checks.check(
+        "thm2-first-remaining-bit-refuse-adj2",
+        "first remaining-bit refuse on the origin run is adj2 at tick 2",
+        refuse_tick == 2
+        and refuse_label == "adj2"
+        and refuse_kind == (2, 0, 1)
+        and is_remaining_bit_type(refuse_kind)
+        and f_mix1(refuse_config) == 0,
+    )
+    checks.check(
+        "thm2-first-refused-neighborhood",
+        "lex-first refused remaining-bit neighborhood is (0,0,0,1,0,1) at (0,1,1)",
+        refuse_site == (0, 1, 1)
+        and refuse_config == (0, 0, 0, 1, 0, 1)
+        and axis_type(refuse_config) == (2, 0, 1)
+        and "(0, 0, 0, 1, 0, 1)" in note
+        and "`(0,1,1)`" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt-adj2",
+        "adj2 refuse and adj2-flipped contrast are displayed, not adopted",
+        contrast_remaining == CONTRAST_REMAINING
+        and contrast_remaining != mix1_remaining
+        and contrast_remaining[2] == 1
+        and contrast_fills is True
+        and cov1_contrast == 8
+        and cov1_contrast > 0
+        and all(cov == 0 for cov in cov1_adj2_off)
+        and len(wt1_adj2_off) == 8
+        and MIX1_REMAINING in wt1_adj2_off
+        and "Do not adopt `adj2`" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted adj2 refuse, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Do not adopt `adj2`" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change and does not adopt adj2",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not adopt `adj2`" in note
+        and "Do not write `Q_*` or `adj2=1` into" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "claim-scope-refuse",
+        "claim_scope reports the first refused neighborhood of F_cut (1,0,0,0,1) from the origin 1-site seed",
+        "On the two-cube with off-patch o=0" in note
+        and "first refused neighborhood of F_cut (1,0,0,0,1)" in note
+        and "origin 1-site seed" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — f_mix1 is evolved from the origin seed and scored on all 12 one-site seeds")
+    print("per_block: checked exactly — first remaining-bit refuse, halt size, and cov1 are exact on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, F_cut (1,0,0,0,1) from the origin first refuses an adj2 neighborhood. Mechanism of Q_*=(wt1=1 and adj2=1) for cov1>0. f_L1 is n≠0 not Hamming. Displayed, not adopted.

## Runner

`scripts/f_cut_mix1_onesite_first_refuse_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.