### PR TITLE
feat(q4c8): cov8>0 is not Q4; N_pos=30

### DIFF
--- a/docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,407 @@
+---
+claim_id: f_cut_cov8_positive_q4_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether positive 8-site coverage is equivalent to (wt1=1) or (adj2=1) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov8_positive_q4_2026_08_15.py
+---
+
+# Whether `cov8>0` Is `Q4` Among The 32 `F_cut` Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 8-site coverage of all 32 cube-covariant
+complement-even maps in `F_cut`, on the twelve-vertex two-cube, over all
+495 unordered 8-site seeds, with off-patch occupancy `0`. The scored
+predicate is `Q4(f) := (wt1=1) or (adj2=1)`. Whether `cov8(f)>0` is
+equivalent to `Q4(f)` is reported. `Q4` is displayed. It is not adopted
+as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov8_positive_q4_2026_08_15.py`](../scripts/f_cut_cov8_positive_q4_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write
+
+```text
+Q4(f) := (wt1=1) or (adj2=1).
+```
+
+Investment #6518 asked the same predicate at seed size `k=4`. Dual `k=8`
+is unique-max together with `k=4,6` (#6465). Not leftover-character of #6518:
+that was cov4>0 iff Q4. New `|S|`. Not leftover-character of #6465: that
+named the unique maximizer at those three sizes. The present object is
+whether positive 8-site coverage is the same cut as `Q4`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 8-set of vertices is
+an 8-site seed. There are `C(12,8)=495` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 12 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov8(f) = |{ S : |S|=8 and f fills from S }|.
+```
+
+Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: `c_{+μ} ≠ c_{-μ}` for
+at least one `μ ∈ {x,y,z}`. Equivalently, some discrete neighbor contrast
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+That map is a control: it has `Q4=1` and `cov8>0`, so it is not a
+counterexample.
+
+**Theorem 1.** Among the 32 maps, cov8(f)>0 iff Q4(f) fails. The
+lex-first counterexample remaining-bit tuple `(0, 0, 0, 1, 0)`
+has
+
+```text
+Q4 = 0
+cov8 = 44
+```
+
+so `cov8>0` holds while `Q4` fails. Remaining-bit order is
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+**Theorem 2.** The three census counts are
+
+```text
+N_Q4 = 24
+N_pos = 30
+N_both = 24
+```
+
+Every `Q4` map has positive 8-site coverage. Six `Q4`-false maps still
+fill at least one 8-site seed.
+
+**Theorem 3.** The failed equivalence, the lex-first counterexample, and
+the triple `(N_Q4, N_pos, N_both)` are displayed. Do not adopt Q4.
+
+Do not write Q4 into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the predicate Q4=(wt1=1) or (adj2=1), and the exact census of cov8>0 versus Q4 are enumerated. The iff fails. The lex-first counterexample is remaining bits (0,0,0,1,0) with cov8=44. No physical law is selected."
+trace_class: upstream_support
+target_claim_id: f_cut_cov8_positive_q4
+target_blocker_text: "whether cov8>0 is the same cut as Q4=(wt1=1) or (adj2=1)"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the cov8>0 versus Q4 census; any physical use must separately derive an Admissibility selector"
+conditional_surface_status: "exact for all 32 F_cut maps on this twelve-vertex patch with off-patch o=0 and all 495 eight-site seeds; no Z^3-wide law and no physical selector"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 495 unordered 8-site seeds;
+- the remaining-bit predicate `Q4(f) := (wt1=1) or (adj2=1)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Decide whether `cov8(f)>0` if and only if `Q4(f)`, among the
+32 members of `F_cut` on the two-cube. If the iff fails, name one lex-first
+counterexample. Report `N_Q4`, `N_pos`, and `N_both`. Display. Do not
+adopt Q4.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+Define
+
+```text
+Q4(f)      = 1  iff  the remaining bit wt1 is 1 or the remaining bit adj2 is 1,
+f_L1(c)    = 1  iff  u(c) ≥ 1.
+```
+
+So `f_L1` has remaining bits `(1, 0, 1, 1, 1)` and therefore `Q4(f_L1)=1`.
+Neither `Q4` nor `f_L1` is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov8(f)` is the number of 8-site seeds whose halt set has cardinality
+12. Write `N_Q4` for the number of maps with `Q4=1`, `N_pos` for the
+number with `cov8>0`, and `N_both` for the number with both. Lex order on
+counterexamples is lexicographic order of remaining-bit tuples.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut` and is not Hamming parity. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive evaluation
+of all 32 maps on all 495 eight-site seeds shows that `cov8(f)>0` is not
+equivalent to `Q4(f)`. The lex-first counterexample remaining-bit tuple is
+`(0, 0, 0, 1, 0)`: that map has `wt1=0` and `adj2=0`, so `Q4=0`, but it
+fills 44 of the 495 seeds, so `cov8 = 44`.
+
+**Theorem 2.** The census on the same 32 maps is
+
+```text
+N_Q4 = 24
+N_pos = 30
+N_both = 24.
+```
+
+The inclusion `Q4 ⇒ (cov8>0)` holds. The converse fails on six maps.
+
+**Theorem 3.** The failed iff, the lex-first remaining-bit tuple
+`(0, 0, 0, 1, 0)`, and the triple `(24, 30, 24)` are displayed. Do not
+adopt Q4 as the physical Admissibility rule.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after empty/full are forced to `0` |
+| `Q4` | remaining-bit predicate `(wt1=1) or (adj2=1)` |
+| 495 eight-site seeds | `C(12,8)` unordered 8-sets on the two-cube |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` and has remaining bits `(1, 0, 1, 1, 1)` |
+| `cov8>0` iff `Q4` | fails; lex-first counterexample `(0, 0, 0, 1, 0)` has `Q4=0` and `cov8=44` |
+| counts | `N_Q4=24`, `N_pos=30`, `N_both=24` |
+| displayed predicate | `Q4`, not adopted |
+
+## What This Does Not Claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No unique-max ranking at `k=8`.
+- No reopening of the `k=4` `#6518` census.
+- No blank-block or other seed-size variant.
+
+## No-Go Discipline Gate
+
+The only negative claim is the failed equivalence: `cov8>0` is not the
+same cut as `Q4` on this 32-map class. The three counts and the lex-first
+counterexample are exact enumerations, not a wall against a later selector.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class | Force vanish-on-empty, vanish-on-full, and `f(c)=f(1-c)`. | Theorem 1 and check `thm1-f-cut-cardinality` give `|F_cut|=32`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| `cov8>0` iff `Q4` | Score every one of the 32 maps by `cov8` and by `Q4`. | Theorem 1 and check `thm1-not-equivalent` give a lex-first counterexample. | **ATTEMPTED** |
+| three counts | Count `N_Q4`, `N_pos`, and `N_both`. | Theorem 2 and check `thm2-counts`. | **ATTEMPTED** |
+| adopt `Q4` | Write `Q4` into Admissibility. | Theorem 3 and check `thm3-displayed-not-adopted`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one negative conclusion: `cov8>0` is not equivalent to `Q4`. The
+six `Q4`-false maps with `cov8>0` are six certificates of the same failed
+converse, so they collapse rather than count as six walls.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| failed iff / lex-first `(0,0,0,1,0)` | no: failure does not name the first remaining-bit witness | yes: one counterexample closes the iff | witness versus the universal claim |
+| `N_Q4=24` / `N_pos=30` | no: twenty-four Q4 maps do not name thirty positive maps | no: thirty positive maps do not name which twenty-four are Q4 | independent counts |
+| `#6518` `cov4` iff / this `cov8` iff | no: a 4-site cut is not 8-site dynamics | no: an 8-site cut does not replace the 4-site census | different `|S|` |
+| `#6465` unique-max / this positive cut | no: uniqueness of a maximizer is not `cov8>0` | no: a positive-coverage test does not name the unique maximizer | different ranking object |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| remaining-bit order `(wt1, opp2, adj2, vertex3, mixed3)` | explicit coordinate system for `Q4` and lex order |
+| all 495 eight-site seeds | explicit seed class; a 4-site ranking is a different residual |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuple `(0, 0, 0, 1, 0)` | displayed witness, not a selected law |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:79` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:123` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:128` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:50` | 495 eight-site seeds | `C(12,8)` unordered 8-sets on the two-cube | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:132` | `Q4` | `(wt1=1) or (adj2=1)` on remaining bits | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:63` | lex-first counterexample | remaining bits `(0, 0, 0, 1, 0)` | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:193` | `cov8(f)` | number of 8-site seeds a map fills | yes |
+| `scripts/f_cut_cov8_positive_q4_2026_08_15.py:53` | `N8_SEEDS=495` | seed-count ceiling | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: all 32 `F_cut` maps | the score is `cov8>0` versus `Q4` on this class |
+| per block | yes: the failed iff and the triple `(24, 30, 24)` | `Q4` does not cut positive 8-site coverage |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: every
+`Q4` map does have `cov8>0`, so the forward implication holds. That
+inclusion does not restore the converse and does not select `Q4` as the
+physical rule. The remaining physical choice — which, if any, `F_cut` map
+is the Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that `#6518` already tested `Q4` against
+positive coverage, so an 8-site score might be called leftover decoration
+of that cut, or that `#6465` already knew `k=8` is a unique-max size, so
+the census might be called leftover ranking of that maximizer. Those
+objections are correctly about `cov4>0` and about uniqueness of a
+maximizer. They do not overturn the stated theorem: on the 495 eight-site
+seeds, `Q4` still fails to cut `cov8>0`, and the lex-first witness is the
+vertex3-only remaining-bit tuple `(0, 0, 0, 1, 0)`. A 4-site cut does not
+name the 8-site cut. This is a new `|S|`.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, `Q4`, and the 495-seed scores are recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the `cov8>0` versus `Q4` census or restores
+the failed iff.
+
+No-Go Discipline disposition: **PASS** for the failed equivalence
+`cov8(f)>0` iff `Q4(f)` and the exact triple `(N_Q4, N_pos, N_both)`
+stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates every remaining-bit map on the two-cube from every
+8-site seed, reports that `cov8(f)>0` is not equivalent to `Q4(f)`, names
+the lex-first counterexample remaining-bit tuple `(0, 0, 0, 1, 0)` with
+`cov8 = 44`, reports `N_Q4 = 24`, `N_pos = 30`, and `N_both = 24`, checks
+that `f_L1` is not Hamming parity, and exhibits `Q4` as displayed, not
+adopted. Declared audit inputs are this note and the axiom memo. No runner
+cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15741,
- "node_count": 5542,
+ "edge_count": 15742,
+ "node_count": 5543,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov8_positive_q4_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov8_positive_q4_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov8_positive_q4_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov8_positive_q4_2026_08_15.py
+runner_sha256: b86a17d913391c86a6c1f72fda0fa2f8898f9cb5fc614412140ad7b3ca86ce5c
+input_fingerprint_sha256: 33fec767af8355e35af0d6725e4bebeb219fd52a73deedd1f699792686eb925f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_eight_site_seeds=495
+equivalent=False
+lex_first_cex=(0, 0, 0, 1, 0)
+lex_first_cex_cov8=44
+lex_first_cex_Q4=0
+N_Q4=24
+N_pos=30
+N_both=24
+f_L1_remaining=(1, 0, 1, 1, 1)
+cov8_f_L1=494
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+f_hamming_cov8=270
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-eight-site-seeds the two-cube has twelve vertices and C(12,8)=495 eight-site seeds
+PASS: thm1-not-equivalent cov8(f)>0 is not equivalent to Q4(f); lex-first counterexample is (0,0,0,1,0)
+PASS: thm2-counts N_Q4=24, N_pos=30, N_both=24
+PASS: thm3-displayed-not-adopted Q4 is displayed and is not adopted as the physical rule
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted Q4, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-equivalence-and-counts the note reports the failed iff, the lex-first counterexample, and the three counts
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6518-or-6465 the residual is cov8>0 vs Q4, not leftover-character of #6518 or #6465
+PASS: claim-scope-equivalence claim_scope states the reported cov8>0 vs Q4 question and displayed-not-adopted
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by whether any of the 495 eight-site seeds fills
+per_block: checked exactly — the iff of cov8>0 with Q4, and the triple (N_Q4, N_pos, N_both), on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov8_positive_q4_2026_08_15.py
+++ b/scripts/f_cut_cov8_positive_q4_2026_08_15.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Whether cov8>0 is equivalent to Q4 among the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov8(f) is the number of unordered 8-site seeds from
+which f fills. Q4(f) is (wt1=1) or (adj2=1). The residual is whether
+cov8(f)>0 iff Q4(f). That is not leftover-character of #6518 (k=4) and not
+the unique-max census of #6465. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2. Q4 is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+EIGHT_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 8)
+)
+N8_SEEDS = 495
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: tuple[int, ...] = (1, 0, 1, 1, 1)
+LEX_FIRST_CEX: tuple[int, ...] = (0, 0, 0, 1, 0)
+CEX_COV8 = 44
+N_Q4_EXPECTED = 24
+N_POS_EXPECTED = 30
+N_BOTH_EXPECTED = 24
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def q4_from_remaining(remaining: tuple[int, ...]) -> int:
+    wt1, _opp2, adj2, _vertex3, _mixed3 = remaining
+    return int(wt1 == 1 or adj2 == 1)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    locked = set(seed)
+    for _tick in range(13):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return len(locked) == 12
+        locked = nxt
+    return False
+
+
+def coverage8(predicate) -> int:
+    return sum(1 for seed in EIGHT_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> tuple[int, ...]:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def predicate_from_bits(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+):
+    assignment = dict(zip(orbit_types, bits, strict=True))
+
+    def predicate(config: Config) -> int:
+        return assignment[type_of[config]]
+
+    return predicate
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    scored: list[tuple[tuple[int, ...], int, int, int]] = []
+    for bits, remaining in members:
+        cov = coverage8(predicate_from_bits(bits, orbit_types, type_of))
+        q4 = q4_from_remaining(remaining)
+        pos = int(cov > 0)
+        scored.append((remaining, cov, q4, pos))
+    scored.sort(key=lambda row: row[0])
+
+    n_q4 = sum(q4 for _remaining, _cov, q4, _pos in scored)
+    n_pos = sum(pos for _remaining, _cov, _q4, pos in scored)
+    n_both = sum(1 for _remaining, _cov, q4, pos in scored if q4 == 1 and pos == 1)
+    equivalent = all((q4 == 1) == (pos == 1) for _remaining, _cov, q4, pos in scored)
+    counterexamples = [row for row in scored if (row[2] == 1) != (row[3] == 1)]
+    lex_first = counterexamples[0] if counterexamples else None
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_by_remaining = {remaining: cov for remaining, cov, _q4, _pos in scored}
+    cov_l1 = cov_by_remaining[l1_remaining]
+    cov_ham = coverage8(f_hamming)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_eight_site_seeds={len(EIGHT_SITE_SEEDS)}")
+    print(f"equivalent={equivalent}")
+    print(f"lex_first_cex={None if lex_first is None else lex_first[0]}")
+    print(f"lex_first_cex_cov8={None if lex_first is None else lex_first[1]}")
+    print(f"lex_first_cex_Q4={None if lex_first is None else lex_first[2]}")
+    print(f"N_Q4={n_q4}")
+    print(f"N_pos={n_pos}")
+    print(f"N_both={n_both}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"cov8_f_L1={cov_l1}")
+    print(f"f_hamming_bits={ham_bits}")
+    print(f"f_hamming_cov8={cov_ham}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV8_POSITIVE_Q4_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-eight-site-seeds",
+        "the two-cube has twelve vertices and C(12,8)=495 eight-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(EIGHT_SITE_SEEDS) == N8_SEEDS
+        and len(set(EIGHT_SITE_SEEDS)) == 495
+        and all(seed <= set(TWO_CUBE) and len(seed) == 8 for seed in EIGHT_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "cov8(f)>0 is not equivalent to Q4(f); lex-first counterexample is (0,0,0,1,0)",
+        equivalent is False
+        and lex_first is not None
+        and lex_first[0] == LEX_FIRST_CEX
+        and lex_first[1] == CEX_COV8
+        and lex_first[2] == 0
+        and lex_first[3] == 1
+        and q4_from_remaining(LEX_FIRST_CEX) == 0
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type)
+        and f"lex-first counterexample remaining-bit tuple `(0, 0, 0, 1, 0)`" in note
+        and "cov8 = 44" in note
+        and "Q4 = 0" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_Q4={n_q4}, N_pos={n_pos}, N_both={n_both}",
+        n_q4 == N_Q4_EXPECTED
+        and n_pos == N_POS_EXPECTED
+        and n_both == N_BOTH_EXPECTED
+        and n_q4 == 24
+        and n_pos == 30
+        and n_both == 24
+        and f"N_Q4 = {n_q4}" in note
+        and f"N_pos = {n_pos}" in note
+        and f"N_both = {n_both}" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "Q4 is displayed and is not adopted as the physical rule",
+        "Do not adopt Q4" in note
+        and "Displayed, not adopted" in note
+        and "Do not write Q4 into Admissibility" in note
+        and l1_remaining == L1_REMAINING
+        and q4_from_remaining(l1_remaining) == 1
+        and cov_l1 > 0,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted Q4, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-equivalence-and-counts",
+        "the note reports the failed iff, the lex-first counterexample, and the three counts",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "Q4(f) := (wt1=1) or (adj2=1)" in note
+        and "cov8(f)>0 iff Q4(f)" in note
+        and "(0, 0, 0, 1, 0)" in note
+        and "N_Q4 = 24" in note
+        and "N_pos = 30" in note
+        and "N_both = 24" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write Q4 into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6518-or-6465",
+        "the residual is cov8>0 vs Q4, not leftover-character of #6518 or #6465",
+        "Not leftover-character of #6518" in note
+        and "that was cov4>0 iff Q4" in note
+        and "Not leftover-character of #6465" in note
+        and "unique-max" in note,
+    )
+    checks.check(
+        "claim-scope-equivalence",
+        "claim_scope states the reported cov8>0 vs Q4 question and displayed-not-adopted",
+        "Among the 32 F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "whether positive 8-site coverage is" in note
+        and "equivalent to (wt1=1) or (adj2=1) is reported" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by whether any of the 495 eight-site seeds fills")
+    print("per_block: checked exactly — the iff of cov8>0 with Q4, and the triple (N_Q4, N_pos, N_both), on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 32 F_cut maps, cov8>0 is not Q4. N_Q4=24 N_pos=30 N_both=24. Lex-first extra is (0,0,0,1,0) with cov8=44. Displayed, not adopted.

## Runner

`scripts/f_cut_cov8_positive_q4_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.