### PR TITLE
feat(ntall): {(1,0,0)} is a class split of non-tot Q_*

### DIFF
--- a/docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,336 @@
+---
+claim_id: f_cut_qstar_nontot_class_split_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, whether every Q_* map with vertex3=0 fails to fill S={(1,0,0)} is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_qstar_nontot_class_split_2026_08_15.py
+---
+
+# Whether `{(1,0,0)}` Is a Class Split of Non-Tot `Q_*`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill of the displayed one-site seed
+`S = {(1, 0, 0)}` by each of the eight cube-covariant cut maps `F_cut`
+with remaining bits `wt1=1` and `adj2=1`, on the twelve-vertex two-cube
+with off-patch occupancy `0`. The scored question is whether every
+`Q_*` map with `vertex3=0` fails to fill `S`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_qstar_nontot_class_split_2026_08_15.py`](../scripts/f_cut_qstar_nontot_class_split_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6528 named the lex-first non-tot `Q_*` map
+`f_nt = (1, 0, 1, 0, 0)` and showed that this map misses
+`S = {(1, 0, 0)}` while `f_L1` fills. Investment #6522 showed that
+among `Q_*` maps, `cov1=12` if and only if `vertex3=1`, so every tot
+map fills every one-site seed. This note asks a new question: whether
+that seed is a class split of the whole non-tot `Q_*` slice, not a
+second-seed test of the named pair.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`Q_*` is the subclass with `wt1=1` and `adj2=1`. It has 8 maps: four
+with `vertex3=1` and four with `vertex3=0`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`. That tuple lies in `Q_*` and
+has `vertex3=1`.
+
+On the two-cube with off-patch occupancy `0`, a map fills a seed `S` if
+occupancy-to-lock from `L_0 = S` reaches the full twelve-vertex patch.
+
+**Theorem 1.** Among the 4 `Q_*` maps with `vertex3=1`, 4 fill
+`S = {(1, 0, 0)}`. Among the 4 `Q_*` maps with `vertex3=0`, 0 fill `S`.
+
+**Theorem 2.** Every `Q_*` map with `vertex3=0` misses `S`. There is no
+lex-first counterexample remaining-bit tuple that fills `S`.
+
+**Theorem 3.** Display. Do not adopt a bit.
+
+Displayed, not adopted.
+
+```text
+N_fill_v3 = 4
+N_fill_nontot = 0
+```
+
+Uniqueness of that seed for the whole non-tot class, not a second-seed
+test of the named pair.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The eight Q_* maps are the F_cut members with wt1=1 and adj2=1. Each is scored exactly on the displayed one-site seed S={(1,0,0)}. Whether every vertex3=0 map misses S is a finite Boolean census on this patch, not a physical Admissibility selector."
+trace_class: frontier_discovery
+target_claim_id: f_cut_qstar_nontot_class_split
+target_blocker_text: "whether every Q_* map with vertex3=0 fails to fill S={(1,0,0)}"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded non-tot Q_* class split; do not adopt a displayed bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The `vertex3` bit below is displayed remaining-bit data, not
+axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The displayed seed is the one-site set `S = {(1, 0, 0)}`.
+
+`Q_*` is the remaining-bit predicate `wt1=1` and `adj2=1`. It holds on
+exactly eight of the 32 maps. The present census is restricted to those
+eight, scored only on `S`.
+
+## Theorem 1 — fill counts of `S` on the two `Q_*` slices
+
+Direct evolution from `S` scores every `Q_*` map. The eight remaining-bit
+tuples and whether each fills `S` are
+
+```text
+(1, 0, 1, 0, 0)  fills_S=0  vertex3=0
+(1, 0, 1, 0, 1)  fills_S=0  vertex3=0
+(1, 1, 1, 0, 0)  fills_S=0  vertex3=0
+(1, 1, 1, 0, 1)  fills_S=0  vertex3=0
+(1, 0, 1, 1, 0)  fills_S=1  vertex3=1
+(1, 0, 1, 1, 1)  fills_S=1  vertex3=1
+(1, 1, 1, 1, 0)  fills_S=1  vertex3=1
+(1, 1, 1, 1, 1)  fills_S=1  vertex3=1
+```
+
+Among the 4 `Q_*` maps with `vertex3=1`, 4 fill `S`. Among the 4 with
+`vertex3=0`, 0 fill `S`. Equivalently,
+
+```text
+N_fill_v3 = 4
+N_fill_nontot = 0.
+```
+
+The last-but-one of the `fills_S=1` rows with `opp2=0` is `f_L1`. The
+first of the `fills_S=0` rows is `f_nt`.
+
+## Theorem 2 — every non-tot `Q_*` map misses `S`
+
+Every `Q_*` map with `vertex3=0` fails to fill `S={(1,0,0)}`. The four
+non-tot remaining-bit tuples are
+
+```text
+(1, 0, 1, 0, 0), (1, 0, 1, 0, 1), (1, 1, 1, 0, 0), (1, 1, 1, 0, 1).
+```
+
+None of them fills `S`. There is no lex-first counterexample tuple. The
+miss of `S` is therefore a class fact of the `vertex3=0` slice of `Q_*`,
+not a property of the named pair `(f_L1, f_nt)` alone.
+
+## Theorem 3 — display, not adoption
+
+The class split of `S` is displayed data. Do not adopt a bit. Do not
+adopt `vertex3`. Do not adopt `Q_*`. Do not adopt `f_L1`.
+Do not write `vertex3` into Admissibility.
+Do not write `Q_*` or `vertex3=1` into Admissibility.
+Do not write the ranking into Admissibility.
+
+The split is a finite fact about occupancy-to-lock on this two-cube
+with off-patch `o=0`. It is not a physical formation-site selector and
+not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `Q_*` as `wt1=1` and `adj2=1` | eight maps, four tot and four non-tot |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, seed `S={(1,0,0)}`, off-patch `o=0` | declared finite patch |
+| `N_fill_v3`, `N_fill_nontot` | 4 and 0 |
+| every `vertex3=0` `Q_*` map misses `S` | holds; no counterexample |
+| leftover of #6528 | refused; that tested the named pair |
+| leftover of #6522 | refused; that named totality, not this seed |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6528: that named `f_nt` and showed that this
+one non-tot map misses `S` while `f_L1` fills. The present object is
+whether every non-tot `Q_*` map misses the same seed.
+
+Not leftover-character of #6522: that showed `cov1=12` iff `vertex3=1`
+on the eight maps, so every tot map fills every one-site seed. The
+present object is the fill table of one displayed seed across the
+non-tot slice.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether every `Q_*` map with `vertex3=0` fails to fill `S={(1,0,0)}`. |
+| V2 | Current main has the named-pair miss (#6528) and the totality identity (#6522), but no landed class-split census of `S` on the four non-tot maps. |
+| V3 | The eight maps and one seed are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite subclass on a displayed seed. |
+| V5 | The split is displayed, not adopted, and is not written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: a named-pair miss is not a class split,
+and a displayed remaining-bit census inside `Q_*` is not axiom content.
+No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of #6528 | treat the class miss as the named-pair split of `f_L1` versus `f_nt` | **ATTEMPTED** |
+| leftover of #6522 | treat the 4-of-4 tot fill as leftover totality | **ATTEMPTED** |
+| adopt the bit | write `vertex3` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch census to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the named-pair split, the totality identity, and
+the off-patch convention are distinct. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the displayed seed `S={(1,0,0)}`, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the `Q_*`
+cut `wt1=1` and `adj2=1` are declared. Unique selection of `f_L1` is not
+silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+every `Q_*` map with `vertex3=0` fails to fill `S`, not leftover-
+character of #6528 and not a second-seed test of the named pair.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the eight `Q_*` maps scored on `S` | no physical law selection |
+| per block | the non-tot class miss of `S` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed, a different off-patch rule, a
+selector outside `Q_*`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** #6528 already showed that `f_nt` misses `S` and `f_L1`
+fills, so a class miss is leftover-character of the named pair.
+
+**Answer:** #6528 tested one non-tot map against one tot map. `Q_*`
+has four maps with `vertex3=0`. The present census scores all four.
+The miss of `S` is unique for the whole non-tot class. That is not a
+second-seed test of the named pair.
+
+### N8 — cross-cycle echo
+
+Investment #6522 already showed that every tot `Q_*` map fills every
+one-site seed. Echoing that 4-of-4 tot fill is not a substitute for
+scoring the four non-tot maps on this seed.
+
+No-Go Discipline disposition: **PASS** for the finite eight-map census
+and the displayed class split. FAIL / DO NOT SHIP for “adopt a bit,”
+“the named pair is the class,” or “`vertex3` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, restricts to the
+eight with `wt1=1` and `adj2=1`, scores fill of `S={(1,0,0)}` on each,
+reports `N_fill_v3` and `N_fill_nontot`, and decides whether every
+`vertex3=0` map misses `S`. Declared audit inputs are this note and the
+axiom memo; the runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_qstar_nontot_class_split_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_qstar_nontot_class_split_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_qstar_nontot_class_split_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_qstar_nontot_class_split_2026_08_15.py
+runner_sha256: 1ee734fc94cffdbdce6615bcdc36362a472f6f901f7082915d91cd7ca9732fb7
+input_fingerprint_sha256: ccad3a9b6f204754f47f30afb0d154060e2cc8e0c3e1887f126728db0937617c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+|Q_*|=8
+S=[(1, 0, 0)]
+N_fill_v3=4
+N_fill_nontot=0
+every_vertex3_0_misses_S=1
+lex_first_counterexample=None
+fills_S(f_L1)=1
+fills_S(f_nt)=0
+Q_* (1, 0, 1, 0, 0) vertex3=0 fills_S=0
+Q_* (1, 0, 1, 0, 1) vertex3=0 fills_S=0
+Q_* (1, 0, 1, 1, 0) vertex3=1 fills_S=1
+Q_* (1, 0, 1, 1, 1) vertex3=1 fills_S=1
+Q_* (1, 1, 1, 0, 0) vertex3=0 fills_S=0
+Q_* (1, 1, 1, 0, 1) vertex3=0 fills_S=0
+Q_* (1, 1, 1, 1, 0) vertex3=1 fills_S=1
+Q_* (1, 1, 1, 1, 1) vertex3=1 fills_S=1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 8 Q_* maps, seed S={(1,0,0)}
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-vertex3-1-fill-count among the 4 Q_* maps with vertex3=1, 4 fill S
+PASS: thm1-vertex3-0-fill-count among the 4 Q_* maps with vertex3=0, 0 fill S
+PASS: thm2-every-nontot-misses every vertex3=0 Q_* map misses S; no counterexample tuple
+PASS: thm3-display-not-adopted the class split is displayed and no bit is adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the non-tot class miss of S and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-named-pair-leftover the residual is the class miss, not a second-seed test of the named pair
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every Q_* map is scored on S={(1, 0, 0)}
+per_block: checked exactly — every vertex3=0 Q_* map misses S and no bit is adopted
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_qstar_nontot_class_split_2026_08_15.py
+++ b/scripts/f_cut_qstar_nontot_class_split_2026_08_15.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Class split of S={(1,0,0)} across non-tot Q_* F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Q_* is the eight-member subclass with remaining bits wt1=1 and adj2=1.
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. f_L1 is the unbalanced-axis predicate (some n_mu != 0), never
+Hamming |c|_1 mod 2. The runner reports how many vertex3=1 Q_* maps fill
+S={(1, 0, 0)} and how many vertex3=0 Q_* maps fill S, and whether every
+vertex3=0 map misses S. Displayed; the runner does not adopt a bit.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+NT_REMAINING: Remaining = (1, 0, 1, 0, 0)
+SPLIT_SEED: frozenset[Site] = frozenset([(1, 0, 0)])
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def bits_from_predicate(
+    predicate,
+    orbit_types: tuple[OrbitType, ...],
+    orbits: dict[OrbitType, frozenset[Config]],
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_mask_of(seed: frozenset[Site]) -> int:
+    index_of = site_index_map()
+    return sum(1 << index_of[site] for site in seed)
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def in_qstar(remaining: Remaining) -> bool:
+    return remaining[0] == 1 and remaining[2] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    type_of = {config: orbit_type for orbit_type, orbit in orbits.items() for config in orbit}
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    neighbors = neighbor_indices()
+    seed_mask = seed_mask_of(SPLIT_SEED)
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+
+    rows: list[tuple[Remaining, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        fills = fills_from_mask(seed_mask, table, neighbors)
+        rows.append((remaining, fills))
+
+    qstar = [(remaining, fills) for remaining, fills in rows if in_qstar(remaining)]
+    v3 = [(remaining, fills) for remaining, fills in qstar if remaining[3] == 1]
+    nontot = [(remaining, fills) for remaining, fills in qstar if remaining[3] == 0]
+    n_fill_v3 = sum(1 for _remaining, fills in v3 if fills)
+    n_fill_nontot = sum(1 for _remaining, fills in nontot if fills)
+    every_nontot_misses = all(not fills for _remaining, fills in nontot)
+    every_v3_fills = all(fills for _remaining, fills in v3)
+    counterexamples = [remaining for remaining, fills in nontot if fills]
+    lex_counter = min(counterexamples) if counterexamples else None
+    q_set = frozenset(remaining for remaining, _fills in qstar)
+    l1_fills = next(fills for remaining, fills in rows if remaining == L1_REMAINING)
+    nt_fills = next(fills for remaining, fills in rows if remaining == NT_REMAINING)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"|Q_*|={len(qstar)}")
+    print(f"S={sorted(SPLIT_SEED)}")
+    print(f"N_fill_v3={n_fill_v3}")
+    print(f"N_fill_nontot={n_fill_nontot}")
+    print(f"every_vertex3_0_misses_S={int(every_nontot_misses)}")
+    print(f"lex_first_counterexample={lex_counter}")
+    print(f"fills_S(f_L1)={int(l1_fills)}")
+    print(f"fills_S(f_nt)={int(nt_fills)}")
+    for remaining, fills in sorted(qstar):
+        print(
+            f"Q_* {remaining} vertex3={remaining[3]} "
+            f"fills_S={int(fills)}"
+        )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_QSTAR_NONTOT_CLASS_SPLIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 8 Q_* maps, seed S={(1,0,0)}",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(TWO_CUBE) == 12
+        and len(qstar) == 8
+        and len(v3) == 4
+        and len(nontot) == 4
+        and SPLIT_SEED == frozenset([(1, 0, 0)])
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and L1_REMAINING in q_set
+        and L1_REMAINING[3] == 1
+        and l1_fills is True,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-vertex3-1-fill-count",
+        "among the 4 Q_* maps with vertex3=1, 4 fill S",
+        n_fill_v3 == 4
+        and every_v3_fills
+        and len(v3) == 4
+        and "Among the 4 `Q_*` maps with `vertex3=1`, 4 fill" in note
+        and "N_fill_v3 = 4" in note,
+    )
+    checks.check(
+        "thm1-vertex3-0-fill-count",
+        "among the 4 Q_* maps with vertex3=0, 0 fill S",
+        n_fill_nontot == 0
+        and every_nontot_misses
+        and len(nontot) == 4
+        and "Among the 4 `Q_*` maps with `vertex3=0`, 0 fill" in note
+        and "N_fill_nontot = 0" in note,
+    )
+    checks.check(
+        "thm2-every-nontot-misses",
+        "every vertex3=0 Q_* map misses S; no counterexample tuple",
+        every_nontot_misses
+        and lex_counter is None
+        and nt_fills is False
+        and NT_REMAINING in {remaining for remaining, _fills in nontot}
+        and frozenset(remaining for remaining, _fills in nontot)
+        == frozenset(
+            (
+                (1, 0, 1, 0, 0),
+                (1, 0, 1, 0, 1),
+                (1, 1, 1, 0, 0),
+                (1, 1, 1, 0, 1),
+            )
+        )
+        and "Every `Q_*` map with `vertex3=0` misses `S`" in note
+        and "There is no lex-first counterexample" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopted",
+        "the class split is displayed and no bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write `vertex3` into Admissibility" in note
+        and "Do not write `Q_*` or `vertex3=1` into" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, "
+        "whether every Q_* map with vertex3=0 fails to fill "
+        "S={(1,0,0)} is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the non-tot class miss of S and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-named-pair-leftover",
+        "the residual is the class miss, not a second-seed test of the named pair",
+        "Not leftover-character of #6528" in note
+        and "Not leftover-character of #6522" in note
+        and "not a second-seed test of the named pair" in note
+        and "Uniqueness of that seed for the whole non-tot class" in note
+        and "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "{(1, 0, 0)}" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every Q_* map is scored on S={(1, 0, 0)}")
+    print("per_block: checked exactly — every vertex3=0 Q_* map misses S and no bit is adopted")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

All 4 Q_* maps with vertex3=1 fill S={(1,0,0)}; all 4 with vertex3=0 miss it. No counterexample. Displayed, not adopted.

## Runner

`scripts/f_cut_qstar_nontot_class_split_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.