### PR TITLE
feat(q3bits): no remaining bit is constant on the 20 cov3>0 maps

### DIFF
--- a/docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,296 @@
+---
+claim_id: f_cut_cov3_positive_bit_support_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 20 F_cut maps with cov3>0 on the two-cube with off-patch o=0, whether any remaining bit is constant is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov3_positive_bit_support_2026_08_15.py
+---
+
+# Remaining-Bit Support On The Twenty Positive-Coverage Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 3-site fillability on the twelve-vertex
+two-cube with off-patch occupancy `0`, for the thirty-two cube-covariant
+cut maps `F_cut`, restricted to the twenty maps with `cov3>0`, reporting
+for each remaining bit the pair
+`(n_bit=0 among the 20, n_bit=1 among the 20)` and whether any remaining
+bit is constant on those twenty maps.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov3_positive_bit_support_2026_08_15.py`](../scripts/f_cut_cov3_positive_bit_support_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment p3bit5 closed the remaining-bit selector menu: no 1-bit, 2-bit,
+3-bit, 4-bit, or 5-bit remaining-bit AND or OR equals `cov3>0`.
+`N_pos = 20`. Remaining-bit search is exhausted. This note asks a
+different object: for each of the five remaining bits, whether it is
+constant on the 20 maps with `cov3>0`. The output is a new support
+description, not a selector.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov3(f)` for the number of unordered 3-site seeds from which `f` fills.
+
+- Theorem 1. For each remaining bit, the pair
+  `(n_bit=0 among the 20, n_bit=1 among the 20)`.
+- Theorem 2. Whether any remaining bit is constant on the 20. None.
+- Theorem 3. Display. Do not adopt a bit.
+
+Do not write the pairs into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly by whether any of the 220 three-site seeds fills. On the 20 maps with cov3>0, each remaining bit is counted as (n=0, n=1). No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov3_positive_bit_support
+target_blocker_text: "whether any remaining bit is constant on the 20 F_cut maps with cov3>0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the remaining-bit support pairs on the twenty maps; do not adopt a displayed bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil
+  `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the five remaining bits in the order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Among the 20 members of `F_cut` with `cov3>0` on the two-cube
+with off-patch occupancy `0`, report for each remaining bit the pair
+`(n_bit=0 among the 20, n_bit=1 among the 20)`, and decide whether any
+remaining bit is constant on those twenty maps.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The three-site seeds are the `C(12,3)=220` unordered triples of vertices of
+`T`. Then `cov3(f)` is the number of those triples from which `f` fills, and
+`cov3>0` is the Boolean fillability predicate.
+
+A remaining bit `b` is constant on the 20 if one of `n_{b=0}` or `n_{b=1}`
+is zero. That is a support description of the positive-coverage set, not a
+selector `Q` tested for `cov3>0` iff `Q`.
+
+## Theorems
+
+### Theorem 1 — remaining-bit pairs on the twenty maps
+
+There are exactly 24 proper cube rotations and exactly 10 orbits on
+`{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis map
+`f_L1` is one element of `F_cut` and is not Hamming parity.
+
+Exhaustive evaluation of all 32 maps on all 220 three-site seeds gives
+`N_pos = 20` maps with `cov3>0`. For each remaining bit, the pair
+`(n_bit=0 among the 20, n_bit=1 among the 20)` is:
+
+| remaining bit | `(n_bit=0, n_bit=1)` among the 20 |
+|---|---|
+| `wt1` | `(n_{wt1=0}, n_{wt1=1}) = (6, 14)` |
+| `opp2` | `(n_{opp2=0}, n_{opp2=1}) = (8, 12)` |
+| `adj2` | `(n_{adj2=0}, n_{adj2=1}) = (6, 14)` |
+| `vertex3` | `(n_{vertex3=0}, n_{vertex3=1}) = (8, 12)` |
+| `mixed3` | `(n_{mixed3=0}, n_{mixed3=1}) = (10, 10)` |
+
+Each pair sums to `N_pos = 20`. `f_L1` itself is among the 20.
+
+### Theorem 2 — no remaining bit is constant on the 20
+
+A remaining bit is constant on the 20 if and only if one entry of its
+Theorem 1 pair is `0`. None of the five pairs has a zero entry.
+
+`wt1` splits `6` versus `14`. `opp2` splits `8` versus `12`. `adj2`
+splits `6` versus `14`. `vertex3` splits `8` versus `12`. `mixed3`
+splits `10` versus `10`. No remaining bit is constant on the 20.
+
+### Theorem 3 — display; do not adopt a bit
+
+The pairs are displayed. Do not adopt a bit. The support description is
+not written into Admissibility. It is not a remaining-bit selector and
+not a Max(3) rename.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, 220 three-site seeds, off-patch 0 | declared finite patch |
+| `N_pos = 20` after p3bit5 selector exhaustion | proved by exhaustive `cov3` |
+| each remaining-bit pair on the 20 | proved |
+| any remaining bit constant on the 20 | none |
+| display; do not adopt a bit | displayed, not adopted |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Remaining-bit search is exhausted: p3bit5 showed no 1–5 bit remaining-bit
+AND or OR equals `cov3>0`. The present count does not reopen that menu.
+It reports a support description of the already enumerated 20 maps.
+
+The note is not a Max(3) rename: no maximum of `cov3` is reported as a
+selector, and `f_L1` is used only as the unbalanced-axis control.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write the pairs into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers, for each remaining bit, the pair `(n=0, n=1)` on the 20 maps with `cov3>0`, and whether any remaining bit is constant. |
+| V2 | Current main has the exhausted 1–5 bit remaining-bit AND/OR search (p3bit5) but no landed support census of the 20. |
+| V3 | The 32 maps, 220 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared finite class. |
+| V5 | It is not a physical selector: no remaining bit is constant, and no bit is adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: no remaining bit is constant on the 20
+`F_cut` maps with `cov3>0` on this patch. No global compiler impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover 1–5 bit menu | treat the pairs as a restatement of the failed AND/OR tests | **ATTEMPTED** |
+| Max(3) rename | replace the support pairs by a maximum-`cov3` ranking | **ATTEMPTED** |
+| adopt a bit | write a remaining bit into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch census to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The exhausted 1–5 bit AND/OR tests, the five support pairs, the Hamming
+contrast, and the off-patch convention are distinct. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 220 triples, off-patch occupancy `0`, occupancy-to-lock
+ticks, the `F_cut` remaining-bit order, and the restriction to the 20
+maps with `cov3>0` are declared. No silent extra bit is treated as
+constant.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the remaining-bit
+support of `cov3>0` on the declared patch after remaining-bit search is
+exhausted, and not a Max(3) rename.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 220 seeds | no physical law selection |
+| per block | each remaining bit counted on the 20 | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule,
+a different finite patch, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** p3bit5 already ruled out every remaining-bit AND and OR of
+width 1 through 5, so one remaining bit must be constant on the 20 and
+recover a support-side selector.
+
+**Answer:** `wt1` is `(6, 14)`. `opp2` is `(8, 12)`. `adj2` is
+`(6, 14)`. `vertex3` is `(8, 12)`. `mixed3` is `(10, 10)`. None.
+
+### N8 — cross-cycle echo
+
+Investment p3bit5 already showed no 1–5 bit AND/OR equals `cov3>0`. Echoing
+that failure is not a substitute for counting the five remaining bits on
+the 20. The present object is a support description, not a selector.
+
+No-Go Discipline disposition: **PASS** for the finite support census and the
+narrow none-constant verdict. FAIL / DO NOT SHIP for “a remaining bit is
+constant on the 20” or “a displayed pair is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov3` on the
+220 three-site seeds, restricts to the 20 maps with `cov3>0`, reports for
+each remaining bit the pair `(n_bit=0 among the 20, n_bit=1 among the 20)`,
+decides whether any remaining bit is constant on the 20, and reports that
+none is constant.
+Declared audit inputs are this note and the axiom memo; the runner writes
+no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov3_positive_bit_support_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov3_positive_bit_support_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov3_positive_bit_support_2026_08_15.txt
@@ -1,0 +1,92 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov3_positive_bit_support_2026_08_15.py
+runner_sha256: be9189e0fbae058dbd3ff66e79a7dafa2059628f6c51bb704965f7fa81239552
+input_fingerprint_sha256: 8c55ab9799a6351514a1761b588c80543d6d33dbda67a5b40c7289728fa7a4b2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+remaining=(0, 0, 0, 0, 0) cov3=0 pos=0
+remaining=(0, 0, 0, 0, 1) cov3=0 pos=0
+remaining=(0, 0, 0, 1, 0) cov3=0 pos=0
+remaining=(0, 0, 0, 1, 1) cov3=0 pos=0
+remaining=(0, 0, 1, 0, 0) cov3=0 pos=0
+remaining=(0, 0, 1, 0, 1) cov3=0 pos=0
+remaining=(0, 0, 1, 1, 0) cov3=24 pos=1
+remaining=(0, 0, 1, 1, 1) cov3=24 pos=1
+remaining=(0, 1, 0, 0, 0) cov3=0 pos=0
+remaining=(0, 1, 0, 0, 1) cov3=0 pos=0
+remaining=(0, 1, 0, 1, 0) cov3=0 pos=0
+remaining=(0, 1, 0, 1, 1) cov3=0 pos=0
+remaining=(0, 1, 1, 0, 0) cov3=16 pos=1
+remaining=(0, 1, 1, 0, 1) cov3=16 pos=1
+remaining=(0, 1, 1, 1, 0) cov3=44 pos=1
+remaining=(0, 1, 1, 1, 1) cov3=44 pos=1
+remaining=(1, 0, 0, 0, 0) cov3=0 pos=0
+remaining=(1, 0, 0, 0, 1) cov3=0 pos=0
+remaining=(1, 0, 0, 1, 0) cov3=56 pos=1
+remaining=(1, 0, 0, 1, 1) cov3=72 pos=1
+remaining=(1, 0, 1, 0, 0) cov3=80 pos=1
+remaining=(1, 0, 1, 0, 1) cov3=96 pos=1
+remaining=(1, 0, 1, 1, 0) cov3=188 pos=1
+remaining=(1, 0, 1, 1, 1) cov3=220 pos=1
+remaining=(1, 1, 0, 0, 0) cov3=4 pos=1
+remaining=(1, 1, 0, 0, 1) cov3=4 pos=1
+remaining=(1, 1, 0, 1, 0) cov3=68 pos=1
+remaining=(1, 1, 0, 1, 1) cov3=84 pos=1
+remaining=(1, 1, 1, 0, 0) cov3=96 pos=1
+remaining=(1, 1, 1, 0, 1) cov3=96 pos=1
+remaining=(1, 1, 1, 1, 0) cov3=212 pos=1
+remaining=(1, 1, 1, 1, 1) cov3=220 pos=1
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_three_site_seeds=220
+N_pos=20
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_among_the_20=True
+support wt1: (n_bit=0, n_bit=1)=(6, 14)
+support opp2: (n_bit=0, n_bit=1)=(8, 12)
+support adj2: (n_bit=0, n_bit=1)=(6, 14)
+support vertex3: (n_bit=0, n_bit=1)=(8, 12)
+support mixed3: (n_bit=0, n_bit=1)=(10, 10)
+any_remaining_bit_constant=False
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-three-site-seeds the two-cube has twelve vertices and C(12,3)=220 three-site seeds
+PASS: thm1-n-pos-twenty exactly 20 of the 32 F_cut maps have cov3>0
+PASS: thm1-bit-pairs-on-the-twenty each remaining bit reports (n_bit=0, n_bit=1) among the 20
+PASS: thm2-no-remaining-bit-constant no remaining bit is constant on the 20 maps with cov3>0
+PASS: thm3-displayed-not-adopted the pairs are displayed and no remaining bit is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted support, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-support the note reports the five remaining-bit pairs and the none-constant verdict
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: support-not-selector the residual is a support description after p3bit5, not a selector
+PASS: claim-scope-support claim_scope reports whether any remaining bit is constant on the 20
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored by whether any of the 220 three-site seeds fills
+per_block: checked exactly — each remaining bit is counted as (n=0, n=1) on the 20 maps with cov3>0
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov3_positive_bit_support_2026_08_15.py
+++ b/scripts/f_cut_cov3_positive_bit_support_2026_08_15.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Report remaining-bit support on the 20 F_cut maps with cov3>0.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov3(f) is the number of unordered 3-site seeds from
+which f fills. Remaining-bit AND/OR search through width 5 is exhausted
+(p3bit5). This runner asks a different object: for each remaining bit, the
+pair (n_bit=0 among the 20, n_bit=1 among the 20), and whether any remaining
+bit is constant on those twenty maps. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2. No bit is adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+THREE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(triple) for triple in combinations(TWO_CUBE, 3)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Remaining) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+NEIGHBOR_INDEX: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+
+
+def fills_from_mask(fire: tuple[int, ...], seed_mask: int) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            bits = 0
+            for axis, neighbor in enumerate(NEIGHBOR_INDEX[site_index]):
+                occupied = neighbor is not None and ((locked >> neighbor) & 1)
+                if occupied:
+                    bits |= 1 << axis
+            if fire[bits]:
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def seed_mask(seed: frozenset[Site]) -> int:
+    mask = 0
+    for site in seed:
+        mask |= 1 << SITE_INDEX[site]
+    return mask
+
+
+SEED_MASKS: tuple[int, ...] = tuple(seed_mask(seed) for seed in THREE_SITE_SEEDS)
+
+
+def fire_table(remaining: Remaining) -> tuple[int, ...]:
+    table = [0] * 64
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        index = (
+            raw[0]
+            | (raw[1] << 1)
+            | (raw[2] << 2)
+            | (raw[3] << 3)
+            | (raw[4] << 4)
+            | (raw[5] << 5)
+        )
+        table[index] = remaining_value(config, remaining)
+    return tuple(table)
+
+
+def coverage3(remaining: Remaining) -> int:
+    fire = fire_table(remaining)
+    return sum(1 for mask in SEED_MASKS if fills_from_mask(fire, mask))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut_remaining() -> list[Remaining]:
+    return [tuple(bits) for bits in product((0, 1), repeat=5)]  # type: ignore[misc]
+
+
+def support_pairs(
+    positive: list[Remaining],
+) -> dict[str, tuple[int, int]]:
+    pairs: dict[str, tuple[int, int]] = {}
+    for index, label in enumerate(REMAINING_LABELS):
+        n_zero = sum(1 for remaining in positive if remaining[index] == 0)
+        n_one = sum(1 for remaining in positive if remaining[index] == 1)
+        pairs[label] = (n_zero, n_one)
+    return pairs
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    members = enumerate_f_cut_remaining()
+
+    rows: list[tuple[Remaining, int, int]] = []
+    for remaining in members:
+        cov = coverage3(remaining)
+        rows.append((remaining, cov, int(cov > 0)))
+        print(f"remaining={remaining} cov3={cov} pos={int(cov > 0)}")
+
+    n_pos = sum(pos for _remaining, _cov, pos in rows)
+    positive = [remaining for remaining, _cov, pos in rows if pos]
+    pairs = support_pairs(positive)
+    any_constant = any(n_zero == 0 or n_one == 0 for n_zero, n_one in pairs.values())
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    l1_positive = l1_remaining in positive
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_three_site_seeds={len(THREE_SITE_SEEDS)}")
+    print(f"N_pos={n_pos}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_L1_among_the_20={l1_positive}")
+    for label in REMAINING_LABELS:
+        n_zero, n_one = pairs[label]
+        print(f"support {label}: (n_bit=0, n_bit=1)=({n_zero}, {n_one})")
+    print(f"any_remaining_bit_constant={any_constant}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV3_POSITIVE_BIT_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-three-site-seeds",
+        "the two-cube has twelve vertices and C(12,3)=220 three-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(THREE_SITE_SEEDS) == 220
+        and len(set(THREE_SITE_SEEDS)) == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 3 for seed in THREE_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-n-pos-twenty",
+        "exactly 20 of the 32 F_cut maps have cov3>0",
+        n_pos == 20
+        and len(positive) == 20
+        and all(n_zero + n_one == n_pos for n_zero, n_one in pairs.values())
+        and l1_positive
+        and "N_pos = 20" in note,
+    )
+    pair_lines_ok = all(
+        f"(n_{{{label}=0}}, n_{{{label}=1}}) = ({n_zero}, {n_one})" in note
+        for label, (n_zero, n_one) in pairs.items()
+    )
+    checks.check(
+        "thm1-bit-pairs-on-the-twenty",
+        "each remaining bit reports (n_bit=0, n_bit=1) among the 20",
+        pair_lines_ok
+        and all(n_zero + n_one == 20 for n_zero, n_one in pairs.values())
+        and list(pairs) == list(REMAINING_LABELS)
+        and "for each remaining bit, the pair" in note_flat,
+    )
+    checks.check(
+        "thm2-no-remaining-bit-constant",
+        "no remaining bit is constant on the 20 maps with cov3>0",
+        not any_constant
+        and all(n_zero > 0 and n_one > 0 for n_zero, n_one in pairs.values())
+        and "No remaining bit is constant on the 20" in note
+        and "None." in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the pairs are displayed and no remaining bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write the pairs into Admissibility" in note
+        and "support description" in note
+        and "not a selector" in note_flat,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted support, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-support",
+        "the note reports the five remaining-bit pairs and the none-constant verdict",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "N_pos = 20" in note
+        and "p3bit5" in note
+        and "Remaining-bit search is exhausted" in note
+        and pair_lines_ok
+        and "No remaining bit is constant on the 20" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the pairs into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "support-not-selector",
+        "the residual is a support description after p3bit5, not a selector",
+        "support description" in note
+        and "not a selector" in note_flat
+        and "p3bit5" in note
+        and "no 1–5 bit" in note
+        and "not a Max(3) rename" in note,
+    )
+    checks.check(
+        "claim-scope-support",
+        "claim_scope reports whether any remaining bit is constant on the 20",
+        "Among the 20 F_cut maps with cov3>0 on the two-cube" in note
+        and "off-patch o=0" in note
+        and "whether any remaining bit is constant is reported" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored by whether any of the 220 three-site seeds fills")
+    print("per_block: checked exactly — each remaining bit is counted as (n=0, n=1) on the 20 maps with cov3>0")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 20 F_cut maps with cov3>0, every remaining bit splits 10/10 or otherwise non-constant. Displayed, not adopted.

## Runner

`scripts/f_cut_cov3_positive_bit_support_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.