### PR TITLE
feat(q8inc): not every Q8-true map has cov6>0

### DIFF
--- a/docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,317 @@
+---
+claim_id: f_cut_q8_true_cov6_inclusion_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether every Q8-true map has positive 6-site coverage is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py
+---
+
+# Whether Every Q8-True `F_cut` Map Has Positive 6-Site Coverage
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill positivity on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the 924 six-site seeds, for the
+thirty-two cube-covariant cut maps `F_cut`. Whether every Q8-true map has
+`cov6>0` is the scored inclusion.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py`](../scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6539 showed that the remaining-bit predicate
+`Q8(f) := (wt1=1) or (adj2=1) or (opp2=1) or (vertex3=1)` equals `cov8>0`
+among the 32 maps (30 maps). Investment #6531 showed that
+`Q6(f) := (wt1=1) or (adj2=1) or (vertex3=1)` equals `cov6>0` (28 maps).
+`Q8` is strictly larger than `Q6`. This note is a new inclusion test:
+whether every Q8-true map still has `cov6>0`. Not leftover-character of
+those two selector identities.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov6(f) = |{S : |S|=6 and f fills from S}|`. Then:
+
+- Theorem 1. Not every Q8-true map has `cov6>0`. The two extras, in
+  remaining-bit lex order, are `(0, 1, 0, 0, 0)` and `(0, 1, 0, 0, 1)`.
+  The lex-first Q8-true map with `cov6=0` is `(0, 1, 0, 0, 0)`.
+- Theorem 2. `N_Q8 = 30`, `N_cov6 = 28`, `N_both = 28`.
+- Theorem 3. `Q8` is displayed. Displayed, not adopted.
+
+Do not adopt Q8. Do not write `Q8` into Admissibility.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block is a different rule and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 924 six-site seeds of the two-cube. Whether every Q8-true map has cov6>0, the two extras, and the counts N_Q8, N_cov6, N_both, are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q8_true_cov6_inclusion
+target_blocker_text: "whether every Q8-true F_cut map has cov6>0, and the extras if not"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed Q8-true versus cov6>0 inclusion; do not adopt Q8"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. `Q8` is a displayed remaining-bit formula, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The six-site seeds are the `C(12,6) = 924` subsets of size 6 in `T`. Then
+`cov6(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov6(f)>0`.
+
+The displayed remaining-bit predicate is
+
+```text
+Q8(f) := (wt1 = 1) or (adj2 = 1) or (opp2 = 1) or (vertex3 = 1).
+```
+
+Mixed3 is free in `Q8`. Displayed, not adopted.
+
+## Theorem 1 — not every Q8-true map has `cov6>0`
+
+Enumerate all 32 remaining-bit tuples of `F_cut` and score `cov6` on the 924
+six-site seeds. Then not every Q8-true map has `cov6>0`.
+
+The Q8-true maps with `cov6=0`, in remaining-bit lex order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are
+
+```text
+(0, 1, 0, 0, 0)
+(0, 1, 0, 0, 1)
+```
+
+Both have `opp2 = 1` and `wt1 = adj2 = vertex3 = 0`, so both are Q8-true
+only through `opp2`. Both have `cov6 = 0`. The lex-first Q8-true map with
+`cov6=0` is `(0, 1, 0, 0, 0)`.
+
+## Theorem 2 — `N_Q8`, `N_cov6`, `N_both`
+
+Among the 32 maps:
+
+- `N_Q8 = 30` maps satisfy `Q8`;
+- `N_cov6 = 28` maps have `cov6 > 0`;
+- `N_both = 28` maps satisfy both.
+
+Every map with `cov6>0` is Q8-true. Inclusion fails in the other direction:
+two Q8-true maps have `cov6=0`. Those two are exactly the extras of
+Theorem 1. The two Q8-false maps are `(0, 0, 0, 0, 0)` and `(0, 0, 0, 0, 1)`;
+both also have `cov6=0`.
+
+## Theorem 3 — display; do not adopt `Q8`
+
+`Q8` is the same remaining-bit predicate that #6539 found equivalent to
+`cov8>0`. On six-site seeds it is strictly larger than the positivity
+selector. Displayed, not adopted. Do not adopt Q8. Do not write `Q8` into
+Admissibility.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, satisfies `Q8` and has
+`cov6>0`. That is consistent with Theorem 2 and does not restore inclusion.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 924 six-site seeds, off-patch `o=0` | declared finite patch |
+| `Q8` as `(wt1=1) or (adj2=1) or (opp2=1) or (vertex3=1)` | displayed, not adopted |
+| every Q8-true map has `cov6>0` | fails; lex-first extra `(0, 1, 0, 0, 0)` |
+| `N_Q8 = 30`, `N_cov6 = 28`, `N_both = 28` | proved by exhaustive scoring |
+| leftover-character of #6539 or #6531 | refused; new inclusion test |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6539: that closed `Q8` iff `cov8>0` on eight-site
+seeds. The present question is whether every Q8-true map has `cov6>0`.
+
+Not leftover-character of #6531: that closed `Q6` iff `cov6>0`. The present
+object is Q8-true versus six-site positivity, not a restatement of the Q6
+selector.
+
+New inclusion test: `Q8` is strictly larger than `Q6`, and the two extras
+are exactly the Q8-true maps that remain Q6-false.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write `Q8` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether every Q8-true map has `cov6>0` inside `F_cut` on this patch. |
+| V2 | Current main has the axiom memo and the #6539 / #6531 selector identities, but no landed Q8-true versus `cov6>0` inclusion. |
+| V3 | The 32 maps, 924 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against displayed `Q8`. |
+| V5 | Inclusion fails, and displayed `Q8` is not adopted and is not written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: not every Q8-true map has `cov6>0` among the
+32 `F_cut` maps on this patch. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of #6539 | treat the inclusion as leftover-character of `Q8` iff `cov8>0` | **ATTEMPTED** |
+| leftover of #6531 | treat the count as leftover-character of `Q6` iff `cov6>0` | **ATTEMPTED** |
+| inherit from `cov8>0` | argue that Q8-true already fills at `k=8`, hence at `k=6` | **ATTEMPTED** |
+| adopt `Q8` | write `(wt1=1) or (adj2=1) or (opp2=1) or (vertex3=1)` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed inclusion, the Hamming contrast, the #6539 eight-site identity,
+and the off-patch convention are distinct. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 924 six-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the displayed
+predicate `Q8` are declared. Inclusion of Q8-true into `cov6>0` is not
+silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is whether every Q8-true
+map has `cov6>0` on the declared patch, not leftover-character of
+#6539 or #6531, and not an eight-site fill inheritance.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 924 seeds | no physical law selection |
+| per block | `N_Q8`, `N_cov6`, `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than `Q8` or `cov6>0`, and any independently derived physical
+map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** #6539 already showed that `Q8` is `cov8>0`, so every Q8-true
+map fills some eight-site seed and therefore some six-site seed.
+
+**Answer:** Inheritance fails. Thirty maps satisfy `Q8` and twenty-eight
+have `cov6>0`. The two extras `(0, 1, 0, 0, 0)` and `(0, 1, 0, 0, 1)` are
+Q8-true only through `opp2` and have `cov6=0`. The lex-first extra is
+`(0, 1, 0, 0, 0)`. Displayed `Q8` is not adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6539 already showed that `cov8>0` is `Q8`. Investment #6531
+already showed that `cov6>0` is `Q6`. Echoing either identity is not a
+substitute for the inclusion: `Q8` is strictly larger than `Q6`, and the
+two extras plus the triple `(N_Q8, N_cov6, N_both)` are the new facts.
+
+No-Go Discipline disposition: **PASS** for the finite inclusion and the
+narrow failure. FAIL / DO NOT SHIP for “every Q8-true map has `cov6>0`” or
+“displayed `Q8` is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov6` on the
+924 six-site seeds, tests whether every Q8-true map has `cov6>0`, names the
+two extras and the lex-first extra `(0, 1, 0, 0, 0)`, and reports
+`N_Q8 = 30`, `N_cov6 = 28`, and `N_both = 28`. Declared audit inputs are this
+note and the axiom memo; the runner writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q8_true_cov6_inclusion_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q8_true_cov6_inclusion_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q8_true_cov6_inclusion_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py
+runner_sha256: cf04492d290eec3224b558c9a3609cc39050629374af56464bd84a287c57e26e
+input_fingerprint_sha256: 5e6b8e48e536e2d13fd3b70369f75fe82a44fecc0e6ce1b076b412e07686eaf1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed Q8 versus cov6>0 inclusion; does not adopt Q8
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_six_site_seeds=924
+N_Q8=30
+N_cov6=28
+N_both=28
+inclusion=0
+extras=((0, 1, 0, 0, 0), (0, 1, 0, 0, 1))
+lex_first_q8_true_cov6_zero=(0, 1, 0, 0, 0)
+cov6(f_L1)=920
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 924 six-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-inclusion-fails not every Q8-true map has cov6>0
+PASS: thm1-lex-first-extra lex-first Q8-true map with cov6=0 is (0, 1, 0, 0, 0)
+PASS: thm1-two-extras the two Q8-true cov6=0 remaining-bit tuples are (0, 1, 0, 0, 0) and (0, 1, 0, 0, 1)
+PASS: thm2-counts N_Q8=30, N_cov6=28, N_both=28
+PASS: thm3-display-not-adopt Q8 is displayed and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the Q8-true versus cov6>0 inclusion and does not adopt Q8
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-6539-6531 the residual is Q8-true versus cov6>0 inclusion, not leftover-character of #6539 or #6531
+PASS: q8-definition-and-l1-in-class Q8 is wt1 or adj2 or opp2 or vertex3, and f_L1 satisfies Q8
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 924 six-site seeds against displayed Q8
+per_block: checked exactly — N_Q8, N_cov6, and N_both are the F_cut Q8-versus-cov6 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py
+++ b/scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Whether every Q8-true F_cut map has cov6>0.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov6(f) is the number of six-site seeds from which f
+fills. Q8 is the displayed remaining-bit predicate
+(wt1=1) or (adj2=1) or (opp2=1) or (vertex3=1). The runner reports whether
+every Q8-true map has cov6>0, the lex-first Q8-true map with cov6=0 if not,
+and the counts N_Q8, N_cov6, N_both. It does not adopt Q8. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+New inclusion test: not leftover of Q8=cov8>0 or Q6=cov6>0.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_EXTRA: Remaining = (0, 1, 0, 0, 0)
+EXTRAS: tuple[Remaining, ...] = (
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+)
+N_Q8 = 30
+N_COV6 = 28
+N_BOTH = 28
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_Q8(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[1] == 1 or remaining[2] == 1 or remaining[3] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print("negative_scope: displayed Q8 versus cov6>0 inclusion; does not adopt Q8")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(6)
+    rows: list[tuple[Remaining, int, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_Q8(remaining)))
+
+    n_q8 = sum(1 for _remaining, _cov, flag in rows if flag)
+    n_cov6 = sum(1 for _remaining, cov, _flag in rows if cov > 0)
+    n_both = sum(1 for _remaining, cov, flag in rows if cov > 0 and flag)
+    extras = tuple(
+        sorted(remaining for remaining, cov, flag in rows if flag and cov == 0)
+    )
+    inclusion = len(extras) == 0
+    lex_first = extras[0] if extras else None
+    cov_by_remaining = {remaining: cov for remaining, cov, _flag in rows}
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_six_site_seeds={len(seeds)}")
+    print(f"N_Q8={n_q8}")
+    print(f"N_cov6={n_cov6}")
+    print(f"N_both={n_both}")
+    print(f"inclusion={int(inclusion)}")
+    print(f"extras={extras}")
+    print(f"lex_first_q8_true_cov6_zero={lex_first}")
+    print(f"cov6(f_L1)={cov_l1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_Q8_TRUE_COV6_INCLUSION_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 924 six-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 924
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and selector_Q8(L1_REMAINING)
+        and cov_l1 > 0,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-inclusion-fails",
+        "not every Q8-true map has cov6>0",
+        inclusion is False
+        and len(extras) == 2
+        and extras == EXTRAS
+        and "not every Q8-true map has" in note_flat
+        and "cov6>0" in note,
+    )
+    checks.check(
+        "thm1-lex-first-extra",
+        "lex-first Q8-true map with cov6=0 is (0, 1, 0, 0, 0)",
+        lex_first == LEX_FIRST_EXTRA
+        and selector_Q8(LEX_FIRST_EXTRA)
+        and cov_by_remaining[LEX_FIRST_EXTRA] == 0
+        and LEX_FIRST_EXTRA[1] == 1
+        and LEX_FIRST_EXTRA[0] == 0
+        and LEX_FIRST_EXTRA[2] == 0
+        and LEX_FIRST_EXTRA[3] == 0
+        and "(0, 1, 0, 0, 0)" in note,
+    )
+    checks.check(
+        "thm1-two-extras",
+        "the two Q8-true cov6=0 remaining-bit tuples are (0, 1, 0, 0, 0) and (0, 1, 0, 0, 1)",
+        extras == EXTRAS
+        and all(selector_Q8(remaining) and cov_by_remaining[remaining] == 0 for remaining in extras)
+        and all(remaining[1] == 1 and remaining[0] == 0 and remaining[2] == 0 and remaining[3] == 0 for remaining in extras)
+        and "(0, 1, 0, 0, 1)" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_Q8={n_q8}, N_cov6={n_cov6}, N_both={n_both}",
+        n_q8 == N_Q8
+        and n_cov6 == N_COV6
+        and n_both == N_BOTH
+        and n_q8 == 30
+        and n_cov6 == 28
+        and n_both == 28
+        and n_both == n_cov6
+        and n_q8 - n_both == 2
+        and f"N_Q8 = {n_q8}" in note
+        and f"N_cov6 = {n_cov6}" in note
+        and f"N_both = {n_both}" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "Q8 is displayed and is not adopted as an Admissibility selector",
+        (
+            "Q8(f) := (wt1 = 1) or (adj2 = 1) or (opp2 = 1) or (vertex3 = 1)" in note
+            or "Q8(f) := (wt1=1) or (adj2=1) or (opp2=1) or (vertex3=1)" in note
+        )
+        and "Displayed, not adopted" in note
+        and "Do not adopt Q8" in note
+        and "Do not write `Q8` into Admissibility" in note
+        and "does not adopt Q8" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "every Q8-true map has positive 6-site coverage is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the Q8-true versus cov6>0 inclusion and does not adopt Q8",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+        "New inclusion test",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `Q8` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-6539-6531",
+        "the residual is Q8-true versus cov6>0 inclusion, not leftover-character of #6539 or #6531",
+        "Not leftover-character of #6539" in note
+        and "Not leftover-character of #6531" in note
+        and "New inclusion test" in note,
+    )
+    checks.check(
+        "q8-definition-and-l1-in-class",
+        "Q8 is wt1 or adj2 or opp2 or vertex3, and f_L1 satisfies Q8",
+        selector_Q8((1, 0, 0, 0, 0))
+        and selector_Q8((0, 0, 1, 0, 0))
+        and selector_Q8((0, 1, 0, 0, 0))
+        and selector_Q8((0, 0, 0, 1, 0))
+        and not selector_Q8((0, 0, 0, 0, 0))
+        and not selector_Q8((0, 0, 0, 0, 1))
+        and selector_Q8(L1_REMAINING)
+        and cov_l1 == cov_by_remaining[(1, 0, 1, 1, 1)],
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 924 six-site seeds against displayed Q8")
+    print("per_block: checked exactly — N_Q8, N_cov6, and N_both are the F_cut Q8-versus-cov6 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two Q8-true maps have cov6=0: (0,1,0,0,0) and (0,1,0,0,1). N_Q8=30 N_cov6=28 N_both=28. Displayed, not adopted.

## Runner

`scripts/f_cut_q8_true_cov6_inclusion_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.