### PR TITLE
feat(extra6cls): both Q8 extras first-refuse adj2

### DIFF
--- a/docs/F_CUT_Q8_EXTRA_SIX_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q8_EXTRA_SIX_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,362 @@
+---
+claim_id: f_cut_q8_extra_six_site_class_refuse_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, whether both Q8-true cov6=0 maps first refuse the same remaining-bit type from the lex-first 6-site f1 fill is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py
+---
+
+# Whether Both Q8-True `cov6=0` Extras First-Refuse The Same Type
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock remaining-bit refuse of the two Q8-true
+`cov6=0` `F_cut` maps on the lex-first six-site seed that `f1` fills, on
+the twelve-vertex two-cube with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py`](../scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment extra6why named the first remaining-bit refuse of
+`f_e0=(0,1,0,0,0)` on the lex-first 6-site seed that `f1` fills: tick `1`,
+site `(1, 1, 0)`, type `adj2`. The pair of Q8-true maps with `cov6=0` is
+`f_e0=(0,1,0,0,0)` and `f_e1=(0,1,0,0,1)`. This note asks whether that
+first refuse is a class fact of the extras: whether both first refuse the
+same remaining-bit type on that same 6-site `f1` fill, or whether the two
+types differ. Not leftover-character of the single-map first refuse of
+`f_e0=(0,1,0,0,0)`. The new object is the two-row extras census.
+Class fact of the extras.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+Write `f1` for remaining bits `(1, 1, 1, 1, 1)`, `f_e0` for remaining
+bits `(0, 1, 0, 0, 0)`, and `f_e1` for remaining bits `(0, 1, 0, 0, 1)`.
+Q8-true means `wt1=1` or `adj2=1` or `opp2=1` or `vertex3=1`. Both extras
+are Q8-true only through `opp2`.
+
+On the two-cube with off-patch occupancy `0`, a remaining-bit refuse of a
+map `f` from a locked set `L` is an unlocked on-patch site whose
+six-neighbor occupancy has a remaining-bit orbit type and `f=0` on that
+neighborhood. Empty and full are forced bits, not remaining bits. Then:
+
+- Theorem 1. For each of the two, the first remaining-bit refuse from
+  `S = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1)}`
+  is type `adj2` `= (2, 0, 1)` at tick `1`, site `(1, 1, 0)`, with
+  `N_refuse = 4`, not `0`.
+- Theorem 2. Both first refuses have the same type `adj2`. The two types
+  do not differ.
+- Theorem 3. That class fact is displayed. Displayed, not adopted.
+
+Do not adopt a bit. Do not write `adj2` into Admissibility.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block is a different rule and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Each of the two Q8-true cov6=0 F_cut maps is scored from the lex-first 6-site seed f1 fills. Both first remaining-bit refuses are type adj2. The refuse is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q8_extra_six_site_class_refuse
+target_blocker_text: "whether both Q8-true cov6=0 extras first refuse the same remaining-bit type on the lex-first 6-site f1 fill remains unnamed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed extras class first-refuse types; do not adopt a remaining bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The remaining-bit type `adj2` is a displayed refuse label, not
+axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+The map `f1` is the remaining-bit assignment that sends every remaining
+orbit to `1`. The map `f_e0` has remaining bits `(0, 1, 0, 0, 0)`. The
+map `f_e1` differs from `f_e0` only on the `mixed3` remaining bit.
+
+A locked set `L` determines occupancies: a lattice neighbor in `L` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `L` by
+
+```text
+L ∪ { v in two-cube \ L : f(neighborhood_6(v; L)) = 1 }.
+```
+
+Tick `1` is the seed itself, before the first such step. Fill means the
+halt set has cardinality 12. There are `C(12,6)=924` unordered 6-site
+seeds. Seeds are ordered by the lex order of the twelve vertices
+`(x,y,z)` with `x` slowest and `z` fastest, then by combination order.
+Coverage `cov6(f)` is the number of those 924 seeds from which `f` fills.
+
+A remaining-bit refuse of `f` at locked set `L` is an unlocked on-patch
+site `v` whose neighborhood axis-type is a remaining-bit orbit (or that
+orbit's complement) and `f(neighborhood_6(v; L))=0`. The first remaining-bit
+refuse from a seed is the lex-first such site on the earliest tick that has
+any. If no such site exists, `N_refuse=0`. `N_refuse` on a tick that has
+refuses is the number of remaining-bit refuses at the locked set just
+before that tick.
+
+Define
+
+```text
+Q8(f)            = 1  iff  wt1(f)=1 or adj2(f)=1 or opp2(f)=1 or vertex3(f)=1,
+f1               = remaining-value of (1, 1, 1, 1, 1),
+f_e0             = remaining-value of (0, 1, 0, 0, 0),
+f_e1             = remaining-value of (0, 1, 0, 0, 1),
+extras           = { f in F_cut : Q8(f)=1 and cov6(f)=0 }.
+```
+
+The two extras remaining-bit tuples, in lex order, are
+
+```text
+(0, 1, 0, 0, 0)
+(0, 1, 0, 0, 1).
+```
+
+`f_e0` is the lex-first member.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut` and is not Hamming parity. The map
+`f1` has remaining bits `(1, 1, 1, 1, 1)` and fills the lex-first 6-site
+seed
+
+```text
+S = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1)}.
+```
+
+The map `f1` fills `S`. Each of the two extras is Q8-true, has `cov6=0`,
+and does not fill `S`. From `S` at tick `1`, the unlocked sites and
+neighborhood types are
+
+```text
+(1, 1, 0)  adj2     (2, 0, 1)   neighborhood (0, 1, 0, 1, 0, 0)
+(1, 1, 1)  adj2     (2, 0, 1)   neighborhood (0, 1, 0, 1, 0, 0)
+(2, 0, 0)  wt1      (1, 0, 2)   neighborhood (0, 1, 0, 0, 0, 0)
+(2, 0, 1)  wt1      (1, 0, 2)   neighborhood (0, 1, 0, 0, 0, 0)
+(2, 1, 0)  empty    (0, 0, 3)
+(2, 1, 1)  empty    (0, 0, 3)
+```
+
+Empty is not a remaining-bit type. Every extras map has `wt1=0` and
+`adj2=0`, so each refuses the four remaining-bit neighborhoods. For each
+of the two, the first remaining-bit refuse from `S` is therefore tick
+`1`, site `(1, 1, 0)`, remaining-bit type `adj2`, with `N_refuse = 4`.
+
+**Theorem 2.** Both first refuses have the same type `adj2`. There is no
+lex-first counterexample tuple: scanning the two extras in lex order, no
+member has `N_refuse=0` and no member first-refuses a remaining-bit type
+other than `adj2`. The two types do not differ, so both types are not
+separately named as a split.
+
+The free bit `mixed3` does not change the first refuse from `S`. That
+type does not appear among the seed neighborhoods of unlocked sites.
+The bit `opp2` is already `1` on both extras and likewise does not
+appear as a first-refuse type here.
+
+**Theorem 3.** The extras class first-refuse type is `adj2`. That is a
+sameness statement for the two Q8-true `cov6=0` maps on this seed: the
+single-map refuse of `f_e0` is the extras class refuse. The refuse is
+displayed. No remaining bit is adopted as the physical Admissibility
+rule. Displayed, not adopted.
+
+## Proof-obligation graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free |
+| `f1` fills `S` | remaining bits `(1, 1, 1, 1, 1)` fill the lex-first 6-site seed |
+| two extras | Q8-true and `cov6=0`; lex-first is `f_e0` |
+| `cov6=0` | each of the two fills none of the 924 six-site seeds |
+| first refuse of each of the two | tick `1`, site `(1, 1, 0)`, type `adj2` |
+| `N_refuse` | `4` remaining-bit refuses on that tick, for each of the two |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` |
+| same type | proved by the two-row extras census |
+| displayed refuse | not adopted |
+
+## What this does not claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No ranking of the other 30 maps in `F_cut`.
+- No adoption of `adj2`, `opp2`, `f_e0`, or `f_e1`.
+- No blank-block or Hamming-as-`f_L1` identification.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It reports whether both Q8-true `cov6=0` maps first-refuse the same remaining-bit type from the 6-site seed `f1` fills. |
+| V2 | The single-map refuse of `f_e0` is named; extras class sameness on that seed is not. |
+| V3 | The 32 maps, the two extras tuples, the 924 seeds, and occupancy-to-lock from `S` are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared finite extras class. |
+| V5 | It is not a physical selector: the refuse is displayed and is not adopted and is not written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: both Q8-true `cov6=0` extras refuse an
+`adj2` neighborhood on the lex-first 6-site seed `f1` fills, so `adj2` is
+not adopted as an Admissibility selector. No global compiler impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover single-map refuse | treat the extras class as leftover-character of the `f_e0` refuse | **ATTEMPTED** |
+| leftover of `cov6=0` | treat the refuse type as leftover-character of the coverage zeros | **ATTEMPTED** |
+| first remaining-bit refuse of each of the two | name each first remaining-bit type from `S`, or `N_refuse=0` | **ATTEMPTED** |
+| type split | find that the two extras first-refuse different remaining-bit types | **ATTEMPTED** |
+| adopt a bit | write `adj2` or `f_e0` into Admissibility | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed Hamming identification, the leftover single-map refuse, and
+the leftover coverage-zero extras are distinct. This note claims no complete
+wall collection. The two identical `adj2` first refuses are two rows
+of one extras certificate, so they collapse rather than count as two
+walls.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 924 six-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the two
+Q8-true `cov6=0` extras are declared. Unique selection of `adj2` is not
+silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is sameness of the first
+remaining-bit refuse type for the Q8-true `cov6=0` extras from `S`, not
+leftover-character of the single-map refuse of `f_e0`, and not a Hamming
+identification.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | both Q8-true `cov6=0` extras scored from `S` | no physical law selection |
+| per block | each first remaining-bit refuse type named | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, the
+other 30 maps in `F_cut`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** extra6why already named `adj2` for `f_e0`, and both extras have
+`adj2=0`, so same-type refuse is leftover-character of that single-map refuse.
+
+**Answer:** the single-map refuse names one remaining-bit tuple. The new
+object is the two-row extras census: whether the free bit `mixed3` changes
+the first refuse type, or whether `N_refuse=0` for some member.
+Displaying that both first refuses are `adj2` names that extras class fact.
+`adj2` is not adopted.
+
+### N8 — cross-cycle echo
+
+Investment extra6why already named the first remaining-bit refuse of `f_e0`
+on this seed. Echoing that single row is not a substitute for the first
+remaining-bit refuse type of both Q8-true `cov6=0` extras from the
+lex-first 6-site `f1` fill.
+
+No-Go Discipline disposition: **PASS** for the two named extras, the
+`f1` fill of `S`, the displayed first remaining-bit refuse types, and the
+sameness of those types. FAIL / DO NOT SHIP for “`adj2` is
+the physical rule” or “displayed `f_e0` is adopted.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, names the two Q8-true `cov6=0` extras, names the lex-first
+6-site seed that `f1` fills, evaluates the first remaining-bit refuse of
+each extras map from that seed or reports `N_refuse=0`, checks that both
+first refuses have the same type `adj2`, and does not adopt a bit.
+Declared audit inputs are this note and the axiom memo; the runner writes
+no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q8_extra_six_site_class_refuse_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q8_extra_six_site_class_refuse_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q8_extra_six_site_class_refuse_2026_08_15.txt
@@ -1,0 +1,64 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py
+runner_sha256: 91140f8ab1159219b27f213b36f084da9b2dc9967acc67e12bedb3b3863853c8
+input_fingerprint_sha256: 46ee40780b828ef9c7abcddcff5b97dd3409934d6961f3b6c707d08a0ba7f80a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.71
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q8_EXTRA_SIX_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: first remaining-bit refuse of each Q8-true cov6=0 extra from S
+negative_scope: adj2 is displayed, not adopted or written into Admissibility
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+N_Q8=30
+N_cov6=28
+N_extras=2
+extras_class=[(0, 1, 0, 0, 0), (0, 1, 0, 0, 1)]
+f_e0_remaining=(0, 1, 0, 0, 0)
+f_e1_remaining=(0, 1, 0, 0, 1)
+f1_remaining=(1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+S={(0,0,0),(0,0,1),(0,1,0),(0,1,1),(1,0,0),(1,0,1)}
+f1_fills_S=True
+f1_history=(6, 10, 12)
+extra (0, 1, 0, 0, 0) tick=1 site=(1, 1, 0) type=adj2 N_refuse=4 fills_S=False history=(6,)
+extra (0, 1, 0, 0, 1) tick=1 site=(1, 1, 0) type=adj2 N_refuse=4 fills_S=False history=(6,)
+same_first_refuse_type=True
+shared_type=adj2
+PASS: audit-inputs AUDIT_INPUT_PATHS are the required static literals and both files exist
+PASS: thm1-rotations-orbits-fcut 24 rotations, 10 orbits, and |F_cut|=32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-s-filled-by-f1 the two-cube has twelve vertices and f1 fills the lex-first 6-site seed S
+PASS: thm1-q8-true-cov6-zero-pair the two Q8-true cov6=0 remaining-bit tuples are (0,1,0,0,0) and (0,1,0,0,1)
+PASS: thm1-class-first-refuse-types each of the two extras has a first remaining-bit refuse from S
+PASS: thm2-both-first-refuse-same-type both first refuses have the same type adj2; the two types do not differ
+PASS: thm3-display-not-adopt the extras class first-refuse type is displayed and is not adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports whether both extras first refuse the same type from S
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-class-refuse the note reports the two extras, S, and first-refuse type adj2
+PASS: not-leftover-extra6why the residual is extras class sameness, not leftover of the single-map refuse
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — both Q8-true cov6=0 extras are scored from S
+per_block: checked exactly — each first remaining-bit refuse type is named, or N_refuse=0
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py
+++ b/scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py
@@ -1,0 +1,860 @@
+#!/usr/bin/env python3
+"""Whether both Q8-true cov6=0 extras first-refuse the same remaining-bit type.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The extras pair is f_e0=(0,1,0,0,0) and f_e1=(0,1,0,0,1). S is
+the lex-first 6-site seed that f1 fills. For each of the two maps the first
+remaining-bit refuse type from S is reported, or N_refuse=0. Whether both
+such first refuses have the same type is displayed; it does not adopt a bit.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. New object: not leftover of the single-map first refuse of
+f_e0=(0,1,0,0,0). Class fact of the extras.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q8_EXTRA_SIX_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q8_EXTRA_SIX_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Seed = tuple[Site, Site, Site, Site, Site, Site]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SIX_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 6)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+AXIS_TYPE_NAME: dict[OrbitType, str] = {
+    (0, 0, 3): "empty",
+    (0, 3, 0): "full",
+    (1, 0, 2): "wt1",
+    (1, 2, 0): "wt1_comp",
+    (0, 1, 2): "opp2",
+    (0, 2, 1): "opp2_comp",
+    (2, 0, 1): "adj2",
+    (2, 1, 0): "adj2_comp",
+    (3, 0, 0): "vertex3",
+    (1, 1, 1): "mixed3",
+}
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+F1_REMAINING: Remaining = (1, 1, 1, 1, 1)
+FE0_REMAINING: Remaining = (0, 1, 0, 0, 0)
+FE1_REMAINING: Remaining = (0, 1, 0, 0, 1)
+SEED_S_SITES: Seed = (
+    (0, 0, 0),
+    (0, 0, 1),
+    (0, 1, 0),
+    (0, 1, 1),
+    (1, 0, 0),
+    (1, 0, 1),
+)
+EXTRAS_CLASS: tuple[Remaining, ...] = (
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def remaining_representative(kind: OrbitType) -> OrbitType | None:
+    if kind in REMAINING_ORDER:
+        return kind
+    image = complement_type(kind)
+    if image in REMAINING_ORDER:
+        return image
+    return None
+
+
+def remaining_label(kind: OrbitType) -> str:
+    representative = remaining_representative(kind)
+    if representative is None:
+        return AXIS_TYPE_NAME[kind]
+    return REMAINING_LABELS[REMAINING_ORDER.index(representative)]
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def make_predicate(remaining: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(config, remaining)
+
+    return predicate
+
+
+def f1(config: Config) -> int:
+    """F_cut remaining bits (1, 1, 1, 1, 1).  Displayed.  Not adopted."""
+    return remaining_value(config, F1_REMAINING)
+
+
+def f_e0(config: Config) -> int:
+    """Lex-first Q8-true remaining-bit map with cov6=0."""
+    return remaining_value(config, FE0_REMAINING)
+
+
+def f_e1(config: Config) -> int:
+    """Second Q8-true remaining-bit map with cov6=0; mixed3=1."""
+    return remaining_value(config, FE1_REMAINING)
+
+
+def q8(remaining: tuple[int, ...]) -> int:
+    return int(
+        remaining[0] == 1
+        or remaining[1] == 1
+        or remaining[2] == 1
+        or remaining[3] == 1
+    )
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_from_seed(predicate, seed: frozenset[Site], halt_bound: int = 13) -> dict:
+    locked = set(seed)
+    history = [len(locked)]
+    for _tick in range(halt_bound):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            break
+        locked = nxt
+        history.append(len(locked))
+    return {
+        "fill": len(locked) == 12,
+        "history": tuple(history),
+        "locks": frozenset(locked),
+        "halt_tick": len(history) - 1,
+    }
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    return bool(run_from_seed(predicate, seed)["fill"])
+
+
+def seed_key(seed: frozenset[Site]) -> Seed:
+    ordered = tuple(sorted(seed))
+    return (
+        ordered[0],
+        ordered[1],
+        ordered[2],
+        ordered[3],
+        ordered[4],
+        ordered[5],
+    )
+
+
+def seed_display(seed: frozenset[Site] | Seed) -> str:
+    sites = seed_key(frozenset(seed))
+    inner = ",".join(f"({a[0]},{a[1]},{a[2]})" for a in sites)
+    return "{" + inner + "}"
+
+
+def remaining_refuse_events(locked: set[Site], predicate) -> list[dict]:
+    rows: list[dict] = []
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        config = neighborhood(site, locked)
+        kind = axis_type(config)
+        representative = remaining_representative(kind)
+        if representative is None:
+            continue
+        if int(predicate(config)) != 0:
+            continue
+        rows.append(
+            {
+                "site": site,
+                "config": config,
+                "axis_type": kind,
+                "remaining_type": representative,
+                "remaining_name": remaining_label(kind),
+                "f_map": int(predicate(config)),
+                "f1": int(f1(config)),
+            }
+        )
+    return rows
+
+
+def first_remaining_refuse(seed: frozenset[Site], predicate, halt_bound: int = 13) -> dict | None:
+    locked = set(seed)
+    for tick in range(1, halt_bound + 1):
+        events = remaining_refuse_events(locked, predicate)
+        if events:
+            first = events[0]
+            return {
+                "tick": tick,
+                "site": first["site"],
+                "config": first["config"],
+                "axis_type": first["axis_type"],
+                "remaining_type": first["remaining_type"],
+                "remaining_name": first["remaining_name"],
+                "n_events": len(events),
+                "events": tuple(events),
+            }
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return None
+        locked = nxt
+    return None
+
+
+def class_first_refuses(seed: frozenset[Site], members: tuple[Remaining, ...]) -> list[dict]:
+    rows: list[dict] = []
+    for remaining in members:
+        predicate = make_predicate(remaining)
+        first = first_remaining_refuse(seed, predicate)
+        if first is None:
+            rows.append(
+                {
+                    "remaining": remaining,
+                    "n_refuse": 0,
+                    "tick": None,
+                    "site": None,
+                    "remaining_name": None,
+                    "remaining_type": None,
+                    "config": None,
+                    "fills": fills_from_seed(predicate, seed),
+                    "history": run_from_seed(predicate, seed)["history"],
+                }
+            )
+            continue
+        rows.append(
+            {
+                "remaining": remaining,
+                "n_refuse": first["n_events"],
+                "tick": first["tick"],
+                "site": first["site"],
+                "remaining_name": first["remaining_name"],
+                "remaining_type": first["remaining_type"],
+                "config": first["config"],
+                "fills": fills_from_seed(predicate, seed),
+                "history": run_from_seed(predicate, seed)["history"],
+            }
+        )
+    return rows
+
+
+def coverage_six(predicate) -> int:
+    return sum(1 for seed in SIX_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    values = tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+    return (values[0], values[1], values[2], values[3], values[4])
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+        if complement_type(orbit_type) != orbit_type
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut_remaining(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[Remaining]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[Remaining] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        members.append(remaining_bits_from_assignment(assignment))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def remaining_display(remaining: tuple[int, ...]) -> str:
+    return "(" + ", ".join(str(bit) for bit in remaining) + ")"
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: first remaining-bit refuse of each Q8-true cov6=0 extra from S")
+    print("negative_scope: adj2 is displayed, not adopted or written into Admissibility")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    remaining_members = enumerate_f_cut_remaining(orbit_types, empty_type, full_type)
+
+    cov6_by_remaining = {
+        remaining: coverage_six(make_predicate(remaining)) for remaining in remaining_members
+    }
+    extras = tuple(
+        sorted(
+            remaining
+            for remaining in remaining_members
+            if q8(remaining) == 1 and cov6_by_remaining[remaining] == 0
+        )
+    )
+    lex_first_extra = extras[0]
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    f1_bits = bits_from_predicate(f1, orbit_types, orbits)
+    fe0_bits = bits_from_predicate(f_e0, orbit_types, orbits)
+    fe1_bits = bits_from_predicate(f_e1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f1_remaining = remaining_bits_from_full(f1_bits, orbit_types)
+    fe0_remaining = remaining_bits_from_full(fe0_bits, orbit_types)
+    fe1_remaining = remaining_bits_from_full(fe1_bits, orbit_types)
+
+    seed_s = frozenset(SEED_S_SITES)
+    lex_first_filled_by_f1 = next(seed for seed in SIX_SITE_SEEDS if fills_from_seed(f1, seed))
+    run_f1 = run_from_seed(f1, seed_s)
+    run_fe0 = run_from_seed(f_e0, seed_s)
+    run_fe1 = run_from_seed(f_e1, seed_s)
+    class_rows = class_first_refuses(seed_s, extras)
+    types = [row["remaining_name"] for row in class_rows]
+    same_type = (
+        len(class_rows) == 2
+        and class_rows[0]["n_refuse"] != 0
+        and class_rows[1]["n_refuse"] != 0
+        and types[0] == types[1]
+    )
+    counterexamples = [
+        row
+        for row in class_rows
+        if row["n_refuse"] == 0
+        or row["remaining_name"] != class_rows[0]["remaining_name"]
+    ]
+    lex_first_counterexample = None
+    if not same_type:
+        lex_first_counterexample = counterexamples[0] if counterexamples else class_rows[0]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={len(remaining_members)}")
+    print(f"N_Q8={sum(1 for member in remaining_members if q8(member) == 1)}")
+    print(f"N_cov6={sum(1 for count in cov6_by_remaining.values() if count > 0)}")
+    print(f"N_extras={len(extras)}")
+    print(f"extras_class={list(extras)}")
+    print(f"f_e0_remaining={fe0_remaining}")
+    print(f"f_e1_remaining={fe1_remaining}")
+    print(f"f1_remaining={f1_remaining}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"S={seed_display(seed_s)}")
+    print(f"f1_fills_S={run_f1['fill']}")
+    print(f"f1_history={run_f1['history']}")
+    for row in class_rows:
+        print(
+            "extra "
+            + remaining_display(row["remaining"])
+            + f" tick={row['tick']} site={row['site']} "
+            + f"type={row['remaining_name']} N_refuse={row['n_refuse']} "
+            + f"fills_S={row['fills']} history={row['history']}"
+        )
+    print(f"same_first_refuse_type={same_type}")
+    print(f"shared_type={types[0] if same_type else None}")
+    if not same_type:
+        print(f"named_types={types}")
+
+    checks.check(
+        "audit-inputs",
+        "AUDIT_INPUT_PATHS are the required static literals and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q8_EXTRA_SIX_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "thm1-rotations-orbits-fcut",
+        "24 rotations, 10 orbits, and |F_cut|=32",
+        len(ROTATIONS) == 24
+        and len(orbit_types) == 10
+        and len(remaining_members) == 32
+        and n_free == 5
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-two-cube-and-s-filled-by-f1",
+        "the two-cube has twelve vertices and f1 fills the lex-first 6-site seed S",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(SIX_SITE_SEEDS) == 924
+        and seed_key(seed_s) == SEED_S_SITES
+        and seed_key(lex_first_filled_by_f1) == SEED_S_SITES
+        and f1_remaining == F1_REMAINING
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type)
+        and run_f1["fill"]
+        and not run_fe0["fill"]
+        and not run_fe1["fill"]
+        and run_fe0["history"] == (6,)
+        and run_fe1["history"] == (6,),
+    )
+    checks.check(
+        "thm1-q8-true-cov6-zero-pair",
+        "the two Q8-true cov6=0 remaining-bit tuples are (0,1,0,0,0) and (0,1,0,0,1)",
+        extras == EXTRAS_CLASS
+        and lex_first_extra == FE0_REMAINING
+        and fe0_remaining == FE0_REMAINING
+        and fe1_remaining == FE1_REMAINING
+        and all(q8(member) == 1 for member in extras)
+        and all(cov6_by_remaining[member] == 0 for member in extras)
+        and all(member[1] == 1 and member[0] == 0 and member[2] == 0 and member[3] == 0 for member in extras)
+        and in_f_cut(fe0_bits, orbit_types, empty_type, full_type)
+        and in_f_cut(fe1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-class-first-refuse-types",
+        "each of the two extras has a first remaining-bit refuse from S",
+        len(class_rows) == 2
+        and all(row["n_refuse"] != 0 for row in class_rows)
+        and all(row["tick"] == 1 for row in class_rows)
+        and all(row["site"] == (1, 1, 0) for row in class_rows)
+        and all(row["remaining_name"] == "adj2" for row in class_rows)
+        and all(row["remaining_type"] == (2, 0, 1) for row in class_rows)
+        and all(row["config"] == (0, 1, 0, 1, 0, 0) for row in class_rows)
+        and all(row["n_refuse"] == 4 for row in class_rows)
+        and all(not row["fills"] for row in class_rows)
+        and all(row["history"] == (6,) for row in class_rows),
+    )
+    checks.check(
+        "thm2-both-first-refuse-same-type",
+        "both first refuses have the same type adj2; the two types do not differ",
+        same_type
+        and lex_first_counterexample is None
+        and types == ["adj2", "adj2"]
+        and class_rows[0]["remaining"] == FE0_REMAINING
+        and class_rows[1]["remaining"] == FE1_REMAINING
+        and f1((0, 1, 0, 1, 0, 0)) == 1
+        and f_e0((0, 1, 0, 1, 0, 0)) == 0
+        and f_e1((0, 1, 0, 1, 0, 0)) == 0,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the extras class first-refuse type is displayed and is not adopted",
+        same_type
+        and "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write `adj2` into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, whether both Q8-true cov6=0 maps "
+        "first refuse the same remaining-bit type from the lex-first 6-site f1 "
+        "fill is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports whether both extras first refuse the same type from S",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `adj2` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-class-refuse",
+        "the note reports the two extras, S, and first-refuse type adj2",
+        "(0, 1, 0, 0, 0)" in note
+        and "(0, 1, 0, 0, 1)" in note
+        and "`S = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1)}`"
+        in note
+        and "N_refuse = 4" in note
+        and "`adj2`" in note
+        and "(2, 0, 1)" in note
+        and "tick `1`" in note
+        and "site `(1, 1, 0)`" in note
+        and "same type" in note,
+    )
+    checks.check(
+        "not-leftover-extra6why",
+        "the residual is extras class sameness, not leftover of the single-map refuse",
+        "Not leftover-character of the single-map first refuse" in note
+        and "f_e0=(0,1,0,0,0)" in note.replace(" ", "")
+        and ("New object" in note or "new object" in note)
+        and "Class fact of the extras" in note_flat,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — both Q8-true cov6=0 extras are scored from S")
+    print("per_block: checked exactly — each first remaining-bit refuse type is named, or N_refuse=0")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among F_cut on the two-cube with off-patch o=0, both Q8-true cov6=0 extras (0,1,0,0,0) and (0,1,0,0,1) first-refuse the same remaining-bit type adj2 from the lex-first 6-site f1 fill. Displayed, not adopted.

## Runner

`scripts/f_cut_q8_extra_six_site_class_refuse_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.