### PR TITLE
feat(mix3c8): mixed3 is not free for cov8 inside Q8

### DIFF
--- a/docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,389 @@
+---
+claim_id: f_cut_q8_mixed3_cov8_freedom_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 30 Q8-true F_cut maps on the two-cube with off-patch o=0, whether mixed3-pairs have equal cov8 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py
+---
+
+# Mixed3 Is Not Free For Integer Cov8 Inside Q8
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact 8-site occupancy-to-lock coverage of the 30 Q8-true
+cube-covariant complement-even maps in `F_cut`, on the twelve-vertex
+two-cube, with off-patch occupancy `0`. Those 30 maps form 15 pairs that
+differ only by the remaining bit `mixed3`. Whether those pairs have equal
+`cov8` is reported. `mixed3` is displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py`](../scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6539: the remaining-bit predicate
+`Q8 = wt1 ∨ opp2 ∨ adj2 ∨ vertex3` equals `cov8>0` on the 32-element class
+`F_cut`. That predicate ignores `mixed3`. The two maps with `cov8=0` are
+the Q8-false mixed3-pair `(0, 0, 0, 0, 0)` and `(0, 0, 0, 0, 1)`. This
+note asks the integer residual inside the 30 Q8-true maps: of the 15 pairs
+that differ only by `mixed3`, how many have equal `cov8`.
+
+Not leftover-character of #6539: that was a positivity selector. The
+present object is the integer `cov8` of each Q8-true mixed3-pair.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 8-subset of vertices
+is an 8-site seed. There are `C(12,8)=495` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. Fill means
+the halt set has cardinality 12. Coverage is
+
+```text
+cov8(f) = |{ S : |S|=8 and f fills from S }|.
+```
+
+A blank-block is a different rule and is not used.
+
+Independent coverage of all 32 maps, then restriction to the 30 Q8-true
+maps as 15 mixed3-pairs:
+
+- Theorem 1. Exactly one of those 15 pairs has equal `cov8`.
+  `N_equal = 1` and `N_diff = 14`. The equal pair is
+  `(0, 1, 0, 0, 0)` and `(0, 1, 0, 0, 1)`, both with `cov8 = 1`.
+- Theorem 2. The lex-first pair that differs is
+  `(0, 0, 0, 1, 0)` versus `(0, 0, 0, 1, 1)`, with
+  `cov8((0, 0, 0, 1, 0)) = 44` and
+  `cov8((0, 0, 0, 1, 1)) = 132`.
+- Theorem 3. The equality count and the differing pair are displayed.
+  Do not adopt mixed3.
+
+Q8-positivity is free of `mixed3`. Integer `cov8` inside Q8 is not.
+Displayed, not adopted.
+
+Do not write mixed3 into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Independent 8-site coverage of the 30 Q8-true F_cut maps, grouped as 15 mixed3-pairs, yields an exact equality count and a named lex-first differing pair. mixed3 is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q8_mixed3_cov8_freedom
+target_blocker_text: "among Q8-true maps, whether mixed3-pairs have equal cov8"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the mixed3-pair cov8 equality count; do not adopt mixed3"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- the complete set of 495 unordered 8-site seeds;
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the remaining-bit predicate
+  `Q8 = wt1 ∨ opp2 ∨ adj2 ∨ vertex3`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Among the 30 Q8-true `F_cut` maps on the two-cube with
+off-patch occupancy `0`, report how many of the 15 mixed3-pairs have
+equal `cov8`. If not all, name the lex-first pair that differs and both
+`cov8` values. Display the count. Do not adopt `mixed3`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+`Q8` is true exactly when at least one of `wt1`, `opp2`, `adj2`, `vertex3`
+is 1. It does not read `mixed3`. The two Q8-false maps are
+`(0, 0, 0, 0, 0)` and `(0, 0, 0, 0, 1)`. The other 30 maps form 15 pairs
+that share the first four remaining bits and differ only in `mixed3`.
+Pairs are ordered by that four-bit prefix in lex order.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed if iterating this rule
+from the seed reaches `L = T` in at most 13 ticks. Runs of distinct maps
+are independent.
+
+## Theorems
+
+### Theorem 1 — one of the fifteen Q8-true mixed3-pairs has equal `cov8`
+
+There are exactly 24 proper cube rotations and exactly 10 orbits on
+`{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis map
+`f_L1` is one element of `F_cut` and is not Hamming parity. Its remaining
+bits are `(1, 0, 1, 1, 1)`, so it is Q8-true.
+
+`Q8` holds on exactly 30 of the 32 maps. Those 30 maps are 15 pairs
+differing only by `mixed3`. Exhaustive `cov8` on all 495 eight-site seeds
+gives `N_equal = 1` and `N_diff = 14`.
+
+The one equal pair is the `opp2`-only pair
+
+```text
+(0, 1, 0, 0, 0)  cov8 = 1
+(0, 1, 0, 0, 1)  cov8 = 1
+```
+
+The two Q8-false maps both have `cov8 = 0`. That pair is outside the
+scored class.
+
+### Theorem 2 — lex-first unequal pair
+
+The 15 prefixes in lex order begin at `(0, 0, 0, 1)`. That first pair
+already differs:
+
+```text
+cov8((0, 0, 0, 1, 0)) = 44
+cov8((0, 0, 0, 1, 1)) = 132
+```
+
+So the lex-first pair that differs is the `vertex3`-only pair
+`(0, 0, 0, 1, 0)` versus `(0, 0, 0, 1, 1)`.
+
+### Theorem 3 — display; do not adopt mixed3
+
+The equality count `N_equal = 1` and the lex-first differing pair with
+coverages `44` and `132` are displayed. Mixed3-freedom of Q8 as a
+positivity selector does not extend to freedom of the integer `cov8`
+inside Q8.
+
+Do not adopt mixed3. Do not write mixed3 into Admissibility. `f_L1`
+remains the unbalanced-axis predicate `n≠0` rather than Hamming parity.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| `F_cut` remaining-bit order | enumerated |
+| `Q8 = wt1 ∨ opp2 ∨ adj2 ∨ vertex3` | defined; ignores `mixed3` |
+| `f_L1` as unbalanced-axis / `n_μ ≠ 0` | defined; Hamming rejected |
+| two-cube, 495 eight-site seeds, off-patch 0 | declared finite patch |
+| 30 Q8-true maps as 15 mixed3-pairs | enumerated |
+| `N_equal = 1`, `N_diff = 14` | proved by coverage |
+| lex-first differing pair and both `cov8` | `(0, 0, 0, 1, 0)` / `44` and `(0, 0, 0, 1, 1)` / `132` |
+| leftover-character of #6539 | refused; positivity is not the integer |
+| physical Admissibility selector | open |
+
+## Current premise boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility identifies the six-neighbor condition domain and covariance
+under proper cubic rotations; it does not supply the formation site, probability, or rate.
+The boolean occupancy predicates and the lock-update rule are explicit
+bounded mathematical input, not axiom text.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Permanence of a lock once formed is used only as the declared update rule on
+this finite patch. No physical readout, content map, or formation rate is
+identified.
+
+## Boundary and imports
+
+Not leftover-character of #6539: that displayed Q8 as a positivity selector
+equal to `cov8>0` and therefore independent of `mixed3`. The present object
+is whether each Q8-true mixed3-pair has the same integer cov8.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No `Z^3`-wide formation law is claimed. Do not write mixed3 into
+Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers how many of the 15 Q8-true mixed3-pairs have equal `cov8`. |
+| V2 | Current main has the positivity fact #6539 (`Q8` iff `cov8>0`, ignoring `mixed3`), but no landed integer-`cov8` mixed3-freedom test inside Q8. |
+| V3 | The 30 maps, 495 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: Q8-positivity freedom of `mixed3` is not integer-`cov8` freedom. |
+| V5 | It is not a physical selector: the equality count is displayed, and `mixed3` is not adopted. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: on this patch, integer `cov8` is not
+constant on Q8-true mixed3-pairs. No global compiler impossibility is
+claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover #6539 | treat integer-`cov8` equality as leftover-character of the positivity selector | **ATTEMPTED** |
+| Q8-false pair | treat the scored class as the two `cov8=0` maps | **ATTEMPTED** |
+| all pairs equal | claim mixed3 is free for integer `cov8` inside Q8 | **ATTEMPTED** |
+| adopt `mixed3` | write the bit into Admissibility | **ATTEMPTED** |
+| lattice-wide formation | lift the patch coverages to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the leftover-#6539 extra, and the off-patch
+convention are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 495 eight-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the
+predicate `Q8` are declared. Equality of mixed3-pair `cov8` values is
+not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is integer-`cov8`
+mixed3-freedom inside Q8, not leftover-character of #6539.
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py:87` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py:131` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py:136` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py:150` | `Q8` predicate | `wt1 ∨ opp2 ∨ adj2 ∨ vertex3`; ignores `mixed3` | yes |
+| `scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py:52` | 495 eight-site seeds | `C(12,8)` unordered 8-subsets on the two-cube | yes |
+| `scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py:181` | `cov8(f)` | number of 8-site seeds a map fills | yes |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 30 Q8-true maps on all 495 eight-site seeds | no physical law selection |
+| per block | mixed3-pair `cov8` equality count on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+The runner prints the same five resolution statements.
+
+### N6 — live partial-closure paths
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+None of the approved primitives supplies a Boolean occupancy map, a
+seed-coverage ranking, or an Admissibility selector.
+
+Live routes include a different seed cardinality, a different off-patch
+rule, a selector other than this equality count, and any independently
+derived physical map from `F_cut` into Admissibility. One partial-closure
+mechanism is displayed rather than suppressed: the `opp2`-only pair is
+the unique Q8-true mixed3-pair with equal `cov8`. That pair does not
+select `mixed3` or `opp2`.
+
+### N7 — hostile steelman
+
+**Steelman:** Because Q8 ignores `mixed3` and equals `cov8>0`, mixed3 is
+dynamically free on every Q8-true pair, so the two maps in each pair must
+fill the same number of 8-site seeds.
+
+**Answer:** Positivity of `cov8` is not the integer `cov8`. Fourteen of
+the fifteen Q8-true mixed3-pairs have unequal coverage. The lex-first
+counterexample is `(0, 0, 0, 1, 0)` with `cov8 = 44` versus
+`(0, 0, 0, 1, 1)` with `cov8 = 132`. That is a new uniqueness inside Q8,
+not leftover-character of the positivity selector.
+
+### N8 — cross-cycle echo
+
+Investment #6539 already displayed that Q8 equals `cov8>0` and therefore
+ignores `mixed3`. Echoing that positivity fact is not a substitute for
+the 15-pair integer comparison.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps; that note's quaternion-axis pair is unused |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No-Go Discipline disposition: **PASS** for the finite equality count and
+the displayed lex-first differing pair. FAIL / DO NOT SHIP for
+“`mixed3` is free for integer `cov8` inside Q8” or “`mixed3` is the
+physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, evaluates `cov8` of all 32 maps, restricts to the 30 Q8-true maps
+as 15 mixed3-pairs, reports `N_equal = 1` and `N_diff = 14`, names the
+lex-first differing pair `(0, 0, 0, 1, 0)` / `(0, 0, 0, 1, 1)` with
+coverages `44` and `132`, checks that `f_L1` is not Hamming parity, and
+exhibits the equality count as displayed, not adopted. Declared audit
+inputs are this note and the axiom memo; the runner writes no cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q8_mixed3_cov8_freedom_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q8_mixed3_cov8_freedom_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q8_mixed3_cov8_freedom_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py
+runner_sha256: b4df6998b3834c64f4be8b67fe29a343ac3561b39f510d45ad545aca65e8e6d4
+input_fingerprint_sha256: 06b36c48c53cad949b54633222f192599e74bb047f498df0a27594e61cec234b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+n_eight_site_seeds=495
+N_Q8=30
+N_Q8_false=2
+N_pairs=15
+N_equal=1
+N_diff=14
+q8_false=[(0, 0, 0, 0, 0), (0, 0, 0, 0, 1)]
+q8_false_cov8=[0, 0]
+equal_pairs=[((0, 1, 0, 0, 0), (0, 1, 0, 0, 1), 1)]
+lex_first_diff=(0, 0, 0, 1, 0) cov8=44; (0, 0, 0, 1, 1) cov8=132
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-eight-site-seeds the two-cube has twelve vertices and 495 eight-site seeds
+PASS: thm1-q8-thirty-maps-as-fifteen-pairs Q8 is true on exactly 30 maps, grouped as 15 mixed3-pairs
+PASS: thm1-one-of-fifteen-pairs-equal exactly one of the 15 Q8-true mixed3-pairs has equal cov8
+PASS: thm2-lex-first-diff-pair lex-first unequal pair is (0,0,0,1,0) cov8=44 versus (0,0,0,1,1) cov8=132
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted mixed3, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-freedom the note reports N_equal=1, the equal opp2 pair, and the lex-first differing pair
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-6539 the residual is integer-cov8 mixed3 freedom inside Q8, not leftover-character of #6539
+PASS: claim-scope-mixed3-freedom claim_scope reports whether mixed3-pairs among the 30 Q8-true maps have equal cov8
+PASS: thm3-display-only the equality count and the differing pair are displayed; mixed3 is not adopted
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every Q8-true F_cut map is scored by how many of the 495 eight-site seeds it fills
+per_block: checked exactly — mixed3-pair cov8 equality is counted on the 15 Q8-true pairs
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py
+++ b/scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Among Q8-true F_cut maps, whether mixed3-pairs have equal cov8.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov8(f) is the number of unordered 8-site seeds from
+which f fills. Q8 is the remaining-bit predicate wt1 OR opp2 OR adj2 OR
+vertex3; it ignores mixed3. f_L1 is the unbalanced-axis predicate (some
+n_mu != 0), never Hamming |c|_1 mod 2. The mixed3-pair cov8 equality
+count inside the 30 Q8-true maps is displayed; mixed3 is not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Bits = tuple[int, ...]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+EIGHT_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 8)
+)
+NEIGHBOR_INDICES: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Bits = (1, 0, 1, 1, 1)
+Q8_FALSE_PREFIX: Bits = (0, 0, 0, 0)
+LEX_FIRST_DIFF_PREFIX: Bits = (0, 0, 0, 1)
+EQUAL_PAIR_PREFIX: Bits = (0, 1, 0, 0)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Bits) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def q8(remaining: Bits) -> bool:
+    """wt1 OR opp2 OR adj2 OR vertex3. Ignores mixed3."""
+    return remaining[0] == 1 or remaining[1] == 1 or remaining[2] == 1 or remaining[3] == 1
+
+
+def fire_table(remaining: Bits) -> dict[Config, int]:
+    return {
+        config: remaining_value(config, remaining)  # type: ignore[misc]
+        for config in product((0, 1), repeat=6)
+    }
+
+
+def fills_from_mask(seed_mask: int, table: dict[Config, int]) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            config = tuple(
+                1 if neighbor is not None and (locked >> neighbor) & 1 else 0
+                for neighbor in NEIGHBOR_INDICES[site_index]
+            )
+            if table[config]:  # type: ignore[index]
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def coverage(remaining: Bits) -> int:
+    table = fire_table(remaining)
+    total = 0
+    for combo in combinations(range(12), 8):
+        seed_mask = 0
+        for index in combo:
+            seed_mask |= 1 << index
+        if fills_from_mask(seed_mask, table):
+            total += 1
+    return total
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> Bits:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Bits:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: Bits, orbit_types: tuple[OrbitType, ...]
+) -> Bits:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[Bits]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[Bits] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        members.append(remaining_bits_from_assignment(assignment))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    cov_by_remaining = {remaining: coverage(remaining) for remaining in members}
+    q8_true = sorted(remaining for remaining in members if q8(remaining))
+    q8_false = sorted(remaining for remaining in members if not q8(remaining))
+    prefixes = sorted({remaining[:4] for remaining in q8_true})
+    pair_rows = []
+    for prefix in prefixes:
+        f0 = prefix + (0,)
+        f1 = prefix + (1,)
+        pair_rows.append((f0, f1, cov_by_remaining[f0], cov_by_remaining[f1]))
+    equal_rows = [row for row in pair_rows if row[2] == row[3]]
+    diff_rows = [row for row in pair_rows if row[2] != row[3]]
+    n_equal = len(equal_rows)
+    n_diff = len(diff_rows)
+    lex_first_diff = diff_rows[0]
+    equal_pair = equal_rows[0] if equal_rows else None
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_eight_site_seeds={len(EIGHT_SITE_SEEDS)}")
+    print(f"N_Q8={len(q8_true)}")
+    print(f"N_Q8_false={len(q8_false)}")
+    print(f"N_pairs={len(pair_rows)}")
+    print(f"N_equal={n_equal}")
+    print(f"N_diff={n_diff}")
+    print(f"q8_false={q8_false}")
+    print(f"q8_false_cov8={[cov_by_remaining[remaining] for remaining in q8_false]}")
+    print(f"equal_pairs={[(row[0], row[1], row[2]) for row in equal_rows]}")
+    print(
+        "lex_first_diff="
+        f"{lex_first_diff[0]} cov8={lex_first_diff[2]}; "
+        f"{lex_first_diff[1]} cov8={lex_first_diff[3]}"
+    )
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_hamming_bits={ham_bits}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_Q8_MIXED3_COV8_FREEDOM_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(set(members)) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        ),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and l1_remaining == L1_REMAINING
+        and q8(l1_remaining)
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-eight-site-seeds",
+        "the two-cube has twelve vertices and 495 eight-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(EIGHT_SITE_SEEDS) == 495
+        and len(set(EIGHT_SITE_SEEDS)) == 495
+        and all(seed <= set(TWO_CUBE) and len(seed) == 8 for seed in EIGHT_SITE_SEEDS),
+    )
+    checks.check(
+        "thm1-q8-thirty-maps-as-fifteen-pairs",
+        "Q8 is true on exactly 30 maps, grouped as 15 mixed3-pairs",
+        len(q8_true) == 30
+        and len(q8_false) == 2
+        and q8_false == [(0, 0, 0, 0, 0), (0, 0, 0, 0, 1)]
+        and all(cov_by_remaining[remaining] == 0 for remaining in q8_false)
+        and all(cov_by_remaining[remaining] > 0 for remaining in q8_true)
+        and len(prefixes) == 15
+        and Q8_FALSE_PREFIX not in prefixes
+        and all(q8(prefix + (0,)) and q8(prefix + (1,)) for prefix in prefixes)
+        and all(not q8(Q8_FALSE_PREFIX + (bit,)) for bit in (0, 1)),
+    )
+    checks.check(
+        "thm1-one-of-fifteen-pairs-equal",
+        "exactly one of the 15 Q8-true mixed3-pairs has equal cov8",
+        n_equal == 1
+        and n_diff == 14
+        and n_equal + n_diff == 15
+        and equal_pair is not None
+        and equal_pair[0] == EQUAL_PAIR_PREFIX + (0,)
+        and equal_pair[1] == EQUAL_PAIR_PREFIX + (1,)
+        and equal_pair[2] == 1
+        and equal_pair[3] == 1
+        and "N_equal = 1" in note
+        and "N_diff = 14" in note,
+    )
+    checks.check(
+        "thm2-lex-first-diff-pair",
+        "lex-first unequal pair is (0,0,0,1,0) cov8=44 versus (0,0,0,1,1) cov8=132",
+        lex_first_diff[0] == LEX_FIRST_DIFF_PREFIX + (0,)
+        and lex_first_diff[1] == LEX_FIRST_DIFF_PREFIX + (1,)
+        and lex_first_diff[2] == 44
+        and lex_first_diff[3] == 132
+        and prefixes[0] == LEX_FIRST_DIFF_PREFIX
+        and cov_by_remaining[(0, 0, 0, 1, 0)] == 44
+        and cov_by_remaining[(0, 0, 0, 1, 1)] == 132
+        and "cov8((0, 0, 0, 1, 0)) = 44" in note
+        and "cov8((0, 0, 0, 1, 1)) = 132" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted mixed3, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-freedom",
+        "the note reports N_equal=1, the equal opp2 pair, and the lex-first differing pair",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "N_equal = 1" in note
+        and "(0, 1, 0, 0, 0)" in note
+        and "(0, 1, 0, 0, 1)" in note
+        and "(0, 0, 0, 1, 0)" in note
+        and "(0, 0, 0, 1, 1)" in note
+        and "Q8 = wt1 ∨ opp2 ∨ adj2 ∨ vertex3" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write mixed3 into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-6539",
+        "the residual is integer-cov8 mixed3 freedom inside Q8, not leftover-character of #6539",
+        "Not leftover-character of #6539" in note
+        and "positivity selector" in note
+        and "integer cov8" in note,
+    )
+    checks.check(
+        "claim-scope-mixed3-freedom",
+        "claim_scope reports whether mixed3-pairs among the 30 Q8-true maps have equal cov8",
+        "Among the 30 Q8-true F_cut maps on the two-cube" in note
+        and "off-patch o=0" in note
+        and "whether mixed3-pairs have equal cov8 is reported" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-display-only",
+        "the equality count and the differing pair are displayed; mixed3 is not adopted",
+        "Do not adopt mixed3" in note
+        and "Displayed, not adopted" in note
+        and n_equal == 1
+        and n_diff == 14,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every Q8-true F_cut map is scored by how many of the 495 eight-site seeds it fills")
+    print("per_block: checked exactly — mixed3-pair cov8 equality is counted on the 15 Q8-true pairs")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 30 Q8-true F_cut maps on the two-cube with off-patch o=0, only 1 of 15 mixed3-pairs have equal cov8. The lex-first split is (0,0,0,1,0) versus (0,0,0,1,1) at cov8=44 and 132. Displayed, not adopted.

## Runner

`scripts/f_cut_q8_mixed3_cov8_freedom_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.