### PR TITLE
feat(c10sel): no displayed remaining-bit Q equals cov10>0

### DIFF
--- a/docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,364 @@
+---
+claim_id: f_cut_cov10_positive_selector_search_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether a displayed remaining-bit predicate equals cov10>0 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov10_positive_selector_search_2026_08_15.py
+---
+
+# Remaining-Bit Search for a Positive 10-Site Coverage Selector
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill positivity on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the 66 ten-site seeds, for the
+thirty-two cube-covariant cut maps `F_cut`, against a displayed remaining-bit
+family.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov10_positive_selector_search_2026_08_15.py`](../scripts/f_cut_cov10_positive_selector_search_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6494 showed that `P = cov2>0`, with
+`P := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`. Investment #6476 showed
+that `Max(k)=Max(12-k)` only for `k=4,5`. This note searches a new displayed
+family on the ten-site seeds: `P`, `Q4`, each 1-bit, and every 2-bit OR of
+the five remaining bits. New k-selector after `P=cov2>0`. Duality is not
+assumed: the search does not import Max(k)=Max(12-k).
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov10(f) = |{S : |S|=10 and f fills from S}|`. The boolean scored here is
+`cov10(f)>0`. Then:
+
+- Theorem 1. None of the displayed remaining-bit predicates equals `cov10>0`.
+  The lex-first remaining-bit miss of each displayed `Q` is named below.
+- Theorem 2. `N_pos = 28`. For each displayed `Q`, `N_Q` and `N_both` are
+  reported below.
+- Theorem 3. The displayed family is displayed. Displayed, not adopted.
+  Do not adopt a bit.
+
+Do not write any displayed remaining-bit formula into Admissibility. The
+extra that would have made `P`, `Q4`, a 1-bit, or a 2-bit OR the positivity
+selector at `k=10` is not present.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 66 ten-site seeds of the two-cube. Whether any displayed remaining-bit predicate equals cov10>0, and the counts N_pos, N_Q, N_both, are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov10_positive_selector_search
+target_blocker_text: "whether a displayed remaining-bit predicate equals cov10>0 among the 32 F_cut maps after P=cov2>0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded remaining-bit search against cov10>0; do not adopt a displayed bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. No displayed remaining-bit formula is axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The ten-site seeds are the `C(12,10) = 66` subsets of size 10 in `T`. Then
+`cov10(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov10(f)>0`. Duality is not assumed: `cov10` is scored on
+those 66 seeds and does not import `Max(k)=Max(12-k)`.
+
+The displayed remaining-bit family, in this order, is:
+
+1. `P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`;
+2. `Q4(f) := (wt1 = 1) or (adj2 = 1)`;
+3. each 1-bit: `bit:wt1`, `bit:opp2`, `bit:adj2`, `bit:vertex3`, `bit:mixed3`;
+4. every 2-bit OR: `wt1|opp2`, `wt1|adj2`, `wt1|vertex3`, `wt1|mixed3`,
+   `opp2|adj2`, `opp2|vertex3`, `opp2|mixed3`, `adj2|vertex3`,
+   `adj2|mixed3`, `vertex3|mixed3`.
+
+Displayed, not adopted. `wt1|adj2` is the same formula as `Q4`.
+
+## Theorem 1 — none of the displayed Q equals `cov10>0`
+
+Enumerate all 32 remaining-bit tuples of `F_cut` and score `cov10` on the 66
+ten-site seeds. For each displayed `Q`, compare the set of maps with
+`Q` true to the set of maps with `cov10>0`.
+
+None of the displayed remaining-bit predicates equals `cov10>0`.
+
+The four maps with `cov10 = 0` are
+
+```text
+(0, 0, 0, 0, 0), (0, 1, 0, 0, 0), (1, 0, 0, 0, 0), (1, 1, 0, 0, 0).
+```
+
+They are exactly the maps with `(adj2, vertex3, mixed3) = (0, 0, 0)`. The
+fourteen `P`-false maps that still have `cov10>0` begin at the lex-first
+miss `(0, 0, 0, 0, 1)`.
+
+The lex-first remaining-bit miss of each displayed `Q`, in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`, is:
+
+- `P`: lex-first miss `(0, 0, 0, 0, 1)`
+- `Q4`: lex-first miss `(0, 0, 0, 0, 1)`
+- `bit:wt1`: lex-first miss `(0, 0, 0, 0, 1)`
+- `bit:opp2`: lex-first miss `(0, 0, 0, 0, 1)`
+- `bit:adj2`: lex-first miss `(0, 0, 0, 0, 1)`
+- `bit:vertex3`: lex-first miss `(0, 0, 0, 0, 1)`
+- `bit:mixed3`: lex-first miss `(0, 0, 0, 1, 0)`
+- `wt1|opp2`: lex-first miss `(0, 0, 0, 0, 1)`
+- `wt1|adj2`: lex-first miss `(0, 0, 0, 0, 1)`
+- `wt1|vertex3`: lex-first miss `(0, 0, 0, 0, 1)`
+- `wt1|mixed3`: lex-first miss `(0, 0, 0, 1, 0)`
+- `opp2|adj2`: lex-first miss `(0, 0, 0, 0, 1)`
+- `opp2|vertex3`: lex-first miss `(0, 0, 0, 0, 1)`
+- `opp2|mixed3`: lex-first miss `(0, 0, 0, 1, 0)`
+- `adj2|vertex3`: lex-first miss `(0, 0, 0, 0, 1)`
+- `adj2|mixed3`: lex-first miss `(0, 0, 0, 1, 0)`
+- `vertex3|mixed3`: lex-first miss `(0, 0, 1, 0, 0)`
+
+## Theorem 2 — `N_pos` and, for each displayed Q, `N_Q` and `N_both`
+
+Among the 32 maps, `N_pos = 28` maps have `cov10>0`.
+
+For each displayed `Q`, write `N_Q` for the number of maps with `Q` true
+and `N_both` for the number of maps with both `Q` true and `cov10>0`:
+
+- `P`: N_Q = 14, N_both = 14
+- `Q4`: N_Q = 24, N_both = 22
+- `bit:wt1`: N_Q = 16, N_both = 14
+- `bit:opp2`: N_Q = 16, N_both = 14
+- `bit:adj2`: N_Q = 16, N_both = 16
+- `bit:vertex3`: N_Q = 16, N_both = 16
+- `bit:mixed3`: N_Q = 16, N_both = 16
+- `wt1|opp2`: N_Q = 24, N_both = 21
+- `wt1|adj2`: N_Q = 24, N_both = 22
+- `wt1|vertex3`: N_Q = 24, N_both = 22
+- `wt1|mixed3`: N_Q = 24, N_both = 22
+- `opp2|adj2`: N_Q = 24, N_both = 22
+- `opp2|vertex3`: N_Q = 24, N_both = 22
+- `opp2|mixed3`: N_Q = 24, N_both = 22
+- `adj2|vertex3`: N_Q = 24, N_both = 24
+- `adj2|mixed3`: N_Q = 24, N_both = 24
+- `vertex3|mixed3`: N_Q = 24, N_both = 24
+
+The row `wt1|adj2` recovers the `Q4` counts `N_Q = 24`, `N_both = 22`
+against the same `N_pos = 28`. No displayed row has `N_Q = N_both = N_pos`.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, has `cov10 = 66 > 0`. That
+is consistent with Theorem 2 and does not restore equality for any
+displayed `Q`.
+
+## Theorem 3 — display; do not adopt a bit
+
+Every predicate above is displayed. Displayed, not adopted. Do not adopt a
+bit. Do not write any displayed remaining-bit formula into Admissibility.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 66 ten-site seeds, off-patch `o=0` | declared finite patch |
+| displayed `P`, `Q4`, 1-bit, 2-bit OR family | displayed, not adopted |
+| some displayed `Q` equals `cov10>0` | fails; none; lex-first miss of each named |
+| `N_pos = 28` and per-`Q` `N_Q`, `N_both` | proved by exhaustive scoring |
+| leftover-character of #6494 | refused; new k-selector after `P=cov2>0` |
+| leftover-character of #6476 | refused; duality is not assumed |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6494: that closed `cov2>0` as `P`, with
+`P := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)`. The present object is a
+search over a displayed remaining-bit family on the ten-site seeds, not a
+restatement that `P` equals two-site positivity.
+
+Not leftover-character of #6476: that closed `Max(k)=Max(12-k)` only for
+`k=4,5`. Duality is not assumed here. New k-selector: `cov10` is scored on
+the 66 ten-site seeds and does not import `Max(k)=Max(12-k)`.
+
+The note is not a Max(10) ranking and not a seed-table: maximizers of
+`cov10` are not selected, and no seed census of a named map is compiled.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not adopt a bit.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether any displayed remaining-bit predicate equals `cov10>0` inside `F_cut` on this patch. |
+| V2 | Current main has the axiom memo and the #6494 fact that `P=cov2>0`, but no landed remaining-bit search at `k=10`. |
+| V3 | The 32 maps, 66 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a displayed remaining-bit family. |
+| V5 | Equality fails for every displayed `Q`, and no bit is adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: none of the displayed remaining-bit
+predicates equals `cov10>0` among the 32 `F_cut` maps on this patch. No
+global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of #6494 | treat the search as leftover-character of `P=cov2>0` | **ATTEMPTED** |
+| leftover of #6476 | replace the `k=10` score by `Max(k)=Max(12-k)` | **ATTEMPTED** |
+| adopt a bit | write a displayed remaining-bit formula into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch count to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed equalities, the Hamming contrast, the #6494 `P` identity, the
+#6476 Max restriction, and the off-patch convention are distinct. This note
+claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 66 ten-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the displayed
+family are declared. Equality of any displayed `Q` with `cov10>0` is not
+silently assumed. Duality is not assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is whether a displayed
+remaining-bit predicate equals 10-site positivity on the declared patch, not
+leftover-character of #6494, and not a Max-duality ranking.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 66 seeds | no physical law selection |
+| per block | `N_pos` and per-`Q` `N_Q`, `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector outside the displayed remaining-bit family, and any independently
+derived physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** after `P=cov2>0`, and with Max duality only at `k=4,5`, a
+1-bit, `P`, `Q4`, or some 2-bit OR must be the positivity selector at
+`k=10`.
+
+**Answer:** None of those seventeen displayed predicates equals `cov10>0`.
+`N_pos = 28`. `P` has `N_Q = 14` and `N_both = 14`. `Q4` has `N_Q = 24`
+and `N_both = 22`. The closest 2-bit OR rows have `N_Q = 24` and
+`N_both = 24`, and still miss `(0, 0, 0, 0, 1)`, `(0, 0, 0, 1, 0)`, or
+`(0, 0, 1, 0, 0)`. No bit is adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6494 already showed that `cov2>0` is `P`. Echoing that
+two-site identity is not a substitute for scoring the displayed
+remaining-bit family at `k=10`: the seventeen lex-first misses and the
+per-`Q` pair `(N_Q, N_both)` are the new search facts. Duality is not
+assumed.
+
+No-Go Discipline disposition: **PASS** for the finite search and the
+narrow equality failure. FAIL / DO NOT SHIP for “a displayed remaining-bit
+predicate equals `cov10>0`” or “a displayed bit is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov10` on the
+66 ten-site seeds, compares positivity with each displayed remaining-bit
+predicate, reports that none equals `cov10>0`, names the lex-first miss of
+each displayed `Q`, and reports `N_pos = 28` together with per-`Q` `N_Q`
+and `N_both`. Declared audit inputs are this note and the axiom memo; the
+runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov10_positive_selector_search_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov10_positive_selector_search_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov10_positive_selector_search_2026_08_15.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov10_positive_selector_search_2026_08_15.py
+runner_sha256: 7706a4a7baee1664d8f7b80028524e6caaeb905598435b3357eec8bde2601ccf
+input_fingerprint_sha256: ca070e88e6c4c6cd28a5c9032afb843d78d8a7f5030a14035a6b06285a6fc3db
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed remaining-bit family versus cov10>0; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_ten_site_seeds=66
+N_pos=28
+n_displayed=17
+n_equal=0
+cov10(f_L1)=66
+cov10=0=((0, 0, 0, 0, 0), (0, 1, 0, 0, 0), (1, 0, 0, 0, 0), (1, 1, 0, 0, 0))
+P N_Q=14 N_both=14 equal=0 lex_miss=(0, 0, 0, 0, 1)
+Q4 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 0, 1)
+bit:wt1 N_Q=16 N_both=14 equal=0 lex_miss=(0, 0, 0, 0, 1)
+bit:opp2 N_Q=16 N_both=14 equal=0 lex_miss=(0, 0, 0, 0, 1)
+bit:adj2 N_Q=16 N_both=16 equal=0 lex_miss=(0, 0, 0, 0, 1)
+bit:vertex3 N_Q=16 N_both=16 equal=0 lex_miss=(0, 0, 0, 0, 1)
+bit:mixed3 N_Q=16 N_both=16 equal=0 lex_miss=(0, 0, 0, 1, 0)
+wt1|opp2 N_Q=24 N_both=21 equal=0 lex_miss=(0, 0, 0, 0, 1)
+wt1|adj2 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 0, 1)
+wt1|vertex3 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 0, 1)
+wt1|mixed3 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 1, 0)
+opp2|adj2 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 0, 1)
+opp2|vertex3 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 0, 1)
+opp2|mixed3 N_Q=24 N_both=22 equal=0 lex_miss=(0, 0, 0, 1, 0)
+adj2|vertex3 N_Q=24 N_both=24 equal=0 lex_miss=(0, 0, 0, 0, 1)
+adj2|mixed3 N_Q=24 N_both=24 equal=0 lex_miss=(0, 0, 0, 1, 0)
+vertex3|mixed3 N_Q=24 N_both=24 equal=0 lex_miss=(0, 0, 1, 0, 0)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 66 ten-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-none-equal no displayed remaining-bit Q equals cov10>0
+PASS: thm1-lex-first-misses the note names the lex-first miss of each displayed Q
+PASS: thm2-n-pos-and-per-q N_pos=28 and each displayed Q reports N_Q and N_both
+PASS: thm3-display-not-adopt the displayed family is displayed and no bit is adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the remaining-bit search against cov10>0 and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-6494-6476 the residual is a new k-selector search; duality is not assumed
+PASS: displayed-family-shape displayed Q are P, Q4, the 5 one-bits, and 10 two-bit ORs
+PASS: independent-k-ten cov10 is scored on the 66 ten-site seeds; Max duality is not used
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 66 ten-site seeds against the displayed remaining-bit family
+per_block: checked exactly — N_pos and per-Q N_Q, N_both are the F_cut positivity-versus-displayed-Q counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov10_positive_selector_search_2026_08_15.py
+++ b/scripts/f_cut_cov10_positive_selector_search_2026_08_15.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""Whether any displayed remaining-bit Q equals cov10>0 on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov10(f) is the number of ten-site seeds from which
+f fills. Displayed Q are P, Q4, each 1-bit, and every 2-bit OR of remaining
+bits. The runner reports whether any displayed Q equals positivity, the
+lex-first miss of each, N_pos, and per-Q N_Q and N_both. It does not adopt
+a bit. Duality is not assumed. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+from typing import Callable
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+Selector = Callable[[Remaining], bool]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+DISPLAYED_NAMES: tuple[str, ...] = (
+    "P",
+    "Q4",
+    "bit:wt1",
+    "bit:opp2",
+    "bit:adj2",
+    "bit:vertex3",
+    "bit:mixed3",
+    "wt1|opp2",
+    "wt1|adj2",
+    "wt1|vertex3",
+    "wt1|mixed3",
+    "opp2|adj2",
+    "opp2|vertex3",
+    "opp2|mixed3",
+    "adj2|vertex3",
+    "adj2|mixed3",
+    "vertex3|mixed3",
+)
+ZERO_REMAINING: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 1, 0, 0, 0),
+    (1, 0, 0, 0, 0),
+    (1, 1, 0, 0, 0),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def displayed_selectors() -> list[tuple[str, Selector]]:
+    labels = REMAINING_LABELS
+    items: list[tuple[str, Selector]] = [
+        ("P", lambda r: r[0] == 1 and (r[2], r[3], r[4]) != (0, 0, 0)),
+        ("Q4", lambda r: r[0] == 1 or r[2] == 1),
+    ]
+    for i, lab in enumerate(labels):
+        items.append((f"bit:{lab}", lambda r, i=i: r[i] == 1))
+    for i in range(5):
+        for j in range(i + 1, 5):
+            items.append(
+                (f"{labels[i]}|{labels[j]}", lambda r, i=i, j=j: r[i] == 1 or r[j] == 1)
+            )
+    return items
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print("negative_scope: displayed remaining-bit family versus cov10>0; does not adopt a bit")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(10)
+    selectors = displayed_selectors()
+    rows: list[tuple[Remaining, int]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov))
+
+    remaining_order = sorted(remaining for remaining, _cov in rows)
+    pos_set = {remaining for remaining, cov in rows if cov > 0}
+    n_pos = len(pos_set)
+    cov_by_remaining = {remaining: cov for remaining, cov in rows}
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+    zeros = tuple(sorted(remaining for remaining, cov in rows if cov == 0))
+
+    scored: list[tuple[str, int, int, bool, Remaining | None]] = []
+    for name, predq in selectors:
+        q_true = {remaining for remaining, _cov in rows if predq(remaining)}
+        n_q = len(q_true)
+        n_both = len(q_true & pos_set)
+        equal = q_true == pos_set
+        misses = [remaining for remaining in remaining_order if predq(remaining) != (remaining in pos_set)]
+        lex_miss = misses[0] if misses else None
+        scored.append((name, n_q, n_both, equal, lex_miss))
+
+    n_equal = sum(1 for _name, _n_q, _n_both, equal, _miss in scored if equal)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_ten_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"n_displayed={len(scored)}")
+    print(f"n_equal={n_equal}")
+    print(f"cov10(f_L1)={cov_l1}")
+    print(f"cov10=0={zeros}")
+    for name, n_q, n_both, equal, lex_miss in scored:
+        print(f"{name} N_Q={n_q} N_both={n_both} equal={int(equal)} lex_miss={lex_miss}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV10_POSITIVE_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 66 ten-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 66
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and cov_l1 == cov_by_remaining[L1_REMAINING]
+        and cov_l1 > 0,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-none-equal",
+        "no displayed remaining-bit Q equals cov10>0",
+        n_equal == 0
+        and len(scored) == 17
+        and all(not equal for _name, _n_q, _n_both, equal, _miss in scored)
+        and "None of the displayed remaining-bit predicates equals" in note,
+    )
+    miss_lines_ok = all(
+        f"`{name}`: lex-first miss `{lex_miss}`" in note
+        for name, _n_q, _n_both, _equal, lex_miss in scored
+        if lex_miss is not None
+    )
+    checks.check(
+        "thm1-lex-first-misses",
+        "the note names the lex-first miss of each displayed Q",
+        all(lex_miss is not None for _name, _n_q, _n_both, _equal, lex_miss in scored)
+        and miss_lines_ok
+        and zeros == ZERO_REMAINING,
+    )
+    count_lines_ok = all(
+        f"`{name}`: N_Q = {n_q}, N_both = {n_both}" in note
+        for name, n_q, n_both, _equal, _miss in scored
+    )
+    checks.check(
+        "thm2-n-pos-and-per-q",
+        f"N_pos={n_pos} and each displayed Q reports N_Q and N_both",
+        n_pos == 28
+        and f"N_pos = {n_pos}" in note
+        and count_lines_ok
+        and any(name == "P" and n_q == 14 and n_both == 14 for name, n_q, n_both, _e, _m in scored)
+        and any(name == "Q4" and n_q == 24 and n_both == 22 for name, n_q, n_both, _e, _m in scored),
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the displayed family is displayed and no bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "does not adopt a bit" in self_source
+        and "Do not write any displayed remaining-bit formula into Admissibility" in note,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "a displayed remaining-bit predicate equals cov10>0 is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the remaining-bit search against cov10>0 and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not adopt a bit" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-6494-6476",
+        "the residual is a new k-selector search; duality is not assumed",
+        "Not leftover-character of #6494" in note
+        and "Not leftover-character of #6476" in note
+        and "New k-selector" in note
+        and "Duality is not assumed" in note
+        and "does not adopt a bit" in self_source,
+    )
+    checks.check(
+        "displayed-family-shape",
+        "displayed Q are P, Q4, the 5 one-bits, and 10 two-bit ORs",
+        [name for name, _n_q, _n_both, _equal, _miss in scored] == list(DISPLAYED_NAMES),
+    )
+    checks.check(
+        "independent-k-ten",
+        "cov10 is scored on the 66 ten-site seeds; Max duality is not used",
+        len(seeds) == 66
+        and "seed_masks_for(10)" in self_source
+        and "Max(k)=Max(12-k)" in note
+        and "Duality is not assumed" in note
+        and "does not import Max(k)=Max(12-k)" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 66 ten-site seeds against the displayed remaining-bit family")
+    print("per_block: checked exactly — N_pos and per-Q N_Q, N_both are the F_cut positivity-versus-displayed-Q counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, no displayed remaining-bit predicate equals cov10>0. N_pos=28. Displayed, not adopted.

## Runner

`scripts/f_cut_cov10_positive_selector_search_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.