### PR TITLE
feat(mix3sel): no 1-bit or 2-bit Q equals mixed3 cov8-equality

### DIFF
--- a/docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,414 @@
+---
+claim_id: f_cut_q8_mixed3_cov8_equality_selector_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 15 Q8-true mixed3-pairs of F_cut on the two-cube with off-patch o=0, whether a displayed remaining-bit predicate equals cov8-equality is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py
+---
+
+# Remaining-Bit Search For Mixed3 Cov8 Equality Inside Q8
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact 8-site occupancy-to-lock coverage of the 30 Q8-true
+cube-covariant complement-even maps in `F_cut`, on the twelve-vertex
+two-cube, with off-patch occupancy `0`. Those 30 maps form 15 pairs that
+differ only by the remaining bit `mixed3`. Whether a displayed 1-bit or
+2-bit predicate on the four free bits `(wt1, opp2, adj2, vertex3)` equals
+`cov8`-equality on those pairs is reported. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py`](../scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment mix3c8 reported that only 1 of the 15 Q8-true mixed3-pairs has
+equal `cov8`, and that the lex-first split is `(0, 0, 0, 1, 0)` versus
+`(0, 0, 0, 1, 1)`. That residual asked an equality count. New selector on the 15 pairs: this note searches remaining-bit predicates on the four free
+bits `(wt1, opp2, adj2, vertex3)` for whether
+`Equal(f) := cov8(f) = cov8(f` with mixed3 flipped`)`. Not leftover-character of mix3c8: that was the count `N_eq = 1` and the named split, not an iff
+against a displayed 1-bit or 2-bit family.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 8-subset of vertices
+is an 8-site seed. There are `C(12,8)=495` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. Fill means
+the halt set has cardinality 12. Coverage is
+
+```text
+cov8(f) = |{ S : |S|=8 and f fills from S }|.
+```
+
+A blank-block is a different rule and is not used.
+
+`Q8 = wt1 ∨ opp2 ∨ adj2 ∨ vertex3`. It ignores `mixed3`. The 30 Q8-true
+maps form 15 pairs that share a four-bit prefix and differ only in
+`mixed3`. For a prefix `p = (wt1, opp2, adj2, vertex3)`,
+
+```text
+Equal(p) := cov8(p+(0,)) = cov8(p+(1,)).
+```
+
+The displayed remaining-bit family, in this order, is:
+
+1. each 1-bit: `bit:wt1`, `bit:opp2`, `bit:adj2`, `bit:vertex3`;
+2. every 2-bit AND of those four bits, in remaining-bit order;
+3. every 2-bit OR of those four bits, in remaining-bit order.
+
+Then:
+
+- Theorem 1. None of the displayed 1-bit or 2-bit predicates equals
+  `Equal`. The lex-first miss of each displayed `Q` is named below.
+- Theorem 2. `N_eq = 1`. For each displayed `Q`, `N_Q` and `N_both` are
+  reported below.
+- Theorem 3. The displayed family is displayed. Displayed, not adopted.
+  Do not adopt a bit.
+
+Do not write any displayed remaining-bit formula into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Independent 8-site coverage of the 30 Q8-true F_cut maps, grouped as 15 mixed3-pairs, is scored against a displayed 1-bit and 2-bit remaining-bit family for equality with Equal. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q8_mixed3_cov8_equality_selector
+target_blocker_text: "whether a displayed remaining-bit predicate equals cov8-equality among the 15 Q8-true mixed3-pairs"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed remaining-bit search against cov8-equality; do not adopt a displayed bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. No displayed remaining-bit formula is axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The eight-site seeds are the `C(12,8) = 495` subsets of size 8 in `T`. Then
+`cov8(f)` is the number of those subsets from which `f` fills.
+
+`Q8` is true exactly when at least one of `wt1`, `opp2`, `adj2`, `vertex3`
+is 1. The two Q8-false maps are `(0, 0, 0, 0, 0)` and `(0, 0, 0, 0, 1)`.
+The other 30 maps form 15 pairs ordered by the four-bit prefix in lex
+order. `Equal` is a predicate on those 15 prefixes.
+
+The displayed remaining-bit family is the four 1-bit predicates and every
+2-bit AND or 2-bit OR of `(wt1, opp2, adj2, vertex3)`, listed in
+Theorem 1. Displayed, not adopted.
+
+## Theorems
+
+### Theorem 1 — no displayed 1-bit or 2-bit `Q` equals `Equal`
+
+There are exactly 24 proper cube rotations and exactly 10 orbits on
+`{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis map
+`f_L1` is one element of `F_cut` and is not Hamming parity. Its remaining
+bits are `(1, 0, 1, 1, 1)`, so it is Q8-true.
+
+`Q8` holds on exactly 30 of the 32 maps. Those 30 maps are 15 pairs
+differing only by `mixed3`. Exhaustive `cov8` on all 495 eight-site seeds
+gives `N_eq = 1` and `N_diff = 14`. The one equal pair is the `opp2`-only
+prefix
+
+```text
+(0, 1, 0, 0, 0)  cov8 = 1
+(0, 1, 0, 0, 1)  cov8 = 1
+```
+
+The lex-first pair that differs is still
+
+```text
+cov8((0, 0, 0, 1, 0)) = 44
+cov8((0, 0, 0, 1, 1)) = 132
+```
+
+None of the sixteen displayed predicates equals `Equal`. None of the
+displayed 1-bit or 2-bit predicates isolates the unique equal prefix
+`(0, 1, 0, 0)`.
+
+The lex-first remaining-bit miss of each displayed `Q`, in the prefix
+order `(wt1, opp2, adj2, vertex3)`, is:
+
+- `bit:wt1`: lex-first miss `(0, 1, 0, 0)`
+- `bit:opp2`: lex-first miss `(0, 1, 0, 1)`
+- `bit:adj2`: lex-first miss `(0, 0, 1, 0)`
+- `bit:vertex3`: lex-first miss `(0, 0, 0, 1)`
+- `wt1 AND opp2`: lex-first miss `(0, 1, 0, 0)`
+- `wt1 AND adj2`: lex-first miss `(0, 1, 0, 0)`
+- `wt1 AND vertex3`: lex-first miss `(0, 1, 0, 0)`
+- `opp2 AND adj2`: lex-first miss `(0, 1, 0, 0)`
+- `opp2 AND vertex3`: lex-first miss `(0, 1, 0, 0)`
+- `adj2 AND vertex3`: lex-first miss `(0, 0, 1, 1)`
+- `wt1 OR opp2`: lex-first miss `(0, 1, 0, 1)`
+- `wt1 OR adj2`: lex-first miss `(0, 0, 1, 0)`
+- `wt1 OR vertex3`: lex-first miss `(0, 0, 0, 1)`
+- `opp2 OR adj2`: lex-first miss `(0, 0, 1, 0)`
+- `opp2 OR vertex3`: lex-first miss `(0, 0, 0, 1)`
+- `adj2 OR vertex3`: lex-first miss `(0, 0, 0, 1)`
+
+### Theorem 2 — `N_eq` and, for each displayed Q, `N_Q` and `N_both`
+
+Among the 15 Q8-true mixed3-pairs, `N_eq = 1` prefix has `Equal` true.
+
+For each displayed `Q`, write `N_Q` for the number of prefixes with `Q`
+true and `N_both` for the number of prefixes with both `Q` true and
+`Equal` true:
+
+- `bit:wt1`: N_Q = 8, N_both = 0
+- `bit:opp2`: N_Q = 8, N_both = 1
+- `bit:adj2`: N_Q = 8, N_both = 0
+- `bit:vertex3`: N_Q = 8, N_both = 0
+- `wt1 AND opp2`: N_Q = 4, N_both = 0
+- `wt1 AND adj2`: N_Q = 4, N_both = 0
+- `wt1 AND vertex3`: N_Q = 4, N_both = 0
+- `opp2 AND adj2`: N_Q = 4, N_both = 0
+- `opp2 AND vertex3`: N_Q = 4, N_both = 0
+- `adj2 AND vertex3`: N_Q = 4, N_both = 0
+- `wt1 OR opp2`: N_Q = 12, N_both = 1
+- `wt1 OR adj2`: N_Q = 12, N_both = 0
+- `wt1 OR vertex3`: N_Q = 12, N_both = 0
+- `opp2 OR adj2`: N_Q = 12, N_both = 1
+- `opp2 OR vertex3`: N_Q = 12, N_both = 1
+- `adj2 OR vertex3`: N_Q = 12, N_both = 0
+
+Every 1-bit predicate has `N_Q = 8 ≠ 1`. Every 2-bit AND has
+`N_Q = 4 ≠ 1`. Every 2-bit OR has `N_Q = 12 ≠ 1`. No displayed row has
+`N_Q = N_both = N_eq`.
+
+`f_L1` has remaining bits `(1, 0, 1, 1, 1)` and prefix `(1, 0, 1, 1)`.
+That pair is unequal (`cov8 = 446` versus `494`), so `Equal` is false on
+the `f_L1` prefix. That is consistent with Theorem 2 and does not restore
+equality for any displayed `Q`.
+
+### Theorem 3 — display; do not adopt a bit
+
+Every predicate above is displayed. Displayed, not adopted. Do not adopt a
+bit. Do not write any displayed remaining-bit formula into Admissibility.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` remaining-bit order | enumerated |
+| `Q8 = wt1 ∨ opp2 ∨ adj2 ∨ vertex3` | defined; ignores `mixed3` |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 495 eight-site seeds, off-patch `o=0` | declared finite patch |
+| 15 Q8-true mixed3-pairs and `Equal` | enumerated |
+| displayed 1-bit and 2-bit family on four free bits | displayed, not adopted |
+| some displayed `Q` equals `Equal` | fails; none; lex-first miss of each named |
+| `N_eq = 1` and per-`Q` `N_Q`, `N_both` | proved by exhaustive scoring |
+| leftover-character of mix3c8 | refused; new selector on the 15 pairs |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of mix3c8: that displayed the equality count
+`N_eq = 1` and the lex-first differing pair. The present object is whether
+`Equal` iff any displayed 1-bit or 2-bit predicate on the four free bits.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not adopt a bit.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether any displayed 1-bit or 2-bit remaining-bit predicate equals `cov8`-equality on the 15 Q8-true mixed3-pairs. |
+| V2 | mix3c8 supplied the equality count and the lex-first split, but no landed 1-bit or 2-bit iff search for `Equal`. |
+| V3 | The 30 maps, 495 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores `Equal` against a displayed remaining-bit family. |
+| V5 | Equality fails for every displayed `Q`, and no bit is adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: none of the displayed 1-bit or 2-bit
+predicates equals `Equal` among the 15 Q8-true mixed3-pairs on this
+patch. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover mix3c8 | treat the search as leftover-character of the equality count | **ATTEMPTED** |
+| leftover Q8-positivity | treat integer-`cov8` equality as leftover-character of `cov8>0` | **ATTEMPTED** |
+| adopt a bit | write a displayed remaining-bit formula into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch count to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed 1-bit tests, the failed 2-bit AND/OR tests, the Hamming
+contrast, the mix3c8 equality count, and the off-patch convention are
+distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 495 eight-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, the predicate
+`Q8`, and the displayed 1-bit and 2-bit family are declared. Equality of
+any displayed `Q` with `Equal` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is whether a displayed
+1-bit or 2-bit remaining-bit predicate equals `cov8`-equality on the
+declared 15 pairs, not leftover-character of mix3c8.
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 30 Q8-true maps on all 495 eight-site seeds | no physical law selection |
+| per block | `Equal` versus each displayed `Q` on the 15 pairs | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+The runner prints the same five resolution statements.
+
+### N6 — live partial-closure paths
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+None of the approved primitives supplies a Boolean occupancy map, a
+seed-coverage ranking, or an Admissibility selector.
+
+Live routes include a different Boolean combination of remaining bits, a
+different seed cardinality, a different off-patch rule, a selector outside
+the displayed 1-bit and 2-bit family, and any independently derived
+physical map from `F_cut` into Admissibility. One partial-closure
+mechanism is displayed rather than suppressed: the unique equal prefix is
+the `opp2`-only pair. That pair does not select `opp2` or `mixed3`.
+
+### N7 — hostile steelman
+
+**Steelman:** because only one of the 15 prefixes is equal, a 1-bit or a
+2-bit AND/OR on the four free bits must recover `Equal`.
+
+**Answer:** Every 1-bit has `N_Q = 8 ≠ 1`. Every 2-bit AND has
+`N_Q = 4 ≠ 1`. Every 2-bit OR has `N_Q = 12 ≠ 1`. The unique equal prefix
+is `(0, 1, 0, 0)`, which is the conjunction of `opp2` with the three
+complementary zeros — a four-bit predicate, not a displayed 1-bit or
+2-bit predicate. No bit is adopted.
+
+### N8 — cross-cycle echo
+
+Investment mix3c8 already displayed `N_eq = 1` and the lex-first split
+`(0, 0, 0, 1, 0)` versus `(0, 0, 0, 1, 1)`. Echoing that equality count is
+not a substitute for scoring the displayed 1-bit and 2-bit family: the
+sixteen lex-first misses and the per-`Q` pair `(N_Q, N_both)` are the new
+search facts.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps; that note's quaternion-axis pair is unused |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No-Go Discipline disposition: **PASS** for the finite search and the
+narrow equality failure. FAIL / DO NOT SHIP for “a displayed remaining-bit
+predicate equals `cov8`-equality” or “a displayed bit is the physical rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov8` on the
+495 eight-site seeds, restricts to the 15 Q8-true mixed3-pairs, compares
+`Equal` with each displayed 1-bit or 2-bit remaining-bit predicate,
+reports that none equals `Equal`, names the lex-first miss of each
+displayed `Q`, and reports `N_eq = 1` together with per-`Q` `N_Q` and
+`N_both`. Declared audit inputs are this note and the axiom memo; the
+runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q8_mixed3_cov8_equality_selector_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.txt
@@ -1,0 +1,79 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py
+runner_sha256: 8d2799252773d7a351bc3d793d158ce8fd798940a29bca9694f1c0f592943007
+input_fingerprint_sha256: 62360a0be028b182ec58607a27c8bae04e693c44fdc95bb0e95c8db7467014fc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed 1-bit and 2-bit remaining-bit family versus cov8-equality on the 15 Q8-true mixed3-pairs; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+free_labels=('wt1', 'opp2', 'adj2', 'vertex3')
+N_free=5
+|F_cut|=32
+n_eight_site_seeds=495
+N_Q8=30
+N_Q8_false=2
+N_pairs=15
+N_eq=1
+N_diff=14
+n_displayed=16
+n_selector_equal=0
+equal_prefixes=[(0, 1, 0, 0)]
+lex_first_diff=(0, 0, 0, 1, 0) cov8=44; (0, 0, 0, 1, 1) cov8=132
+f_L1_remaining=(1, 0, 1, 1, 1)
+f_L1_prefix=(1, 0, 1, 1) cov8=494 partner_cov8=446
+f_hamming_bits=(0, 0, 0, 0, 1, 1, 1, 0, 0, 1)
+bit:wt1 N_Q=8 N_both=0 equal=0 lex_miss=(0, 1, 0, 0)
+bit:opp2 N_Q=8 N_both=1 equal=0 lex_miss=(0, 1, 0, 1)
+bit:adj2 N_Q=8 N_both=0 equal=0 lex_miss=(0, 0, 1, 0)
+bit:vertex3 N_Q=8 N_both=0 equal=0 lex_miss=(0, 0, 0, 1)
+wt1 AND opp2 N_Q=4 N_both=0 equal=0 lex_miss=(0, 1, 0, 0)
+wt1 AND adj2 N_Q=4 N_both=0 equal=0 lex_miss=(0, 1, 0, 0)
+wt1 AND vertex3 N_Q=4 N_both=0 equal=0 lex_miss=(0, 1, 0, 0)
+opp2 AND adj2 N_Q=4 N_both=0 equal=0 lex_miss=(0, 1, 0, 0)
+opp2 AND vertex3 N_Q=4 N_both=0 equal=0 lex_miss=(0, 1, 0, 0)
+adj2 AND vertex3 N_Q=4 N_both=0 equal=0 lex_miss=(0, 0, 1, 1)
+wt1 OR opp2 N_Q=12 N_both=1 equal=0 lex_miss=(0, 1, 0, 1)
+wt1 OR adj2 N_Q=12 N_both=0 equal=0 lex_miss=(0, 0, 1, 0)
+wt1 OR vertex3 N_Q=12 N_both=0 equal=0 lex_miss=(0, 0, 0, 1)
+opp2 OR adj2 N_Q=12 N_both=1 equal=0 lex_miss=(0, 0, 1, 0)
+opp2 OR vertex3 N_Q=12 N_both=1 equal=0 lex_miss=(0, 0, 0, 1)
+adj2 OR vertex3 N_Q=12 N_both=0 equal=0 lex_miss=(0, 0, 0, 1)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 495 eight-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-fifteen-q8-true-pairs Q8 is true on exactly 30 maps, grouped as 15 mixed3-pairs
+PASS: thm1-none-equal no displayed 1-bit or 2-bit Q equals cov8-equality on the 15 pairs
+PASS: thm1-lex-first-misses the note names the lex-first miss of each displayed Q
+PASS: thm2-n-eq-and-per-q N_eq=1 and each displayed Q reports N_Q and N_both
+PASS: thm3-display-not-adopt the displayed family is displayed and no bit is adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the remaining-bit search against cov8-equality
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-mix3c8 the residual is a new selector on the 15 pairs, not leftover mix3c8
+PASS: displayed-family-shape displayed Q are the 4 one-bits, 6 two-bit ANDs, and 6 two-bit ORs
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every Q8-true F_cut map is scored by how many of the 495 eight-site seeds it fills
+per_block: checked exactly — Equal versus each displayed 1-bit or 2-bit Q is scored on the 15 Q8-true mixed3-pairs
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py
+++ b/scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Whether a displayed 1-bit or 2-bit Q equals cov8-equality on 15 pairs.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov8(f) is the number of unordered 8-site seeds from
+which f fills. Q8 is wt1 OR opp2 OR adj2 OR vertex3; it ignores mixed3.
+Among the 15 Q8-true mixed3-pairs, Equal(prefix) means the two maps that
+differ only by mixed3 have the same cov8. Displayed Q are each 1-bit and
+every 2-bit AND or 2-bit OR of (wt1, opp2, adj2, vertex3). The runner
+reports whether Equal iff any displayed Q, the lex-first miss of each if
+none, N_eq, and per-Q N_Q and N_both. It does not adopt a bit. f_L1 is
+the unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+from typing import Callable
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Bits = tuple[int, ...]
+Prefix = tuple[int, int, int, int]
+Selector = Callable[[Prefix], bool]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+EIGHT_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 8)
+)
+NEIGHBOR_INDICES: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+FREE_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3")
+L1_REMAINING: Bits = (1, 0, 1, 1, 1)
+Q8_FALSE_PREFIX: Prefix = (0, 0, 0, 0)
+EQUAL_PAIR_PREFIX: Prefix = (0, 1, 0, 0)
+LEX_FIRST_DIFF_PREFIX: Prefix = (0, 0, 0, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Bits) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def q8(remaining: Bits) -> bool:
+    """wt1 OR opp2 OR adj2 OR vertex3. Ignores mixed3."""
+    return remaining[0] == 1 or remaining[1] == 1 or remaining[2] == 1 or remaining[3] == 1
+
+
+def fire_table(remaining: Bits) -> dict[Config, int]:
+    return {
+        config: remaining_value(config, remaining)  # type: ignore[misc]
+        for config in product((0, 1), repeat=6)
+    }
+
+
+def fills_from_mask(seed_mask: int, table: dict[Config, int]) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            config = tuple(
+                1 if neighbor is not None and (locked >> neighbor) & 1 else 0
+                for neighbor in NEIGHBOR_INDICES[site_index]
+            )
+            if table[config]:  # type: ignore[index]
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def coverage(remaining: Bits) -> int:
+    table = fire_table(remaining)
+    total = 0
+    for combo in combinations(range(12), 8):
+        seed_mask = 0
+        for index in combo:
+            seed_mask |= 1 << index
+        if fills_from_mask(seed_mask, table):
+            total += 1
+    return total
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> Bits:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Bits:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+
+
+def remaining_bits_from_full(
+    bits: Bits, orbit_types: tuple[OrbitType, ...]
+) -> Bits:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[Bits]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[Bits] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        members.append(remaining_bits_from_assignment(assignment))
+    return members
+
+
+def displayed_selectors() -> list[tuple[str, Selector]]:
+    items: list[tuple[str, Selector]] = []
+    for i, lab in enumerate(FREE_LABELS):
+        items.append((f"bit:{lab}", lambda prefix, i=i: prefix[i] == 1))
+    for i, j in combinations(range(4), 2):
+        items.append(
+            (
+                f"{FREE_LABELS[i]} AND {FREE_LABELS[j]}",
+                lambda prefix, i=i, j=j: prefix[i] == 1 and prefix[j] == 1,
+            )
+        )
+    for i, j in combinations(range(4), 2):
+        items.append(
+            (
+                f"{FREE_LABELS[i]} OR {FREE_LABELS[j]}",
+                lambda prefix, i=i, j=j: prefix[i] == 1 or prefix[j] == 1,
+            )
+        )
+    return items
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed 1-bit and 2-bit remaining-bit family "
+        "versus cov8-equality on the 15 Q8-true mixed3-pairs; does not adopt a bit"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+
+    members = enumerate_f_cut(orbit_types, empty_type, full_type)
+    cov_by_remaining = {remaining: coverage(remaining) for remaining in members}
+    q8_true = sorted(remaining for remaining in members if q8(remaining))
+    q8_false = sorted(remaining for remaining in members if not q8(remaining))
+    prefixes = sorted({remaining[:4] for remaining in q8_true})
+    pair_rows = []
+    for prefix in prefixes:
+        f0 = prefix + (0,)
+        f1 = prefix + (1,)
+        pair_rows.append((prefix, f0, f1, cov_by_remaining[f0], cov_by_remaining[f1]))
+    equal_rows = [row for row in pair_rows if row[3] == row[4]]
+    diff_rows = [row for row in pair_rows if row[3] != row[4]]
+    n_eq = len(equal_rows)
+    n_diff = len(diff_rows)
+    eq_set = {row[0] for row in equal_rows}
+    lex_first_diff = diff_rows[0]
+
+    selectors = displayed_selectors()
+    scored: list[tuple[str, int, int, bool, Prefix | None]] = []
+    for name, predq in selectors:
+        q_true = {prefix for prefix in prefixes if predq(prefix)}
+        n_q = len(q_true)
+        n_both = len(q_true & eq_set)
+        equal = q_true == eq_set
+        misses = [prefix for prefix in prefixes if predq(prefix) != (prefix in eq_set)]
+        lex_miss = misses[0] if misses else None
+        scored.append((name, n_q, n_both, equal, lex_miss))
+    n_selector_equal = sum(1 for _name, _n_q, _n_both, equal, _miss in scored if equal)
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    l1_prefix = l1_remaining[:4]
+    cov_l1 = cov_by_remaining[l1_remaining]
+    cov_l1_partner = cov_by_remaining[l1_prefix + (1 - l1_remaining[4],)]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"free_labels={FREE_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"n_eight_site_seeds={len(EIGHT_SITE_SEEDS)}")
+    print(f"N_Q8={len(q8_true)}")
+    print(f"N_Q8_false={len(q8_false)}")
+    print(f"N_pairs={len(pair_rows)}")
+    print(f"N_eq={n_eq}")
+    print(f"N_diff={n_diff}")
+    print(f"n_displayed={len(scored)}")
+    print(f"n_selector_equal={n_selector_equal}")
+    print(f"equal_prefixes={[row[0] for row in equal_rows]}")
+    print(
+        "lex_first_diff="
+        f"{lex_first_diff[1]} cov8={lex_first_diff[3]}; "
+        f"{lex_first_diff[2]} cov8={lex_first_diff[4]}"
+    )
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"f_L1_prefix={l1_prefix} cov8={cov_l1} partner_cov8={cov_l1_partner}")
+    print(f"f_hamming_bits={ham_bits}")
+    for name, n_q, n_both, equal, lex_miss in scored:
+        print(
+            f"{name} N_Q={n_q} N_both={n_both} equal={int(equal)} lex_miss={lex_miss}"
+        )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_Q8_MIXED3_COV8_EQUALITY_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 495 eight-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(orbit_sizes.values()) == 64
+        and orbit_sizes == expected_sizes
+        and n_free == 5
+        and n_cut == 32
+        and len(members) == 32
+        and len(set(members)) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and len(TWO_CUBE) == 12
+        and len(EIGHT_SITE_SEEDS) == 495
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and q8(l1_remaining),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-fifteen-q8-true-pairs",
+        "Q8 is true on exactly 30 maps, grouped as 15 mixed3-pairs",
+        len(q8_true) == 30
+        and len(q8_false) == 2
+        and q8_false == [(0, 0, 0, 0, 0), (0, 0, 0, 0, 1)]
+        and all(cov_by_remaining[remaining] == 0 for remaining in q8_false)
+        and all(cov_by_remaining[remaining] > 0 for remaining in q8_true)
+        and len(prefixes) == 15
+        and Q8_FALSE_PREFIX not in prefixes
+        and all(q8(prefix + (0,)) and q8(prefix + (1,)) for prefix in prefixes),
+    )
+    checks.check(
+        "thm1-none-equal",
+        "no displayed 1-bit or 2-bit Q equals cov8-equality on the 15 pairs",
+        n_selector_equal == 0
+        and len(scored) == 16
+        and all(not equal for _name, _n_q, _n_both, equal, _miss in scored)
+        and "None of the displayed" in note
+        and n_eq == 1
+        and n_diff == 14
+        and equal_rows[0][0] == EQUAL_PAIR_PREFIX
+        and equal_rows[0][3] == 1
+        and equal_rows[0][4] == 1,
+    )
+    miss_lines_ok = all(
+        f"`{name}`: lex-first miss `{lex_miss}`" in note
+        for name, _n_q, _n_both, _equal, lex_miss in scored
+        if lex_miss is not None
+    )
+    checks.check(
+        "thm1-lex-first-misses",
+        "the note names the lex-first miss of each displayed Q",
+        all(lex_miss is not None for _name, _n_q, _n_both, _equal, lex_miss in scored)
+        and miss_lines_ok
+        and lex_first_diff[0] == LEX_FIRST_DIFF_PREFIX
+        and lex_first_diff[3] == 44
+        and lex_first_diff[4] == 132,
+    )
+    count_lines_ok = all(
+        f"`{name}`: N_Q = {n_q}, N_both = {n_both}" in note
+        for name, n_q, n_both, _equal, _miss in scored
+    )
+    checks.check(
+        "thm2-n-eq-and-per-q",
+        f"N_eq={n_eq} and each displayed Q reports N_Q and N_both",
+        n_eq == 1
+        and f"N_eq = {n_eq}" in note
+        and count_lines_ok,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the displayed family is displayed and no bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "does not adopt a bit" in self_source
+        and "Do not write any displayed remaining-bit formula into Admissibility" in note,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+    claim_scope = (
+        "Among the 15 Q8-true mixed3-pairs of F_cut on the two-cube with "
+        "off-patch o=0, whether a displayed remaining-bit predicate equals "
+        "cov8-equality is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the remaining-bit search against cov8-equality",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower()
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not adopt a bit" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-mix3c8",
+        "the residual is a new selector on the 15 pairs, not leftover mix3c8",
+        "Not leftover-character of mix3c8" in note
+        and "New selector on the 15 pairs" in note
+        and "does not adopt a bit" in self_source,
+    )
+    checks.check(
+        "displayed-family-shape",
+        "displayed Q are the 4 one-bits, 6 two-bit ANDs, and 6 two-bit ORs",
+        [name for name, _n_q, _n_both, _equal, _miss in scored]
+        == [
+            "bit:wt1",
+            "bit:opp2",
+            "bit:adj2",
+            "bit:vertex3",
+            "wt1 AND opp2",
+            "wt1 AND adj2",
+            "wt1 AND vertex3",
+            "opp2 AND adj2",
+            "opp2 AND vertex3",
+            "adj2 AND vertex3",
+            "wt1 OR opp2",
+            "wt1 OR adj2",
+            "wt1 OR vertex3",
+            "opp2 OR adj2",
+            "opp2 OR vertex3",
+            "adj2 OR vertex3",
+        ],
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+
+    print(
+        "per_element: checked exactly — each of the 64 neighbor 6-tuples "
+        "is assigned its axis-type orbit"
+    )
+    print(
+        "per_site: checked exactly — each of the twelve two-cube vertices "
+        "uses the same six-direction stencil"
+    )
+    print(
+        "per_mode: checked exactly — every Q8-true F_cut map is scored by "
+        "how many of the 495 eight-site seeds it fills"
+    )
+    print(
+        "per_block: checked exactly — Equal versus each displayed 1-bit or "
+        "2-bit Q is scored on the 15 Q8-true mixed3-pairs"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Z^3-wide formation law "
+        "or physical Admissibility selector is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 15 Q8-true mixed3-pairs on the two-cube with off-patch o=0, Equal is not equivalent to any displayed 1-bit or 2-bit predicate. N_eq=1. Displayed, not adopted.

## Runner

`scripts/f_cut_q8_mixed3_cov8_equality_selector_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.