### PR TITLE
feat(q66c7): cov7 of Q66 is 776 versus 792

### DIFF
--- a/docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,329 @@
+---
+claim_id: f_cut_q66_cov7_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, the 7-site coverages of F_cut (1,1,1,1,0) and (1,1,1,1,1) are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q66_cov7_census_2026_08_15.py
+---
+
+# Seven-Site Coverage Of The Two `#6548` Totality Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 7-site coverage of the two cube-covariant
+cut maps `F_cut` with remaining-bit tuples `(1, 1, 1, 1, 0)` and
+`(1, 1, 1, 1, 1)`, on the twelve-vertex two-cube, over all 792 unordered
+seven-site seeds, with off-patch occupancy `0`. Those two maps are the
+`#6548` tot pair (`Q66` and `cov2=66`). The pair of coverages is
+displayed. Neither map is adopted as the physical Admissibility rule.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q66_cov7_census_2026_08_15.py`](../scripts/f_cut_q66_cov7_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment #6548 showed that the remaining-bit predicate
+`Q66(f) := (wt1=1) and (adj2=1) and (opp2=1) and (vertex3=1)` is
+equivalent to `cov2=66` among the 32 maps. The two maps that satisfy
+`Q66` are
+
+```text
+f0 = (1, 1, 1, 1, 0)
+f1 = (1, 1, 1, 1, 1)
+```
+
+in remaining-bit order `(wt1, opp2, adj2, vertex3, mixed3)`. Mixed3 is
+free in `Q66`. Neighboring seed cardinalities of the same pair are
+already scored: `cov6(f0)=904`, `cov6(f1)=924` and `cov8(f0)=471`,
+`cov8(f1)=495`. This note scores a new seed cardinality: seven-site
+seeds. New k for the 2-site tot pair, not leftover-character of #6548
+and not a Max(7) rename.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`. That map is a control, not a
+scored tot pair member.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov7(f) = |{S : |S|=7 and f fills from S}|`. Then:
+
+- Theorem 1. `cov7(f0) = 776` and `cov7(f1) = 792`.
+- Theorem 2. The two scores are not both `792`. The difference is
+  `cov7(f1) − cov7(f0) = 16`. The map `f1` attains the seven-site ceiling
+  `m7=792`; the map `f0` misses sixteen seeds.
+- Theorem 3. The pair is displayed. Displayed, not adopted.
+
+Do not adopt a map. Do not write `f0` or `f1` into Admissibility. The
+2-site tot pair is not a 7-site tot pair: only `f1` fills every seven-site
+seed.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The two Q66 maps are scored exactly on the 792 seven-site seeds of the two-cube. The pair cov7(f0)=776, cov7(f1)=792 and the difference 16 are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q66_cov7_census
+target_blocker_text: "cov7 of the two Q66 maps and whether both equal 792"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 7-site tot-pair census; do not adopt a displayed map"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The pair `(f0, f1)` is a displayed remaining-bit pair, not
+axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The seven-site seeds are the `C(12,7) = 792` subsets of size 7 in `T`. Then
+`cov7(f)` is the number of those subsets from which `f` fills. The
+comparison ceiling `m7=792` is that seed count: a map attains `m7`
+exactly when it fills every seven-site seed. Do not list the seeds.
+
+The displayed remaining-bit predicate that names the pair is
+
+```text
+Q66(f) := (wt1 = 1) and (adj2 = 1) and (opp2 = 1) and (vertex3 = 1).
+```
+
+Mixed3 is free in `Q66`. The two maps with `Q66` true are `f0` and `f1`.
+Displayed, not adopted.
+
+## Theorem 1 — `cov7(f0)` and `cov7(f1)`
+
+Enumerate the 32 remaining-bit tuples of `F_cut`, isolate the two `Q66`
+maps, and score `cov7` on the 792 seven-site seeds. Then
+
+```text
+cov7(f0) = 776
+cov7(f1) = 792
+```
+
+with `f0 = (1, 1, 1, 1, 0)` and `f1 = (1, 1, 1, 1, 1)`. Both maps lie in
+`F_cut`. The control `f_L1 = (1, 0, 1, 1, 1)` is not a `Q66` map and is
+not scored as part of the tot pair.
+
+## Theorem 2 — not both `792`; the difference is `16`
+
+Because `cov7(f0) = 776 < 792` and `cov7(f1) = 792`, the two scores are
+not both equal to `792`. The difference is
+
+```text
+cov7(f1) − cov7(f0) = 16.
+```
+
+So `f1` attains `m7=792` and `f0` misses sixteen of the 792 seven-site
+seeds. The `#6548` tot pair is not jointly 7-site total.
+
+## Theorem 3 — display; do not adopt a map
+
+The pair
+
+```text
+(cov7(f0), cov7(f1)) = (776, 792)
+```
+
+is displayed. Displayed, not adopted. Do not adopt a map. Do not write
+`f0` or `f1` into Admissibility.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, has `cov7 = 792`. That
+control is consistent with Theorem 1 and does not restore joint
+attainment of `m7` by the tot pair.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 792 seven-site seeds, off-patch `o=0` | declared finite patch |
+| `Q66` as `wt1=adj2=opp2=vertex3=1` | displayed name of the pair, not adopted |
+| `cov7(f0)=776`, `cov7(f1)=792` | proved by exhaustive scoring |
+| both equal `792` | fails; difference `16` |
+| leftover-character of #6548 | refused; new k for the 2-site tot pair |
+| adoption of a map | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of #6548: that closed `cov2=66` iff `Q66` on
+two-site seeds. The present count is `cov7` on 792 seven-site seeds, a
+different seed family. New k for the 2-site tot pair.
+
+The note is not a Max(7) ranking and not a seed-table: maximizers of
+`cov7` among the 32 maps are not selected, and no seed census of a named
+map is compiled.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write `f0` or `f1` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the 7-site coverages of the two `#6548` tot maps on this patch. |
+| V2 | Current main has the axiom memo and the `#6548` fact that `cov2=66` is `Q66`, but no landed 7-site score of that pair. |
+| V3 | The two maps, 792 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite pair at a new seed cardinality. |
+| V5 | Joint 7-site totality fails, and neither displayed map is adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: the two `Q66` maps do not both attain
+`cov7=792` on this patch. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of #6548 | treat the 7-site pair as leftover-character of `cov2=66` iff `Q66` | **ATTEMPTED** |
+| Max(7) rename | replace the tot-pair census by a 7-site maximizer ranking | **ATTEMPTED** |
+| both equal 792 | assert `cov7(f0)=cov7(f1)=792` | **ATTEMPTED** |
+| adopt a map | write `f0` or `f1` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The pair of scores, the Hamming contrast, the `#6548` two-site identity,
+and the off-patch convention are distinct. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 792 seven-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the displayed
+pair `f0`, `f1` are declared. Joint 7-site totality is not silently
+assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is the 7-site coverage of
+the two `#6548` tot maps on the declared patch, not leftover-character of
+#6548, and not a Max(7) ranking.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the two `Q66` maps scored on 792 seeds | no physical law selection |
+| per block | pair `(776, 792)` and difference `16` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than the displayed pair, and any independently derived physical
+map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** #6548 already showed that these two maps fill every two-site
+seed, so every later `k` inherits joint totality.
+
+**Answer:** Inheritance fails at `k=7`. The map `f1` still fills every
+seven-site seed, but `f0` fills only `776` of `792`. The difference is
+`16`. Displayed maps are not adopted.
+
+### N8 — cross-cycle echo
+
+Investment #6548 already showed that `cov2=66` is `Q66`. Echoing that fact
+is not a substitute for the seven-site count: `k=7` is a new seed family, and
+the pair `(776, 792)` with difference `16` is a seven-site fact.
+
+No-Go Discipline disposition: **PASS** for the finite pair and the
+narrow failure of joint 7-site totality. FAIL / DO NOT SHIP for
+“both `Q66` maps have `cov7=792`” or “a displayed map is the physical
+rule.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, isolates the two
+`Q66` remaining-bit tuples `f0=(1,1,1,1,0)` and `f1=(1,1,1,1,1)`, scores
+`cov7` on the 792 seven-site seeds, reports `cov7(f0) = 776` and
+`cov7(f1) = 792`, reports that the scores are not both `792`, and reports
+the difference `16`. Declared audit inputs are this note and the axiom
+memo; the runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q66_cov7_census_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q66_cov7_census_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q66_cov7_census_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q66_cov7_census_2026_08_15.py
+runner_sha256: 897db344d23e736f6a05ada1d02de354f03b6226e7f042278755d030e462c2f5
+input_fingerprint_sha256: af6aa97bfaad33fc1dac2957316bf09b73adfd595ec33573bdf16250c3dc8b4f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed tot pair versus cov7; does not adopt a map
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_seven_site_seeds=792
+Q66_maps=((1, 1, 1, 1, 0), (1, 1, 1, 1, 1))
+cov7(f0)=776
+cov7(f1)=792
+cov7(f_L1)=792
+both_equal_792=0
+difference=16
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 792 seven-site seeds
+PASS: thm1-q66-pair the Q66 maps are exactly f0=(1,1,1,1,0) and f1=(1,1,1,1,1)
+PASS: thm1-cov7-pair cov7(f0)=776 and cov7(f1)=792
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm2-not-both-792 the two scores are not both 792
+PASS: thm2-difference cov7(f1)-cov7(f0)=16
+PASS: thm3-display-not-adopt the pair is displayed and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the two-map 7-site census and does not adopt a map
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-6548 the residual is 7-site coverage of the tot pair, not leftover-character of #6548
+PASS: q66-definition-and-l1-outside Q66 is wt1=adj2=opp2=vertex3=1 and f_L1 is outside the pair
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — the two Q66 maps are scored on 792 seven-site seeds
+per_block: checked exactly — cov7(f0), cov7(f1), and the difference are the tot-pair 7-site census on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q66_cov7_census_2026_08_15.py
+++ b/scripts/f_cut_q66_cov7_census_2026_08_15.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""cov7 of the two Q66 F_cut maps on the two-cube.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov7(f) is the number of seven-site seeds from which f
+fills. The two Q66 maps are f0=(1,1,1,1,0) and f1=(1,1,1,1,1). The runner
+reports cov7 of both, whether both equal 792, and the difference. It does
+not adopt a map. f_L1 is the unbalanced-axis predicate (some n_mu != 0),
+never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+F0_REMAINING: Remaining = (1, 1, 1, 1, 0)
+F1_REMAINING: Remaining = (1, 1, 1, 1, 1)
+COV7_F0 = 776
+COV7_F1 = 792
+COV7_L1 = 792
+M7 = 792
+COV7_DIFF = 16
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_Q66(remaining: Remaining) -> bool:
+    return remaining[0] == 1 and remaining[1] == 1 and remaining[2] == 1 and remaining[3] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed tot pair versus cov7; does not adopt a map"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(7)
+    remaining_to_bits = {remaining: bits for bits, remaining in members}
+    q66_remaining = tuple(sorted(remaining for remaining in remaining_to_bits if selector_Q66(remaining)))
+    targets = (F0_REMAINING, F1_REMAINING, L1_REMAINING)
+    cov_by_remaining: dict[Remaining, int] = {}
+    for remaining in targets:
+        table = predicate_table(remaining_to_bits[remaining], orbit_types, type_of)
+        cov_by_remaining[remaining] = coverage_from_masks(table, seeds, neighbors)
+    cov0 = cov_by_remaining[F0_REMAINING]
+    cov1 = cov_by_remaining[F1_REMAINING]
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+    both_792 = cov0 == M7 and cov1 == M7
+    difference = cov1 - cov0
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_seven_site_seeds={len(seeds)}")
+    print(f"Q66_maps={q66_remaining}")
+    print(f"cov7(f0)={cov0}")
+    print(f"cov7(f1)={cov1}")
+    print(f"cov7(f_L1)={cov_l1}")
+    print(f"both_equal_792={int(both_792)}")
+    print(f"difference={difference}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_Q66_COV7_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 792 seven-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 792
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-q66-pair",
+        "the Q66 maps are exactly f0=(1,1,1,1,0) and f1=(1,1,1,1,1)",
+        q66_remaining == (F0_REMAINING, F1_REMAINING)
+        and selector_Q66(F0_REMAINING)
+        and selector_Q66(F1_REMAINING)
+        and not selector_Q66(L1_REMAINING)
+        and F0_REMAINING in remaining_to_bits
+        and F1_REMAINING in remaining_to_bits
+        and L1_REMAINING in remaining_to_bits,
+    )
+    checks.check(
+        "thm1-cov7-pair",
+        "cov7(f0)=776 and cov7(f1)=792",
+        cov0 == COV7_F0
+        and cov1 == COV7_F1
+        and cov0 == 776
+        and cov1 == 792
+        and "cov7(f0) = 776" in note
+        and "cov7(f1) = 792" in note,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and not selector_Q66(L1_REMAINING)
+        and cov_l1 == COV7_L1,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm2-not-both-792",
+        "the two scores are not both 792",
+        both_792 is False
+        and cov0 != M7
+        and cov1 == M7
+        and "not both" in note_flat
+        and "not both `792`" in note,
+    )
+    checks.check(
+        "thm2-difference",
+        "cov7(f1)-cov7(f0)=16",
+        difference == COV7_DIFF
+        and difference == 16
+        and cov1 - cov0 == 16
+        and "cov7(f1) − cov7(f0) = 16" in note
+        and "difference is `16`" in note_flat,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the pair is displayed and is not adopted as an Admissibility selector",
+        "(cov7(f0), cov7(f1)) = (776, 792)" in note
+        and "Displayed, not adopted" in note
+        and "Do not adopt a map" in note
+        and "Do not write `f0` or `f1` into Admissibility" in note
+        and "does not adopt a map" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, the 7-site coverages of F_cut "
+        "(1,1,1,1,0) and (1,1,1,1,1) are reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the two-map 7-site census and does not adopt a map",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `f0` or `f1` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-6548",
+        "the residual is 7-site coverage of the tot pair, not leftover-character of #6548",
+        "Not leftover-character of #6548" in note
+        and "New k for the 2-site tot pair" in note
+        and "not leftover-character of #6548" in note,
+    )
+    checks.check(
+        "q66-definition-and-l1-outside",
+        "Q66 is wt1=adj2=opp2=vertex3=1 and f_L1 is outside the pair",
+        selector_Q66((1, 1, 1, 1, 0))
+        and selector_Q66((1, 1, 1, 1, 1))
+        and not selector_Q66((1, 0, 1, 1, 1))
+        and not selector_Q66((1, 1, 1, 0, 1))
+        and not selector_Q66((0, 1, 1, 1, 1))
+        and cov_l1 == cov_by_remaining[(1, 0, 1, 1, 1)],
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — the two Q66 maps are scored on 792 seven-site seeds")
+    print("per_block: checked exactly — cov7(f0), cov7(f1), and the difference are the tot-pair 7-site census on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the two Q66 maps on the two-cube with off-patch o=0, cov7(f0)=776 and cov7(f1)=792. The difference is 16; only f1 attains the 7-site ceiling. Displayed, not adopted.

## Runner

`scripts/f_cut_q66_cov7_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.