### PR TITLE
feat(c10bit3): cov10>0 iff adj2 or vertex3 or mixed3

### DIFF
--- a/docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,383 @@
+---
+claim_id: f_cut_cov10_three_bit_selector_search_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether a displayed 3-bit remaining-bit predicate equals cov10>0 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py
+---
+
+# Three-Bit Remaining-Bit Search For A Selector Equal To `cov10>0`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 10-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+thirty-two cube-covariant cut maps `F_cut`, against every displayed
+3-bit remaining-bit AND and every displayed 3-bit remaining-bit OR of
+`{wt1, opp2, adj2, vertex3, mixed3}`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py`](../scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+The first remaining-bit menu at new `k=10` (investment #6566) showed that
+no displayed 1-bit remaining-bit predicate and no 2-bit OR equals
+`cov10>0`, with `N_pos = 28`. That leftover left open the next width:
+every AND of three remaining bits and every OR of three remaining bits.
+This note completes that menu. Same pattern as #6524 after #6514.
+Next width after the first failed menu at the same new `k=10`. Not
+leftover-character of that 1-bit / 2-bit OR menu and not a Max(10) rename.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov10(f) = |{S : |S|=10 and f fills from S}|`. Then:
+
+- Theorem 1. One displayed 3-bit OR equals `cov10>0`:
+  `adj2 OR vertex3 OR mixed3`. No displayed 3-bit AND equals `cov10>0`.
+  One lex-first remaining-bit miss is reported for each failed displayed
+  `Q`.
+- Theorem 2. `N_pos = 28`. For each displayed `Q`, the pair
+  `(N_Q, N_both)` is reported in the table below.
+- Theorem 3. The menu is displayed. Do not adopt a bit.
+
+Do not write a remaining-bit formula into Admissibility. Displayed, not
+adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 66 ten-site seeds of the two-cube. Whether cov10>0 equals any displayed 3-bit AND or 3-bit OR is a finite exact fact. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov10_three_bit_selector_search
+target_blocker_text: "whether a displayed 3-bit remaining-bit predicate equals cov10>0 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 10-site 3-bit positivity selector search; do not adopt a displayed bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The candidates below are displayed remaining-bit formulas, not
+axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The ten-site seeds are the `C(12,10) = 66` subsets of size 10 in `T`. Then
+`cov10(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov10(f)>0`. Duality is not assumed: `cov10` is scored on
+those 66 seeds.
+
+The displayed remaining-bit predicates are every AND of three remaining
+bits and every OR of three remaining bits, in remaining-bit order. There
+are twenty displayed candidates. Displayed, not adopted.
+
+## Theorem 1 — one displayed 3-bit OR equals `cov10>0`; lex-first misses of the rest
+
+Enumerate all 32 remaining-bit tuples of `F_cut` and score `cov10` on the
+66 ten-site seeds. Then `cov10(f) > 0` if and only if
+`adj2 OR vertex3 OR mixed3`. No displayed 3-bit AND equals `cov10>0`.
+The other nine displayed 3-bit ORs fail.
+
+`N_pos = 28`. The four maps with `cov10 = 0` are exactly the maps with
+`(adj2, vertex3, mixed3) = (0, 0, 0)`:
+
+```text
+(0, 0, 0, 0, 0), (0, 1, 0, 0, 0), (1, 0, 0, 0, 0), (1, 1, 0, 0, 0).
+```
+
+The lex-first remaining-bit miss of each failed displayed `Q`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, is:
+
+| displayed `Q` | `cov10>0` iff `Q` | lex-first miss | `cov10` of miss | `Q` at miss |
+|---|---|---|---:|---|
+| `wt1 AND opp2 AND adj2` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 AND opp2 AND vertex3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 AND opp2 AND mixed3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 AND adj2 AND vertex3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 AND adj2 AND mixed3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 AND vertex3 AND mixed3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `opp2 AND adj2 AND vertex3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `opp2 AND adj2 AND mixed3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `opp2 AND vertex3 AND mixed3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `adj2 AND vertex3 AND mixed3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 OR opp2 OR adj2` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 OR opp2 OR vertex3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 OR opp2 OR mixed3` | no | `(0, 0, 0, 1, 0)` | 28 | 0 |
+| `wt1 OR adj2 OR vertex3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `wt1 OR adj2 OR mixed3` | no | `(0, 0, 0, 1, 0)` | 28 | 0 |
+| `wt1 OR vertex3 OR mixed3` | no | `(0, 0, 1, 0, 0)` | 18 | 0 |
+| `opp2 OR adj2 OR vertex3` | no | `(0, 0, 0, 0, 1)` | 4 | 0 |
+| `opp2 OR adj2 OR mixed3` | no | `(0, 0, 0, 1, 0)` | 28 | 0 |
+| `opp2 OR vertex3 OR mixed3` | no | `(0, 0, 1, 0, 0)` | 18 | 0 |
+| `adj2 OR vertex3 OR mixed3` | yes | none | — | — |
+
+Every displayed 3-bit AND is missed first by remaining bits
+`(0, 0, 0, 0, 1)`: `cov10 = 4 > 0` and the AND is false. Each failed
+3-bit OR is missed first by a remaining-bit tuple on which the OR is
+false and `cov10 > 0`. The matching OR has no miss.
+
+## Theorem 2 — `N_pos` and, for each displayed `Q`, `N_Q` and `N_both`
+
+Among the 32 maps, `N_pos = 28` maps have `cov10 > 0`. For each displayed
+`Q`, write `N_Q` for the number of maps with `Q` true and `N_both` for
+the number with both `Q` and `cov10>0`.
+
+| displayed `Q` | `N_Q` | `N_pos` | `N_both` |
+|---|---:|---:|---:|
+| `wt1 AND opp2 AND adj2` | 4 | 28 | 4 |
+| `wt1 AND opp2 AND vertex3` | 4 | 28 | 4 |
+| `wt1 AND opp2 AND mixed3` | 4 | 28 | 4 |
+| `wt1 AND adj2 AND vertex3` | 4 | 28 | 4 |
+| `wt1 AND adj2 AND mixed3` | 4 | 28 | 4 |
+| `wt1 AND vertex3 AND mixed3` | 4 | 28 | 4 |
+| `opp2 AND adj2 AND vertex3` | 4 | 28 | 4 |
+| `opp2 AND adj2 AND mixed3` | 4 | 28 | 4 |
+| `opp2 AND vertex3 AND mixed3` | 4 | 28 | 4 |
+| `adj2 AND vertex3 AND mixed3` | 4 | 28 | 4 |
+| `wt1 OR opp2 OR adj2` | 28 | 28 | 25 |
+| `wt1 OR opp2 OR vertex3` | 28 | 28 | 25 |
+| `wt1 OR opp2 OR mixed3` | 28 | 28 | 25 |
+| `wt1 OR adj2 OR vertex3` | 28 | 28 | 26 |
+| `wt1 OR adj2 OR mixed3` | 28 | 28 | 26 |
+| `wt1 OR vertex3 OR mixed3` | 28 | 28 | 26 |
+| `opp2 OR adj2 OR vertex3` | 28 | 28 | 26 |
+| `opp2 OR adj2 OR mixed3` | 28 | 28 | 26 |
+| `opp2 OR vertex3 OR mixed3` | 28 | 28 | 26 |
+| `adj2 OR vertex3 OR mixed3` | 28 | 28 | 28 |
+
+Every 3-bit AND has `N_Q = 4 ≠ 28`. Every 3-bit OR has `N_Q = 28`.
+Equivalence holds only for `adj2 OR vertex3 OR mixed3`, the unique
+displayed row with `N_Q = 28`, `N_pos = 28`, and `N_both = 28`. The other
+3-bit ORs share `N_Q = 28` and miss three or two positive maps.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, satisfies every displayed
+3-bit OR, fails every displayed 3-bit AND that requires `opp2`, and has
+`cov10 = 66`. That is consistent with Theorem 2 and does not restore any
+failed equivalence.
+
+## Theorem 3 — display; do not adopt a bit
+
+The menu, the counts, the matching OR, and the lex-first misses are
+displayed data. Do not adopt a bit. Do not adopt a 3-bit AND. Do not adopt a 3-bit OR. Do not adopt `f_L1`. Do not write a remaining-bit
+formula into Admissibility. Admissibility does not name these
+remaining-bit formulas.
+
+The identities here are finite facts about occupancy-to-lock on this
+two-cube with off-patch `o=0`. They are not a physical formation-site
+selector and not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 66 ten-site seeds, off-patch `o=0` | declared finite patch |
+| each 3-bit AND and each 3-bit OR versus `cov10>0` | one OR matches; lex-first miss of each failed `Q` |
+| `N_pos = 28` and per-`Q` `(N_Q, N_both)` | proved by exhaustive scoring |
+| leftover-character of the 1-bit / 2-bit OR menu | refused; next width at same `k` |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of the failed 1-bit / 2-bit OR menu at `k=10`:
+investment #6566 already showed `N_pos = 28` and that no 1-bit predicate
+or 2-bit OR equals `cov10>0`. The present count is the next width: the
+ten 3-bit ANDs and the ten 3-bit ORs.
+
+Same pattern as #6524 after #6514: after the first failed menu, the next
+width is scored at the same `k`. This is not a restatement of #6524,
+which scored `cov3>0`, and not leftover-character of #6566.
+
+The note is not a Max(10) ranking and not a seed-table: maximizers of
+`cov10` are not selected, and no seed census of a named map is compiled
+beyond the positivity boolean.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write a remaining-bit formula into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether any displayed 3-bit remaining-bit predicate equals `cov10>0` inside `F_cut` on this patch. |
+| V2 | The first failed menu at this `k` scored 1-bit predicates and 2-bit ORs (#6566). Current main has no landed 3-bit remaining-bit positivity search for `cov10>0`. |
+| V3 | The 32 maps, 66 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a declared 3-bit candidate menu. |
+| V5 | Equivalence holds for one displayed 3-bit OR, the rest fail, and no bit is adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: among the 32 `F_cut` maps on this patch,
+no displayed 3-bit AND equals `cov10>0`, and nine of the ten displayed
+3-bit ORs fail. The one matching OR is displayed, not adopted. No global
+compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover 1-bit / 2-bit OR menu | treat the search as a restatement of the failed 1-bit / 2-bit OR tests | **ATTEMPTED** |
+| leftover of #6524 | treat 10-site 3-bit positivity as leftover-character of the `cov3` 3-bit search | **ATTEMPTED** |
+| Max(10) rename | replace the fillability search by a maximum-`cov10` ranking | **ATTEMPTED** |
+| adopt a bit | write a remaining-bit formula into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed 1-bit / 2-bit OR tests, the twenty 3-bit tests, the Hamming
+contrast, and the off-patch convention are distinct. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 66 ten-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the
+displayed 3-bit menu are declared. Equivalence of `cov10>0` with a 3-bit
+AND or OR is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether a
+displayed 3-bit remaining-bit predicate equals `cov10>0` on the declared
+patch, completing the next width after the first failed menu at this
+`k`, and not a Max(10) ranking.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 66 seeds | no physical law selection |
+| per block | `N_pos` and per-`Q` `(N_Q, N_both)` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different Boolean combination of remaining bits, a
+different seed family, a different off-patch rule, a selector outside the
+displayed 3-bit menu, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** the 1-bit / 2-bit OR menu already failed at this `k`, so a
+3-bit AND or a 3-bit OR must recover `cov10>0`, and that match must be
+written into Admissibility.
+
+**Answer:** One displayed 3-bit OR, `adj2 OR vertex3 OR mixed3`, equals
+`cov10>0`, with `(N_Q, N_pos, N_both) = (28, 28, 28)`. Every 3-bit AND
+has `N_Q = 4 ≠ 28`. The other 3-bit ORs have `N_both` equal to 25 or 26.
+The lex-first AND miss `(0, 0, 0, 0, 1)` has `cov10 = 4` and every
+displayed AND false. Displayed predicates are not adopted.
+
+### N8 — cross-cycle echo
+
+The first failed menu at `k=10` (#6566) already showed that no 1-bit or
+2-bit OR equals `cov10>0`. Investment #6524 already showed that no
+displayed 3-bit `Q` equals `cov3>0`. Echoing either fact is not a
+substitute for the ten-site 3-bit count: the matching OR, the lex-first
+misses, and the triples `(N_Q, N_pos, N_both)` are ten-site 3-bit facts.
+
+No-Go Discipline disposition: **PASS** for the finite candidate census
+and the narrow equivalence report. FAIL / DO NOT SHIP for “a displayed
+3-bit AND or OR is the physical rule” or “a displayed bit is adopted.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov10` on the
+66 ten-site seeds, tests every displayed 3-bit AND and every displayed
+3-bit OR against `cov10>0`, reports that `adj2 OR vertex3 OR mixed3`
+equals `cov10>0`, reports one lex-first miss of each failed `Q`, and
+reports `N_pos = 28` together with each `(N_Q, N_both)`. Declared audit
+inputs are this note and the axiom memo; the runner writes no cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov10_three_bit_selector_search_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov10_three_bit_selector_search_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov10_three_bit_selector_search_2026_08_15.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py
+runner_sha256: 1010ceb0637789826243ffabc6079f13df3b1890e22e52b0782bbc1e6e4bfa21
+input_fingerprint_sha256: 8bd4ad19172af87cb3483aa95a7cf039cf7f43c380dd54a7d064d1b71f1464ad
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed 3-bit remaining-bit candidates versus cov10>0; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_ten_site_seeds=66
+N_pos=28
+cov10(f_L1)=66
+n_candidates=20
+matching_candidates=['adj2 OR vertex3 OR mixed3']
+candidate wt1 AND opp2 AND adj2: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate wt1 AND opp2 AND vertex3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate wt1 AND opp2 AND mixed3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate wt1 AND adj2 AND vertex3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate wt1 AND adj2 AND mixed3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate wt1 AND vertex3 AND mixed3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate opp2 AND adj2 AND vertex3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate opp2 AND adj2 AND mixed3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate opp2 AND vertex3 AND mixed3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate adj2 AND vertex3 AND mixed3: equiv=0 N_Q=4 N_both=4 fp=0 fn=24 lex=(0, 0, 0, 0, 1)
+candidate wt1 OR opp2 OR adj2: equiv=0 N_Q=28 N_both=25 fp=3 fn=3 lex=(0, 0, 0, 0, 1)
+candidate wt1 OR opp2 OR vertex3: equiv=0 N_Q=28 N_both=25 fp=3 fn=3 lex=(0, 0, 0, 0, 1)
+candidate wt1 OR opp2 OR mixed3: equiv=0 N_Q=28 N_both=25 fp=3 fn=3 lex=(0, 0, 0, 1, 0)
+candidate wt1 OR adj2 OR vertex3: equiv=0 N_Q=28 N_both=26 fp=2 fn=2 lex=(0, 0, 0, 0, 1)
+candidate wt1 OR adj2 OR mixed3: equiv=0 N_Q=28 N_both=26 fp=2 fn=2 lex=(0, 0, 0, 1, 0)
+candidate wt1 OR vertex3 OR mixed3: equiv=0 N_Q=28 N_both=26 fp=2 fn=2 lex=(0, 0, 1, 0, 0)
+candidate opp2 OR adj2 OR vertex3: equiv=0 N_Q=28 N_both=26 fp=2 fn=2 lex=(0, 0, 0, 0, 1)
+candidate opp2 OR adj2 OR mixed3: equiv=0 N_Q=28 N_both=26 fp=2 fn=2 lex=(0, 0, 0, 1, 0)
+candidate opp2 OR vertex3 OR mixed3: equiv=0 N_Q=28 N_both=26 fp=2 fn=2 lex=(0, 0, 1, 0, 0)
+candidate adj2 OR vertex3 OR mixed3: equiv=1 N_Q=28 N_both=28 fp=0 fn=0 lex=None
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 66 ten-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-three-bit-and-or one displayed 3-bit OR equals cov10>0; no displayed 3-bit AND equals it
+PASS: thm1-lex-first-miss-of-each one lex-first remaining-bit miss is reported for each failed displayed Q
+PASS: thm2-counts N_pos=28 and each displayed Q reports N_Q and N_both
+PASS: thm3-display-not-adopt the menu is displayed and no bit is adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the 3-bit remaining-bit search and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-one-bit-two-bit-or the residual is the next-width 3-bit menu, not leftover-character of the failed 1-bit / 2-bit OR tests
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 66 ten-site seeds against the displayed 3-bit menu
+per_block: checked exactly — N_pos and each (N_Q, N_both) are the F_cut positivity-versus-Q counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py
+++ b/scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+"""Search 3-bit remaining-bit candidates for cov10>0 on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov10(f) is the number of ten-site seeds from which f
+fills. Candidates are every 3-bit AND and every 3-bit OR of
+{wt1, opp2, adj2, vertex3, mixed3}. Whether any equals cov10>0 is reported.
+If a displayed Q fails, one lex-first miss of that Q is reported. The
+runner does not adopt a bit. f_L1 is the unbalanced-axis predicate
+(some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+TRIPLE_INDICES: tuple[tuple[int, int, int], ...] = tuple(combinations(range(5), 3))
+EQUAL_OR_NAME = "adj2 OR vertex3 OR mixed3"
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def candidate_menu() -> list[tuple[str, object]]:
+    ands = [
+        (
+            " AND ".join(REMAINING_LABELS[i] for i in triple),
+            (lambda rem, triple=triple: all(rem[i] == 1 for i in triple)),
+        )
+        for triple in TRIPLE_INDICES
+    ]
+    ors = [
+        (
+            " OR ".join(REMAINING_LABELS[i] for i in triple),
+            (lambda rem, triple=triple: any(rem[i] == 1 for i in triple)),
+        )
+        for triple in TRIPLE_INDICES
+    ]
+    return ands + ors
+
+
+def score_candidate(
+    rows: list[tuple[Remaining, int]],
+    predicate,
+) -> dict:
+    tp = tn = fp = fn = 0
+    misses: list[tuple[Remaining, int, bool]] = []
+    for remaining, cov in rows:
+        q = bool(predicate(remaining))
+        pos = cov > 0
+        if pos and q:
+            tp += 1
+        elif (not pos) and (not q):
+            tn += 1
+        elif (not pos) and q:
+            fp += 1
+            misses.append((remaining, cov, q))
+        else:
+            fn += 1
+            misses.append((remaining, cov, q))
+    lex = min(misses, key=lambda row: row[0]) if misses else None
+    return {
+        "tp": tp,
+        "tn": tn,
+        "fp": fp,
+        "fn": fn,
+        "equiv": int(fp == 0 and fn == 0),
+        "N_Q": tp + fp,
+        "N_both": tp,
+        "lex": lex,
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed 3-bit remaining-bit candidates versus cov10>0; "
+        "does not adopt a bit"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(10)
+    rows: list[tuple[Remaining, int]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov))
+
+    scores = {name: score_candidate(rows, pred) for name, pred in candidate_menu()}
+    matching = [name for name, score in scores.items() if score["equiv"] == 1]
+    n_pos = sum(1 for _remaining, cov in rows if cov > 0)
+    cov_by_remaining = {remaining: cov for remaining, cov in rows}
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+    and_names = [" AND ".join(REMAINING_LABELS[i] for i in triple) for triple in TRIPLE_INDICES]
+    or_names = [" OR ".join(REMAINING_LABELS[i] for i in triple) for triple in TRIPLE_INDICES]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_ten_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"cov10(f_L1)={cov_l1}")
+    print(f"n_candidates={len(scores)}")
+    print(f"matching_candidates={matching}")
+    for name, score in scores.items():
+        lex = score["lex"]
+        print(
+            f"candidate {name}: equiv={score['equiv']} N_Q={score['N_Q']} "
+            f"N_both={score['N_both']} fp={score['fp']} fn={score['fn']} "
+            f"lex={None if lex is None else lex[0]}"
+        )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV10_THREE_BIT_SELECTOR_SEARCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 66 ten-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 66
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and cov_l1 == 66
+        and L1_REMAINING in cov_by_remaining,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    and_fail = all(scores[name]["equiv"] == 0 for name in and_names)
+    or_match = [name for name in or_names if scores[name]["equiv"] == 1]
+    or_fail = [name for name in or_names if scores[name]["equiv"] == 0]
+    checks.check(
+        "thm1-three-bit-and-or",
+        "one displayed 3-bit OR equals cov10>0; no displayed 3-bit AND equals it",
+        and_fail
+        and matching == [EQUAL_OR_NAME]
+        and or_match == [EQUAL_OR_NAME]
+        and len(and_names) == 10
+        and len(or_names) == 10
+        and len(or_fail) == 9
+        and all(scores[name]["N_Q"] == 4 for name in and_names)
+        and all(scores[name]["N_Q"] == 28 for name in or_names)
+        and scores[EQUAL_OR_NAME]["N_both"] == 28
+        and scores[EQUAL_OR_NAME]["equiv"] == 1
+        and f"`{EQUAL_OR_NAME}`" in note
+        and "equals `cov10>0`" in note,
+    )
+    expected_lex = {
+        "wt1 AND opp2 AND adj2": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 AND opp2 AND vertex3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 AND opp2 AND mixed3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 AND adj2 AND vertex3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 AND adj2 AND mixed3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 AND vertex3 AND mixed3": ((0, 0, 0, 0, 1), 4, False),
+        "opp2 AND adj2 AND vertex3": ((0, 0, 0, 0, 1), 4, False),
+        "opp2 AND adj2 AND mixed3": ((0, 0, 0, 0, 1), 4, False),
+        "opp2 AND vertex3 AND mixed3": ((0, 0, 0, 0, 1), 4, False),
+        "adj2 AND vertex3 AND mixed3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 OR opp2 OR adj2": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 OR opp2 OR vertex3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 OR opp2 OR mixed3": ((0, 0, 0, 1, 0), 28, False),
+        "wt1 OR adj2 OR vertex3": ((0, 0, 0, 0, 1), 4, False),
+        "wt1 OR adj2 OR mixed3": ((0, 0, 0, 1, 0), 28, False),
+        "wt1 OR vertex3 OR mixed3": ((0, 0, 1, 0, 0), 18, False),
+        "opp2 OR adj2 OR vertex3": ((0, 0, 0, 0, 1), 4, False),
+        "opp2 OR adj2 OR mixed3": ((0, 0, 0, 1, 0), 28, False),
+        "opp2 OR vertex3 OR mixed3": ((0, 0, 1, 0, 0), 18, False),
+    }
+    computed_lex = {
+        name: (score["lex"][0], score["lex"][1], score["lex"][2])
+        for name, score in scores.items()
+        if score["lex"] is not None
+    }
+    checks.check(
+        "thm1-lex-first-miss-of-each",
+        "one lex-first remaining-bit miss is reported for each failed displayed Q",
+        computed_lex == expected_lex
+        and scores[EQUAL_OR_NAME]["lex"] is None
+        and all(f"`{name}`" in note for name in expected_lex)
+        and "`(0, 0, 0, 0, 1)`" in note
+        and "`(0, 0, 0, 1, 0)`" in note
+        and "`(0, 0, 1, 0, 0)`" in note
+        and "lex-first" in note,
+    )
+    expected_counts = {
+        "wt1 AND opp2 AND adj2": (4, 4),
+        "wt1 AND opp2 AND vertex3": (4, 4),
+        "wt1 AND opp2 AND mixed3": (4, 4),
+        "wt1 AND adj2 AND vertex3": (4, 4),
+        "wt1 AND adj2 AND mixed3": (4, 4),
+        "wt1 AND vertex3 AND mixed3": (4, 4),
+        "opp2 AND adj2 AND vertex3": (4, 4),
+        "opp2 AND adj2 AND mixed3": (4, 4),
+        "opp2 AND vertex3 AND mixed3": (4, 4),
+        "adj2 AND vertex3 AND mixed3": (4, 4),
+        "wt1 OR opp2 OR adj2": (28, 25),
+        "wt1 OR opp2 OR vertex3": (28, 25),
+        "wt1 OR opp2 OR mixed3": (28, 25),
+        "wt1 OR adj2 OR vertex3": (28, 26),
+        "wt1 OR adj2 OR mixed3": (28, 26),
+        "wt1 OR vertex3 OR mixed3": (28, 26),
+        "opp2 OR adj2 OR vertex3": (28, 26),
+        "opp2 OR adj2 OR mixed3": (28, 26),
+        "opp2 OR vertex3 OR mixed3": (28, 26),
+        "adj2 OR vertex3 OR mixed3": (28, 28),
+    }
+    computed_counts = {
+        name: (score["N_Q"], score["N_both"]) for name, score in scores.items()
+    }
+    checks.check(
+        "thm2-counts",
+        f"N_pos={n_pos} and each displayed Q reports N_Q and N_both",
+        n_pos == 28
+        and computed_counts == expected_counts
+        and f"N_pos = {n_pos}" in note
+        and "N_Q = 4" in note
+        and "N_Q = 28" in note
+        and "N_both = 28" in note
+        and all(str(pair[0]) in note and str(pair[1]) in note for pair in expected_counts.values()),
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the menu is displayed and no bit is adopted as an Admissibility selector",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not adopt a 3-bit AND" in note
+        and "Do not adopt a 3-bit OR" in note
+        and "Do not write a remaining-bit formula into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "a displayed 3-bit remaining-bit predicate equals cov10>0 is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the 3-bit remaining-bit search and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write a remaining-bit formula into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-one-bit-two-bit-or",
+        "the residual is the next-width 3-bit menu, not leftover-character of the failed 1-bit / 2-bit OR tests",
+        "Not leftover-character of the failed 1-bit / 2-bit OR menu" in note
+        and "Next width after the first failed menu" in note
+        and "Same pattern as #6524 after #6514" in note
+        and "#6566" in note
+        and "not a Max(10) rename" in note_flat,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 66 ten-site seeds against the displayed 3-bit menu")
+    print("per_block: checked exactly — N_pos and each (N_Q, N_both) are the F_cut positivity-versus-Q counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov10>0 iff adj2=1 or vertex3=1 or mixed3=1. N_pos=N_Q=N_both=28. No displayed 3-bit AND equals cov10>0. Displayed, not adopted.

## Runner

`scripts/f_cut_cov10_three_bit_selector_search_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.