### PR TITLE
feat(c4q10): cov4>0 is not Q10

### DIFF
--- a/docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,335 @@
+---
+claim_id: f_cut_cov4_q10_selector_test_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether cov4>0 equals adj2∨vertex3∨mixed3 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov4_q10_selector_test_2026_08_15.py
+---
+
+# Whether `cov4>0` Equals `Q10` Among The 32 `F_cut` Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 4-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+thirty-two cube-covariant cut maps `F_cut`, against the displayed
+remaining-bit predicate `Q10 := (adj2=1) or (vertex3=1) or (mixed3=1)`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov4_q10_selector_test_2026_08_15.py`](../scripts/f_cut_cov4_q10_selector_test_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c10bit3 closed the 10-site positivity question:
+`cov10>0` if and only if the remaining-bit predicate
+
+```text
+Q10 := (adj2 = 1) or (vertex3 = 1) or (mixed3 = 1).
+```
+
+Investment #6518 closed the 4-site positivity question:
+`cov4>0` if and only if `Q4 := (wt1 = 1) or (adj2 = 1)`.
+Investment #6476 is Max duality only at `k=4,5`. Duality is not assumed
+for positivity, so `cov10>0 iff Q10` does not transfer to
+`cov4>0 iff Q10`. This note scores that transfer on the same 32 maps.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov4(f) = |{S : |S|=4 and f fills from S}|`. Then:
+
+- Theorem 1. `cov4(f) > 0` is not equivalent to `Q10(f)` among the 32
+  maps. The lex-first remaining-bit miss is `(0, 0, 0, 0, 1)`, which has
+  `Q10 = 1` and `cov4 = 0`.
+- Theorem 2. `N_pos = 24`, `N_Q10 = 28`, `N_both = 22`.
+- Theorem 3. `Q10` is displayed. Displayed, not adopted.
+
+Do not adopt Q10. Do not write `Q10` into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 495 four-site seeds. Whether cov4>0 equals Q10=adj2∨vertex3∨mixed3 is a finite Boolean identity on this patch, not a physical Admissibility selector."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov4_q10_selector_test
+target_blocker_text: "whether cov4>0 iff Q10 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded cov4-versus-Q10 comparison; do not adopt Q10"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The candidate `Q10` below is a displayed remaining-bit formula,
+not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The four-site seeds are the `C(12,4) = 495` subsets of size 4 in `T`. Then
+`cov4(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov4(f)>0`.
+
+`Q10` and the #6518 control `Q4` are functions of the remaining-bit tuple
+only. Duality of Max at `k=4,5` is not used.
+
+## Theorem 1 — `cov4>0` is not `Q10`; lex-first miss
+
+Direct evolution on the 495 four-site seeds scores every `F_cut` map.
+`cov4(f) > 0` is not equivalent to `Q10(f)` on all 32 maps.
+
+The lex-first remaining-bit miss, in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`, is `(0, 0, 0, 0, 1)`. That map has
+`mixed3 = 1`, so `Q10` is true, and `cov4 = 0`.
+
+The identity would have held only if positivity at `k=4` inherited the
+`k=10` selector. Duality is not assumed: #6476 licenses Max only at
+`k=4,5`, and does not identify `cov4>0` with `cov10>0` or with `Q10`.
+The miss is therefore a new `k=4` fact, not leftover-character of
+c10bit3 and not leftover-character of #6518.
+
+`f_L1` itself has remaining bits `(1, 0, 1, 1, 1)`, so `Q10` is true and
+`cov4 = 489`. That is consistent with the miss and does not restore
+equivalence.
+
+## Theorem 2 — `N_pos`, `N_Q10`, `N_both`
+
+Among the 32 maps:
+
+- `N_pos = 24` maps have `cov4 > 0`;
+- `N_Q10 = 28` maps satisfy `Q10`;
+- `N_both = 22` maps satisfy both.
+
+Equivalence fails in both directions. The two maps with `cov4>0` and
+`Q10` false are the #6490 exceptions `(1, 0, 0, 0, 0)` and
+`(1, 1, 0, 0, 0)`, each with `wt1 = 1` and
+`(adj2, vertex3, mixed3) = (0, 0, 0)`, and each with `cov4 = 7`. The six
+maps with `Q10` true and `cov4 = 0` are the remaining-bit tuples with
+`wt1 = 0`, `adj2 = 0`, and `(vertex3, mixed3) ≠ (0, 0)`:
+
+```text
+(0, 0, 0, 0, 1), (0, 0, 0, 1, 0), (0, 0, 0, 1, 1),
+(0, 1, 0, 0, 1), (0, 1, 0, 1, 0), (0, 1, 0, 1, 1).
+```
+
+Reconfirming #6518 on the same scoring: `cov4>0` equals `Q4 = wt1 ∨ adj2`
+on all 32 maps (`N_Q4 = 24`, `N_both(Q4) = 24`). That control is
+displayed only. It is not a transfer of `Q10` across `k`.
+
+## Theorem 3 — display, not adoption
+
+`Q10` is displayed data. Do not adopt Q10. Do not adopt `Q4`. Do not
+adopt `f_L1`. Do not write `Q10` into Admissibility. Admissibility does
+not name this remaining-bit formula.
+
+The failed identity `cov4>0 ⇔ adj2∨vertex3∨mixed3` is a finite fact
+about occupancy-to-lock on this two-cube with off-patch `o=0`. It is not
+a physical formation-site selector and not an axiom edit.
+
+Displayed, not adopted.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 495 four-site seeds, off-patch `o=0` | declared finite patch |
+| `Q10` as `adj2∨vertex3∨mixed3` | displayed, not adopted |
+| `cov4>0` iff `Q10` | fails; lex-first miss `(0, 0, 0, 0, 1)` |
+| `N_pos = 24`, `N_Q10 = 28`, `N_both = 22` | proved by exhaustive scoring |
+| duality of Max at `k=4,5` | not assumed for positivity |
+| leftover-character of c10bit3 or #6518 | refused; new comparison |
+| adoption of `Q10` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of c10bit3: that closed `cov10>0` iff `Q10` on
+ten-site seeds. The present object is `cov4>0` versus the same displayed
+predicate on 495 four-site seeds. New k.
+
+Not leftover-character of #6518: that closed `cov4>0` iff `Q4`. The
+present comparison is `cov4>0` versus `Q10`, a different remaining-bit
+formula.
+
+#6476 is Max duality only at `k=4,5`. Duality is not assumed. The note
+does not identify `cov4>0` with `cov10>0` and does not import a Max
+ranking.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether `cov4>0` equals `adj2∨vertex3∨mixed3` on the 32 `F_cut` maps. |
+| V2 | Current main has the axiom memo, the c10bit3 identity `Q10=cov10>0`, and the #6518 identity `Q4=cov4>0`, but no landed `cov4` versus `Q10` test. |
+| V3 | The 32 maps, 495 seeds, and Boolean predicates are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a declared candidate. |
+| V5 | The candidate is displayed, not adopted, and is not written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: `cov4>0` is not `Q10` on this patch, and
+a displayed miss is not axiom content. No global compiler impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of c10bit3 | treat the 4-site test as restating `Q10=cov10>0` | **ATTEMPTED** |
+| leftover of #6518 | treat the test as restating `Q4=cov4>0` | **ATTEMPTED** |
+| duality transfer | inherit positivity from `k=10` by #6476 Max duality | **ATTEMPTED** |
+| adopt `Q10` | write `adj2∨vertex3∨mixed3` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed equivalence, the Hamming contrast, the #6490 pair, the
+#6476 Max-only duality bound, and the off-patch convention are distinct.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 495 four-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the
+displayed predicate `Q10` are declared. Duality of positivity across
+`k` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+`cov4>0` equals `Q10` on this patch, not leftover-character of c10bit3
+or #6518, and not a Max transfer.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 495 seeds against `Q10` | no physical law selection |
+| per block | the failed identity and the three counts on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule,
+a selector other than `Q10` or `Q4`, and any independently derived
+physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** c10bit3 already showed that positivity is `Q10`, and
+#6476 already pairs `k=4` with `k=8` or `k=10` by duality, so
+`cov4>0` is `Q10`.
+
+**Answer:** #6476 is Max only at `k=4,5`. Duality is not assumed for
+positivity. Twenty-four maps have `cov4>0` and twenty-eight satisfy
+`Q10`; twenty-two satisfy both. The lex-first miss `(0, 0, 0, 0, 1)`
+has `Q10` true and `cov4 = 0`. Displayed `Q10` is not adopted.
+
+### N8 — cross-cycle echo
+
+Investment c10bit3 already showed that `cov10>0` is `Q10`. Investment
+#6518 already showed that `cov4>0` is `Q4`. Echoing either identity is
+not a substitute for testing `Q10` against 4-site positivity.
+
+No-Go Discipline disposition: **PASS** for the finite comparison and the
+lex-first miss. FAIL / DO NOT SHIP for “adopt Q10,” “`cov4>0` is `Q10`,”
+or “duality transfers the `k=10` selector.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov4` on the
+495 four-site seeds, tests whether `cov4>0` equals displayed `Q10`,
+reports the lex-first remaining-bit miss `(0, 0, 0, 0, 1)`, and reports
+`N_pos = 24`, `N_Q10 = 28`, and `N_both = 22`. Declared
+audit inputs are this note and the axiom memo; the runner writes no cache
+and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov4_q10_selector_test_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov4_q10_selector_test_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov4_q10_selector_test_2026_08_15.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov4_q10_selector_test_2026_08_15.py
+runner_sha256: 46eaf3ac31a423b56fbce3f6e13018ed26bc34af0ebc19ea39accdf66f6be4fb
+input_fingerprint_sha256: 87e54ae398542fc20d68cdff95adad7db88d23d5e06dfb3cfb85bddd1af780b8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed Q10 versus cov4>0; does not adopt Q10; duality is not assumed
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_four_site_seeds=495
+N_pos=24
+N_Q10=28
+N_both=22
+N_Q4=24
+N_both_Q4=24
+n_mismatch=8
+lex_first_miss=(0, 0, 0, 0, 1)
+lex_first_cov4=0
+lex_first_Q10=1
+cov4(f_L1)=489
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 495 four-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-not-equivalent cov4>0 is not equivalent to Q10 among the 32 F_cut maps
+PASS: thm1-lex-first-miss lex-first miss remaining-bit tuple is (0, 0, 0, 0, 1)
+PASS: thm2-counts N_pos=24, N_Q10=28, N_both=22
+PASS: thm2-q4-control on the same scoring, cov4>0 equals Q4 and is not Q10
+PASS: thm3-display-not-adopted Q10 is displayed and is not adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports whether cov4>0 equals Q10 and does not adopt Q10
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: duality-not-assumed Max duality at k=4,5 is not used to transfer positivity
+PASS: not-leftover-c10bit3-6518 the residual is cov4 versus Q10, not leftover-character of c10bit3 or #6518
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 495 four-site seeds against displayed Q10
+per_block: checked exactly — N_pos, N_Q10, and N_both are the F_cut positivity-versus-Q10 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov4_q10_selector_test_2026_08_15.py
+++ b/scripts/f_cut_cov4_q10_selector_test_2026_08_15.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Test whether cov4>0 equals Q10 among the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov4(f) is the number of four-site seeds from which f
+fills. Q10 is the displayed remaining-bit predicate
+(adj2=1) or (vertex3=1) or (mixed3=1). Displayed, not adopted. Duality is
+not assumed. f_L1 is the unbalanced-axis predicate (some n_mu != 0), never
+Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_MISS: Remaining = (0, 0, 0, 0, 1)
+EXCEPTIONS_6490: tuple[Remaining, ...] = (
+    (1, 0, 0, 0, 0),
+    (1, 1, 0, 0, 0),
+)
+Q10_NOT_POS: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 1),
+    (0, 0, 0, 1, 0),
+    (0, 0, 0, 1, 1),
+    (0, 1, 0, 0, 1),
+    (0, 1, 0, 1, 0),
+    (0, 1, 0, 1, 1),
+)
+N_POS = 24
+N_Q10 = 28
+N_BOTH = 22
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def selector_Q10(remaining: Remaining) -> bool:
+    _wt1, _opp2, adj2, vertex3, mixed3 = remaining
+    return adj2 == 1 or vertex3 == 1 or mixed3 == 1
+
+
+def selector_Q4(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, _vertex3, _mixed3 = remaining
+    return wt1 == 1 or adj2 == 1
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed Q10 versus cov4>0; "
+        "does not adopt Q10; duality is not assumed"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(4)
+    rows: list[tuple[Remaining, int, bool, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_Q10(remaining), selector_Q4(remaining)))
+    rows.sort(key=lambda item: item[0])
+
+    n_pos = sum(1 for _remaining, cov, _q10, _q4 in rows if cov > 0)
+    n_q10 = sum(1 for _remaining, _cov, q10, _q4 in rows if q10)
+    n_both = sum(1 for _remaining, cov, q10, _q4 in rows if cov > 0 and q10)
+    n_q4 = sum(1 for _remaining, _cov, _q10, q4 in rows if q4)
+    n_both_q4 = sum(1 for _remaining, cov, _q10, q4 in rows if cov > 0 and q4)
+    mismatches = [
+        (remaining, cov, q10)
+        for remaining, cov, q10, _q4 in rows
+        if (cov > 0) != q10
+    ]
+    lex_first = mismatches[0] if mismatches else None
+    pos_not_q10 = frozenset(
+        remaining for remaining, cov, q10, _q4 in rows if cov > 0 and not q10
+    )
+    q10_not_pos = frozenset(
+        remaining for remaining, cov, q10, _q4 in rows if q10 and cov == 0
+    )
+    cov_l1 = next(cov for remaining, cov, _q10, _q4 in rows if remaining == L1_REMAINING)
+    cov_6490 = {
+        remaining: next(cov for rem, cov, _q10, _q4 in rows if rem == remaining)
+        for remaining in EXCEPTIONS_6490
+    }
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_four_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_Q10={n_q10}")
+    print(f"N_both={n_both}")
+    print(f"N_Q4={n_q4}")
+    print(f"N_both_Q4={n_both_q4}")
+    print(f"n_mismatch={len(mismatches)}")
+    print(f"lex_first_miss={None if lex_first is None else lex_first[0]}")
+    if lex_first is not None:
+        print(f"lex_first_cov4={lex_first[1]}")
+        print(f"lex_first_Q10={int(lex_first[2])}")
+    print(f"cov4(f_L1)={cov_l1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV4_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 495 four-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(seeds) == 495
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and L1_REMAINING == (1, 0, 1, 1, 1)
+        and selector_Q10(L1_REMAINING)
+        and cov_l1 == 489,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "cov4>0 is not equivalent to Q10 among the 32 F_cut maps",
+        len(mismatches) > 0
+        and n_pos != n_q10
+        and all((cov > 0) == q10 for _remaining, cov, q10, _q4 in rows) is False
+        and "`cov4(f) > 0` is not equivalent to `Q10(f)`" in note
+    )
+    checks.check(
+        "thm1-lex-first-miss",
+        "lex-first miss remaining-bit tuple is (0, 0, 0, 0, 1)",
+        lex_first is not None
+        and lex_first[0] == LEX_FIRST_MISS
+        and lex_first[1] == 0
+        and lex_first[2] is True
+        and selector_Q10(LEX_FIRST_MISS)
+        and "(0, 0, 0, 0, 1)" in note
+        and "cov4 = 0" in note
+        and "lex-first remaining-bit miss" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        "N_pos=24, N_Q10=28, N_both=22",
+        n_pos == N_POS
+        and n_q10 == N_Q10
+        and n_both == N_BOTH
+        and n_pos == 24
+        and n_q10 == 28
+        and n_both == 22
+        and "N_pos = 24" in note
+        and "N_Q10 = 28" in note
+        and "N_both = 22" in note
+        and pos_not_q10 == frozenset(EXCEPTIONS_6490)
+        and q10_not_pos == frozenset(Q10_NOT_POS)
+        and cov_6490 == {(1, 0, 0, 0, 0): 7, (1, 1, 0, 0, 0): 7}
+        and len(mismatches) == 8,
+    )
+    checks.check(
+        "thm2-q4-control",
+        "on the same scoring, cov4>0 equals Q4 and is not Q10",
+        n_q4 == 24
+        and n_both_q4 == 24
+        and all((cov > 0) == q4 for _remaining, cov, _q10, q4 in rows)
+        and "#6518" in note
+        and "Q4 := (wt1 = 1) or (adj2 = 1)" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopted",
+        "Q10 is displayed and is not adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt Q10" in note
+        and "Do not write `Q10` into Admissibility" in note
+        and "does not adopt Q10" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "cov4>0 equals adj2∨vertex3∨mixed3 is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports whether cov4>0 equals Q10 and does not adopt Q10",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "duality-not-assumed",
+        "Max duality at k=4,5 is not used to transfer positivity",
+        "Duality is not assumed" in note
+        and "#6476" in note
+        and "only at `k=4,5`" in note
+        and "duality is not assumed" in self_source,
+    )
+    checks.check(
+        "not-leftover-c10bit3-6518",
+        "the residual is cov4 versus Q10, not leftover-character of c10bit3 or #6518",
+        "Not leftover-character of c10bit3" in note
+        and "Not leftover-character of #6518" in note
+        and "Q10 := (adj2 = 1) or (vertex3 = 1) or (mixed3 = 1)" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 495 four-site seeds against displayed Q10")
+    print("per_block: checked exactly — N_pos, N_Q10, and N_both are the F_cut positivity-versus-Q10 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov4>0 is not equivalent to Q10. N_pos=24, N_Q10=28, N_both=22. Lex-first miss (0,0,0,0,1). Displayed, not adopted.

## Runner

`scripts/f_cut_cov4_q10_selector_test_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.