### PR TITLE
feat(c10cls): all four Q10-false maps first-refuse adj2

### DIFF
--- a/docs/F_CUT_Q10_FALSE_TEN_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q10_FALSE_TEN_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,355 @@
+---
+claim_id: f_cut_q10_false_ten_site_class_refuse_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, whether all four Q10-false maps first refuse the same remaining-bit type from the lex-first 10-site f1 fill is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py
+---
+
+# Whether All Four Q10-False Maps First-Refuse The Same Type
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock remaining-bit refuse of the four
+Q10-false `F_cut` maps on the lex-first ten-site seed that `f1` fills, on
+the twelve-vertex two-cube with off-patch occupancy `0`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py`](../scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c10zero named the first remaining-bit refuse of the lex-first
+Q10-false map `f_z0=(0,0,0,0,0)`. The four zeros are the maps with
+`adj2=vertex3=mixed3=0`. This note asks whether that first refuse is a
+class fact of the Q10 zeros: whether all four first refuse the same
+remaining-bit type on the same 10-site `f1` fill, or whether the types
+differ. Not leftover-character of the single-map first refuse of
+`f_z0=(0,0,0,0,0)`. The new object is the four-row Q10-false census.
+Class fact of the Q10 zeros.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+Write `f1` for remaining bits `(1, 1, 1, 1, 1)` and `f_z0` for remaining
+bits `(0, 0, 0, 0, 0)`. Q10-false means `adj2=0` and `vertex3=0` and
+`mixed3=0`. Equivalently, on this two-cube, `cov10=0`.
+
+On the two-cube with off-patch occupancy `0`, a remaining-bit refuse of a
+map `f` from a locked set `L` is an unlocked on-patch site whose
+six-neighbor occupancy has a remaining-bit orbit type and `f=0` on that
+neighborhood. Empty and full are forced bits, not remaining bits. Then:
+
+- Theorem 1. For each of the four, the first remaining-bit refuse from
+  `S = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1)}`
+  is type `adj2` `= (2, 0, 1)` at tick `1`, site `(2, 1, 0)`, with
+  `N_refuse = 2`, not `0`.
+- Theorem 2. All four first refuses have the same type `adj2`. The four
+  types do not differ.
+- Theorem 3. That class fact is displayed. Displayed, not adopted.
+
+Do not adopt a bit. Do not write `adj2` into Admissibility.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block is a different rule and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Each of the four Q10-false F_cut maps is scored from the lex-first 10-site seed f1 fills. All four first remaining-bit refuses are type adj2. The refuse is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q10_false_ten_site_class_refuse
+target_blocker_text: "whether all four Q10-false maps first refuse the same remaining-bit type on the lex-first 10-site f1 fill remains unnamed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the displayed Q10-false class first-refuse types; do not adopt a remaining bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The remaining-bit type `adj2` is a displayed refuse label, not
+axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+The map `f1` is the remaining-bit assignment that sends every remaining
+orbit to `1`. The map `f_z0` has remaining bits `(0, 0, 0, 0, 0)`.
+
+A locked set `L` determines occupancies: a lattice neighbor in `L` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `L` by
+
+```text
+L ∪ { v in two-cube \ L : f(neighborhood_6(v; L)) = 1 }.
+```
+
+Tick `1` is the seed itself, before the first such step. Fill means the
+halt set has cardinality 12. There are `C(12,10)=66` unordered 10-site
+seeds. Seeds are ordered by the lex order of the twelve vertices
+`(x,y,z)` with `x` slowest and `z` fastest, then by combination order.
+Coverage `cov10(f)` is the number of those 66 seeds from which `f` fills.
+
+A remaining-bit refuse of `f` at locked set `L` is an unlocked on-patch
+site `v` whose neighborhood axis-type is a remaining-bit orbit (or that
+orbit's complement) and `f(neighborhood_6(v; L))=0`. The first remaining-bit
+refuse from a seed is the lex-first such site on the earliest tick that has
+any. If no such site exists, `N_refuse=0`. `N_refuse` on a tick that has
+refuses is the number of remaining-bit refuses at the locked set just
+before that tick.
+
+Define
+
+```text
+Q10(f)           = 1  iff  adj2(f)=1 or vertex3(f)=1 or mixed3(f)=1,
+f1               = remaining-value of (1, 1, 1, 1, 1),
+f_z0             = remaining-value of (0, 0, 0, 0, 0),
+zeros            = { f in F_cut : adj2(f)=vertex3(f)=mixed3(f)=0 }.
+```
+
+The four zeros remaining-bit tuples, in lex order, are
+
+```text
+(0, 0, 0, 0, 0)
+(0, 1, 0, 0, 0)
+(1, 0, 0, 0, 0)
+(1, 1, 0, 0, 0).
+```
+
+`f_z0` is the lex-first member. These are exactly the maps with `cov10=0`.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The unbalanced-axis
+map `f_L1` is one element of `F_cut` and is not Hamming parity. The map
+`f1` has remaining bits `(1, 1, 1, 1, 1)` and fills the lex-first 10-site
+seed
+
+```text
+S = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1)}.
+```
+
+The map `f1` fills `S`. Each of the four zeros is Q10-false, has `cov10=0`,
+and does not fill `S`. From `S` at tick `1`, the unlocked sites and
+neighborhood types are
+
+```text
+(2, 1, 0)  adj2     (2, 0, 1)   neighborhood (0, 1, 0, 1, 0, 0)
+(2, 1, 1)  adj2     (2, 0, 1)   neighborhood (0, 1, 0, 1, 0, 0)
+```
+
+Every zeros map has `adj2=0`, so each refuses both remaining-bit
+neighborhoods. For each of the four, the first remaining-bit refuse from
+`S` is therefore tick `1`, site `(2, 1, 0)`, remaining-bit type `adj2`,
+with `N_refuse = 2`.
+
+**Theorem 2.** All four first refuses have the same type `adj2`. There is
+no lex-first counterexample tuple: scanning the four zeros in lex order, no
+member has `N_refuse=0` and no member first-refuses a remaining-bit type
+other than `adj2`. The four types do not differ, so the types are not
+separately named as a split.
+
+The free bits `wt1` and `opp2` do not change the first refuse from `S`.
+Those types do not appear among the seed neighborhoods of unlocked sites.
+The bits `vertex3` and `mixed3` are already `0` on every zeros map.
+
+**Theorem 3.** The Q10-false class first-refuse type is `adj2`. That is a
+sameness statement for the four Q10-false maps on this seed: the
+single-map refuse of `f_z0` is the Q10 zeros class refuse. The refuse is
+displayed. No remaining bit is adopted as the physical Admissibility
+rule. Displayed, not adopted.
+
+## Proof-obligation graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free |
+| `f1` fills `S` | remaining bits `(1, 1, 1, 1, 1)` fill the lex-first 10-site seed |
+| four zeros | `adj2=vertex3=mixed3=0`; lex-first is `f_z0` |
+| `cov10=0` | each of the four fills none of the 66 ten-site seeds |
+| first refuse of each of the four | tick `1`, site `(2, 1, 0)`, type `adj2` |
+| `N_refuse` | `2` remaining-bit refuses on that tick, for each of the four |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` |
+| same type | proved by the four-row Q10-false census |
+| displayed refuse | not adopted |
+
+## What this does not claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No ranking of the other 28 maps in `F_cut`.
+- No adoption of `adj2`, `wt1`, `opp2`, or `f_z0`.
+- No blank-block or Hamming-as-`f_L1` identification.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It reports whether all four Q10-false maps first-refuse the same remaining-bit type from the 10-site seed `f1` fills. |
+| V2 | The single-map refuse of `f_z0` is named; Q10 zeros class sameness on that seed is not. |
+| V3 | The 32 maps, the four zeros tuples, the 66 seeds, and occupancy-to-lock from `S` are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Admissibility: it scores a declared finite zeros class. |
+| V5 | It is not a physical selector: the refuse is displayed and is not adopted and is not written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: all four Q10-false maps refuse an
+`adj2` neighborhood on the lex-first 10-site seed `f1` fills, so `adj2` is
+not adopted as an Admissibility selector. No global compiler impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover single-map refuse | treat the Q10 zeros class as leftover-character of the `f_z0` refuse | **ATTEMPTED** |
+| leftover of `cov10=0` | treat the refuse type as leftover-character of the coverage zeros | **ATTEMPTED** |
+| first remaining-bit refuse of each of the four | name each first remaining-bit type from `S`, or `N_refuse=0` | **ATTEMPTED** |
+| type split | find that the four zeros first-refuse different remaining-bit types | **ATTEMPTED** |
+| adopt a bit | write `adj2` or `f_z0` into Admissibility | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed Hamming identification, the leftover single-map refuse, and
+the leftover coverage-zero class are distinct. This note claims no complete
+wall collection. The four identical `adj2` first refuses are four rows
+of one zeros certificate, so they collapse rather than count as four
+walls.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 66 ten-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the four
+Q10-false zeros are declared. Unique selection of `adj2` is not
+silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is sameness of the first
+remaining-bit refuse type for the Q10-false zeros from `S`, not
+leftover-character of the single-map refuse of `f_z0`, and not a Hamming
+identification.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all four Q10-false zeros scored from `S` | no physical law selection |
+| per block | each first remaining-bit refuse type named | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, the
+other 28 maps in `F_cut`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** c10zero already named `adj2` for `f_z0`, and all four zeros have
+`adj2=0`, so same-type refuse is leftover-character of that single-map refuse.
+
+**Answer:** the single-map refuse names one remaining-bit tuple. The new
+object is the four-row Q10-false census: whether the free bits `wt1` and
+`opp2` change the first refuse type, or whether `N_refuse=0` for some
+member. Displaying that all four first refuses are `adj2` names that Q10
+zeros class fact. `adj2` is not adopted.
+
+### N8 — cross-cycle echo
+
+Investment c10zero already named the first remaining-bit refuse of `f_z0`
+on this seed. Echoing that single row is not a substitute for the first
+remaining-bit refuse type of all four Q10-false maps from the
+lex-first 10-site `f1` fill.
+
+No-Go Discipline disposition: **PASS** for the four named zeros, the
+`f1` fill of `S`, the displayed first remaining-bit refuse types, and the
+sameness of those types. FAIL / DO NOT SHIP for “`adj2` is
+the physical rule” or “displayed `f_z0` is adopted.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut`, names the four Q10-false zeros, names the lex-first
+10-site seed that `f1` fills, evaluates the first remaining-bit refuse of
+each zeros map from that seed or reports `N_refuse=0`, checks that all four
+first refuses have the same type `adj2`, and does not adopt a bit.
+Declared audit inputs are this note and the axiom memo; the runner writes
+no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q10_false_ten_site_class_refuse_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q10_false_ten_site_class_refuse_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q10_false_ten_site_class_refuse_2026_08_15.txt
@@ -1,0 +1,65 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py
+runner_sha256: c6fb4fd4d1df36e68a2d560e5fc029139c5ebb2ac3ccb922f3ac13657089d3a3
+input_fingerprint_sha256: d3c5a88b8a7e2d067098b1958dfdc6815e9a4593eb16a75f96eddb645d1c235b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q10_FALSE_TEN_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: first remaining-bit refuse of each Q10-false map from S
+negative_scope: adj2 is displayed, not adopted or written into Admissibility
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+N_Q10=28
+N_cov10=28
+N_zeros=4
+zeros_class=[(0, 0, 0, 0, 0), (0, 1, 0, 0, 0), (1, 0, 0, 0, 0), (1, 1, 0, 0, 0)]
+f_z0_remaining=(0, 0, 0, 0, 0)
+f1_remaining=(1, 1, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+S={(0,0,0),(0,0,1),(0,1,0),(0,1,1),(1,0,0),(1,0,1),(1,1,0),(1,1,1),(2,0,0),(2,0,1)}
+f1_fills_S=True
+f1_history=(10, 12)
+zero (0, 0, 0, 0, 0) tick=1 site=(2, 1, 0) type=adj2 N_refuse=2 fills_S=False history=(10,)
+zero (0, 1, 0, 0, 0) tick=1 site=(2, 1, 0) type=adj2 N_refuse=2 fills_S=False history=(10,)
+zero (1, 0, 0, 0, 0) tick=1 site=(2, 1, 0) type=adj2 N_refuse=2 fills_S=False history=(10,)
+zero (1, 1, 0, 0, 0) tick=1 site=(2, 1, 0) type=adj2 N_refuse=2 fills_S=False history=(10,)
+same_first_refuse_type=True
+shared_type=adj2
+PASS: audit-inputs AUDIT_INPUT_PATHS are the required static literals and both files exist
+PASS: thm1-rotations-orbits-fcut 24 rotations, 10 orbits, and |F_cut|=32
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-s-filled-by-f1 the two-cube has twelve vertices and f1 fills the lex-first 10-site seed S
+PASS: thm1-q10-false-four-zeros the four Q10-false remaining-bit tuples are adj2=vertex3=mixed3=0
+PASS: thm1-class-first-refuse-types each of the four zeros has a first remaining-bit refuse from S
+PASS: thm2-all-four-first-refuse-same-type all four first refuses have the same type adj2; the four types do not differ
+PASS: thm3-display-not-adopt the Q10-false class first-refuse type is displayed and is not adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports whether all four Q10-false maps first refuse the same type from S
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-class-refuse the note reports the four zeros, S, and first-refuse type adj2
+PASS: not-leftover-c10zero the residual is Q10 zeros class sameness, not leftover of the single-map refuse
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — all four Q10-false zeros are scored from S
+per_block: checked exactly — each first remaining-bit refuse type is named, or N_refuse=0
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py
+++ b/scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py
@@ -1,0 +1,861 @@
+#!/usr/bin/env python3
+"""Whether all four Q10-false maps first-refuse the same remaining-bit type.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The four zeros are the maps with adj2=vertex3=mixed3=0. S is
+the lex-first 10-site seed that f1 fills. For each of the four maps the first
+remaining-bit refuse type from S is reported, or N_refuse=0. Whether all four
+such first refuses have the same type is displayed; it does not adopt a bit.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. New object: not leftover of the single-map first refuse of
+f_z0=(0,0,0,0,0). Class fact of the Q10 zeros.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q10_FALSE_TEN_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q10_FALSE_TEN_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Seed = tuple[Site, Site, Site, Site, Site, Site, Site, Site, Site, Site]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TEN_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 10)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+AXIS_TYPE_NAME: dict[OrbitType, str] = {
+    (0, 0, 3): "empty",
+    (0, 3, 0): "full",
+    (1, 0, 2): "wt1",
+    (1, 2, 0): "wt1_comp",
+    (0, 1, 2): "opp2",
+    (0, 2, 1): "opp2_comp",
+    (2, 0, 1): "adj2",
+    (2, 1, 0): "adj2_comp",
+    (3, 0, 0): "vertex3",
+    (1, 1, 1): "mixed3",
+}
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+F1_REMAINING: Remaining = (1, 1, 1, 1, 1)
+FZ0_REMAINING: Remaining = (0, 0, 0, 0, 0)
+SEED_S_SITES: Seed = (
+    (0, 0, 0),
+    (0, 0, 1),
+    (0, 1, 0),
+    (0, 1, 1),
+    (1, 0, 0),
+    (1, 0, 1),
+    (1, 1, 0),
+    (1, 1, 1),
+    (2, 0, 0),
+    (2, 0, 1),
+)
+Q10_FALSE_CLASS: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 1, 0, 0, 0),
+    (1, 0, 0, 0, 0),
+    (1, 1, 0, 0, 0),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def remaining_representative(kind: OrbitType) -> OrbitType | None:
+    if kind in REMAINING_ORDER:
+        return kind
+    image = complement_type(kind)
+    if image in REMAINING_ORDER:
+        return image
+    return None
+
+
+def remaining_label(kind: OrbitType) -> str:
+    representative = remaining_representative(kind)
+    if representative is None:
+        return AXIS_TYPE_NAME[kind]
+    return REMAINING_LABELS[REMAINING_ORDER.index(representative)]
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: tuple[int, ...]) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def make_predicate(remaining: tuple[int, ...]):
+    def predicate(config: Config) -> int:
+        return remaining_value(config, remaining)
+
+    return predicate
+
+
+def f1(config: Config) -> int:
+    """F_cut remaining bits (1, 1, 1, 1, 1).  Displayed.  Not adopted."""
+    return remaining_value(config, F1_REMAINING)
+
+
+def f_z0(config: Config) -> int:
+    """Lex-first Q10-false remaining-bit map."""
+    return remaining_value(config, FZ0_REMAINING)
+
+
+def q10(remaining: tuple[int, ...]) -> int:
+    return int(remaining[2] == 1 or remaining[3] == 1 or remaining[4] == 1)
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def neighborhood(site: Site, locked: set[Site]) -> Config:
+    values = []
+    for direction in DIRECTIONS:
+        neighbor = (
+            site[0] + direction[0],
+            site[1] + direction[1],
+            site[2] + direction[2],
+        )
+        values.append(1 if neighbor in locked else 0)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
+
+
+def evolve(locked: set[Site], predicate) -> set[Site]:
+    nxt = set(locked)
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        if predicate(neighborhood(site, locked)):
+            nxt.add(site)
+    return nxt
+
+
+def run_from_seed(predicate, seed: frozenset[Site], halt_bound: int = 13) -> dict:
+    locked = set(seed)
+    history = [len(locked)]
+    for _tick in range(halt_bound):
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            break
+        locked = nxt
+        history.append(len(locked))
+    return {
+        "fill": len(locked) == 12,
+        "history": tuple(history),
+        "locks": frozenset(locked),
+        "halt_tick": len(history) - 1,
+    }
+
+
+def fills_from_seed(predicate, seed: frozenset[Site]) -> bool:
+    return bool(run_from_seed(predicate, seed)["fill"])
+
+
+def seed_key(seed: frozenset[Site]) -> Seed:
+    ordered = tuple(sorted(seed))
+    if len(ordered) != 10:
+        raise ValueError("expected 10-site seed")
+    return (
+        ordered[0],
+        ordered[1],
+        ordered[2],
+        ordered[3],
+        ordered[4],
+        ordered[5],
+        ordered[6],
+        ordered[7],
+        ordered[8],
+        ordered[9],
+    )
+
+
+def seed_display(seed: frozenset[Site] | Seed) -> str:
+    sites = seed_key(frozenset(seed))
+    inner = ",".join(f"({a[0]},{a[1]},{a[2]})" for a in sites)
+    return "{" + inner + "}"
+
+
+def remaining_refuse_events(locked: set[Site], predicate) -> list[dict]:
+    rows: list[dict] = []
+    for site in TWO_CUBE:
+        if site in locked:
+            continue
+        config = neighborhood(site, locked)
+        kind = axis_type(config)
+        representative = remaining_representative(kind)
+        if representative is None:
+            continue
+        if int(predicate(config)) != 0:
+            continue
+        rows.append(
+            {
+                "site": site,
+                "config": config,
+                "axis_type": kind,
+                "remaining_type": representative,
+                "remaining_name": remaining_label(kind),
+                "f_map": int(predicate(config)),
+                "f1": int(f1(config)),
+            }
+        )
+    return rows
+
+
+def first_remaining_refuse(seed: frozenset[Site], predicate, halt_bound: int = 13) -> dict | None:
+    locked = set(seed)
+    for tick in range(1, halt_bound + 1):
+        events = remaining_refuse_events(locked, predicate)
+        if events:
+            first = events[0]
+            return {
+                "tick": tick,
+                "site": first["site"],
+                "config": first["config"],
+                "axis_type": first["axis_type"],
+                "remaining_type": first["remaining_type"],
+                "remaining_name": first["remaining_name"],
+                "n_events": len(events),
+                "events": tuple(events),
+            }
+        nxt = evolve(locked, predicate)
+        if nxt == locked:
+            return None
+        locked = nxt
+    return None
+
+
+def class_first_refuses(seed: frozenset[Site], members: tuple[Remaining, ...]) -> list[dict]:
+    rows: list[dict] = []
+    for remaining in members:
+        predicate = make_predicate(remaining)
+        first = first_remaining_refuse(seed, predicate)
+        if first is None:
+            rows.append(
+                {
+                    "remaining": remaining,
+                    "n_refuse": 0,
+                    "tick": None,
+                    "site": None,
+                    "remaining_name": None,
+                    "remaining_type": None,
+                    "config": None,
+                    "fills": fills_from_seed(predicate, seed),
+                    "history": run_from_seed(predicate, seed)["history"],
+                }
+            )
+            continue
+        rows.append(
+            {
+                "remaining": remaining,
+                "n_refuse": first["n_events"],
+                "tick": first["tick"],
+                "site": first["site"],
+                "remaining_name": first["remaining_name"],
+                "remaining_type": first["remaining_type"],
+                "config": first["config"],
+                "fills": fills_from_seed(predicate, seed),
+                "history": run_from_seed(predicate, seed)["history"],
+            }
+        )
+    return rows
+
+
+def coverage_ten(predicate) -> int:
+    return sum(1 for seed in TEN_SITE_SEEDS if fills_from_seed(predicate, seed))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    values = tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)
+    return (values[0], values[1], values[2], values[3], values[4])
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+        if complement_type(orbit_type) != orbit_type
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut_remaining(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[Remaining]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[Remaining] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        members.append(remaining_bits_from_assignment(assignment))
+    return members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def remaining_display(remaining: tuple[int, ...]) -> str:
+    return "(" + ", ".join(str(bit) for bit in remaining) + ")"
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: first remaining-bit refuse of each Q10-false map from S")
+    print("negative_scope: adj2 is displayed, not adopted or written into Admissibility")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    remaining_members = enumerate_f_cut_remaining(orbit_types, empty_type, full_type)
+
+    cov10_by_remaining = {
+        remaining: coverage_ten(make_predicate(remaining)) for remaining in remaining_members
+    }
+    zeros = tuple(
+        sorted(
+            remaining
+            for remaining in remaining_members
+            if remaining[2] == 0 and remaining[3] == 0 and remaining[4] == 0
+        )
+    )
+    zeros_by_cov = tuple(
+        sorted(remaining for remaining in remaining_members if cov10_by_remaining[remaining] == 0)
+    )
+    lex_first_zero = zeros[0]
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    f1_bits = bits_from_predicate(f1, orbit_types, orbits)
+    fz0_bits = bits_from_predicate(f_z0, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    f1_remaining = remaining_bits_from_full(f1_bits, orbit_types)
+    fz0_remaining = remaining_bits_from_full(fz0_bits, orbit_types)
+
+    seed_s = frozenset(SEED_S_SITES)
+    lex_first_filled_by_f1 = next(seed for seed in TEN_SITE_SEEDS if fills_from_seed(f1, seed))
+    run_f1 = run_from_seed(f1, seed_s)
+    run_fz0 = run_from_seed(f_z0, seed_s)
+    class_rows = class_first_refuses(seed_s, zeros)
+    types = [row["remaining_name"] for row in class_rows]
+    same_type = (
+        len(class_rows) == 4
+        and all(row["n_refuse"] != 0 for row in class_rows)
+        and len(set(types)) == 1
+    )
+    counterexamples = [
+        row
+        for row in class_rows
+        if row["n_refuse"] == 0
+        or row["remaining_name"] != class_rows[0]["remaining_name"]
+    ]
+    lex_first_counterexample = None
+    if not same_type:
+        lex_first_counterexample = counterexamples[0] if counterexamples else class_rows[0]
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={len(remaining_members)}")
+    print(f"N_Q10={sum(1 for member in remaining_members if q10(member) == 1)}")
+    print(f"N_cov10={sum(1 for count in cov10_by_remaining.values() if count > 0)}")
+    print(f"N_zeros={len(zeros)}")
+    print(f"zeros_class={list(zeros)}")
+    print(f"f_z0_remaining={fz0_remaining}")
+    print(f"f1_remaining={f1_remaining}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"S={seed_display(seed_s)}")
+    print(f"f1_fills_S={run_f1['fill']}")
+    print(f"f1_history={run_f1['history']}")
+    for row in class_rows:
+        print(
+            "zero "
+            + remaining_display(row["remaining"])
+            + f" tick={row['tick']} site={row['site']} "
+            + f"type={row['remaining_name']} N_refuse={row['n_refuse']} "
+            + f"fills_S={row['fills']} history={row['history']}"
+        )
+    print(f"same_first_refuse_type={same_type}")
+    print(f"shared_type={types[0] if same_type else None}")
+    if not same_type:
+        print(f"named_types={types}")
+
+    checks.check(
+        "audit-inputs",
+        "AUDIT_INPUT_PATHS are the required static literals and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q10_FALSE_TEN_SITE_CLASS_REFUSE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "thm1-rotations-orbits-fcut",
+        "24 rotations, 10 orbits, and |F_cut|=32",
+        len(ROTATIONS) == 24
+        and len(orbit_types) == 10
+        and len(remaining_members) == 32
+        and n_free == 5
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-two-cube-and-s-filled-by-f1",
+        "the two-cube has twelve vertices and f1 fills the lex-first 10-site seed S",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TEN_SITE_SEEDS) == 66
+        and seed_key(seed_s) == SEED_S_SITES
+        and seed_key(lex_first_filled_by_f1) == SEED_S_SITES
+        and f1_remaining == F1_REMAINING
+        and in_f_cut(f1_bits, orbit_types, empty_type, full_type)
+        and run_f1["fill"]
+        and run_f1["history"] == (10, 12)
+        and not run_fz0["fill"]
+        and run_fz0["history"] == (10,),
+    )
+    checks.check(
+        "thm1-q10-false-four-zeros",
+        "the four Q10-false remaining-bit tuples are adj2=vertex3=mixed3=0",
+        zeros == Q10_FALSE_CLASS
+        and zeros == zeros_by_cov
+        and lex_first_zero == FZ0_REMAINING
+        and fz0_remaining == FZ0_REMAINING
+        and all(q10(member) == 0 for member in zeros)
+        and all(cov10_by_remaining[member] == 0 for member in zeros)
+        and all(member[2] == 0 and member[3] == 0 and member[4] == 0 for member in zeros)
+        and all((cov10_by_remaining[member] > 0) == (q10(member) == 1) for member in remaining_members)
+        and in_f_cut(fz0_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-class-first-refuse-types",
+        "each of the four zeros has a first remaining-bit refuse from S",
+        len(class_rows) == 4
+        and all(row["n_refuse"] != 0 for row in class_rows)
+        and all(row["tick"] == 1 for row in class_rows)
+        and all(row["site"] == (2, 1, 0) for row in class_rows)
+        and all(row["remaining_name"] == "adj2" for row in class_rows)
+        and all(row["remaining_type"] == (2, 0, 1) for row in class_rows)
+        and all(row["config"] == (0, 1, 0, 1, 0, 0) for row in class_rows)
+        and all(row["n_refuse"] == 2 for row in class_rows)
+        and all(not row["fills"] for row in class_rows)
+        and all(row["history"] == (10,) for row in class_rows),
+    )
+    checks.check(
+        "thm2-all-four-first-refuse-same-type",
+        "all four first refuses have the same type adj2; the four types do not differ",
+        same_type
+        and lex_first_counterexample is None
+        and types == ["adj2", "adj2", "adj2", "adj2"]
+        and class_rows[0]["remaining"] == (0, 0, 0, 0, 0)
+        and class_rows[1]["remaining"] == (0, 1, 0, 0, 0)
+        and class_rows[2]["remaining"] == (1, 0, 0, 0, 0)
+        and class_rows[3]["remaining"] == (1, 1, 0, 0, 0)
+        and f1((0, 1, 0, 1, 0, 0)) == 1
+        and f_z0((0, 1, 0, 1, 0, 0)) == 0,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "the Q10-false class first-refuse type is displayed and is not adopted",
+        same_type
+        and "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write `adj2` into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "On the two-cube with off-patch o=0, whether all four Q10-false maps "
+        "first refuse the same remaining-bit type from the lex-first 10-site f1 "
+        "fill is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports whether all four Q10-false maps first refuse the same type from S",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `adj2` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-class-refuse",
+        "the note reports the four zeros, S, and first-refuse type adj2",
+        "(0, 0, 0, 0, 0)" in note
+        and "(0, 1, 0, 0, 0)" in note
+        and "(1, 0, 0, 0, 0)" in note
+        and "(1, 1, 0, 0, 0)" in note
+        and "`S = {(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 0, 1)}`"
+        in note
+        and "N_refuse = 2" in note
+        and "`adj2`" in note
+        and "(2, 0, 1)" in note
+        and "tick `1`" in note
+        and "site `(2, 1, 0)`" in note
+        and "same type" in note,
+    )
+    checks.check(
+        "not-leftover-c10zero",
+        "the residual is Q10 zeros class sameness, not leftover of the single-map refuse",
+        "Not leftover-character of the single-map first refuse" in note
+        and "f_z0=(0,0,0,0,0)" in note.replace(" ", "")
+        and ("New object" in note or "new object" in note)
+        and "Class fact of the Q10 zeros" in note_flat,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — all four Q10-false zeros are scored from S")
+    print("per_block: checked exactly — each first remaining-bit refuse type is named, or N_refuse=0")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the two-cube with off-patch o=0, all four Q10-false maps first-refuse remaining-bit type adj2 from the lex-first 10-site f1 fill. Displayed, not adopted.

## Runner

`scripts/f_cut_q10_false_ten_site_class_refuse_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.