### PR TITLE
feat(qstarc10): among Q_star, cov10=66 iff vertex3 and mixed3

### DIFF
--- a/docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,441 @@
+---
+claim_id: f_cut_qstar_cov10_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 8 F_cut maps with wt1=1 and adj2=1 on the two-cube with off-patch o=0, the cov10 values and whether a displayed restriction equals totality or positivity are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_qstar_cov10_census_2026_08_15.py
+---
+
+# Ten-Site Coverage Census Of The Eight `Q_*` Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 10-site coverage of the eight
+cube-covariant cut maps in `Q_*` — the `F_cut` subclass with `wt1=1`
+and `adj2=1` — on the twelve-vertex two-cube with off-patch occupancy
+`0`, over all 66 unordered 10-site seeds, in remaining-bit lex order,
+together with whether a displayed remaining-bit restriction equals
+10-site totality or positivity. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_qstar_cov10_census_2026_08_15.py`](../scripts/f_cut_qstar_cov10_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `Q_*` for the eight maps with `wt1=1` and `adj2=1`.
+Those eight remaining-bit tuples, in remaining-bit lex order, are
+
+```text
+(1, 0, 1, 0, 0), (1, 0, 1, 0, 1), (1, 0, 1, 1, 0), (1, 0, 1, 1, 1),
+(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+Investment c10bit3 defined `Q10` as the positivity predicate `cov10>0`.
+Every map in `Q_*` already has `adj2=1`, so `Q10` is true on all eight
+on this patch. That leftover is positivity, not a 10-site score and not
+a totality test. The present object is the 10-site coverage of each of
+those eight maps, and whether `cov10=66` is the displayed conjunction
+`k := (vertex3=1 and mixed3=1)`, another displayed remaining-bit
+restriction, or only the already-known fact that all eight have
+`cov10>0`. Every map in `Q_*` has `cov10>0` on this patch. cov10>0 is not Q4.
+New k inside Q_*, not a Q4 rename.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 10-set of vertices is
+a 10-site seed. There are `C(12,10)=66` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 13 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov10(f) = |{ S : |S|=10 and f fills from S }|.
+```
+
+The comparison ceiling `m10=66` is that seed count: a map attains `m10`
+exactly when it fills every 10-site seed. Do not list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`,
+which sits in `Q_*`.
+
+**Theorem 1.** Exhaustive evaluation of each of the eight `Q_*` maps on
+all 66 ten-site seeds, in remaining-bit lex order, gives
+
+```text
+cov10((1, 0, 1, 0, 0)) = 18
+cov10((1, 0, 1, 0, 1)) = 22
+cov10((1, 0, 1, 1, 0)) = 62
+cov10((1, 0, 1, 1, 1)) = 66
+cov10((1, 1, 1, 0, 0)) = 18
+cov10((1, 1, 1, 0, 1)) = 22
+cov10((1, 1, 1, 1, 0)) = 62
+cov10((1, 1, 1, 1, 1)) = 66
+```
+
+**Theorem 2.** The eight maps are not all 10-site total. Among those
+eight, `cov10=66` is equivalent to `vertex3=1` and `mixed3=1`.
+Positivity is not a remaining-bit restriction: `N_pos = 8`. The
+totality counts are
+
+```text
+N_tot10 = 2
+N_k = 2
+N_both = 2
+N_pos = 8
+```
+
+The two tot10 maps are `(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)`. The
+displayed `k` holds on exactly those same two remaining-bit tuples. The
+map `(1, 0, 1, 1, 1)` — which is `f_L1` — has `cov10=66` and `opp2=0`,
+and still has `k=1` because `k` does not use `opp2`. The displayed
+restriction that equals totality is `k`. The displayed restriction that
+equals positivity is the empty restriction inside `Q_*` (already
+`adj2=1`).
+
+**Theorem 3.** The eight-line census and the tot10 iff `k` test
+are displayed. Do not adopt a bit.
+
+Do not write the ranking into Admissibility. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the eight-element Q_* subclass, the exact cov10 census in remaining-bit lex order, and the tot10-iff-k test are enumerated. No physical law is selected."
+trace_class: frontier_discovery
+target_claim_id: f_cut_qstar_cov10_census
+target_blocker_text: "cov10 of each of the eight Q_* maps, and whether cov10=66 iff vertex3=mixed3=1, another displayed restriction, or positivity only"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the Q_* cov10 census and the tot10-iff-k test; do not adopt a displayed bit"
+conditional_surface_status: "exact for the eight Q_* maps on this twelve-vertex patch with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 66 unordered 10-site seeds;
+- the eight remaining-bit tuples of `Q_*`;
+- the displayed conjunction `k := (vertex3=1 and mixed3=1)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Report `cov10` of each of the eight `Q_*` maps on the two-cube,
+in remaining-bit lex order, and decide whether `cov10=66` is equivalent to
+`vertex3=1` and `mixed3=1` among those eight, or another displayed
+restriction, or only positivity of all eight. Display the census and the
+verdict. Do not adopt a bit.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`Q_*` is the subclass with `wt1=1` and `adj2=1`. It has three free bits
+(`opp2`, `vertex3`, `mixed3`) and size 8. Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+k(f)        = 1  iff  vertex3(f)=1 and mixed3(f)=1,
+Q10(f)      = 1  iff  cov10(f) > 0.
+```
+
+So `f_L1` has remaining bits `(1, 0, 1, 1, 1)` and is one of the eight
+`Q_*` maps. The displayed `k` holds on exactly two of those eight:
+`(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov10(f)` is the number of 10-site seeds whose halt set has cardinality
+12. Write `m10=66` for the number of 10-site seeds. A map attains `m10` if
+and only if it fills every such seed. Off-patch occupancy `0` is an
+explicit default; a blank-block is a different rule.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The subclass
+`Q_*` is the eight members with `wt1=1` and `adj2=1`, listed in
+remaining-bit lex order in the Result Up Front. The unbalanced-axis map
+`f_L1` is one element of `Q_*` and is not Hamming parity. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive evaluation
+of each of the eight on all 66 ten-site seeds gives the census
+
+```text
+cov10((1, 0, 1, 0, 0)) = 18
+cov10((1, 0, 1, 0, 1)) = 22
+cov10((1, 0, 1, 1, 0)) = 62
+cov10((1, 0, 1, 1, 1)) = 66
+cov10((1, 1, 1, 0, 0)) = 18
+cov10((1, 1, 1, 0, 1)) = 22
+cov10((1, 1, 1, 1, 0)) = 62
+cov10((1, 1, 1, 1, 1)) = 66
+```
+
+**Theorem 2.** Write `N_tot10` for the number of `Q_*` maps with
+`cov10=66`, `N_k` for the number with `k=1`, `N_both` for the
+number with both, and `N_pos` for the number with `cov10>0`. Then
+`N_tot10 = 2`, `N_k = 2`, `N_both = 2`, and `N_pos = 8`. Because the
+first three counts agree and the two tot10 maps are exactly the two
+`k` maps, `cov10=66` is equivalent to `vertex3=1` and `mixed3=1`
+among the eight. All eight are positive, so positivity is not a
+remaining-bit cut inside `Q_*`.
+
+**Theorem 3.** The eight-line census and the equivalence are displayed.
+Do not adopt a bit. Do not write the ranking into Admissibility.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after empty/full are forced to `0` |
+| `|Q_*|=8` | remaining bits with `wt1=1` and `adj2=1`, lex-ordered |
+| 66 ten-site seeds | `C(12,10)` unordered 10-sets on the two-cube; `m10=66` |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` and has remaining bits `(1, 0, 1, 1, 1)` |
+| eight-line `cov10` census | exhaustive `cov10` on `Q_*` yields `(18, 22, 62, 66, 18, 22, 62, 66)` |
+| tot10 iff `k` | holds: `N_tot10 = 2`, `N_k = 2`, `N_both = 2` |
+| positivity of all eight | `N_pos = 8`; `Q10` is already true on `Q_*` |
+| displayed tuples | the eight `Q_*` remaining-bit tuples and `k`, not adopted |
+
+## What This Does Not Claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No ranking of the other 24 maps in `F_cut`.
+- No reopening of a leftover `Q10=cov10>0` residual as Q4.
+- No adoption of `k`, of `f_L1`, or of any remaining bit.
+- No blank-block or 5-site variant.
+
+## No-Go Discipline Gate
+
+The census is an exact enumeration, not a wall. The tot10-iff-`k` test
+holds among `Q_*` and is not an Admissibility selector.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class and `Q_*` | Force vanish-on-empty, vanish-on-full, `f(c)=f(1-c)`, then `wt1=adj2=1`. | Theorem 1 and checks `thm1-f-cut-cardinality` / `thm1-qstar-eight-lex` give `|F_cut|=32` and `|Q_*|=8`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| eight-map 10-site score | Score each `Q_*` map by `cov10` on all 66 seeds in lex order. | Theorem 1 and check `thm1-cov10-census-lex`. | **ATTEMPTED** |
+| tot10 iff `k` | Ask whether `cov10=66` equals `vertex3=mixed3=1` among the eight. | Theorem 2 and check `thm2-tot10-iff-k`. | **ATTEMPTED** |
+| adopt a bit | Write `k` or any remaining bit into Admissibility. | Theorem 3 and check `thm3-displayed-not-adopted`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is no wall. The eight `cov10` integers are an exact enumeration.
+The passing tot10-iff-`k` test is one displayed conjunction on this
+eight-map list, not a physical selector.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| eight `cov10` integers / tot10-iff-`k` | yes: the census names who attains 66 | no: equivalence does not name the six non-total scores | independent census versus the iff test |
+| tot10 pair `(1, 0, 1, 1, 1)` / `(1, 1, 1, 1, 1)` | no: tot10 without `opp2` does not force `opp2` | no: tot10 with `opp2` does not forbid tot10 without it | independent remaining-bit witnesses of the same `k` |
+| leftover `Q10` / this census | no: `cov10>0 is not Q4`; every `Q_*` map has `cov10>0` | no: an eight-line score does not rename a positivity residual | New k inside `Q_*` |
+| positivity of all eight / tot10 iff `k` | no: `N_pos = 8` does not name who attains 66 | no: a two-map totality cut does not reopen positivity | displayed restriction equals totality, not positivity |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| `Q_*` | explicit `wt1=1` and `adj2=1` subclass; the other 24 maps are unclaimed |
+| all 66 ten-site seeds | explicit seed class; a 5-site ranking is a different residual |
+| displayed `k` | explicit conjunction of two remaining bits; not a derived law |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuples of `Q_*` | displayed witnesses, not selected laws |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:78` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:122` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:127` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:54` | 66 ten-site seeds | `C(12,10)` unordered 10-sets on the two-cube | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:141` | `Q_*` membership | `wt1=1` and `adj2=1` | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:146` | displayed `k` | `vertex3=1` and `mixed3=1` | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:243` | `cov10(f)` | number of 10-site seeds a map fills | yes |
+| `scripts/f_cut_qstar_cov10_census_2026_08_15.py:66` | `m10=66` | seed-count ceiling | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: the eight `Q_*` maps | the score is these eight maps on all 66 seeds; other classes are unclaimed |
+| per block | yes: the census against tot10 iff `k` | `cov10=66` equals the displayed conjunction among the eight |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: two of
+the eight maps fill every 10-site seed, and six do not. That split makes
+`k` coincide with tot10 among `Q_*` on this patch and does not select
+either tot10 map as the physical rule. The remaining physical choice —
+which, if any, `F_cut` map is the Admissibility occupancy predicate —
+stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that c10bit3 already asked whether `Q10`,
+meaning `cov10>0`, holds, and that `Q_*` already has `adj2=1`, so an
+eight-line 10-site census plus the two-bit conjunction `k` might be
+called leftover decoration of that positivity residual, or leftover
+decoration of Q4. That objection is correctly about a different
+predicate: positivity versus totality. It does not overturn the stated
+theorem: on the 66 ten-site seeds the eight `cov10` values are the
+integers above, every `Q_*` map has `cov10>0`, and `cov10=66` holds
+exactly when `vertex3=1` and `mixed3=1`. A positivity menu does not
+name the 10-site scores. `cov10>0 is not Q4`. This is a new `k` inside
+`Q_*`, not a Q4 rename.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the eight `Q_*` maps, and the 66-seed scores are recomputed
+here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the eight-map `cov10` census or replaces
+`cov10=66` iff `k` among `Q_*`.
+
+No-Go Discipline disposition: **PASS** for the tot10-iff-`k` test
+and the exact eight-line `cov10` census stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut` and the eight-element `Q_*` subclass, evaluates each remaining-bit
+tuple in lex order on the two-cube from every 10-site seed, reports the
+eight `cov10` values, checks that `cov10=66` is equivalent to
+`vertex3=1` and `mixed3=1`, checks that all eight have `cov10>0`,
+checks that `f_L1` is not Hamming parity, and exhibits the census and
+`k` as displayed, not adopted. Declared audit inputs are this note and
+the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_qstar_cov10_census_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_qstar_cov10_census_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_qstar_cov10_census_2026_08_15.txt
@@ -1,0 +1,74 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_qstar_cov10_census_2026_08_15.py
+runner_sha256: df466cc9203e2fe996e9c7eb093270f3b5c34c3a48a9e0829d688ccb819c3865
+input_fingerprint_sha256: e1241d57b2a722047209017383d7e4d93b3b38ed0519541dc84c3e0cc67b59e4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+|Q_*|=8
+n_ten_site_seeds=66
+m10=66
+remaining=(1, 0, 1, 0, 0) cov10=18 tot10=0 pos=1 k=0
+remaining=(1, 0, 1, 0, 1) cov10=22 tot10=0 pos=1 k=0
+remaining=(1, 0, 1, 1, 0) cov10=62 tot10=0 pos=1 k=0
+remaining=(1, 0, 1, 1, 1) cov10=66 tot10=1 pos=1 k=1
+remaining=(1, 1, 1, 0, 0) cov10=18 tot10=0 pos=1 k=0
+remaining=(1, 1, 1, 0, 1) cov10=22 tot10=0 pos=1 k=0
+remaining=(1, 1, 1, 1, 0) cov10=62 tot10=0 pos=1 k=0
+remaining=(1, 1, 1, 1, 1) cov10=66 tot10=1 pos=1 k=1
+N_tot10=2
+N_pos=8
+N_k=2
+N_both=2
+tot10_iff_k=True
+all_pos=True
+all_tot=False
+tot10_maps=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+k_maps=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+witness=[]
+f_L1_remaining=(1, 0, 1, 1, 1)
+cov10_f_L1=66
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-qstar-eight-lex Q_* is the eight remaining-bit tuples with wt1=1 and adj2=1 in lex order
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-ten-site-seeds the two-cube has twelve vertices and C(12,10)=66 ten-site seeds
+PASS: thm1-cov10-census-lex cov10 of each of the eight Q_* maps is reported in remaining-bit lex order
+PASS: thm2-tot10-iff-k cov10=66 iff (vertex3=1 and mixed3=1) is decided among Q_*
+PASS: thm3-displayed-not-adopted the census and k-test are displayed and no remaining bit is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted census, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-census the note reports the eight cov10 values, the iff verdict, and Q_*
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-q4 the residual is the Q_* cov10 census, not leftover Q10=cov10>0
+PASS: claim-scope-census claim_scope states the eight-map cov10 census and the restriction report
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the eight Q_* maps is scored by how many of the 66 ten-site seeds it fills
+per_block: checked exactly — tot10 iff k is the Q_* ten-site totality test against the displayed conjunction
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_qstar_cov10_census_2026_08_15.py
+++ b/scripts/f_cut_qstar_cov10_census_2026_08_15.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""Census cov10 of the eight Q_* maps and test tot10 iff k.
+
+Q_* is the F_cut subclass with wt1=1 and adj2=1 (eight remaining-bit
+tuples). F_cut is the cube-covariant class with f(empty)=f(full)=0 and
+f(c)=f(1-c). Dynamics are occupancy-to-lock on the twelve-vertex
+two-cube with off-patch occupancy 0. Coverage cov10(f) is the number of
+unordered 10-site seeds from which f fills. The displayed selector k is
+vertex3=1 and mixed3=1. Q10 is the positivity predicate cov10>0; every
+Q_* map already has adj2=1, so Q10 holds on all eight. This is a new k
+inside Q_*, not leftover Q10 and not a Q4 rename. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+TEN_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(decuple) for decuple in combinations(TWO_CUBE, 10)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+M10 = 66
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Remaining) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def in_qstar(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, _vertex3, _mixed3 = remaining
+    return wt1 == 1 and adj2 == 1
+
+
+def selector_k(remaining: Remaining) -> bool:
+    """Displayed k: vertex3=1 and mixed3=1."""
+    _wt1, _opp2, _adj2, vertex3, mixed3 = remaining
+    return vertex3 == 1 and mixed3 == 1
+
+
+def enumerate_qstar() -> list[Remaining]:
+    members: list[Remaining] = []
+    for bits in product((0, 1), repeat=5):
+        remaining: Remaining = (bits[0], bits[1], bits[2], bits[3], bits[4])
+        if in_qstar(remaining):
+            members.append(remaining)
+    return members
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+NEIGHBOR_INDEX: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+
+
+def fills_from_mask(fire: tuple[int, ...], seed_mask: int) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            bits = 0
+            for axis, neighbor in enumerate(NEIGHBOR_INDEX[site_index]):
+                occupied = neighbor is not None and ((locked >> neighbor) & 1)
+                if occupied:
+                    bits |= 1 << axis
+            if fire[bits]:
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def seed_mask(seed: frozenset[Site]) -> int:
+    mask = 0
+    for site in seed:
+        mask |= 1 << SITE_INDEX[site]
+    return mask
+
+
+SEED_MASKS: tuple[int, ...] = tuple(seed_mask(seed) for seed in TEN_SITE_SEEDS)
+
+
+def fire_table(remaining: Remaining) -> tuple[int, ...]:
+    table = [0] * 64
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        index = (
+            raw[0]
+            | (raw[1] << 1)
+            | (raw[2] << 2)
+            | (raw[3] << 3)
+            | (raw[4] << 4)
+            | (raw[5] << 5)
+        )
+        table[index] = remaining_value(config, remaining)
+    return tuple(table)
+
+
+def coverage10(remaining: Remaining) -> int:
+    fire = fire_table(remaining)
+    return sum(1 for mask in SEED_MASKS if fills_from_mask(fire, mask))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    qstar = enumerate_qstar()
+    ranked = [(remaining, coverage10(remaining)) for remaining in qstar]
+    n_tot10 = sum(1 for _remaining, cov in ranked if cov == M10)
+    n_pos = sum(1 for _remaining, cov in ranked if cov > 0)
+    n_k = sum(1 for remaining, _cov in ranked if selector_k(remaining))
+    n_both = sum(1 for remaining, cov in ranked if cov == M10 and selector_k(remaining))
+    tot10_iff_k = all((cov == M10) == selector_k(remaining) for remaining, cov in ranked)
+    all_pos = all(cov > 0 for _remaining, cov in ranked)
+    all_tot = all(cov == M10 for _remaining, cov in ranked)
+    tot10_maps = [remaining for remaining, cov in ranked if cov == M10]
+    k_maps = [remaining for remaining, _cov in ranked if selector_k(remaining)]
+    witness = [
+        remaining for remaining, cov in ranked if (cov == M10) != selector_k(remaining)
+    ]
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_l1 = next(cov for remaining, cov in ranked if remaining == l1_remaining)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"|Q_*|={len(qstar)}")
+    print(f"n_ten_site_seeds={len(TEN_SITE_SEEDS)}")
+    print(f"m10={M10}")
+    for remaining, cov in ranked:
+        print(
+            f"remaining={remaining} cov10={cov} tot10={int(cov == M10)} "
+            f"pos={int(cov > 0)} k={int(selector_k(remaining))}"
+        )
+    print(f"N_tot10={n_tot10}")
+    print(f"N_pos={n_pos}")
+    print(f"N_k={n_k}")
+    print(f"N_both={n_both}")
+    print(f"tot10_iff_k={tot10_iff_k}")
+    print(f"all_pos={all_pos}")
+    print(f"all_tot={all_tot}")
+    print(f"tot10_maps={tot10_maps}")
+    print(f"k_maps={k_maps}")
+    print(f"witness={witness}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"cov10_f_L1={cov_l1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_QSTAR_COV10_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-qstar-eight-lex",
+        "Q_* is the eight remaining-bit tuples with wt1=1 and adj2=1 in lex order",
+        len(qstar) == 8
+        and qstar
+        == [
+            (1, 0, 1, 0, 0),
+            (1, 0, 1, 0, 1),
+            (1, 0, 1, 1, 0),
+            (1, 0, 1, 1, 1),
+            (1, 1, 1, 0, 0),
+            (1, 1, 1, 0, 1),
+            (1, 1, 1, 1, 0),
+            (1, 1, 1, 1, 1),
+        ]
+        and all(in_qstar(remaining) for remaining in qstar)
+        and qstar == sorted(qstar),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_qstar(l1_remaining)
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-ten-site-seeds",
+        "the two-cube has twelve vertices and C(12,10)=66 ten-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(TEN_SITE_SEEDS) == 66
+        and len(set(TEN_SITE_SEEDS)) == 66
+        and all(seed <= set(TWO_CUBE) and len(seed) == 10 for seed in TEN_SITE_SEEDS),
+    )
+    census_ok = True
+    for remaining, cov in ranked:
+        spaced = f"cov10({remaining}) = {cov}"
+        compact = f"cov10{remaining} = {cov}".replace(" ", "")
+        if spaced not in note and compact not in note.replace(" ", ""):
+            census_ok = False
+    checks.check(
+        "thm1-cov10-census-lex",
+        "cov10 of each of the eight Q_* maps is reported in remaining-bit lex order",
+        len(ranked) == 8
+        and [remaining for remaining, _cov in ranked] == qstar
+        and census_ok
+        and all(0 <= cov <= M10 for _remaining, cov in ranked)
+        and "remaining-bit lex order" in note,
+    )
+    checks.check(
+        "thm2-tot10-iff-k",
+        "cov10=66 iff (vertex3=1 and mixed3=1) is decided among Q_*",
+        n_tot10 == 2
+        and n_k == 2
+        and n_both == 2
+        and tot10_iff_k
+        and not all_tot
+        and all_pos
+        and n_pos == 8
+        and tot10_maps == [(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+        and k_maps == [(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+        and witness == []
+        and cov_l1 == M10
+        and l1_remaining in tot10_maps
+        and selector_k(l1_remaining)
+        and "N_tot10 = 2" in note
+        and "N_k = 2" in note
+        and "N_both = 2" in note
+        and "equivalent" in note
+        and "N_pos = 8" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the census and k-test are displayed and no remaining bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write the ranking into Admissibility" in note
+        and "cov10>0 is not Q4" in note
+        and "New k inside Q_*" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted census, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-census",
+        "the note reports the eight cov10 values, the iff verdict, and Q_*",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 0, 1, 0, 0)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "Q_*" in note
+        and "vertex3=1 and mixed3=1" in note
+        and "cov10=66" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-q4",
+        "the residual is the Q_* cov10 census, not leftover Q10=cov10>0",
+        "cov10>0 is not Q4" in note
+        and "New k inside Q_*" in note
+        and "not a Q4 rename" in note
+        and "Q10" in note,
+    )
+    checks.check(
+        "claim-scope-census",
+        "claim_scope states the eight-map cov10 census and the restriction report",
+        "Among the 8 F_cut maps with wt1=1 and" in note
+        and "adj2=1 on the two-cube with off-patch o=0" in note
+        and "the cov10 values and whether a displayed restriction equals" in note
+        and "totality or positivity are reported" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the eight Q_* maps is scored by how many of the 66 ten-site seeds it fills")
+    print("per_block: checked exactly — tot10 iff k is the Q_* ten-site totality test against the displayed conjunction")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 8 Q_* maps on the two-cube with off-patch o=0, cov10=66 iff vertex3=1 and mixed3=1. All eight have cov10>0. Displayed, not adopted.

## Runner

`scripts/f_cut_qstar_cov10_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.