### PR TITLE
feat(qstartot8): among Q_star, Max(8) is unique f1, not vertex3 and mixed3

### DIFF
--- a/docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,436 @@
+---
+claim_id: f_cut_qstar_cov8_max_selector_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 8 F_cut maps with wt1=1 and adj2=1 on the two-cube with off-patch o=0, whether maximal cov8 equals vertex3=mixed3=1 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py
+---
+
+# Maximal Eight-Site Coverage Versus `vertex3` And `mixed3` Inside `Q_*`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 8-site coverage of the eight
+cube-covariant cut maps in `Q_*` — the `F_cut` subclass with `wt1=1`
+and `adj2=1` — on the twelve-vertex two-cube with off-patch occupancy
+`0`, over all 495 unordered 8-site seeds, in remaining-bit lex order,
+together with whether maximal `cov8` among those eight equals the
+displayed conjunction `vertex3=1` and `mixed3=1`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py`](../scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `Q_*` for the eight maps with `wt1=1` and `adj2=1`.
+Those eight remaining-bit tuples, in remaining-bit lex order, are
+
+```text
+(1, 0, 1, 0, 0), (1, 0, 1, 0, 1), (1, 0, 1, 1, 0), (1, 0, 1, 1, 1),
+(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+Investment among `Q_*` scored tot3/tot5/tot7/tot10 and found each of
+those totalities iff `vertex3=1` and `mixed3=1`. That is a family of
+totality residuals at other seed sizes. The present object is maximal
+`cov8` among those same eight maps, and whether Max(8) equals the
+displayed conjunction `Q := (vertex3=1 and mixed3=1)`. New k inside Q_*,
+not leftover tot3/tot5/tot7/tot10.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 8-set of vertices is
+an 8-site seed. There are `C(12,8)=495` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 13 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov8(f) = |{ S : |S|=8 and f fills from S }|.
+```
+
+Write `m8` for the maximum of `cov8` among the eight. Max(8) is the set
+of `Q_*` maps attaining `m8`. The seed-count ceiling is 495: a map
+attains that ceiling exactly when it fills every 8-site seed. Do not
+list the seeds.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`,
+which sits in `Q_*`.
+
+**Theorem 1.** Exhaustive evaluation of each of the eight `Q_*` maps on
+all 495 eight-site seeds, in remaining-bit lex order, gives
+
+```text
+cov8((1, 0, 1, 0, 0)) = 158
+cov8((1, 0, 1, 0, 1)) = 182
+cov8((1, 0, 1, 1, 0)) = 446
+cov8((1, 0, 1, 1, 1)) = 494
+cov8((1, 1, 1, 0, 0)) = 175
+cov8((1, 1, 1, 0, 1)) = 183
+cov8((1, 1, 1, 1, 0)) = 471
+cov8((1, 1, 1, 1, 1)) = 495
+```
+
+Thus `m8 = 495`, attained only by `(1, 1, 1, 1, 1)`. The displayed `Q`
+holds on `(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)`. Maximal `cov8` among
+the eight is not equivalent to `vertex3=1` and `mixed3=1`.
+
+**Theorem 2.** Write `N_max` for the number of `Q_*` maps attaining
+`m8`, `N_Q` for the number with `Q=1`, and `N_both` for the number
+with both. Then
+
+```text
+N_max = 1
+N_Q = 2
+N_both = 1
+```
+
+The unique maximizer is `(1, 1, 1, 1, 1)`. The two `Q` maps are
+`(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)`. The lex-first miss is
+`(1, 0, 1, 1, 1)` — which is `f_L1` — with `Q=1` and `cov8=494`.
+
+**Theorem 3.** The eight-line census and the Max(8) iff `Q` test
+are displayed. Do not adopt a bit.
+
+Do not write the ranking into Admissibility. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The ten-orbit reconstruction, the 32-element F_cut, the eight-element Q_* subclass, the exact cov8 census in remaining-bit lex order, and the Max(8)-iff-Q test are enumerated. No physical law is selected."
+trace_class: frontier_discovery
+target_claim_id: f_cut_qstar_cov8_max_selector
+target_blocker_text: "whether maximal cov8 among the eight Q_* maps equals vertex3=mixed3=1"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the Q_* cov8 census and the Max(8)-iff-Q test; do not adopt a displayed bit"
+conditional_surface_status: "exact for the eight Q_* maps on this twelve-vertex patch with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Mathematical Objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3`, nearest-neighbor adjacency, and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule covariant
+under those rotations. Record supplies permanence of a lock and unreadability
+of an absent record. Qubit is unused beyond the ambient one-site algebra
+boundary: the maps here are Boolean occupancy predicates, not `M_2(C)`-valued
+laws.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the 24 proper signed-permutation rotations of the three axes
+  (`det = +1`);
+- occupancy 6-tuples on the ordered neighbor stencil
+  `(+x,-x,+y,-y,+z,-z)`;
+- the two-cube vertex set `{0,1,2}×{0,1}×{0,1}`;
+- the off-patch occupancy default `0`;
+- the complete set of 495 unordered 8-site seeds;
+- the eight remaining-bit tuples of `Q_*`;
+- the displayed conjunction `Q := (vertex3=1 and mixed3=1)`.
+
+No observational comparator, literature constant, Wilson weight, rate, or
+generator is imported. No Record scalar functional appears.
+
+## Exact Target And Objects
+
+**Target.** Report `cov8` of each of the eight `Q_*` maps on the two-cube,
+in remaining-bit lex order, and decide whether maximal `cov8` is equivalent
+to `vertex3=1` and `mixed3=1` among those eight. Display the census and the
+verdict. Do not adopt a bit.
+
+Write a neighbor configuration as `c ∈ {0,1}^6`. A proper cube rotation `R`
+acts by `(R·c)(d) = c(R^{-1}d)` on the six face directions `d`. A map
+`f:{0,1}^6 → {0,1}` is cube-covariant when `f(R·c)=f(c)` for every such `R`.
+Equivalently, `f` is constant on each orbit.
+
+The axis type of `c` is the triple `(u,b,e)` with `u+b+e=3`, where `u` is
+the number of axes with `c_{+} ≠ c_{-}`, `b` the number with
+`(c_{+},c_{-})=(1,1)`, and `e` the number with `(c_{+},c_{-})=(0,0)`. These
+ten types are exactly the ten orbits. Complement sends `(u,b,e)` to
+`(u,e,b)`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`F_cut` is the class of cube-covariant maps with `f(empty)=f(full)=0` and
+`f(c)=f(1-c)`. The empty/full pair is forced to `0`. The remaining free
+data are three complement-pair bits and two complement-fixed orbit bits,
+so `|F_cut|=32`. The remaining-bit tuple is those five bits in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`.
+
+`Q_*` is the subclass with `wt1=1` and `adj2=1`. It has three free bits
+(`opp2`, `vertex3`, `mixed3`) and size 8. Define
+
+```text
+f_L1(c)     = 1  iff  u(c) ≥ 1,
+Q(f)        = 1  iff  vertex3(f)=1 and mixed3(f)=1.
+```
+
+So `f_L1` has remaining bits `(1, 0, 1, 1, 1)` and is one of the eight
+`Q_*` maps. The displayed `Q` holds on exactly two of those eight:
+`(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)`. Neither map is adopted.
+
+A locked set `S` determines occupancies: a lattice neighbor in `S` has
+occupancy `1`, and every other neighbor — including every off-patch
+neighbor — has occupancy `0`. One synchronous tick replaces `S` by
+
+```text
+S ∪ { v in two-cube \ S : f(neighborhood_6(v; S)) = 1 }.
+```
+
+Then `cov8(f)` is the number of 8-site seeds whose halt set has cardinality
+12. Write `m8` for the maximum of those eight integers. A map is in Max(8)
+if and only if it attains `m8`. Off-patch occupancy `0` is an explicit
+default; a blank-block is a different rule.
+
+## Theorems
+
+**Theorem 1.** There are exactly 24 proper cube rotations and exactly 10
+orbits on `{0,1}^6`. The three cuts leave `|F_cut|=32`. The subclass
+`Q_*` is the eight members with `wt1=1` and `adj2=1`, listed in
+remaining-bit lex order in the Result Up Front. The unbalanced-axis map
+`f_L1` is one element of `Q_*` and is not Hamming parity. On the
+twelve-vertex two-cube with off-patch occupancy `0`, exhaustive evaluation
+of each of the eight on all 495 eight-site seeds gives the census
+
+```text
+cov8((1, 0, 1, 0, 0)) = 158
+cov8((1, 0, 1, 0, 1)) = 182
+cov8((1, 0, 1, 1, 0)) = 446
+cov8((1, 0, 1, 1, 1)) = 494
+cov8((1, 1, 1, 0, 0)) = 175
+cov8((1, 1, 1, 0, 1)) = 183
+cov8((1, 1, 1, 1, 0)) = 471
+cov8((1, 1, 1, 1, 1)) = 495
+```
+
+Maximal `cov8` among the eight is `m8 = 495`, attained only by
+`(1, 1, 1, 1, 1)`. That is not equivalent to `vertex3=1` and `mixed3=1`.
+
+**Theorem 2.** Write `N_max` for the number of `Q_*` maps with
+`cov8=m8`, `N_Q` for the number with `Q=1`, and `N_both` for the
+number with both. Then `N_max = 1`, `N_Q = 2`, and `N_both = 1`.
+The lex-first miss is `(1, 0, 1, 1, 1)`: it has `Q=1` and
+`cov8=494 < m8`.
+
+**Theorem 3.** The eight-line census and the failed equivalence are
+displayed. Do not adopt a bit. Do not write the ranking into
+Admissibility.
+
+## Proof-Obligation Graph
+
+| obligation | exact disposition |
+|---|---|
+| 24 proper cube rotations | signed permutations of the three axes with determinant `+1` |
+| 10 orbits on `{0,1}^6` | axis-type classes `(u,b,e)` partition the 64 cells with the listed sizes |
+| `|F_cut|=32` | three complement-pairs and two complement-fixed orbits remain free after empty/full are forced to `0` |
+| `|Q_*|=8` | remaining bits with `wt1=1` and `adj2=1`, lex-ordered |
+| 495 eight-site seeds | `C(12,8)` unordered 8-sets on the two-cube |
+| `f_L1` is not Hamming | unbalanced-axis predicate disagrees with `|c|_1 mod 2` and has remaining bits `(1, 0, 1, 1, 1)` |
+| eight-line `cov8` census | exhaustive `cov8` on `Q_*` yields `(158, 182, 446, 494, 175, 183, 471, 495)` |
+| Max(8) iff `Q` | fails: `N_max = 1`, `N_Q = 2`, `N_both = 1`; lex-first miss `(1, 0, 1, 1, 1)` |
+| displayed tuples | the eight `Q_*` remaining-bit tuples and `Q`, not adopted |
+
+## What This Does Not Claim
+
+- No physical Admissibility selector.
+- No `Z^3`-wide formation law.
+- No ranking of the other 24 maps in `F_cut`.
+- No reopening of tot3/tot5/tot7/tot10 as a selector.
+- No adoption of `Q`, of `f_L1`, or of any remaining bit.
+- No blank-block or other-`k` variant.
+
+## No-Go Discipline Gate
+
+The census is an exact enumeration, not a wall. The Max(8)-iff-`Q` test
+fails among `Q_*` and is not an Admissibility selector.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| orbit reconstruction | Recompute the 24 rotations and the 10 axis-type orbits. | Theorem 1 and checks `thm1-twenty-four-rotations` / `thm1-ten-orbits`. | **ATTEMPTED** |
+| three-cut class and `Q_*` | Force vanish-on-empty, vanish-on-full, `f(c)=f(1-c)`, then `wt1=adj2=1`. | Theorem 1 and checks `thm1-f-cut-cardinality` / `thm1-qstar-eight-lex` give `|F_cut|=32` and `|Q_*|=8`. | **ATTEMPTED** |
+| Hamming-as-`f_L1` | Test whether `|c|_1 mod 2` equals the unbalanced-axis predicate. | Theorem 1 and check `thm1-f-L1-not-hamming` separate the maps. | **ATTEMPTED** |
+| eight-map 8-site score | Score each `Q_*` map by `cov8` on all 495 seeds in lex order. | Theorem 1 and check `thm1-max-not-iff-q`. | **ATTEMPTED** |
+| Max(8) iff `Q` | Ask whether maximal `cov8` equals `vertex3=mixed3=1` among the eight. | Theorem 2 and check `thm2-counts-and-lex-first-miss`. | **ATTEMPTED** |
+| adopt a bit | Write `Q` or any remaining bit into Admissibility. | Theorem 3 and check `thm3-displayed-not-adopted`. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is no wall. The eight `cov8` integers are an exact enumeration.
+The failing Max(8)-iff-`Q` test is one displayed conjunction on this
+eight-map list, not a physical selector.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| eight `cov8` integers / Max(8)-iff-`Q` | yes: the census names who attains `m8` | no: the failed equivalence does not name the six non-maximal scores | independent census versus the iff test |
+| maximizer `(1, 1, 1, 1, 1)` / miss `(1, 0, 1, 1, 1)` | no: tot8 with `opp2` does not force the `opp2=0` `Q` map to attain `m8` | no: the miss does not forbid the `opp2=1` maximizer | independent remaining-bit witnesses of the same `Q` |
+| leftover tot3/tot5/tot7/tot10 / this Max(8) test | no: totality at other seed sizes does not name Max(8) | no: an eight-site maximizer test does not replace those totalities | New k inside `Q_*` |
+| tot8 ceiling / Max(8) | yes here: `m8` happens to equal the seed count | no in general: a unique maximizer need not fill every seed | reported fact, not a new law |
+
+Physical law selection is not a wall: this note makes no negative theorem
+about the existence of a selector and simply does not claim one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “work on the twelve-vertex two-cube” | explicit patch hypothesis; not a `Z^3` theorem |
+| off-patch occupancy `0` | explicit default; blank-block is a different rule |
+| `F_cut` | explicit three-cut class; the other 992 covariant maps are excluded |
+| `Q_*` | explicit `wt1=1` and `adj2=1` subclass; the other 24 maps are unclaimed |
+| all 495 eight-site seeds | explicit seed class; tot3/tot5/tot7/tot10 are different residuals |
+| displayed `Q` | explicit conjunction of two remaining bits; not a derived law |
+| “lock” | Record permanence on this Boolean occupancy model, not a possibility-valued law |
+| “cube-covariant” | invariance under the 24 proper rotations, cited to Lattice/Admissibility |
+| Hamming parity | displayed mutation only |
+| remaining-bit tuples of `Q_*` | displayed witnesses, not selected laws |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and cubic rotations | sites are `Z^3` with proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | covariant nearest-neighbor rule | covariance is the class filter, not a selector | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:79` | lock permanence | a locked site stays locked | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:83` | unreadability of absence | unlocked and off-patch sites contribute occupancy `0`, not a readout | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:80` | 24 proper rotations | signed permutations with determinant `+1` | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:124` | `f_L1` definition | unbalanced-axis predicate, not Hamming | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:129` | Hamming mutation | `|c|_1 mod 2` is a different map | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:55` | 495 eight-site seeds | `C(12,8)` unordered 8-sets on the two-cube | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:143` | `Q_*` membership | `wt1=1` and `adj2=1` | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:148` | displayed `Q` | `vertex3=1` and `mixed3=1` | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:245` | `cov8(f)` | number of 8-site seeds a map fills | yes |
+| `scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py:67` | seed-count 495 | `C(12,8)` ceiling used as the comparison scale | yes |
+
+No evidence citation is used to claim that a physical occupancy law, a
+formation rate, or a `Z^3`-wide selector has been closed.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 neighbor 6-tuples | each is assigned its axis-type orbit; no broader cell class is classified |
+| per site | yes: the twelve two-cube vertices | each uses the same six-direction stencil with off-patch occupancy `0` |
+| per mode | yes: the eight `Q_*` maps | the score is these eight maps on all 495 seeds; other classes are unclaimed |
+| per block | yes: the census against Max(8) iff `Q` | maximal `cov8` is not the displayed conjunction among the eight |
+| lattice wide | no | no `Z^3`-wide formation or Admissibility selector is asserted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms` node.
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of them
+supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is displayed rather than suppressed: one of
+the eight maps fills every 8-site seed, one `Q` map misses a single seed,
+and six maps miss more. That split makes Max(8) strictly smaller than `Q`
+among `Q_*` on this patch and does not select the maximizer as the
+physical rule. The remaining physical choice — which, if any, `F_cut` map
+is the Admissibility occupancy predicate — stays explicit.
+
+The open derivation-obligation registry
+(`docs/audit/data/derivation_obligations.json`) names no occupancy-to-lock
+coverage target; those open gates are unused here.
+
+### N7 — hostile steelman
+
+The strongest objection is that tot3/tot5/tot7/tot10 already asked
+whether those totalities equal `vertex3=1` and `mixed3=1` among `Q_*`,
+so an eight-line 8-site census plus the same two-bit conjunction might
+be called leftover decoration of those totality tests. That objection
+is correctly about different seed classes, or about totality rather than
+the maximizer set. It does not overturn the stated theorem: on the 495
+eight-site seeds the eight `cov8` values are the integers above, `m8=495`
+is attained only by `(1, 1, 1, 1, 1)`, and `Q` also holds on
+`(1, 0, 1, 1, 1)` with `cov8=494`. A tot7 census does not name the
+8-site maximizer set. This is a new `k` inside `Q_*`, not leftover
+tot3/tot5/tot7/tot10.
+
+### N8 — cross-cycle echo
+
+Repository search found nearby occupancy and covariance surfaces. They are
+context, not load-bearing dependencies. The 24 rotations, 10 orbits,
+`F_cut`, the eight `Q_*` maps, and the 495-seed scores are recomputed
+here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md` | proper-cubic covariance of a local rule | covariance is used only as the orbit filter for Boolean maps |
+| `docs/PHYSICAL_SPATIAL_BLOCK_SEAM_DICHOTOMY_CYCLE728_NOTE_2026-08-04.md` | two-cell box `{0,1,2}×{0,1}×{0,1}` | the same twelve spatial vertices are the patch; the seam cost is unused |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | one covariant nearest-neighbor rule | the axiom names the contract; this note does not select the rule |
+
+No earlier mechanism retires the eight-map `cov8` census or replaces
+Max(8) iff `Q` among `Q_*`.
+
+No-Go Discipline disposition: **PASS** for the Max(8)-iff-`Q` test
+and the exact eight-line `cov8` census stated above.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility. A
+> site never carries more than one record; records are permanent.
+
+> Only records are readable. A readout value is determined by record content
+> alone. A site with no record cannot be read.
+
+## Runner Contract
+
+The companion runner reconstructs the 24 rotations and 10 orbits, rebuilds
+`F_cut` and the eight-element `Q_*` subclass, evaluates each remaining-bit
+tuple in lex order on the two-cube from every 8-site seed, reports the
+eight `cov8` values, checks that maximal `cov8` is not equivalent to
+`vertex3=1` and `mixed3=1`, reports `N_max`, `N_Q`, `N_both` and the
+lex-first miss, checks that `f_L1` is not Hamming parity, and exhibits
+the census and `Q` as displayed, not adopted. Declared audit inputs are
+this note and the axiom memo. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_qstar_cov8_max_selector_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_qstar_cov8_max_selector_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_qstar_cov8_max_selector_2026_08_15.txt
@@ -1,0 +1,72 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py
+runner_sha256: c47e4910b3d0a4ef22e825c7f76a4efe03180ade6fcbd4ed2a34c2c37cca0526
+input_fingerprint_sha256: 5a03b0fc3fe3e5fd632338e2c181da1cc3f012d82e81770f35091fd2e52f7c27
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+n_rotations=24
+n_orbits=10
+orbit_types_and_sizes=(0, 0, 3):1,(0, 1, 2):3,(0, 2, 1):3,(0, 3, 0):1,(1, 0, 2):6,(1, 1, 1):12,(1, 2, 0):6,(2, 0, 1):12,(2, 1, 0):12,(3, 0, 0):8
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+|Q_*|=8
+n_eight_site_seeds=495
+m8=495
+remaining=(1, 0, 1, 0, 0) cov8=158 max8=0 Q=0
+remaining=(1, 0, 1, 0, 1) cov8=182 max8=0 Q=0
+remaining=(1, 0, 1, 1, 0) cov8=446 max8=0 Q=0
+remaining=(1, 0, 1, 1, 1) cov8=494 max8=0 Q=1
+remaining=(1, 1, 1, 0, 0) cov8=175 max8=0 Q=0
+remaining=(1, 1, 1, 0, 1) cov8=183 max8=0 Q=0
+remaining=(1, 1, 1, 1, 0) cov8=471 max8=0 Q=0
+remaining=(1, 1, 1, 1, 1) cov8=495 max8=1 Q=1
+N_max=1
+N_Q=2
+N_both=1
+max_iff_Q=False
+max_maps=[(1, 1, 1, 1, 1)]
+Q_maps=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+misses=[(1, 0, 1, 1, 1)]
+lex_first_miss=(1, 0, 1, 1, 1)
+f_L1_remaining=(1, 0, 1, 1, 1)
+cov8_f_L1=494
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-qstar-eight-lex Q_* is the eight remaining-bit tuples with wt1=1 and adj2=1 in lex order
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-eight-site-seeds the two-cube has twelve vertices and C(12,8)=495 eight-site seeds
+PASS: thm1-max-not-iff-q maximal cov8 among the eight is not equivalent to vertex3=mixed3=1
+PASS: thm2-counts-and-lex-first-miss N_max, N_Q, N_both and the lex-first miss are reported
+PASS: thm3-displayed-not-adopted the Max(8)-iff-Q test is displayed and no remaining bit is adopted
+PASS: lattice-and-admissibility-parents the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule
+PASS: note-contract bounded theorem, displayed-not-adopted Max(8) test, and machine status
+PASS: claim-type-and-gate N1-N8 and a passing no-go disposition are source-visible
+PASS: forbidden-phrases-absent the note and runner omit the dispatch-forbidden phrases
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: note-reports-max-selector the note reports the eight cov8 values, the iff verdict, and Q_*
+PASS: no-axiom-edit the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: not-leftover-totality the residual is Max(8) iff Q among Q_*, not leftover tot3/tot5/tot7/tot10
+PASS: claim-scope-max-selector claim_scope states whether maximal cov8 equals vertex3=mixed3=1
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the eight Q_* maps is scored by how many of the 495 eight-site seeds it fills
+per_block: checked exactly — Max(8) iff Q is the Q_* eight-site maximizer test against the displayed conjunction
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py
+++ b/scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Test whether Max(8) among Q_* equals vertex3 and mixed3.
+
+Q_* is the F_cut subclass with wt1=1 and adj2=1 (eight remaining-bit
+tuples). F_cut is the cube-covariant class with f(empty)=f(full)=0 and
+f(c)=f(1-c). Dynamics are occupancy-to-lock on the twelve-vertex
+two-cube with off-patch occupancy 0. Coverage cov8(f) is the number of
+unordered 8-site seeds from which f fills. Max(8) is the set of Q_*
+maps attaining the maximum of cov8 among those eight. The displayed
+selector Q is vertex3=1 and mixed3=1. Investment tot3/tot5/tot7/tot10
+iff that same cut; this is a new k inside Q_* for maximal cov8, not
+leftover totality at those other seed sizes. f_L1 is the unbalanced-axis
+predicate (some n_mu != 0), never Hamming |c|_1 mod 2. Displayed, not
+adopted.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+EIGHT_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(octuple) for octuple in combinations(TWO_CUBE, 8)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+M8_SEEDS = 495
+DISPLAYED_MISS: Remaining = (1, 0, 1, 1, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Remaining) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def in_qstar(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, _vertex3, _mixed3 = remaining
+    return wt1 == 1 and adj2 == 1
+
+
+def selector_q(remaining: Remaining) -> bool:
+    """Displayed Q: vertex3=1 and mixed3=1."""
+    _wt1, _opp2, _adj2, vertex3, mixed3 = remaining
+    return vertex3 == 1 and mixed3 == 1
+
+
+def enumerate_qstar() -> list[Remaining]:
+    members: list[Remaining] = []
+    for bits in product((0, 1), repeat=5):
+        remaining: Remaining = (bits[0], bits[1], bits[2], bits[3], bits[4])
+        if in_qstar(remaining):
+            members.append(remaining)
+    return members
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+NEIGHBOR_INDEX: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+
+
+def fills_from_mask(fire: tuple[int, ...], seed_mask: int) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            bits = 0
+            for axis, neighbor in enumerate(NEIGHBOR_INDEX[site_index]):
+                occupied = neighbor is not None and ((locked >> neighbor) & 1)
+                if occupied:
+                    bits |= 1 << axis
+            if fire[bits]:
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def seed_mask(seed: frozenset[Site]) -> int:
+    mask = 0
+    for site in seed:
+        mask |= 1 << SITE_INDEX[site]
+    return mask
+
+
+SEED_MASKS: tuple[int, ...] = tuple(seed_mask(seed) for seed in EIGHT_SITE_SEEDS)
+
+
+def fire_table(remaining: Remaining) -> tuple[int, ...]:
+    table = [0] * 64
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        index = (
+            raw[0]
+            | (raw[1] << 1)
+            | (raw[2] << 2)
+            | (raw[3] << 3)
+            | (raw[4] << 4)
+            | (raw[5] << 5)
+        )
+        table[index] = remaining_value(config, remaining)
+    return tuple(table)
+
+
+def coverage8(remaining: Remaining) -> int:
+    fire = fire_table(remaining)
+    return sum(1 for mask in SEED_MASKS if fills_from_mask(fire, mask))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    qstar = enumerate_qstar()
+    ranked = [(remaining, coverage8(remaining)) for remaining in qstar]
+    m8 = max(cov for _remaining, cov in ranked)
+    n_max = sum(1 for _remaining, cov in ranked if cov == m8)
+    n_q = sum(1 for remaining, _cov in ranked if selector_q(remaining))
+    n_both = sum(
+        1 for remaining, cov in ranked if cov == m8 and selector_q(remaining)
+    )
+    max_iff_q = all((cov == m8) == selector_q(remaining) for remaining, cov in ranked)
+    max_maps = [remaining for remaining, cov in ranked if cov == m8]
+    q_maps = [remaining for remaining, _cov in ranked if selector_q(remaining)]
+    misses = [
+        remaining
+        for remaining, cov in ranked
+        if (cov == m8) != selector_q(remaining)
+    ]
+    lex_first_miss = misses[0] if misses else None
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_l1 = next(cov for remaining, cov in ranked if remaining == l1_remaining)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print("orbit_types_and_sizes=" + ",".join(f"{t}:{orbit_sizes[t]}" for t in orbit_types))
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"|Q_*|={len(qstar)}")
+    print(f"n_eight_site_seeds={len(EIGHT_SITE_SEEDS)}")
+    print(f"m8={m8}")
+    for remaining, cov in ranked:
+        print(
+            f"remaining={remaining} cov8={cov} max8={int(cov == m8)} "
+            f"Q={int(selector_q(remaining))}"
+        )
+    print(f"N_max={n_max}")
+    print(f"N_Q={n_q}")
+    print(f"N_both={n_both}")
+    print(f"max_iff_Q={max_iff_q}")
+    print(f"max_maps={max_maps}")
+    print(f"Q_maps={q_maps}")
+    print(f"misses={misses}")
+    print(f"lex_first_miss={lex_first_miss}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"cov8_f_L1={cov_l1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_QSTAR_COV8_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-qstar-eight-lex",
+        "Q_* is the eight remaining-bit tuples with wt1=1 and adj2=1 in lex order",
+        len(qstar) == 8
+        and qstar
+        == [
+            (1, 0, 1, 0, 0),
+            (1, 0, 1, 0, 1),
+            (1, 0, 1, 1, 0),
+            (1, 0, 1, 1, 1),
+            (1, 1, 1, 0, 0),
+            (1, 1, 1, 0, 1),
+            (1, 1, 1, 1, 0),
+            (1, 1, 1, 1, 1),
+        ]
+        and all(in_qstar(remaining) for remaining in qstar)
+        and qstar == sorted(qstar),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_qstar(l1_remaining)
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0],
+    )
+    checks.check(
+        "thm1-two-cube-and-eight-site-seeds",
+        "the two-cube has twelve vertices and C(12,8)=495 eight-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(EIGHT_SITE_SEEDS) == M8_SEEDS
+        and len(set(EIGHT_SITE_SEEDS)) == M8_SEEDS
+        and all(seed <= set(TWO_CUBE) and len(seed) == 8 for seed in EIGHT_SITE_SEEDS),
+    )
+    census_ok = True
+    for remaining, cov in ranked:
+        spaced = f"cov8({remaining}) = {cov}"
+        compact = f"cov8{remaining} = {cov}".replace(" ", "")
+        if spaced not in note and compact not in note.replace(" ", ""):
+            census_ok = False
+    checks.check(
+        "thm1-max-not-iff-q",
+        "maximal cov8 among the eight is not equivalent to vertex3=mixed3=1",
+        not max_iff_q
+        and m8 == 495
+        and n_max == 1
+        and n_q == 2
+        and n_both == 1
+        and max_maps == [(1, 1, 1, 1, 1)]
+        and q_maps == [(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+        and census_ok
+        and "not equivalent" in note
+        and "remaining-bit lex order" in note,
+    )
+    checks.check(
+        "thm2-counts-and-lex-first-miss",
+        "N_max, N_Q, N_both and the lex-first miss are reported",
+        n_max == 1
+        and n_q == 2
+        and n_both == 1
+        and lex_first_miss == DISPLAYED_MISS
+        and misses == [(1, 0, 1, 1, 1)]
+        and l1_remaining == DISPLAYED_MISS
+        and cov_l1 == 494
+        and selector_q(l1_remaining)
+        and l1_remaining not in max_maps
+        and "N_max = 1" in note
+        and "N_Q = 2" in note
+        and "N_both = 1" in note
+        and "(1, 0, 1, 1, 1)" in note
+        and "lex-first miss" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the Max(8)-iff-Q test is displayed and no remaining bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write the ranking into Admissibility" in note
+        and "New k inside Q_*" in note,
+    )
+    checks.check(
+        "lattice-and-admissibility-parents",
+        "the live axiom memo supplies Z^3, proper cubic rotations, and a covariant nearest-neighbor rule",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site." in axiom
+        and "one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "note-contract",
+        "bounded theorem, displayed-not-adopted Max(8) test, and machine status",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "Displayed, not adopted" in note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "N1-N8 and a passing no-go disposition are source-visible",
+        all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        "the note and runner omit the dispatch-forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "note-reports-max-selector",
+        "the note reports the eight cov8 values, the iff verdict, and Q_*",
+        "(wt1, opp2, adj2, vertex3, mixed3)" in note
+        and "(1, 0, 1, 0, 0)" in note
+        and "(1, 1, 1, 1, 1)" in note
+        and "Q_*" in note
+        and "vertex3=1 and mixed3=1" in note
+        and "maximal cov8" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the theorem proposes no axiom change",
+        "no axiom or approved primitive is added" in note
+        and "hypothetical_axiom_status" in note
+        and "Do not write the ranking into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "not-leftover-totality",
+        "the residual is Max(8) iff Q among Q_*, not leftover tot3/tot5/tot7/tot10",
+        "New k inside Q_*" in note
+        and "not leftover tot3/tot5/tot7/tot10" in note
+        and "tot3/tot5/tot7/tot10" in note,
+    )
+    checks.check(
+        "claim-scope-max-selector",
+        "claim_scope states whether maximal cov8 equals vertex3=mixed3=1",
+        "Among the 8 F_cut maps with wt1=1 and" in note
+        and "adj2=1 on the two-cube with off-patch o=0" in note
+        and "whether maximal cov8 equals vertex3=mixed3=1" in note
+        and "is reported" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the eight Q_* maps is scored by how many of the 495 eight-site seeds it fills")
+    print("per_block: checked exactly — Max(8) iff Q is the Q_* eight-site maximizer test against the displayed conjunction")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 8 Q_* maps on the two-cube with off-patch o=0, maximal cov8 is unique f1. N_max=1, N_Q=2, N_both=1. The miss is f_L1. Displayed, not adopted.

## Runner

`scripts/f_cut_qstar_cov8_max_selector_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.