### PR TITLE
feat(c12q10): every F_cut map has cov12>0; not Q10, Q8, or Q4

### DIFF
--- a/docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,355 @@
+---
+claim_id: f_cut_cov12_q10_selector_test_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether a displayed remaining-bit predicate equals cov12>0 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov12_q10_selector_test_2026_08_15.py
+---
+
+# Whether `cov12>0` Equals `Q10`, `Q8`, or `Q4`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 12-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored on every one
+of the 32 cube-covariant cut maps `F_cut`. The scored identities are
+whether `cov12>0` if and only if displayed `Q10`, if and only if displayed
+`Q8`, or if and only if displayed `Q4`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov12_q10_selector_test_2026_08_15.py`](../scripts/f_cut_cov12_q10_selector_test_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c10bit3 named that `Q10=cov10>0` only, with the remaining-bit
+formula `Q10 := adj2 ∨ vertex3 ∨ mixed3`. Investment #6539 named that
+`Q8 := wt1 ∨ opp2 ∨ adj2 ∨ vertex3` equals `cov8>0`. Investment #6518
+named that `Q4 := wt1 ∨ adj2` equals `cov4>0`. This note tests whether
+any of those displayed predicates equals `cov12>0`. New k=12. Not
+leftover-character of c10bit3, not leftover-character of #6539, and not
+leftover-character of #6518.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`. That tuple has
+`Q10=Q8=Q4=1`.
+
+On the two-cube with off-patch `o=0`, write
+`cov12(f) = |{S : |S|=12 and f fills from S}|`. There is one 12-site
+seed: the whole two-cube. The boolean scored here is `cov12(f)>0`.
+
+**Theorem 1.** Among all 32 `F_cut` maps, `cov12>0` is not equivalent to
+`Q10`, is not equivalent to `Q8`, and is not equivalent to `Q4`. Each
+identity fails. The lex-first remaining-bit miss of each is
+`(0, 0, 0, 0, 0)`: that map has `cov12=1` and `Q10=Q8=Q4=0`.
+
+**Theorem 2.** The census integers on the 32-map set are
+
+```text
+N_pos = 32
+N_Q10 = 28
+N_both_Q10 = 28
+N_Q8 = 30
+N_both_Q8 = 30
+N_Q4 = 24
+N_both_Q4 = 24.
+```
+
+**Theorem 3.** The identities are displayed only. Displayed, not adopted.
+Do not adopt a bit. Do not adopt Q10. Do not adopt Q8. Do not adopt Q4.
+Do not write `Q10` into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are scored exactly on the one twelve-site seed. Whether cov12>0 equals Q10, Q8, or Q4 is a finite Boolean identity on this patch, and each identity fails. Not a physical Admissibility selector."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov12_q10_selector_test
+target_blocker_text: "whether cov12>0 equals Q10, Q8, or Q4 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded cov12>0 versus Q10, Q8, and Q4 identities; do not adopt a bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The displayed remaining-bit formulas below are not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The twelve-site seeds are the `C(12,12) = 1` subsets of size 12 in `T`.
+That unique seed is `T` itself. Then `cov12(f)` is 1 if `f` fills from
+`T` and 0 otherwise. Starting from `L_0 = T` the locked set is already
+`T`, so every `F_cut` map fills. The boolean scored here is `cov12(f)>0`.
+
+The displayed remaining-bit predicates are
+
+```text
+Q10(f) := (adj2=1) or (vertex3=1) or (mixed3=1)
+Q8(f) := (wt1=1) or (opp2=1) or (adj2=1) or (vertex3=1)
+Q4(f) := (wt1=1) or (adj2=1)
+```
+
+`Q10` holds on exactly 28 of the 32 maps. `Q8` holds on exactly 30.
+`Q4` holds on exactly 24. Duality is not assumed: `cov12` is scored on
+the one twelve-site seed.
+
+## Theorem 1 — `cov12>0` versus `Q10`, `Q8`, and `Q4` on all 32
+
+Direct evolution on the one twelve-site seed scores every `F_cut` map.
+Every map has `cov12 = 1`. The identities
+
+```text
+cov12(f) > 0  ⇔  Q10(f) = 1
+cov12(f) > 0  ⇔  Q8(f) = 1
+cov12(f) > 0  ⇔  Q4(f) = 1
+```
+
+each fail. The lex-first remaining-bit miss of each is `(0, 0, 0, 0, 0)`:
+that map has `cov12=1` and `Q10=Q8=Q4=0`. There are four `Q10` misses,
+two `Q8` misses, and eight `Q4` misses. In particular
+`f_L1 = (1, 0, 1, 1, 1)` has `Q10=Q8=Q4=1` and `cov12=1`, so it is not
+a miss.
+
+## Theorem 2 — census integers
+
+Write `N_pos` for the number of `F_cut` maps with `cov12>0`, and for each
+displayed `Q` write `N_Q` for the number with `Q=1` and `N_both` for the
+number with both. Then
+
+```text
+N_pos = 32
+N_Q10 = 28
+N_both_Q10 = 28
+N_Q8 = 30
+N_both_Q8 = 30
+N_Q4 = 24
+N_both_Q4 = 24.
+```
+
+These integers are counted from the scored 32-map table. They fail to
+coincide because each identity of Theorem 1 fails: positivity holds on
+every map, while each displayed `Q` is false on a nonempty lex-first
+slice.
+
+## Theorem 3 — display, not adoption
+
+The failure of `cov12>0 ⇔ Q10`, of `cov12>0 ⇔ Q8`, and of
+`cov12>0 ⇔ Q4` on all 32 `F_cut` maps is displayed data. Displayed,
+not adopted. Do not adopt a bit. Do not adopt Q10. Do not adopt Q8. Do
+not adopt Q4. Do not adopt `adj2`. Do not adopt `vertex3`. Do not adopt
+`mixed3`. Do not adopt `f_L1`. Do not write `Q10` into Admissibility.
+Admissibility does not name this remaining-bit formula.
+
+The census is a finite fact about occupancy-to-lock on this two-cube
+with off-patch `o=0`. It is not a physical formation-site selector and
+not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `Q10` as `adj2=1` or `vertex3=1` or `mixed3=1` | twenty-eight maps |
+| `Q8` as `wt1=1` or `opp2=1` or `adj2=1` or `vertex3=1` | thirty maps |
+| `Q4` as `wt1=1` or `adj2=1` | twenty-four maps |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, one twelve-site seed, off-patch `o=0` | declared finite patch |
+| `cov12>0` iff `Q10`, iff `Q8`, or iff `Q4` | all fail; lex-first miss `(0, 0, 0, 0, 0)` |
+| `N_pos`, per-`Q` `N_Q` and `N_both` | 32; 28/28; 30/30; 24/24 |
+| leftover of c10bit3 | refused; that was `Q10=cov10>0` |
+| leftover of #6539 | refused; that named `Q8=cov8>0` |
+| leftover of #6518 | refused; that named `Q4=cov4>0` |
+| adoption of a bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of c10bit3: that closed `Q10=cov10>0` only. The
+present object is whether the same displayed formula equals twelve-site
+positivity.
+
+Not leftover-character of #6539: that closed `cov8>0` as `Q8`. New k=12
+is not a restatement of eight-site positivity.
+
+Not leftover-character of #6518: that closed `cov4>0` as `Q4`. The
+present object is the same displayed formula against `cov12>0`.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not adopt a bit. Do not adopt Q10.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether `cov12>0` equals `Q10`, `Q8`, or `Q4` among all 32 `F_cut` maps. |
+| V2 | Current main has the axiom memo and the named `Q10=cov10>0`, `Q8=cov8>0`, and `Q4=cov4>0` identities, but no landed twelve-site test. |
+| V3 | The 32 maps and the one twelve-site seed are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against three displayed predicates at a new `k`. |
+| V5 | Each identity fails, is displayed, and no bit is adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: none of `Q10`, `Q8`, or `Q4` is
+`cov12>0` among the 32 `F_cut` maps on this patch. No global compiler
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of c10bit3 | treat the `k=12` test as leftover-character of `Q10=cov10>0` | **ATTEMPTED** |
+| leftover of #6539 | treat the test as leftover-character of `Q8=cov8>0` | **ATTEMPTED** |
+| leftover of #6518 | treat the test as leftover-character of `Q4=cov4>0` | **ATTEMPTED** |
+| adopt a bit | write `Q10`, `Q8`, or `Q4` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the c10bit3 `Q10=cov10>0` identity, the #6539
+`Q8` identity, the #6518 `Q4` identity, and the off-patch convention
+are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the one twelve-site seed, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the three
+displayed formulas are declared. Equality of any displayed `Q` with
+`cov12>0` is not silently assumed. Duality is not assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+`cov12>0` equals `Q10`, `Q8`, or `Q4` on all 32 `F_cut` maps, not
+leftover-character of c10bit3, not leftover-character of #6539, and not
+leftover-character of #6518.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the 32 `F_cut` maps scored on one seed | no physical law selection |
+| per block | the `cov12>0`–displayed-`Q` identities on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule,
+a selector outside the displayed three, and any independently derived
+physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** c10bit3 already recorded that `Q10=cov10>0`, #6539 already
+named `Q8=cov8>0`, and #6518 already named `Q4=cov4>0`, so one of those
+must also be twelve-site positivity.
+
+**Answer:** none of them is. `N_pos = 32`, `N_Q10 = 28`, `N_Q8 = 30`,
+and `N_Q4 = 24`. The lex-first miss of each is `(0, 0, 0, 0, 0)`. New
+k=12. Do not adopt a bit.
+
+### N8 — cross-cycle echo
+
+Investment c10bit3 already showed `Q10=cov10>0` only. Investment #6539
+already showed `Q8=cov8>0`. Investment #6518 already showed `Q4=cov4>0`.
+Echoing any of those facts is not a substitute for testing `cov12>0`
+against the three displayed predicates on all 32. New k=12.
+
+No-Go Discipline disposition: **PASS** for the finite 32-map census
+and the three displayed failed identities. FAIL / DO NOT SHIP for
+“adopt a bit,” “`Q10` is the physical rule,” or “write `Q10` into
+Admissibility.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov12` on
+the one twelve-site seed, decides whether `cov12>0` if and only if
+`Q10`, if and only if `Q8`, or if and only if `Q4`, reports one
+lex-first miss of each failure, and reports `N_pos` and, for each
+displayed `Q`, `N_Q` and `N_both`. Declared audit inputs are this note
+and the axiom memo; the runner writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov12_q10_selector_test_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov12_q10_selector_test_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov12_q10_selector_test_2026_08_15.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov12_q10_selector_test_2026_08_15.py
+runner_sha256: 7776b83c8650f2f5807b954a50a3431a28d42076c5b37492f8501aa6b0aef34f
+input_fingerprint_sha256: 723845c760f88908a8a69bc271a16771b71201da217f9a4eb5d768983db6ee17
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed cov12>0 versus Q10, Q8, and Q4 on all 32 F_cut maps; does not adopt a bit; does not adopt Q10
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_twelve_site_seeds=1
+N_pos=32
+Q10: equiv=0 N_Q=28 N_both=28 lex_first_miss=(0, 0, 0, 0, 0) cov12_miss=1
+Q8: equiv=0 N_Q=30 N_both=30 lex_first_miss=(0, 0, 0, 0, 0) cov12_miss=1
+Q4: equiv=0 N_Q=24 N_both=24 lex_first_miss=(0, 0, 0, 0, 0) cov12_miss=1
+cov12(f_L1)=1
+cov12=0=()
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, one twelve-site seed
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-displayed-q Q10 is adj2 or vertex3 or mixed3; Q8 is wt1 or opp2 or adj2 or vertex3; Q4 is wt1 or adj2
+PASS: thm1-not-equivalent among all 32 F_cut maps, cov12>0 is not Q10, not Q8, and not Q4
+PASS: thm2-census N_pos = 32 and each displayed Q reports N_Q and N_both
+PASS: thm3-display-not-adopted the identities are displayed and no bit is adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the cov12>0 versus displayed-Q identities and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-c10bit3-q8-q4 the residual is a new k=12 predicate versus invested Q10=cov10>0, Q8, and Q4
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on the one twelve-site seed against Q10, Q8, and Q4
+per_block: checked exactly — N_pos and per-Q N_Q, N_both are the F_cut positivity-versus-displayed-Q counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov12_q10_selector_test_2026_08_15.py
+++ b/scripts/f_cut_cov12_q10_selector_test_2026_08_15.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Whether cov12>0 equals Q10, Q8, or Q4 on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov12(f) is the number of twelve-site seeds from which
+f fills. There is one such seed: the whole two-cube. Q10 is the remaining-bit
+cut adj2=1 or vertex3=1 or mixed3=1 (the invested cov10>0 selector). Q8 is
+wt1 or opp2 or adj2 or vertex3. Q4 is wt1 or adj2. The runner reports whether
+cov12>0 iff Q10, iff Q8, or iff Q4, one lex-first miss of each failure, and
+the census integers N_pos and, for each displayed Q, N_Q and N_both. The
+identities are displayed; the runner does not adopt a bit and does not adopt
+Q10. f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+from typing import Callable
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+Selector = Callable[[Remaining], bool]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_MISS: Remaining = (0, 0, 0, 0, 0)
+N_POS = 32
+N_Q10 = 28
+N_BOTH_Q10 = 28
+N_Q8 = 30
+N_BOTH_Q8 = 30
+N_Q4 = 24
+N_BOTH_Q4 = 24
+COV12_L1 = 1
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_Q10(remaining: Remaining) -> bool:
+    return remaining[2] == 1 or remaining[3] == 1 or remaining[4] == 1
+
+
+def selector_Q8(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[1] == 1 or remaining[2] == 1 or remaining[3] == 1
+
+
+def selector_Q4(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[2] == 1
+
+
+def displayed_selectors() -> list[tuple[str, Selector]]:
+    return [
+        ("Q10", selector_Q10),
+        ("Q8", selector_Q8),
+        ("Q4", selector_Q4),
+    ]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed cov12>0 versus Q10, Q8, and Q4 on all "
+        "32 F_cut maps; does not adopt a bit; does not adopt Q10"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(12)
+    rows: list[tuple[Remaining, int]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov))
+
+    n_pos = sum(1 for _remaining, cov in rows if cov > 0)
+    scores: dict[str, dict[str, object]] = {}
+    for name, selector in displayed_selectors():
+        n_q = sum(1 for remaining, _cov in rows if selector(remaining))
+        n_both = sum(1 for remaining, cov in rows if selector(remaining) and cov > 0)
+        equivalent = all((cov > 0) == selector(remaining) for remaining, cov in rows)
+        misses = [
+            remaining
+            for remaining, cov in sorted(rows)
+            if (cov > 0) != selector(remaining)
+        ]
+        lex_miss = misses[0] if misses else None
+        lex_cov = next((cov for remaining, cov in rows if remaining == lex_miss), None)
+        scores[name] = {
+            "N_Q": n_q,
+            "N_both": n_both,
+            "equiv": equivalent,
+            "lex": lex_miss,
+            "lex_cov": lex_cov,
+            "n_miss": len(misses),
+        }
+
+    cov_l1 = next(cov for remaining, cov in rows if remaining == L1_REMAINING)
+    zeros = tuple(sorted(remaining for remaining, cov in rows if cov == 0))
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_twelve_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    for name in ("Q10", "Q8", "Q4"):
+        score = scores[name]
+        print(
+            f"{name}: equiv={int(bool(score['equiv']))} N_Q={score['N_Q']} "
+            f"N_both={score['N_both']} lex_first_miss={score['lex']} "
+            f"cov12_miss={score['lex_cov']}"
+        )
+    print(f"cov12(f_L1)={cov_l1}")
+    print(f"cov12=0={zeros}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV12_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, one twelve-site seed",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 1
+        and seeds == ((1 << 12) - 1,)
+        and len(TWO_CUBE) == 12
+        and len(rows) == 32
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and selector_Q10(L1_REMAINING)
+        and selector_Q8(L1_REMAINING)
+        and selector_Q4(L1_REMAINING)
+        and cov_l1 == COV12_L1
+        and cov_l1 > 0,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-displayed-q",
+        "Q10 is adj2 or vertex3 or mixed3; Q8 is wt1 or opp2 or adj2 or vertex3; Q4 is wt1 or adj2",
+        scores["Q10"]["N_Q"] == N_Q10
+        and scores["Q8"]["N_Q"] == N_Q8
+        and scores["Q4"]["N_Q"] == N_Q4
+        and selector_Q10((0, 0, 0, 0, 1))
+        and selector_Q10((0, 0, 1, 0, 0))
+        and selector_Q10((0, 0, 0, 1, 0))
+        and selector_Q10(L1_REMAINING)
+        and not selector_Q10((0, 0, 0, 0, 0))
+        and not selector_Q10((0, 1, 0, 0, 0))
+        and not selector_Q10((1, 0, 0, 0, 0))
+        and not selector_Q10((1, 1, 0, 0, 0))
+        and selector_Q8((1, 0, 0, 0, 0))
+        and selector_Q8((0, 1, 0, 0, 0))
+        and not selector_Q8((0, 0, 0, 0, 0))
+        and not selector_Q8((0, 0, 0, 0, 1))
+        and selector_Q4((1, 0, 0, 0, 0))
+        and selector_Q4((0, 0, 1, 0, 0))
+        and not selector_Q4((0, 0, 0, 0, 0))
+        and not selector_Q4((0, 0, 0, 1, 0))
+        and "Q10(f) := (adj2=1) or (vertex3=1) or (mixed3=1)" in note
+        and "Q8(f) := (wt1=1) or (opp2=1) or (adj2=1) or (vertex3=1)" in note
+        and "Q4(f) := (wt1=1) or (adj2=1)" in note,
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "among all 32 F_cut maps, cov12>0 is not Q10, not Q8, and not Q4",
+        scores["Q10"]["equiv"] is False
+        and scores["Q8"]["equiv"] is False
+        and scores["Q4"]["equiv"] is False
+        and scores["Q10"]["lex"] == LEX_FIRST_MISS
+        and scores["Q8"]["lex"] == LEX_FIRST_MISS
+        and scores["Q4"]["lex"] == LEX_FIRST_MISS
+        and scores["Q10"]["lex_cov"] == 1
+        and scores["Q8"]["lex_cov"] == 1
+        and scores["Q4"]["lex_cov"] == 1
+        and scores["Q10"]["n_miss"] == 4
+        and scores["Q8"]["n_miss"] == 2
+        and scores["Q4"]["n_miss"] == 8
+        and zeros == ()
+        and all(cov == 1 for _remaining, cov in rows)
+        and "is not equivalent to `Q10`" in note_flat
+        and "is not equivalent to `Q8`" in note_flat
+        and "is not equivalent to `Q4`" in note_flat
+        and "The lex-first remaining-bit miss" in note
+        and "`(0, 0, 0, 0, 0)`" in note,
+    )
+    checks.check(
+        "thm2-census",
+        "N_pos = 32 and each displayed Q reports N_Q and N_both",
+        n_pos == N_POS
+        and scores["Q10"]["N_Q"] == N_Q10
+        and scores["Q10"]["N_both"] == N_BOTH_Q10
+        and scores["Q8"]["N_Q"] == N_Q8
+        and scores["Q8"]["N_both"] == N_BOTH_Q8
+        and scores["Q4"]["N_Q"] == N_Q4
+        and scores["Q4"]["N_both"] == N_BOTH_Q4
+        and n_pos != N_Q10
+        and n_pos != N_Q8
+        and n_pos != N_Q4
+        and "N_pos = 32" in note
+        and "N_Q10 = 28" in note
+        and "N_both_Q10 = 28" in note
+        and "N_Q8 = 30" in note
+        and "N_both_Q8 = 30" in note
+        and "N_Q4 = 24" in note
+        and "N_both_Q4 = 24" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopted",
+        "the identities are displayed and no bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not adopt Q10" in note
+        and "Do not adopt Q8" in note
+        and "Do not adopt Q4" in note
+        and "Do not write `Q10` into Admissibility" in note
+        and "does not adopt a bit" in self_source
+        and "does not adopt Q10" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "a displayed remaining-bit predicate equals cov12>0 is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the cov12>0 versus displayed-Q identities and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `Q10` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-c10bit3-q8-q4",
+        "the residual is a new k=12 predicate versus invested Q10=cov10>0, Q8, and Q4",
+        "Not leftover-character of c10bit3" in note
+        and "Not leftover-character of #6539" in note
+        and "Not leftover-character of #6518" in note
+        and "Q10=cov10>0" in note
+        and "New k=12" in note
+        and "does not adopt a bit" in self_source
+        and "does not adopt Q10" in self_source,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on the one twelve-site seed against Q10, Q8, and Q4")
+    print("per_block: checked exactly — N_pos and per-Q N_Q, N_both are the F_cut positivity-versus-displayed-Q counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov12>0 for all 32. It is not Q10, not Q8, and not Q4. Lex-first miss of each is (0,0,0,0,0), which still fills. Displayed, not adopted.

## Runner

`scripts/f_cut_cov12_q10_selector_test_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.