### PR TITLE
feat(q10c1): cov1>0 is not Q10; positivity implies Q10

### DIFF
--- a/docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,301 @@
+---
+claim_id: f_cut_cov1_q10_selector_test_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether cov1>0 equals adj2∨vertex3∨mixed3 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov1_q10_selector_test_2026_08_15.py
+---
+
+# Whether Positive 1-Site Coverage Equals Q10 Among the 32 F_cut Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock fill positivity on the twelve-vertex two-cube
+with off-patch occupancy `0`, scored on the twelve one-site seeds, for the
+thirty-two cube-covariant cut maps `F_cut`, against the displayed remaining-bit
+predicate `Q10`.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov1_q10_selector_test_2026_08_15.py`](../scripts/f_cut_cov1_q10_selector_test_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment named `Q10 := (adj2=1) or (vertex3=1) or (mixed3=1)` as
+the displayed 3-bit OR equal to `cov10>0`. Investment #6516 closed
+`Q_* = cov1>0`, with `Q_* := (wt1=1) and (adj2=1)`. This
+note tests whether `cov1>0` equals that newly named `Q10` on the same
+one-site seeds. Duality is not assumed: the test does not import
+`Max(k)=Max(12-k)` and does not transfer the `k=10` identity to `k=1`.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov1(f) = |{S : |S|=1 and f fills from S}|`. The boolean scored here is
+`cov1(f)>0`. Then:
+
+- Theorem 1. cov1>0 is not equivalent to `Q10` among the 32 maps. The
+  lex-first remaining-bit miss is `(0, 0, 0, 0, 1)`, which has `Q10 = 1`
+  and `cov1 = 0`.
+- Theorem 2. `N_pos = 8`, `N_Q10 = 28`, `N_both = 8`.
+- Theorem 3. `Q10` is displayed. Displayed, not adopted. Do not adopt
+  `Q10`.
+
+Do not write `Q10` into Admissibility. The extra that would have made the
+`cov10>0` 3-bit OR the one-site positivity selector is not present.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the twelve one-site seeds of the two-cube. Whether cov1>0 equals Q10, and the counts N_pos, N_Q10, N_both, are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov1_q10_selector_test
+target_blocker_text: "whether cov1>0 equals adj2 or vertex3 or mixed3 among the 32 F_cut maps"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded Q10 test against cov1>0; do not adopt Q10"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared mathematical objects
+
+The only scientific dependency is the current four-axiom authority linked
+above. Lattice supplies `Z^3` with nearest-neighbor adjacency and proper cubic
+rotations. Admissibility supplies one fixed nearest-neighbor rule, covariant
+under those motions. Record is not used as a formation-site selector: the
+dynamics here are a declared occupancy-to-lock predicate on a finite patch.
+Reading notes on Admissibility state that the local law
+it does not supply the formation site, probability, or rate.
+Records form.
+When present, a record locks exactly one admissible local possibility.
+A readout value is determined by record content alone.
+A site with no record cannot be read.
+
+The following are declared mathematical scaffolding, not measured or fitted
+physics inputs:
+
+- the two-cube `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices of two unit
+  cubes sharing the face `x=1`);
+- off-patch occupancy `0` (a neighbor of a site in `T` that is not itself in
+  `T` is treated as unoccupied; a blank-block is a different rule);
+- the six-direction stencil `{±e_x, ±e_y, ±e_z}` at every site;
+- the 24 proper cube rotations;
+- the ten axis-type orbits of `{0,1}^6` under those rotations;
+- the class `F_cut` of cube-covariant maps with `f(empty)=f(full)=0` and
+  complement symmetry `f(c)=f(1-c)`;
+- the displayed predicate `Q10 := (adj2=1) or (vertex3=1) or (mixed3=1)`.
+
+No observational comparator, literature constant, rate, or generator is
+imported. Hamming parity is a contrast map only; it is not `f_L1`.
+
+## Exact target and objects
+
+**Target.** Decide whether `cov1(f)>0` equals `Q10(f)` among the 32 members
+of `F_cut` on `T`. If not, name one lex-first remaining-bit miss. Report
+`N_pos`, `N_Q10`, and `N_both`. Display `Q10`. Do not adopt `Q10`.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0. Complement
+swaps `n_both` with `n_empty`. The five remaining bits of `F_cut`, in the
+order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values on orbit types
+`(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`. Complement partners
+are forced equal; empty and full are fixed at 0.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The one-site seeds are the 12 vertices of `T`. Then
+`cov1(f)` is the number of those sites from which `f` fills. Write
+`Q10(f) = 1` when at least one of `adj2`, `vertex3`, `mixed3` is 1.
+
+## Theorems
+
+### Theorem 1 — `cov1>0` is not `Q10`; lex-first miss
+
+There are exactly 24 proper cube rotations and exactly 10 orbits on
+`{0,1}^6`. The three cuts leave `|F_cut| = 32`. The unbalanced-axis map
+`f_L1` is one element of `F_cut` and is not Hamming parity.
+
+Among the 32 maps, cov1>0 is not equivalent to `Q10`. The lex-first
+remaining-bit miss, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, is
+`(0, 0, 0, 0, 1)`: that map has `Q10 = 1` and `cov1 = 0`.
+
+### Theorem 2 — counts
+
+Write `N_pos` for the number of maps with `cov1>0`, `N_Q10` for the number
+with `Q10=1`, and `N_both` for the number with both. Exhaustive scoring
+gives
+
+```text
+N_pos = 8
+N_Q10 = 28
+N_both = 8
+```
+
+So every positive map is `Q10`-true, and twenty `Q10`-true maps still have
+`cov1 = 0`. The four maps with `adj2=vertex3=mixed3=0` are among the zeros
+and are not misses.
+
+### Theorem 3 — display; do not adopt `Q10`
+
+`Q10` is displayed as the 3-bit OR `adj2∨vertex3∨mixed3`. Displayed, not
+adopted. Do not adopt `Q10`. Do not write a remaining-bit formula into Admissibility.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 12 one-site seeds, off-patch `o=0` | declared finite patch |
+| displayed `Q10` | displayed, not adopted |
+| `cov1>0` equals `Q10` | fails; lex-first miss `(0, 0, 0, 0, 1)` |
+| `N_pos = 8`, `N_Q10 = 28`, `N_both = 8` | proved by exhaustive scoring |
+| leftover-character of `Q10=cov10>0` | refused; that was `Q10=cov10>0` |
+| leftover-character of #6516 | refused; that was `Q_*=cov1>0` |
+| Max duality | refused; duality is not assumed |
+| adoption of `Q10` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of `Q10=cov10>0`: that was `Q10=cov10>0` on the 66
+ten-site seeds. The present object is the same displayed 3-bit OR scored
+against one-site positivity, not a restatement that `Q10` equals
+`cov10>0`.
+
+Not leftover-character of #6516: that was `Q_*=cov1>0`, with
+`Q_* := (wt1=1) and (adj2=1)`. The present test asks
+whether the weaker `Q10` also equals `cov1>0`. Duality is not assumed.
+
+The note is not a Max(1) ranking and not a seed-table: maximizers of
+`cov1` are not selected, and no seed census of a named map is compiled.
+
+Off-patch occupancy `0` is an explicit default on this patch. A blank-block
+is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not adopt `Q10`.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether `cov1>0` equals `Q10` inside `F_cut` on this patch. |
+| V2 | Current main has the axiom memo, the `Q10=cov10>0` naming, and the #6516 fact that `Q_*=cov1>0`, but no landed test of `Q10` against `cov1>0`. |
+| V3 | The 32 maps, 12 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a displayed 3-bit OR. |
+| V5 | Equality fails, and `Q10` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: `cov1>0` is not `Q10` among the 32 `F_cut`
+maps on this patch. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of `Q10=cov10>0` | treat the test as leftover-character of `Q10=cov10>0` | **ATTEMPTED** |
+| leftover of #6516 | treat the test as leftover-character of `Q_*=cov1>0` | **ATTEMPTED** |
+| Max duality | replace the `k=1` score by `Max(k)=Max(12-k)` | **ATTEMPTED** |
+| adopt `Q10` | write `adj2∨vertex3∨mixed3` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The failed equality, the Hamming contrast, the `Q10=cov10>0` identity, the
+#6516 `Q_*` identity, and the off-patch convention are distinct. This note
+claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 12 one-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and displayed
+`Q10` are declared. Equality of `cov1>0` with `Q10` is not silently
+assumed. Duality is not assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one covariant
+nearest-neighbor rule. The residual answered here is whether `cov1>0` equals
+`Q10` on the declared patch, not leftover-character of `Q10=cov10>0`, not
+leftover-character of #6516, and not a Max-duality ranking.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 12 seeds | no physical law selection |
+| per block | `N_pos`, `N_Q10`, `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule, a
+selector other than `Q10`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** after `Q10=cov10>0`, the same 3-bit OR must be the one-site
+positivity selector, or else duality from `k=10` to `k=1` would force it.
+
+**Answer:** Duality is not assumed. `N_pos = 8` while `N_Q10 = 28`. The
+lex-first miss `(0, 0, 0, 0, 1)` has `Q10 = 1` and `cov1 = 0`. `Q10` is
+displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+The `Q10=cov10>0` identity already showed that `Q10` equals `cov10>0`. Investment
+#6516 already showed that `cov1>0` is `Q_*`. Echoing either identity is not
+a substitute for testing `Q10` against `cov1>0`: the lex-first miss and
+the triple `(N_pos, N_Q10, N_both)` are the new comparison facts. Duality
+is not assumed.
+
+No-Go Discipline disposition: **PASS** for the finite test and the
+narrow equality failure. FAIL / DO NOT SHIP for “`cov1>0` equals `Q10`”
+or “`Q10` is the physical rule.”
+
+## Live parent quotes
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov1` on the
+12 one-site seeds, tests whether `cov1>0` equals `Q10`, reports the
+lex-first miss `(0, 0, 0, 0, 1)`, and reports `N_pos`, `N_Q10`, and
+`N_both`. Declared audit inputs are this note and the axiom memo; the
+runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov1_q10_selector_test_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov1_q10_selector_test_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov1_q10_selector_test_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov1_q10_selector_test_2026_08_15.py
+runner_sha256: 8deae51f0e63ad24183c7a26953c248e45b083992846ad455accef400d3a480b
+input_fingerprint_sha256: 9d8164b9e740d282ffe253f305a7c980bbd32598763b6b9f7591f2115e96aadf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed Q10 versus cov1>0; does not adopt Q10; duality is not assumed
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_one_site_seeds=12
+N_pos=8
+N_Q10=28
+N_both=8
+equiv=0
+n_miss=20
+lex_first_miss=(0, 0, 0, 0, 1)
+lex_first_miss_cov1=0
+lex_first_miss_Q10=1
+cov1(f_L1)=12
+Q10(f_L1)=1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 12 one-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-not-iff cov1>0 is not equivalent to Q10 among the 32 maps
+PASS: thm1-lex-first-miss the lex-first remaining-bit miss is (0, 0, 0, 0, 1) with cov1=0 and Q10=1
+PASS: thm2-counts N_pos=8, N_Q10=28, N_both=8
+PASS: thm3-display-not-adopt Q10 is displayed and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the Q10 test against cov1>0 and does not adopt Q10
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-q10-or-6516 the residual is Q10 versus cov1>0, not leftover-character of Q10=cov10>0 or #6516
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 12 one-site seeds against displayed Q10
+per_block: checked exactly — N_pos, N_Q10, and N_both are the F_cut positivity-versus-Q10 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov1_q10_selector_test_2026_08_15.py
+++ b/scripts/f_cut_cov1_q10_selector_test_2026_08_15.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Test whether cov1>0 equals Q10 among the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov1(f) is the number of one-site seeds from
+which f fills. Q10 is the displayed remaining-bit predicate
+(adj2=1) or (vertex3=1) or (mixed3=1). The runner does not adopt Q10.
+f_L1 is the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. Duality is not assumed.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_MISS: Remaining = (0, 0, 0, 0, 1)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def q10_from_remaining(remaining: Remaining) -> bool:
+    return remaining[2] == 1 or remaining[3] == 1 or remaining[4] == 1
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed Q10 versus cov1>0; does not adopt Q10; "
+        "duality is not assumed"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(1)
+    rows: list[tuple[Remaining, int, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, q10_from_remaining(remaining)))
+
+    n_pos = sum(1 for _remaining, cov, _q10 in rows if cov > 0)
+    n_q10 = sum(1 for _remaining, _cov, q10 in rows if q10)
+    n_both = sum(1 for _remaining, cov, q10 in rows if cov > 0 and q10)
+    misses = [
+        (remaining, cov, q10)
+        for remaining, cov, q10 in rows
+        if (cov > 0) != q10
+    ]
+    lex = min(misses, key=lambda row: row[0]) if misses else None
+    equiv = len(misses) == 0
+    cov_by_remaining = {remaining: cov for remaining, cov, _q10 in rows}
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+    q10_l1 = q10_from_remaining(L1_REMAINING)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_one_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_Q10={n_q10}")
+    print(f"N_both={n_both}")
+    print(f"equiv={int(equiv)}")
+    print(f"n_miss={len(misses)}")
+    print(f"lex_first_miss={None if lex is None else lex[0]}")
+    print(f"lex_first_miss_cov1={None if lex is None else lex[1]}")
+    print(f"lex_first_miss_Q10={None if lex is None else int(lex[2])}")
+    print(f"cov1(f_L1)={cov_l1}")
+    print(f"Q10(f_L1)={int(q10_l1)}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV1_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 12 one-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 12
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and cov_l1 > 0
+        and q10_l1
+        and L1_REMAINING in cov_by_remaining,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-not-iff",
+        "cov1>0 is not equivalent to Q10 among the 32 maps",
+        not equiv
+        and len(misses) == 20
+        and n_pos != n_q10
+        and "cov1>0 is not equivalent to `Q10`" in note,
+    )
+    checks.check(
+        "thm1-lex-first-miss",
+        "the lex-first remaining-bit miss is (0, 0, 0, 0, 1) with cov1=0 and Q10=1",
+        lex is not None
+        and lex[0] == LEX_FIRST_MISS
+        and lex[1] == 0
+        and lex[2] is True
+        and cov_by_remaining[LEX_FIRST_MISS] == 0
+        and q10_from_remaining(LEX_FIRST_MISS)
+        and "`(0, 0, 0, 0, 1)`" in note
+        and "lex-first" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_pos={n_pos}, N_Q10={n_q10}, N_both={n_both}",
+        n_pos == 8
+        and n_q10 == 28
+        and n_both == 8
+        and f"N_pos = {n_pos}" in note
+        and f"N_Q10 = {n_q10}" in note
+        and f"N_both = {n_both}" in note
+        and all((cov > 0) == (remaining[0] == 1 and remaining[2] == 1) for remaining, cov, _q10 in rows),
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "Q10 is displayed and is not adopted as an Admissibility selector",
+        "Displayed, not adopted" in note
+        and "Do not adopt `Q10`" in note
+        and "Do not write a remaining-bit formula into Admissibility" in note
+        and "does not adopt Q10" in self_source
+        and "adj2∨vertex3∨mixed3" in note,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "cov1>0 equals adj2∨vertex3∨mixed3 is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the Q10 test against cov1>0 and does not adopt Q10",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write a remaining-bit formula into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-q10-or-6516",
+        "the residual is Q10 versus cov1>0, not leftover-character of Q10=cov10>0 or #6516",
+        "Not leftover-character of `Q10=cov10>0`" in note
+        and "that was `Q10=cov10>0`" in note
+        and "Not leftover-character of #6516" in note
+        and "that was `Q_*=cov1>0`" in note
+        and "Duality is not assumed" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 12 one-site seeds against displayed Q10")
+    print("per_block: checked exactly — N_pos, N_Q10, and N_both are the F_cut positivity-versus-Q10 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov1>0 is not equivalent to Q10. N_pos=8, N_Q10=28, N_both=8 so cov1>0 implies Q10. Displayed, not adopted.

## Runner

`scripts/f_cut_cov1_q10_selector_test_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.