### PR TITLE
feat(c9q10): cov9>0 is not Q10; positivity implies Q10

### DIFF
--- a/docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,341 @@
+---
+claim_id: f_cut_cov9_q10_selector_test_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether cov9>0 equals adj2∨vertex3∨mixed3 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov9_q10_selector_test_2026_08_15.py
+---
+
+# Whether `cov9>0` Equals `adj2 ∨ vertex3 ∨ mixed3`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 9-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored on every one
+of the 32 cube-covariant cut maps `F_cut`. The scored identity is
+whether `cov9>0` if and only if the displayed three-bit OR
+`Q10 := adj2 ∨ vertex3 ∨ mixed3` holds.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov9_q10_selector_test_2026_08_15.py`](../scripts/f_cut_cov9_q10_selector_test_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c10bit3 named that `cov10>0` if and only if
+`Q10 := adj2 ∨ vertex3 ∨ mixed3`. Investment c9sel showed that no
+1-bit remaining-bit predicate and no 2-bit OR equals `cov9>0`, and the
+following 3-bit menu showed that no 3-bit AND or 3-bit OR equals
+`cov9>0`. This note tests whether the same displayed named `Q10` also
+equals `cov9>0`. New k for the named 3-bit OR. Not leftover-character
+of c9sel and not leftover-character of c10bit3.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`. That tuple has `adj2=vertex3=mixed3=1`,
+so `Q10(f_L1)=1`.
+
+On the two-cube with off-patch `o=0`, write
+`cov9(f) = |{S : |S|=9 and f fills from S}|`. There are `C(12,9)=220`
+nine-site seeds. The boolean scored here is `cov9(f)>0`.
+
+**Theorem 1.** Among all 32 `F_cut` maps, `cov9>0` is not equivalent to
+`Q10`. The identity fails. The lex-first remaining-bit miss is
+`(0, 0, 0, 0, 1)`: that map has `Q10=1` and `cov9=0`.
+
+**Theorem 2.** The three census integers on the 32-map set are
+
+```text
+N_pos = 26
+N_Q10 = 28
+N_both = 26.
+```
+
+**Theorem 3.** The identity is displayed only. Displayed, not adopted.
+Do not adopt Q10. Do not write `Q10` into Admissibility.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are scored exactly on the 220 nine-site seeds. Whether cov9>0 equals adj2 or vertex3 or mixed3 is a finite Boolean identity on this patch, and it fails. Not a physical Admissibility selector."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov9_q10_selector_test
+target_blocker_text: "whether cov9>0 equals adj2 or vertex3 or mixed3 among the 32 F_cut maps after Q10 already names cov10>0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded cov9>0 versus Q10 identity; do not adopt Q10"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The three remaining bits below are displayed remaining-bit
+data, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The nine-site seeds are the `C(12,9) = 220` subsets of size 9 in `T`.
+Then `cov9(f)` is the number of those subsets from which `f` fills. The
+boolean scored here is `cov9(f)>0`.
+
+`Q10` is the remaining-bit predicate
+
+```text
+Q10(f) := (adj2=1) or (vertex3=1) or (mixed3=1).
+```
+
+It holds on exactly 28 of the 32 maps: the four maps with
+`(adj2, vertex3, mixed3) = (0, 0, 0)` are `Q10=0`. Duality is not
+assumed: `cov9` is scored on the 220 nine-site seeds.
+
+## Theorem 1 — `cov9>0` versus `Q10` on all 32
+
+Direct evolution on the 220 nine-site seeds scores every `F_cut` map.
+The identity
+
+```text
+cov9(f) > 0  ⇔  Q10(f) = 1
+```
+
+fails. The lex-first remaining-bit miss is `(0, 0, 0, 0, 1)`: `Q10=1`
+and `cov9=0`. That map is mixed3-only. The six maps with `cov9=0` are
+
+```text
+(0, 0, 0, 0, 0), (0, 0, 0, 0, 1), (0, 1, 0, 0, 0),
+(1, 0, 0, 0, 0), (1, 0, 0, 0, 1), (1, 1, 0, 0, 0).
+```
+
+The two mismatches are the `Q10`-true zeros `(0, 0, 0, 0, 1)` and
+`(1, 0, 0, 0, 1)`. Every `Q10`-false map has `cov9=0`, so `cov9>0`
+implies `Q10`. The converse fails. In particular
+`f_L1 = (1, 0, 1, 1, 1)` has `Q10=1` and `cov9=220 > 0`, so it is not
+a miss.
+
+## Theorem 2 — the three census integers
+
+Write `N_pos` for the number of `F_cut` maps with `cov9>0`, `N_Q10` for
+the number with `Q10=1`, and `N_both` for the number with both. Then
+
+```text
+N_pos = 26
+N_Q10 = 28
+N_both = 26.
+```
+
+These three integers are counted from the scored 32-map table. They
+fail to coincide because the identity of Theorem 1 fails: two `Q10`
+maps have `cov9=0`, and no positive map has `Q10=0`.
+
+## Theorem 3 — display, not adoption
+
+The failure of `cov9>0 ⇔ Q10` on all 32 `F_cut` maps is displayed
+data. Displayed, not adopted. Do not adopt Q10. Do not adopt a bit. Do
+not adopt `adj2`. Do not adopt `vertex3`. Do not adopt `mixed3`. Do not
+adopt `f_L1`. Do not write `Q10` into Admissibility.
+Admissibility does not name this remaining-bit formula.
+
+The census is a finite fact about occupancy-to-lock on this two-cube
+with off-patch `o=0`. It is not a physical formation-site selector and
+not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `Q10` as `adj2=1` or `vertex3=1` or `mixed3=1` | twenty-eight maps |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 220 nine-site seeds, off-patch `o=0` | declared finite patch |
+| `cov9>0` iff `Q10` on those 32 | fails; lex-first miss `(0, 0, 0, 0, 1)` |
+| `N_pos`, `N_Q10`, `N_both` | 26, 28, 26 |
+| leftover of c9sel | refused; that closed no 1–2-bit and no 3-bit equals `cov9>0` |
+| leftover of c10bit3 | refused; that named `Q10=cov10>0` |
+| adoption of `Q10` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of c9sel: that closed that no 1-bit remaining-bit
+predicate, no 2-bit OR, and no 3-bit AND or 3-bit OR equals `cov9>0`.
+The present object is whether the named c10bit3 predicate `Q10` equals
+nine-site positivity. New k for the named 3-bit OR.
+
+Not leftover-character of c10bit3: that closed `cov10>0` as `Q10`.
+The present object is the same displayed formula against `cov9>0`, not
+a restatement of the ten-site identity.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not adopt Q10.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether `cov9>0` equals `Q10` among all 32 `F_cut` maps. |
+| V2 | Current main has the axiom memo and the named `Q10=cov10>0` identity, but no landed `Q10`-versus-`cov9>0` test. |
+| V3 | The 32 maps and 220 seeds are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a new displayed predicate. |
+| V5 | The identity fails, is displayed, and `Q10` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: `Q10` is not `cov9>0` among the 32
+`F_cut` maps on this patch. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of c9sel | treat the `Q10` test as leftover-character of the failed 1–2-bit and 3-bit `cov9>0` searches | **ATTEMPTED** |
+| leftover of c10bit3 | treat the `k=9` test as leftover-character of `Q10=cov10>0` | **ATTEMPTED** |
+| adopt Q10 | write `Q10` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| lattice-wide formation | lift the patch census to a `Z^3` formation law | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the c9sel failed `cov9` menu, the c10bit3 `cov10`
+identity, and the off-patch convention are distinct. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 220 nine-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and the
+three-bit OR `adj2=1` or `vertex3=1` or `mixed3=1` are declared.
+Equality of `Q10` with `cov9>0` is not silently assumed. Duality is
+not assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+`cov9>0` equals `Q10` on all 32 `F_cut` maps, not leftover-character
+of c9sel and not leftover-character of c10bit3.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the 32 `F_cut` maps scored on 220 seeds | no physical law selection |
+| per block | the `cov9>0`–`Q10` identity on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule,
+a selector outside `Q10`, and any independently derived physical map
+from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** c10bit3 already recorded that `Q10` is positivity at
+`k=10`, and c9sel already scored every 1-bit, 2-bit, and 3-bit formula
+against `cov9>0`, so naming `Q10` at `k=9` cannot add a fact.
+
+**Answer:** `Q10` fails at `k=9`. `N_pos = 26`, `N_Q10 = 28`, and
+`N_both = 26`. The lex-first miss is `(0, 0, 0, 0, 1)`. Positivity
+implies `Q10`, but `Q10` is not `cov9>0`. New k for the named 3-bit
+OR. Do not adopt Q10.
+
+### N8 — cross-cycle echo
+
+Investment c9sel already showed that no 1–2-bit and no 3-bit remaining-bit
+`Q` equals `cov9>0`. Investment c10bit3 already showed that `cov10>0`
+is `Q10`. Echoing either fact is not a substitute for testing `cov9>0`
+against named `Q10` on all 32. New k for the named 3-bit OR.
+
+No-Go Discipline disposition: **PASS** for the finite 32-map census
+and the displayed failed identity. FAIL / DO NOT SHIP for
+“adopt Q10,” “`Q10` is the physical rule,” or “write `Q10` into
+Admissibility.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov9` on
+the 220 nine-site seeds, decides whether `cov9>0` if and only if
+`Q10`, reports the lex-first miss if the identity fails, and reports
+`N_pos`, `N_Q10`, and `N_both`. Declared audit inputs are this note
+and the axiom memo; the runner writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov9_q10_selector_test_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov9_q10_selector_test_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov9_q10_selector_test_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov9_q10_selector_test_2026_08_15.py
+runner_sha256: aa0a1316a89d8c59375c9b6c99812fe94b05a31a48fd9aa431155fd6f691b61d
+input_fingerprint_sha256: d5b8d252647feeb0c0838bafbc25a0e65119730918a3ff679dd74785f3ba9745
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed cov9>0 versus Q10 on all 32 F_cut maps; does not adopt Q10
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_nine_site_seeds=220
+N_pos=26
+N_Q10=28
+N_both=26
+cov9>0_iff_Q10=0
+lex_first_miss=(0, 0, 0, 0, 1)
+cov9(f_L1)=220
+cov9=0=((0, 0, 0, 0, 0), (0, 0, 0, 0, 1), (0, 1, 0, 0, 0), (1, 0, 0, 0, 0), (1, 0, 0, 0, 1), (1, 1, 0, 0, 0))
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 220 nine-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-q10-is-three-bit-or Q10 is adj2 or vertex3 or mixed3
+PASS: thm1-not-equivalent among all 32 F_cut maps, cov9>0 is not equivalent to Q10
+PASS: thm2-census N_pos = 26, N_Q10 = 28, N_both = 26
+PASS: thm3-display-not-adopted the identity is displayed and Q10 is not adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the cov9>0 versus Q10 identity and does not adopt Q10
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-c9sel-c10bit3 the residual is a new k for the named 3-bit OR
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 220 nine-site seeds against Q10
+per_block: checked exactly — N_pos, N_Q10, N_both are the F_cut positivity-versus-Q10 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov9_q10_selector_test_2026_08_15.py
+++ b/scripts/f_cut_cov9_q10_selector_test_2026_08_15.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""Whether cov9>0 equals Q10 := adj2 or vertex3 or mixed3 on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov9(f) is the number of nine-site seeds from which
+f fills. Q10 is the remaining-bit cut adj2=1 or vertex3=1 or mixed3=1.
+The runner reports whether cov9>0 iff Q10 on all 32 maps, the lex-first
+miss if the identity fails, and the census integers N_pos, N_Q10, N_both.
+The identity is displayed; the runner does not adopt Q10. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_MISS: Remaining = (0, 0, 0, 0, 1)
+N_POS = 26
+N_Q10 = 28
+N_BOTH = 26
+COV9_L1 = 220
+ZEROS: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 0, 0, 0, 1),
+    (0, 1, 0, 0, 0),
+    (1, 0, 0, 0, 0),
+    (1, 0, 0, 0, 1),
+    (1, 1, 0, 0, 0),
+)
+MISSES: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 1),
+    (1, 0, 0, 0, 1),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def in_q10(remaining: Remaining) -> bool:
+    return remaining[2] == 1 or remaining[3] == 1 or remaining[4] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed cov9>0 versus Q10 on all 32 F_cut maps; "
+        "does not adopt Q10"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(9)
+    rows: list[tuple[Remaining, int]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov))
+
+    n_pos = sum(1 for _remaining, cov in rows if cov > 0)
+    n_q10 = sum(1 for remaining, _cov in rows if in_q10(remaining))
+    n_both = sum(1 for remaining, cov in rows if in_q10(remaining) and cov > 0)
+    equivalent = all((cov > 0) == in_q10(remaining) for remaining, cov in rows)
+    misses = [
+        remaining
+        for remaining, cov in sorted(rows)
+        if (cov > 0) != in_q10(remaining)
+    ]
+    lex_miss = misses[0] if misses else None
+    cov_l1 = next(cov for remaining, cov in rows if remaining == L1_REMAINING)
+    zeros = tuple(sorted(remaining for remaining, cov in rows if cov == 0))
+    q10_false_pos = tuple(
+        sorted(remaining for remaining, cov in rows if cov > 0 and not in_q10(remaining))
+    )
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_nine_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_Q10={n_q10}")
+    print(f"N_both={n_both}")
+    print(f"cov9>0_iff_Q10={int(equivalent)}")
+    print(f"lex_first_miss={lex_miss}")
+    print(f"cov9(f_L1)={cov_l1}")
+    print(f"cov9=0={zeros}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV9_Q10_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 220 nine-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 220
+        and len(TWO_CUBE) == 12
+        and len(rows) == 32
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and in_q10(L1_REMAINING)
+        and cov_l1 == COV9_L1
+        and cov_l1 > 0,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-q10-is-three-bit-or",
+        "Q10 is adj2 or vertex3 or mixed3",
+        n_q10 == N_Q10
+        and in_q10((0, 0, 0, 0, 1))
+        and in_q10((0, 0, 1, 0, 0))
+        and in_q10((0, 0, 0, 1, 0))
+        and in_q10(L1_REMAINING)
+        and not in_q10((0, 0, 0, 0, 0))
+        and not in_q10((0, 1, 0, 0, 0))
+        and not in_q10((1, 0, 0, 0, 0))
+        and not in_q10((1, 1, 0, 0, 0))
+        and "Q10(f) := (adj2=1) or (vertex3=1) or (mixed3=1)" in note,
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "among all 32 F_cut maps, cov9>0 is not equivalent to Q10",
+        equivalent is False
+        and lex_miss == LEX_FIRST_MISS
+        and zeros == ZEROS
+        and q10_false_pos == ()
+        and tuple(misses) == MISSES
+        and len(misses) == 2
+        and "The identity fails" in note
+        and "The lex-first remaining-bit miss is" in note
+        and "`(0, 0, 0, 0, 1)`" in note,
+    )
+    checks.check(
+        "thm2-census",
+        "N_pos = 26, N_Q10 = 28, N_both = 26",
+        n_pos == N_POS
+        and n_q10 == N_Q10
+        and n_both == N_BOTH
+        and n_pos != n_q10
+        and n_both == n_pos
+        and n_both != n_q10
+        and "N_pos = 26" in note
+        and "N_Q10 = 28" in note
+        and "N_both = 26" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopted",
+        "the identity is displayed and Q10 is not adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt Q10" in note
+        and "Do not write `Q10` into Admissibility" in note
+        and "does not adopt Q10" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "cov9>0 equals adj2∨vertex3∨mixed3 is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the cov9>0 versus Q10 identity and does not adopt Q10",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `Q10` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-c9sel-c10bit3",
+        "the residual is a new k for the named 3-bit OR",
+        "Not leftover-character of c9sel" in note
+        and "Not leftover-character of c10bit3" in note
+        and "New k for the named 3-bit OR" in note
+        and "does not adopt Q10" in self_source,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 220 nine-site seeds against Q10")
+    print("per_block: checked exactly — N_pos, N_Q10, N_both are the F_cut positivity-versus-Q10 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov9>0 is not equivalent to Q10. N_pos=26, N_Q10=28, N_both=26 so cov9>0 implies Q10. Lex-first miss (0,0,0,0,1). Displayed, not adopted.

## Runner

`scripts/f_cut_cov9_q10_selector_test_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.