### PR TITLE
feat(qstartot9): among Q_star, Max(9) iff vertex3 and mixed3

### DIFF
--- a/docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,418 @@
+---
+claim_id: f_cut_qstar_cov9_max_selector_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 8 F_cut maps with wt1=1 and adj2=1 on the two-cube with off-patch o=0, whether maximal cov9 equals vertex3=mixed3=1 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py
+---
+
+# Whether Maximal `cov9` Among `Q_*` Equals Displayed `vertex3 ∧ mixed3`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 9-site coverage of the eight
+cube-covariant cut maps in `Q_*` — the `F_cut` subclass with `wt1=1`
+and `adj2=1` — on the twelve-vertex two-cube with off-patch occupancy
+`0`, over all 220 unordered 9-site seeds, and whether maximal `cov9`
+among those eight equals the displayed conjunction `vertex3=1` and
+`mixed3=1`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py`](../scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment: among `Q_*`, tot3/5/7/10 iff `vertex3 ∧ mixed3`. Max(4/6/8)
+is unique `f1`. Test whether maximal `cov9` iff that same cut among the
+eight. New odd k. `f_L1` is `n ≠ 0`, not Hamming.
+
+The 24 proper cube rotations act on neighbor 6-tuples in `{0,1}^6` and
+partition those 64 cells into 10 orbits. Cube-covariant predicates are the
+`{0,1}`-assignments to those orbits. The three displayed cuts
+
+1. vanish on empty: `f(empty)=0`,
+2. vanish on full: `f(full)=0`,
+3. complement-even: `f(c)=f(1-c)`
+
+leave five free bits, so
+
+```text
+|F_cut| = 32.
+```
+
+The five remaining bits, in the displayed order
+`(wt1, opp2, adj2, vertex3, mixed3)`, are the values on the three
+complement-pairs and two complement-fixed orbits after empty and full are
+forced to `0`. Write `Q_*` for the eight maps with `wt1=1` and `adj2=1`.
+Those eight remaining-bit tuples, in remaining-bit lex order, are
+
+```text
+(1, 0, 1, 0, 0), (1, 0, 1, 0, 1), (1, 0, 1, 1, 0), (1, 0, 1, 1, 1),
+(1, 1, 1, 0, 0), (1, 1, 1, 0, 1), (1, 1, 1, 1, 0), (1, 1, 1, 1, 1).
+```
+
+Not leftover-character of tot3, tot5, tot7, or tot10: those closed
+totality at other odd seed sizes as the same displayed cut. Not
+leftover-character of Max(4/6/8): those even-k maximizers were unique
+`f1`. The present object is maximal `cov9` among the same eight maps.
+New odd k inside `Q_*`.
+
+On the two-cube `{0,1,2}×{0,1}×{0,1}`, each unordered 9-set of vertices is
+a 9-site seed. There are `C(12,9)=220` such seeds. Off-patch neighbors
+have occupancy `0`. Each tick, every unlocked on-patch vertex evaluates
+`f` on its six-neighbor occupancy tuple and locks if `f=1`. The process
+is synchronous and stops at a fixed point in at most 13 ticks. Fill means
+`|locks_halt|=12`. Coverage is
+
+```text
+cov9(f) = |{ S : |S|=9 and f fills from S }|.
+```
+
+Write `m9` for the maximum of `cov9` among the eight. Duality is not
+assumed: `cov9` is scored on the 220 nine-site seeds and does not import
+`Max(k)=Max(12-k)` or the three-site census. Off-patch occupancy `0` is
+an explicit default. A blank-block is a different rule and is not used.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. The remaining-bit tuple of `f_L1` is `(1, 0, 1, 1, 1)`,
+which sits in `Q_*`. Displayed `Q` is
+
+```text
+Q(f) := (vertex3=1) and (mixed3=1).
+```
+
+That cut holds on exactly two of the eight: `(1, 0, 1, 1, 1)` and
+`(1, 1, 1, 1, 1)`.
+
+**Theorem 1.** Among the eight `Q_*` maps, maximal `cov9` is equivalent
+to `vertex3=1` and `mixed3=1`. Exhaustive evaluation on all 220
+nine-site seeds, in remaining-bit lex order, gives
+
+```text
+cov9((1, 0, 1, 0, 0)) = 68
+cov9((1, 0, 1, 0, 1)) = 72
+cov9((1, 0, 1, 1, 0)) = 200
+cov9((1, 0, 1, 1, 1)) = 220
+cov9((1, 1, 1, 0, 0)) = 72
+cov9((1, 1, 1, 0, 1)) = 72
+cov9((1, 1, 1, 1, 0)) = 204
+cov9((1, 1, 1, 1, 1)) = 220
+```
+
+So `m9 = 220 = C(12,9)`. The two maximizers are exactly the two `Q`
+maps. The identity holds.
+
+**Theorem 2.** The three census integers on the eight-map set are
+
+```text
+N_max = 2
+N_Q = 2
+N_both = 2
+```
+
+Because those three counts agree and the maximizers are exactly the `Q`
+maps, there is no lex-first miss. In particular `f_L1 = (1, 0, 1, 1, 1)`
+attains `cov9 = 220` and satisfies `Q`.
+
+**Theorem 3.** The identity is displayed only. Displayed, not adopted.
+Do not adopt a bit. Do not write Q into Admissibility. Admissibility does
+not name this remaining-bit formula.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The eight Q_* maps are scored exactly on the 220 nine-site seeds. Whether maximal cov9 equals vertex3=mixed3=1 is a finite Boolean identity on this patch. Not a physical Admissibility selector."
+trace_class: frontier_discovery
+target_claim_id: f_cut_qstar_cov9_max_selector
+target_blocker_text: "whether maximal cov9 among the eight Q_* maps equals vertex3=mixed3=1 after tot3/5/7/10 already named that cut and Max(4/6/8) was unique f1"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded Max(9) versus Q identity; do not adopt a bit"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. The two remaining bits below are displayed remaining-bit
+data, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1, 0, 2)`, `(0, 1, 2)`, `(2, 0, 1)`, `(3, 0, 0)`, `(1, 1, 1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+| remaining name | `(u,b,e)` | orbit size | complement image |
+|---|---|---:|---|
+| empty | `(0,0,3)` | 1 | full |
+| full | `(0,3,0)` | 1 | empty |
+| `opp2` | `(0,1,2)` | 3 | `(0,2,1)` |
+| `wt1` | `(1,0,2)` | 6 | `(1,2,0)` |
+| `adj2` | `(2,0,1)` | 12 | `(2,1,0)` |
+| `mixed3` | `(1,1,1)` | 12 | itself |
+| `vertex3` | `(3,0,0)` | 8 | itself |
+
+`Q_*` is the subclass with `wt1=1` and `adj2=1`. It has three free bits
+(`opp2`, `vertex3`, `mixed3`) and size 8.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The nine-site seeds are the `C(12,9) = 220` subsets of size 9 in `T`.
+Then `cov9(f)` is the number of those subsets from which `f` fills.
+Duality is not assumed: `cov9` is scored on those 220 seeds.
+
+`Q` is the remaining-bit predicate
+
+```text
+Q(f) := (vertex3=1) and (mixed3=1).
+```
+
+It holds on exactly two of the eight maps. Displayed, not adopted.
+
+## Theorem 1 — maximal `cov9` versus `Q` on the eight
+
+Direct evolution on the 220 nine-site seeds scores every `Q_*` map.
+The identity
+
+```text
+cov9(f) = m9  ⇔  Q(f) = 1
+```
+
+holds among the eight, with `m9 = 220`. The eight-line census in
+remaining-bit lex order is the table in the Result up front. The two
+maps that attain 220 are `(1, 0, 1, 1, 1)` and `(1, 1, 1, 1, 1)`. Those
+are exactly the maps with `vertex3=mixed3=1`. The six maps with `Q=0`
+have `cov9 ∈ {68, 72, 200, 204}`.
+
+In particular `f_L1 = (1, 0, 1, 1, 1)` has `Q=1` and `cov9=220`. The
+map `f1 = (1, 1, 1, 1, 1)` has the same pair. Unlike Max(4/6/8), the
+odd-k maximum is not unique `f1`.
+
+## Theorem 2 — the three census integers
+
+Write `N_max` for the number of `Q_*` maps with `cov9 = m9`, `N_Q` for
+the number with `Q=1`, and `N_both` for the number with both. Then
+
+```text
+N_max = 2
+N_Q = 2
+N_both = 2
+```
+
+These three integers are counted from the scored eight-map table. They
+coincide because the identity of Theorem 1 holds. There is no lex-first
+miss.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, satisfies `Q` and has
+`cov9 = 220`. That is consistent with Theorem 2.
+
+## Theorem 3 — display, not adoption
+
+The identity `Max(9) ⇔ Q` on the eight `Q_*` maps is displayed data.
+Displayed, not adopted. Do not adopt a bit. Do not adopt `vertex3`. Do
+not adopt `mixed3`. Do not adopt `f_L1`. Do not write Q into
+Admissibility. Admissibility does not name this remaining-bit formula.
+
+The census is a finite fact about occupancy-to-lock on this two-cube
+with off-patch `o=0`. It is not a physical formation-site selector and
+not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `Q_*` as the eight maps with `wt1=1` and `adj2=1` | remaining-bit lex order |
+| `Q` as `vertex3=1` and `mixed3=1` | two maps |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 220 nine-site seeds, off-patch `o=0` | declared finite patch |
+| maximal `cov9` iff `Q` on those eight | holds; `m9=220` |
+| `N_max`, `N_Q`, `N_both` | 2, 2, 2; no lex-first miss |
+| leftover of tot3/5/7/10 | refused; those are other odd k |
+| leftover of Max(4/6/8) | refused; those even maxima were unique `f1` |
+| adoption of `Q` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of tot3, tot5, tot7, or tot10: those closed
+totality at `k ∈ {3,5,7,10}` as `vertex3 ∧ mixed3`. The present object
+is maximal `cov9` at new odd k.
+
+Not leftover-character of Max(4/6/8): those even-k tests found a unique
+maximizer `f1` and a `Q`-true miss at `f_L1`. Here both `Q` maps attain
+the nine-site ceiling.
+
+Duality is not assumed: `C(12,9)=C(12,3)=220`, but the nine-site scores
+are not the three-site scores and are computed on the 220 nine-site seeds.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write Q into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether maximal `cov9` equals `Q` among the eight `Q_*` maps. |
+| V2 | tot3/5/7/10 already named that cut at other odd seed sizes. Max(4/6/8) was unique `f1`. Current main has no landed focused Max(9) test inside `Q_*`. |
+| V3 | The eight maps and 220 seeds are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a named displayed 2-bit AND. |
+| V5 | The identity holds, is displayed, and `Q` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The positive content is narrow: maximal `cov9` equals `Q` among the
+eight `Q_*` maps on this patch. No global compiler necessity is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of tot3 | treat the nine-site test as leftover-character of tot3 | **ATTEMPTED** |
+| leftover of tot5/7/10 | treat the test as leftover-character of those odd-k totals | **ATTEMPTED** |
+| leftover of Max(4/6/8) | treat the test as leftover-character of the even-k unique-`f1` maxima | **ATTEMPTED** |
+| adopt Q | write `Q` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the tot3/5/7/10 odd-k identities, the Max(4/6/8)
+even-k unique-`f1` facts, and the off-patch convention are distinct.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 220 nine-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, the `Q_*`
+cut `wt1=adj2=1`, and the two-bit AND `vertex3=1` and `mixed3=1` are
+declared. Equality of `Q` with maximal `cov9` is not silently assumed.
+Duality is not assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+maximal `cov9` equals `Q` on the eight `Q_*` maps, not leftover-character
+of tot3 and not leftover-character of Max(4/6/8). New odd k.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the eight `Q_*` maps scored on 220 seeds | no physical law selection |
+| per block | the Max(9)–`Q` identity on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different seed family, a different off-patch rule,
+a selector outside `Q`, and any independently derived physical map
+from `F_cut` into Admissibility.
+
+Approved primitives are `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive`. None of
+them supplies a Boolean occupancy map, a seed-coverage ranking, or an
+Admissibility selector.
+
+### N7 — hostile steelman
+
+**Steelman:** tot3/5/7/10 already recorded that `Q` is totality at those
+odd sizes, so the same 2-bit AND must also be the k=9 maximizer and
+must be written into Admissibility; alternatively Max(4/6/8) already
+showed unique `f1`, so Max(9) must be unique `f1` as well.
+
+**Answer:** the nine-site census is independent. `N_max = 2`, `N_Q = 2`,
+and `N_both = 2`. Both `Q` maps attain `cov9 = 220`. Max(9) is not
+unique `f1`. Duality is not assumed. Do not adopt a bit.
+
+### N8 — cross-cycle echo
+
+Investment tot3/5/7/10 already showed that totality at those odd sizes
+is `Q`. Investment Max(4/6/8) already showed unique `f1` at those even
+sizes. Echoing either fact is not a substitute for testing maximal
+`cov9` against named `Q` on the eight. New odd k.
+
+No-Go Discipline disposition: **PASS** for the finite eight-map census
+and the displayed identity. FAIL / DO NOT SHIP for
+“adopt Q,” “`Q` is the physical rule,” or “write Q into
+Admissibility.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the eight `Q_*` maps, scores `cov9` on
+the 220 nine-site seeds, decides whether maximal `cov9` if and only if
+`Q`, reports the lex-first miss if the identity fails, and reports
+`N_max`, `N_Q`, and `N_both`. Declared audit inputs are this note
+and the axiom memo; the runner writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_qstar_cov9_max_selector_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_qstar_cov9_max_selector_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_qstar_cov9_max_selector_2026_08_15.txt
@@ -1,0 +1,71 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py
+runner_sha256: 4df1867652f771e10f4f5d273925133c59a17783c33a19aca8b9d5f846870fa2
+input_fingerprint_sha256: b5c64658ade150f92fbbf62b749d0645cd7b351f4c4ab14dc50745c9f384c6c7
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed Max(9) versus Q among the eight Q_* maps; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+N_free=5
+|F_cut|=32
+|Q_*|=8
+n_nine_site_seeds=220
+m9=220
+remaining=(1, 0, 1, 0, 0) cov9=68 max=0 Q=0
+remaining=(1, 0, 1, 0, 1) cov9=72 max=0 Q=0
+remaining=(1, 0, 1, 1, 0) cov9=200 max=0 Q=0
+remaining=(1, 0, 1, 1, 1) cov9=220 max=1 Q=1
+remaining=(1, 1, 1, 0, 0) cov9=72 max=0 Q=0
+remaining=(1, 1, 1, 0, 1) cov9=72 max=0 Q=0
+remaining=(1, 1, 1, 1, 0) cov9=204 max=0 Q=0
+remaining=(1, 1, 1, 1, 1) cov9=220 max=1 Q=1
+N_max=2
+N_Q=2
+N_both=2
+max_cov9_iff_Q=1
+max_maps=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+Q_maps=[(1, 0, 1, 1, 1), (1, 1, 1, 1, 1)]
+lex_first_miss=None
+f_L1_remaining=(1, 0, 1, 1, 1)
+cov9_f_L1=220
+cov9_f1=220
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-twenty-four-rotations exactly 24 proper cube rotations
+PASS: thm1-ten-orbits exactly 10 orbits partition the 64 cells of {0,1}^6
+PASS: thm1-orbit-sizes orbit sizes are the axis-type class sizes
+PASS: thm1-f-cut-cardinality F_cut has five free bits and size 32
+PASS: thm1-qstar-eight-lex Q_* is the eight remaining-bit tuples with wt1=1 and adj2=1 in lex order
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-two-cube-and-nine-site-seeds the two-cube has twelve vertices and C(12,9)=220 nine-site seeds
+PASS: thm1-max-cov9-iff-Q among the eight Q_* maps, maximal cov9 equals vertex3=mixed3=1
+PASS: thm2-census N_max = 2, N_Q = 2, N_both = 2 and there is no miss
+PASS: thm3-display-not-adopted the identity is displayed and no remaining bit is adopted
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the Max(9) versus Q identity and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-prior-k the residual is a new odd k inside Q_*, not leftover of tot3/5/7/10 or Max(4/6/8)
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — each of the eight Q_* maps is scored on 220 nine-site seeds against Q
+per_block: checked exactly — N_max, N_Q, N_both are the Q_* Max(9)-versus-Q counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py
+++ b/scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3
+"""Whether maximal cov9 among Q_* equals vertex3 and mixed3.
+
+Q_* is the F_cut subclass with wt1=1 and adj2=1 (eight remaining-bit
+tuples). F_cut is the cube-covariant class with f(empty)=f(full)=0 and
+f(c)=f(1-c). Dynamics are occupancy-to-lock on the twelve-vertex
+two-cube with off-patch occupancy 0. Coverage cov9(f) is the number of
+unordered 9-site seeds from which f fills. Q is the displayed cut
+vertex3=1 and mixed3=1. The runner reports whether maximal cov9 among
+the eight equals Q, the census integers N_max, N_Q, N_both, and the
+lex-first miss if the identity fails. Displayed, not adopted. f_L1 is
+the unbalanced-axis predicate (some n_mu != 0), never Hamming
+|c|_1 mod 2. Duality is not assumed. The runner does not adopt a bit.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+NINE_SITE_SEEDS: tuple[frozenset[Site], ...] = tuple(
+    frozenset(combo) for combo in combinations(TWO_CUBE, 9)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+F1_REMAINING: Remaining = (1, 1, 1, 1, 1)
+M9 = 220
+N_MAX = 2
+N_Q = 2
+N_BOTH = 2
+CENSUS: dict[Remaining, int] = {
+    (1, 0, 1, 0, 0): 68,
+    (1, 0, 1, 0, 1): 72,
+    (1, 0, 1, 1, 0): 200,
+    (1, 0, 1, 1, 1): 220,
+    (1, 1, 1, 0, 0): 72,
+    (1, 1, 1, 0, 1): 72,
+    (1, 1, 1, 1, 0): 204,
+    (1, 1, 1, 1, 1): 220,
+}
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def remaining_value(config: Config, remaining: Remaining) -> int:
+    kind = axis_type(config)
+    if kind in (axis_type(EMPTY), axis_type(FULL)):
+        return 0
+    assignment = dict(zip(REMAINING_ORDER, remaining, strict=True))
+    if kind in assignment:
+        return assignment[kind]
+    return assignment[complement_type(kind)]
+
+
+def in_qstar(remaining: Remaining) -> bool:
+    wt1, _opp2, adj2, _vertex3, _mixed3 = remaining
+    return wt1 == 1 and adj2 == 1
+
+
+def selector_q(remaining: Remaining) -> bool:
+    """Displayed Q: vertex3=1 and mixed3=1."""
+    _wt1, _opp2, _adj2, vertex3, mixed3 = remaining
+    return vertex3 == 1 and mixed3 == 1
+
+
+def enumerate_qstar() -> list[Remaining]:
+    members: list[Remaining] = []
+    for bits in product((0, 1), repeat=5):
+        remaining: Remaining = (bits[0], bits[1], bits[2], bits[3], bits[4])
+        if in_qstar(remaining):
+            members.append(remaining)
+    return members
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        if any(axis_type(member) != orbit_type for member in orbit):
+            raise RuntimeError("orbit mixed axis types")
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+SITE_INDEX: dict[Site, int] = {site: index for index, site in enumerate(TWO_CUBE)}
+NEIGHBOR_INDEX: tuple[tuple[int | None, ...], ...] = tuple(
+    tuple(
+        SITE_INDEX.get(
+            (site[0] + direction[0], site[1] + direction[1], site[2] + direction[2])
+        )
+        for direction in DIRECTIONS
+    )
+    for site in TWO_CUBE
+)
+
+
+def fills_from_mask(fire: tuple[int, ...], seed_mask: int) -> bool:
+    locked = seed_mask
+    for _tick in range(13):
+        nxt = locked
+        for site_index in range(12):
+            if (locked >> site_index) & 1:
+                continue
+            bits = 0
+            for axis, neighbor in enumerate(NEIGHBOR_INDEX[site_index]):
+                occupied = neighbor is not None and ((locked >> neighbor) & 1)
+                if occupied:
+                    bits |= 1 << axis
+            if fire[bits]:
+                nxt |= 1 << site_index
+        if nxt == locked:
+            return locked == (1 << 12) - 1
+        locked = nxt
+    return False
+
+
+def seed_mask(seed: frozenset[Site]) -> int:
+    mask = 0
+    for site in seed:
+        mask |= 1 << SITE_INDEX[site]
+    return mask
+
+
+SEED_MASKS: tuple[int, ...] = tuple(seed_mask(seed) for seed in NINE_SITE_SEEDS)
+
+
+def fire_table(remaining: Remaining) -> tuple[int, ...]:
+    table = [0] * 64
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        index = (
+            raw[0]
+            | (raw[1] << 1)
+            | (raw[2] << 2)
+            | (raw[3] << 3)
+            | (raw[4] << 4)
+            | (raw[5] << 5)
+        )
+        table[index] = remaining_value(config, remaining)
+    return tuple(table)
+
+
+def coverage9(remaining: Remaining) -> int:
+    fire = fire_table(remaining)
+    return sum(1 for mask in SEED_MASKS if fills_from_mask(fire, mask))
+
+
+def bits_from_predicate(
+    predicate, orbit_types: tuple[OrbitType, ...], orbits: dict[OrbitType, frozenset[Config]]
+) -> tuple[int, ...]:
+    bits = []
+    for orbit_type in orbit_types:
+        sample = next(iter(orbits[orbit_type]))
+        value = int(predicate(sample))
+        if any(int(predicate(member)) != value for member in orbits[orbit_type]):
+            raise RuntimeError("predicate is not cube-covariant")
+        bits.append(value)
+    return tuple(bits)
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def remaining_bits_from_full(
+    bits: tuple[int, ...], orbit_types: tuple[OrbitType, ...]
+) -> Remaining:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    return remaining_bits_from_assignment(assignment)
+
+
+def in_f_cut(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> bool:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    if assignment[empty_type] != 0 or assignment[full_type] != 0:
+        return False
+    return all(
+        assignment[orbit_type] == assignment[complement_type(orbit_type)]
+        for orbit_type in orbit_types
+    )
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print(
+        "negative_scope: displayed Max(9) versus Q among the eight Q_* maps; "
+        "does not adopt a bit"
+    )
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    orbit_sizes = {orbit_type: len(orbits[orbit_type]) for orbit_type in orbit_types}
+    empty_type = axis_type(EMPTY)
+    full_type = axis_type(FULL)
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    n_cut = 1 << n_free
+    qstar = enumerate_qstar()
+    ranked = [(remaining, coverage9(remaining)) for remaining in qstar]
+    m9 = max(cov for _remaining, cov in ranked)
+    n_max = sum(1 for _remaining, cov in ranked if cov == m9)
+    n_q = sum(1 for remaining, _cov in ranked if selector_q(remaining))
+    n_both = sum(1 for remaining, cov in ranked if cov == m9 and selector_q(remaining))
+    equivalent = all((cov == m9) == selector_q(remaining) for remaining, cov in ranked)
+    max_maps = [remaining for remaining, cov in ranked if cov == m9]
+    q_maps = [remaining for remaining, _cov in ranked if selector_q(remaining)]
+    misses = [
+        remaining
+        for remaining, cov in ranked
+        if (cov == m9) != selector_q(remaining)
+    ]
+    lex_miss = misses[0] if misses else None
+
+    l1_bits = bits_from_predicate(f_L1, orbit_types, orbits)
+    ham_bits = bits_from_predicate(f_hamming, orbit_types, orbits)
+    l1_remaining = remaining_bits_from_full(l1_bits, orbit_types)
+    cov_l1 = next(cov for remaining, cov in ranked if remaining == l1_remaining)
+    cov_f1 = next(cov for remaining, cov in ranked if remaining == F1_REMAINING)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"N_free={n_free}")
+    print(f"|F_cut|={n_cut}")
+    print(f"|Q_*|={len(qstar)}")
+    print(f"n_nine_site_seeds={len(NINE_SITE_SEEDS)}")
+    print(f"m9={m9}")
+    for remaining, cov in ranked:
+        print(
+            f"remaining={remaining} cov9={cov} max={int(cov == m9)} "
+            f"Q={int(selector_q(remaining))}"
+        )
+    print(f"N_max={n_max}")
+    print(f"N_Q={n_q}")
+    print(f"N_both={n_both}")
+    print(f"max_cov9_iff_Q={int(equivalent)}")
+    print(f"max_maps={max_maps}")
+    print(f"Q_maps={q_maps}")
+    print(f"lex_first_miss={lex_miss}")
+    print(f"f_L1_remaining={l1_remaining}")
+    print(f"cov9_f_L1={cov_l1}")
+    print(f"cov9_f1={cov_f1}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_QSTAR_COV9_MAX_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-twenty-four-rotations",
+        "exactly 24 proper cube rotations",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "thm1-ten-orbits",
+        "exactly 10 orbits partition the 64 cells of {0,1}^6",
+        len(orbit_types) == 10 and sum(orbit_sizes.values()) == 64,
+    )
+    expected_sizes = {
+        (0, 0, 3): 1,
+        (0, 1, 2): 3,
+        (0, 2, 1): 3,
+        (0, 3, 0): 1,
+        (1, 0, 2): 6,
+        (1, 1, 1): 12,
+        (1, 2, 0): 6,
+        (2, 0, 1): 12,
+        (2, 1, 0): 12,
+        (3, 0, 0): 8,
+    }
+    checks.check(
+        "thm1-orbit-sizes",
+        "orbit sizes are the axis-type class sizes",
+        orbit_sizes == expected_sizes,
+    )
+    checks.check(
+        "thm1-f-cut-cardinality",
+        "F_cut has five free bits and size 32",
+        n_free == 5
+        and n_cut == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and empty_type == (0, 0, 3)
+        and full_type == (0, 3, 0)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-qstar-eight-lex",
+        "Q_* is the eight remaining-bit tuples with wt1=1 and adj2=1 in lex order",
+        len(qstar) == 8
+        and qstar
+        == [
+            (1, 0, 1, 0, 0),
+            (1, 0, 1, 0, 1),
+            (1, 0, 1, 1, 0),
+            (1, 0, 1, 1, 1),
+            (1, 1, 1, 0, 0),
+            (1, 1, 1, 0, 1),
+            (1, 1, 1, 1, 0),
+            (1, 1, 1, 1, 1),
+        ]
+        and all(in_qstar(remaining) for remaining in qstar)
+        and qstar == sorted(qstar),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and l1_remaining == L1_REMAINING
+        and in_qstar(l1_remaining)
+        and selector_q(l1_remaining)
+        and in_f_cut(l1_bits, orbit_types, empty_type, full_type),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        l1_bits != ham_bits
+        and any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-two-cube-and-nine-site-seeds",
+        "the two-cube has twelve vertices and C(12,9)=220 nine-site seeds",
+        len(TWO_CUBE) == 12
+        and len(set(TWO_CUBE)) == 12
+        and len(NINE_SITE_SEEDS) == 220
+        and len(set(NINE_SITE_SEEDS)) == 220
+        and all(seed <= set(TWO_CUBE) and len(seed) == 9 for seed in NINE_SITE_SEEDS),
+    )
+    census_ok = True
+    for remaining, cov in ranked:
+        spaced = f"cov9({remaining}) = {cov}"
+        if spaced not in note:
+            census_ok = False
+        if CENSUS[remaining] != cov:
+            census_ok = False
+    checks.check(
+        "thm1-max-cov9-iff-Q",
+        "among the eight Q_* maps, maximal cov9 equals vertex3=mixed3=1",
+        equivalent
+        and m9 == M9
+        and ranked == [(remaining, CENSUS[remaining]) for remaining in qstar]
+        and census_ok
+        and all(0 <= cov <= M9 for _remaining, cov in ranked)
+        and "remaining-bit lex order" in note
+        and "maximal cov9" in note
+        and "equivalent" in note,
+    )
+    checks.check(
+        "thm2-census",
+        "N_max = 2, N_Q = 2, N_both = 2 and there is no miss",
+        n_max == N_MAX
+        and n_q == N_Q
+        and n_both == N_BOTH
+        and n_max == n_q == n_both
+        and max_maps == [L1_REMAINING, F1_REMAINING]
+        and q_maps == [L1_REMAINING, F1_REMAINING]
+        and misses == []
+        and lex_miss is None
+        and cov_l1 == M9
+        and cov_f1 == M9
+        and "N_max = 2" in note
+        and "N_Q = 2" in note
+        and "N_both = 2" in note
+        and "no lex-first miss" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopted",
+        "the identity is displayed and no remaining bit is adopted",
+        "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write Q into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 8 F_cut maps with wt1=1 and adj2=1 on the two-cube with "
+        "off-patch o=0, whether maximal cov9 equals vertex3=mixed3=1 is "
+        "reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the Max(9) versus Q identity and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write Q into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-prior-k",
+        "the residual is a new odd k inside Q_*, not leftover of tot3/5/7/10 or Max(4/6/8)",
+        "New odd k" in note
+        and "Not leftover-character of tot3" in note
+        and "Not leftover-character of Max(4/6/8)" in note
+        and "does not adopt a bit" in self_source
+        and "Duality is not assumed" in note,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — each of the eight Q_* maps is scored on 220 nine-site seeds against Q")
+    print("per_block: checked exactly — N_max, N_Q, N_both are the Q_* Max(9)-versus-Q counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 8 Q_* maps on the two-cube with off-patch o=0, maximal cov9 iff vertex3 and mixed3. N_max=2, N_Q=2, N_both=2. No miss. Displayed, not adopted.

## Runner

`scripts/f_cut_qstar_cov9_max_selector_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.