### PR TITLE
feat(c3p): cov3>0 is not P; positivity does not imply P

### DIFF
--- a/docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,343 @@
+---
+claim_id: f_cut_cov3_p_selector_test_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether cov3>0 equals P, and whether positivity implies P, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov3_p_selector_test_2026_08_15.py
+---
+
+# Whether `cov3>0` Equals Displayed `P`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 3-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+thirty-two cube-covariant cut maps `F_cut`, against displayed `P`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov3_p_selector_test_2026_08_15.py`](../scripts/f_cut_cov3_p_selector_test_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c3q10 showed that cov3>0 does not imply Q10 for the displayed
+remaining-bit predicate `(adj2=1) or (vertex3=1) or (mixed3=1)`. Investment
+#6494 already named as cov2>0 the remaining-bit predicate
+
+```text
+P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0).
+```
+
+`P` is not a pure AND/OR of remaining bits. Not leftover-character of the
+1–5-bit remaining-bit menu. This note tests that named selector at the
+seed size where Q10-imply failed (`k=3`).
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov3(f) = |{S : |S|=3 and f fills from S}|`. Then:
+
+- Theorem 1. `cov3>0` is not equivalent to `P`. Positivity does not
+  imply `P`. One lex-first remaining-bit miss is reported.
+- Theorem 2. `N_pos = 20`, `N_P = 14`, `N_both = 13`.
+- Theorem 3. `P` is displayed. Do not adopt P.
+
+Do not write `P` into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 220 three-site seeds of the two-cube. Whether cov3>0 equals displayed P, and whether positivity implies P, are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov3_p_selector_test
+target_blocker_text: "whether cov3>0 equals P among the 32 F_cut maps, and whether positivity implies P"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 3-site positivity-versus-P comparison; do not adopt displayed P"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. `P` is a displayed remaining-bit formula, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The three-site seeds are the `C(12,3) = 220` subsets of size 3 in `T`. Then
+`cov3(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov3(f)>0`. Duality is not assumed: `cov3` is scored on
+those 220 seeds.
+
+The displayed remaining-bit predicate is
+
+```text
+P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0).
+```
+
+That is `wt1` and at least one of `adj2`, `vertex3`, `mixed3`. Opp2 is
+free in `P`. Displayed, not adopted.
+
+## Theorem 1 — `cov3>0` is not equivalent to `P`; one lex-first miss
+
+Enumerate all 32 remaining-bit tuples of `F_cut` and score `cov3` on the
+220 three-site seeds. Then `cov3(f) > 0` is not equivalent to `P`. There
+are eight mismatches. Positivity does not imply `P`.
+
+The one `P`-true map with `cov3 = 0` is
+`(1, 0, 0, 0, 1)`.
+
+The seven `P`-false maps with `cov3 > 0` are
+`(0, 0, 1, 1, 0)` (`cov3 = 24`), `(0, 0, 1, 1, 1)` (`cov3 = 24`),
+`(0, 1, 1, 0, 0)` (`cov3 = 16`), `(0, 1, 1, 0, 1)` (`cov3 = 16`),
+`(0, 1, 1, 1, 0)` (`cov3 = 44`), `(0, 1, 1, 1, 1)` (`cov3 = 44`),
+and `(1, 1, 0, 0, 0)` (`cov3 = 4`).
+
+The lex-first remaining-bit miss, in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`, is `(0, 0, 1, 1, 0)`: `cov3 = 24`
+and `P` is false (`wt1 = 0`). That same map is the lex-first witness that
+positivity does not imply `P`.
+
+The map `(1, 1, 0, 0, 0)` is the unique remaining-bit tuple at which
+Q10-imply already failed (`cov3 = 4` and `Q10` false). It likewise has
+`P` false, so the same witness refuses `cov3>0 ⇒ P`.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, satisfies `P` and has
+`cov3 = 220`. That is consistent with Theorem 2 and does not restore
+equivalence.
+
+## Theorem 2 — `N_pos`, `N_P`, `N_both`
+
+Among the 32 maps:
+
+- `N_pos = 20` maps have `cov3 > 0`;
+- `N_P = 14` maps satisfy `P`;
+- `N_both = 13` maps satisfy both.
+
+The counts already refuse equivalence: `N_both = 13` is strictly smaller
+than both `N_pos` and `N_P`. The eight mismatches of Theorem 1 account
+for the gap of seven on the positivity side and one on the `P` side.
+
+## Theorem 3 — display; do not adopt P
+
+`P` is the remaining-bit predicate already named as cov2>0. On this
+patch it does not equal 3-site positivity, and positivity does not imply
+`P`. Displayed, not adopted. Do not adopt P. Do not write `P` into
+Admissibility. Admissibility does not name this remaining-bit formula.
+
+The identities here are finite facts about occupancy-to-lock on this
+two-cube with off-patch `o=0`. They are not a physical formation-site
+selector and not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 220 three-site seeds, off-patch `o=0` | declared finite patch |
+| `P` as `(wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)` | displayed, not adopted |
+| `cov3>0` iff `P` | fails; lex-first miss `(0, 0, 1, 1, 0)` |
+| positivity implies `P` | fails; witness `(0, 0, 1, 1, 0)` |
+| `N_pos = 20`, `N_P = 14`, `N_both = 13` | proved by exhaustive scoring |
+| leftover-character of the 1–5-bit remaining-bit menu | refused; `P` is not a pure AND/OR |
+| leftover-character of c3q10 / Q10-imply | refused; named `P` at the same `k` |
+| leftover-character of naming `P` as `cov2>0` | refused; new seed size |
+| adoption of `P` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of the 1–5-bit remaining-bit menu: that menu was
+the pure AND and the pure OR of remaining bits of each width. `P` is
+not a pure AND/OR. The present object is whether the separately named
+identity already named as cov2>0 equals 3-site positivity, and whether
+positivity implies `P`.
+
+Not leftover-character of c3q10: that closed `cov3>0` does not imply
+`Q10` at this same seed size. Echoing that `Q10` implication failure is
+not a substitute for the named-`P` comparison. The test is at the
+Q10-imply seed size because that is where one-sided positivity first
+failed for the 3-bit OR.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write `P` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether 3-site positivity equals displayed `P` inside `F_cut` on this patch, and whether positivity implies `P`. |
+| V2 | Current main has the axiom memo, the failed 1–5-bit AND/OR menu for `cov3>0`, the named identity `P=cov2>0`, and the c3q10 fact that `cov3>0` does not imply `Q10`, but no landed 3-site positivity-versus-`P` implication test. |
+| V3 | The 32 maps, 220 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a named mixed remaining-bit predicate at the seed size where Q10-imply failed. |
+| V5 | Equivalence fails, positivity does not imply `P`, one lex-first miss is reported, and displayed `P` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: among the 32 `F_cut` maps on this patch,
+`cov3>0` is not `P`, and positivity does not imply `P`. Displayed
+`P` is not axiom content. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of the 1–5-bit remaining-bit menu | treat the mixed predicate as leftover-character of the pure AND/OR menu | **ATTEMPTED** |
+| leftover of c3q10 / Q10-imply | treat the named-`P` test as leftover-character of the `Q10` implication failure | **ATTEMPTED** |
+| leftover of naming `P` as `cov2>0` | treat three-site positivity as leftover-character of the two-site closed form | **ATTEMPTED** |
+| adopt `P` | write `(wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the 1–5-bit AND/OR menu, the `Q10` implication,
+the two-site naming of `P`, and the off-patch convention are distinct.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 220 three-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and displayed
+`P` are declared. Equivalence of `cov3>0` with `P` is not silently
+assumed, and the implication `cov3>0 ⇒ P` is not silently assumed.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+3-site positivity equals displayed `P` on the declared patch, as a
+test of the named `cov2>0` selector at the seed size where Q10-imply
+failed, and not leftover-character of the 1–5-bit remaining-bit menu.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 220 seeds | no physical law selection |
+| per block | `N_pos`, `N_P`, and `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different Boolean combination of remaining bits, a
+different seed family, a different off-patch rule, a selector other than
+`P` or `cov3>0`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** `P` already equals positivity at `k=2`, so the same
+selector must be the `k=3` selector, positivity must imply `P`, and
+that match must be written into Admissibility.
+
+**Answer:** `P` fails at `k=3`: fourteen maps satisfy `P` and twenty
+maps have `cov3>0`, but only thirteen satisfy both. The lex-first miss
+`(0, 0, 1, 1, 0)` has `cov3 = 24` and `P` false, so positivity does
+not imply `P`. The Q10-imply witness `(1, 1, 0, 0, 0)` has `cov3 = 4`
+and `P` false as well. Displayed `P` is not adopted.
+
+### N8 — cross-cycle echo
+
+The 1–5-bit remaining-bit menu already showed that no pure AND or OR of
+those widths equals `cov3>0`. Investment c3q10 already showed that
+`cov3>0` does not imply `Q10`. Naming `P` as `cov2>0` already closed
+the two-site identity. Echoing any of those facts is not a substitute
+for the three-site `P` count: the lex-first miss and the triple
+`(N_pos, N_P, N_both) = (20, 14, 13)` are three-site facts.
+
+No-Go Discipline disposition: **PASS** for the finite comparison and the
+narrow nonequivalence report. FAIL / DO NOT SHIP for “displayed `P`
+is the physical rule” or “adopt P.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov3` on the
+220 three-site seeds, compares positivity with displayed `P`, reports that
+the two are not equivalent, reports that positivity does not imply `P`,
+reports one lex-first miss `(0, 0, 1, 1, 0)` with `cov3 = 24`, and reports
+`N_pos = 20`, `N_P = 14`, and `N_both = 13`. Declared audit inputs are
+this note and the axiom memo; the runner writes no cache and authors no
+audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov3_p_selector_test_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov3_p_selector_test_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov3_p_selector_test_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov3_p_selector_test_2026_08_15.py
+runner_sha256: 90dc9795856a605299e05a2393f0e1e9138633f2d39b83c9282e1e5bd5e90ef1
+input_fingerprint_sha256: 54451d2bf1eda8e020e9140ba53f778f4cf54fdfaf84bcf5b5c0ece406fff318
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed P versus cov3>0; does not adopt P
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_three_site_seeds=220
+N_pos=20
+N_P=14
+N_both=13
+N_mismatch=8
+cov3(f_L1)=220
+lex_first_miss=(0, 0, 1, 1, 0)
+lex_first_cov3=24
+lex_first_P=0
+equiv=0
+pos_implies_P=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 220 three-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-not-equivalent cov3>0 is not equivalent to P among the 32 F_cut maps
+PASS: thm1-lex-first-miss one lex-first remaining-bit miss is (0, 0, 1, 1, 0)
+PASS: thm1-pos-not-imply-p positivity does not imply P; witness is (0, 0, 1, 1, 0)
+PASS: thm2-counts N_pos=20, N_P=14, N_both=13
+PASS: thm2-split one P-true map has cov3=0 and seven P-false maps have cov3>0
+PASS: thm3-display-not-adopt P is displayed and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the 3-site positivity-versus-P comparison and does not adopt P
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-bit-menu-or-q10 P is not leftover of the 1-5-bit AND/OR menu; test is at the Q10-imply k
+PASS: p-definition-and-l1-in-class P is wt1 and (adj2,vertex3,mixed3)!=(0,0,0) and f_L1 satisfies P
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 220 three-site seeds against displayed P
+per_block: checked exactly — N_pos, N_P, and N_both are the F_cut positivity-versus-P counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov3_p_selector_test_2026_08_15.py
+++ b/scripts/f_cut_cov3_p_selector_test_2026_08_15.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Whether cov3>0 equals P on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov3(f) is the number of three-site seeds from which f
+fills. P is the displayed remaining-bit predicate (wt1=1) and
+(adj2,vertex3,mixed3)!=(0,0,0), already named as cov2>0. The runner reports
+whether positivity equals P, whether positivity implies P, one lex-first
+miss if not, and the counts N_pos, N_P, N_both. It does not adopt P. f_L1
+is the unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1
+mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_MISS: Remaining = (0, 0, 1, 1, 0)
+MISS_COV3 = 24
+N_POS = 20
+N_P = 14
+N_BOTH = 13
+P_TRUE_ZEROS: tuple[Remaining, ...] = (
+    (1, 0, 0, 0, 1),
+)
+P_FALSE_POS: tuple[Remaining, ...] = (
+    (0, 0, 1, 1, 0),
+    (0, 0, 1, 1, 1),
+    (0, 1, 1, 0, 0),
+    (0, 1, 1, 0, 1),
+    (0, 1, 1, 1, 0),
+    (0, 1, 1, 1, 1),
+    (1, 1, 0, 0, 0),
+)
+POS_WITNESS: Remaining = (0, 0, 1, 1, 0)
+POS_WITNESS_COV3 = 24
+Q10_IMPLY_FAIL: Remaining = (1, 1, 0, 0, 0)
+Q10_IMPLY_FAIL_COV3 = 4
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_P(remaining: Remaining) -> bool:
+    return remaining[0] == 1 and (remaining[2], remaining[3], remaining[4]) != (0, 0, 0)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print("negative_scope: displayed P versus cov3>0; does not adopt P")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(3)
+    rows: list[tuple[Remaining, int, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_P(remaining)))
+
+    n_p = sum(1 for _remaining, _cov, flag in rows if flag)
+    n_pos = sum(1 for _remaining, cov, _flag in rows if cov > 0)
+    n_both = sum(1 for _remaining, cov, flag in rows if cov > 0 and flag)
+    mismatches = [
+        (remaining, cov, flag)
+        for remaining, cov, flag in rows
+        if flag != (cov > 0)
+    ]
+    p_true_zeros = frozenset(
+        remaining for remaining, cov, flag in mismatches if flag and cov == 0
+    )
+    p_false_pos = frozenset(
+        remaining for remaining, cov, flag in mismatches if (not flag) and cov > 0
+    )
+    lex_first = min(mismatches, key=lambda row: row[0]) if mismatches else None
+    cov_by_remaining = {remaining: cov for remaining, cov, _flag in rows}
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+    pos_implies_p = all((not (cov > 0)) or flag for _remaining, cov, flag in rows)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_three_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_P={n_p}")
+    print(f"N_both={n_both}")
+    print(f"N_mismatch={len(mismatches)}")
+    print(f"cov3(f_L1)={cov_l1}")
+    print(f"lex_first_miss={None if lex_first is None else lex_first[0]}")
+    print(f"lex_first_cov3={None if lex_first is None else lex_first[1]}")
+    print(f"lex_first_P={None if lex_first is None else int(lex_first[2])}")
+    print(f"equiv={int(len(mismatches) == 0)}")
+    print(f"pos_implies_P={int(pos_implies_p)}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV3_P_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 220 three-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 220
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and selector_P(L1_REMAINING)
+        and cov_l1 == 220,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "cov3>0 is not equivalent to P among the 32 F_cut maps",
+        len(mismatches) > 0
+        and n_both != n_pos
+        and n_both != n_p
+        and all(selector_P(remaining) == (cov > 0) for remaining, cov, _flag in rows) is False
+        and "is not equivalent to `P`" in note_flat,
+    )
+    checks.check(
+        "thm1-lex-first-miss",
+        "one lex-first remaining-bit miss is (0, 0, 1, 1, 0)",
+        lex_first is not None
+        and lex_first[0] == LEX_FIRST_MISS
+        and lex_first[1] == MISS_COV3
+        and lex_first[2] is False
+        and cov_by_remaining[LEX_FIRST_MISS] == 24
+        and selector_P(LEX_FIRST_MISS) is False
+        and "(0, 0, 1, 1, 0)" in note
+        and "cov3 = 24" in note
+        and "lex-first" in note,
+    )
+    checks.check(
+        "thm1-pos-not-imply-p",
+        "positivity does not imply P; witness is (0, 0, 1, 1, 0)",
+        pos_implies_p is False
+        and p_false_pos == frozenset(P_FALSE_POS)
+        and cov_by_remaining[POS_WITNESS] == POS_WITNESS_COV3
+        and selector_P(POS_WITNESS) is False
+        and cov_by_remaining[Q10_IMPLY_FAIL] == Q10_IMPLY_FAIL_COV3
+        and selector_P(Q10_IMPLY_FAIL) is False
+        and "Positivity does not imply" in note
+        and "`(0, 0, 1, 1, 0)`" in note
+        and "`(1, 1, 0, 0, 0)`" in note
+        and "cov3 = 4" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_pos={n_pos}, N_P={n_p}, N_both={n_both}",
+        n_pos == N_POS
+        and n_p == N_P
+        and n_both == N_BOTH
+        and n_pos == 20
+        and n_p == 14
+        and n_both == 13
+        and f"N_pos = {n_pos}" in note
+        and f"N_P = {n_p}" in note
+        and f"N_both = {n_both}" in note,
+    )
+    checks.check(
+        "thm2-split",
+        "one P-true map has cov3=0 and seven P-false maps have cov3>0",
+        p_true_zeros == frozenset(P_TRUE_ZEROS)
+        and p_false_pos == frozenset(P_FALSE_POS)
+        and len(mismatches) == 8
+        and all(selector_P(remaining) and cov_by_remaining[remaining] == 0 for remaining in P_TRUE_ZEROS)
+        and all((not selector_P(remaining)) and cov_by_remaining[remaining] > 0 for remaining in P_FALSE_POS)
+        and "`(1, 0, 0, 0, 1)`" in note
+        and "`(0, 0, 1, 1, 0)`" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "P is displayed and is not adopted as an Admissibility selector",
+        (
+            "P(f) := (wt1=1) and (adj2,vertex3,mixed3)≠(0,0,0)" in note
+            or "P(f) := (wt1 = 1) and (adj2, vertex3, mixed3) ≠ (0, 0, 0)" in note
+        )
+        and "Displayed, not adopted" in note
+        and "Do not adopt P" in note
+        and "Do not write `P` into Admissibility" in note
+        and "does not adopt P" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "cov3>0 equals P, and whether positivity implies P, is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the 3-site positivity-versus-P comparison and does not adopt P",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `P` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-bit-menu-or-q10",
+        "P is not leftover of the 1-5-bit AND/OR menu; test is at the Q10-imply k",
+        "Not leftover-character of the 1–5-bit remaining-bit menu" in note
+        and "not a pure AND/OR" in note
+        and "already named as cov2>0" in note
+        and "cov3>0 does not imply Q10" in note
+        and "Q10-imply" in note
+        and "does not adopt P" in self_source,
+    )
+    checks.check(
+        "p-definition-and-l1-in-class",
+        "P is wt1 and (adj2,vertex3,mixed3)!=(0,0,0) and f_L1 satisfies P",
+        selector_P((1, 0, 1, 1, 1))
+        and selector_P((1, 0, 0, 0, 1))
+        and selector_P((1, 0, 0, 1, 0))
+        and not selector_P((1, 1, 0, 0, 0))
+        and not selector_P((0, 0, 1, 1, 0))
+        and not selector_P((0, 0, 0, 0, 0))
+        and not selector_P((1, 0, 0, 0, 0))
+        and cov_l1 == cov_by_remaining[(1, 0, 1, 1, 1)],
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 220 three-site seeds against displayed P")
+    print("per_block: checked exactly — N_pos, N_P, and N_both are the F_cut positivity-versus-P counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov3>0 is not equivalent to P. N_pos=20, N_P=14, N_both=13. Positivity does not imply P. Lex-first miss (0,0,1,1,0). Displayed, not adopted.

## Runner

`scripts/f_cut_cov3_p_selector_test_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.