### PR TITLE
feat(q4f7): among Q4-false, cov7>0 iff vertex3

### DIFF
--- a/docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,353 @@
+---
+claim_id: f_cut_q4_false_cov7_vertex3_selector_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 8 F_cut maps with wt1=0 and adj2=0 on the two-cube with off-patch o=0, whether cov7>0 equals vertex3=1 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py
+---
+
+# Whether `cov7>0` Equals Displayed `vertex3=1` Among the Eight Q4-False Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 7-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+eight cube-covariant cut maps in `F_cut` with `wt1=0` and `adj2=0`,
+against displayed `Q := (vertex3=1)`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py`](../scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c7q4 scored all 32 `F_cut` maps and found `N_pos = N_Q4 = 24`
+but `N_both = 20`. Equivalence of `cov7>0` with
+`Q4 := (wt1=1) or (adj2=1)` therefore fails, and positivity does not
+imply `Q4`. The four Q4-false positives are exactly the remaining-bit
+pattern `(0, *, 0, 1, *)`. That is the imply-fail residual. This note
+names the imply-fail residual and tests the new one-bit predicate on
+those eight Q4-false maps. Not leftover-character of the 32-map c7q4
+count, and not leftover-character of the k=4 identity `Q4=cov4>0`.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`. The eight maps
+with `wt1=0` and `adj2=0` are exactly the Q4-false members.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`, which is Q4-true and is not one
+of the eight maps scored here.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov7(f) = |{S : |S|=7 and f fills from S}|`. Then, among the eight
+maps with `wt1=0` and `adj2=0`:
+
+- Theorem 1. `cov7>0` equals `Q`, where `Q := (vertex3=1)`. There is no
+  remaining-bit miss.
+- Theorem 2. `N_pos = 4`, `N_Q = 4`, `N_both = 4`.
+- Theorem 3. `Q` is displayed. Do not adopt a bit.
+
+Do not write `vertex3` into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The eight Q4-false F_cut maps are enumerated by remaining bits and scored exactly on the 792 seven-site seeds of the two-cube. Whether cov7>0 equals displayed vertex3=1 is a finite exact fact. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q4_false_cov7_vertex3_selector
+target_blocker_text: "whether cov7>0 equals vertex3=1 among the 8 F_cut maps with wt1=0 and adj2=0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 7-site positivity-versus-vertex3 comparison on the eight Q4-false maps; do not adopt displayed Q"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. `Q` is a displayed remaining-bit formula, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+The eight Q4-false maps are the remaining-bit tuples with `wt1=0` and
+`adj2=0`. Opp2, vertex3, and mixed3 remain free. They are
+
+```text
+(0, 0, 0, 0, 0), (0, 0, 0, 0, 1), (0, 0, 0, 1, 0), (0, 0, 0, 1, 1),
+(0, 1, 0, 0, 0), (0, 1, 0, 0, 1), (0, 1, 0, 1, 0), (0, 1, 0, 1, 1).
+```
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The seven-site seeds are the `C(12,7) = 792` subsets of size 7 in `T`. Then
+`cov7(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov7(f)>0`. Duality is not assumed: `cov7` is scored on
+those 792 seeds.
+
+The displayed remaining-bit predicate on this eight-map slice is
+
+```text
+Q(f) := (vertex3 = 1).
+```
+
+Opp2 and mixed3 remain free in `Q`. Displayed, not adopted. Do not adopt a
+bit.
+
+## Theorem 1 — `cov7>0` equals `Q` among the eight Q4-false maps
+
+Enumerate the eight remaining-bit tuples with `wt1=0` and `adj2=0` and
+score `cov7` on the 792 seven-site seeds. Then `cov7(f) > 0` if and only
+if `Q(f)`. There is no remaining-bit miss.
+
+The four maps with `cov7 = 0` are exactly the four with `vertex3 = 0`:
+
+| remaining bits | `cov7` | `Q` |
+|---|---:|---:|
+| `(0, 0, 0, 0, 0)` | 0 | 0 |
+| `(0, 0, 0, 0, 1)` | 0 | 0 |
+| `(0, 1, 0, 0, 0)` | 0 | 0 |
+| `(0, 1, 0, 0, 1)` | 0 | 0 |
+
+The four maps with `cov7 > 0` are exactly the four with `vertex3 = 1`,
+which is the pattern `(0, *, 0, 1, *)`:
+
+| remaining bits | `cov7` | `Q` |
+|---|---:|---:|
+| `(0, 0, 0, 1, 0)` | 16 | 1 |
+| `(0, 0, 0, 1, 1)` | 80 | 1 |
+| `(0, 1, 0, 1, 0)` | 40 | 1 |
+| `(0, 1, 0, 1, 1)` | 108 | 1 |
+
+Those four positives are the imply-fail residual of the 32-map test: they
+are Q4-false and 7-site positive. On this slice they are exactly `Q`. The
+lex-first positive is `(0, 0, 0, 1, 0)` with `cov7 = 16`.
+
+`f_L1` is not among the eight maps. Its remaining bits `(1, 0, 1, 1, 1)`
+are Q4-true. That is consistent with restricting the test to Q4-false
+maps and does not restore a 32-map selector.
+
+## Theorem 2 — `N_pos`, `N_Q`, `N_both`
+
+Among the eight Q4-false maps:
+
+- `N_pos = 4` maps have `cov7 > 0`;
+- `N_Q = 4` maps satisfy `Q`;
+- `N_both = 4` maps satisfy both.
+
+The counts match the iff of Theorem 1: `N_pos = N_Q = N_both = 4`. There
+is no lex-first miss. The parent 32-map triple remains
+`(N_pos, N_Q4, N_both) = (24, 24, 20)` and is not this eight-map triple.
+
+## Theorem 3 — display; do not adopt a bit
+
+`Q` is the remaining-bit predicate `vertex3=1` on the eight Q4-false
+maps. On this patch it equals 7-site positivity. Displayed, not adopted.
+Do not adopt a bit. Do not write `vertex3` into Admissibility.
+Admissibility does not name this remaining-bit formula.
+
+The identities here are finite facts about occupancy-to-lock on this
+two-cube with off-patch `o=0`. They are not a physical formation-site
+selector and not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| eight Q4-false `F_cut` maps (`wt1=0` and `adj2=0`) | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 792 seven-site seeds, off-patch `o=0` | declared finite patch |
+| `Q` as `(vertex3=1)` | displayed, not adopted |
+| `cov7>0` iff `Q` among those eight | holds; no remaining-bit miss |
+| `N_pos = 4`, `N_Q = 4`, `N_both = 4` | proved by exhaustive scoring |
+| names the imply-fail residual | the four Q4-false positives `(0, *, 0, 1, *)` |
+| leftover-character of the 32-map c7q4 count | refused; new one-bit test on the eight |
+| leftover-character of the k=4 Q4 naming | refused; new seed size and new slice |
+| adoption of a remaining bit | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of the 32-map c7q4 count: that already showed
+`N_pos = N_Q4 = 24` and `N_both = 20`, and it named the four Q4-false
+positives `(0, *, 0, 1, *)`. Echoing that split is not a substitute for
+testing whether `cov7>0` equals `vertex3=1` among the eight Q4-false
+maps. This note names the imply-fail residual.
+
+Not leftover-character of the k=4 Q4 naming: that closed `Q4=cov4>0` on
+all 32 maps at a different seed size. Restricting to Q4-false maps and
+scoring seven-site positivity against `vertex3` is a different object.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write `vertex3` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether 7-site positivity equals displayed `vertex3=1` among the eight Q4-false maps on this patch. |
+| V2 | Current main has the axiom memo and the 32-map c7q4 split, but no landed eight-map 7-site positivity-versus-`vertex3` test. |
+| V3 | The eight maps, 792 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared eight-map slice against a newly displayed one-bit predicate. |
+| V5 | Equivalence holds, the counts are `(4, 4, 4)`, no miss is reported, and displayed `Q` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: among the eight Q4-false `F_cut` maps on
+this patch, `cov7>0` equals displayed `vertex3=1`. Displayed `Q` is not
+axiom content. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of the 32-map c7q4 count | treat the eight-map iff as leftover-character of `(24, 24, 20)` | **ATTEMPTED** |
+| leftover of the k=4 Q4 naming | treat seven-site positivity on this slice as leftover-character of `Q4=cov4>0` | **ATTEMPTED** |
+| adopt `vertex3` | write `vertex3=1` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+| duality shortcut | replace the 792 seven-site seeds by five-site seeds | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the 32-map c7q4 split, the four-site OR, the
+off-patch convention, and the duality shortcut are distinct. This note
+claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 792 seven-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, the eight-map
+slice `wt1=0` and `adj2=0`, and displayed `Q` are declared. Equivalence
+of `cov7>0` with `vertex3=1` on that slice is scored, not imported.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+7-site positivity equals displayed `vertex3=1` among the eight Q4-false
+maps on the declared patch. The note names the imply-fail residual of
+the 32-map test and is not leftover-character of that count.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the eight Q4-false maps scored on 792 seeds | no physical law selection |
+| per block | `N_pos`, `N_Q`, and `N_both` on this slice | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different Boolean combination of remaining bits, a
+different seed family, a different off-patch rule, a selector other than
+`Q` or `cov7>0`, the complementary 24 Q4-true maps, and any independently
+derived physical map from `F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** the four Q4-false positives are already named by the
+pattern `(0, *, 0, 1, *)`, so `vertex3=1` is only a rename of that
+pattern, the eight-map iff is leftover-character of the 32-map imply
+fail, and the bit must be written into Admissibility.
+
+**Answer:** naming the four positives does not score the four zeros, and
+it does not prove that every `vertex3=1` Q4-false map is 7-site positive.
+The eight-map census is the missing comparison: `N_pos = N_Q = N_both = 4`
+and there is no miss. Displayed `Q` is not adopted.
+
+### N8 — cross-cycle echo
+
+The 32-map c7q4 count already showed that `cov7>0` is not `Q4` and that
+positivity does not imply `Q4`. The k=4 naming already showed
+`Q4=cov4>0`. Echoing either fact is not a substitute for the eight-map
+`vertex3` count: the four zeros, the four positives, and the triple
+`(N_pos, N_Q, N_both) = (4, 4, 4)` are seven-site facts on this slice.
+
+No-Go Discipline disposition: **PASS** for the finite comparison and the
+narrow equivalence report. FAIL / DO NOT SHIP for “displayed `Q` is the
+physical rule” or “adopt a bit.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, restricts to the
+eight with `wt1=0` and `adj2=0`, scores `cov7` on the 792 seven-site
+seeds, compares positivity with displayed `Q := (vertex3=1)`, reports
+that the two are equivalent on that slice, reports no remaining-bit
+miss, and reports `N_pos = 4`, `N_Q = 4`, and `N_both = 4`. Declared
+audit inputs are this note and the axiom memo; the runner writes no
+cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q4_false_cov7_vertex3_selector_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py
+runner_sha256: c4a80e8c8d9570c9a7645d781d8397be88eabcfa77f231266587824f58ea6113
+input_fingerprint_sha256: 00ad4b33a48fef5e045cfe752ef8d2458a5da9455ac61f88311e2ee9f9b14cc6
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed Q versus cov7>0 on the eight Q4-false maps; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_q4_false=8
+n_7_site_seeds=792
+N_pos=4
+N_Q=4
+N_both=4
+N_mismatch=0
+lex_first_miss=None
+equiv=1
+slice_cov7=[((0, 0, 0, 0, 0), 0), ((0, 0, 0, 0, 1), 0), ((0, 0, 0, 1, 0), 16), ((0, 0, 0, 1, 1), 80), ((0, 1, 0, 0, 0), 0), ((0, 1, 0, 0, 1), 0), ((0, 1, 0, 1, 0), 40), ((0, 1, 0, 1, 1), 108)]
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, eight Q4-false maps, 792 7-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-eight-q4-false the eight maps with wt1=0 and adj2=0 are exactly the Q4-false class
+PASS: thm1-iff-vertex3 cov7>0 equals vertex3=1 among the eight Q4-false maps; no miss
+PASS: thm2-counts N_pos=4, N_Q=4, N_both=4
+PASS: thm2-four-positives the four positives are exactly (0, *, 0, 1, *) and match the scored cov7 values
+PASS: thm3-display-not-adopt Q is displayed vertex3=1 and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the eight-map positivity-versus-vertex3 comparison and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: names-imply-fail-residual the note names the imply-fail residual and refuses leftover-character of c7q4 and of Q4=cov4>0
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — the eight Q4-false F_cut maps are scored on 792 7-site seeds against displayed Q
+per_block: checked exactly — N_pos, N_Q, and N_both are the eight-map positivity-versus-vertex3 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py
+++ b/scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Whether cov7>0 equals vertex3 among the eight Q4-false F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov7(f) is the number of 7-site seeds from which f
+fills. The eight Q4-false maps are those with wt1=0 and adj2=0. Q is the
+displayed remaining-bit predicate vertex3=1. The runner reports whether
+positivity equals Q on that slice, the counts N_pos, N_Q, N_both, and one
+lex-first miss if not equivalent. It does not adopt a bit. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+N_POS = 4
+N_Q = 4
+N_BOTH = 4
+Q4_FALSE: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 0, 0, 0, 1),
+    (0, 0, 0, 1, 0),
+    (0, 0, 0, 1, 1),
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+    (0, 1, 0, 1, 0),
+    (0, 1, 0, 1, 1),
+)
+POSITIVES: tuple[Remaining, ...] = (
+    (0, 0, 0, 1, 0),
+    (0, 0, 0, 1, 1),
+    (0, 1, 0, 1, 0),
+    (0, 1, 0, 1, 1),
+)
+ZEROS: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 0, 0, 0, 1),
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+)
+COV7_ON_SLICE: dict[Remaining, int] = {
+    (0, 0, 0, 0, 0): 0,
+    (0, 0, 0, 0, 1): 0,
+    (0, 0, 0, 1, 0): 16,
+    (0, 0, 0, 1, 1): 80,
+    (0, 1, 0, 0, 0): 0,
+    (0, 1, 0, 0, 1): 0,
+    (0, 1, 0, 1, 0): 40,
+    (0, 1, 0, 1, 1): 108,
+}
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_Q4(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[2] == 1
+
+
+def selector_Q(remaining: Remaining) -> bool:
+    return remaining[3] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print("negative_scope: displayed Q versus cov7>0 on the eight Q4-false maps; does not adopt a bit")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(7)
+    all_rows: list[tuple[Remaining, int, bool, bool]] = []
+    for bits, remaining in members:
+        q4 = selector_Q4(remaining)
+        if q4:
+            all_rows.append((remaining, -1, q4, selector_Q(remaining)))
+            continue
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        all_rows.append((remaining, cov, q4, selector_Q(remaining)))
+
+    slice_rows = [
+        (remaining, cov, q_flag)
+        for remaining, cov, q4, q_flag in all_rows
+        if not q4
+    ]
+    n_q4_false = sum(1 for _remaining, _cov, q4, _q in all_rows if not q4)
+    n_q4 = sum(1 for _remaining, _cov, q4, _q in all_rows if q4)
+    n_pos = sum(1 for _remaining, cov, _q in slice_rows if cov > 0)
+    n_q = sum(1 for _remaining, _cov, q_flag in slice_rows if q_flag)
+    n_both = sum(1 for _remaining, cov, q_flag in slice_rows if cov > 0 and q_flag)
+    mismatches = [
+        (remaining, cov, q_flag)
+        for remaining, cov, q_flag in slice_rows
+        if q_flag != (cov > 0)
+    ]
+    positives = frozenset(remaining for remaining, cov, _q in slice_rows if cov > 0)
+    zeros = frozenset(remaining for remaining, cov, _q in slice_rows if cov == 0)
+    lex_first = min(mismatches, key=lambda row: row[0]) if mismatches else None
+    cov_by_remaining = {remaining: cov for remaining, cov, _q in slice_rows}
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_q4_false={n_q4_false}")
+    print(f"n_7_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_Q={n_q}")
+    print(f"N_both={n_both}")
+    print(f"N_mismatch={len(mismatches)}")
+    print(f"lex_first_miss={None if lex_first is None else lex_first[0]}")
+    print(f"equiv={int(len(mismatches) == 0)}")
+    print(f"slice_cov7={sorted((remaining, cov) for remaining, cov, _q in slice_rows)}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_Q4_FALSE_COV7_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, eight Q4-false maps, 792 7-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and n_q4_false == 8
+        and n_q4 == 24
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 792
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and selector_Q4(L1_REMAINING)
+        and not (L1_REMAINING[0] == 0 and L1_REMAINING[2] == 0),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-eight-q4-false",
+        "the eight maps with wt1=0 and adj2=0 are exactly the Q4-false class",
+        frozenset(remaining for remaining, _cov, _q in slice_rows) == frozenset(Q4_FALSE)
+        and all((not selector_Q4(remaining)) for remaining in Q4_FALSE)
+        and all(selector_Q4(remaining) or remaining in Q4_FALSE for remaining, _cov, _q4, _q in all_rows)
+        and "wt1=0 and adj2=0" in note,
+    )
+    checks.check(
+        "thm1-iff-vertex3",
+        "cov7>0 equals vertex3=1 among the eight Q4-false maps; no miss",
+        len(mismatches) == 0
+        and all(selector_Q(remaining) == (cov > 0) for remaining, cov, _q in slice_rows)
+        and lex_first is None
+        and "equals `Q`" in note_flat
+        and "no remaining-bit miss" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_pos={n_pos}, N_Q={n_q}, N_both={n_both}",
+        n_pos == N_POS
+        and n_q == N_Q
+        and n_both == N_BOTH
+        and n_pos == 4
+        and n_q == 4
+        and n_both == 4
+        and f"N_pos = {n_pos}" in note
+        and f"N_Q = {n_q}" in note
+        and f"N_both = {n_both}" in note,
+    )
+    checks.check(
+        "thm2-four-positives",
+        "the four positives are exactly (0, *, 0, 1, *) and match the scored cov7 values",
+        positives == frozenset(POSITIVES)
+        and zeros == frozenset(ZEROS)
+        and all(selector_Q(remaining) for remaining in POSITIVES)
+        and all(not selector_Q(remaining) for remaining in ZEROS)
+        and all(cov_by_remaining[remaining] == COV7_ON_SLICE[remaining] for remaining in Q4_FALSE)
+        and "(0, *, 0, 1, *)" in note
+        and "cov7 = 16" in note
+        and "(0, 0, 0, 1, 0)" in note,
+    )
+
+    checks.check(
+        "thm3-display-not-adopt",
+        "Q is displayed vertex3=1 and is not adopted as an Admissibility selector",
+        (
+            "Q(f) := (vertex3 = 1)" in note
+            or "Q := (vertex3=1)" in note
+        )
+        and "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not write `vertex3` into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 8 F_cut maps with wt1=0 and adj2=0 on the two-cube with "
+        "off-patch o=0, whether cov7>0 equals vertex3=1 is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the eight-map positivity-versus-vertex3 comparison and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `vertex3` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "names-imply-fail-residual",
+        "the note names the imply-fail residual and refuses leftover-character of c7q4 and of Q4=cov4>0",
+        "names the imply-fail residual" in note
+        and "Not leftover-character of the 32-map c7q4 count" in note
+        and "Not leftover-character of the k=4 Q4 naming" in note
+        and "Q4=cov4>0" in note
+        and "N_pos = N_Q4 = 24" in note
+        and "N_both = 20" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — the eight Q4-false F_cut maps are scored on 792 7-site seeds against displayed Q")
+    print("per_block: checked exactly — N_pos, N_Q, and N_both are the eight-map positivity-versus-vertex3 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 8 F_cut maps with wt1=0 and adj2=0 on the two-cube with off-patch o=0, cov7>0 iff vertex3. N_pos=N_Q=N_both=4. No miss. Displayed, not adopted.

## Runner

`scripts/f_cut_q4_false_cov7_vertex3_selector_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.