### PR TITLE
feat(q4f11): among Q4-false, cov11>0 iff vertex3

### DIFF
--- a/docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,336 @@
+---
+claim_id: f_cut_q4_false_cov11_vertex3_selector_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 8 F_cut maps with wt1=0 and adj2=0 on the two-cube with off-patch o=0, whether cov11>0 equals vertex3=1 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py
+---
+
+# Whether `cov11>0` Equals Displayed `vertex3` Among The Eight `Q4`-False Maps
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 11-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+eight cube-covariant cut maps in `F_cut` with `wt1=0` and `adj2=0`,
+against displayed `Q := (vertex3=1)`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py`](../scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c11q4 scored all 32 `F_cut` maps at seed size 11 against
+displayed `Q4 := (wt1=1) or (adj2=1)` and reported the same
+`24/24/20` split as c7q4: `N_pos = 24`, `N_Q4 = 24`, `N_both = 20`.
+The four `Q4`-false positives were exactly `(0,*,0,1,*)`. That residue
+is the eight-map class with `wt1=0` and `adj2=0`. This note is a new
+`k` question on that residual: whether, among those eight maps,
+`cov11>0` equals displayed `vertex3`. New k for that residual. Not
+leftover-character of the 32-map `Q4` count, and not leftover-character
+of the c7q4 split.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`, so `f_L1` is not one of the
+eight `Q4`-false maps.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov11(f) = |{S : |S|=11 and f fills from S}|`. Among the eight maps
+with `wt1=0` and `adj2=0`, write
+
+```text
+Q(f) := (vertex3 = 1).
+```
+
+Then:
+
+- Theorem 1. `cov11>0` is equivalent to `Q` among those eight maps.
+- Theorem 2. `N_pos = 4`, `N_Q = 4`, `N_both = 4`. There is no miss.
+- Theorem 3. `Q` is displayed. Do not adopt a bit.
+
+Do not write `vertex3` into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The eight Q4-false F_cut maps are enumerated by remaining bits and scored exactly on the 12 eleven-site seeds of the two-cube. Whether cov11>0 equals displayed vertex3=1 is a finite exact fact. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_q4_false_cov11_vertex3_selector
+target_blocker_text: "whether cov11>0 equals vertex3=1 among the eight F_cut maps with wt1=0 and adj2=0"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 11-site positivity-versus-vertex3 comparison on the Q4-false class; do not adopt displayed vertex3"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. Displayed `Q` is a remaining-bit formula, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The eleven-site seeds are the `C(12,11) = 12` subsets of size 11 in `T`.
+Then `cov11(f)` is the number of those subsets from which `f` fills. The
+boolean scored here is `cov11(f)>0`. Duality is not assumed: `cov11` is
+scored on those 12 seeds.
+
+The eight-map class is the subset of `F_cut` with remaining bits
+
+```text
+(wt1, opp2, adj2, vertex3, mixed3) = (0, *, 0, *, *).
+```
+
+That is exactly `wt1=0` and `adj2=0`. Opp2, vertex3, and mixed3 remain
+free, so the class has size 8. Displayed `Q4` is used only to name this
+class. The displayed predicate on the class is
+
+```text
+Q(f) := (vertex3=1).
+```
+
+Opp2 and mixed3 are free in `Q`. Displayed, not adopted.
+
+## Theorem 1 — `cov11>0` equals `Q` among the eight maps
+
+Enumerate the eight remaining-bit tuples with `wt1=0` and `adj2=0` and
+score `cov11` on the 12 eleven-site seeds. Then `cov11(f) > 0` if and
+only if `Q(f)` holds.
+
+The four maps with `vertex3 = 1` each have `cov11 = 8`:
+`(0, 0, 0, 1, 0)`, `(0, 0, 0, 1, 1)`, `(0, 1, 0, 1, 0)`, and
+`(0, 1, 0, 1, 1)`. The four maps with `vertex3 = 0` each have
+`cov11 = 0`: `(0, 0, 0, 0, 0)`, `(0, 0, 0, 0, 1)`, `(0, 1, 0, 0, 0)`,
+and `(0, 1, 0, 0, 1)`. There is no mismatch.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, is outside the eight-map
+class. Its 11-site coverage is not used as a selector on this class.
+
+## Theorem 2 — `N_pos`, `N_Q`, `N_both`
+
+Among the eight maps:
+
+- `N_pos = 4` maps have `cov11 > 0`;
+- `N_Q = 4` maps satisfy `Q`;
+- `N_both = 4` maps satisfy both.
+
+The counts match: `N_pos = N_Q = N_both = 4`. There is no lex-first miss.
+If the iff had failed, the runner would report one lex-first remaining-bit
+miss in the order `(wt1, opp2, adj2, vertex3, mixed3)`.
+
+## Theorem 3 — display; do not adopt a bit
+
+`Q` is the displayed remaining-bit predicate `vertex3=1` on the eight
+`Q4`-false maps. On this patch it equals 11-site positivity inside that
+class. Displayed, not adopted. Do not adopt a bit. Do not adopt vertex3.
+Do not write `vertex3` into Admissibility. Admissibility does not name
+this remaining-bit formula.
+
+The identities here are finite facts about occupancy-to-lock on this
+two-cube with off-patch `o=0`. They are not a physical formation-site
+selector and not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| eight-map class `wt1=0` and `adj2=0` | enumerated |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 12 eleven-site seeds, off-patch `o=0` | declared finite patch |
+| `Q` as `(vertex3=1)` | displayed, not adopted |
+| `cov11>0` iff `Q` among the eight | holds; `N_pos = N_Q = N_both = 4` |
+| leftover-character of the 32-map `Q4` count | refused; new residual on the eight |
+| leftover-character of the c7q4 split | refused; new class and displayed bit |
+| adoption of `vertex3` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of the 32-map `Q4` count: that already showed
+`cov11>0` is not `Q4` among the 32 maps, with the same `24/24/20` split
+as c7q4 and the same four `Q4`-false positives `(0,*,0,1,*)`. The present
+object is whether displayed `vertex3` equals 11-site positivity on that
+eight-map class. New k for that residual.
+
+Not leftover-character of the c7q4 split: that was a seven-site
+`Q4` comparison on all 32 maps. Echoing that split is not a substitute
+for the eight-map `vertex3` comparison at seed size 11.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write `vertex3` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether 11-site positivity equals displayed `vertex3` among the eight `Q4`-false maps on this patch. |
+| V2 | Current main has the axiom memo but no landed eight-map `cov11`-versus-`vertex3` test. |
+| V3 | The eight maps, 12 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared eight-map class against a newly displayed 1-bit predicate. |
+| V5 | Equivalence holds, the triple `(N_pos, N_Q, N_both) = (4, 4, 4)` is reported, and displayed `vertex3` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: displayed `vertex3` is not axiom content
+and is not adopted, even though it equals `cov11>0` on this eight-map
+class. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of the 32-map `Q4` count | treat the eight-map test as leftover-character of c11q4 | **ATTEMPTED** |
+| leftover of the c7q4 split | treat the eleven-site eight-map test as leftover-character of c7q4 | **ATTEMPTED** |
+| leftover of a 32-map 2-bit OR | replace the eight-map `vertex3` test by a 32-map OR | **ATTEMPTED** |
+| adopt `vertex3` | write `(vertex3=1)` into Admissibility | **ATTEMPTED** |
+| blank-block off-patch | replace occupancy `0` by a blank-block | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the 32-map `Q4` count, the c7q4 split, a 32-map
+OR, and the off-patch convention are distinct. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 12 eleven-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the eight-map class `wt1=0` and `adj2=0`, and
+displayed `Q` are declared. Equivalence of `cov11>0` with `Q` is scored,
+not imported.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+11-site positivity equals displayed `vertex3` among the eight `Q4`-false
+maps on the declared patch, as a new k for that residual, and not
+leftover-character of the 32-map `Q4` count.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | the eight `Q4`-false maps scored on 12 seeds | no physical law selection |
+| per block | `N_pos`, `N_Q`, and `N_both` on this class | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different remaining-bit predicate on the eight,
+a different seed family, a different off-patch rule, a selector other
+than `Q` or `cov11>0`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** the four `Q4`-false positives of c11q4 are already
+`(0,*,0,1,*)`, so `vertex3` is the physical selector on the residue and
+must be written into Admissibility.
+
+**Answer:** among the eight maps, `cov11>0` equals displayed `Q`, with
+`N_pos = N_Q = N_both = 4`. That is a finite displayed fact on this
+patch. Displayed `vertex3` is not adopted.
+
+### N8 — cross-cycle echo
+
+The 32-map `Q4` count already showed the `24/24/20` split and the four
+`Q4`-false positives `(0,*,0,1,*)`. The c7q4 split already showed the
+same counts at seed size 7. Echoing either fact is not a substitute for
+the eight-map `vertex3` comparison at seed size 11: the iff and the
+triple `(N_pos, N_Q, N_both) = (4, 4, 4)` are eight-map facts.
+
+No-Go Discipline disposition: **PASS** for the finite comparison and the
+narrow display report. FAIL / DO NOT SHIP for “displayed `vertex3`
+is the physical rule” or “adopt vertex3.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the eight `F_cut` maps with `wt1=0` and
+`adj2=0`, scores `cov11` on the 12 eleven-site seeds, compares positivity
+with displayed `Q := (vertex3=1)`, reports that the two are equivalent,
+reports `N_pos = 4`, `N_Q = 4`, and `N_both = 4`, and reports that there
+is no miss. Declared audit inputs are this note and the axiom memo; the
+runner writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_q4_false_cov11_vertex3_selector_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py
+runner_sha256: e549622e33d5e2701d1df57eb4f0dba9a486c815b6526fb56d02930347691ed8
+input_fingerprint_sha256: 77a26cf43dbdbe3c66c7d96c00fcf4ece7d1bc2b1e199aba66155f8a6a2fc16f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed vertex3 versus cov11>0 on the eight; does not adopt a bit
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+|Q4_false|=8
+n_11_site_seeds=12
+N_pos=4
+N_Q=4
+N_both=4
+N_mismatch=0
+lex_first_miss=None
+equiv=1
+class_rows=(0, 0, 0, 0, 0):0,(0, 0, 0, 0, 1):0,(0, 0, 0, 1, 0):8,(0, 0, 0, 1, 1):8,(0, 1, 0, 0, 0):0,(0, 1, 0, 0, 1):0,(0, 1, 0, 1, 0):8,(0, 1, 0, 1, 1):8
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 8 Q4-false maps, 12 eleven-site seeds
+PASS: thm1-q4-false-class the eight maps are exactly wt1=0 and adj2=0
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-equivalence cov11>0 equals vertex3=1 among the eight Q4-false maps
+PASS: thm1-positive-coverages vertex3=1 maps have cov11=8 and vertex3=0 maps have cov11=0
+PASS: thm2-counts N_pos=4, N_Q=4, N_both=4; no miss
+PASS: thm3-display-not-adopt Q is displayed vertex3=1 and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the eight-map cov11-versus-vertex3 comparison and does not adopt a bit
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover the residual is the eight-map vertex3 test, not leftover of c11q4 or c7q4
+PASS: q-definition Q is (vertex3=1) and Q4-false is wt1=0 and adj2=0
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every Q4-false F_cut map is scored on 12 eleven-site seeds against displayed vertex3
+per_block: checked exactly — N_pos, N_Q, and N_both are the eight-map positivity-versus-vertex3 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py
+++ b/scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""Whether cov11>0 equals vertex3 among the 8 Q4-false F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. The eight Q4-false maps are those with wt1=0 and adj2=0.
+Coverage cov11(f) is the number of 11-site seeds from which f fills. Q is
+the displayed remaining-bit predicate (vertex3=1). The runner reports
+whether positivity equals Q, the counts N_pos, N_Q, N_both, and one
+lex-first miss if not equivalent. It does not adopt a bit. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+Q4_FALSE_CLASS: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 0, 0, 0, 1),
+    (0, 0, 0, 1, 0),
+    (0, 0, 0, 1, 1),
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+    (0, 1, 0, 1, 0),
+    (0, 1, 0, 1, 1),
+)
+VERTEX3_POS: tuple[Remaining, ...] = (
+    (0, 0, 0, 1, 0),
+    (0, 0, 0, 1, 1),
+    (0, 1, 0, 1, 0),
+    (0, 1, 0, 1, 1),
+)
+VERTEX3_ZERO: tuple[Remaining, ...] = (
+    (0, 0, 0, 0, 0),
+    (0, 0, 0, 0, 1),
+    (0, 1, 0, 0, 0),
+    (0, 1, 0, 0, 1),
+)
+POS_COV11 = 8
+ZERO_COV11 = 0
+N_POS = 4
+N_Q = 4
+N_BOTH = 4
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_Q4(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[2] == 1
+
+
+def selector_Q(remaining: Remaining) -> bool:
+    return remaining[3] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print("negative_scope: displayed vertex3 versus cov11>0 on the eight; does not adopt a bit")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(11)
+
+    q4_false_members = [
+        (bits, remaining) for bits, remaining in members if remaining[0] == 0 and remaining[2] == 0
+    ]
+    rows: list[tuple[Remaining, int, bool]] = []
+    for bits, remaining in q4_false_members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_Q(remaining)))
+
+    n_q = sum(1 for _remaining, _cov, flag in rows if flag)
+    n_pos = sum(1 for _remaining, cov, _flag in rows if cov > 0)
+    n_both = sum(1 for _remaining, cov, flag in rows if cov > 0 and flag)
+    mismatches = [
+        (remaining, cov, flag)
+        for remaining, cov, flag in rows
+        if flag != (cov > 0)
+    ]
+    lex_first = min(mismatches, key=lambda row: row[0]) if mismatches else None
+    cov_by_remaining = {remaining: cov for remaining, cov, _flag in rows}
+    remaining_set = frozenset(remaining for remaining, _cov, _flag in rows)
+    equiv = len(mismatches) == 0
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"|Q4_false|={len(rows)}")
+    print(f"n_11_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_Q={n_q}")
+    print(f"N_both={n_both}")
+    print(f"N_mismatch={len(mismatches)}")
+    print(f"lex_first_miss={None if lex_first is None else lex_first[0]}")
+    print(f"equiv={int(equiv)}")
+    print("class_rows=" + ",".join(f"{remaining}:{cov}" for remaining, cov, _flag in sorted(rows)))
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_Q4_FALSE_COV11_VERTEX3_SELECTOR_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 8 Q4-false maps, 12 eleven-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 12
+        and len(TWO_CUBE) == 12
+        and len(rows) == 8
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-q4-false-class",
+        "the eight maps are exactly wt1=0 and adj2=0",
+        remaining_set == frozenset(Q4_FALSE_CLASS)
+        and all((not selector_Q4(remaining)) for remaining, _cov, _flag in rows)
+        and all(remaining[0] == 0 and remaining[2] == 0 for remaining in remaining_set)
+        and L1_REMAINING not in remaining_set
+        and "wt1=0 and adj2=0" in note,
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and selector_Q4(L1_REMAINING)
+        and selector_Q(L1_REMAINING)
+        and L1_REMAINING == (1, 0, 1, 1, 1),
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-equivalence",
+        "cov11>0 equals vertex3=1 among the eight Q4-false maps",
+        equiv
+        and n_pos == n_q == n_both == 4
+        and all(selector_Q(remaining) == (cov > 0) for remaining, cov, _flag in rows)
+        and "is equivalent to `Q`" in note_flat
+        and lex_first is None,
+    )
+    checks.check(
+        "thm1-positive-coverages",
+        "vertex3=1 maps have cov11=8 and vertex3=0 maps have cov11=0",
+        all(cov_by_remaining[remaining] == POS_COV11 for remaining in VERTEX3_POS)
+        and all(cov_by_remaining[remaining] == ZERO_COV11 for remaining in VERTEX3_ZERO)
+        and frozenset(VERTEX3_POS) | frozenset(VERTEX3_ZERO) == remaining_set
+        and "cov11 = 8" in note
+        and "cov11 = 0" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_pos={n_pos}, N_Q={n_q}, N_both={n_both}; no miss",
+        n_pos == N_POS
+        and n_q == N_Q
+        and n_both == N_BOTH
+        and n_pos == 4
+        and n_q == 4
+        and n_both == 4
+        and lex_first is None
+        and f"N_pos = {n_pos}" in note
+        and f"N_Q = {n_q}" in note
+        and f"N_both = {n_both}" in note
+        and "There is no miss" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "Q is displayed vertex3=1 and is not adopted as an Admissibility selector",
+        (
+            "Q(f) := (vertex3 = 1)" in note
+            or "Q(f) := (vertex3=1)" in note
+        )
+        and "Displayed, not adopted" in note
+        and "Do not adopt a bit" in note
+        and "Do not adopt vertex3" in note
+        and "Do not write `vertex3` into Admissibility" in note
+        and "does not adopt a bit" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 8 F_cut maps with wt1=0 and adj2=0 on the two-cube with "
+        "off-patch o=0, whether cov11>0 equals vertex3=1 is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the eight-map cov11-versus-vertex3 comparison and does not adopt a bit",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `vertex3` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover",
+        "the residual is the eight-map vertex3 test, not leftover of c11q4 or c7q4",
+        "Not leftover-character of the 32-map `Q4` count" in note
+        and "Not leftover-character of the c7q4 split" in note
+        and "New k for that residual" in note
+        and "does not adopt a bit" in self_source,
+    )
+    checks.check(
+        "q-definition",
+        "Q is (vertex3=1) and Q4-false is wt1=0 and adj2=0",
+        selector_Q((0, 0, 0, 1, 0))
+        and selector_Q((0, 1, 0, 1, 1))
+        and not selector_Q((0, 0, 0, 0, 0))
+        and not selector_Q((0, 1, 0, 0, 1))
+        and not selector_Q4((0, 0, 0, 1, 0))
+        and selector_Q4((1, 0, 0, 0, 0))
+        and selector_Q4((0, 0, 1, 0, 0)),
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every Q4-false F_cut map is scored on 12 eleven-site seeds against displayed vertex3")
+    print("per_block: checked exactly — N_pos, N_Q, and N_both are the eight-map positivity-versus-vertex3 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 8 F_cut maps with wt1=0 and adj2=0 on the two-cube with off-patch o=0, cov11>0 iff vertex3. N_pos=N_Q=N_both=4. No miss. Displayed, not adopted.

## Runner

`scripts/f_cut_q4_false_cov11_vertex3_selector_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.