### PR TITLE
feat(c9q6): cov9>0 is not Q6; positivity does not imply Q6

### DIFF
--- a/docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,363 @@
+---
+claim_id: f_cut_cov9_q6_selector_test_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether cov9>0 equals wt1∨adj2∨vertex3, and whether positivity implies that OR, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/f_cut_cov9_q6_selector_test_2026_08_15.py
+---
+
+# Whether `cov9>0` Equals Displayed `wt1 ∨ adj2 ∨ vertex3`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-to-lock 9-site fill positivity on the
+twelve-vertex two-cube with off-patch occupancy `0`, scored for the
+thirty-two cube-covariant cut maps `F_cut`, against displayed `Q6`.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/f_cut_cov9_q6_selector_test_2026_08_15.py`](../scripts/f_cut_cov9_q6_selector_test_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result up front
+
+Investment c5q6 showed that `cov5>0` implies `Q6`, with `N_pos = 21`,
+`N_Q6 = 28`, and `N_both = 21`. Investment c7q6 showed that `cov7>0`
+implies `Q6`, with `N_pos = 24`, `N_Q6 = 28`, and `N_both = 24`.
+Investment c11q6 showed that `cov11>0` implies `Q6`, with `N_pos = 24`,
+`N_Q6 = 28`, and `N_both = 24`. Investment c9sel already reported
+`N_pos = 26` and `N_Q6 = 28` inside a remaining-bit menu search at
+nine-site seeds. The 3-bit OR
+
+```text
+Q6(f) := (wt1 = 1) or (adj2 = 1) or (vertex3 = 1).
+```
+
+was already named at k=6 by `Q6=cov6>0`. This note tests that named
+3-bit OR at nine-site seeds. New k for the named 3-bit OR. Not
+leftover-character of c5q6, not leftover-character of c7q6, not
+leftover-character of c11q6, and not leftover-character of c9sel.
+
+`F_cut` is the cube-covariant class of `{0,1}`-valued maps on the six
+nearest-neighbor occupancy bits with `f(empty)=f(full)=0` and `f(c)=f(1-c)`.
+It has five free remaining bits and size 32. Remaining bits are ordered as
+`(wt1, opp2, adj2, vertex3, mixed3)`. Thus `|F_cut| = 32`.
+
+`f_L1(c)=1` if and only if some axis is unbalanced: the signed pair
+`n_μ = c_{+μ} − c_{-μ}` is nonzero. This is **not** Hamming parity
+`|c|_1 mod 2`. `f_L1` is the 10-orbit reading `n ≠ 0`, not Hamming. Its
+remaining-bit tuple is `(1, 0, 1, 1, 1)`.
+
+On the two-cube with off-patch occupancy `0`, write
+`cov9(f) = |{S : |S|=9 and f fills from S}|`. Then:
+
+- Theorem 1. `cov9>0` is not equivalent to `Q6`. Positivity does not
+  imply `Q6`. One lex-first remaining-bit miss is reported.
+- Theorem 2. `N_pos = 26`, `N_Q6 = 28`, `N_both = 25`.
+- Theorem 3. `Q6` is displayed. Do not adopt Q6.
+
+Do not write `Q6` into Admissibility. Displayed, not adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The 32 F_cut maps are enumerated by remaining bits and scored exactly on the 220 nine-site seeds of the two-cube. Whether cov9>0 equals displayed Q6, and whether positivity implies that OR, are finite exact facts. No physical Admissibility selector is claimed."
+trace_class: frontier_discovery
+target_claim_id: f_cut_cov9_q6_selector_test
+target_blocker_text: "whether cov9>0 equals wt1 or adj2 or vertex3 among the 32 F_cut maps, and whether positivity implies that OR"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded 9-site positivity-versus-Q6 comparison; do not adopt displayed Q6"
+conditional_surface_status: "exact for occupancy-to-lock on the twelve-vertex two-cube with off-patch occupancy 0; no Z^3-wide formation law"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current premise boundary
+
+The only scientific dependency is the current four-axiom authority linked
+above. The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom memo says the distribution concerns which possibility a forming
+record locks, conditional on formation at that site; it does not supply the
+formation site, probability, or rate.
+
+The current Record boundary is:
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no formation-site selector and no occupancy-to-lock
+predicate. `Q6` is a displayed remaining-bit formula, not axiom content.
+
+## Exact objects
+
+The two-cube is `T = {0,1,2} × {0,1} × {0,1}` (twelve vertices). Off-patch
+occupancy `0` is the explicit default: a neighbor of a site in `T` that is
+not itself in `T` is treated as unoccupied. A blank-block is a different
+rule and is not used.
+
+A configuration `c ∈ {0,1}^6` is a six-tuple of neighbor occupancies in
+direction order `(+x,-x,+y,-y,+z,-z)`. Axis type is
+`(n_unbalanced, n_both, n_empty)`, where an axis is unbalanced if its two
+bits differ, both if both bits are 1, and empty if both bits are 0.
+Complement swaps `n_both` with `n_empty`. The five remaining bits of
+`F_cut`, in the order `(wt1, opp2, adj2, vertex3, mixed3)`, are the values
+on orbit types `(1,0,2)`, `(0,1,2)`, `(2,0,1)`, `(3,0,0)`, `(1,1,1)`.
+Complement partners are forced equal; empty and full are fixed at 0. Thus
+`N_free = 5` and `|F_cut| = 32`.
+
+Occupancy-to-lock: from a locked set `L ⊂ T`, a site `x ∈ T \ L` locks at
+the next tick if and only if `f` of its six-neighbor occupancy (off-patch
+entries 0) equals 1. The map `f` fills from a seed `S` if iterating this
+rule from `L_0 = S` reaches `L = T` in at most 13 ticks.
+
+The nine-site seeds are the `C(12,9) = 220` subsets of size 9 in `T`. Then
+`cov9(f)` is the number of those subsets from which `f` fills. The boolean
+scored here is `cov9(f)>0`. Duality is not assumed: `cov9` is scored on
+those 220 seeds.
+
+The displayed remaining-bit predicate is
+
+```text
+Q6(f) := (wt1=1) or (adj2=1) or (vertex3=1).
+```
+
+That is `wt1∨adj2∨vertex3`. Opp2 and mixed3 are free in `Q6`.
+Displayed, not adopted.
+
+## Theorem 1 — `cov9>0` is not equivalent to `Q6`; positivity does not imply `Q6`
+
+Enumerate all 32 remaining-bit tuples of `F_cut` and score `cov9` on the
+220 nine-site seeds. Then `cov9(f) > 0` is not equivalent to `Q6`. There
+are four mismatches. Positivity does not imply `Q6`: there is one
+`Q6`-false positive.
+
+The three `Q6`-true maps with `cov9 = 0` are
+`(1, 0, 0, 0, 0)`, `(1, 0, 0, 0, 1)`, and `(1, 1, 0, 0, 0)`.
+
+The unique `Q6`-false map with `cov9 > 0` is `(0, 1, 0, 0, 1)`:
+`wt1 = 0`, `adj2 = 0`, `vertex3 = 0`, and `cov9 = 4`. That witness
+refuses `cov9>0 ⇒ Q6`.
+
+The lex-first remaining-bit miss, in the order
+`(wt1, opp2, adj2, vertex3, mixed3)`, is `(0, 1, 0, 0, 1)`: `cov9 = 4`
+and `Q6` is false.
+
+`f_L1`, with remaining bits `(1, 0, 1, 1, 1)`, satisfies `Q6` and has
+`cov9 = 220`. That is consistent with Theorem 2 and does not restore
+equivalence.
+
+## Theorem 2 — `N_pos`, `N_Q6`, `N_both`
+
+Among the 32 maps:
+
+- `N_pos = 26` maps have `cov9 > 0`;
+- `N_Q6 = 28` maps satisfy `Q6`;
+- `N_both = 25` maps satisfy both.
+
+The counts already refuse equivalence and refuse the one-sided
+implication: `N_both = 25` is strictly smaller than both `N_pos = 26`
+and `N_Q6 = 28`. Three mismatches are `Q6`-true zeros. One mismatch is
+the `Q6`-false positive of Theorem 1. Necessity fails; sufficiency fails.
+
+## Theorem 3 — display; do not adopt Q6
+
+`Q6` is the remaining-bit predicate already named at k=6. On this patch
+it does not equal 9-site positivity, and positivity does not imply `Q6`.
+Displayed, not adopted. Do not adopt Q6. Do not write `Q6` into
+Admissibility. Admissibility does not name this remaining-bit formula.
+
+The identities here are finite facts about occupancy-to-lock on this
+two-cube with off-patch `o=0`. They are not a physical formation-site
+selector and not an axiom edit.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record wording | quoted; no edit |
+| `F_cut` as the 32 cube-covariant cut maps | enumerated by remaining bits |
+| `f_L1` as unbalanced-axis / `n ≠ 0` | defined; Hamming rejected |
+| two-cube, 220 nine-site seeds, off-patch `o=0` | declared finite patch |
+| `Q6` as `(wt1=1) or (adj2=1) or (vertex3=1)` | displayed, not adopted |
+| `cov9>0` iff `Q6` | fails; lex-first miss `(0, 1, 0, 0, 1)` |
+| positivity implies `Q6` | fails; unique `Q6`-false positive `(0, 1, 0, 0, 1)` |
+| `N_pos = 26`, `N_Q6 = 28`, `N_both = 25` | proved by exhaustive scoring |
+| leftover-character of c5q6 | refused; named 3-bit OR at a new k |
+| leftover-character of c7q6 | refused; named 3-bit OR at a new k |
+| leftover-character of c11q6 | refused; named 3-bit OR at a new k |
+| leftover-character of c9sel | refused; dedicated iff and imply test |
+| leftover-character of the naming of `Q6` at k=6 | refused; same OR, new comparison to `cov9>0` |
+| adoption of `Q6` | refused |
+| physical Admissibility selector | open |
+
+## Boundary and imports
+
+Not leftover-character of c5q6: that already showed that `cov5>0` implies
+`Q6`, with `N_pos = 21`, `N_Q6 = 28`, and `N_both = 21`. Echoing a
+five-site implication is not a substitute for the nine-site iff test.
+
+Not leftover-character of c7q6: that already showed that `cov7>0` implies
+`Q6`, with `N_pos = 24`, `N_Q6 = 28`, and `N_both = 24`. Echoing a
+seven-site implication is not a substitute for the nine-site iff test.
+
+Not leftover-character of c11q6: that already showed that `cov11>0`
+implies `Q6`, with `N_pos = 24`, `N_Q6 = 28`, and `N_both = 24`. Echoing
+an eleven-site implication is not a substitute for the nine-site iff test.
+
+Not leftover-character of c9sel: that remaining-bit menu already reported
+`N_pos = 26` and `N_Q6 = 28` and that `cov9>0` is not equivalent to `Q6`.
+A search report is not a substitute for the dedicated positivity-versus-`Q6`
+iff and implication theorems at this seed size.
+
+New k for the named 3-bit OR: naming `wt1∨adj2∨vertex3` at k=6 is not a
+substitute for scoring it against `cov9>0` on the 32 maps.
+
+Off-patch occupancy `0` is an explicit default on this patch. A
+blank-block is a different rule and is not used.
+
+No observation, fit, continuum limit, or Hamming-as-`f_L1`
+identification is imported. No `Z^3`-wide formation law is claimed.
+Do not write `Q6` into Admissibility.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether 9-site positivity equals displayed `Q6` inside `F_cut` on this patch, and whether positivity implies that OR. |
+| V2 | Current main has the axiom memo. Investments c5q6, c7q6, and c11q6 already showed that `cov5>0`, `cov7>0`, and `cov11>0` imply `Q6`. Investment c9sel already reported `N_pos = 26` and `N_Q6 = 28`. There is no landed 9-site positivity-versus-`Q6` iff and imply test. |
+| V3 | The 32 maps, 220 seeds, and occupancy-to-lock evolution are independently finite and exact. |
+| V4 | The theorem is more than restating Admissibility: it scores a declared finite class against a named 3-bit OR at a new seed size. |
+| V5 | Equivalence fails, positivity does not imply `Q6`, one lex-first miss is reported, and displayed `Q6` is not adopted or written into Admissibility. |
+
+## No-Go Discipline gate
+
+The negative content is narrow: among the 32 `F_cut` maps on this patch,
+`cov9>0` is not `Q6`. Positivity does not imply `Q6`. Displayed `Q6` is
+not axiom content. No global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| Hamming parity | identify `f_L1` with `|c|_1 mod 2` | **ATTEMPTED** |
+| leftover of c5q6 | treat the test as leftover-character of “`cov5>0` implies `Q6`” | **ATTEMPTED** |
+| leftover of c7q6 | treat the test as leftover-character of “`cov7>0` implies `Q6`” | **ATTEMPTED** |
+| leftover of c11q6 | treat the test as leftover-character of “`cov11>0` implies `Q6`” | **ATTEMPTED** |
+| leftover of c9sel | treat the dedicated test as leftover-character of the nine-site menu counts | **ATTEMPTED** |
+| adopt `Q6` | write `(wt1=1) or (adj2=1) or (vertex3=1)` into Admissibility | **ATTEMPTED** |
+
+### N2 — wall independence
+
+The Hamming contrast, the c5q6 implication, the c7q6 implication, the
+c11q6 implication, the c9sel menu counts, and the naming of `Q6` at k=6
+are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The two-cube, the 220 nine-site seeds, off-patch occupancy `0`,
+occupancy-to-lock ticks, the `F_cut` remaining-bit order, and displayed
+`Q6` are declared. Equivalence of `cov9>0` with `Q6` is not silently
+assumed. The implication `cov9>0 ⇒ Q6` is scored and fails; it is not
+imported from the odd-k implications.
+
+### N4 — source residual matching
+
+The live axiom memo supplies `Z^3`, proper cubic rotations, and one
+covariant nearest-neighbor rule. The residual answered here is whether
+9-site positivity equals displayed `Q6` on the declared patch, and
+whether positivity implies that OR, as the named 3-bit OR at a new k,
+and not leftover-character of c5q6, leftover-character of c7q6,
+leftover-character of c11q6, or leftover-character of c9sel.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | 64 neighbor 6-tuples by axis-type orbit | no continuum occupancy |
+| per site | twelve two-cube vertices, same stencil | no privileged site |
+| per mode | all 32 `F_cut` maps scored on 220 seeds | no physical law selection |
+| per block | `N_pos`, `N_Q6`, and `N_both` on this patch | no Admissibility write-in |
+| lattice wide | checked and not executed | no `Z^3`-wide formation law |
+
+### N6 — live partial-closure paths
+
+Live routes include a different Boolean combination of remaining bits, a
+different seed family, a different off-patch rule, a selector other than
+`Q6` or `cov9>0`, and any independently derived physical map from
+`F_cut` into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** c5q6, c7q6, and c11q6 already showed that positivity
+implies the named 3-bit OR `Q6` at three nearby seed sizes, and c9sel
+already counted `N_pos = 26` and `N_Q6 = 28`, so either the nine-site
+comparison is leftover-character of those reports, or the same
+implication must hold at k=9 and must be written into Admissibility as
+the physical selector.
+
+**Answer:** `Q6` fails equivalence at this k, and positivity does not
+imply `Q6`: twenty-eight maps satisfy `Q6` and twenty-six maps have
+`cov9>0`, but only twenty-five maps satisfy both. The lex-first miss
+`(0, 1, 0, 0, 1)` has `cov9 = 4` and `Q6` false. The three `Q6`-true
+zeros are `(1, 0, 0, 0, 0)`, `(1, 0, 0, 0, 1)`, and `(1, 1, 0, 0, 0)`.
+Displayed `Q6` is not adopted.
+
+### N8 — cross-cycle echo
+
+Investment c5q6 already showed that `cov5>0` implies `Q6`, with
+`(N_pos, N_Q6, N_both) = (21, 28, 21)`. Investment c7q6 already showed
+that `cov7>0` implies `Q6`, with `(N_pos, N_Q6, N_both) = (24, 28, 24)`.
+Investment c11q6 already showed that `cov11>0` implies `Q6`, with
+`(N_pos, N_Q6, N_both) = (24, 28, 24)`. Investment c9sel already
+reported `N_pos = 26` and `N_Q6 = 28` inside a menu search. The naming
+of `Q6` at k=6 already wrote `wt1∨adj2∨vertex3`. Echoing any of those
+facts is not a substitute for the nine-site `Q6` iff test: the lex-first
+miss and the triple `(N_pos, N_Q6, N_both) = (26, 28, 25)` are nine-site
+facts about this named OR.
+
+No-Go Discipline disposition: **PASS** for the finite comparison, the
+narrow nonequivalence report, and the failed implication. FAIL / DO NOT SHIP
+for “displayed `Q6` is the physical rule” or “adopt Q6.”
+
+## Live parent quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+## Runner contract
+
+The companion runner enumerates the 32 `F_cut` maps, scores `cov9` on the
+220 nine-site seeds, compares positivity with displayed `Q6`, reports that
+the two are not equivalent, reports that positivity does not imply `Q6`,
+reports one lex-first miss `(0, 1, 0, 0, 1)` with `cov9 = 4`, and reports
+`N_pos = 26`, `N_Q6 = 28`, and `N_both = 25`. Declared audit inputs are
+this note and the axiom memo; the runner writes no cache and authors no
+audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4663,6 +4663,10 @@
    "out_degree": 1
   },
   "extensional_nearest_neighbor_rule_deep_probe_2026-07-13": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
+  },
+  "f_cut_cov9_q6_selector_test_bounded_theorem_note_2026-08-15": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },

--- a/logs/runner-cache/f_cut_cov9_q6_selector_test_2026_08_15.txt
+++ b/logs/runner-cache/f_cut_cov9_q6_selector_test_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/f_cut_cov9_q6_selector_test_2026_08_15.py
+runner_sha256: 3eb1cd4112d0412c1f960eaa8fa6c05449ebd36161f0f855d0148d2eeb7b17b0
+input_fingerprint_sha256: 692e4e979a92d6a7cdcf943eca1796145dc4fdefbad9cb3b8e240d5648f5aada
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice/Admissibility/Record boundary only; no observation or fit
+negative_scope: displayed Q6 versus cov9>0; does not adopt Q6
+n_rotations=24
+n_orbits=10
+remaining_labels=('wt1', 'opp2', 'adj2', 'vertex3', 'mixed3')
+|F_cut|=32
+n_nine_site_seeds=220
+N_pos=26
+N_Q6=28
+N_both=25
+N_mismatch=4
+cov9(f_L1)=220
+lex_first_miss=(0, 1, 0, 0, 1)
+lex_first_cov9=4
+lex_first_Q6=0
+equiv=0
+pos_implies_Q6=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple
+PASS: thm1-host 24 rotations, 10 orbits, 32 F_cut maps, 220 nine-site seeds
+PASS: thm1-f-L1-is-unbalanced-axis f_L1 is 1 iff some axis has c_+ != c_-
+PASS: thm1-f-L1-not-hamming f_L1 is n!=0, not Hamming |c|_1 mod 2
+PASS: thm1-not-equivalent cov9>0 is not equivalent to Q6 among the 32 F_cut maps
+PASS: thm1-lex-first-miss one lex-first remaining-bit miss is (0, 1, 0, 0, 1)
+PASS: thm1-pos-implies-q6 positivity does not imply Q6; unique Q6-false positive is (0, 1, 0, 0, 1)
+PASS: thm2-counts N_pos=26, N_Q6=28, N_both=25
+PASS: thm2-split three Q6-true maps have cov9=0 and one Q6-false map has cov9>0
+PASS: thm3-display-not-adopt Q6 is displayed and is not adopted as an Admissibility selector
+PASS: source-lattice-admissibility Lattice rotations and Admissibility covariance are pinned
+PASS: source-record-boundary Record lock, content-only readout, unreadable absence, and formation residual are pinned
+PASS: claim-scope claim_scope reports the 9-site positivity-versus-Q6 comparison and does not adopt Q6
+PASS: note-contract machine fields, three theorems, and forbidden-phrase hygiene hold
+PASS: no-axiom-edit the axiom memo is unedited and the theorem proposes no axiom change
+PASS: off-patch-zero off-patch occupancy is the explicit 0 default, not a blank-block
+PASS: l1-definition-in-note the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming
+PASS: not-leftover-c5q6-c7q6-c11q6-or-c9sel the residual is new k for the named 3-bit OR, not leftover of c5q6/c7q6/c11q6 or c9sel
+PASS: q6-definition-and-l1-in-class Q6 is wt1 or adj2 or vertex3 and f_L1 satisfies Q6
+per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit
+per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil
+per_mode: checked exactly — every F_cut map is scored on 220 nine-site seeds against displayed Q6
+per_block: checked exactly — N_pos, N_Q6, and N_both are the F_cut positivity-versus-Q6 counts on this patch
+lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/f_cut_cov9_q6_selector_test_2026_08_15.py
+++ b/scripts/f_cut_cov9_q6_selector_test_2026_08_15.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+"""Whether cov9>0 equals Q6 on the 32 F_cut maps.
+
+F_cut is the cube-covariant class with f(empty)=f(full)=0 and f(c)=f(1-c).
+Dynamics are occupancy-to-lock on the twelve-vertex two-cube with off-patch
+occupancy 0. Coverage cov9(f) is the number of nine-site seeds from which f
+fills. Q6 is the displayed remaining-bit predicate already named at k=6:
+(wt1=1) or (adj2=1) or (vertex3=1). The runner reports whether positivity
+equals Q6, whether positivity implies Q6, one lex-first miss if not, and
+the counts N_pos, N_Q6, N_both. It does not adopt Q6. f_L1 is the
+unbalanced-axis predicate (some n_mu != 0), never Hamming |c|_1 mod 2.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Direction = tuple[int, int, int]
+Config = tuple[int, int, int, int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+OrbitType = tuple[int, int, int]
+Site = tuple[int, int, int]
+Remaining = tuple[int, int, int, int, int]
+
+DIRECTIONS: tuple[Direction, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+EMPTY: Config = (0, 0, 0, 0, 0, 0)
+FULL: Config = (1, 1, 1, 1, 1, 1)
+TWO_CUBE: tuple[Site, ...] = tuple(
+    (x, y, z) for x in range(3) for y in range(2) for z in range(2)
+)
+REMAINING_ORDER: tuple[OrbitType, ...] = (
+    (1, 0, 2),
+    (0, 1, 2),
+    (2, 0, 1),
+    (3, 0, 0),
+    (1, 1, 1),
+)
+REMAINING_LABELS: tuple[str, ...] = ("wt1", "opp2", "adj2", "vertex3", "mixed3")
+EMPTY_TYPE: OrbitType = (0, 0, 3)
+FULL_TYPE: OrbitType = (0, 3, 0)
+L1_REMAINING: Remaining = (1, 0, 1, 1, 1)
+LEX_FIRST_MISS: Remaining = (0, 1, 0, 0, 1)
+MISS_COV9 = 4
+N_POS = 26
+N_Q6 = 28
+N_BOTH = 25
+Q6_TRUE_ZEROS: tuple[Remaining, ...] = (
+    (1, 0, 0, 0, 0),
+    (1, 0, 0, 0, 1),
+    (1, 1, 0, 0, 0),
+)
+Q6_FALSE_POS: tuple[Remaining, ...] = (
+    (0, 1, 0, 0, 1),
+)
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Direction) -> Direction:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def rotate_config(config: Config, rotation: Rotation) -> Config:
+    occupancy = {direction: config[index] for index, direction in enumerate(DIRECTIONS)}
+    forward = {direction: rotate_vector(rotation, direction) for direction in DIRECTIONS}
+    inverse = {image: source for source, image in forward.items()}
+    return tuple(occupancy[inverse[direction]] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def axis_type(config: Config) -> OrbitType:
+    n_unbalanced = 0
+    n_both = 0
+    n_empty = 0
+    for axis in range(3):
+        plus = config[2 * axis]
+        minus = config[2 * axis + 1]
+        if plus != minus:
+            n_unbalanced += 1
+        elif plus == 1:
+            n_both += 1
+        else:
+            n_empty += 1
+    return (n_unbalanced, n_both, n_empty)
+
+
+def complement_type(orbit_type: OrbitType) -> OrbitType:
+    unbalanced, both, empty = orbit_type
+    return (unbalanced, empty, both)
+
+
+def f_L1(config: Config) -> int:
+    """1 iff some axis is unbalanced: n_mu != 0.  Not Hamming parity."""
+    return int(any(config[2 * axis] != config[2 * axis + 1] for axis in range(3)))
+
+
+def f_hamming(config: Config) -> int:
+    return sum(config) % 2
+
+
+def build_orbits() -> dict[OrbitType, frozenset[Config]]:
+    orbits: dict[OrbitType, frozenset[Config]] = {}
+    seen: set[Config] = set()
+    for raw in product((0, 1), repeat=6):
+        config: Config = (raw[0], raw[1], raw[2], raw[3], raw[4], raw[5])
+        if config in seen:
+            continue
+        orbit: set[Config] = set()
+        stack = [config]
+        while stack:
+            current = stack.pop()
+            if current in orbit:
+                continue
+            orbit.add(current)
+            for rotation in ROTATIONS:
+                stack.append(rotate_config(current, rotation))
+        orbit_type = axis_type(config)
+        orbits[orbit_type] = frozenset(orbit)
+        seen.update(orbit)
+    return orbits
+
+
+def remaining_bits_from_assignment(assignment: dict[OrbitType, int]) -> Remaining:
+    return tuple(assignment[orbit_type] for orbit_type in REMAINING_ORDER)  # type: ignore[return-value]
+
+
+def f_cut_free_data(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> tuple[list[tuple[OrbitType, OrbitType]], list[OrbitType]]:
+    used: set[OrbitType] = set()
+    pairs: list[tuple[OrbitType, OrbitType]] = []
+    fixed: list[OrbitType] = []
+    for orbit_type in orbit_types:
+        if orbit_type in used:
+            continue
+        image = complement_type(orbit_type)
+        if image == orbit_type:
+            fixed.append(orbit_type)
+        else:
+            pair = tuple(sorted((orbit_type, image)))
+            pairs.append((pair[0], pair[1]))
+            used.add(orbit_type)
+            used.add(image)
+    free_pairs = [pair for pair in pairs if empty_type not in pair and full_type not in pair]
+    free_fixed = [orbit_type for orbit_type in fixed if orbit_type not in (empty_type, full_type)]
+    return free_pairs, free_fixed
+
+
+def enumerate_f_cut(
+    orbit_types: tuple[OrbitType, ...],
+    empty_type: OrbitType,
+    full_type: OrbitType,
+) -> list[tuple[tuple[int, ...], Remaining]]:
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, empty_type, full_type)
+    n_free = len(free_pairs) + len(free_fixed)
+    members: list[tuple[tuple[int, ...], Remaining]] = []
+    for mask in range(1 << n_free):
+        assignment = {empty_type: 0, full_type: 0}
+        for rank, pair in enumerate(free_pairs):
+            value = (mask >> rank) & 1
+            assignment[pair[0]] = value
+            assignment[pair[1]] = value
+        for rank, orbit_type in enumerate(free_fixed):
+            assignment[orbit_type] = (mask >> (len(free_pairs) + rank)) & 1
+        bits = tuple(assignment[orbit_type] for orbit_type in orbit_types)
+        remaining = remaining_bits_from_assignment(assignment)
+        members.append((bits, remaining))
+    return members
+
+
+def site_index_map() -> dict[Site, int]:
+    return {site: index for index, site in enumerate(TWO_CUBE)}
+
+
+def neighbor_indices() -> tuple[tuple[int, ...], ...]:
+    index_of = site_index_map()
+    rows = []
+    for site in TWO_CUBE:
+        row = []
+        for direction in DIRECTIONS:
+            neighbor = (
+                site[0] + direction[0],
+                site[1] + direction[1],
+                site[2] + direction[2],
+            )
+            row.append(index_of.get(neighbor, -1))
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def seed_masks_for(k: int) -> tuple[int, ...]:
+    index_of = site_index_map()
+    return tuple(
+        sum(1 << index_of[site] for site in combo) for combo in combinations(TWO_CUBE, k)
+    )
+
+
+def predicate_table(
+    bits: tuple[int, ...],
+    orbit_types: tuple[OrbitType, ...],
+    type_of: dict[Config, OrbitType],
+) -> tuple[int, ...]:
+    assignment = dict(zip(orbit_types, bits, strict=True))
+    table = []
+    for packed in range(64):
+        config = (
+            packed & 1,
+            (packed >> 1) & 1,
+            (packed >> 2) & 1,
+            (packed >> 3) & 1,
+            (packed >> 4) & 1,
+            (packed >> 5) & 1,
+        )
+        table.append(assignment[type_of[config]])
+    return tuple(table)
+
+
+def evolve_mask(locked: int, table: tuple[int, ...], neighbors: tuple[tuple[int, ...], ...]) -> int:
+    nxt = locked
+    for site in range(12):
+        if (locked >> site) & 1:
+            continue
+        occupancy = 0
+        for direction, neighbor in enumerate(neighbors[site]):
+            if neighbor >= 0 and (locked >> neighbor) & 1:
+                occupancy |= 1 << direction
+        if table[occupancy]:
+            nxt |= 1 << site
+    return nxt
+
+
+def fills_from_mask(
+    seed_mask: int,
+    table: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> bool:
+    locked = seed_mask
+    full_mask = (1 << 12) - 1
+    for _tick in range(13):
+        nxt = evolve_mask(locked, table, neighbors)
+        if nxt == locked:
+            return locked == full_mask
+        locked = nxt
+    return False
+
+
+def coverage_from_masks(
+    table: tuple[int, ...],
+    seeds: tuple[int, ...],
+    neighbors: tuple[tuple[int, ...], ...],
+) -> int:
+    return sum(1 for seed in seeds if fills_from_mask(seed, table, neighbors))
+
+
+def selector_Q6(remaining: Remaining) -> bool:
+    return remaining[0] == 1 or remaining[2] == 1 or remaining[3] == 1
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+        (ROOT / path).read_text(encoding="utf-8")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice/Admissibility/Record "
+        "boundary only; no observation or fit"
+    )
+    print("negative_scope: displayed Q6 versus cov9>0; does not adopt Q6")
+
+    orbits = build_orbits()
+    orbit_types = tuple(sorted(orbits))
+    type_of = {config: orbit_type for orbit_type, group in orbits.items() for config in group}
+    free_pairs, free_fixed = f_cut_free_data(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    members = enumerate_f_cut(orbit_types, EMPTY_TYPE, FULL_TYPE)
+    neighbors = neighbor_indices()
+    seeds = seed_masks_for(9)
+    rows: list[tuple[Remaining, int, bool]] = []
+    for bits, remaining in members:
+        table = predicate_table(bits, orbit_types, type_of)
+        cov = coverage_from_masks(table, seeds, neighbors)
+        rows.append((remaining, cov, selector_Q6(remaining)))
+
+    n_q6 = sum(1 for _remaining, _cov, flag in rows if flag)
+    n_pos = sum(1 for _remaining, cov, _flag in rows if cov > 0)
+    n_both = sum(1 for _remaining, cov, flag in rows if cov > 0 and flag)
+    mismatches = [
+        (remaining, cov, flag)
+        for remaining, cov, flag in rows
+        if flag != (cov > 0)
+    ]
+    q6_true_zeros = frozenset(
+        remaining for remaining, cov, flag in mismatches if flag and cov == 0
+    )
+    q6_false_pos = frozenset(
+        remaining for remaining, cov, flag in mismatches if (not flag) and cov > 0
+    )
+    lex_first = min(mismatches, key=lambda row: row[0]) if mismatches else None
+    cov_by_remaining = {remaining: cov for remaining, cov, _flag in rows}
+    cov_l1 = cov_by_remaining[L1_REMAINING]
+    pos_implies_q6 = all((not (cov > 0)) or flag for _remaining, cov, flag in rows)
+
+    print(f"n_rotations={len(ROTATIONS)}")
+    print(f"n_orbits={len(orbit_types)}")
+    print(f"remaining_labels={REMAINING_LABELS}")
+    print(f"|F_cut|={len(members)}")
+    print(f"n_nine_site_seeds={len(seeds)}")
+    print(f"N_pos={n_pos}")
+    print(f"N_Q6={n_q6}")
+    print(f"N_both={n_both}")
+    print(f"N_mismatch={len(mismatches)}")
+    print(f"cov9(f_L1)={cov_l1}")
+    print(f"lex_first_miss={None if lex_first is None else lex_first[0]}")
+    print(f"lex_first_cov9={None if lex_first is None else lex_first[1]}")
+    print(f"lex_first_Q6={None if lex_first is None else int(lex_first[2])}")
+    print(f"equiv={int(len(mismatches) == 0)}")
+    print(f"pos_implies_Q6={int(pos_implies_q6)}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required note-plus-axiom string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120
+        and 'AUDIT_INPUT_PATHS = (\n'
+        '    "docs/F_CUT_COV9_Q6_SELECTOR_TEST_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ')' in self_source,
+    )
+    checks.check(
+        "thm1-host",
+        "24 rotations, 10 orbits, 32 F_cut maps, 220 nine-site seeds",
+        len(ROTATIONS) == 24
+        and len(set(ROTATIONS)) == 24
+        and len(orbit_types) == 10
+        and sum(len(orbits[orbit_type]) for orbit_type in orbit_types) == 64
+        and len(members) == 32
+        and len(free_pairs) == 3
+        and len(free_fixed) == 2
+        and len(seeds) == 220
+        and len(TWO_CUBE) == 12
+        and EMPTY_TYPE == axis_type(EMPTY)
+        and FULL_TYPE == axis_type(FULL)
+        and REMAINING_ORDER == ((1, 0, 2), (0, 1, 2), (2, 0, 1), (3, 0, 0), (1, 1, 1)),
+    )
+    checks.check(
+        "thm1-f-L1-is-unbalanced-axis",
+        "f_L1 is 1 iff some axis has c_+ != c_-",
+        all(
+            f_L1(config) == int(axis_type(config)[0] >= 1)
+            for config in product((0, 1), repeat=6)
+        )
+        and selector_Q6(L1_REMAINING)
+        and cov_l1 == 220,
+    )
+    checks.check(
+        "thm1-f-L1-not-hamming",
+        "f_L1 is n!=0, not Hamming |c|_1 mod 2",
+        any(f_L1(config) != f_hamming(config) for config in product((0, 1), repeat=6))
+        and "sum(config) % 2"
+        not in self_source.split("def f_L1", 1)[1].split("def f_hamming", 1)[0]
+        and "n ≠ 0" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "thm1-not-equivalent",
+        "cov9>0 is not equivalent to Q6 among the 32 F_cut maps",
+        len(mismatches) > 0
+        and n_both != n_pos
+        and n_both != n_q6
+        and n_pos != n_q6
+        and all(selector_Q6(remaining) == (cov > 0) for remaining, cov, _flag in rows) is False
+        and "is not equivalent to `Q6`" in note_flat,
+    )
+    checks.check(
+        "thm1-lex-first-miss",
+        "one lex-first remaining-bit miss is (0, 1, 0, 0, 1)",
+        lex_first is not None
+        and lex_first[0] == LEX_FIRST_MISS
+        and lex_first[1] == MISS_COV9
+        and lex_first[2] is False
+        and cov_by_remaining[LEX_FIRST_MISS] == 4
+        and selector_Q6(LEX_FIRST_MISS) is False
+        and "(0, 1, 0, 0, 1)" in note
+        and "cov9 = 4" in note
+        and "lex-first" in note,
+    )
+    checks.check(
+        "thm1-pos-implies-q6",
+        "positivity does not imply Q6; unique Q6-false positive is (0, 1, 0, 0, 1)",
+        pos_implies_q6 is False
+        and q6_false_pos == frozenset(Q6_FALSE_POS)
+        and q6_false_pos == frozenset({(0, 1, 0, 0, 1)})
+        and selector_Q6((0, 1, 0, 0, 1)) is False
+        and cov_by_remaining[(0, 1, 0, 0, 1)] == 4
+        and "Positivity does not imply" in note
+        and "`(0, 1, 0, 0, 1)`" in note,
+    )
+    checks.check(
+        "thm2-counts",
+        f"N_pos={n_pos}, N_Q6={n_q6}, N_both={n_both}",
+        n_pos == N_POS
+        and n_q6 == N_Q6
+        and n_both == N_BOTH
+        and n_pos == 26
+        and n_q6 == 28
+        and n_both == 25
+        and f"N_pos = {n_pos}" in note
+        and f"N_Q6 = {n_q6}" in note
+        and f"N_both = {n_both}" in note,
+    )
+    checks.check(
+        "thm2-split",
+        "three Q6-true maps have cov9=0 and one Q6-false map has cov9>0",
+        q6_true_zeros == frozenset(Q6_TRUE_ZEROS)
+        and q6_false_pos == frozenset(Q6_FALSE_POS)
+        and len(mismatches) == 4
+        and all(selector_Q6(remaining) and cov_by_remaining[remaining] == 0 for remaining in Q6_TRUE_ZEROS)
+        and all((not selector_Q6(remaining)) and cov_by_remaining[remaining] > 0 for remaining in Q6_FALSE_POS)
+        and "`(1, 0, 0, 0, 0)`" in note
+        and "`(1, 0, 0, 0, 1)`" in note
+        and "`(1, 1, 0, 0, 0)`" in note
+        and "`(0, 1, 0, 0, 1)`" in note,
+    )
+    checks.check(
+        "thm3-display-not-adopt",
+        "Q6 is displayed and is not adopted as an Admissibility selector",
+        (
+            "Q6(f) := (wt1 = 1) or (adj2 = 1) or (vertex3 = 1)" in note
+            or "Q6(f) := (wt1=1) or (adj2=1) or (vertex3=1)" in note
+        )
+        and "Displayed, not adopted" in note
+        and "Do not adopt Q6" in note
+        and "Do not write `Q6` into Admissibility" in note
+        and "does not adopt Q6" in self_source,
+    )
+
+    lattice_sites = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    formation_residual = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    records_form = "Records form."
+
+    checks.check(
+        "source-lattice-admissibility",
+        "Lattice rotations and Admissibility covariance are pinned",
+        lattice_sites in axiom_flat
+        and admissibility in axiom_flat
+        and lattice_sites in note_flat
+        and admissibility in note_flat,
+    )
+    checks.check(
+        "source-record-boundary",
+        "Record lock, content-only readout, unreadable absence, and formation residual are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        )
+        and all(
+            phrase in note_flat
+            for phrase in (
+                records_form,
+                record_lock,
+                record_content,
+                record_absence,
+                formation_residual,
+            )
+        ),
+    )
+
+    claim_scope = (
+        "Among the 32 F_cut maps on the two-cube with off-patch o=0, whether "
+        "cov9>0 equals wt1∨adj2∨vertex3, and whether positivity implies "
+        "that OR, is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the 9-site positivity-versus-Q6 comparison and does not adopt Q6",
+        claim_scope in note and "Displayed, not adopted" in note,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "reachability_to_target: advances",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "Theorem 1",
+        "Theorem 2",
+        "Theorem 3",
+        "|F_cut| = 32",
+        "No-Go Discipline disposition: **PASS**",
+    )
+    forbidden = ("G_" + "N", "1/" + "r", "1/" + "r^2", "Lattice-" + "named", "not a " + "TOE")
+    checks.check(
+        "note-contract",
+        "machine fields, three theorems, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and note.count("**ATTEMPTED**") == 6
+        and not any(phrase in note or phrase in self_source for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the axiom memo is unedited and the theorem proposes no axiom change",
+        "### Lattice / Physical Locality" in axiom
+        and "### Qubit / Site Possibility" in axiom
+        and "### Admissibility / Local Constraint" in axiom
+        and "### Record / Fixed Reality" in axiom
+        and "F_cut" not in axiom
+        and "f_L1" not in axiom
+        and "no axiom or approved primitive is added" in note
+        and "Do not write `Q6` into Admissibility" in note,
+    )
+    checks.check(
+        "off-patch-zero",
+        "off-patch occupancy is the explicit 0 default, not a blank-block",
+        "off-patch occupancy `0`" in note
+        and "off-patch o=0" in note
+        and "blank-block is a different rule" in note,
+    )
+    checks.check(
+        "l1-definition-in-note",
+        "the note defines f_L1 as unbalanced-axis / n != 0 and rejects Hamming",
+        "`f_L1(c)=1` if and only if some axis is unbalanced" in note_flat
+        and "`n_μ = c_{+μ} − c_{-μ}` is nonzero" in note
+        and "This is **not** Hamming parity" in note,
+    )
+    checks.check(
+        "not-leftover-c5q6-c7q6-c11q6-or-c9sel",
+        "the residual is new k for the named 3-bit OR, not leftover of c5q6/c7q6/c11q6 or c9sel",
+        "Not leftover-character of c5q6" in note
+        and "Not leftover-character of c7q6" in note
+        and "Not leftover-character of c11q6" in note
+        and "Not leftover-character of c9sel" in note
+        and "New k for the named 3-bit OR" in note
+        and "cov5>0` implies `Q6" in note
+        and "cov7>0` implies `Q6" in note
+        and "cov11>0" in note
+        and "N_pos = 26" in note
+        and "N_Q6 = 28" in note
+        and "does not adopt Q6" in self_source,
+    )
+    checks.check(
+        "q6-definition-and-l1-in-class",
+        "Q6 is wt1 or adj2 or vertex3 and f_L1 satisfies Q6",
+        selector_Q6((1, 0, 1, 1, 1))
+        and selector_Q6((0, 0, 0, 1, 0))
+        and selector_Q6((0, 0, 1, 0, 0))
+        and selector_Q6((1, 0, 0, 0, 0))
+        and selector_Q6((1, 1, 0, 0, 0))
+        and not selector_Q6((0, 0, 0, 0, 0))
+        and not selector_Q6((0, 0, 0, 0, 1))
+        and not selector_Q6((0, 1, 0, 0, 0))
+        and not selector_Q6((0, 1, 0, 0, 1))
+        and cov_l1 == cov_by_remaining[(1, 0, 1, 1, 1)],
+    )
+
+    print("per_element: checked exactly — each of the 64 neighbor 6-tuples is assigned its axis-type orbit")
+    print("per_site: checked exactly — each of the twelve two-cube vertices uses the same six-direction stencil")
+    print("per_mode: checked exactly — every F_cut map is scored on 220 nine-site seeds against displayed Q6")
+    print("per_block: checked exactly — N_pos, N_Q6, and N_both are the F_cut positivity-versus-Q6 counts on this patch")
+    print("lattice_wide: checked and not executed — no Z^3-wide formation law or physical Admissibility selector is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 32 F_cut maps on the two-cube with off-patch o=0, cov9>0 is not equivalent to Q6. N_pos=26, N_Q6=28, N_both=25. Positivity does not imply Q6. Unique Q6-false positive (0,1,0,0,1). Displayed, not adopted.

## Runner

`scripts/f_cut_cov9_q6_selector_test_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.