### PR TITLE
feat(l1mink): displayed L1 ell1 arrival is not Minkowski light

### DIFF
--- a/docs/L1_MINKOWSKI_LIGHT_MATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/L1_MINKOWSKI_LIGHT_MATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,348 @@
+---
+claim_id: l1_minkowski_light_match_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Whether displayed L1 arrival `t=ℓ¹` on the radius-4 integer ball matches Euclidean-isotropic `c` and the discrete `ℓ²` null cone is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/l1_minkowski_light_match_2026_08_15.py
+---
+
+# Displayed L1 Arrival Does Not Match Observed Minkowski Light
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact integer comparison of the already-displayed origin-seed
+arrival `t(v)=|v|_1` on the radius-4 ball in `Z^3` against Euclidean-isotropic
+unit `c` and the discrete `ℓ²` null set. No occupancy step is re-run. No new
+spatial patch is grown. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/l1_minkowski_light_match_2026_08_15.py`](../scripts/l1_minkowski_light_match_2026_08_15.py)
+
+## Result Up Front
+
+The displayed first-arrival function from an origin seed on the cubic lattice
+is the taxicab / `ℓ¹` arrival
+
+```text
+t(v) = |v_1| + |v_2| + |v_3|
+```
+
+on `Z^3`. This note scores that already-displayed function on the finite set
+of nonzero integer vectors with `|v|_1 ≤ 4`. It does not attach `ℓ¹` as a
+primitive, does not write Minkowski structure or a boost into Admissibility,
+and does not adopt a Wick map.
+
+Observed light, used here only as an external comparison object, has one
+Euclidean-isotropic speed, discrete null relation `t^2 = |v|_2^2`, and
+Lorentz boosts that mix the time coordinate with a spatial axis.
+
+On the scored ball the displayed arrival matches none of those three
+properties.
+
+| census | value |
+|---|---:|
+| `N_ball` | `128` |
+| `N_null` | `24` |
+| `N_both` | `24` |
+
+`N_ball` is the number of nonzero `v ∈ Z^3` with `|v|_1 ≤ 4`. `N_null` is
+the number of those vectors with `t(v)^2 = |v|_2^2`. `N_both` is the same
+set, because the null comparison is evaluated only on the scored ball.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Those sentences supply the cubic graph and its 24 proper cube rotations. They
+do not supply a Minkowski metric, a Lorentz boost, an isotropic Euclidean
+speed, or an arrival law. The arrival `t=ℓ¹` is a displayed graph-distance
+function on that nearest-neighbor adjacency, scored here and not adopted.
+
+The scored object is taxicab arrival. It is not Hamming weight. An occupancy
+face of the form `n≠0` is not used and is not re-run.
+
+## Exact Objects
+
+For `v=(v_1,v_2,v_3) ∈ Z^3` write
+
+```text
+t(v) := |v_1| + |v_2| + |v_3|,
+|v|_2^2 := v_1^2 + v_2^2 + v_3^2.
+```
+
+The scored set is
+
+```text
+B := { v ∈ Z^3 : v ≠ 0 and t(v) ≤ 4 }.
+```
+
+The discrete null set on that ball is
+
+```text
+N := { v ∈ B : t(v)^2 = |v|_2^2 }.
+```
+
+All comparisons are integer. No continuum interpolant and no new occupancy
+propagation on a `4×4×4` or any other spatial patch is introduced.
+
+## Theorem 1 — Euclidean-Isotropic Unit `c` Fails
+
+A Euclidean-isotropic unit speed would require the ratio
+
+```text
+t(v)^2 / |v|_2^2
+```
+
+to be constant on `B`. It is not. The axis witness `(1,0,0)` gives
+
+```text
+t=1,   |v|_2^2=1,   t^2 / |v|_2^2 = 1.
+```
+
+The face-diagonal witness `(1,1,0)` gives
+
+```text
+t=2,   |v|_2^2=2,   t^2 / |v|_2^2 = 2.
+```
+
+A common positive rescaling `t ↦ k t` cannot equalize those two ratios,
+because both numerator and the comparison remain homogeneous of degree two
+and the ratio `2/1` is invariant. Therefore displayed `ℓ¹` arrival is not
+one Euclidean-isotropic `c`.
+
+## Theorem 2 — Discrete `ℓ²` Null Is A Proper Subset
+
+The identity `t(v)^2 = |v|_2^2` expands to
+
+```text
+2(|v_1 v_2| + |v_1 v_3| + |v_2 v_3|) = 0,
+```
+
+so at most one coordinate is nonzero. On `B` those axis vectors are exactly
+the `6×4=24` points `±r e_i` for `r=1,2,3,4` and `i=1,2,3`. The
+face-diagonal witness `(1,1,0)` lies in `B` with arrival `2` and
+`|v|_2^2=2`, but `t^2=4 ≠ 2`. Hence `N` is a proper subset of `B`, with
+
+```text
+N_ball=128,    N_null=24,    N_both=24.
+```
+
+Displayed `ℓ¹` arrival is therefore not the discrete `ℓ²` null cone.
+
+## Theorem 3 — Cube Rotations Do Not Mix Time And Space
+
+Observed Lorentz boosts mix a time coordinate with a spatial axis. The
+standard rational boost with `γ=5/4` and `β=3/5` sends
+
+```text
+(t,x) ↦ ((5t-3x)/4, (5x-3t)/4)
+```
+
+and therefore mixes `t` with `x`.
+
+The Lattice axiom's 24 proper cube rotations act on `Z^3` alone. Each is a
+signed permutation of determinant `+1`. Every such map preserves every `ℓ¹`
+sphere `{v : t(v)=r}` and every Euclidean length-squared `|v|_2^2`. The
+arrival value `t(v)` is unchanged because it is a function of the spatial
+vector only; no rotation manufactures a mixed `(t,x)` pair.
+
+Displayed L1 light is therefore not observed Minkowski light. The comparison
+is displayed, not adopted. This note does not write Minkowski structure, a
+boost, or a Wick map into Admissibility.
+
+## Representative Witnesses
+
+| `v` | `t=|v|_1` | `|v|_2^2` | `t^2/|v|_2^2` | in `N`? |
+|---|---:|---:|---:|---|
+| `(1,0,0)` | `1` | `1` | `1` | yes |
+| `(2,0,0)` | `2` | `4` | `1` | yes |
+| `(1,1,0)` | `2` | `2` | `2` | no |
+| `(1,1,1)` | `3` | `3` | `3` | no |
+| `(2,1,0)` | `3` | `5` | `9/5` | no |
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer comparison of displayed t=ℓ¹ on the radius-4 ball against isotropic-c constancy, the discrete ℓ² null set, and the 24 cube rotations. Observed Minkowski structure is an external comparison object, not a derived or adopted law."
+trace_class: negative_route_pruning
+target_claim_id: displayed_l1_matches_observed_minkowski_light
+target_blocker_text: "displayed L1 arrival is taxicab; observed light is Euclidean-isotropic with an ℓ² null cone and boosts"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Keep t=ℓ¹ displayed and unattached. Do not adopt a Wick map or write a boost into Admissibility. Any Lorentzian reconstruction is a separate bridge."
+conditional_surface_status: "exact on the scored radius-4 integer ball; no occupancy re-run and no adopted Minkowski law"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Proof-Obligation Boundary
+
+| Obligation | Disposition |
+|---|---|
+| identify displayed arrival as `t=ℓ¹` | scored displayed function; not attached |
+| Euclidean-isotropic unit `c` on `B` | closed by Theorem 1; ratios `1` and `2` |
+| discrete `ℓ²` null census | closed by Theorem 2; `128/24/24` |
+| 24 proper cube rotations preserve `ℓ¹` spheres | closed by Theorem 3 |
+| cube rotations mix `t` with a spatial axis | closed in the negative; they do not |
+| observed boosts mix `t` and `x` | external comparison identity only |
+| re-run occupancy or grow a new patch | outside the claim |
+| adopt Minkowski, a boost, or a Wick map | outside the claim; not written into axioms |
+
+The proof boundary is **CONDITIONAL** on treating `t=ℓ¹` as the already
+displayed arrival and treating Minkowski light as an external comparison
+object. Displayed, not adopted.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice / Admissibility wording | cubic graph and 24 proper rotations | approved `minimal_axioms`; no Minkowski content |
+| displayed arrival `t=ℓ¹` | scored function | displayed graph distance; not attached |
+| radius-4 integer ball | finite comparison domain | declared; integer enumeration only |
+| Euclidean-isotropic `c` and `t^2=|v|_2^2` | external comparison objects | not derived, not adopted |
+| Lorentz boosts | external comparison objects | not derived, not adopted |
+| occupancy / `n≠0` face | unused | not re-run |
+| Hamming weight | unused | not the arrival function |
+| observational data | input | none fitted |
+
+## Boundary And Non-Claims
+
+- The note does not attach `ℓ¹` as a primitive or as axiom content.
+- It does not write Minkowski structure, a Lorentz boost, or a Wick map into
+  Admissibility or any other axiom.
+- It does not re-run an occupancy step and does not grow L1 on a `4×4×4` or
+  any new spatial patch.
+- It does not identify Hamming weight with arrival.
+- It does not claim that a later, separately derived Lorentzian reconstruction
+  is impossible.
+- It does not edit an axiom or install a framework primitive.
+
+## Value Gate (V1–V5)
+
+| # | Question | Answer |
+|---|---|---|
+| V1 | Named obstruction addressed? | It scores whether displayed `t=ℓ¹` matches Euclidean-isotropic `c` and the discrete `ℓ²` null cone. |
+| V2 | New content? | The durable content is the exact radius-4 census and the three closed mismatch theorems. |
+| V3 | Independently checkable? | Yes. The ball, ratios, null set, and 24 rotations are exact integers. |
+| V4 | More than a restatement? | Yes. Prior display of taxicab arrival is not itself a comparison to observed light. |
+| V5 | One-step relabel? | No. Constancy, null membership, and boost-versus-cube-rotation are distinct checks. |
+
+## No-Go Discipline Gate
+
+The only negative shipped is: the displayed arrival `t=ℓ¹` on the radius-4
+integer ball is not Euclidean-isotropic unit `c`, is not the discrete `ℓ²`
+null cone, and is not mixed by the 24 cube rotations the way a Lorentz boost
+mixes `t` and `x`. No global Lorentzian non-derivability is claimed.
+
+### N1 — Materially distinct routes
+
+| Route | Attempt and outcome | Marker |
+|---|---|---|
+| Constant rescaling of `t` | `t ↦ k t` leaves the ratio of `(1,0,0)` to `(1,1,0)` equal to `2` | **ATTEMPTED** |
+| Restrict the domain to axes | Then `t^2=|v|_2^2` holds, but `(1,1,0)` is excluded from the scored ball comparison | **ATTEMPTED** |
+| Replace arrival by Hamming / support count | `(2,0,0)` has support-count `1` and taxicab arrival `2`; that is a different function | **ATTEMPTED** |
+| Replace arrival by Euclidean `|v|_2` | That is not the displayed function being scored | **ATTEMPTED** |
+| Adopt a Wick map or boost | Exits the claim; Minkowski is not written into Admissibility | **ATTEMPTED** |
+| Re-run occupancy on a new patch | Exits the claim; the arrival function is scored as already displayed | **ATTEMPTED** |
+
+### N2 — Wall independence
+
+For a later Lorentzian reconstruction the open set is not collapsed by this
+mismatch:
+
+- `W1`: a physical clock / time-metric bridge;
+- `W2`: an isotropic Euclidean spatial form at the comparison interface;
+- `W3`: a boost or mixing law relating time and space.
+
+| Pair | First closes second? | Second closes first? | Independent? |
+|---|---:|---:|---:|
+| `W1/W2` | no | no | yes |
+| `W1/W3` | no | no | yes |
+| `W2/W3` | no | no | yes |
+
+Scoring displayed `ℓ¹` against those objects does not attach any of them.
+
+### N3 — Hidden-condition scan
+
+| Phrase/object | Classification |
+|---|---|
+| displayed `t=ℓ¹` | explicit scored function; not attached |
+| radius-4 integer ball | explicit finite domain |
+| Euclidean-isotropic `c` | external comparison object |
+| discrete `ℓ²` null | external comparison object |
+| 24 proper cube rotations | Lattice axiom content |
+| Lorentz boosts | external comparison identity; not adopted |
+| occupancy / Hamming | unused, not hidden premises |
+
+### N4 — Residual matching
+
+| Witness | Witness residual | Current residual | Match? |
+|---|---|---|---:|
+| displayed taxicab arrival | `t(v)=|v|_1` from an origin seed | score that function, do not re-derive it | yes |
+| observed Minkowski light | isotropic `c`, `ℓ²` null, boosts | report the mismatch on the radius-4 ball | yes |
+
+This is not leftover character of a prior occupancy or first-arrival display.
+Those displays supply the function being scored; they do not already compare
+it to observed Minkowski light.
+
+### N5 — Rhetoric audit
+
+- per-element: every nonzero integer vector with `|v|_1 ≤ 4` is enumerated;
+- per-site: only the origin-seed displayed arrival is used; no new site law;
+- per-mode: no spectral decomposition is used or excluded;
+- per-block: the radius-4 ball is the only comparison block;
+- lattice-wide: no new lattice dynamics, occupancy growth, or adopted
+  Minkowski law is claimed.
+
+### N6 — Partial-closure path
+
+A separately supplied or derived Lorentzian reconstruction, clock map, or
+continuum comparison remains live. Closing any such bridge would be new
+structure, not a match of the displayed `ℓ¹` arrival. The axioms need not be
+edited to keep that route open.
+
+### N7 — Hostile steelman
+
+> Graph distance on `Z^3` is only a discrete stand-in. After a Wick rotation
+> or a large-scale Euclidean-to-Lorentzian map, the same cubic symmetry could
+> present as Minkowski light. The mismatch is an artifact of scoring the
+> raw taxicab function.
+
+**Answer.** The claim scores the displayed function, not a hypothetical later
+map. Theorem 1 and Theorem 2 fail on that function with integer witnesses.
+Theorem 3 records that the 24 cube rotations already present in the Lattice
+axiom do not mix `t` with `x`. A Wick map or boost would be additional
+adopted structure, which this note refuses to write into Admissibility.
+
+### N8 — Cross-cycle echo
+
+Kinetic-form isotropy, when approved, equalizes Euclidean temporal and
+spatial quadratic coefficients. Linear temporal reparameterization of such a
+form is a coordinate identity and does not select a physical clock. The
+present note agrees with that boundary: displayed `ℓ¹` arrival is not itself
+Minkowski light, and no clock or boost is adopted here.
+
+**No-Go Discipline status: PASS** for the narrowed displayed-versus-observed
+comparison.
+
+## Primary Runner
+
+The paired runner enumerates the radius-4 integer ball, computes the three
+census integers, checks the two ratio witnesses, classifies the discrete
+null set, generates the 24 proper cube rotations, compares them to a
+rational boost identity, and pins the note/axiom contract. It writes no
+cache and no governance surface.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11712,6 +11712,10 @@
   },
   "kubo_range_of_validity_note": {
    "deps_hash": "ba29b296b2a4",
+   "out_degree": 1
+  },
+  "l1_minkowski_light_match_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a": {

--- a/logs/runner-cache/l1_minkowski_light_match_2026_08_15.txt
+++ b/logs/runner-cache/l1_minkowski_light_match_2026_08_15.txt
@@ -1,0 +1,50 @@
+===== runner cache v1 =====
+runner: scripts/l1_minkowski_light_match_2026_08_15.py
+runner_sha256: 774a1e38837b9ef0d276260ad9463787a0c641cabfd4fb4a27d10ca56a3c10b8
+input_fingerprint_sha256: f116407bd50d6adf429fb19c062196c36bfcb7cfce6fc7b425e274fa5dc2c22e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/L1_MINKOWSKI_LIGHT_MATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: displayed t=l1 is scored as already displayed; Euclidean-isotropic c, discrete l2 null, and boosts are external comparison objects; no observation or fit is used
+package_local_integrity_reads: the note and current minimal axiom are read; no cache or governance surface is written
+claim_scope: Whether displayed L1 arrival t=l1 on the radius-4 integer ball matches Euclidean-isotropic c and the discrete l2 null cone is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and current axiom memo
+PASS: lattice-axiom the authority supplies Z^3, nearest-neighbor adjacency, and proper cubic rotations
+PASS: admissibility-axiom Admissibility is a nearest-neighbor rule covariant under those rotations
+PASS: axioms-unedited the axiom memo contains no Minkowski, boost, Wick, or attached L1 arrival
+PASS: integer-ball-census the nonzero radius-4 l1 ball has N_ball=128 distinct integer vectors
+PASS: l1-sphere-formula the l1 spheres have sizes 6, 18, 38, 66, matching 4 r^2 + 2
+PASS: theorem1-axis-witness (1,0,0) gives t^2 / |v|_2^2 = 1/1 = 1
+PASS: theorem1-face-witness (1,1,0) gives t^2 / |v|_2^2 = 4/2 = 2
+PASS: theorem1-not-constant t^2 / |v|_2^2 is not constant on the scored ball
+PASS: constant-rescale-fails a common positive rescaling of t cannot equalize the two witness ratios
+PASS: theorem2-census N_ball=128, N_null=24, N_both=24
+PASS: theorem2-proper-subset the discrete null set on the ball is a proper subset; (1,1,0) is the witness
+PASS: theorem2-axis-characterization null vectors on the ball are exactly the 24 axis points, and no off-axis point is null
+PASS: arrival-not-hamming displayed arrival is taxicab l1, not Hamming / support count
+PASS: cube-rotation-order there are exactly 24 proper cube rotations
+PASS: theorem3-l1-spheres every proper cube rotation preserves every l1 sphere and every |v|_2^2
+PASS: theorem3-no-time-mix cube rotations act on space only and leave the arrival value unmixed
+PASS: observed-boost-mixes the comparison boost (gamma=5/4, beta=3/5) mixes t with x
+PASS: note-claim-contract the note states the three theorems, census, and displayed-not-adopted scope
+PASS: note-dependency-contract frontmatter names only the current axiom boundary
+PASS: note-no-go-contract the note records all eight stress-test sections
+PASS: note-quotes-axioms the note quotes the Lattice and Admissibility sentences it uses
+PASS: note-reports-census the note reports the independently computed census integers
+PASS: forbidden-rhetoric note and runner avoid the forbidden phrases and rejected broad claims
+PASS: no-occupancy-rerun the source refuses a new occupancy step and a new spatial patch
+per_element: checked — every nonzero integer vector with |v|_1 <= 4 is enumerated exactly
+per_site: checked and not executed — only the origin-seed displayed arrival is scored; no new site law is claimed
+per_mode: checked and not executed — no spectral decomposition is used
+per_block: checked — the radius-4 integer ball is the only comparison block
+lattice_wide: checked and not executed — no occupancy growth and no adopted Minkowski law is claimed
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/l1_minkowski_light_match_2026_08_15.py
+++ b/scripts/l1_minkowski_light_match_2026_08_15.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Exact integer comparison of displayed L1 arrival to observed Minkowski light.
+
+Scores the already-displayed origin-seed arrival t(v)=|v|_1 on the nonzero
+radius-4 integer ball.  No occupancy step is re-run, no new spatial patch is
+grown, and no Minkowski structure is written into the axioms.
+"""
+
+from __future__ import annotations
+
+import ast
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/L1_MINKOWSKI_LIGHT_MATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/L1_MINKOWSKI_LIGHT_MATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Vec = tuple[int, int, int]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def arrival(vec: Vec) -> int:
+    """Displayed taxicab / ℓ¹ arrival from the origin."""
+
+    return abs(vec[0]) + abs(vec[1]) + abs(vec[2])
+
+
+def euclid_sq(vec: Vec) -> int:
+    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]
+
+
+def support_count(vec: Vec) -> int:
+    """Number of nonzero coordinates; not the displayed arrival."""
+
+    return sum(1 for coord in vec if coord != 0)
+
+
+def radius_four_ball() -> tuple[Vec, ...]:
+    points: list[Vec] = []
+    for coords in product(range(-4, 5), repeat=3):
+        vec = (int(coords[0]), int(coords[1]), int(coords[2]))
+        if vec != (0, 0, 0) and arrival(vec) <= 4:
+            points.append(vec)
+    return tuple(points)
+
+
+def apply_matrix(matrix: tuple[tuple[int, int, int], ...], vec: Vec) -> Vec:
+    return tuple(
+        matrix[i][0] * vec[0] + matrix[i][1] * vec[1] + matrix[i][2] * vec[2]
+        for i in range(3)
+    )
+
+
+def permutation_sign(perm: tuple[int, int, int]) -> int:
+    inversions = 0
+    for i in range(3):
+        for j in range(i + 1, 3):
+            inversions += int(perm[i] > perm[j])
+    return -1 if inversions % 2 else 1
+
+
+def proper_cube_rotations() -> tuple[tuple[tuple[int, int, int], ...], ...]:
+    rotations: list[tuple[tuple[int, int, int], ...]] = []
+    for perm in permutations(range(3)):
+        perm_t = (int(perm[0]), int(perm[1]), int(perm[2]))
+        for signs in product((-1, 1), repeat=3):
+            if permutation_sign(perm_t) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src in range(3):
+                matrix[perm_t[src]][src] = signs[src]
+            rotations.append(tuple(tuple(row) for row in matrix))
+    return tuple(rotations)
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                    return ast.literal_eval(node.value)
+    raise RuntimeError("AUDIT_INPUT_PATHS assignment not found")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: displayed t=l1 is scored as already "
+        "displayed; Euclidean-isotropic c, discrete l2 null, and boosts are "
+        "external comparison objects; no observation or fit is used"
+    )
+    print(
+        "package_local_integrity_reads: the note and current minimal axiom "
+        "are read; no cache or governance surface is written"
+    )
+    print(
+        "claim_scope: Whether displayed L1 arrival t=l1 on the radius-4 "
+        "integer ball matches Euclidean-isotropic c and the discrete l2 "
+        "null cone is reported. Displayed, not adopted."
+    )
+
+    expected_paths = (
+        "docs/L1_MINKOWSKI_LIGHT_MATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    parsed_paths = parse_audit_input_paths(runner_source)
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and current axiom memo",
+        AUDIT_INPUT_PATHS == expected_paths
+        and parsed_paths == expected_paths
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+        (AUDIT_INPUT_PATHS, parsed_paths),
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility_sentence = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    checks.check(
+        "lattice-axiom",
+        "the authority supplies Z^3, nearest-neighbor adjacency, and proper cubic rotations",
+        lattice_sentence in normalized_axiom,
+    )
+    checks.check(
+        "admissibility-axiom",
+        "Admissibility is a nearest-neighbor rule covariant under those rotations",
+        admissibility_sentence in normalized_axiom,
+    )
+    axiom_forbidden = (
+        "Minkowski",
+        "Lorentz boost",
+        "t(v)=|v|_1",
+        "Wick",
+    )
+    checks.check(
+        "axioms-unedited",
+        "the axiom memo contains no Minkowski, boost, Wick, or attached L1 arrival",
+        all(phrase not in axiom for phrase in axiom_forbidden),
+        [phrase for phrase in axiom_forbidden if phrase in axiom],
+    )
+
+    ball = radius_four_ball()
+    n_ball = len(ball)
+    null_set = tuple(vec for vec in ball if arrival(vec) * arrival(vec) == euclid_sq(vec))
+    n_null = len(null_set)
+    n_both = n_null
+    unique_ball = set(ball)
+    checks.check(
+        "integer-ball-census",
+        "the nonzero radius-4 l1 ball has N_ball=128 distinct integer vectors",
+        n_ball == 128 and len(unique_ball) == 128,
+        n_ball,
+    )
+    sphere_counts = {
+        radius: sum(1 for vec in ball if arrival(vec) == radius) for radius in (1, 2, 3, 4)
+    }
+    checks.check(
+        "l1-sphere-formula",
+        "the l1 spheres have sizes 6, 18, 38, 66, matching 4 r^2 + 2",
+        sphere_counts == {1: 6, 2: 18, 3: 38, 4: 66}
+        and all(sphere_counts[radius] == 4 * radius * radius + 2 for radius in (1, 2, 3, 4)),
+        sphere_counts,
+    )
+
+    axis = (1, 0, 0)
+    face = (1, 1, 0)
+    axis_ratio_num = arrival(axis) * arrival(axis)
+    axis_ratio_den = euclid_sq(axis)
+    face_ratio_num = arrival(face) * arrival(face)
+    face_ratio_den = euclid_sq(face)
+    checks.check(
+        "theorem1-axis-witness",
+        "(1,0,0) gives t^2 / |v|_2^2 = 1/1 = 1",
+        axis in unique_ball
+        and axis_ratio_num == 1
+        and axis_ratio_den == 1
+        and axis_ratio_num // axis_ratio_den == 1,
+        (axis_ratio_num, axis_ratio_den),
+    )
+    checks.check(
+        "theorem1-face-witness",
+        "(1,1,0) gives t^2 / |v|_2^2 = 4/2 = 2",
+        face in unique_ball
+        and face_ratio_num == 4
+        and face_ratio_den == 2
+        and face_ratio_num // face_ratio_den == 2,
+        (face_ratio_num, face_ratio_den),
+    )
+    distinct_ratios = {
+        (arrival(vec) * arrival(vec), euclid_sq(vec)) for vec in ball
+    }
+    reduced = set()
+    for num, den in distinct_ratios:
+        gcd = num
+        value = den
+        while value:
+            gcd, value = value, gcd % value
+        reduced.add((num // gcd, den // gcd))
+    checks.check(
+        "theorem1-not-constant",
+        "t^2 / |v|_2^2 is not constant on the scored ball",
+        len(reduced) > 1 and (1, 1) in reduced and (2, 1) in reduced,
+        reduced,
+    )
+    common_scale_preserves_split = (1 * 9, 1 * 9) != (2 * 9, 1 * 9)
+    checks.check(
+        "constant-rescale-fails",
+        "a common positive rescaling of t cannot equalize the two witness ratios",
+        common_scale_preserves_split
+        and (face_ratio_num * axis_ratio_den) != (axis_ratio_num * face_ratio_den),
+    )
+
+    axis_null = all(
+        arrival(vec) * arrival(vec) == euclid_sq(vec)
+        for vec in ball
+        if support_count(vec) == 1
+    )
+    off_axis_not_null = all(
+        arrival(vec) * arrival(vec) != euclid_sq(vec)
+        for vec in ball
+        if support_count(vec) > 1
+    )
+    checks.check(
+        "theorem2-census",
+        "N_ball=128, N_null=24, N_both=24",
+        n_ball == 128 and n_null == 24 and n_both == 24,
+        (n_ball, n_null, n_both),
+    )
+    checks.check(
+        "theorem2-proper-subset",
+        "the discrete null set on the ball is a proper subset; (1,1,0) is the witness",
+        n_null < n_ball
+        and face not in set(null_set)
+        and arrival(face) == 2
+        and euclid_sq(face) == 2
+        and arrival(face) * arrival(face) == 4,
+        (n_null, n_ball, face),
+    )
+    checks.check(
+        "theorem2-axis-characterization",
+        "null vectors on the ball are exactly the 24 axis points, and no off-axis point is null",
+        axis_null
+        and off_axis_not_null
+        and all(support_count(vec) == 1 for vec in null_set)
+        and len(null_set) == 24,
+    )
+
+    ham_axis = (2, 0, 0)
+    checks.check(
+        "arrival-not-hamming",
+        "displayed arrival is taxicab l1, not Hamming / support count",
+        arrival(ham_axis) == 2
+        and support_count(ham_axis) == 1
+        and arrival(face) == 2
+        and support_count(face) == 2
+        and arrival(ham_axis) != support_count(ham_axis),
+        (arrival(ham_axis), support_count(ham_axis)),
+    )
+
+    rotations = proper_cube_rotations()
+    checks.check(
+        "cube-rotation-order",
+        "there are exactly 24 proper cube rotations",
+        len(rotations) == 24 and len(set(rotations)) == 24,
+        len(rotations),
+    )
+    identity = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    sphere_preserved = all(
+        arrival(apply_matrix(matrix, vec)) == arrival(vec)
+        and euclid_sq(apply_matrix(matrix, vec)) == euclid_sq(vec)
+        for matrix in rotations
+        for vec in ball
+    )
+    spheres_invariant = True
+    for radius in (1, 2, 3, 4):
+        sphere = {vec for vec in ball if arrival(vec) == radius}
+        for matrix in rotations:
+            image = {apply_matrix(matrix, vec) for vec in sphere}
+            if image != sphere:
+                spheres_invariant = False
+    checks.check(
+        "theorem3-l1-spheres",
+        "every proper cube rotation preserves every l1 sphere and every |v|_2^2",
+        identity in rotations and sphere_preserved and spheres_invariant,
+    )
+    checks.check(
+        "theorem3-no-time-mix",
+        "cube rotations act on space only and leave the arrival value unmixed",
+        all(len(matrix) == 3 and all(len(row) == 3 for row in matrix) for matrix in rotations)
+        and all(arrival(apply_matrix(matrix, face)) == arrival(face) for matrix in rotations),
+    )
+
+    # Observed comparison identity only: the 3-4-5 rational boost mixes t and x.
+    t_in, x_in = 4, 0
+    t_out = 5 * t_in - 3 * x_in
+    x_out = 5 * x_in - 3 * t_in
+    checks.check(
+        "observed-boost-mixes",
+        "the comparison boost (gamma=5/4, beta=3/5) mixes t with x",
+        t_out == 20 and x_out == -12 and t_out != 4 * t_in,
+        (t_out, x_out),
+    )
+
+    required_note_phrases = (
+        "t(v) = |v_1| + |v_2| + |v_3|",
+        "N_ball=128",
+        "N_null=24",
+        "N_both=24",
+        "(1,0,0)",
+        "(1,1,0)",
+        "t^2 / |v|_2^2 = 1",
+        "t^2 / |v|_2^2 = 2",
+        "Displayed, not adopted",
+        "does not write Minkowski structure, a Lorentz boost, or a Wick map into",
+        "It is not Hamming weight",
+        "occupancy face of the form `n≠0` is not used",
+        "does not grow L1 on a `4×4×4`",
+        "claim_scope: \"Whether displayed L1 arrival `t=ℓ¹` on the radius-4 integer ball matches Euclidean-isotropic `c` and the discrete `ℓ²` null cone is reported. Displayed, not adopted.\"",
+        "actual_current_surface_status: bounded-support",
+        "hypothetical_axiom_status: \"no edit\"",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "**No-Go Discipline status: PASS**",
+        "**Type:** bounded_theorem",
+    )
+    checks.check(
+        "note-claim-contract",
+        "the note states the three theorems, census, and displayed-not-adopted scope",
+        all(phrase in note or phrase in normalized_note for phrase in required_note_phrases),
+        [phrase for phrase in required_note_phrases if phrase not in note and phrase not in normalized_note],
+    )
+    checks.check(
+        "note-dependency-contract",
+        "frontmatter names only the current axiom boundary",
+        "  - minimal_axioms" in note
+        and "upstream_dependencies:" in note
+        and note.count("\n  - ") == 1,
+    )
+    checks.check(
+        "note-no-go-contract",
+        "the note records all eight stress-test sections",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    checks.check(
+        "note-quotes-axioms",
+        "the note quotes the Lattice and Admissibility sentences it uses",
+        lattice_sentence in normalized_note and admissibility_sentence in normalized_note,
+    )
+    checks.check(
+        "note-reports-census",
+        "the note reports the independently computed census integers",
+        f"`N_ball` | `{n_ball}`" in note
+        and f"`N_null` | `{n_null}`" in note
+        and f"`N_both` | `{n_both}`" in note,
+    )
+
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "Therefore Minkowski is impossible",
+        "write Minkowski into Admissibility as axiom content",
+        "occupancy is re-run",
+        "grow L1 on a new 4x4x4 patch",
+    )
+    checks.check(
+        "forbidden-rhetoric",
+        "note and runner avoid the forbidden phrases and rejected broad claims",
+        all(phrase not in note for phrase in forbidden),
+        [phrase for phrase in forbidden if phrase in note],
+    )
+    checks.check(
+        "no-occupancy-rerun",
+        "the source refuses a new occupancy step and a new spatial patch",
+        "No occupancy step is re-run" in note
+        and "No new spatial patch is grown" in normalized_note
+        and "4×4×4" in note
+        and "any new spatial patch" in normalized_note,
+    )
+
+    print(
+        "per_element: checked — every nonzero integer vector with |v|_1 <= 4 "
+        "is enumerated exactly"
+    )
+    print(
+        "per_site: checked and not executed — only the origin-seed displayed "
+        "arrival is scored; no new site law is claimed"
+    )
+    print(
+        "per_mode: checked and not executed — no spectral decomposition is used"
+    )
+    print(
+        "per_block: checked — the radius-4 integer ball is the only comparison block"
+    )
+    print(
+        "lattice_wide: checked and not executed — no occupancy growth and no "
+        "adopted Minkowski law is claimed"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed L1 arrival t=|v|_1 on the radius-4 integer ball is not Euclidean-isotropic c and is not the discrete ell2 null cone. Witness (1,1,0): t=2, |v|_2^2=2, t^2=4. Census N_ball=128, N_null=24, N_both=24. The 24 proper cube rotations do not mix t with x. Displayed mismatch, not adopted. No axiom edit.

## Runner

`scripts/l1_minkowski_light_match_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.