### PR TITLE
feat(hopiso): cube-covariant NN hop costs force diamond light

### DIFF
--- a/docs/CUBE_COVARIANT_NN_HOP_COST_MINKOWSKI_MISMATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CUBE_COVARIANT_NN_HOP_COST_MINKOWSKI_MISMATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,318 @@
+---
+claim_id: cube_covariant_nn_hop_cost_minkowski_mismatch_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Whether every cube-covariant 6-NN hop-cost gives arrival proportional to ℓ¹, and whether that matches Euclidean-isotropic c / the discrete ℓ² null cone on the radius-4 integer ball, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py
+---
+
+# Cube-Covariant Six-Neighbor Hop Cost Forces First Arrival Proportional To ℓ¹
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact hop-cost covariance under the proper cube group on the six
+nearest-neighbor directions, the implied first-arrival function on the
+radius-4 integer ball, and a displayed comparison to Euclidean-isotropic `c`
+and the discrete `ℓ²` null cone. No occupancy step is run. No physical clock,
+boost, or Wick map is selected.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py`](../scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py)
+
+## Result Up Front
+
+Lattice names nearest-neighbor adjacency on `Z^3` and proper cubic rotations
+about each site. The six axis directions `{±x,±y,±z}` are one orbit of the
+proper cube group `G+` of order `24`. A hop-cost on that unit orbit is a map
+
+`w : {±x,±y,±z} → {positive integers}`.
+
+Cube-covariant means `w(gv)=w(v)` for every `g∈G+` and every axis direction
+`v`. Because the six directions form a single orbit, every cube-covariant `w`
+is a positive constant `w_0`. First arrival from the origin using only those
+hops is then the displayed function
+
+`t(v) = w_0 |v|_1`.
+
+That arrival is scored only as a displayed comparison object. It is not
+attached as a named kernel and is not written into Lattice or Admissibility.
+
+Euclidean-isotropic `c` would require `t(v)^2 / |v|_2^2` constant on nonzero
+`v` with `|v|_1 ≤ 4`. It is not: `(1,0,0)` gives `w_0^2` and `(1,1,0)` gives
+`2 w_0^2`. The discrete null set `{v : t(v)^2 = |v|_2^2}` is a proper subset
+of the same ball; the same witness `(1,1,0)` lies off the cone. Both
+comparisons are independent of the constant `w_0 ≥ 1`.
+
+Therefore no cube-covariant 6-NN unit-orbit member matches the displayed
+Minkowski-light comparisons. Displayed, not adopted. Do not adopt a Wick map.
+Do not write Minkowski into Admissibility.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences supply the six-neighbor graph and the proper-cube covariance
+used to score hop costs. They do not name a hop-cost, a first-arrival clock, a
+null cone, a boost, or a Wick map. This note does not edit them.
+
+Record is unused. The current Record boundary remains:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+No occupancy is grown on a new patch. The radius-4 integer ball is an
+enumeration domain for the already-displayed arrival function, not a new
+spatial construction.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "G+ orbit uniqueness, constancy of every cube-covariant hop-cost, first-arrival t(v)=w_0 |v|_1, and the two radius-4 comparison failures are finite exact statements. Minkowski light is a displayed comparator, not an adopted law."
+trace_class: negative_route_pruning
+target_claim_id: cube_covariant_nn_hop_cost_minkowski_mismatch
+target_blocker_text: "score whether cube-covariant 6-NN unit-orbit hop-costs can match Euclidean-isotropic c or the discrete ℓ² null cone"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Do not attach a named arrival kernel; if a later route wants isotropic c it must change the hop set, drop cube covariance, or add structure that is not scored here."
+conditional_surface_status: "exact for cube-covariant positive-integer hop-costs on the six-direction unit orbit; no adopted clock or axiom edit"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`, and
+
+`A = {±e_1, ±e_2, ±e_3}`.
+
+A proper cube matrix is a `3×3` monomial signed-permutation matrix with
+exactly one nonzero entry `±1` in each row and column and determinant `+1`.
+The proper cube group `G+` is the set of all such matrices. It acts on
+`Z^3` by ordinary matrix multiplication, and the action preserves `A`.
+
+A hop-cost is a map `w:A → {1,2,3,…}`. It is cube-covariant when
+`w(gv)=w(v)` for all `g∈G+` and all `v∈A`.
+
+A path from the origin to `v∈Z^3` is a finite sequence of steps from `A`.
+Its cost is the sum of `w` along the steps. First arrival `t(v)` is the
+minimal cost; `t(0)=0`. Only the six-direction unit orbit is used. Face
+diagonals and longer steps are a different hop set and are not scored.
+
+The taxicab and Euclidean quadratic forms on `Z^3` are the displayed
+comparators
+
+`|v|_1 = |v_1|+|v_2|+|v_3|`,
+
+`|v|_2^2 = v_1^2+v_2^2+v_3^2`.
+
+The finite comparison domain is the nonzero integer ball `|v|_1 ≤ 4`.
+
+## Theorem 1 — One Orbit, Constant Cost, Arrival Proportional To ℓ¹
+
+Every vector in `A` is `G+`-equivalent to `e_1`. Explicitly, the 90-degree
+rotation about `e_3` with matrix
+
+```text
+[[ 0,-1, 0],
+ [ 1, 0, 0],
+ [ 0, 0, 1]]
+```
+
+sends `e_1 ↦ e_2 ↦ -e_1 ↦ -e_2 ↦ e_1`. The 90-degree rotation about `e_2`
+with matrix
+
+```text
+[[ 0, 0, 1],
+ [ 0, 1, 0],
+ [-1, 0, 0]]
+```
+
+sends `e_1 ↦ -e_3` and `-e_3 ↦ -e_1`, and likewise places `±e_3` in the same
+orbit. Direct enumeration of `G+` confirms `|G+|=24` and `|G+ · e_1|=6`.
+
+If `w` is cube-covariant and `v=g e_1`, then `w(v)=w(e_1)`. Hence `w` is
+constant on `A`. Write `w_0` for that common positive integer.
+
+Any walk from `0` to `v` uses at least `|v|_1` steps, because each step
+changes one coordinate by `±1`. Extra cancelling pairs only raise the cost.
+A coordinate-monotone walk with exactly `|v_i|` steps of sign `sign(v_i)`
+along each axis exists and has cost `w_0 |v|_1`. Therefore
+
+`t(v) = w_0 |v|_1`.
+
+The identity is checked on the radius-4 ball by shortest-path search against
+the closed form. It is a displayed arrival, not an adopted physical clock.
+
+## Theorem 2 — Euclidean-Isotropic `c` Fails On The Radius-4 Ball
+
+Euclidean-isotropic unit `c` would require the displayed ratio
+
+`t(v)^2 / |v|_2^2`
+
+to be constant on nonzero `v` with `|v|_1 ≤ 4`. Substituting Theorem 1 gives
+
+`w_0^2 |v|_1^2 / |v|_2^2`.
+
+At `(1,0,0)` the value is `w_0^2`. At `(1,1,0)` the value is `2 w_0^2`.
+These are unequal for every integer `w_0 ≥ 1`. The mismatch is therefore
+forced by cube-covariant 6-NN hop costs, not by a special choice of the
+constant.
+
+## Theorem 3 — Discrete Null Cone Is A Proper Subset
+
+The displayed discrete null comparison is `t(v)^2 = |v|_2^2`. On the
+nonzero radius-4 ball this is a proper subset. The witness `(1,1,0)` has
+
+`t(1,1,0)^2 = 4 w_0^2`, `|v|_2^2 = 2`,
+
+so it is never null for integer `w_0 ≥ 1`. Axis sites with `w_0=1` do lie
+on the displayed cone, which is enough to show the cone is nonempty and
+still a proper subset.
+
+No cube-covariant 6-NN unit-orbit member therefore matches both displayed
+Minkowski-light comparisons (isotropic `c` and the discrete `ℓ²` null cone).
+The comparison is displayed, not adopted. A Wick map is not adopted. Minkowski
+structure is not written into Admissibility.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| quote current Lattice nearest-neighbor and proper-cube wording | source-bound |
+| quote current Admissibility covariance wording | source-bound |
+| enumerate `G+` and the six-direction orbit | closed by finite listing |
+| cube-covariant hop-costs are constant | closed by one-orbit transitivity |
+| first arrival equals `w_0 |v|_1` | closed by counting plus shortest-path check |
+| isotropic-`c` ratio fails on the radius-4 ball | closed by the two witnesses |
+| discrete null cone is a proper subset | closed by the same face-diagonal witness |
+| adopt Minkowski, a boost, or a Wick map | outside the claim |
+| grow occupancy on a new patch | not executed |
+| edit Lattice or Admissibility | `hypothetical_axiom_status: no edit` |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a physical light law is not a proof leaf because it is
+expressly not part of the target.
+
+## Imports And Non-Claims
+
+Only the current axiom memo is imported. No occupancy construction, no named
+arrival kernel, no boost matrix, and no Wick substitution is imported. The
+Euclidean-isotropic `c` test and the discrete `ℓ²` null test are displayed
+comparators on a finite integer ball.
+
+The theorem does not say that isotropic light is impossible in every later
+construction. It says that cube-covariant positive-integer hop-costs on the
+six-direction unit orbit force `t ∝ ℓ¹`, and that this displayed arrival fails
+the two stated comparisons.
+
+## Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It isolates hop-cost covariance on the Lattice six-neighbor orbit as the mechanism that forces first arrival proportional to `ℓ¹`. |
+| V2 | Current main names proper cubic rotations and nearest-neighbor adjacency, but does not score this hop-cost orbit argument against the displayed light comparisons. |
+| V3 | Group order, orbit size, shortest-path arrival, and the two witnesses are independently finite and exact. |
+| V4 | The result is more than a restatement of Lattice because it enumerates the hop-cost invariants and compares the implied arrival to two explicit tests. |
+| V5 | The comparisons remain displayed; the note does not install Minkowski structure or a clock. |
+
+## No-Go Discipline Gate
+
+The negative claim is restricted to cube-covariant 6-NN unit-orbit hop-costs
+and to the two displayed light comparisons on the radius-4 integer ball. No
+global impossibility of isotropic light is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| cube-covariant 6-NN hop-cost | equalize costs on the single `G+` orbit | executed; forces `t=w_0 |v|_1` |
+| non-covariant hop-cost | assign unequal axis costs | lives only after dropping cube covariance; mutation fails covariance |
+| larger hop set | add face diagonals or longer steps | different member; not the 6-NN unit orbit scored here |
+| drop covariance but keep 6-NN | direction-dependent costs | live different-object route; not cube-covariant |
+| occupancy on a new patch | grow a spatial configuration | not executed |
+| Wick map or boost | change the comparison form | not adopted |
+| write Minkowski into Admissibility | enlarge the axiom | forbidden; `no edit` |
+
+### N2 — wall independence
+
+Cube covariance, the six-direction hop set, the positive-integer cost type,
+and the two light comparisons are distinct inputs. The note claims no
+complete wall collection beyond this scored class.
+
+### N3 — hidden-condition scan
+
+The hop set, the group `G+`, cube covariance, the shortest-path arrival, the
+radius-4 domain, and both comparison predicates are declared. Occupancy,
+a Wick map, a boost, and an axiom edit are not silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies nearest-neighbor adjacency and proper cubic
+rotations, and an Admissibility rule covariant under those rotations. It does
+not name Minkowski light. The residual scored here is hop-cost covariance
+versus the displayed comparisons, not a leftover named-kernel character.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | six axis directions and named witnesses `(1,0,0)`, `(1,1,0)` | no continuum spacetime classification |
+| per site | first arrival from the origin on `Z^3` | no occupancy field |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | radius-4 integer ball | no new spatial patch |
+| lattice wide | checked and not executed | no global light-law derivation |
+
+### N6 — live partial-closure paths
+
+A later construction may change the hop set, drop cube covariance, or add
+structure that is not a 6-NN unit-orbit hop-cost. Those are different
+objects. They are not scored here and are not filled by writing Minkowski
+into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** A different positive integer on each axis could restore
+isotropic `c` while remaining a 6-NN member.
+
+**Answer:** The six directions are one `G+` orbit, so cube covariance forbids
+unequal axis costs. After covariance the only remaining free parameter is the
+overall constant `w_0`, which cancels out of the mismatch `2 w_0^2 ≠ w_0^2`.
+
+### N8 — cross-cycle echo
+
+This note does not attach a named arrival kernel and does not treat the
+comparison as leftover character of a previously named line or member. It
+scores only hop-cost covariance on the Lattice six-neighbor orbit and the
+displayed arrival `t ∝ ℓ¹`.
+
+**Gate disposition:** PASS for orbit constancy, displayed arrival
+`t(v)=w_0 |v|_1`, and the two finite comparison failures. FAIL / DO NOT SHIP
+for “Minkowski is adopted,” “Admissibility now contains a boost,” “a Wick map
+is selected,” or “occupancy was grown on a new patch.”
+
+## Primary Runner
+
+The primary runner enumerates `G+`, checks that the six directions are one
+orbit, tests cube-covariant constancy, computes first arrival by shortest
+path, compares `t^2/|v|_2^2` on the named witnesses, and confirms the
+discrete-null witness. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2821,6 +2821,10 @@
   "cte_rconn_spatial_tensor_color_bridge_is_a_cross_domain_coincidence_narrow_no_go_note_2026-06-08": {
    "deps_hash": "825a4024d61b",
    "out_degree": 4
+  },
+  "cube_covariant_nn_hop_cost_minkowski_mismatch_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cubic_anisotropy_sections_so3_frame_bounded_theorem_note_2026-06-17": {
    "deps_hash": "04fc7d8812c4",

--- a/logs/runner-cache/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.txt
+++ b/logs/runner-cache/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py
+runner_sha256: cd710d90d9a621e38de336f1731971781ecf6c0efb2f08582e88a90881f8b8c6
+input_fingerprint_sha256: bc3f4ae5c0222edb082ca8b2e6beb2c9e8cbfda6dc621a36c478d1b22ed6df5b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CUBE_COVARIANT_NN_HOP_COST_MINKOWSKI_MISMATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: current Lattice and Admissibility wording are source-bound; Minkowski light is a displayed comparator
+construction: G+ orbit of the six NN directions, cube-covariant hop-costs, shortest-path first arrival
+negative_scope: displayed t proportional to ell^1 fails isotropic c and the discrete ell^2 null cone; no axiom edit
+PASS: audit-inputs declared inputs are exactly the source note and the axiom memo
+PASS: source-lattice current cubic nearest-neighbor and proper-cube wording is pinned
+PASS: source-admissibility current covariance and local-condition wording is pinned
+PASS: source-no-minkowski-in-axioms the axiom memo does not name Minkowski, a boost, or a Wick map
+PASS: group-order the proper cube group has 24 matrices of determinant +1
+PASS: single-orbit the six axis directions are one G+ orbit of e_1
+PASS: covariant-constant every constant hop-cost is cube-covariant and the unequal mutation is not
+PASS: first-arrival-form shortest-path arrival equals w_0 |v|_1 on the radius-4 ball
+PASS: ratio-witnesses (1,0,0) gives w_0^2 and (1,1,0) gives 2 w_0^2 for every tested w_0
+PASS: ratio-not-constant t^2 / |v|_2^2 is not constant on the nonzero radius-4 ball
+PASS: discrete-null-subset discrete null t^2 = |v|_2^2 is a proper subset; (1,1,0) is the witness
+N_ball=128 N_null_w1=24 N_null_w2=0
+PASS: no-minkowski-match no cube-covariant 6-NN unit-orbit member matches both displayed light tests
+PASS: identity-rotations the named 90-degree generators sit in G+ and move e_1 onto the other axes
+PASS: note-contract machine fields, displayed-not-adopted boundary, N1-N8, and forbidden-phrase hygiene hold
+per_element: six axis directions, G+ orbit, and the two named witnesses are executed
+per_site: first arrival is shortest-path cost from the origin on Z^3
+per_mode: checked and not executed — no spectral claim occurs
+per_block: the radius-4 integer ball is the comparison domain
+lattice_wide: checked and not executed — no occupancy step and no axiom edit
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py
+++ b/scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Exact checks for cube-covariant 6-NN hop-cost versus displayed light tests."""
+
+from __future__ import annotations
+
+from heapq import heappop, heappush
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/CUBE_COVARIANT_NN_HOP_COST_MINKOWSKI_MISMATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Point = tuple[int, int, int]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+HopCost = dict[Point, int]
+
+AXES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+ORIGIN: Point = (0, 0, 0)
+AXIS_WITNESS: Point = (1, 0, 0)
+FACE_WITNESS: Point = (1, 1, 0)
+RADIUS = 4
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def matrix_det(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_linear(matrix: Matrix, vector: Point) -> Point:
+    return tuple(sum(matrix[i][j] * vector[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def proper_cube_group() -> tuple[Matrix, ...]:
+    """Signed permutation matrices with determinant +1."""
+    group: list[Matrix] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = []
+            for i in range(3):
+                row = [0, 0, 0]
+                row[perm[i]] = signs[i]
+                rows.append(tuple(row))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix_det(matrix) == 1:
+                group.append(matrix)
+    return tuple(group)
+
+
+def hop_orbit(seed: Point, group: tuple[Matrix, ...]) -> frozenset[Point]:
+    return frozenset(apply_linear(matrix, seed) for matrix in group)
+
+
+def l1_norm(vector: Point) -> int:
+    return abs(vector[0]) + abs(vector[1]) + abs(vector[2])
+
+
+def l2_sq(vector: Point) -> int:
+    return vector[0] * vector[0] + vector[1] * vector[1] + vector[2] * vector[2]
+
+
+def radius_ball(radius: int) -> tuple[Point, ...]:
+    points = []
+    for x, y, z in product(range(-radius, radius + 1), repeat=3):
+        point = (x, y, z)
+        if l1_norm(point) <= radius:
+            points.append(point)
+    return tuple(points)
+
+
+def constant_hop_cost(weight: int) -> HopCost:
+    if weight < 1:
+        raise ValueError("hop costs must be positive integers")
+    return {axis: weight for axis in AXES}
+
+
+def is_cube_covariant(weights: HopCost, group: tuple[Matrix, ...]) -> bool:
+    if set(weights) != set(AXES):
+        return False
+    if any(value < 1 for value in weights.values()):
+        return False
+    return all(
+        weights[apply_linear(matrix, axis)] == weights[axis]
+        for matrix in group
+        for axis in AXES
+    )
+
+
+def first_arrival(target: Point, weights: HopCost) -> int:
+    """Shortest-path cost from the origin on the six-direction graph."""
+    if target == ORIGIN:
+        return 0
+    bound = max(weights.values()) * (l1_norm(target) + 2)
+    best = {ORIGIN: 0}
+    queue: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while queue:
+        cost, site = heappop(queue)
+        if cost != best[site]:
+            continue
+        if site == target:
+            return cost
+        for hop, hop_weight in weights.items():
+            neighbor = (site[0] + hop[0], site[1] + hop[1], site[2] + hop[2])
+            next_cost = cost + hop_weight
+            if next_cost > bound:
+                continue
+            if next_cost < best.get(neighbor, bound + 1):
+                best[neighbor] = next_cost
+                heappush(queue, (next_cost, neighbor))
+    raise RuntimeError(f"no path found to {target}")
+
+
+def arrival_ratio(vector: Point, weights: HopCost) -> int:
+    """Return t(v)^2 / |v|_2^2 when that quotient is an integer."""
+    if vector == ORIGIN:
+        raise ValueError("ratio is undefined at the origin")
+    arrival = first_arrival(vector, weights)
+    spatial = l2_sq(vector)
+    if arrival * arrival % spatial != 0:
+        raise ValueError("displayed ratio is not an integer on this site")
+    return (arrival * arrival) // spatial
+
+
+def is_discrete_null(vector: Point, weights: HopCost) -> bool:
+    return first_arrival(vector, weights) ** 2 == l2_sq(vector)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice and Admissibility wording are source-bound; Minkowski light is a displayed comparator")
+    print("construction: G+ orbit of the six NN directions, cube-covariant hop-costs, shortest-path first arrival")
+    print("negative_scope: displayed t proportional to ell^1 fails isotropic c and the discrete ell^2 null cone; no axiom edit")
+
+    checks.check(
+        "audit-inputs",
+        "declared inputs are exactly the source note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CUBE_COVARIANT_NN_HOP_COST_MINKOWSKI_MISMATCH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    cubic_rotations = "proper cubic rotations about each site"
+    admissibility_cov = "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations."
+    admissibility_law = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor and proper-cube wording is pinned",
+        lattice_sentence in normalized_axiom
+        and cubic_rotations in normalized_axiom
+        and lattice_sentence in note
+        and cubic_rotations in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current covariance and local-condition wording is pinned",
+        admissibility_cov in normalized_axiom
+        and admissibility_law in normalized_axiom
+        and admissibility_cov in normalized_note
+        and admissibility_law in normalized_note,
+    )
+    checks.check(
+        "source-no-minkowski-in-axioms",
+        "the axiom memo does not name Minkowski, a boost, or a Wick map",
+        all(token not in axiom for token in ("Minkowski", "boost", "Wick")),
+    )
+
+    group = proper_cube_group()
+    orbit = hop_orbit(AXIS_WITNESS, group)
+    checks.check(
+        "group-order",
+        "the proper cube group has 24 matrices of determinant +1",
+        len(group) == 24 and len(set(group)) == 24 and all(matrix_det(matrix) == 1 for matrix in group),
+        residual=len(group),
+    )
+    checks.check(
+        "single-orbit",
+        "the six axis directions are one G+ orbit of e_1",
+        orbit == frozenset(AXES) and len(orbit) == 6,
+        residual=sorted(orbit),
+    )
+
+    weights_one = constant_hop_cost(1)
+    weights_two = constant_hop_cost(2)
+    weights_three = constant_hop_cost(3)
+    unequal = dict(weights_one)
+    unequal[(0, 1, 0)] = 2
+    checks.check(
+        "covariant-constant",
+        "every constant hop-cost is cube-covariant and the unequal mutation is not",
+        is_cube_covariant(weights_one, group)
+        and is_cube_covariant(weights_two, group)
+        and is_cube_covariant(weights_three, group)
+        and not is_cube_covariant(unequal, group),
+    )
+
+    ball = radius_ball(RADIUS)
+    nonzero = tuple(point for point in ball if point != ORIGIN)
+    arrival_ok = all(
+        first_arrival(point, weights_one) == l1_norm(point)
+        and first_arrival(point, weights_two) == 2 * l1_norm(point)
+        and first_arrival(point, weights_three) == 3 * l1_norm(point)
+        for point in nonzero
+    )
+    checks.check(
+        "first-arrival-form",
+        "shortest-path arrival equals w_0 |v|_1 on the radius-4 ball",
+        arrival_ok and first_arrival(ORIGIN, weights_one) == 0,
+    )
+
+    ratio_pairs = []
+    for weight in (1, 2, 3, 5):
+        costs = constant_hop_cost(weight)
+        axis_ratio = arrival_ratio(AXIS_WITNESS, costs)
+        face_ratio = arrival_ratio(FACE_WITNESS, costs)
+        ratio_pairs.append((weight, axis_ratio, face_ratio))
+        if axis_ratio != weight * weight or face_ratio != 2 * weight * weight:
+            break
+    checks.check(
+        "ratio-witnesses",
+        "(1,0,0) gives w_0^2 and (1,1,0) gives 2 w_0^2 for every tested w_0",
+        all(axis == weight * weight and face == 2 * weight * weight for weight, axis, face in ratio_pairs)
+        and len(ratio_pairs) == 4,
+        residual=ratio_pairs,
+    )
+    checks.check(
+        "ratio-not-constant",
+        "t^2 / |v|_2^2 is not constant on the nonzero radius-4 ball",
+        arrival_ratio(AXIS_WITNESS, weights_one) != arrival_ratio(FACE_WITNESS, weights_one)
+        and arrival_ratio(AXIS_WITNESS, weights_two) != arrival_ratio(FACE_WITNESS, weights_two),
+    )
+
+    null_one = tuple(point for point in nonzero if is_discrete_null(point, weights_one))
+    null_two = tuple(point for point in nonzero if is_discrete_null(point, weights_two))
+    checks.check(
+        "discrete-null-subset",
+        "discrete null t^2 = |v|_2^2 is a proper subset; (1,1,0) is the witness",
+        FACE_WITNESS in nonzero
+        and FACE_WITNESS not in null_one
+        and not is_discrete_null(FACE_WITNESS, weights_two)
+        and len(null_one) < len(nonzero)
+        and len(null_two) < len(nonzero)
+        and AXIS_WITNESS in null_one,
+        residual=(len(nonzero), len(null_one), len(null_two)),
+    )
+    print(f"N_ball={len(nonzero)} N_null_w1={len(null_one)} N_null_w2={len(null_two)}")
+
+    no_match = all(
+        arrival_ratio(AXIS_WITNESS, constant_hop_cost(weight))
+        != arrival_ratio(FACE_WITNESS, constant_hop_cost(weight))
+        and not is_discrete_null(FACE_WITNESS, constant_hop_cost(weight))
+        for weight in (1, 2, 3, 5)
+    )
+    checks.check(
+        "no-minkowski-match",
+        "no cube-covariant 6-NN unit-orbit member matches both displayed light tests",
+        no_match and is_cube_covariant(weights_one, group),
+    )
+
+    rot_z: Matrix = ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+    rot_y: Matrix = ((0, 0, 1), (0, 1, 0), (-1, 0, 0))
+    checks.check(
+        "identity-rotations",
+        "the named 90-degree generators sit in G+ and move e_1 onto the other axes",
+        rot_z in group
+        and rot_y in group
+        and apply_linear(rot_z, AXIS_WITNESS) == (0, 1, 0)
+        and apply_linear(rot_y, AXIS_WITNESS) == (0, 0, -1),
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: negative_route_pruning",
+        "reachability_to_target: prunes",
+        'hypothetical_axiom_status: "no edit"',
+        "t(v) = w_0 |v|_1",
+        "(1,0,0)` gives `w_0^2",
+        "(1,1,0)` gives",
+        "2 w_0^2",
+        "Displayed, not adopted",
+        "Do not adopt a Wick map",
+        "Do not write Minkowski into Admissibility",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "No occupancy is grown on a new patch",
+    )
+    slash_r = "/" + "r"
+    forbidden = (
+        "G" + "_N",
+        "1" + slash_r,
+        "1" + slash_r + "^2",
+        "Lattice" + "-named",
+        "not a " + "TOE",
+        "new axiom",
+        "we adopt",
+        "runner-cache",
+        "trace_class: direct_blocker_closure",
+        "reachability_to_target: partially_closes",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, displayed-not-adopted boundary, N1-N8, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{i}" in note for i in range(1, 9))
+        and not any(phrase in note for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "L1" not in note,
+        residual=[phrase for phrase in required if phrase not in note],
+    )
+
+    print("per_element: six axis directions, G+ orbit, and the two named witnesses are executed")
+    print("per_site: first arrival is shortest-path cost from the origin on Z^3")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: the radius-4 integer ball is the comparison domain")
+    print("lattice_wide: checked and not executed — no occupancy step and no axiom edit")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Every cube-covariant 6-NN hop-cost is constant because the six directions are one G+ orbit. First arrival is t=w0 |v|_1. On the radius-4 ball this is not Euclidean-isotropic c: (1,0,0) gives w0^2 and (1,1,0) gives 2 w0^2. Discrete null is a proper subset (witness (1,1,0)). Displayed class mismatch, not adopted. No axiom edit.

## Runner

`scripts/cube_covariant_nn_hop_cost_minkowski_mismatch_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.