### PR TITLE
feat(wav2chi): tick-2 Record content can be P-odd

### DIFF
--- a/docs/TWO_TICK_RECORD_CONTENT_CHIRAL_RIVAL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_TICK_RECORD_CONTENT_CHIRAL_RIVAL_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,330 @@
+---
+claim_id: two_tick_record_content_chiral_rival_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Whether a two-tick rival whose tick-2 neighbor alphabet is Record content {0,+,−} admits a P-odd formation predicate (the July-3 k=3 pair), while occupancy-only tick-1 cannot, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_tick_record_content_chiral_rival_2026_08_15.py
+---
+
+# Two-Tick Record-Content Chiral Rival (Displayed, Not Adopted)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact finite formation predicates on the six nearest-neighbor
+directions. Tick 1 is occupancy-only. Tick 2 is allowed to read Record
+content in the three-letter alphabet `{0,+,−}`. The July-3 unique `k=3`
+chiral pair is used only as a displayed rival predicate. No rule is written
+into Admissibility. L1 is not attached.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_tick_record_content_chiral_rival_2026_08_15.py`](../scripts/two_tick_record_content_chiral_rival_2026_08_15.py)
+
+## Question
+
+Investment `#6630` / July-3: occupancy-only L1 formation is automatically
+achiral. July-3 theorem 3: a chiral rule needs a 3-value channel; the unique
+`k=3` pair is the handed fully-mixed patterns. Investment `#6328`: L1 lock
+labels do not feed `n`. Those leftovers are not this residual. `#6328` is
+`10→L1`'s refusal. `#6630` is occupancy-only. The new residual is whether a
+*rival* two-tick member may let tick-2 formation depend on neighbor *record
+content* (Record is readable) and whether that tick-2 rule can be `P`-odd.
+
+`f_L1` is `n≠0`, not Hamming. This note does not attach L1. It does not
+reopen born-compiler / color-unital-m3. Occupancy is not run on a
+`20→`new spatial patch.
+
+## Answer
+
+Yes as a displayed capacity, no as an adopted rule.
+
+Tick 1 stays the occupancy predicate on `{0,1}^6`. Tick 2 may use the
+three-letter nearest-neighbor condition `{0,+,−}` that Record plus
+Admissibility already allow: absence is unread, and two readable Record
+contents are distinct. The July-3 unique `k=3` pair is then a well-defined
+formation predicate `f` on that alphabet, and `f` is not `P`-invariant. Every
+two-letter occupancy projection of `f` is `P`-invariant, so occupancy-only
+tick 1 cannot carry the same `P`-odd grade. A Record-conditioned two-tick
+rival can therefore match a `P`-odd / V−A *capacity* that L1 cannot.
+Displayed, not adopted. Do not write the pair or V−A into Admissibility.
+
+claim_scope: Whether a two-tick rival whose tick-2 neighbor alphabet is
+Record content `{0,+,−}` admits a P-odd formation predicate (the July-3 k=3
+pair), while occupancy-only tick-1 cannot, is reported. Displayed, not
+adopted.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite enumeration of six-direction colorings exhibits one P-odd three-letter formation predicate and P-invariance of every occupancy projection; the rival is displayed, not adopted."
+trace_class: displayed_rival
+target_claim_id: two_tick_record_content_chiral_rival
+target_blocker_text: "can a two-tick rival use Record content to be chiral"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "leave the pair displayed; do not adopt it, do not attach L1, and do not write it into Admissibility"
+conditional_surface_status: "exact for the named six-direction alphabets and the July-3 k=3 pair re-earned as a formation predicate"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+Quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The distribution concerns which possibility a forming record locks, conditional
+on formation at that site; it does not supply the formation site, probability,
+or rate.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+
+July-3 theorem 3 is the classification fact used as a named finite object, not
+as an axiom edit:
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+At `k=3` there is exactly one chiral pair, whose members are the handed
+fully-mixed patterns (every axis bi-colored, every value used twice). The
+paired runner re-earns that pair on the six axis directions and does not
+consume a cache.
+
+## Algebra
+
+Order the six nearest-neighbor directions as
+
+```text
+(+x, -x, +y, -y, +z, -z).
+```
+
+Spatial inversion `P = -I` is central in the full cubic group and acts by
+swapping opposite directions:
+
+```text
+P · (+x,-x,+y,-y,+z,-z) = (-x,+x,-y,+y,-z,+z).
+```
+
+The proper cubic group `G+` has 24 elements. It acts by permuting the six
+directions.
+
+**Tick 1 (occupancy, two-letter).** A neighbor condition is `c ∈ {0,1}^6`.
+Write `d = c_1+⋯+c_6` and `n = d/3`. Formation is
+
+```text
+f_L1(c) = 1  iff  n≠0.
+```
+
+That is the occupancy predicate `d≠0`, not a Hamming-grade rule and not a
+function of lock labels. `#6630` / July-3 theorem 2 already make every
+openness-level (two-letter) proper-covariant rule automatically `P`-even.
+The runner re-earns: all 64 occupancy colorings are proper-equivalent to
+their `P`-images, and `f_L1` itself is `P`-invariant. Exactly 63 of the 64
+occupancy patterns form.
+
+**Tick 2 (Record content, three-letter).** Each neighbor is `0` (no record),
+`+`, or `−` (two readable Record contents). That is a 3-letter nearest-neighbor
+condition allowed by Record + Admissibility. The configuration space is
+
+```text
+{0,+,−}^6,    |{0,+,−}^6| = 3^6 = 729.
+```
+
+A *handed fully-mixed* coloring is one in which every axis is bi-colored with
+two distinct letters and every letter is used exactly twice. There are exactly
+48 such colorings. They split into two `G+`-orbits of size 24. `P` exchanges
+the two orbits and no proper element does. That is the unique `k=3` chiral
+pair.
+
+A runner-anchored representative of one hand is
+
+```text
+r = (0, +, 0, −, +, −).
+```
+
+Every axis of `r` is bi-colored and the letter counts are `2/2/2`. Define the
+displayed rival formation predicate `f` to be the indicator of the proper
+orbit of `r`:
+
+```text
+f(c) = 1  iff  c ∈ G+ · r.
+```
+
+This is a well-defined function `{0,+,−}^6 → {0,1}`. It is not attached to
+L1. L1 remains the occupancy rule `f_L1`.
+
+The occupancy (two-letter) projection of a three-letter coloring is
+
+```text
+π(0)=0,   π(+)=π(−)=1,   π(c)_i = π(c_i).
+```
+
+The occupancy projection of `f` is the set `{π(c) : f(c)=1} ⊂ {0,1}^6`, or
+equivalently the existential predicate `F_occ(b)=1` iff some lift of `b` lies
+in `G+ · r`. A general two-letter projection is the same construction for an
+arbitrary letter map `{0,+,−} → {0,1}`.
+
+## Theorem 1 — the July-3 k=3 pair is a P-odd tick-2 predicate
+
+The July-3 unique `k=3` chiral pair is a well-defined formation predicate `f`
+on `{0,+,−}^6`. Direct enumeration gives
+
+```text
+N_form    = |{c : f(c)=1}|           = 24,
+N_P_form  = |{c : f(P·c)=1}|         = 24,
+N_both    = |{c : f(c)=f(P·c)=1}|    = 0.
+```
+
+Hence `N_both < N_form`, so `f` is not `P`-invariant. Tick-2 *can* be
+`P`-odd.
+
+*Proof.* The 24 proper direction permutations produce 24 distinct images of
+`r`. Their `P`-images form a disjoint 24-set, the other hand. If `f(c)=1`
+then `P·c` lies in the other hand, so `f(P·c)=0`. The two counts are
+therefore complementary and the intersection is empty. Burnside orbit counts
+on the 729 colorings recover July-3 theorem 3: 57 proper orbits, 56 full
+orbits, difference one chiral pair. Every member of either orbit is handed
+fully-mixed, and every handed fully-mixed coloring lies in the pair.
+
+## Theorem 2 — occupancy projections cannot carry the same P-odd grade
+
+Every two-letter (occupancy) projection of `f` is `P`-invariant.
+Occupancy-only tick-1 cannot carry the same `P`-odd grade.
+
+*Proof.* Let `ψ:{0,+,−}→{0,1}` be any letter map and write
+`S_ψ = {ψ∘c : f(c)=1}`. For the occupancy map `π` one has `|S_π|=12` and
+`P(S_π)=S_π`. The same identity `P(S_ψ)=S_ψ` holds for all eight maps to
+`{0,1}`. In particular the existential occupancy predicate of `f` is
+`P`-even.
+
+Independently, tick-1 formation is `f_L1(c)=(n≠0)` on `{0,1}^6`. That
+predicate depends on occupancy only. It is `P`-invariant because `P` merely
+reorders the six bits. Stronger: every one of the 64 occupancy colorings is
+proper-equivalent to its `P`-image, so no occupancy-only formation set that
+is a union of proper orbits can be `P`-odd. Occupancy-only tick-1 therefore
+cannot carry the `P`-odd grade that `f` carries on `{0,+,−}^6`.
+
+## Theorem 3 — displayed V−A capacity, not an adopted rule
+
+Displayed: a Record-conditioned two-tick rival can match a `P`-odd / V−A
+*capacity* that L1 cannot. Displayed, not adopted. Do not write the pair or
+V−A into Admissibility. Do not attach L1.
+
+The only load-bearing statements are Theorems 1 and 2. Theorem 3 names the
+comparison: L1, kept as `f_L1` with `n≠0`, has no `P`-odd formation grade;
+the displayed tick-2 rival does. The pair is not selected as the framework's
+fixed admissibility rule. No V−A coupling, no weak current, and no fermion
+sector identification is derived. The word "capacity" is used only for this
+finite `P`-odd possibility.
+
+## What this note does and does not claim
+
+- It reports whether the named two-tick rival *admits* a `P`-odd tick-2
+  predicate. It does not adopt that rival.
+- It does not attach L1. `f_L1` remains `n≠0`, not Hamming, and lock labels
+  still do not feed `n`.
+- It does not write the pair or V−A into Admissibility, and it does not edit
+  any axiom, primitive, or registry.
+- It does not reopen born-compiler / color-unital-m3.
+- It is not leftover-character of `#6328` or of `#6630`.
+- It does not run occupancy on a `20→`new spatial patch.
+- It does not identify the physical condition alphabet beyond the displayed
+  tick-2 hypothesis that Record content `{0,+,−}` is readable.
+- Formation site, probability, process, and rate remain unsupplied.
+
+## No-Go Discipline
+
+The negative statement is only: occupancy-only tick-1 cannot host the same
+`P`-odd grade as the displayed three-letter pair. It is not a no-go against
+every future chiral proposal.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome |
+|---|---|---|
+| occupancy-only L1, `f_L1` is `n≠0` | **ATTEMPTED** | automatically `P`-even; `#6630` / July-3 theorem 2 |
+| feed L1 lock labels into `n` | **ATTEMPTED** | `#6328` already refuses; not this residual |
+| tick-2 reads Record content `{0,+,−}` | **DISPLAYED** | July-3 unique `k=3` pair is `P`-odd |
+| write the pair or V−A into Admissibility | **REFUSED** | displayed, not adopted |
+| attach the pair to L1 | **REFUSED** | do not attach L1 |
+| born-compiler / color-unital-m3 | **REFUSED** | not reopened |
+| occupancy on a `20→`new spatial patch | **REFUSED** | not executed |
+
+### N2 — wall independence
+
+One wall is claimed: two-letter occupancy cannot carry this `P`-odd grade.
+The displayed existence of a three-letter `P`-odd predicate is a positive
+enumeration, not a second impossibility wall.
+
+### N3 — hidden-wall scan
+
+The alphabets, `P`, `G+`, `f`, `f_L1`, and the projections are declared. No
+dynamics, no spatial 20-site patch, no Born compiler, and no axiom edit is
+imported.
+
+### N4 — residual matching
+
+The residual answered is exactly the tick-2 Record-content chirality
+question. It is not the leftover character of `#6328` or `#6630`.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — all 729 three-letter and 64 two-letter colorings
+per-site: not applicable — one origin star, six directions
+per-mode: not applicable
+per-block: executed — the unique k=3 pair and its occupancy projections
+lattice-wide: not executed — no new spatial patch
+```
+
+### N6 — partial-closure paths
+
+A later derivation could still refuse tick-2 content dependence, or could
+adopt a different three-letter predicate. Either path is additional work.
+Adopting the pair would be an axiom-level or rule-level act and is out of
+scope.
+
+### N7 — steelman
+
+The strongest objection is that tick-2 is still "the" admissibility rule, so
+July-3 already classified it and nothing new is displayed. The distinction
+held here is only compositional: occupancy-only tick-1 is forced achiral,
+while a *rival two-tick member* whose second tick is allowed to read Record
+content can host the already-classified `k=3` pair. The pair itself is not
+new. The two-tick capacity comparison is the reported residual.
+
+### N8 — cross-cycle echo
+
+July-3 theorem 2 and theorem 3 are used as named finite facts and are
+re-earned on the same six directions. No status is borrowed from those
+notes' audit rows.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/two_tick_record_content_chiral_rival_2026_08_15.py
+```
+
+The runner re-earns the unique `k=3` pair, evaluates `N_form`, `N_P_form`,
+and `N_both`, checks every two-letter projection, pins `f_L1` as `n≠0`, and
+refuses axiom edits. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18629,6 +18629,10 @@
   "two_site_swap_corner_hosts_m3_with_unit_p_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
+  },
+  "two_tick_record_content_chiral_rival_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "u0_plaquette_quartic_derivation_narrow_theorem_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/two_tick_record_content_chiral_rival_2026_08_15.txt
+++ b/logs/runner-cache/two_tick_record_content_chiral_rival_2026_08_15.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/two_tick_record_content_chiral_rival_2026_08_15.py
+runner_sha256: 1f958f6379a81ca3e5a10642b6c2fb182a230dee9af56b0afdac110b0d3f8c70
+input_fingerprint_sha256: 20375f0ea9fc633e289bc7ec5d4aa3004bee1ea817914ebb161ce6c738eb77ff
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+two-tick Record-content chiral rival (displayed, not adopted)
+AUDIT_INPUT_PATHS:
+  docs/TWO_TICK_RECORD_CONTENT_CHIRAL_RIVAL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: exact six-direction colorings; no 20-site spatial patch
+PASS: audit-input-paths-exact-literals  (declared=('docs/TWO_TICK_RECORD_CONTENT_CHIRAL_RIVAL_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: note-claim-scope
+PASS: source-admissibility-rule
+PASS: source-distribution-sentence
+PASS: source-formation-boundary
+PASS: source-record-readable-content
+PASS: note-f-L1-is-n-nonzero-not-hamming
+PASS: note-displayed-not-adopted
+PASS: note-does-not-attach-L1
+PASS: note-does-not-write-pair-into-admissibility
+PASS: note-does-not-reopen-born-compiler-or-color-unital-m3
+PASS: note-no-forbidden-phrases
+PASS: note-no-spatial-patch
+PASS: alphabets-exact  (3^6=729; 2^6=64; |G|=48)
+PASS: p-central-swap
+PASS: july3-unique-k3-pair  (Burnside 57/56; orbit sizes 24/24)
+PASS: representative-fully-mixed  (rep=('0', '+', '0', '−', '+', '−'))
+PASS: theorem1-N-form-N-P-form-N-both  (N_form=24, N_P_form=24, N_both=0)
+PASS: theorem1-f-not-P-invariant
+PASS: note-reports-N-counts
+PASS: theorem2-occupancy-projection-P-invariant  (|S_π|=12)
+PASS: theorem2-every-two-letter-projection-P-invariant
+PASS: tick1-f-L1-n-nonzero
+PASS: tick1-cannot-carry-P-odd-grade
+PASS: rival-not-identified-with-L1
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_tick_record_content_chiral_rival_2026_08_15.py
+++ b/scripts/two_tick_record_content_chiral_rival_2026_08_15.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Displayed two-tick Record-content chiral rival: tick-2 can be P-odd.
+
+Tick 1 is occupancy-only with f_L1 given by n≠0. Tick 2 uses the readable
+Record alphabet {0,+,−}. The July-3 unique k=3 pair is re-earned as a
+formation predicate and left displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import sys
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/TWO_TICK_RECORD_CONTENT_CHIRAL_RIVAL_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_TICK_RECORD_CONTENT_CHIRAL_RIVAL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+LETTERS = ("0", "+", "−")
+LETTER_INDEX = {letter: index for index, letter in enumerate(LETTERS)}
+REPRESENTATIVE = ("0", "+", "0", "−", "+", "−")
+CLAIM_SCOPE = (
+    "Whether a two-tick rival whose tick-2 neighbor alphabet is Record "
+    "content {0,+,−} admits a P-odd formation predicate (the July-3 k=3 "
+    "pair), while occupancy-only tick-1 cannot, is reported. Displayed, "
+    "not adopted."
+)
+FORBIDDEN_PHRASES = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def det3(matrix: tuple[tuple[int, int, int], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def matvec(
+    matrix: tuple[tuple[int, int, int], ...], vector: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return tuple(sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3))
+
+
+def cubic_records() -> tuple[tuple[tuple[tuple[int, int, int], ...], int, tuple[int, ...]], ...]:
+    records = []
+    seen: set[tuple[tuple[int, int, int], ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(tuple(row) for row in matrix)
+            if key in seen:
+                continue
+            seen.add(key)
+            direction_perm = tuple(DIR_INDEX[matvec(key, direction)] for direction in DIRS)
+            records.append((key, det3(key), direction_perm))
+    return tuple(records)
+
+
+RECORDS = cubic_records()
+PROPER_PERMS = tuple(perm for _matrix, determinant, perm in RECORDS if determinant == 1)
+FULL_PERMS = tuple(perm for _matrix, _determinant, perm in RECORDS)
+P_MATRIX = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+P_PERM = next(perm for matrix, _determinant, perm in RECORDS if matrix == P_MATRIX)
+
+
+def act(perm: tuple[int, ...], coloring: tuple[str, ...]) -> tuple[str, ...]:
+    out = [""] * 6
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def all_colorings(alphabet: tuple[str, ...]) -> tuple[tuple[str, ...], ...]:
+    return tuple(itertools.product(alphabet, repeat=6))
+
+
+def cycle_count(perm: tuple[int, ...]) -> int:
+    seen = [False] * 6
+    cycles = 0
+    for start in range(6):
+        if seen[start]:
+            continue
+        cycles += 1
+        here = start
+        while not seen[here]:
+            seen[here] = True
+            here = perm[here]
+    return cycles
+
+
+def burnside_orbits(perms: tuple[tuple[int, ...], ...], alphabet_size: int) -> int:
+    total = sum(alphabet_size ** cycle_count(perm) for perm in perms)
+    if total % len(perms) != 0:
+        raise ValueError("Burnside count is not integral")
+    return total // len(perms)
+
+
+def orbit_of(seed: tuple[str, ...], perms: tuple[tuple[int, ...], ...]) -> frozenset[tuple[str, ...]]:
+    return frozenset(act(perm, seed) for perm in perms)
+
+
+def proper_equiv_to_p_image(coloring: tuple[str, ...]) -> bool:
+    image = act(P_PERM, coloring)
+    return any(act(perm, coloring) == image for perm in PROPER_PERMS)
+
+
+def is_fully_mixed(coloring: tuple[str, ...]) -> bool:
+    axis_mixed = all(coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3))
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_mixed and counts == [2, 2, 2]
+
+
+def occupancy(coloring: tuple[str, ...]) -> tuple[int, ...]:
+    return tuple(0 if letter == "0" else 1 for letter in coloring)
+
+
+def letter_map_image(
+    coloring: tuple[str, ...], mapping: tuple[int, int, int]
+) -> tuple[int, ...]:
+    return tuple(mapping[LETTER_INDEX[letter]] for letter in coloring)
+
+
+def n_of_occupancy(bits: tuple[int, ...]) -> float:
+    return sum(bits) / 3
+
+
+def f_l1(bits: tuple[int, ...]) -> bool:
+    return n_of_occupancy(bits) != 0
+
+
+def audit_input_literal() -> tuple[str, ...]:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                value = ast.literal_eval(node.value)
+                if not isinstance(value, tuple) or not all(isinstance(item, str) for item in value):
+                    raise TypeError("AUDIT_INPUT_PATHS must be a tuple of strings")
+                return value
+    raise RuntimeError("AUDIT_INPUT_PATHS assignment not found")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("two-tick Record-content chiral rival (displayed, not adopted)")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: exact six-direction colorings; no 20-site spatial patch")
+
+    declared = audit_input_literal()
+    checks.check(
+        "audit-input-paths-exact-literals",
+        declared == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        f"declared={declared}",
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in normalize(note.replace("`", "")))
+
+    admissibility_rule = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice "
+        "translations and proper cubic rotations."
+    )
+    distribution_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-admissibility-rule",
+        admissibility_rule in normalized_axiom and admissibility_rule in normalized_note,
+    )
+    checks.check(
+        "source-distribution-sentence",
+        distribution_sentence in normalized_axiom and distribution_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-record-readable-content",
+        "Records form." in axiom
+        and record_lock in normalized_axiom
+        and record_content in normalized_axiom
+        and record_absence in normalized_axiom
+        and record_lock in normalized_note
+        and record_content in normalized_note
+        and record_absence in normalized_note,
+    )
+
+    checks.check(
+        "note-f-L1-is-n-nonzero-not-hamming",
+        "f_L1" in note
+        and "n≠0" in note
+        and "not Hamming" in note
+        and "Hamming-grade" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "Displayed, not adopted" in note and "displayed, not adopted" in note,
+    )
+    checks.check(
+        "note-does-not-attach-L1",
+        "does not attach L1" in note and "Do not attach L1" in note,
+    )
+    checks.check(
+        "note-does-not-write-pair-into-admissibility",
+        "Do not write the pair or V−A into Admissibility" in note
+        and "hypothetical_axiom_status: no edit" in note,
+    )
+    checks.check(
+        "note-does-not-reopen-born-compiler-or-color-unital-m3",
+        "does not reopen born-compiler / color-unital-m3" in note,
+    )
+    checks.check(
+        "note-no-forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN_PHRASES),
+    )
+    checks.check(
+        "note-no-spatial-patch",
+        "20→" in note and "not executed" in note,
+    )
+
+    three_letter = all_colorings(LETTERS)
+    two_letter = all_colorings(("0", "1"))
+    checks.check(
+        "alphabets-exact",
+        len(three_letter) == 729 and len(two_letter) == 64 and len(RECORDS) == 48 and len(PROPER_PERMS) == 24,
+        f"3^{6}={len(three_letter)}; 2^{6}={len(two_letter)}; |G|={len(RECORDS)}",
+    )
+    checks.check(
+        "p-central-swap",
+        P_PERM == (1, 0, 3, 2, 5, 4) and det3(P_MATRIX) == -1,
+    )
+
+    proper_k3 = burnside_orbits(PROPER_PERMS, 3)
+    full_k3 = burnside_orbits(FULL_PERMS, 3)
+    forming = orbit_of(REPRESENTATIVE, PROPER_PERMS)
+    p_forming = orbit_of(act(P_PERM, REPRESENTATIVE), PROPER_PERMS)
+    fully_mixed = tuple(coloring for coloring in three_letter if is_fully_mixed(coloring))
+    checks.check(
+        "july3-unique-k3-pair",
+        proper_k3 == 57
+        and full_k3 == 56
+        and proper_k3 - full_k3 == 1
+        and len(forming) == 24
+        and len(p_forming) == 24
+        and forming.isdisjoint(p_forming)
+        and forming | p_forming == frozenset(fully_mixed)
+        and len(fully_mixed) == 48,
+        f"Burnside {proper_k3}/{full_k3}; orbit sizes {len(forming)}/{len(p_forming)}",
+    )
+    checks.check(
+        "representative-fully-mixed",
+        REPRESENTATIVE in forming
+        and is_fully_mixed(REPRESENTATIVE)
+        and all(is_fully_mixed(coloring) for coloring in forming)
+        and all(act(P_PERM, coloring) in p_forming for coloring in forming),
+        f"rep={REPRESENTATIVE}",
+    )
+
+    def f(coloring: tuple[str, ...]) -> bool:
+        return coloring in forming
+
+    n_form = sum(1 for coloring in three_letter if f(coloring))
+    n_p_form = sum(1 for coloring in three_letter if f(act(P_PERM, coloring)))
+    n_both = sum(
+        1 for coloring in three_letter if f(coloring) and f(act(P_PERM, coloring))
+    )
+    checks.check(
+        "theorem1-N-form-N-P-form-N-both",
+        n_form == 24 and n_p_form == 24 and n_both == 0 and n_both < n_form,
+        f"N_form={n_form}, N_P_form={n_p_form}, N_both={n_both}",
+    )
+    checks.check(
+        "theorem1-f-not-P-invariant",
+        any(f(coloring) != f(act(P_PERM, coloring)) for coloring in three_letter)
+        and all(not f(act(P_PERM, coloring)) for coloring in forming),
+    )
+    checks.check(
+        "note-reports-N-counts",
+        "N_form" in note and "N_P_form" in note and "N_both" in note and "N_both < N_form" in note,
+    )
+
+    occ_image = {occupancy(coloring) for coloring in forming}
+    p_occ_image = {act(P_PERM, bits) for bits in occ_image}
+    checks.check(
+        "theorem2-occupancy-projection-P-invariant",
+        occ_image == p_occ_image and len(occ_image) == 12,
+        f"|S_π|={len(occ_image)}",
+    )
+
+    all_maps_p_even = True
+    for mapping in itertools.product((0, 1), repeat=3):
+        image = {letter_map_image(coloring, mapping) for coloring in forming}
+        if {act(P_PERM, bits) for bits in image} != image:
+            all_maps_p_even = False
+            break
+    checks.check(
+        "theorem2-every-two-letter-projection-P-invariant",
+        all_maps_p_even,
+    )
+
+    occupancy_bits = tuple(tuple(int(bit) for bit in coloring) for coloring in two_letter)
+    tick1_form = tuple(bits for bits in occupancy_bits if f_l1(bits))
+    tick1_p_even = all(f_l1(bits) == f_l1(act(P_PERM, bits)) for bits in occupancy_bits)
+    all_occupancy_p_related = all(
+        proper_equiv_to_p_image(tuple("1" if bit else "0" for bit in bits))
+        for bits in occupancy_bits
+    )
+    checks.check(
+        "tick1-f-L1-n-nonzero",
+        len(tick1_form) == 63
+        and not f_l1((0, 0, 0, 0, 0, 0))
+        and f_l1((1, 0, 0, 0, 0, 0))
+        and n_of_occupancy((1, 1, 1, 1, 1, 1)) == 2.0,
+    )
+    checks.check(
+        "tick1-cannot-carry-P-odd-grade",
+        tick1_p_even and all_occupancy_p_related,
+    )
+    checks.check(
+        "rival-not-identified-with-L1",
+        forming != {coloring for coloring in three_letter if occupancy(coloring) != (0, 0, 0, 0, 0, 0)}
+        and REPRESENTATIVE not in {("0",) * 6},
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

A two-tick rival whose tick-2 neighbor alphabet is Record content {0,+,−} admits the July-3 unique k=3 chiral pair as a P-odd formation predicate (N_form=24, N_P_form=24, N_both=0). Every occupancy projection is P-invariant, so occupancy-only tick-1 cannot carry that grade. Displayed rival capacity, not adopted. No axiom edit.

## Runner

`scripts/two_tick_record_content_chiral_rival_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.