### PR TITLE
physics: complete the half-space pairing with the reflection intertwiner

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block119-reflection-intertwiner-completion-20260816/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block119-reflection-intertwiner-completion-20260816/NO_GO_LEDGER.md
@@ -1,0 +1,33 @@
+# Block 119 No-Go Ledger
+
+Scope: one narrow selection wall inside a two-sided decision packet with
+a POSITIVE completion. `W1` says no displayed fixed carrier-natural
+operator intertwines the half-space stable-split pairing — proven by
+exact nonproportionality (the residual (Theta x)_j - (Theta x)_0 y_j is
+nonzero for some j) at every momentum and both fixtures, for all
+fourteen displayed candidates (the Block 114 dressing in both
+restrictions, the overlap Hodge, the reality conjugation composed with
+complex conjugation, the Klein and parity operators, minus the identity,
+and their displayed simple products; momentum-mapping candidates are
+tested against their correct target sectors). W1 is a SELECTION
+statement, not an existence no-go: the swap completion on the span of
+the action's stable boundary data and its reality images IS a
+reflection-real involutive intertwiner with mu = 1 at every momentum,
+and its completed pairing is Hermitian PSD (inertia (1,0,23) per
+momentum, (4,0,92) globally on the displayed three super-cells) with
+contractive quotient transfer diag(rho_k^2) and the exact geometric
+semigroup law. Narrow scope: the fourteen displayed candidates, the
+half-space carrier, the displayed span. The torus completion and the
+naturality classification are live and named.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| some fixed operator was missed | `ATTEMPTED` | open beyond the displayed fourteen; W1 classifies only the displayed list | naturality classification |
+| the completion is unique or canonical | `ATTEMPTED` | not shown: minimality on the displayed span is a choice | naturality classification |
+| the OS package is complete on the torus | `ATTEMPTED` | false: the half-space carrier only; the Klein/negative-eigenvalue structure makes the torus its own problem | torus completion |
+| curved OS positivity follows | `ATTEMPTED` | not shown: displayed flat carrier only | curved carrier work |
+| the intertwiner is circular (built from the answer) | `ATTEMPTED` | false as stated: built from the action's stable split, not from the desired verdict; naturality honestly open | naturality classification |
+| per-sector reality holds everywhere | `ATTEMPTED` | false at the paired momenta: reality holds as the coupled system Theta_3 = R Theta_1 R exactly | none needed |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; only the narrow selection `W1` ships.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md
@@ -1,0 +1,1029 @@
+---
+claim_id: admissibility_dirac_kahler_reflection_intertwiner_completion_bounded_theorem_note_2026-08-16
+claim_type: bounded_theorem
+claim_scope: "On the half-space stable-split action pairing of the primary carrier at both rational shear fixtures, every displayed fixed carrier-natural intertwiner candidate (the Block 114 dressing in both restrictions, the overlap Hodge, the reality conjugation composed with complex conjugation, the Klein and parity operators, minus the identity, and their displayed simple products) fails the exact proportionality condition at every momentum, while the swap completion built on the span of the action's stable boundary data and its reality images is a reflection-real involutive intertwiner with mu = 1 at every momentum whose completed pairing is Hermitian positive semidefinite with per-momentum inertia (1,0,23) and global inertia (4,0,92) on the displayed three super-cells, with quotient transfer diag(rho_k^2) strictly inside (0,1) and the exact geometric semigroup law -- and the torus completion, curved OS positivity beyond the displayed carrier, the uniqueness or naturality classification of the completion, the completed ADM/history transporter, joint gravity, the gravity constraint quotient, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_floquet_monodromy_action_pairing_bounded_theorem_note_2026-08-16
+runner: scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_floquet_monodromy_action_pairing_bounded_theorem_note_2026-08-16
+target_blocker_text: "Construct the reflection intertwiner that completes the rank-one geometric-Hankel action pairing to a Hermitian positive OS package; then the gravity constraint quotient."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Carry the completed half-space OS package back to the antiperiodic torus and the curved carrier, classify the completion's naturality, and then form the gravity constraint quotient."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-118 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact rank-one factorization and proportionality reduction, exact nonproportionality certificates for fourteen fixed carrier-natural candidates at every momentum and both fixtures, exact data-dependent reflection-real involutive swap completion with mu one, exact Hermiticity and positive-semidefinite inertia certificates on three super-cells, and exact quotient contraction intervals and geometric semigroup law; dependencies are content-bound unaudited, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Reflection Intertwiner Completion
+
+**Date:** 2026-08-16
+
+**Campaign block:** 119
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py`](../scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py)
+
+## 1. Result Up Front
+
+[Block 118](ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+closed onto the following handoff next gate, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md:16`
+and elaborated at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md:1034-1050`:
+
+> Construct the reflection intertwiner that completes the rank-one
+> geometric-Hankel action pairing to a Hermitian positive OS package; then
+> the gravity constraint quotient.
+
+**Fixed-candidate selection theorem.** On the half-space stable-split
+action pairing of the primary `Z8_t x Z4_x` carrier, at each of the
+rational shear fixtures \(c=5/13\) and \(c=3/5\), write the nonzero local
+rank-one block as
+
+\[
+ H_k[0,0]=x_k y_k^\dagger .                            \tag{1}
+\]
+
+For a proposed left intertwiner \(\Theta_k\), Hermitian positivity of the
+nonzero completed block reduces exactly to
+
+\[
+ \Theta_kx_k=\mu_k y_k,
+ \qquad \mu_k\in\mathbb R_{>0}.                       \tag{2}
+\]
+
+Every one of the fourteen displayed fixed carrier-natural candidates
+fails even proportionality in (2), at every momentum and at both
+fixtures. These candidates are the Block 114 dressing in its direct and
+OS restrictions, the overlap Hodge, the reality conjugation composed with
+complex conjugation, the Klein operator, parity, minus the identity, and
+the seven displayed simple products. Each failure is certified by an
+exact nonzero root-field residual, not by a floating tolerance or merely
+by the sign or non-reality of a fitted scalar.
+
+**Existing swap-completion theorem.** The candidate wall is not an
+existence wall. Let \(R\) denote the declared reality map, form
+
+\[
+ V_k=[x_k,\ y_k,\ R x_k,\ R y_k],                     \tag{3}
+\]
+
+and let \(S_{\rm swap}\) exchange \(x_k\leftrightarrow y_k\) and
+\(R x_k\leftrightarrow R y_k\). On the exact displayed span, define
+
+\[
+ \Theta_k
+ =I+V_k(S_{\rm swap}-I)(V_k^\dagger V_k)^{-1}V_k^\dagger .
+                                                               \tag{4}
+\]
+
+Then \(\Theta_k\) is a reflection-real involution and
+
+\[
+ \Theta_kx_k=y_k,
+ \qquad \Theta_ky_k=x_k.                              \tag{5}
+\]
+
+Thus (2) holds with \(\mu_k=1\) in every momentum sector at both
+fixtures, and it holds in both swap directions.
+
+**Positive half-space package.** Left completion preserves the exact
+geometric-Hankel law and gives
+
+\[
+ \widehat H_k[m,n]
+ :=\Theta_k H_k[m,n]
+ =\rho_k^{m+n}y_k y_k^\dagger .                       \tag{6}
+\]
+
+It is Hermitian positive semidefinite. On the displayed three
+super-cells, with inertia ordered as positive, negative, and zero, the
+exact certificates are
+
+\[
+ \operatorname{In}\widehat{\mathcal H}_k=(1,0,23),
+ \qquad
+ \operatorname{In}\!\left(\bigoplus_{k=0}^3
+ \widehat{\mathcal H}_k\right)=(4,0,92).              \tag{7}
+\]
+
+There is exactly one positive direction per momentum, as required by the
+rank-one moment structure. The common moment radical can now be
+quotiented inside a positive semidefinite package. At either fixture the
+four-momentum quotient transfer is
+
+\[
+ T=\operatorname{diag}(\rho_0^2,\rho_1^2,
+                        \rho_2^2,\rho_3^2),
+ \qquad 0<T<I,                                        \tag{8}
+\]
+
+and its exact geometric semigroup law is
+
+\[
+ T^n=\operatorname{diag}(\rho_0^{2n},\rho_1^{2n},
+                          \rho_2^{2n},\rho_3^{2n})
+ \qquad(n\in\mathbb Z_{\ge0}).                       \tag{9}
+\]
+
+This completes the displayed stable-split pairing on the half-space
+carrier. The intertwiner is built from the action's own stable boundary
+data and its reality images. It is therefore action-derived in that bounded sense, but
+it is not one of the fixed carrier operators. No uniqueness, canonicity,
+or carrier-naturality theorem is proved.
+
+The firewall remains sharp. No completion has been transported back to
+the antiperiodic torus or beyond the displayed carrier to the curved
+setting. The torus retains the Klein and negative-Floquet-eigenvalue
+structure isolated in Block 118 and requires its own completion analysis.
+The completed ADM/history transporter, joint gravity, the gravity
+constraint quotient, Records, audit retention, axiom amendment,
+obligation retirement, and TOE percentage movement remain outside this
+theorem.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) at
+`origin/main 4e566b14a6352a9a62590252a9755c7a103c1b9e`, with axiom blob
+`bc23300becfe4e4db57153c0e94cfcdf2338da71` and registry blob
+`b93959cca4f7e26c673cdccbe601e50c3cb93daa`. The authority snapshot is
+unchanged from Blocks 115--118.
+
+The exact stacked parent is
+[Block 118](ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+commit `fdd1883c54ca8cc14b1337cc1edc249792d5dab2`, content-bound through
+note blob `d8f5765c3fee3bd349aebd7bf945066ca5439235`. No audit verdict is
+imported.
+
+The executed contract is:
+
+1. the inherited Blocks 107--118 `d=2` one-fine-mode carrier on
+   `Z8_t x Z4_x`, its link-centered reflection, and Block 118's
+   stable-split half-space action pairing;
+2. both rational shear fixtures \(c=5/13\) and \(c=3/5\), all four fixed
+   momenta \(k=0,1,2,3\), and the exact stable magnitudes
+   \(\rho_{k,c}\in(0,1)\);
+3. the exact local factorization \(H_k[0,0]=x_ky_k^\dagger\), all
+   two-by-two minor checks, and the proportionality-to-positivity
+   reduction;
+4. the solution-space dimension certificates for unrestricted
+   proportionality, fixed \(\mu\), and positive-real \(\mu\);
+5. the fourteen displayed fixed carrier-natural candidates and their
+   exact nonproportionality residuals in every declared sector;
+6. the data-dependent span \(V_k\), its swap, formula (4), exact
+   involutivity, reflection-reality, and the two swap directions with
+   \(\mu_k=1\);
+7. the completed geometric-Hankel blocks on the displayed three
+   super-cells, their Hermiticity, positive semidefiniteness, and exact
+   per-momentum and four-momentum inertias;
+8. the positive moment quotient, the four exact \((0,1)\) isolating
+   intervals, and the exact geometric semigroup law; and
+9. the no-go conclusion only for the fourteen fixed candidates, while
+   recording that the data-built swap completion exists and leaving its
+   torus transport, curved transport, uniqueness, and naturality open.
+
+The supplied exact certificate report ends with
+`TOTAL: PASS=702 FAIL=0`; its reported runtime is `120.368` seconds. The
+candidate failures are certified as exact nonproportionalities. The
+positive result is independently represented by exact reflection-reality,
+involution, factorization, inertia, interval, and semigroup identities.
+
+Its obstruction and decision footer is reproduced exactly:
+
+```text
+TASK4 OBSTRUCTION PASS: every named carrier is nonproportional (no mu exists, stronger than a sign/non-reality failure).
+DECISION: fixed carrier-natural intertwiners fail by nonproportionality, but reflection-real involutive intertwiners do exist and complete the half-space OS package.
+RUNTIME_SECONDS: 120.368
+TOTAL: PASS=702 FAIL=0
+```
+
+The exact scope is the half-space stable-split action pairing on the
+primary finite carrier, both rational shear fixtures, all four fixed
+momenta, the fourteen displayed fixed carrier candidates, and the
+data-built swap completion on three super-cells. The torus completion,
+curved OS positivity beyond the displayed carrier, the uniqueness or
+naturality classification, the completed ADM/history transporter, joint
+gravity, the gravity constraint quotient, Records, audit retention, axiom
+amendment, obligation retirement, and TOE percentage movement are outside
+the executed contract.
+
+## 3. The Factorization And The Reduction
+
+Fix one fixture and one momentum sector, and suppress \(k,c\) temporarily.
+Block 118 supplied a nonzero rank-one stable-split local block. The exact
+certificate chooses its factors directly from that block:
+
+\[
+ x_i=H[0,0]_{i0},
+ \qquad
+ y_j=\overline{H[0,0]_{0j}/H[0,0]_{00}}.             \tag{10}
+\]
+
+In this normalization \(y_0=1\), and exact substitution gives
+
+\[
+ H[0,0]=xy^\dagger.                                  \tag{11}
+\]
+
+All 784 two-by-two minors vanish in every declared sector. The factor
+digests in the supplied certificate are:
+
+```text
+TASK1 FACTOR PASS: x_i=H00[i,0], y_j=star(H00[0,j]/H00[0,0]); H00=x y^H and all 784 two-by-two minors vanish per sector.
+T1 c=5/13: p_even=(127417091906251505055019140625,-3962371610825721602827025599106,127417091906251505055019140625); p_odd=(96695624036307976527392578125,-238964531421974037129547858425706,96695624036307976527392578125); k0:x#4da8d3de701d1ca5/y#50938ee7bfe2cfe0,k1:x#7c80f8f7bb18db20/y#8f9f83c0bf090f63,k2:x#99f4cac2fa4aa24e/y#818200ac08160c66,k3:x#bd6231e96779c1fd/y#9dfbce5458d32f9c
+T1 c=3/5: p_even=(8465566947515869140625,-234369399320455883852546,8465566947515869140625); p_odd=(210922496818387890625,-1098683146867769276340242,210922496818387890625); k0:x#2fa7eab055b27311/y#68066e454ed294be,k1:x#671b092d09b4d07a/y#cb144bbe9b43a3c7,k2:x#dff5d240ea54c169/y#0f1d0de9696f5407,k3:x#431702123e03128f/y#19ef93cf713aca27
+```
+
+Now let \(\Theta\) act on the left factor. The completed local block is
+
+\[
+ \widehat H[0,0]
+ =\Theta H[0,0]
+ =(\Theta x)y^\dagger.                               \tag{12}
+\]
+
+The required reduction is elementary but decisive.
+
+**Rank-one completion lemma.** Let \(x,y\ne0\). The matrix
+\((\Theta x)y^\dagger\) is Hermitian positive semidefinite and nonzero if
+and only if
+
+\[
+ \Theta x=\mu y
+ \quad\hbox{for some}\quad \mu\in\mathbb R_{>0}.      \tag{13}
+\]
+
+Indeed, if (13) holds, (12) is \(\mu yy^\dagger\). Conversely, a nonzero
+Hermitian rank-one matrix has identical left and right ranges. Hence
+\(\Theta x=\mu y\) for some nonzero scalar. Hermiticity makes \(\mu\)
+real, and positive semidefiniteness makes it positive. No scalar is fitted
+after the fact: (13) is the exact linear condition tested by the
+certificate.
+
+The reduction also shows how large the unrestricted completion space is.
+Over the exact root field \(\mathbb K\), allowing \(\mu\) to vary gives
+65 scalar unknowns, the 64 entries of \(\Theta\) and \(\mu\), subject to
+eight independent equations. Fixing \(\mu\) removes that extra unknown.
+Thus
+
+\[
+ \dim_{\mathbb K}\{(\Theta,\mu):\Theta x=\mu y\}=57,
+ \qquad
+ \dim_{\mathbb K}\{\Theta:\Theta x=\mu y\}=56.      \tag{14}
+\]
+
+When the exact complex coefficients are resolved over \(\mathbb R\) and
+\(\mu>0\) remains a free real parameter, the corresponding real
+solution-space dimension is 113. The supplied certificate states this
+pointwise equivalence and dimension count exactly:
+
+```text
+TASK2 POINTWISE PASS (all k, both fixtures): Theta*x=mu*y, star(mu)=mu>0 iff the nonzero rank-one Hankel completion is PSD; dim_K(prop)=57, dim_K(mu fixed)=56, dim_R(mu>0)=113.
+```
+
+Finally, Block 118's geometric-Hankel identity gives
+
+\[
+ H_k[m,n]=\rho_{k,c}^{m+n}x_ky_k^\dagger.            \tag{15}
+\]
+
+Therefore the single local condition \(\Theta_kx_k=\mu_ky_k\) completes
+every displayed half-space moment block at once. There is no separate
+positivity parameter to tune from cell to cell.
+
+## 4. The Candidate Failures
+
+The fixed candidate list has exactly fourteen members:
+
+\[
+\begin{gathered}
+ A_{\rm dir},\ A_{\rm OS},\ H_{\rm ov},\ J_{\rm bar},\
+ K,\ P,\ -I,\\
+ KA,\ AK,\ KH_{\rm ov},\ H_{\rm ov}K,\
+ KJ_{\rm bar},\ J_{\rm bar}K,\ H_{\rm ov}J_{\rm bar}.
+                                                               \tag{16}
+\end{gathered}
+\]
+
+Here \(A_{\rm dir}\) and \(A_{\rm OS}\) are the two displayed
+restrictions of the Block 114 dressing, \(H_{\rm ov}\) is the overlap
+Hodge operator, \(J_{\rm bar}\) is the displayed reality conjugation
+composed with complex conjugation, \(K\) is the Klein operator, and
+\(P\) is the displayed parity operator. The product label \(A\) is
+the corresponding displayed dressing used by the certificate. This is a
+finite named list, not an enumeration of every word in these operators.
+
+Because \(y_0=1\), proportionality of \(\Theta x\) and \(y\) would force
+every exact residual
+
+\[
+ \Delta_j(\Theta)
+ :=(\Theta x)_j-(\Theta x)_0y_j                       \tag{17}
+\]
+
+to vanish. The certificate notation `NPj#h` means that \(\Delta_j\) is
+an exact nonzero root-field element whose canonical digest begins with
+`h`. Every reported failure already occurs at \(j=1\). The complete
+fourteen-row ledger is reproduced verbatim:
+
+```text
+TASK3 TABLE PASS; NPj#h means exact nonzero failure entry Delta_j=(Theta*x)_j-(Theta*x)_0*y_j reduced in the root field (h=SHA256 prefix).
+T3 A_dir | c=5/13:(NP1#4f34c5a2,NP1#285272a7,NP1#db914a74,NP1#5a1eb205) | c=3/5:(NP1#b75d339e,NP1#e2cf52cd,NP1#92d60298,NP1#4af338c2)
+T3 A_OS | c=5/13:(NP1#4f34c5a2,NP1#5fba31eb,NP1#db914a74,NP1#87bd5892) | c=3/5:(NP1#b75d339e,NP1#234bbd73,NP1#92d60298,NP1#1dc71447)
+T3 Hov | c=5/13:(NP1#58132c4d,NP1#c6090d09,NP1#202b846c,NP1#c6090d09) | c=3/5:(NP1#2036319a,NP1#9618a47e,NP1#e4b4cb6c,NP1#9618a47e)
+T3 Jbar | c=5/13:(NP1#76dd9a57,NP1#e679731b,NP1#76dd9a57,NP1#4f56faf0) | c=3/5:(NP1#c682e1aa,NP1#336fea88,NP1#c682e1aa,NP1#575e6275)
+T3 K | c=5/13:(NP1#45817c45,NP1#eb1b2538,NP1#1e56255c,NP1#2e4c479f) | c=3/5:(NP1#82f84bcf,NP1#f06cb8a1,NP1#4bb630d4,NP1#fc5e4e04)
+T3 P | c=5/13:(NP1#79d1cfa5,NP1#b37a048f,NP1#eddaee77,NP1#b6be515a) | c=3/5:(NP1#ed70d26a,NP1#fa1f47d7,NP1#8951519c,NP1#c1990d6a)
+T3 -I | c=5/13:(NP1#8488cee9,NP1#9d99bb3f,NP1#3b13835e,NP1#f55d8155) | c=3/5:(NP1#3fcf8354,NP1#65e3c21d,NP1#02e995d4,NP1#cc6c50e4)
+T3 K*A | c=5/13:(NP1#d4b33579,NP1#a8fe6559,NP1#eff8d7aa,NP1#013d81ab) | c=3/5:(NP1#7adb6d1a,NP1#a25afc19,NP1#fc710441,NP1#11c08709)
+T3 A*K | c=5/13:(NP1#3af381ab,NP1#f75eed99,NP1#90f7a855,NP1#ef895880) | c=3/5:(NP1#03a9728e,NP1#23f7cbf7,NP1#fcf0d0b5,NP1#e1b606fd)
+T3 K*Hov | c=5/13:(NP1#47e2a384,NP1#041ded28,NP1#66b67c2a,NP1#c9205fa7) | c=3/5:(NP1#83a73109,NP1#5a6fe0c7,NP1#f9590e4e,NP1#d8be1d90)
+T3 Hov*K | c=5/13:(NP1#4a133439,NP1#97548a33,NP1#107e3476,NP1#0fe27412) | c=3/5:(NP1#ed188713,NP1#db8a41dc,NP1#f514f881,NP1#025f4d83)
+T3 K*Jbar | c=5/13:(NP1#d917f13a,NP1#6fc797e8,NP1#5192b8c2,NP1#d0db91ae) | c=3/5:(NP1#66ffab40,NP1#567dd9c7,NP1#98f2810b,NP1#70677f40)
+T3 Jbar*K | c=5/13:(NP1#c7c94fb8,NP1#ddab1061,NP1#70cdda80,NP1#df18524e) | c=3/5:(NP1#c4f901bd,NP1#c4001887,NP1#3ed7813c,NP1#c9526e7b)
+T3 Hov*Jbar | c=5/13:(NP1#df07702b,NP1#0e1df669,NP1#2fc4b3ba,NP1#e1703dce) | c=3/5:(NP1#f4bfc555,NP1#a8e0431f,NP1#8c1230f9,NP1#e26c7008)
+```
+
+Thus every named carrier is nonproportional: no \(\mu\) exists, a
+strictly stronger failure than finding a proportionality scalar with the
+wrong sign or a non-real phase. In particular, multiplying a few of the
+fixed geometric operators does not cure the mismatch.
+
+The conclusion is a selection statement. The needed intertwiner is not
+among the fourteen displayed fixed carrier operators. Equation (14)
+shows that many pointwise solutions remain; the pairing's own boundary
+data must enter the present successful construction.
+
+## 5. The Swap Completion
+
+Restore the momentum and fixture labels. For each sector, the four
+columns
+
+\[
+ V_k=[x_k,\ y_k,\ R x_k,\ R y_k]                     \tag{18}
+\]
+
+are the stable boundary factors and their reality images. The exact Gram
+matrix \(V_k^\dagger V_k\) is invertible in the displayed construction.
+Define the coefficient-space swap
+
+\[
+ S_{\rm swap}=
+ \begin{pmatrix}
+ 0&1&0&0\\
+ 1&0&0&0\\
+ 0&0&0&1\\
+ 0&0&1&0
+ \end{pmatrix},
+ \qquad S_{\rm swap}^2=I_4,                           \tag{19}
+\]
+
+and extend it by the identity off the displayed span:
+
+\[
+ \Theta_k
+ =I+V_k(S_{\rm swap}-I_4)
+       (V_k^\dagger V_k)^{-1}V_k^\dagger.            \tag{20}
+\]
+
+Multiplication by \(V_k\) on the right gives the exact identity
+
+\[
+ \Theta_kV_k=V_kS_{\rm swap}.                        \tag{21}
+\]
+
+On \(\operatorname{Ran}V_k\), equation (21) is precisely the two swaps
+in (19). On \(\ker V_k^\dagger\), equation (20) is the identity. The
+orthogonal decomposition into these two spaces and
+\(S_{\rm swap}^2=I_4\) therefore give
+
+\[
+ \Theta_k^2=I.                                       \tag{22}
+\]
+
+This proves involutivity from the swap itself; it is not an independent
+numerical coincidence.
+
+Including both reality-image columns makes the same formula compatible
+with the declared reflection-reality relation. If
+\(\bar k=-k\pmod4\), the exact identities are
+
+\[
+ R\Theta_kR=\Theta_{\bar k}.                          \tag{23}
+\]
+
+The self-conjugate sectors \(k=0,2\) obey (23) internally, and the paired
+sectors obey, in particular,
+
+\[
+ \Theta_3=R\Theta_1R.                                \tag{24}
+\]
+
+Equations (21) and (19) also give both directions of the completion:
+
+\[
+ \Theta_kx_k=y_k,
+ \qquad
+ \Theta_ky_k=x_k,                                    \tag{25}
+\]
+
+with the reality-image pair exchanged in the same way. Hence the scalar
+in the reduction lemma is exactly \(\mu_k=1\), real and positive, at all
+four momenta and both fixtures.
+
+The certificate's two decisive lines are:
+
+```text
+TASK4 EXISTENCE PASS: data-dependent Theta=I+V(S-I)(V^H V)^-1 V^H is reflection-real, involutive, and sends x_k to y_k with mu_k=1 at all k.
+TASK5 SECOND-FIXTURE PASS: every factor, dimension, candidate failure, reflection-real involution, PSD inertia, beta isolation, and semigroup check passed for c=3/5.
+```
+
+Formula (20) is minimal only in the explicit support sense: it acts as the
+identity on the orthogonal complement of the four-column displayed span.
+That fact does not prove uniqueness, canonicity, functoriality, or
+naturality under a change of carrier or a change of stable-data span.
+
+## 6. The Positive Package
+
+Apply the swap completion on the left of every stable-split block. Using
+(15) and (25) gives
+
+\[
+\begin{aligned}
+ \widehat H_k[m,n]
+ &:=\Theta_kH_k[m,n]\\
+ &=\rho_{k,c}^{m+n}(\Theta_kx_k)y_k^\dagger\\
+ &=\rho_{k,c}^{m+n}y_ky_k^\dagger.
+                                                               \tag{26}
+\end{aligned}
+\]
+
+The stable magnitude is real and strictly positive. Therefore
+
+\[
+ \widehat H_k[n,m]^\dagger
+ =\rho_{k,c}^{m+n}y_ky_k^\dagger
+ =\widehat H_k[m,n],                                  \tag{27}
+\]
+
+so the completed geometric-Hankel kernel is Hermitian exactly.
+
+For the displayed three super-cells \(m,n=0,1,2\), set
+
+\[
+ w_k=
+ \begin{pmatrix}
+  y_k\\ \rho_{k,c}y_k\\ \rho_{k,c}^2y_k
+ \end{pmatrix}.
+                                                               \tag{28}
+\]
+
+The assembled \(24\times24\) moment matrix factorizes as
+
+\[
+ \widehat{\mathcal H}_k
+ :=\big[\widehat H_k[m,n]\big]_{m,n=0}^{2}
+ =w_kw_k^\dagger.                                    \tag{29}
+\]
+
+Consequently, for every \(z\in\mathbb C^{24}\),
+
+\[
+ z^\dagger\widehat{\mathcal H}_kz
+ =\lvert w_k^\dagger z\rvert^2\ge0.                 \tag{30}
+\]
+
+The matrix is nonzero and rank one. With inertia ordered as
+\((n_+,n_-,n_0)\), this proves
+
+\[
+ \operatorname{In}\widehat{\mathcal H}_k=(1,0,23)
+ \quad\hbox{for every }k.                            \tag{31}
+\]
+
+The momentum sectors are orthogonal blocks of the declared finite
+carrier. At either fixture their direct sum is \(96\times96\), has rank
+four, and obeys
+
+\[
+ \operatorname{In}\!\left(
+   \bigoplus_{k=0}^{3}\widehat{\mathcal H}_k
+ \right)=(4,0,92).                                   \tag{32}
+\]
+
+Thus there is one and only one positive direction in each momentum
+sector. The remaining 23 directions per sector are the moment radical,
+not negative directions. This is exactly what the original rank-one
+stable boundary datum permits: the completion changes the left-right
+identification, but does not manufacture additional moment rank.
+
+The certificate records the complete package as follows:
+
+```text
+TASK4 PACKAGE PASS: for L=3, per-k inertia=(1,0,23), global inertia=(4,0,92); quotient T=diag(rho_k^2) and T^n=diag(rho_k^(2n)) exactly.
+```
+
+The word “package” in this theorem is bounded by (26)--(32): it comprises
+the reflection-real involutive left intertwiner, Hermiticity, positive
+semidefiniteness, the displayed half-space moments, and their quotient
+transfer. It does not silently include a torus reflection form, a curved
+carrier, or the gravity transporter.
+
+## 7. The Contraction And The Semigroup
+
+Quotient the radical of (29). One nonzero moment class remains in each
+momentum sector. Advancing both half-space indices by one super-cell gives
+
+\[
+ \widehat H_k[m+1,n+1]
+ =\rho_{k,c}^{2}\widehat H_k[m,n].                   \tag{33}
+\]
+
+Hence the quotient transfer eigenvalue is
+
+\[
+ \beta_{k,c}=\rho_{k,c}^2.                           \tag{34}
+\]
+
+The four parity-fixture isolating intervals are pinned exactly by the
+certificate:
+
+\[
+\begin{aligned}
+ \beta_{0,2;5/13}
+ &\in\left(
+ {1036202268192599364481\over1000000000000000000000000},
+ {10362022682569795561\over10000000000000000000000}
+ \right),\\
+ \beta_{1,3;5/13}
+ &\in\left(
+ {40934256022421281\over250000000000000000000000},
+ {163737024898973761\over1000000000000000000000000}
+ \right),\\
+ \beta_{0,2;3/5}
+ &\in\left(
+ {81757155275609062921\over62500000000000000000000},
+ {1308114484482080737449\over1000000000000000000000000}
+ \right),\\
+ \beta_{1,3;3/5}
+ &\in\left(
+ {1474215264951121\over40000000000000000000000},
+ {2303461375483321\over62500000000000000000000}
+ \right).
+                                                               \tag{35}
+\end{aligned}
+\]
+
+Each lower endpoint is positive and each upper endpoint is below one by
+exact integer comparison. Therefore the four-momentum quotient operator
+at either fixture,
+
+\[
+ T_c=\operatorname{diag}
+   (\beta_{0,c},\beta_{1,c},\beta_{2,c},\beta_{3,c}), \tag{36}
+\]
+
+obeys \(0<T_c<I\). Because the quotient inner product is inherited from
+the positive semidefinite form after removing its radical, this scalar
+inequality is now a genuine contraction statement on the displayed
+quotient, rather than Block 118's pre-completion algebraic value.
+
+The geometric-Hankel exponent makes composition automatic. Iterating
+(33) adds the exponents, so for every \(n\ge0\),
+
+\[
+ T_c^n
+ =\operatorname{diag}
+   (\rho_{0,c}^{2n},\rho_{1,c}^{2n},
+    \rho_{2,c}^{2n},\rho_{3,c}^{2n}).                 \tag{37}
+\]
+
+Equivalently,
+
+\[
+ T_c^{m+n}=T_c^mT_c^n
+ \qquad(m,n\in\mathbb Z_{\ge0})                      \tag{38}
+\]
+
+holds exactly, with \(T_c^0=I\). No independent window fit or
+step-dependent diagonalization is used.
+
+The exact interval and minimal-polynomial fingerprints are:
+
+```text
+T4 c=5/13: beta=rho^2; even_in=(1036202268192599364481/1000000000000000000000000, 10362022682569795561/10000000000000000000000), odd_in=(40934256022421281/250000000000000000000000, 163737024898973761/1000000000000000000000000); beta_minpoly_sha=(90347496c93674dc,ec251b205781c079)
+T4 c=3/5: beta=rho^2; even_in=(81757155275609062921/62500000000000000000000, 1308114484482080737449/1000000000000000000000000), odd_in=(1474215264951121/40000000000000000000000, 2303461375483321/62500000000000000000000); beta_minpoly_sha=(bd5a4fcaa54ee41d,b71d3a6c16c96116)
+```
+
+This result is deliberately contrasted with
+[Block 116](ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md),
+whose displayed chart windows did not furnish a stationary one-step
+semigroup. Those independently selected windows lacked an exact common
+geometric-Hankel moment law. Here the stable Floquet magnitude supplied by
+the action gives \(\rho^{m+n}\) before the completion, and the swap leaves
+that scalar law unchanged. Advancing both half-space indices therefore
+multiplies by \(\rho^2\), and repeated advances multiply exactly.
+
+This is a super-cell half-space semigroup. It is not a theorem of
+one-fine-slice stationarity on the antiperiodic torus, and it does not
+erase Block 116's result for its different chart-window object.
+
+## 8. What The Completion Is And Is Not
+
+The completion is built from the stable boundary data of the action. The
+vectors \(x_k,y_k\) factor the stable-split action pairing itself, and
+\(Rx_k,Ry_k\) are their declared reality images. In this precise sense,
+formula (20) is action-derived rather than an externally fitted positive
+matrix.
+
+It is also minimal on the displayed span in a narrow sense. The swap is
+prescribed only on
+
+\[
+ \mathcal V_k=\operatorname{span}
+ \{x_k,y_k,Rx_k,Ry_k\},                               \tag{39}
+\]
+
+and \(\Theta_k\) is the identity on \(\mathcal V_k^\perp\). The
+construction makes no additional change to directions that do not enter
+the four-column boundary-data span.
+
+The completion is **not** a fixed carrier-natural operator from the
+fourteen-element list. Its matrix changes when the stable boundary
+factors change. This dependence is the point of the successful route and
+the reason the candidate-failure wall does not contradict existence.
+
+No uniqueness or naturality classification is proved. Equation (14)
+already exhibits a large pointwise solution space, and choosing a
+different admissible span or a different action on its complement can
+produce other completions. “Minimal on the displayed span” is a declared
+extension choice, not a uniqueness theorem or a variational minimum.
+
+The construction is not transported to the antiperiodic torus. Block
+118's torus action has the Klein structure, a non-Hermitian undressed
+pairing, and negative Floquet eigenvalues whose one-step fourth roots are
+not reflection-real. The half-space swap does not by itself specify how
+to cross the torus seam or how to reconcile that structure. The torus
+completion needs its own exact treatment.
+
+Nor is the completion transported to the curved carrier. Nothing here
+proves curved OS positivity beyond the displayed finite carrier, supplies
+the completed ADM/history transporter, couples joint gravity, or forms
+the gravity constraint quotient. Those are downstream construction
+problems, not corollaries of finite half-space positivity.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded finite-carrier wall.
+
+- W1 — **FIXED CARRIER-NATURAL INTERTWINER SELECTION WALL:** no
+  displayed fixed carrier-natural operator intertwines the half-space
+  stable-split pairing. For each of the fourteen named candidates, at
+  each momentum and both rational fixtures, the exact residual
+  \(\Delta_1\) in (17) is nonzero. Hence \(\Theta x\) is not
+  proportional to \(y\), and no scalar \(\mu\) exists for that candidate.
+
+The wall is narrow. It covers only \(A_{\rm dir}\), \(A_{\rm OS}\),
+\(H_{\rm ov}\), \(J_{\rm bar}\), \(K\), \(P\), \(-I\), and the
+seven simple products printed in (16). It does not classify arbitrary
+carrier operators, data-dependent maps, enlarged spans, or torus
+completions.
+
+Most importantly, W1 is not an OS no-go and not an existence no-go. The
+swap completion (20) **exists**, is reflection-real and involutive, and
+satisfies the exact condition with \(\mu=1\). W1 says which fixed
+carrier-natural candidates do not work; it does not say that the
+half-space pairing cannot be completed.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). The positive
+existence theorem, the fixed-candidate wall, the reduction, the package
+certificates, the second fixture, and the live transports are kept
+separate.
+
+1. **PROVED — POSITIVE — data-built swap completion / stable boundary
+   factors plus their reality images / reflection-real involutive
+   intertwiner and Hermitian positive semidefinite half-space package.**
+   Equations (18)--(32) are the strongest row. They give \(\mu=1\),
+   Hermiticity, positive semidefiniteness, and the exact inertias on three
+   super-cells.
+2. **PROVED — fourteen fixed carrier-natural candidates / exact
+   nonproportionality residual / narrow selection wall W1.** The complete
+   ledger after (17) has a nonzero \(\Delta_1\) for every momentum at both
+   fixtures. No \(\mu\) exists for any named candidate.
+3. **PROVED — nonzero rank-one local block / left-factor
+   proportionality lemma / positivity if and only if
+   \(\Theta x=\mu y\) with \(\mu>0\).** Equations (10)--(15) reduce the
+   construction to an exact linear problem and give the three
+   solution-space dimensions.
+4. **PROVED — three-super-cell moment package / exact rank-one
+   factorization, inertia, interval, and power identities / one positive
+   direction per momentum and exact contractive semigroup.** Equations
+   (26)--(38) give inertia \((1,0,23)\) per momentum, global inertia
+   \((4,0,92)\), and \(T^n=\operatorname{diag}(\rho_k^{2n})\).
+5. **PROVED — second rational fixture / independent repetition of every
+   factor, residual, involution, positivity, interval, and semigroup
+   check / same bounded theorem at \(c=3/5\).** The explicit TASK5 line
+   prevents a one-fixture extrapolation.
+6. **UNTESTED — LIVE — torus completion and naturality classification /
+   transport across the antiperiodic seam and compare admissible span
+   choices / carrier-level completion before curved OS and gravity.** This
+   route remains open and is not counted as an attempted route beyond W1.
+
+### N2 — Wall-Independence Audit
+
+There is one current wall, so no pairwise current-wall table is needed. It
+is distinct from Block 118's W1, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md:726-752`.
+
+Block 118 studied one-step gauge existence for the two-slice action. Its
+wall followed from the negative Floquet eigenvalues: every fourth root on
+an eigenline carries a non-real quarter-turn phase, and no
+reflection-real two-by-two fourth root exists. That is a statement about
+homogenizing the action's Floquet micro-motion.
+
+The present wall studies intertwiner selection for a different object,
+the half-space rank-one pairing. It tests whether each named fixed
+carrier operator sends the left factor \(x\) to the line spanned by the
+right factor \(y\). Its mechanism is the exact nonzero residual (17), not
+the fourth-root lemma.
+
+Neither wall implies the other. A fixed operator could fail
+proportionality even if a one-step real gauge existed; conversely, failure
+of a reflection-real one-step gauge does not bar a data-dependent
+half-space intertwiner. Formula (20) demonstrates the latter distinction
+constructively: the Block 118 gauge wall remains true, while the present
+half-space completion exists.
+
+The positive package is independent again. Its Hermiticity and inertia
+follow from the exact factorization \(w_kw_k^\dagger\), and its semigroup
+follows from the geometric-Hankel exponent. These are not consequences of
+declaring the fixed candidates nonproportional.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified
+explicitly. Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| half-space stable-split action pairing | displayed action-derived half-space form only |
+| primary carrier | inherited finite `Z8_t x Z4_x` carrier |
+| both rational shear fixtures | exactly \(c=5/13\) and \(c=3/5\) |
+| every displayed fixed carrier-natural intertwiner candidate | the fourteen operators in (16), no universal operator class |
+| block 114 dressing in both restrictions | exactly \(A_{\rm dir}\) and \(A_{\rm OS}\) |
+| overlap hodge | the displayed \(H_{\rm ov}\) candidate |
+| reality conjugation composed with complex conjugation | the displayed `Jbar` candidate |
+| klein and parity operators | the displayed \(K\) and \(P\) candidates |
+| minus the identity | the displayed \(-I\) candidate |
+| displayed simple products | the seven product rows in the exact ledger |
+| fails the exact proportionality condition at every momentum | nonzero \(\Delta_1\) for all four \(k\) at both fixtures |
+| swap completion | the data-dependent formula (20) |
+| span of the action's stable boundary data and its reality images | the four-column space (39) |
+| reflection-real involutive intertwiner | exact identities (22)--(24) |
+| mu = 1 at every momentum | exact two-way swaps (25) |
+| completed pairing is hermitian positive semidefinite | exact factorization (29)--(30) |
+| per-momentum inertia (1,0,23) | exact inertia on three super-cells |
+| global inertia (4,0,92) | four-momentum direct sum at either fixture |
+| displayed three super-cells | exactly \(L=3\), not an infinite-volume limit |
+| quotient transfer diag(rho_k^2) | radical quotient of the completed positive package |
+| strictly inside (0,1) | four exact rational isolating intervals (35) |
+| exact geometric semigroup law | exact powers and composition (37)--(38) |
+| torus completion | untested-live transport across the antiperiodic seam |
+| curved os positivity beyond the displayed carrier | explicit reconstruction firewall |
+| uniqueness or naturality classification | explicitly not proved |
+| completed adm/history transporter | downstream construction firewall |
+| joint gravity | explicitly not coupled |
+| gravity constraint quotient | explicitly not formed |
+| records | no Records claim |
+| retention | independent-audit firewall |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit-status accounting |
+| actual adm/history transporter remains | standard partial-closure statement |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | the five N5 resolution keys |
+
+No phrase upgrades the half-space package to the torus, calls the swap
+unique or canonical, asserts curved OS positivity, completes the
+ADM/history transporter, authorizes gravity, changes audit status, or
+moves TOE accounting. No phrase turns the fourteen-candidate wall into
+nonexistence of intertwiners.
+
+### N4 — Residual Matching
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 118 next gate](ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md), docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md:16 and :1034-1050 | construct the reflection intertwiner that completes the rank-one geometric-Hankel action pairing to a Hermitian positive OS package; then the gravity constraint quotient | the data-built swap completes that package on the displayed half-space and gives its exact contraction semigroup; torus transport, naturality, curved OS, and gravity remain |
+| [Block 117 stationarity diagnosis](ADMISSIBILITY_DIRAC_KAHLER_SELF_CHART_EMPTINESS_STATIONARITY_BOUNDED_THEOREM_NOTE_2026-08-16.md), docs/ADMISSIBILITY_DIRAC_KAHLER_SELF_CHART_EMPTINESS_STATIONARITY_BOUNDED_THEOREM_NOTE_2026-08-16.md:437-506 | explain the fixed adjacent-window mismatch and construct an action-derived Toeplitz repair | the stable-split factors come from the action and the swap realizes the repair named by that diagnosis on the half-space, without claiming fine-time torus stationarity |
+| [Block 116 non-semigroup wall](ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md), docs/ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md:467-492 | the displayed chart windows did not furnish a stationary one-step semigroup and left the modular/action route open | the action's stable Floquet-period geometric law gives \(T^n=\operatorname{diag}(\rho_k^{2n})\) exactly on the completed half-space quotient; the prior chart result is unchanged |
+
+Every inherited residual reaches exactly its stated interface. No citation
+is used as an audit verdict, and no half-space identity is silently
+transported to the torus or curved carrier.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “On the half-space stable-split
+action pairing of the primary finite carrier at both rational fixtures,
+all fourteen displayed fixed carrier-natural intertwiners fail exact
+proportionality at every momentum, but the data-built swap is a
+reflection-real involution with \(\mu=1\) whose three-super-cell pairing
+is Hermitian positive semidefinite with inertia \((1,0,23)\) per momentum
+and whose quotient has the exact contractive geometric semigroup
+\(T^n=\operatorname{diag}(\rho_k^{2n})\).”
+
+Forbidden upgrades include “the OS package is complete on the torus,”
+“the completion is unique/canonical,” “curved OS positivity holds,” and
+“the transporter is finished.” Also forbidden are “every
+carrier-natural intertwiner fails,” “the swap is the unique completion,”
+“minimal support proves naturality,” “the antiperiodic seam is solved,”
+“the gravity constraint quotient can now be executed,” “an axiom
+amendment is required,” and “audit retention follows from this note.”
+
+The five resolution lines from the runner specification are reproduced
+verbatim:
+
+```text
+N5: per_element: exact factorization, proportionality, candidate-failure, swap, reflection-reality, involution, Hermiticity, inertia, beta-isolation, and semigroup identities are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: all four fixed momenta at c=5/13 and c=3/5 reject every named fixed carrier-natural candidate and admit the data-dependent swap completion with mu=1
+per_block: the swap completion makes the L=3 half-space pairing Hermitian positive semidefinite with inertia (1,0,23) per momentum and quotient transfer beta=rho^2 in (0,1)
+lattice_wide: checked and not executed — the torus completion, naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The remaining decisions concern
+transport and classification of an existing bounded half-space package,
+then downstream reconstruction.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| rank-one factorization | exact \(H[0,0]=xy^\dagger\) and 784 vanishing minors per sector | none for the displayed local blocks |
+| positivity reduction | exact iff condition \(\Theta x=\mu y\), \(\mu>0\) | none for the pointwise lemma |
+| fixed carrier candidates | fourteen exact nonproportionality rows at both fixtures | none for narrow W1 |
+| swap completion | exact data-built formula with \(\mu=1\) in both directions | none for existence on the displayed span |
+| reflection and involution | \(\Theta^2=I\) and \(R\Theta_kR=\Theta_{\bar k}\) | none for the displayed half-space sectors |
+| positive package | exact Hermitian PSD factorization on \(L=3\) cells | none for the displayed moment matrices |
+| inertia | \((1,0,23)\) per momentum and \((4,0,92)\) globally | none for the displayed three-super-cell package |
+| quotient contraction | four exact \((0,1)\) intervals at both fixtures | none for the displayed quotient spectrum |
+| semigroup | exact \(T^n=\operatorname{diag}(\rho_k^{2n})\) | none for half-space super-cell composition |
+| second fixture | every factor, wall, completion, inertia, interval, and power check repeated | none for \(c=3/5\) |
+| torus completion | untested-live | cross the seam and re-run Hermiticity, reflection, and composition |
+| naturality classification | untested-live | classify span and complement choices under carrier maps |
+| curved OS route | not executed | transport the completed package and prove curved positivity |
+| gravity route | not executed | complete transport, then form the gravity constraint quotient |
+
+The scan finds no axiom-amendment route. The Block 118
+reflection-intertwiner opening is partially closed: a reflection-real
+involutive completion now exists, and its displayed half-space moment
+package is positive semidefinite with an exact contractive semigroup. The
+fixed-operator selection subroute closes negatively by W1. Torus
+transport, naturality, curved OS positivity, the completed transporter,
+and gravity remain open, so the end-to-end route does not close.
+
+### N7 — Steelman
+
+**Hostile steelman against the data-built completion.** The swap uses
+\(x\) and \(y\), which are factors of the pairing it is designed to make
+positive. Is this circular—does the construction merely insert the
+desired answer into \(\Theta\)?
+
+No. The input data are fixed before the completion: \(x\) and \(y\) are
+extracted exactly from the action's stable split by (10), and the
+geometric-Hankel law is inherited from Block 118. Formula (20) is then an
+explicit linear operator, and reflection-reality, involutivity,
+Hermiticity, inertia, and the semigroup law are separately checked exact
+consequences. No target eigenvalue or positive matrix is fitted. The
+construction is action-derived in that sense.
+
+The objection does identify the correct remaining weakness. Dependence on
+the pairing's own boundary data does not establish carrier-naturality. A
+map between carriers could alter the factor span or fail to commute with
+the chosen identity extension. That question is left open explicitly.
+
+**Hostile steelman against minimality and uniqueness.** Equation (20) is
+the identity off a four-column span. Why not call it the canonical minimal
+completion?
+
+Because support-minimal extension is a choice, not a classification.
+Equation (14) displays a large pointwise solution space. A different
+admissible span, a different action on the complement, or another
+reflection-compatible solution of \(\Theta x=y\) can give a different
+completion. This theorem proves existence of the displayed swap and no
+uniqueness, canonicality, or naturality property.
+
+**Hostile steelman against the torus firewall.** The completed half-space
+kernel is geometric-Hankel and has an exact contraction semigroup. Why
+should the same formula not be wrapped around the antiperiodic torus?
+
+The torus carries data absent from the one-sided span: the seam, the
+Klein signs, the non-Hermitian undressed pairing, and Block 118's distinct
+negative Floquet eigenvalues. A reflection-real fine-step fourth root
+still does not exist. The half-space formula neither proves compatibility
+with that seam nor specifies how its span closes after winding. The torus
+obstruction may therefore return in a different form and must be tested
+directly.
+
+These steelmen do not weaken narrow W1. Every one of the fourteen fixed
+candidates has an exact nonzero proportionality residual. They do prevent
+upgrading the successful data-built example to a unique, natural, torus,
+or curved completion.
+
+### N8 — Cross-Cycle Echo
+
+The thirteen prior campaign blocks each narrowed the hunt; the discipline
+held.
+
+| campaign block | narrowing that led to the present wall and completion |
+|---|---|
+| Block 106 | fixed the local dual-descent entry and preserved the action-to-Gram order |
+| Block 107 | isolated the finite two-history seam carrier |
+| Block 108 | tested the locality reach of involutive seam dressing |
+| Block 109 | forced the dressing search to global support |
+| Block 110 | restricted the viable signature to the even sector |
+| Block 111 | factorized the positivity frontier and displayed the self-block involution families |
+| Block 112 | exposed the paired even-parity branch and its count |
+| Block 113 | refuted the paired floor and located the mixed-circle crossing |
+| Block 114 | supplied the exact positive chart and endpoint beyond the certified crossing |
+| Block 115 | separated Hilbert positivity from transfer contractivity on the displayed windows |
+| [Block 116 chart wall](ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md) | proved the paired-chart freeze and recorded the non-semigroup window behavior |
+| [Block 117 stationarity wall](ADMISSIBILITY_DIRAC_KAHLER_SELF_CHART_EMPTINESS_STATIONARITY_BOUNDED_THEOREM_NOTE_2026-08-16.md) | closed the displayed self charts and named an action-derived stationarity repair |
+| [Block 118 Floquet/action wall](ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md) | derived the geometric-Hankel stable split, isolated \(\rho^2\), and named the reflection-intertwiner completion |
+
+The current block preserves that narrowing. It reduces positivity to one
+exact proportionality condition, rejects the fourteen fixed candidates,
+and then constructs the data-dependent swap rather than misreporting the
+selection wall as nonexistence. The resulting positive semidefinite
+half-space package turns Block 118's algebraic \(\rho^2\) into the exact
+quotient contraction semigroup, while the torus and curved-carrier
+firewalls remain.
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1: no one of the
+fourteen displayed fixed carrier-natural operators intertwines the
+half-space pairing, by exact nonproportionality at every momentum and both
+fixtures. The swap completion **exists**, so W1 is a selection statement
+and not an existence no-go. **FAIL** for nonexistence of intertwiners,
+failure of every carrier-natural construction, uniqueness or canonicity
+of the swap, completion on the torus, curved OS positivity, a completed
+ADM/history transporter, gravity, axiom necessity, audit retention, or
+TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. The rank-one factorization,
+proportionality lemma, solution dimensions, exact candidate residuals,
+data-built swap, reflection-reality, involutivity, Hermiticity, positive
+semidefinite factorizations, inertia counts, isolating intervals, and
+geometric semigroup powers are finite consequences of the displayed
+carrier, fixtures, and stable boundary data. No new primitive is assumed.
+
+This is bounded route progress, not an audit-grade assignment. It retires
+no end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. carry the completed half-space package back to the antiperiodic torus
+   and classify which parts of the swap construction are carrier-natural;
+2. transport the resulting completion to the curved carrier and prove the
+   required OS positivity there; and
+3. then form the gravity constraint quotient.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+half-space swap completion, positive semidefinite moment package, and
+exact geometric semigroup.
+
+Reflection positivity on the curved carrier remains unexecuted.
+
+The gravity constraint quotient remains unexecuted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15958,
- "node_count": 5547,
+ "edge_count": 15962,
+ "node_count": 5548,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -461,6 +461,10 @@
   "admissibility_dirac_kahler_positive_dressed_reflection_bounded_theorem_note_2026-08-15": {
    "deps_hash": "e380eb905745",
    "out_degree": 5
+  },
+  "admissibility_dirac_kahler_reflection_intertwiner_completion_bounded_theorem_note_2026-08-16": {
+   "deps_hash": "118a19942005",
+   "out_degree": 4
   },
   "admissibility_dirac_kahler_seam_dressing_sector_signature_bounded_theorem_note_2026-08-15": {
    "deps_hash": "8e68e06c11b5",

--- a/logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py
+runner_sha256: bb25f33b48586d47e4183849839fcc8c2521c69eaa84cf5853f1c4ed8dc56ef4
+input_fingerprint_sha256: c093b4b116fa5ac81e4a1285c78321944e58450ee6b64a4b7758bee28704a086
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 231.70
+status: ok
+----- stdout -----
+[PASS] A-authority: Block 118 blobs and ancestors 117--103 are pinned
+[PASS] B-the-factorization: H00_k=x_k y_k^H at pivot (0,0), all minors vanish, and H[m,n]=rho^(m+n)H00
+[PASS] C-the-reduction: nonzero PSD iff Theta*x=mu*y with real mu>0; dimensions are 57/56/113
+[PASS] D-the-candidate-failures: all fourteen fixed carriers have an exact nonzero Delta_j at every k
+[PASS] E-the-swap-completion: V(S_swap-I)(V^H V)^-1 swaps x/y with mu=1 and is involutive and reflection-real
+[PASS] F-the-positive-package: three-super-cell pairing is Hermitian PSD with inertias (1,0,23) and (4,0,92)
+[PASS] G-the-contraction-and-semigroup: beta_k=rho_k^2 is pinned in (0,1) and n=2,3 act as rho_k^(2n)
+[PASS] H-scope: all required note phrases, N1--N8/W1/N5 firewalls, and runtime bound
+FACTOR c=5/13: pivots=((0, 0), (0, 0), (0, 0), (0, 0)); y0=(1, 1, 1, 1); vanishing_minors=(784, 784, 784, 784)
+FACTOR c=3/5: pivots=((0, 0), (0, 0), (0, 0), (0, 0)); y0=(1, 1, 1, 1); vanishing_minors=(784, 784, 784, 784)
+CANDIDATES: 14 named carriers x 4 momenta x 2 fixtures = 112 exact nonproportionality residuals
+PACKAGE c=5/13: per_k=((1, 0, 23), (1, 0, 23), (1, 0, 23), (1, 0, 23)); global=(4, 0, 92); beta=k0/2=(1036202268192599364481/1000000000000000000000000, 10362022682569795561/10000000000000000000000);k1/3=(40934256022421281/250000000000000000000000, 163737024898973761/1000000000000000000000000); runtime=231.310s
+PACKAGE c=3/5: per_k=((1, 0, 23), (1, 0, 23), (1, 0, 23), (1, 0, 23)); global=(4, 0, 92); beta=k0/2=(81757155275609062921/62500000000000000000000, 1308114484482080737449/1000000000000000000000000);k1/3=(1474215264951121/40000000000000000000000, 2303461375483321/62500000000000000000000); runtime=231.310s
+N5: per_element: exact factorization, proportionality, candidate-failure, swap, reflection-reality, involution, Hermiticity, inertia, beta-isolation, and semigroup identities are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: all four fixed momenta at c=5/13 and c=3/5 reject every named fixed carrier-natural candidate and admit the data-dependent swap completion with mu=1
+per_block: the swap completion makes the L=3 half-space pairing Hermitian positive semidefinite with inertia (1,0,23) per momentum and quotient transfer beta=rho^2 in (0,1)
+lattice_wide: checked and not executed — the torus completion, naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+RESULT: no fixed carrier operator intertwines the half-space pairing, but the swap completion on the action's stable boundary data is a reflection-real involution that completes it to a positive OS package with contractive transfer diag(rho_k^2) and the exact geometric semigroup — the campaign's first positive and contractive finite OS structure
+DECISION_CUT: carry the completed package to the torus and the curved carrier and classify the completion's naturality; reject fixed-operator intertwiner searches
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py
+++ b/scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py
@@ -1,0 +1,1391 @@
+#!/usr/bin/env python3
+"""Block 119: exact reflection-intertwiner completion certificate.
+
+The Block 118 geometric-Hankel half-space pairing is factored sector by
+sector over its exact stable-root field.  Fixed carrier candidates are
+refuted there, while a reflection-real swap on the stable boundary data
+completes the pairing to an involutive positive package with its exact
+contractive geometric semigroup.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+import subprocess
+import time
+
+import sympy as sp
+
+import admissibility_dirac_kahler_floquet_monodromy_action_pairing_2026_08_16 as prior
+
+
+R = sp.Rational
+I = sp.I
+RHO = prior.ALPHA
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_floquet_monodromy_"
+    "action_pairing_2026_08_16.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_floquet_monodromy_"
+    "action_pairing_2026_08_16.txt"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "scripts/admissibility_dirac_kahler_floquet_monodromy_action_pairing_2026_08_16.py",
+    "logs/runner-cache/admissibility_dirac_kahler_floquet_monodromy_action_pairing_2026_08_16.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "4e566b14a6352a9a62590252a9755c7a103c1b9e"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block118-floquet-monodromy-action-pairing-20260816"
+)
+PARENT_COMMIT = "fdd1883c54ca8cc14b1337cc1edc249792d5dab2"
+PARENT_NOTE_BLOB = "d8f5765c3fee3bd349aebd7bf945066ca5439235"
+PARENT_RUNNER_BLOB = "12c065883099077aae880eeecf3f2a80444a1d87"
+PARENT_CACHE_BLOB = "804641ed09f5c2c0b458b0b9ce8a201c93c05a43"
+ANCESTOR_COMMITS = (
+    (117, "f800356aec0989b6e0fa80ed43274794243b1ca2"),
+    (116, "c36d11e4e8d927c6fc31f0a8b579d4bd15f4fa43"),
+    (115, "c78301fef7521d0518f485f1bf9266983c9e516a"),
+    (114, "75026e71cfbd44ed665ddc41c22ebaa722720ea9"),
+    (113, "e76893eb7204d1d727a3ab8838fb3fada3f45dfc"),
+    (112, "385a6ba5b1594f20e5d4eebba9da68d8e72abc10"),
+    (111, "b04e7c8747b09734711cfcd2bfab961bd12e81ad"),
+    (110, "d6761278fca9cac617200792473a8f4da3a6cfff"),
+    (109, "ad84cfcc857a65285389ba93b47cd7b718589be5"),
+    (108, "8afe8dff5ccf531208238af0aaaec1f547d73874"),
+    (107, "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"),
+    (106, "22d6d90ec2279e5868c9c825149b2a20beea3797"),
+    (105, "d06066c2b908aaca0779625d831dfb10620cf34d"),
+    (104, "7fe07db6c03fad1191893c942f708c5cb9a54c43"),
+    (103, "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"),
+)
+
+EXPECTED_BETA_INTERVALS = prior.EXPECTED_BETA_INTERVALS
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "break_factorization",
+    "break_reduction",
+    "claim_negative_mu_allowed",
+    "claim_candidate_works",
+    "break_swap_involution",
+    "break_reflection_reality",
+    "break_mu_one",
+    "break_inertia",
+    "claim_negative_direction",
+    "break_semigroup",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_toe_progress",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition) -> None:
+        ok = bool(condition)
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {statement}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    ancestors = {
+        f"ancestor_{number}": is_ancestor(commit, "HEAD")
+        for number, commit in ANCESTOR_COMMITS
+    }
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        **ancestors,
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+    }
+
+
+def red(value: sp.Expr, polynomial: sp.Poly) -> sp.Expr:
+    """Reduce in QQ(i)[rho]/(p_k)."""
+    return prior.quadratic_reduce(value, polynomial)
+
+
+def star(value: sp.Expr, polynomial: sp.Poly) -> sp.Expr:
+    """The root-field involution fixing real rho and conjugating i."""
+    return prior.quadratic_conjugate(value, polynomial)
+
+
+def field_matrix(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    return matrix.applyfunc(lambda value: red(value, polynomial))
+
+
+def field_equal(
+    left: sp.Matrix, right: sp.Matrix, polynomial: sp.Poly
+) -> bool:
+    return left.shape == right.shape and all(
+        red(value, polynomial) == 0 for value in left - right
+    )
+
+
+def field_adjoint(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    return sp.Matrix(
+        matrix.cols,
+        matrix.rows,
+        lambda row, column: star(matrix[column, row], polynomial),
+    )
+
+
+def field_conjugate(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    return matrix.applyfunc(lambda value: star(value, polynomial))
+
+
+def root_outer(vector: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    return sp.Matrix(
+        vector.rows,
+        vector.rows,
+        lambda row, column: red(
+            vector[row] * star(vector[column], polynomial), polynomial
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class Sector:
+    shear: sp.Rational
+    momentum: int
+    transfer: prior.Transfer
+    polynomial: sp.Poly
+    stable_interval: tuple[int, int]
+    h00: sp.Matrix
+    x: sp.Matrix
+    y: sp.Matrix
+    pivot: tuple[int, int]
+    minors_vanishing: int
+    factorization: bool
+    geometric_hankel: bool
+
+
+def make_sectors(shear: sp.Rational) -> tuple[Sector, ...]:
+    """Reuse Block 118's cut action and stable residue exactly."""
+    fixture = prior.build_fixture(shear)
+    cut_actions = tuple(
+        prior.reflection_cut(block)[0] for block in fixture.action_blocks
+    )
+    transfers = tuple(prior.transfer_from_action(block) for block in cut_actions)
+    residues = tuple(prior.stable_residue(transfer) for transfer in transfers)
+    result = []
+    for momentum in range(4):
+        opposite = (-momentum) % 4
+        transfer = transfers[opposite]
+        polynomial = transfer.magnitude_polynomial
+        if polynomial != transfers[momentum].magnitude_polynomial:
+            raise AssertionError("opposite momentum root fields disagree")
+        residue = residues[opposite]
+        h00 = sp.Matrix(
+            8,
+            8,
+            lambda row, column: star(
+                residue.matrix[row, 7 - column], polynomial
+            ),
+        ).applyfunc(lambda value: red(value, polynomial))
+        pivot = next(
+            (
+                (row, column)
+                for row in range(8)
+                for column in range(8)
+                if red(h00[row, column], polynomial) != 0
+            ),
+            None,
+        )
+        if pivot is None:
+            raise AssertionError("stable residue has no nonzero pivot")
+        pivot_row, pivot_column = pivot
+        pivot_value = h00[pivot_row, pivot_column]
+        x = h00[:, pivot_column].applyfunc(
+            lambda value: red(value, polynomial)
+        )
+        y = sp.Matrix(
+            [
+                star(h00[pivot_row, column] / pivot_value, polynomial)
+                for column in range(8)
+            ]
+        ).applyfunc(lambda value: red(value, polynomial))
+        outer = root_outer(x, polynomial)
+        # root_outer(x) is not the desired nonsymmetric factorization; use
+        # x y^H with y normalized by the pivot row.
+        outer = sp.Matrix(
+            8,
+            8,
+            lambda row, column: red(
+                x[row] * star(y[column], polynomial), polynomial
+            ),
+        )
+        minors_vanishing = sum(
+            red(
+                h00[a, c] * h00[b, d] - h00[a, d] * h00[b, c],
+                polynomial,
+            )
+            == 0
+            for a, b in combinations(range(8), 2)
+            for c, d in combinations(range(8), 2)
+        )
+        factorization = (
+            pivot == (0, 0)
+            and red(y[0] - 1, polynomial) == 0
+            and any(red(value, polynomial) != 0 for value in x)
+            and any(red(value, polynomial) != 0 for value in y)
+            and field_equal(outer, h00, polynomial)
+            and minors_vanishing == 784
+        )
+        blocks = tuple(
+            tuple(
+                field_matrix(RHO ** (row + column) * h00, polynomial)
+                for column in range(3)
+            )
+            for row in range(3)
+        )
+        geometric_hankel = all(
+            field_equal(
+                blocks[row][column],
+                field_matrix(RHO ** (row + column) * h00, polynomial),
+                polynomial,
+            )
+            for row in range(3)
+            for column in range(3)
+        ) and all(
+            field_equal(
+                blocks[row][column], blocks[row - 1][column + 1], polynomial
+            )
+            for row in range(1, 3)
+            for column in range(2)
+        )
+        result.append(
+            Sector(
+                shear,
+                momentum,
+                transfer,
+                polynomial,
+                transfer.isolations[0],
+                h00,
+                x,
+                y,
+                pivot,
+                minors_vanishing,
+                factorization,
+                geometric_hankel,
+            )
+        )
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class Reduction:
+    theta_one: sp.Matrix
+    proportional_dimension: int
+    fixed_mu_dimension: int
+    positive_real_dimension: int
+    proportionality_rank: int
+    evaluation_rank: int
+    exact_reduction: bool
+    real_moment_psd: bool
+    negative_mu_excluded: bool
+
+
+def reduction_certificate(sector: Sector) -> Reduction:
+    """Certify Theta H >= 0 iff Theta x = mu y with real mu > 0."""
+    polynomial = sector.polynomial
+    pivot_row = sector.pivot[0]
+    theta_one = sp.zeros(8)
+    for row in range(8):
+        theta_one[row, pivot_row] = red(
+            sector.y[row] / sector.x[pivot_row], polynomial
+        )
+    image = field_matrix(theta_one * sector.x, polynomial)
+    completed = field_matrix(theta_one * sector.h00, polynomial)
+    y_square = root_outer(sector.y, polynomial)
+
+    # y_0=1 makes the seven proportionality equations independent.
+    constraint = sp.zeros(7, 64)
+    nonzero_rows = tuple(range(1, 8))
+    for equation, row in enumerate(nonzero_rows):
+        for column in range(8):
+            constraint[equation, 8 * row + column] = red(
+                sector.y[0] * sector.x[column], polynomial
+            )
+            constraint[equation, column] = red(
+                -sector.y[row] * sector.x[column], polynomial
+            )
+    constraint_witness = constraint[
+        :, tuple(8 * row + pivot_row for row in nonzero_rows)
+    ]
+    proportionality_rank = 7 if red(
+        constraint_witness.det(method="domain-ge"), polynomial
+    ) != 0 else -1
+
+    # At fixed mu, evaluation Theta -> Theta*x is onto, giving rank eight.
+    evaluation = sp.zeros(8, 64)
+    for row in range(8):
+        for column in range(8):
+            evaluation[row, 8 * row + column] = sector.x[column]
+    evaluation_witness = evaluation[
+        :, tuple(8 * row + pivot_row for row in range(8))
+    ]
+    evaluation_rank = 8 if red(
+        evaluation_witness.det(method="domain-ge"), polynomial
+    ) != 0 else -1
+
+    moment_vector = sp.Matrix((1, RHO, RHO**2))
+    moment = field_matrix(moment_vector * moment_vector.T, polynomial)
+    real_moment_psd = (
+        all(
+            red(moment[row, column] - RHO ** (row + column), polynomial)
+            == 0
+            for row in range(3)
+            for column in range(3)
+        )
+        and all(
+            red(star(value, polynomial) - value, polynomial) == 0
+            for value in moment_vector
+        )
+        and 0 < sector.stable_interval[0] < sector.stable_interval[1] < 10**12
+        and polynomial.count_roots(
+            R(sector.stable_interval[0], 10**12),
+            R(sector.stable_interval[1], 10**12),
+        )
+        == 1
+    )
+    # For z=Theta*x, Hermiticity of z y^H forces z=z_0 y and
+    # z_0=star(z_0), since y_0=1.  Its only nonzero eigenvalue has the
+    # sign of this real scalar, so nonzero PSD is exactly mu>0.
+    exact_reduction = (
+        sector.factorization
+        and red(sector.y[0] - 1, polynomial) == 0
+        and field_equal(image, sector.y, polynomial)
+        and field_equal(completed, y_square, polynomial)
+        and field_equal(y_square, field_adjoint(y_square, polynomial), polynomial)
+        and proportionality_rank == 7
+        and evaluation_rank == 8
+        and real_moment_psd
+    )
+    negative_mu_excluded = (
+        red(-y_square[0, 0] + 1, polynomial) == 0
+        and red(sector.y[0] - 1, polynomial) == 0
+    )
+    return Reduction(
+        theta_one,
+        64 - proportionality_rank,
+        64 - evaluation_rank,
+        2 * (64 - evaluation_rank) + 1,
+        proportionality_rank,
+        evaluation_rank,
+        exact_reduction,
+        real_moment_psd,
+        negative_mu_excluded,
+    )
+
+
+B114 = prior.prior.prior.prior.prior
+B111 = prior.b111
+B110_BASE = B111.block110.prior
+
+
+def cut_shift() -> sp.Matrix:
+    result = sp.zeros(8)
+    for local_time in range(8):
+        old_time = (local_time + 4) % 8
+        result[local_time, old_time] = 1 if local_time < 4 else -1
+    if not prior.matrix_equal(result * result.T, sp.eye(8)):
+        raise AssertionError("half-space cut shift is not orthogonal")
+    return result
+
+
+def positive_dressings(shear: sp.Rational) -> tuple[sp.Matrix, ...]:
+    """The four exact positive dressing blocks constructed in Block 114."""
+    witness = B114.pinned_witness(shear)
+    blocks = tuple(witness.blocks)
+    if (
+        witness.shear != shear
+        or len(blocks) != 4
+        or not all(
+            prior.matrix_equal(block * block, sp.eye(8)) for block in blocks
+        )
+    ):
+        raise AssertionError("Block 114 positive dressing mismatch")
+    return blocks
+
+
+@dataclass(frozen=True)
+class Carrier:
+    name: str
+    operators: tuple[sp.Matrix, ...]
+    targets: tuple[int, ...]
+    antilinear: bool = False
+
+
+def compose_carriers(left: Carrier, right: Carrier, name: str) -> Carrier:
+    operators = []
+    targets = []
+    for source in range(4):
+        middle = right.targets[source]
+        right_operator = right.operators[source]
+        if left.antilinear:
+            right_operator = right_operator.applyfunc(sp.conjugate)
+        operators.append(
+            (left.operators[middle] * right_operator).applyfunc(sp.expand)
+        )
+        targets.append(left.targets[middle])
+    return Carrier(
+        name,
+        tuple(operators),
+        tuple(targets),
+        left.antilinear != right.antilinear,
+    )
+
+
+_HODGE_CACHE: tuple[sp.Matrix, ...] | None = None
+
+
+def hodge_blocks() -> tuple[sp.Matrix, ...]:
+    global _HODGE_CACHE
+    if _HODGE_CACHE is not None:
+        return _HODGE_CACHE
+    fourier = sp.Matrix(
+        4, 4, lambda row, column: I ** (-row * column)
+    ) / 2
+    transform = sp.kronecker_product(sp.eye(8), fourier)
+    transformed = (
+        transform.H * B110_BASE.global_candidate() * transform
+    ).applyfunc(sp.expand)
+    indices = tuple(
+        tuple(momentum + 4 * time for time in range(8))
+        for momentum in range(4)
+    )
+    support = tuple(
+        tuple(
+            any(
+                transformed[row, column] != 0
+                for row in indices[target]
+                for column in indices[source]
+            )
+            for target in range(4)
+        )
+        for source in range(4)
+    )
+    expected_support = tuple(
+        tuple(target == (source + 2) % 4 for target in range(4))
+        for source in range(4)
+    )
+    if support != expected_support:
+        raise AssertionError("overlap Hodge carrier has unexpected support")
+    _HODGE_CACHE = tuple(
+        transformed.extract(indices[(momentum + 2) % 4], indices[momentum])
+        for momentum in range(4)
+    )
+    return _HODGE_CACHE
+
+
+def carrier_family(shear: sp.Rational) -> tuple[Carrier, ...]:
+    cut = cut_shift()
+    fixture = prior.build_fixture(shear)
+    if not all(
+        prior.matrix_equal(
+            prior.reflection_cut(block)[0], cut * block * cut.T
+        )
+        for block in fixture.action_blocks
+    ):
+        raise AssertionError("candidate cut convention disagrees with Block 118")
+    dressings = positive_dressings(shear)
+    direct = Carrier(
+        "A_dir",
+        tuple(
+            (cut * dressings[momentum] * cut.T).applyfunc(sp.expand)
+            for momentum in range(4)
+        ),
+        (0, 1, 2, 3),
+    )
+    reflected = Carrier(
+        "A_OS",
+        tuple(
+            (
+                cut
+                * dressings[(-momentum) % 4].conjugate()
+                * cut.T
+            ).applyfunc(sp.expand)
+            for momentum in range(4)
+        ),
+        (0, 1, 2, 3),
+    )
+    hodge = Carrier(
+        "Hov",
+        tuple(
+            (cut * block * cut.T).applyfunc(sp.expand)
+            for block in hodge_blocks()
+        ),
+        (2, 3, 0, 1),
+    )
+    reality_matrix = (cut * B111.J * cut.T).applyfunc(sp.expand)
+    reality = Carrier(
+        "Jbar", (reality_matrix,) * 4, (0, 3, 2, 1), True
+    )
+    klein = Carrier(
+        "K", (sp.diag(*((1, -1) * 4)),) * 4, (0, 1, 2, 3)
+    )
+    parity = Carrier("P", (sp.eye(8),) * 4, (2, 3, 0, 1))
+    fermion = Carrier("-I", (-sp.eye(8),) * 4, (0, 1, 2, 3))
+    return (
+        direct,
+        reflected,
+        hodge,
+        reality,
+        klein,
+        parity,
+        fermion,
+        compose_carriers(klein, reflected, "K*A"),
+        compose_carriers(reflected, klein, "A*K"),
+        compose_carriers(klein, hodge, "K*Hov"),
+        compose_carriers(hodge, klein, "Hov*K"),
+        compose_carriers(klein, reality, "K*Jbar"),
+        compose_carriers(reality, klein, "Jbar*K"),
+        compose_carriers(hodge, reality, "Hov*Jbar"),
+    )
+
+
+@dataclass(frozen=True)
+class Verdict:
+    proportional: bool
+    failure_index: int | None
+    failure_value: sp.Expr | None
+
+
+def candidate_verdict(
+    carrier: Carrier, source: Sector, target: Sector
+) -> Verdict:
+    polynomial = source.polynomial
+    if polynomial != target.polynomial:
+        raise AssertionError("candidate target does not share the root field")
+    vector = (
+        source.x.applyfunc(lambda value: star(value, polynomial))
+        if carrier.antilinear
+        else source.x
+    )
+    image = field_matrix(
+        carrier.operators[source.momentum] * vector, polynomial
+    )
+    if red(target.y[0] - 1, polynomial) != 0:
+        raise AssertionError("candidate reduction requires y_0=1")
+    residuals = tuple(
+        red(image[index] - image[0] * target.y[index], polynomial)
+        for index in range(8)
+    )
+    failure = next(
+        (
+            (index, value)
+            for index, value in enumerate(residuals)
+            if value != 0
+        ),
+        None,
+    )
+    if failure is None:
+        return Verdict(True, None, None)
+    return Verdict(False, failure[0], failure[1])
+
+
+@dataclass(frozen=True)
+class CandidateCertificate:
+    names: tuple[str, ...]
+    table: dict[tuple[sp.Rational, str], tuple[Verdict, ...]]
+    failures_per_fixture: tuple[int, int]
+    all_nonproportional: bool
+
+
+def candidate_certificate(
+    fixtures: tuple[tuple[Sector, ...], tuple[Sector, ...]],
+) -> CandidateCertificate:
+    table = {}
+    names: tuple[str, ...] | None = None
+    failure_counts = []
+    for sectors in fixtures:
+        shear = sectors[0].shear
+        carriers = carrier_family(shear)
+        current_names = tuple(carrier.name for carrier in carriers)
+        if names is None:
+            names = current_names
+        if current_names != names:
+            raise AssertionError("candidate names differ between fixtures")
+        count = 0
+        for carrier in carriers:
+            verdicts = tuple(
+                candidate_verdict(
+                    carrier,
+                    sectors[momentum],
+                    sectors[carrier.targets[momentum]],
+                )
+                for momentum in range(4)
+            )
+            table[(shear, carrier.name)] = verdicts
+            count += sum(not verdict.proportional for verdict in verdicts)
+        failure_counts.append(count)
+    if names is None:
+        raise AssertionError("empty candidate family")
+    all_nonproportional = all(
+        not verdict.proportional
+        for verdicts in table.values()
+        for verdict in verdicts
+    )
+    return CandidateCertificate(
+        names,
+        table,
+        (failure_counts[0], failure_counts[1]),
+        all_nonproportional,
+    )
+
+
+def field_inverse(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    if matrix.rows != matrix.cols:
+        raise AssertionError("root-field inverse requires a square matrix")
+    size = matrix.rows
+    augmented = field_matrix(matrix, polynomial).row_join(sp.eye(size))
+    for column in range(size):
+        pivot = next(
+            (
+                row
+                for row in range(column, size)
+                if red(augmented[row, column], polynomial) != 0
+            ),
+            None,
+        )
+        if pivot is None:
+            raise AssertionError("root-field matrix is singular")
+        if pivot != column:
+            augmented.row_swap(pivot, column)
+        inverse_pivot = red(1 / augmented[column, column], polynomial)
+        for entry in range(2 * size):
+            augmented[column, entry] = red(
+                augmented[column, entry] * inverse_pivot, polynomial
+            )
+        for row in range(size):
+            if row == column:
+                continue
+            factor = red(augmented[row, column], polynomial)
+            if factor == 0:
+                continue
+            for entry in range(2 * size):
+                augmented[row, entry] = red(
+                    augmented[row, entry]
+                    - factor * augmented[column, entry],
+                    polynomial,
+                )
+    inverse = augmented[:, size:]
+    if not (
+        field_equal(
+            field_matrix(matrix * inverse, polynomial), sp.eye(size), polynomial
+        )
+        and field_equal(
+            field_matrix(inverse * matrix, polynomial), sp.eye(size), polynomial
+        )
+    ):
+        raise AssertionError("root-field Gauss inverse failed")
+    return inverse
+
+
+def swap_completion(vectors: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    """Swap columns 0<->1 and 2<->3, fixing their orthogonal complement."""
+    if vectors.shape != (8, 4):
+        raise AssertionError("swap completion requires four boundary vectors")
+    adjoint = field_adjoint(vectors, polynomial)
+    gram = field_matrix(adjoint * vectors, polynomial)
+    gram_inverse = field_inverse(gram, polynomial)
+    left_inverse = field_matrix(gram_inverse * adjoint, polynomial)
+    swap = sp.zeros(4)
+    swap[1, 0] = swap[0, 1] = 1
+    swap[3, 2] = swap[2, 3] = 1
+    theta = field_matrix(
+        sp.eye(8)
+        + vectors * (swap - sp.eye(4)) * left_inverse,
+        polynomial,
+    )
+    if not (
+        field_equal(left_inverse * vectors, sp.eye(4), polynomial)
+        and field_equal(theta * vectors, vectors * swap, polynomial)
+        and field_equal(theta * theta, sp.eye(8), polynomial)
+    ):
+        raise AssertionError("swap completion identities failed")
+    return theta
+
+
+def reality_vector(
+    reality: sp.Matrix, vector: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    return field_matrix(
+        reality * vector.applyfunc(lambda value: star(value, polynomial)),
+        polynomial,
+    )
+
+
+def reality_conjugate(
+    reality: sp.Matrix, matrix: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    return field_matrix(
+        reality * field_conjugate(matrix, polynomial) * reality,
+        polynomial,
+    )
+
+
+@dataclass(frozen=True)
+class Completion:
+    shear: sp.Rational
+    reality: sp.Matrix
+    thetas: tuple[sp.Matrix, ...]
+    mu_one: bool
+    involutive: bool
+    self_reflection_real: bool
+    global_reflection_reality: bool
+
+
+def reflection_real_completion(sectors: tuple[Sector, ...]) -> Completion:
+    shear = sectors[0].shear
+    if len(sectors) != 4 or any(sector.shear != shear for sector in sectors):
+        raise AssertionError("completion requires one four-sector fixture")
+    cut = cut_shift()
+    reality = (cut * B111.J * cut.T).applyfunc(sp.expand)
+    if not prior.matrix_equal(reality * reality, sp.eye(8)):
+        raise AssertionError("transported Block 111 reality is not involutive")
+    thetas: list[sp.Matrix | None] = [None] * 4
+
+    for momentum in (0, 2):
+        sector = sectors[momentum]
+        polynomial = sector.polynomial
+        rx = reality_vector(reality, sector.x, polynomial)
+        ry = reality_vector(reality, sector.y, polynomial)
+        vectors = sp.Matrix.hstack(sector.x, sector.y, rx, ry)
+        thetas[momentum] = swap_completion(vectors, polynomial)
+
+    one = sectors[1]
+    three = sectors[3]
+    vectors = sp.Matrix.hstack(
+        one.x,
+        one.y,
+        reality_vector(reality, three.x, one.polynomial),
+        reality_vector(reality, three.y, one.polynomial),
+    )
+    thetas[1] = swap_completion(vectors, one.polynomial)
+    thetas[3] = reality_conjugate(reality, thetas[1], one.polynomial)
+    if any(theta is None for theta in thetas):
+        raise AssertionError("not all reflection blocks were constructed")
+    resolved = tuple(theta for theta in thetas if theta is not None)
+
+    mu_one = all(
+        field_equal(
+            resolved[momentum] * sector.x, sector.y, sector.polynomial
+        )
+        and field_equal(
+            resolved[momentum] * sector.y, sector.x, sector.polynomial
+        )
+        for momentum, sector in enumerate(sectors)
+    )
+    involutive = all(
+        field_equal(
+            resolved[momentum] * resolved[momentum],
+            sp.eye(8),
+            sector.polynomial,
+        )
+        for momentum, sector in enumerate(sectors)
+    )
+    self_reflection_real = all(
+        field_equal(
+            resolved[momentum],
+            reality_conjugate(
+                reality, resolved[momentum], sectors[momentum].polynomial
+            ),
+            sectors[momentum].polynomial,
+        )
+        for momentum in (0, 2)
+    )
+    global_reflection_reality = all(
+        field_equal(
+            resolved[(-momentum) % 4],
+            reality_conjugate(
+                reality, resolved[momentum], sectors[momentum].polynomial
+            ),
+            sectors[momentum].polynomial,
+        )
+        for momentum in range(4)
+    )
+    return Completion(
+        shear,
+        reality,
+        resolved,
+        mu_one,
+        involutive,
+        self_reflection_real,
+        global_reflection_reality,
+    )
+
+
+def rank_one_outer_inertia(
+    vector: sp.Matrix, gram: sp.Matrix, polynomial: sp.Poly
+) -> tuple[int, int, int]:
+    """Exact inertia of w w^H when the displayed unit coordinate is present."""
+    outer = root_outer(vector, polynomial)
+    if (
+        vector.cols != 1
+        or red(vector[0] - 1, polynomial) != 0
+        or not field_equal(gram, outer, polynomial)
+        or not field_equal(gram, field_adjoint(gram, polynomial), polynomial)
+    ):
+        return (-1, -1, -1)
+    # The stable root is real.  Thus q^H(w w^H)q=|w^H q|^2, and w_0=1
+    # makes the unique nonzero direction strictly positive.
+    return (1, 0, vector.rows - 1)
+
+
+@dataclass(frozen=True)
+class SectorPackage:
+    completed_h00: sp.Matrix
+    three_cell_gram: sp.Matrix
+    inertia: tuple[int, int, int]
+    hermitian: bool
+    psd: bool
+    beta: sp.Expr
+    beta_polynomial: sp.Poly
+    beta_interval: tuple[sp.Rational, sp.Rational]
+    contractive: bool
+    quotient_transfer: bool
+    semigroup: bool
+    displayed_n2_n3: bool
+
+
+@dataclass(frozen=True)
+class PositivePackage:
+    shear: sp.Rational
+    sectors: tuple[SectorPackage, ...]
+    per_momentum_inertia: tuple[tuple[int, int, int], ...]
+    global_inertia: tuple[int, int, int]
+    hermitian: bool
+    psd: bool
+    contraction: bool
+    semigroup: bool
+
+
+def sector_package(sector: Sector, theta: sp.Matrix) -> SectorPackage:
+    polynomial = sector.polynomial
+    completed_h00 = field_matrix(theta * sector.h00, polynomial)
+    y_square = root_outer(sector.y, polynomial)
+    moment_vector = sp.Matrix((1, RHO, RHO**2))
+    moment = field_matrix(moment_vector * moment_vector.T, polynomial)
+    three_cell_gram = field_matrix(
+        sp.kronecker_product(moment, completed_h00), polynomial
+    )
+    three_cell_vector = field_matrix(
+        sp.kronecker_product(moment_vector, sector.y), polynomial
+    )
+    completed_exact = field_equal(completed_h00, y_square, polynomial)
+    inertia = rank_one_outer_inertia(
+        three_cell_vector, three_cell_gram, polynomial
+    )
+    hermitian = (
+        completed_exact
+        and field_equal(
+            completed_h00, field_adjoint(completed_h00, polynomial), polynomial
+        )
+        and field_equal(
+            three_cell_gram,
+            field_adjoint(three_cell_gram, polynomial),
+            polynomial,
+        )
+    )
+    psd = inertia[1] == 0 and inertia[0] == 1
+
+    beta = red(RHO**2, polynomial)
+    beta_polynomial = prior.square_root_polynomial(polynomial)
+    lower, upper = sector.stable_interval
+    scale = 10**12
+    beta_interval = (R(lower**2, scale**2), R(upper**2, scale**2))
+    contractive = (
+        0 < beta_interval[0] < beta_interval[1] < 1
+        and beta_polynomial.count_roots(*beta_interval) == 1
+        and red(
+            beta_polynomial.as_expr().subs(prior.BETA, beta), polynomial
+        )
+        == 0
+    )
+
+    quotient_transfer = all(
+        field_equal(
+            field_matrix(
+                RHO ** (row + column + 2) * completed_h00, polynomial
+            ),
+            field_matrix(
+                beta * RHO ** (row + column) * completed_h00, polynomial
+            ),
+            polynomial,
+        )
+        for row in range(3)
+        for column in range(3)
+    )
+    displayed_n2_n3 = all(
+        field_equal(
+            field_matrix(
+                RHO ** (row + column + 2 * steps) * completed_h00,
+                polynomial,
+            ),
+            field_matrix(
+                beta**steps
+                * RHO ** (row + column)
+                * completed_h00,
+                polynomial,
+            ),
+            polynomial,
+        )
+        for steps in (2, 3)
+        for row in range(3)
+        for column in range(3)
+    )
+    semigroup = displayed_n2_n3 and all(
+        red(
+            beta ** (left_steps + right_steps)
+            - beta**left_steps * beta**right_steps,
+            polynomial,
+        )
+        == 0
+        for left_steps in range(4)
+        for right_steps in range(4)
+    )
+    return SectorPackage(
+        completed_h00,
+        three_cell_gram,
+        inertia,
+        hermitian,
+        psd,
+        beta,
+        beta_polynomial,
+        beta_interval,
+        contractive,
+        quotient_transfer,
+        semigroup,
+        displayed_n2_n3,
+    )
+
+
+def positive_package(
+    sectors: tuple[Sector, ...], completion: Completion
+) -> PositivePackage:
+    packages = tuple(
+        sector_package(sector, completion.thetas[momentum])
+        for momentum, sector in enumerate(sectors)
+    )
+    per_momentum = tuple(package.inertia for package in packages)
+    global_inertia = tuple(
+        sum(package.inertia[index] for package in packages)
+        for index in range(3)
+    )
+    return PositivePackage(
+        completion.shear,
+        packages,
+        per_momentum,
+        global_inertia,
+        all(package.hermitian for package in packages),
+        all(package.psd for package in packages),
+        all(package.contractive for package in packages),
+        all(
+            package.quotient_transfer
+            and package.semigroup
+            and package.displayed_n2_n3
+            for package in packages
+        ),
+    )
+
+
+def normalized_note() -> str:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+    return " ".join(raw_note.lower().split())
+
+
+SCOPE_KEYS = (
+    "swap_completion",
+    "reflection_intertwiner",
+    "involutive",
+    "mu_one",
+    "candidate_failure",
+    "stable_boundary",
+    "sector_inertia",
+    "global_inertia",
+    "quotient_transfer",
+    "geometric_semigroup",
+    "half_space_carrier",
+    "torus_firewall",
+    "os_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity",
+    "adm",
+    "n1_n8",
+    "w1",
+    "n5_resolution",
+)
+
+
+def scope_certificate(note: str, mutation: str) -> dict[str, bool]:
+    result = {
+        "swap_completion": "swap completion" in note,
+        "reflection_intertwiner": "reflection intertwiner" in note,
+        "involutive": "involutive" in note,
+        "mu_one": "mu = 1" in note or "theta x = y" in note,
+        "candidate_failure": (
+            ("carrier-natural" in note or "carrier natural" in note)
+            and "fail" in note
+        ),
+        "stable_boundary": "stable boundary data" in note,
+        "sector_inertia": (
+            "inertia (1,0,23)" in note or "one positive direction" in note
+        ),
+        "global_inertia": "(4,0,92)" in note or "rank four" in note,
+        "quotient_transfer": (
+            "diag(rho_k^2)" in note or "contractive quotient transfer" in note
+        ),
+        "geometric_semigroup": "geometric semigroup" in note,
+        "half_space_carrier": "half-space carrier" in note,
+        "torus_firewall": "torus" in note and "remains" in note,
+        "os_boundary": (
+            "not an os no-go" in note or "not a curved os no-go" in note
+        ),
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "gravity": "gravity constraint quotient remains unexecuted" in note,
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "w1": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    return result
+
+
+def beta_interval_text(package: PositivePackage) -> str:
+    return ";".join(
+        f"k{momentum}/{momentum + 2}={package.sectors[momentum].beta_interval}"
+        for momentum in (0, 1)
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started = time.monotonic()
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    checks.check(
+        "A-authority",
+        "Block 118 blobs and ancestors 117--103 are pinned",
+        AUDIT_TIMEOUT_SEC == 600
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/audit/data/axiom_premise_nodes.json",
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "scripts/admissibility_dirac_kahler_floquet_monodromy_action_pairing_2026_08_16.py",
+            "logs/runner-cache/admissibility_dirac_kahler_floquet_monodromy_action_pairing_2026_08_16.txt",
+        )
+        and authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and all(
+            authority[f"ancestor_{number}"] for number in range(103, 118)
+        )
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB,
+    )
+
+    fixtures = (
+        make_sectors(prior.PRIMARY_SHEAR),
+        make_sectors(prior.SECOND_SHEAR),
+    )
+    factorization = all(
+        sector.factorization
+        and sector.geometric_hankel
+        and sector.pivot == (0, 0)
+        and sector.minors_vanishing == 784
+        for sectors in fixtures
+        for sector in sectors
+    )
+    if mutation == "break_factorization":
+        factorization = False
+    checks.check(
+        "B-the-factorization",
+        "H00_k=x_k y_k^H at pivot (0,0), all minors vanish, and H[m,n]=rho^(m+n)H00",
+        factorization,
+    )
+
+    reductions = tuple(
+        tuple(reduction_certificate(sector) for sector in sectors)
+        for sectors in fixtures
+    )
+    reduction_facts = all(
+        item.exact_reduction
+        and item.real_moment_psd
+        and item.negative_mu_excluded
+        and item.proportionality_rank == 7
+        and item.evaluation_rank == 8
+        and (
+            item.proportional_dimension,
+            item.fixed_mu_dimension,
+            item.positive_real_dimension,
+        )
+        == (57, 56, 113)
+        for fixture_reductions in reductions
+        for item in fixture_reductions
+    )
+    if mutation == "break_reduction":
+        reduction_facts = False
+    negative_mu_allowed = mutation == "claim_negative_mu_allowed"
+    checks.check(
+        "C-the-reduction",
+        "nonzero PSD iff Theta*x=mu*y with real mu>0; dimensions are 57/56/113",
+        reduction_facts and not negative_mu_allowed,
+    )
+
+    candidates = candidate_certificate(fixtures)
+    expected_candidates = (
+        "A_dir",
+        "A_OS",
+        "Hov",
+        "Jbar",
+        "K",
+        "P",
+        "-I",
+        "K*A",
+        "A*K",
+        "K*Hov",
+        "Hov*K",
+        "K*Jbar",
+        "Jbar*K",
+        "Hov*Jbar",
+    )
+    candidate_works_claimed = mutation == "claim_candidate_works"
+    checks.check(
+        "D-the-candidate-failures",
+        "all fourteen fixed carriers have an exact nonzero Delta_j at every k",
+        candidates.names == expected_candidates
+        and candidates.failures_per_fixture == (56, 56)
+        and candidates.all_nonproportional
+        and not candidate_works_claimed,
+    )
+
+    completions = tuple(
+        reflection_real_completion(sectors) for sectors in fixtures
+    )
+    involutive = all(completion.involutive for completion in completions)
+    reflection_reality = all(
+        completion.self_reflection_real
+        and completion.global_reflection_reality
+        for completion in completions
+    )
+    mu_one = all(completion.mu_one for completion in completions)
+    if mutation == "break_swap_involution":
+        involutive = False
+    if mutation == "break_reflection_reality":
+        reflection_reality = False
+    if mutation == "break_mu_one":
+        mu_one = False
+    checks.check(
+        "E-the-swap-completion",
+        "V(S_swap-I)(V^H V)^-1 swaps x/y with mu=1 and is involutive and reflection-real",
+        involutive and reflection_reality and mu_one,
+    )
+
+    packages = tuple(
+        positive_package(sectors, completion)
+        for sectors, completion in zip(fixtures, completions)
+    )
+    inertia_facts = all(
+        package.hermitian
+        and package.psd
+        and package.per_momentum_inertia == ((1, 0, 23),) * 4
+        and package.global_inertia == (4, 0, 92)
+        for package in packages
+    )
+    if mutation == "break_inertia":
+        inertia_facts = False
+    negative_direction_claimed = mutation == "claim_negative_direction"
+    checks.check(
+        "F-the-positive-package",
+        "three-super-cell pairing is Hermitian PSD with inertias (1,0,23) and (4,0,92)",
+        inertia_facts and not negative_direction_claimed,
+    )
+
+    beta_pins = tuple(
+        tuple(
+            package.sectors[momentum].beta_interval for momentum in (0, 1)
+        )
+        for package in packages
+    )
+    semigroup_facts = all(
+        package.contraction and package.semigroup for package in packages
+    )
+    if mutation == "break_semigroup":
+        semigroup_facts = False
+    checks.check(
+        "G-the-contraction-and-semigroup",
+        "beta_k=rho_k^2 is pinned in (0,1) and n=2,3 act as rho_k^(2n)",
+        beta_pins == EXPECTED_BETA_INTERVALS and semigroup_facts,
+    )
+
+    note_scope = scope_certificate(normalized_note(), mutation)
+    elapsed_before_scope = time.monotonic() - started
+    checks.check(
+        "H-scope",
+        "all required note phrases, N1--N8/W1/N5 firewalls, and runtime bound",
+        set(note_scope) == set(SCOPE_KEYS)
+        and all(note_scope.values())
+        and elapsed_before_scope <= 400,
+    )
+
+    for sectors in fixtures:
+        print(
+            f"FACTOR c={sectors[0].shear}: pivots="
+            f"{tuple(sector.pivot for sector in sectors)}; "
+            f"y0={tuple(red(sector.y[0], sector.polynomial) for sector in sectors)}; "
+            f"vanishing_minors={tuple(sector.minors_vanishing for sector in sectors)}"
+        )
+    print(
+        "CANDIDATES: 14 named carriers x 4 momenta x 2 fixtures = "
+        "112 exact nonproportionality residuals"
+    )
+    for package in packages:
+        print(
+            f"PACKAGE c={package.shear}: per_k={package.per_momentum_inertia}; "
+            f"global={package.global_inertia}; beta={beta_interval_text(package)}; "
+            f"runtime={time.monotonic() - started:.3f}s"
+        )
+    print(
+        "N5: per_element: exact factorization, proportionality, candidate-failure, swap, reflection-reality, involution, Hermiticity, inertia, beta-isolation, and semigroup identities are checked"
+    )
+    print(
+        "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus"
+    )
+    print(
+        "per_mode: all four fixed momenta at c=5/13 and c=3/5 reject every named fixed carrier-natural candidate and admit the data-dependent swap completion with mu=1"
+    )
+    print(
+        "per_block: the swap completion makes the L=3 half-space pairing Hermitian positive semidefinite with inertia (1,0,23) per momentum and quotient transfer beta=rho^2 in (0,1)"
+    )
+    print(
+        "lattice_wide: checked and not executed — the torus completion, naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open"
+    )
+    print(
+        "RESULT: no fixed carrier operator intertwines the half-space pairing, but the swap completion on the action's stable boundary data is a reflection-real involution that completes it to a positive OS package with contractive transfer diag(rho_k^2) and the exact geometric semigroup — the campaign's first positive and contractive finite OS structure"
+    )
+    print(
+        "DECISION_CUT: carry the completed package to the torus and the curved carrier and classify the completion's naturality; reject fixed-operator intertwiner searches"
+    )
+    print(
+        "TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Block 119 — The Reflection Intertwiner Completion

Stacked on #6624 (Block 118). Fifth-file discipline: bounded_theorem note,
runner, cache, block ledger, refreshed citation manifest.

### Result

Block 118 named the reflection intertwiner as the object that could
complete the rank-one geometric-Hankel action pairing. This block decides
it, two-sidedly:

- **The selection wall.** Every displayed fixed carrier-natural candidate
  fails the exact proportionality condition `Theta x_k ∝ y_k` at every
  momentum and both fixtures: the Block 114 dressing (direct and
  OS-reflected), the overlap Hodge, the reality conjugation composed with
  complex conjugation, the Klein and parity operators, `-I`, and their
  displayed simple products — fourteen rows, with momentum-mapping
  candidates (Hodge, parity) tested against their correct target sectors.
  All failures already occur at the first residual entry.
- **The completion exists.** The swap completion
  `Theta = I + V(S_swap − I)(V^H V)^{-1} V^H` on the four-column span
  `V = [x, y, Rx, Ry]` of the action's stable boundary data and its
  reality images is involutive *structurally* (the swap squares to the
  identity on the span; identity off it), sends `x ↔ y` with `mu = 1`
  (real, positive — exactly what the PSD reduction requires), is
  per-sector reflection-real at the self-conjugate momenta, and satisfies
  the coupled identity `Theta_3 = R Theta_1 R` at the paired momenta —
  forced, because R's column permutation `(0↔2)(1↔3)` commutes with the
  swap `(0↔1)(2↔3)`.
- **The positive package.** The completed kernel is exactly
  `rho^{m+n} y y^H` — Hermitian PSD with inertia `(1,0,23)` per momentum
  and `(4,0,92)` globally on the displayed three super-cells (one genuine
  positive direction per momentum: the rank-one moment structure). The
  quotient transfer is `diag(rho_k^2)` with all four contractive values
  pinned in `(0,1)` by exact isolating intervals, and the geometric
  semigroup law `T^n = diag(rho_k^{2n})` holds exactly — resolving, on
  this carrier, the non-semigroup pathology Block 116 found for the
  chart windows. **This is the campaign's first positive and contractive
  finite OS package.**
- **Firewalls.** Half-space carrier only; the completion is built from
  the pairing's own boundary data (action-derived in that bounded sense)
  and is not shown unique, canonical, or carrier-natural; the torus
  completion (where the antiperiodic wrap re-enters) and curved OS
  positivity are the named continuations, then the gravity constraint
  quotient.

### Verification

- Runner: 8/8 PASS (~230 s); recomputes everything live — the rank-one
  factorization with all 784 vanishing minors, the PSD reduction with
  determinant rank witnesses (57/56/113 solution-space dimensions), all
  fourteen candidate residuals (digests not imported), the swap
  completion identities, inertia, contraction intervals, and the
  semigroup law. Mutation sweep: 15/15 clean. N5 byte-identical.
- Independent cross-model verification (Claude fraction checker,
  machinery-disjoint, two rounds): factorization, reduction, candidate
  failures, and the swap involution confirmed — including the structural
  classification that *every* involutive intertwiner is a scaled swap in
  the `(x,y)` basis; the coupled-pair reflection reality
  `Theta_3 = R Theta_1 R` verified against independently built `k=3`
  modes, with full-rank `V` at every sector; the checker also
  self-corrected its own earlier convention artifacts (spatial-Klein
  test; reflected-arm pencil), leaving the worker's taxonomy standing.
- `vocab_lint` and `audit_lint --strict` clean.
- `run_pipeline.sh` exits 1 at the pre-existing dependency-policy
  epoch-debt gate (queue item
  `2026-08-08-dependency-policy-epoch-debt-helper-registry`); identical
  on the clean base — unrelated to this PR.

### TOE accounting

Zero obligation retirement; no TOE percentage moves; retained-positive
end-to-end theory count remains zero. Bounded theorem; audit-lane
referral for any verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
