### PR TITLE
feat(wav2run): chiral tick-2 pair does not fire on the two-cube

### DIFF
--- a/docs/TWO_CUBE_TWO_TICK_CHIRAL_RIVAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_CUBE_TWO_TICK_CHIRAL_RIVAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,343 @@
+---
+claim_id: two_cube_two_tick_chiral_rival_execution_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0, whether executing occupancy tick-1 then the July-3 k=3 pair at tick-2 yields a P-odd lock set while preserving tick-1 locks is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py
+---
+
+# Two-Cube Two-Tick Chiral Rival Execution (Displayed, Not Adopted)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact execution of occupancy tick-1 then the July-3 unique `k=3`
+chiral pair at tick-2 on the same twelve-vertex two-cube that L1 uses. Off-patch
+occupancy is `o=0`. The origin seed is locked with displayed content `+`. The
+rival is displayed, not adopted. L1 is not attached. No 4×4×4 or other new
+patch is opened.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py`](../scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Investment leftover-character is refused. `#6632` displayed that the July-3
+`k=3` pair is a `P`-odd predicate on `{0,+,−}^6`. L1 two-tick composition
+keeps labels out of `n`. Those leftovers are not this residual. The residual
+answered here is only the *execution* of that pair as tick 2 on the same
+two-cube, not a new patch.
+
+`f_L1` is `n≠0`, not Hamming. This note does not attach L1.
+
+Work on the finite vertex set of two unit cubes that share a face:
+
+```text
+A = [0,1]^3,     B = [1,2] x [0,1] x [0,1].
+```
+
+The twelve-vertex patch is the union of those cubes. Occupancy off this
+patch is `0`. The origin seed `(0,0,0)` is already locked with displayed
+content `+`.
+
+**Tick 1.** An unread patch site forms if and only if the occupancy vector
+`n` is nonzero, with
+
+```text
+n_μ = (o_{+μ} − o_{-μ}) / 3.
+```
+
+That is `f_L1`, occupancy-only. Newly formed sites receive lock labels from
+the sign of `n_μ` along the unique occupied axis. If several components of
+`n` are nonzero, the displayed default label is `+`. Existing locks are not
+overwritten.
+
+New locks: `(1,0,0)`, `(0,1,0)`, `(0,0,1)`. Each has a unique nonzero
+component `n_μ = −1/3`, so each receives lock label `−`. The tick-1 lock
+set is
+
+```text
+L_1 = {(0,0,0), (1,0,0), (0,1,0), (0,0,1)}.
+```
+
+The occupancy predicate is `P`-even: swapping opposite neighbor occupancy
+bits sends `n → −n` and leaves `n≠0` unchanged. So the tick-1 lock set is
+`P`-even (occupancy-only).
+
+**Tick 2.** Neighbor alphabet `{0,+,−}`. Absence, including off-patch
+`o=0`, is the letter `0`. A locked neighbor contributes its Record
+content. Formation uses the July-3 unique `k=3` chiral pair: the proper
+orbit of the runner-anchored representative
+
+```text
+r = (0, +, 0, −, +, −)
+```
+
+on the ordered directions `(+x,−x,+y,−y,+z,−z)`. Existing locks are not
+overwritten.
+
+No unread patch site sees a handed fully-mixed six-tuple. The newly formed
+set is empty:
+
+```text
+N_new = 0.
+```
+
+The tick-2 lock set is therefore `L_2 = L_1`. Spatial inversion `P = −I`
+sends that set to
+
+```text
+P(L_2) = {(0,0,0), (−1,0,0), (0,−1,0), (0,0,−1)}.
+```
+
+The pair `(tick-2 lock set, P of that set)` differs, so tick-2 execution is
+`P`-odd on this patch. Tick-1 locks persist at tick 2 (permanence).
+
+Displayed rival execution, not adopted. Do not write the pair into Admissibility. Do not attach L1.
+
+claim_scope: On the two-cube with off-patch o=0, whether executing occupancy
+tick-1 then the July-3 k=3 pair at tick-2 yields a P-odd lock set while
+preserving tick-1 locks is reported. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact two-tick execution on a supplied twelve-vertex patch: occupancy tick-1, July-3 k=3 pair at tick-2, reported N_new, permanence, and whether the tick-2 lock set equals its spatial P image. Displayed, not adopted."
+trace_class: displayed_rival
+target_claim_id: two_cube_two_tick_chiral_rival_execution
+target_blocker_text: "run the July-3 k=3 pair as tick 2 on the same two-cube"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "leave the executed rival displayed; do not adopt it, do not attach L1, and do not write the pair into Admissibility"
+conditional_surface_status: "exact for the named twelve-vertex two-cube, off-patch o=0, origin seed +, occupancy tick-1, and the July-3 k=3 pair re-earned as tick-2 formation"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+Quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The distribution concerns which possibility a forming record locks, conditional
+on formation at that site; it does not supply the formation site, probability,
+or rate.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility. A
+site never carries more than one record; records are permanent.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+
+July-3 theorem 3 is used as a named finite object, not as an axiom edit:
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+At `k=3` there is exactly one chiral pair, whose members are the handed
+fully-mixed patterns. The paired runner re-earns that pair on the six axis
+directions and does not consume a cache.
+
+## Algebra
+
+Order the six nearest-neighbor directions as
+
+```text
+(+x, −x, +y, −y, +z, −z).
+```
+
+Spatial inversion `P = −I` swaps opposite directions and sends a site
+`(x,y,z)` to `(−x,−y,−z)`.
+
+Occupancy of a site is `1` if that site is on-patch and locked, else `0`.
+Off-patch occupancy is identically `0`. The occupancy vector at an unread
+site is `n` with components `n_μ = (o_{+μ} − o_{−μ}) / 3`. Formation at
+tick 1 is `n≠0`. That is not the Hamming count of occupied neighbors:
+opposite-pair occupancy cancels and does not form.
+
+A forming tick-1 site receives the sign of its unique nonzero `n_μ` as a
+lock label in `{+,−}`. Several nonzero components use the displayed default
+`+`. The seed label `+` is displayed and is not overwritten.
+
+Tick-2 formation is the indicator of the proper cubic orbit of
+
+```text
+r = (0, +, 0, −, +, −).
+```
+
+Every axis of `r` is bi-colored and the letter counts are `2/2/2`. That
+orbit has 24 colorings; `P` exchanges it with a disjoint 24-orbit. The
+union is exactly the 48 handed fully-mixed colorings. Tick 2 does not
+overwrite existing locks.
+
+## Theorem 1 — tick-1 lock set is P-even; tick-1 locks persist
+
+Tick-1 lock set is `P`-even (occupancy-only). Tick-1 locks persist at tick 2
+(permanence).
+
+*Proof.* On this patch the unread sites that see a nonzero occupancy
+vector from the origin seed are exactly `(1,0,0)`, `(0,1,0)`, and
+`(0,0,1)`. For each of those sites, `P` acting on the six occupancy bits
+swaps the two slots of the unique occupied axis and leaves `n≠0`
+unchanged, so the same three sites form. No other on-patch site has
+`n≠0` after the seed. Thus `L_1` is the occupancy-only lock set, and the
+formation predicate is `P`-even.
+
+At `(1,0,0)` one has `n = (−1/3, 0, 0)`, and cyclically for the other two
+axis sites. Each therefore locks `−`. The seed stays `+`.
+
+Tick 2 is forbidden to overwrite existing locks. Record permanence is the
+quoted axiom sentence. The runner checks `L_1 ⊂ L_2` and that every tick-1
+label is unchanged. That is permanence.
+
+## Theorem 2 — N_new and the pair (tick-2 lock set, P of that set)
+
+Tick-2 newly formed set is nonempty or empty; report `N_new`. The pair
+(tick-2 lock set, `P` of that set) is reported. If they differ, tick-2
+execution is `P`-odd on this patch.
+
+*Proof.* After tick 1 the unread on-patch sites are
+
+```text
+(1,1,0), (1,0,1), (0,1,1), (1,1,1), (2,0,0), (2,1,0), (2,0,1), (2,1,1).
+```
+
+Each sees at most two locked neighbors, so its six-tuple uses the letter
+`0` at least four times and is not handed fully-mixed. Direct evaluation
+gives `f(c)=0` and `f(P·c)=0` at every unread site. Therefore
+`N_new = 0` and `L_2 = L_1`.
+
+Spatial inversion of that lock set is
+
+```text
+P(L_2) = {(0,0,0), (−1,0,0), (0,−1,0), (0,0,−1)}.
+```
+
+The three negative-axis sites are off-patch. Hence `L_2 ≠ P(L_2)`, and
+tick-2 execution is `P`-odd on this patch.
+
+The emptiness of the new set is part of the report, not a defect of the
+check. The July-3 pair remains a `P`-odd predicate on `{0,+,−}^6`; on this
+two-cube after occupancy tick-1 it simply does not fire. The `P`-odd
+comparison required here is the comparison of the executed lock *set* with
+its spatial image.
+
+This execution is not the occupancy two-tick composition. Occupancy tick-2
+would form `(1,1,0)`, `(1,0,1)`, `(0,1,1)`, and `(2,0,0)`. Those sites stay
+unread under the chiral pair.
+
+## Theorem 3 — displayed rival execution, not adopted
+
+Displayed rival execution, not adopted. Do not write the pair into Admissibility. Do not attach L1.
+
+The only load-bearing statements are Theorems 1 and 2. The pair is not
+selected as the framework's fixed admissibility rule. Occupancy tick-1 is
+used as a displayed formation step, not as an attachment of L1. No axiom,
+primitive, or registry is edited.
+
+## What this note does and does not claim
+
+- It reports the formed set, permanence of tick-1 locks, `N_new`, and
+  whether the tick-2 lock set equals its spatial `P` image.
+- It does not attach L1. `f_L1` remains `n≠0`, not Hamming, and lock labels
+  do not feed `n`.
+- It does not write the pair into Admissibility.
+- It is not leftover-character of `#6632` (predicate only) or of L1
+  two-tick composition.
+- It does not reopen parked exercises.
+- It does not open a 4×4×4 or other new patch.
+- Formation site, probability, process, and rate remain unsupplied.
+
+## No-Go Discipline
+
+The negative statement is only: on this two-cube, occupancy tick-1 followed
+by the July-3 pair at tick-2 adds no new lock. It is not a no-go against
+every future content-conditioned execution.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome |
+|---|---|---|
+| occupancy-only tick-1, `f_L1` is `n≠0` | **EXECUTED** | three axis locks; `P`-even predicate |
+| Hamming neighbor count as formation | **REFUSED** | opposite-pair occupancy is not `n≠0` |
+| July-3 `k=3` pair as tick-2 | **EXECUTED** | `N_new = 0`; `L_2 ≠ P(L_2)` |
+| occupancy tick-2 on the same patch | **REFUSED** | leftover-character of L1 two-tick composition |
+| write the pair into Admissibility | **REFUSED** | displayed, not adopted |
+| attach L1 | **REFUSED** | do not attach L1 |
+| 4×4×4 or other new patch | **REFUSED** | same two-cube only |
+
+### N2 — wall independence
+
+One execution report is claimed. Emptiness of the new set is not a second
+impossibility wall.
+
+### N3 — hidden-wall scan
+
+The patch, seed label, occupancy kernel, lock-label rule, `P`, and the
+July-3 pair are declared. No dynamics, no 4×4×4 patch, and no axiom edit is
+imported.
+
+### N4 — residual matching
+
+The residual answered is the execution of the already-displayed `P`-odd
+predicate as tick 2 on the two-cube. It is not the leftover character of
+the predicate-only display or of occupancy two-tick composition.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — occupancy n and the six-letter coloring at each unread site
+per-site: executed — twelve-vertex two-cube, off-patch o=0
+per-mode: not applicable
+per-block: executed — tick-1 lock set, N_new, L_2 versus P(L_2)
+lattice-wide: not executed — no new spatial patch
+```
+
+### N6 — partial-closure paths
+
+A later execution could change the seed label, allow a later occupancy
+tick before the pair, or refuse content-conditioned formation. Adopting
+the pair would be an axiom-level or rule-level act and is out of scope.
+
+### N7 — steelman
+
+The strongest objection is that `L_2 ≠ P(L_2)` is inherited from the
+origin seed and off-patch `o=0`, not from a fired chiral pair. That is
+true and is reported: `N_new = 0`, so the pair does not add the odd
+grade. The required comparison is still the executed lock set against its
+spatial image. Both facts are part of the report.
+
+### N8 — cross-cycle echo
+
+July-3 theorem 3 is used as a named finite fact and is re-earned on the
+same six directions. No status is borrowed from that note's audit row.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py
+```
+
+The runner reconstructs the twelve-vertex two-cube, executes occupancy
+tick-1 with sign labels, re-earns the unique `k=3` pair, reports `N_new`,
+compares the tick-2 lock set with its spatial `P` image, checks
+permanence, and refuses axiom edits. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18597,6 +18597,10 @@
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
    "out_degree": 1
+  },
+  "two_cube_two_tick_chiral_rival_execution_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {
    "deps_hash": "bd71c5f30cb7",

--- a/logs/runner-cache/two_cube_two_tick_chiral_rival_execution_2026_08_15.txt
+++ b/logs/runner-cache/two_cube_two_tick_chiral_rival_execution_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py
+runner_sha256: 8a1191681fe06d41483ef37406c52705bdaeac018ce5bf93a4492acea82ef9a8
+input_fingerprint_sha256: ad46bdbf3b0d94d66ed946fae4823763a79c140de465b9ec501d7dc113aa7e7d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+two-cube two-tick chiral rival execution (displayed, not adopted)
+AUDIT_INPUT_PATHS:
+  docs/TWO_CUBE_TWO_TICK_CHIRAL_RIVAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: same twelve-vertex two-cube; no 4x4x4 or other new patch
+PASS: audit-input-paths-exact-literals  (declared=('docs/TWO_CUBE_TWO_TICK_CHIRAL_RIVAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: note-claim-scope
+PASS: source-admissibility
+PASS: source-formation-boundary
+PASS: source-record
+PASS: note-f-L1-is-n-nonzero-not-hamming
+PASS: note-displayed-not-adopted
+PASS: note-does-not-attach-L1
+PASS: note-does-not-write-pair-into-admissibility
+PASS: note-same-two-cube-no-new-patch
+PASS: note-no-forbidden-phrases
+PASS: patch-twelve-vertices
+PASS: off-patch-occupancy-zero
+PASS: empty-occupancy-fixed-point
+PASS: tick1-new-locks  (new=[(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: tick1-labels-from-sign-n-mu  (labels={(0, 0, 0): '+', (1, 0, 0): '−', (0, 0, 1): '−', (0, 1, 0): '−'})
+PASS: tick1-not-hamming
+PASS: theorem1-tick1-lock-set-P-even
+N_new=0
+tick2_lock_set=((0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 0))
+P_of_tick2_lock_set=((-1, 0, 0), (0, -1, 0), (0, 0, -1), (0, 0, 0))
+tick2_lock_set_P_odd=True
+PASS: july3-unique-k3-pair
+PASS: theorem2-N-new  (N_new=0)
+PASS: theorem2-lock-set-and-P-of-set  (P_odd=True)
+PASS: theorem2-pair-does-not-fire
+PASS: theorem1-permanence
+PASS: tick2-does-not-overwrite
+PASS: note-reports-N-new-and-P-odd-pair
+PASS: theorem3-displayed-rival
+PASS: mutation-hamming-is-not-f-L1
+PASS: mutation-L1-occupancy-tick2-is-not-this-execution
+TOTAL: PASS=30 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py
+++ b/scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Execute occupancy tick-1 then the July-3 k=3 pair at tick-2 on the two-cube.
+
+The same twelve-vertex patch that L1 uses is reused. Tick 1 forms by
+occupancy n≠0 and writes lock labels from sign(n_μ). Tick 2 reads neighbor
+Record content in {0,+,−} and forms by the July-3 unique k=3 chiral pair.
+Existing locks are not overwritten. The rival is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_CUBE_TWO_TICK_CHIRAL_RIVAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_TWO_TICK_CHIRAL_RIVAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Site = tuple[int, int, int]
+Coloring = tuple[str, ...]
+AXES: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+DIRS: tuple[Site, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+LETTERS = ("0", "+", "−")
+SEED: Site = (0, 0, 0)
+SEED_CONTENT = "+"
+DEFAULT_MULTI_AXIS_LABEL = "+"
+REPRESENTATIVE: Coloring = ("0", "+", "0", "−", "+", "−")
+ZERO_N = (Fraction(0), Fraction(0), Fraction(0))
+CLAIM_SCOPE = (
+    "On the two-cube with off-patch o=0, whether executing occupancy "
+    "tick-1 then the July-3 k=3 pair at tick-2 yields a P-odd lock set "
+    "while preserving tick-1 locks is reported. Displayed, not adopted."
+)
+FORBIDDEN_PHRASES = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add_site(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def invert_site(site: Site) -> Site:
+    return (-site[0], -site[1], -site[2])
+
+
+def cube_a_vertices() -> frozenset[Site]:
+    return frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+
+
+def cube_b_vertices() -> frozenset[Site]:
+    return frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+
+
+def patch_vertices() -> frozenset[Site]:
+    return cube_a_vertices() | cube_b_vertices()
+
+
+def occupancy_bit(site: Site, locks: frozenset[Site]) -> int:
+    if site not in patch_vertices():
+        return 0
+    return 1 if site in locks else 0
+
+
+def n_vector(site: Site, locks: frozenset[Site]) -> tuple[Fraction, Fraction, Fraction]:
+    components = []
+    for axis in AXES:
+        plus = occupancy_bit(add_site(site, axis), locks)
+        minus = occupancy_bit(add_site(site, invert_site(axis)), locks)
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+def occupancy_forms(site: Site, locks: frozenset[Site]) -> bool:
+    if site in locks or site not in patch_vertices():
+        return False
+    return n_vector(site, locks) != ZERO_N
+
+
+def hamming_would_form(site: Site, locks: frozenset[Site]) -> bool:
+    if site in locks or site not in patch_vertices():
+        return False
+    return sum(occupancy_bit(add_site(site, step), locks) for step in DIRS) != 0
+
+
+def occupancy_tuple(site: Site, locks: frozenset[Site]) -> tuple[int, ...]:
+    return tuple(occupancy_bit(add_site(site, step), locks) for step in DIRS)
+
+
+def act_bits(perm: tuple[int, ...], bits: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * 6
+    for source, image in enumerate(perm):
+        out[image] = bits[source]
+    return tuple(out)
+
+
+def f_l1_bits(bits: tuple[int, ...]) -> bool:
+    n = tuple(Fraction(bits[2 * axis] - bits[2 * axis + 1], 3) for axis in range(3))
+    return n != ZERO_N
+
+
+def lock_label(site: Site, locks: frozenset[Site]) -> str:
+    n = n_vector(site, locks)
+    nonzero = [(axis, component) for axis, component in zip(AXES, n) if component != 0]
+    if len(nonzero) == 1:
+        component = nonzero[0][1]
+        if component > 0:
+            return "+"
+        if component < 0:
+            return "−"
+    return DEFAULT_MULTI_AXIS_LABEL
+
+
+def neighbor_coloring(site: Site, labels: dict[Site, str]) -> Coloring:
+    colors = []
+    for step in DIRS:
+        neighbor = add_site(site, step)
+        colors.append(labels.get(neighbor, "0"))
+    return tuple(colors)
+
+
+def det3(matrix: tuple[tuple[int, int, int], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def matvec(
+    matrix: tuple[tuple[int, int, int], ...], vector: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return tuple(sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3))
+
+
+def cubic_records() -> tuple[tuple[tuple[tuple[int, int, int], ...], int, tuple[int, ...]], ...]:
+    records = []
+    seen: set[tuple[tuple[int, int, int], ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(tuple(row) for row in matrix)
+            if key in seen:
+                continue
+            seen.add(key)
+            direction_perm = tuple(DIR_INDEX[matvec(key, direction)] for direction in DIRS)
+            records.append((key, det3(key), direction_perm))
+    return tuple(records)
+
+
+RECORDS = cubic_records()
+PROPER_PERMS = tuple(perm for _matrix, determinant, perm in RECORDS if determinant == 1)
+P_MATRIX = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+P_PERM = next(perm for matrix, _determinant, perm in RECORDS if matrix == P_MATRIX)
+
+
+def act_color(perm: tuple[int, ...], coloring: Coloring) -> Coloring:
+    out = [""] * 6
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def orbit_of(seed: Coloring, perms: tuple[tuple[int, ...], ...]) -> frozenset[Coloring]:
+    return frozenset(act_color(perm, seed) for perm in perms)
+
+
+FORMING_ORBIT = orbit_of(REPRESENTATIVE, PROPER_PERMS)
+P_FORMING_ORBIT = orbit_of(act_color(P_PERM, REPRESENTATIVE), PROPER_PERMS)
+
+
+def is_fully_mixed(coloring: Coloring) -> bool:
+    axis_mixed = all(coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3))
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_mixed and counts == [2, 2, 2]
+
+
+def chiral_forms(coloring: Coloring) -> bool:
+    return coloring in FORMING_ORBIT
+
+
+def audit_input_literal() -> tuple[str, ...]:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                value = ast.literal_eval(node.value)
+                if not isinstance(value, tuple) or not all(isinstance(item, str) for item in value):
+                    raise TypeError("AUDIT_INPUT_PATHS must be a tuple of strings")
+                return value
+    raise RuntimeError("AUDIT_INPUT_PATHS assignment not found")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    patch = patch_vertices()
+
+    print("two-cube two-tick chiral rival execution (displayed, not adopted)")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: same twelve-vertex two-cube; no 4x4x4 or other new patch")
+
+    declared = audit_input_literal()
+    checks.check(
+        "audit-input-paths-exact-literals",
+        declared == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        f"declared={declared}",
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check("note-claim-scope", CLAIM_SCOPE in normalize(note.replace("`", "")))
+
+    admissibility_rule = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice "
+        "translations and proper cubic rotations."
+    )
+    distribution_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_permanence = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-admissibility",
+        admissibility_rule in normalized_axiom
+        and distribution_sentence in normalized_axiom
+        and admissibility_rule in normalized_note
+        and distribution_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-record",
+        "Records form." in axiom
+        and record_lock in normalized_axiom
+        and record_permanence in normalized_axiom
+        and record_content in normalized_axiom
+        and record_absence in normalized_axiom
+        and record_lock in normalized_note
+        and record_permanence in normalized_note
+        and record_content in normalized_note
+        and record_absence in normalized_note,
+    )
+    checks.check(
+        "note-f-L1-is-n-nonzero-not-hamming",
+        "f_L1" in note and "n≠0" in note and "not Hamming" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "Displayed, not adopted" in note and "displayed, not adopted" in note,
+    )
+    checks.check(
+        "note-does-not-attach-L1",
+        "does not attach L1" in note and "Do not attach L1" in note,
+    )
+    checks.check(
+        "note-does-not-write-pair-into-admissibility",
+        "Do not write the pair into Admissibility" in note
+        and "hypothetical_axiom_status: no edit" in note,
+    )
+    checks.check(
+        "note-same-two-cube-no-new-patch",
+        "twelve-vertex" in note
+        and "4×4×4" in note
+        and "not a new patch" in note,
+    )
+    checks.check(
+        "note-no-forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN_PHRASES),
+    )
+
+    checks.check("patch-twelve-vertices", len(patch) == 12)
+    checks.check(
+        "off-patch-occupancy-zero",
+        occupancy_bit((-1, 0, 0), frozenset({SEED})) == 0
+        and occupancy_bit((0, -1, 0), frozenset({SEED})) == 0
+        and occupancy_bit((3, 0, 0), frozenset({SEED})) == 0,
+    )
+    checks.check(
+        "empty-occupancy-fixed-point",
+        not any(occupancy_forms(site, frozenset()) for site in patch),
+    )
+
+    seed_locks = frozenset({SEED})
+    tick1_new = frozenset(site for site in patch if occupancy_forms(site, seed_locks))
+    expected_tick1 = frozenset({(1, 0, 0), (0, 1, 0), (0, 0, 1)})
+    checks.check(
+        "tick1-new-locks",
+        tick1_new == expected_tick1,
+        f"new={sorted(tick1_new)}",
+    )
+
+    tick1_labels = {SEED: SEED_CONTENT}
+    for site in tick1_new:
+        tick1_labels[site] = lock_label(site, seed_locks)
+    checks.check(
+        "tick1-labels-from-sign-n-mu",
+        tick1_labels[(1, 0, 0)] == "−"
+        and tick1_labels[(0, 1, 0)] == "−"
+        and tick1_labels[(0, 0, 1)] == "−"
+        and n_vector((1, 0, 0), seed_locks) == (Fraction(-1, 3), Fraction(0), Fraction(0)),
+        f"labels={tick1_labels}",
+    )
+    checks.check(
+        "tick1-not-hamming",
+        occupancy_forms((2, 0, 0), seed_locks) is False
+        and hamming_would_form((2, 0, 0), seed_locks) is False
+        and f_l1_bits((1, 1, 0, 0, 0, 0)) is False
+        and sum((1, 1, 0, 0, 0, 0)) != 0,
+    )
+
+    tick1_locks = seed_locks | tick1_new
+    tick1_predicate_p_even = all(
+        f_l1_bits(occupancy_tuple(site, seed_locks))
+        == f_l1_bits(act_bits(P_PERM, occupancy_tuple(site, seed_locks)))
+        for site in patch
+    )
+    checks.check(
+        "theorem1-tick1-lock-set-P-even",
+        tick1_predicate_p_even
+        and tick1_new == frozenset(site for site in patch if occupancy_forms(site, seed_locks)),
+    )
+
+    unread_after_tick1 = sorted(site for site in patch if site not in tick1_locks)
+    colorings = {site: neighbor_coloring(site, tick1_labels) for site in unread_after_tick1}
+    tick2_new = frozenset(site for site, coloring in colorings.items() if chiral_forms(coloring))
+    n_new = len(tick2_new)
+    tick2_locks = tick1_locks | tick2_new
+    tick2_labels = dict(tick1_labels)
+    for site in tick2_new:
+        tick2_labels[site] = DEFAULT_MULTI_AXIS_LABEL
+    p_tick2 = frozenset(invert_site(site) for site in tick2_locks)
+    tick2_p_odd = tick2_locks != p_tick2
+
+    print(f"N_new={n_new}")
+    print(f"tick2_lock_set={tuple(sorted(tick2_locks))}")
+    print(f"P_of_tick2_lock_set={tuple(sorted(p_tick2))}")
+    print(f"tick2_lock_set_P_odd={tick2_p_odd}")
+
+    checks.check(
+        "july3-unique-k3-pair",
+        len(FORMING_ORBIT) == 24
+        and len(P_FORMING_ORBIT) == 24
+        and FORMING_ORBIT.isdisjoint(P_FORMING_ORBIT)
+        and REPRESENTATIVE in FORMING_ORBIT
+        and is_fully_mixed(REPRESENTATIVE)
+        and P_PERM == (1, 0, 3, 2, 5, 4),
+    )
+    checks.check("theorem2-N-new", n_new == 0, f"N_new={n_new}")
+    checks.check(
+        "theorem2-lock-set-and-P-of-set",
+        tick2_locks == tick1_locks
+        and p_tick2 == frozenset({(0, 0, 0), (-1, 0, 0), (0, -1, 0), (0, 0, -1)})
+        and tick2_p_odd,
+        f"P_odd={tick2_p_odd}",
+    )
+    checks.check(
+        "theorem2-pair-does-not-fire",
+        all(not chiral_forms(coloring) for coloring in colorings.values())
+        and all(not chiral_forms(act_color(P_PERM, coloring)) for coloring in colorings.values())
+        and all(not is_fully_mixed(coloring) for coloring in colorings.values()),
+    )
+    checks.check(
+        "theorem1-permanence",
+        tick1_locks.issubset(tick2_locks)
+        and all(tick2_labels[site] == tick1_labels[site] for site in tick1_locks)
+        and tick1_new.isdisjoint(tick2_new),
+    )
+    checks.check(
+        "tick2-does-not-overwrite",
+        all(site not in tick1_locks for site in tick2_new)
+        and SEED in tick2_locks
+        and tick2_labels[SEED] == SEED_CONTENT,
+    )
+    checks.check(
+        "note-reports-N-new-and-P-odd-pair",
+        "N_new" in note
+        and "N_new = 0" in note
+        and "tick-2 lock set" in note
+        and "P of that set" in note,
+    )
+    checks.check(
+        "theorem3-displayed-rival",
+        "Displayed rival execution" in note
+        and "not adopted" in note
+        and "we adopt" not in note.lower()
+        and "Codex" not in note,
+    )
+    checks.check(
+        "mutation-hamming-is-not-f-L1",
+        f_l1_bits((1, 1, 0, 0, 0, 0)) is False
+        and sum((1, 1, 0, 0, 0, 0)) == 2,
+    )
+    checks.check(
+        "mutation-L1-occupancy-tick2-is-not-this-execution",
+        occupancy_forms((1, 1, 0), tick1_locks)
+        and occupancy_forms((2, 0, 0), tick1_locks)
+        and (1, 1, 0) not in tick2_new
+        and (2, 0, 0) not in tick2_new,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

On the two-cube with origin seed +, occupancy tick-1 forms the three axis sites and is P-even; those locks persist. Tick-2 July-3 k=3 pair does not fire (N_new=0). Lock set differs from its P-image by seed/off-patch geometry, not a new chiral lock. Displayed rival execution, not adopted. No axiom edit.

## Runner

`scripts/two_cube_two_tick_chiral_rival_execution_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.