### PR TITLE
feat(mixlab): no tick-1 labeling fires the chiral pair

### DIFF
--- a/docs/TWO_CUBE_TICK1_LABELING_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_CUBE_TICK1_LABELING_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,315 @@
+---
+claim_id: two_cube_tick1_labeling_chiral_fire_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the two-cube with off-patch o=0 and seed +, whether any of the 8 tick-1 {+,−} labelings of the three axis sites makes the July-3 k=3 pair fire at tick 2 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py
+---
+
+# Two-Cube Tick-1 Labeling Chiral Fire (Displayed, Not Adopted)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact eight-labeling census on the same twelve-vertex two-cube
+that occupancy tick-1 uses. Off-patch occupancy is `o=0`. The origin seed is
+locked with displayed content `+`. Tick 1 forms the three axis sites by
+`n≠0`. Each of those sites is then labeled independently by `{+,−}`. Tick 2
+uses the July-3 unique `k=3` pair on neighbor contents `{0,+,−}`. The census
+is displayed, not adopted. L1 is not attached. No 4×4×4 or other new patch
+is opened. Same two-cube only; this is not a new patch.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py`](../scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Investment `#6632` displayed that the July-3 `k=3` pair is a `P`-odd
+predicate on `{0,+,−}^6`. Investment `#6634` (wav2run) executed one labeling
+— lock labels from the sign of `n_μ`, which assigns `−` at each tick-1 axis
+site — and obtained `N_new=0`. That closed one labeling. This residual is
+not leftover-char of wav2run. The question here is whether *any* of the
+eight `{+,−}` assignments to the three tick-1 sites makes tick-2 `N_new>0`.
+
+`f_L1` is `n≠0`, not Hamming. This note does not attach L1.
+
+Work on the finite vertex set of two unit cubes that share a face:
+
+```text
+A = [0,1]^3,     B = [1,2] x [0,1] x [0,1].
+```
+
+The twelve-vertex patch is the union of those cubes. Occupancy off this
+patch is `0`. The origin seed `(0,0,0)` is already locked with displayed
+content `+`.
+
+**Tick 1.** An unread patch site forms if and only if the occupancy vector
+`n` is nonzero, with
+
+```text
+n_μ = (o_{+μ} − o_{−μ}) / 3.
+```
+
+That is `f_L1`, occupancy-only. Existing locks are not overwritten. New
+locks are always `(1,0,0)`, `(0,1,0)`, `(0,0,1)`. Labeling of those three
+sites is then enumerated: each site receives an independent letter in
+`{+,−}`, eight assignments. The seed stays `+`. Sign of `n_μ` is one of
+those eight (all `−`); it is not privileged.
+
+**Tick 2.** Neighbor alphabet `{0,+,−}`. Absence, including off-patch
+`o=0`, is the letter `0`. A locked neighbor contributes its Record
+content. Formation uses the July-3 unique `k=3` chiral pair: the proper
+orbit of the runner-anchored representative
+
+```text
+r = (0, +, 0, −, +, −)
+```
+
+on the ordered directions `(+x,−x,+y,−y,+z,−z)`. Existing locks are not
+overwritten.
+
+For each of the eight labelings, every unread patch site sees at most two
+locked neighbors. Its six-tuple therefore uses the letter `0` at least four
+times and is not handed fully-mixed. Direct evaluation gives `N_new = 0` on
+every labeling. Report that none of the 8 labelings has N_new>0. There is no
+lex-first firing labeling and no new sites to report.
+
+`N_fire = 0`. Among the empty collection of firing labelings there is no
+new-lock set, so the `P`-odd comparison of a fired new-lock set with its
+`P`-image has empty domain.
+
+Displayed, not adopted. Do not write a labeling rule into Admissibility. Do not attach L1.
+
+claim_scope: On the two-cube with off-patch o=0 and seed +, whether any of the 8
+tick-1 {+,−} labelings of the three axis sites makes the July-3 k=3 pair fire at
+tick 2 is reported. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact eight-labeling census on a supplied twelve-vertex patch: occupancy tick-1, free {+,−} labels on the three axis sites, July-3 k=3 pair at tick-2, reported N_new, N_fire, and P-oddness of any fired new-lock set. Displayed, not adopted."
+trace_class: displayed_rival
+target_claim_id: two_cube_tick1_labeling_chiral_fire
+target_blocker_text: "among the 8 tick-1 labelings, does any make tick-2 N_new>0"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "leave the census displayed; do not adopt a labeling rule, do not attach L1, and do not write a labeling rule into Admissibility"
+conditional_surface_status: "exact for the named twelve-vertex two-cube, off-patch o=0, origin seed +, occupancy tick-1, eight tick-1 {+,−} labelings, and the July-3 k=3 pair re-earned as tick-2 formation"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+Quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The distribution concerns which possibility a forming record locks, conditional
+on formation at that site; it does not supply the formation site, probability,
+or rate.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility. A
+site never carries more than one record; records are permanent.
+
+Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read.
+
+July-3 theorem 3 is used as a named finite object, not as an axiom edit:
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+At `k=3` there is exactly one chiral pair, whose members are the handed
+fully-mixed patterns. The paired runner re-earns that pair on the six axis
+directions and does not consume a cache.
+
+## Algebra
+
+Order the six nearest-neighbor directions as
+
+```text
+(+x, −x, +y, −y, +z, −z).
+```
+
+Spatial inversion `P = −I` swaps opposite directions and sends a site
+`(x,y,z)` to `(−x,−y,−z)`.
+
+Occupancy of a site is `1` if that site is on-patch and locked, else `0`.
+Off-patch occupancy is identically `0`. The occupancy vector at an unread
+site is `n` with components `n_μ = (o_{+μ} − o_{−μ}) / 3`. Formation at
+tick 1 is `n≠0`. That is not the Hamming count of occupied neighbors:
+opposite-pair occupancy cancels and does not form.
+
+Tick-1 lock *sites* are occupancy-only. Tick-1 lock *labels* are the eight
+assignments of `{+,−}` to `(1,0,0)`, `(0,1,0)`, `(0,0,1)` in that order.
+Lexicographic order on those triples uses `+` before `−`. The seed label
+`+` is displayed and is not overwritten.
+
+Tick-2 formation is the indicator of the proper cubic orbit of
+
+```text
+r = (0, +, 0, −, +, −).
+```
+
+Every axis of `r` is bi-colored and the letter counts are `2/2/2`. That
+orbit has 24 colorings; `P` exchanges it with a disjoint 24-orbit. The
+union is exactly the 48 handed fully-mixed colorings. Tick 2 does not
+overwrite existing locks. Labels do not feed occupancy: every labeling
+shares the same four locked sites after tick 1.
+
+## Theorem 1 — N_new for each of the eight labelings
+
+For each of the 8 labelings, `N_new` at tick 2 is reported. Whether any
+labeling has `N_new>0`. If yes, one lex-first labeling and its new sites.
+If none, report that.
+
+*Proof.* On this patch the unread sites that see a nonzero occupancy
+vector from the origin seed are exactly `(1,0,0)`, `(0,1,0)`, and
+`(0,0,1)`. No other on-patch site has `n≠0` after the seed. Those three
+sites are then labeled by each of the eight `{+,−}` triples.
+
+After tick 1 the unread on-patch sites are
+
+```text
+(1,1,0), (1,0,1), (0,1,1), (1,1,1), (2,0,0), (2,1,0), (2,0,1), (2,1,1).
+```
+
+Each sees at most two locked neighbors, independently of the three labels.
+Its six-tuple therefore uses the letter `0` at least four times and cannot
+be handed fully-mixed. The July-3 pair therefore returns false at every
+unread site, for every labeling. Direct evaluation of all eight six-tuples
+confirms `N_new = 0` throughout. None of the 8 labelings has `N_new>0`.
+There is no lex-first firing labeling.
+
+## Theorem 2 — N_fire and P-oddness among those that fire
+
+`N_fire` is the number of labelings with `N_new>0`. Among those that fire,
+whether the new-lock set is `P`-odd (differs from its `P`-image).
+
+*Proof.* Theorem 1 gives `N_new = 0` on every labeling, so `N_fire = 0`.
+The collection of firing new-lock sets is empty. The `P`-odd comparison is
+therefore not instantiated. Emptiness of that collection is the report,
+not a claim that a nonexistent new-lock set is `P`-even or `P`-odd.
+
+The July-3 pair remains a `P`-odd predicate on `{0,+,−}^6`. On this
+two-cube after occupancy tick-1, no tick-1 `{+,−}` labeling makes that
+predicate fire.
+
+## Theorem 3 — displayed, not adopted
+
+Displayed, not adopted. Do not write a labeling rule into Admissibility. Do not attach L1.
+
+The only load-bearing statements are Theorems 1 and 2. No labeling of the
+three axis sites is selected as a physical rule. Occupancy tick-1 is used
+as a displayed formation step, not as an attachment of L1. No axiom,
+primitive, or registry is edited.
+
+## What this note does and does not claim
+
+- It reports `N_new` for each of the eight tick-1 labelings, whether any
+  has `N_new>0`, `N_fire`, and the empty-domain `P`-odd question among
+  firers.
+- It does not attach L1. `f_L1` remains `n≠0`, not Hamming, and lock labels
+  do not feed `n`.
+- It does not write a labeling rule into Admissibility.
+- It is not leftover-char of wav2run: wav2run closed the single sign-of-
+  `n_μ` labeling; this census is the remaining eight-assignment question.
+- It does not reopen parked exercises.
+- It does not open a 4×4×4 or other new patch.
+- Formation site, probability, process, and rate remain unsupplied.
+
+## No-Go Discipline
+
+The negative statement is only: on this two-cube, none of the eight tick-1
+`{+,−}` labelings makes the July-3 pair fire at tick 2. It is not a no-go
+against every future content-conditioned execution.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome |
+|---|---|---|
+| occupancy-only tick-1, `f_L1` is `n≠0` | **EXECUTED** | three axis locks, labels free |
+| Hamming neighbor count as formation | **REFUSED** | opposite-pair occupancy is not `n≠0` |
+| all eight tick-1 `{+,−}` labelings at tick-2 | **EXECUTED** | `N_new = 0` on each; `N_fire = 0` |
+| sign of `n_μ` only (wav2run) | **REFUSED** | leftover-char of wav2run; one labeling |
+| occupancy tick-2 on the same patch | **REFUSED** | leftover-character of L1 two-tick composition |
+| write a labeling rule into Admissibility | **REFUSED** | displayed, not adopted |
+| attach L1 | **REFUSED** | do not attach L1 |
+| 4×4×4 or other new patch | **REFUSED** | same two-cube only |
+
+### N2 — wall independence
+
+One census report is claimed. Emptiness of every new set is not a second
+impossibility wall.
+
+### N3 — hidden-wall scan
+
+The patch, seed label, occupancy kernel, eight labelings, `P`, and the
+July-3 pair are declared. No dynamics, no 4×4×4 patch, and no axiom edit is
+imported.
+
+### N4 — residual matching
+
+The residual answered is whether any of the eight tick-1 labelings makes
+the already-displayed `P`-odd pair fire at tick 2. It is not leftover-char
+of wav2run (that closed one labeling).
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — occupancy n and the six-letter coloring at each unread site, each of 8 labelings
+per-site: executed — twelve-vertex two-cube, off-patch o=0
+per-mode: not applicable
+per-block: executed — eight N_new values, N_fire, empty firer P-odd domain
+lattice-wide: not executed — no new spatial patch
+```
+
+### N6 — partial-closure paths
+
+A later execution could change the seed label, grow the patch, or refuse
+content-conditioned formation. Adopting a labeling rule would be an
+axiom-level or rule-level act and is out of scope.
+
+### N7 — steelman
+
+The strongest objection is that eight zeros were already implied by
+wav2run's "at most two locked neighbors" geometry, so the census is
+redundant. The residual was still the eight-assignment question: labels
+could have mattered if any unread site had seen four locked neighbors.
+None does. The runner enumerates all eight rather than inferring from one.
+
+### N8 — cross-cycle echo
+
+July-3 theorem 3 is used as a named finite fact and is re-earned on the
+same six directions. No status is borrowed from that note's audit row.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py
+```
+
+The runner reconstructs the twelve-vertex two-cube, forms occupancy
+tick-1, assigns each of the eight `{+,−}` labelings to the three axis
+sites, re-earns the unique `k=3` pair, reports `N_new` per labeling,
+`N_fire`, and the empty firer `P`-odd domain, and refuses axiom edits.
+Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18597,6 +18597,10 @@
   "two_band_orbital_response_closed_form_bounded_theorem_note_2026-06-12": {
    "deps_hash": "10b6ffe3f823",
    "out_degree": 1
+  },
+  "two_cube_tick1_labeling_chiral_fire_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_endpoint_gauss_law_invariance_profile_bounded_theorem_note_2026-06-05": {
    "deps_hash": "bd71c5f30cb7",

--- a/logs/runner-cache/two_cube_tick1_labeling_chiral_fire_2026_08_15.txt
+++ b/logs/runner-cache/two_cube_tick1_labeling_chiral_fire_2026_08_15.txt
@@ -1,0 +1,64 @@
+===== runner cache v1 =====
+runner: scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py
+runner_sha256: 8199283e7fcd97d0e8736cfa2de62212352b3afa88ebf52f42102f5f139aad4a
+input_fingerprint_sha256: ea35cb2645328b5ebfa6b6c8a46904edb7320524c05d9c34a7e0be7a271a7885
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+two-cube tick-1 labeling chiral-fire census (displayed, not adopted)
+AUDIT_INPUT_PATHS:
+  docs/TWO_CUBE_TICK1_LABELING_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+construction: same twelve-vertex two-cube; no 4x4x4 or other new patch
+PASS: audit-input-paths-exact-literals  (declared=('docs/TWO_CUBE_TICK1_LABELING_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: note-claim-scope
+PASS: source-admissibility
+PASS: source-formation-boundary
+PASS: source-record
+PASS: note-f-L1-is-n-nonzero-not-hamming
+PASS: note-displayed-not-adopted
+PASS: note-does-not-attach-L1
+PASS: note-does-not-write-labeling-rule-into-admissibility
+PASS: note-same-two-cube-no-new-patch
+PASS: note-not-leftover-wav2run
+PASS: note-no-forbidden-phrases
+PASS: patch-twelve-vertices
+PASS: off-patch-occupancy-zero
+PASS: tick1-new-locks  (new=[(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: tick1-not-hamming
+tick1_axis_order=(1,0,0),(0,1,0),(0,0,1)
+labeling +++ N_new=0 new=()
+labeling ++− N_new=0 new=()
+labeling +−+ N_new=0 new=()
+labeling +−− N_new=0 new=()
+labeling −++ N_new=0 new=()
+labeling −+− N_new=0 new=()
+labeling −−+ N_new=0 new=()
+labeling −−− N_new=0 new=()
+any_fire=False
+N_fire=0
+lex_first_firing=none
+theorem1: none of the 8 labelings has N_new>0
+PASS: july3-unique-k3-pair
+PASS: theorem1-eight-labelings  (count=8)
+PASS: theorem1-N-new-all-zero  (N_new=(0, 0, 0, 0, 0, 0, 0, 0))
+PASS: theorem1-none-report
+PASS: theorem2-N-fire  (N_fire=0)
+PASS: theorem2-among-firers-P-odd-empty-domain
+PASS: unread-at-most-two-locked-neighbors  (max_locked=2)
+PASS: tick2-does-not-overwrite
+PASS: wav2run-sign-n-mu-is-one-of-eight
+PASS: mutation-hamming-is-not-f-L1
+PASS: mutation-occupancy-tick2-is-not-this-census
+PASS: note-reports-census
+PASS: theorem3-displayed-not-adopted
+TOTAL: PASS=31 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py
+++ b/scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Census all eight tick-1 {+,−} labelings of the two-cube axis sites.
+
+Tick 1 forms by occupancy n≠0. Tick-1 lock labels are then assigned freely
+in {+,−} at (1,0,0), (0,1,0), (0,0,1). Tick 2 forms by the July-3 unique
+k=3 chiral pair on neighbor Record content {0,+,−}. Existing locks are not
+overwritten. The census is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_CUBE_TICK1_LABELING_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_CUBE_TICK1_LABELING_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Site = tuple[int, int, int]
+Coloring = tuple[str, ...]
+AXES: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+TICK1_SITES: tuple[Site, Site, Site] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+DIRS: tuple[Site, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+LETTERS = ("0", "+", "−")
+LABELS = ("+", "−")
+SEED: Site = (0, 0, 0)
+SEED_CONTENT = "+"
+REPRESENTATIVE: Coloring = ("0", "+", "0", "−", "+", "−")
+ZERO_N = (Fraction(0), Fraction(0), Fraction(0))
+CLAIM_SCOPE = (
+    "On the two-cube with off-patch o=0 and seed +, whether any of the 8 "
+    "tick-1 {+,−} labelings of the three axis sites makes the July-3 k=3 "
+    "pair fire at tick 2 is reported. Displayed, not adopted."
+)
+FORBIDDEN_PHRASES = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add_site(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def invert_site(site: Site) -> Site:
+    return (-site[0], -site[1], -site[2])
+
+
+def cube_a_vertices() -> frozenset[Site]:
+    return frozenset((x, y, z) for x in (0, 1) for y in (0, 1) for z in (0, 1))
+
+
+def cube_b_vertices() -> frozenset[Site]:
+    return frozenset((x, y, z) for x in (1, 2) for y in (0, 1) for z in (0, 1))
+
+
+def patch_vertices() -> frozenset[Site]:
+    return cube_a_vertices() | cube_b_vertices()
+
+
+def occupancy_bit(site: Site, locks: frozenset[Site]) -> int:
+    if site not in patch_vertices():
+        return 0
+    return 1 if site in locks else 0
+
+
+def n_vector(site: Site, locks: frozenset[Site]) -> tuple[Fraction, Fraction, Fraction]:
+    components = []
+    for axis in AXES:
+        plus = occupancy_bit(add_site(site, axis), locks)
+        minus = occupancy_bit(add_site(site, invert_site(axis)), locks)
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+def occupancy_forms(site: Site, locks: frozenset[Site]) -> bool:
+    if site in locks or site not in patch_vertices():
+        return False
+    return n_vector(site, locks) != ZERO_N
+
+
+def hamming_would_form(site: Site, locks: frozenset[Site]) -> bool:
+    if site in locks or site not in patch_vertices():
+        return False
+    return sum(occupancy_bit(add_site(site, step), locks) for step in DIRS) != 0
+
+
+def f_l1_bits(bits: tuple[int, ...]) -> bool:
+    n = tuple(Fraction(bits[2 * axis] - bits[2 * axis + 1], 3) for axis in range(3))
+    return n != ZERO_N
+
+
+def neighbor_coloring(site: Site, labels: dict[Site, str]) -> Coloring:
+    return tuple(labels.get(add_site(site, step), "0") for step in DIRS)
+
+
+def locked_neighbor_count(site: Site, locks: frozenset[Site]) -> int:
+    return sum(occupancy_bit(add_site(site, step), locks) for step in DIRS)
+
+
+def det3(matrix: tuple[tuple[int, int, int], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def matvec(
+    matrix: tuple[tuple[int, int, int], ...], vector: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return tuple(sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3))
+
+
+def cubic_records() -> tuple[tuple[tuple[tuple[int, int, int], ...], int, tuple[int, ...]], ...]:
+    records = []
+    seen: set[tuple[tuple[int, int, int], ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(tuple(row) for row in matrix)
+            if key in seen:
+                continue
+            seen.add(key)
+            direction_perm = tuple(DIR_INDEX[matvec(key, direction)] for direction in DIRS)
+            records.append((key, det3(key), direction_perm))
+    return tuple(records)
+
+
+RECORDS = cubic_records()
+PROPER_PERMS = tuple(perm for _matrix, determinant, perm in RECORDS if determinant == 1)
+P_MATRIX = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+P_PERM = next(perm for matrix, _determinant, perm in RECORDS if matrix == P_MATRIX)
+
+
+def act_color(perm: tuple[int, ...], coloring: Coloring) -> Coloring:
+    out = [""] * 6
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def orbit_of(seed: Coloring, perms: tuple[tuple[int, ...], ...]) -> frozenset[Coloring]:
+    return frozenset(act_color(perm, seed) for perm in perms)
+
+
+FORMING_ORBIT = orbit_of(REPRESENTATIVE, PROPER_PERMS)
+P_FORMING_ORBIT = orbit_of(act_color(P_PERM, REPRESENTATIVE), PROPER_PERMS)
+
+
+def is_fully_mixed(coloring: Coloring) -> bool:
+    axis_mixed = all(coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3))
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_mixed and counts == [2, 2, 2]
+
+
+def chiral_forms(coloring: Coloring) -> bool:
+    return coloring in FORMING_ORBIT
+
+
+def all_labelings() -> tuple[tuple[str, str, str], ...]:
+    return tuple(itertools.product(LABELS, repeat=3))
+
+
+def labels_for(assignment: tuple[str, str, str]) -> dict[Site, str]:
+    labels = {SEED: SEED_CONTENT}
+    for site, letter in zip(TICK1_SITES, assignment):
+        labels[site] = letter
+    return labels
+
+
+def tick2_new_sites(
+    unread: tuple[Site, ...], labels: dict[Site, str]
+) -> frozenset[Site]:
+    return frozenset(site for site in unread if chiral_forms(neighbor_coloring(site, labels)))
+
+
+def is_p_odd_set(sites: frozenset[Site]) -> bool:
+    return sites != frozenset(invert_site(site) for site in sites)
+
+
+def audit_input_literal() -> tuple[str, ...]:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                value = ast.literal_eval(node.value)
+                if not isinstance(value, tuple) or not all(isinstance(item, str) for item in value):
+                    raise TypeError("AUDIT_INPUT_PATHS must be a tuple of strings")
+                return value
+    raise RuntimeError("AUDIT_INPUT_PATHS assignment not found")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    patch = patch_vertices()
+
+    print("two-cube tick-1 labeling chiral-fire census (displayed, not adopted)")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("construction: same twelve-vertex two-cube; no 4x4x4 or other new patch")
+
+    declared = audit_input_literal()
+    checks.check(
+        "audit-input-paths-exact-literals",
+        declared == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        f"declared={declared}",
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+    checks.check("note-claim-scope", CLAIM_SCOPE in normalize(note.replace("`", "")))
+
+    admissibility_rule = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice "
+        "translations and proper cubic rotations."
+    )
+    distribution_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "it does not supply the formation site, probability, or rate."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_permanence = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-admissibility",
+        admissibility_rule in normalized_axiom
+        and distribution_sentence in normalized_axiom
+        and admissibility_rule in normalized_note
+        and distribution_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-record",
+        "Records form." in axiom
+        and record_lock in normalized_axiom
+        and record_permanence in normalized_axiom
+        and record_content in normalized_axiom
+        and record_absence in normalized_axiom
+        and record_lock in normalized_note
+        and record_permanence in normalized_note
+        and record_content in normalized_note
+        and record_absence in normalized_note,
+    )
+    checks.check(
+        "note-f-L1-is-n-nonzero-not-hamming",
+        "f_L1" in note and "n≠0" in note and "not Hamming" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "Displayed, not adopted" in note and "displayed, not adopted" in note,
+    )
+    checks.check(
+        "note-does-not-attach-L1",
+        "does not attach L1" in note and "Do not attach L1" in note,
+    )
+    checks.check(
+        "note-does-not-write-labeling-rule-into-admissibility",
+        "Do not write a labeling rule into Admissibility" in note
+        and "hypothetical_axiom_status: no edit" in note,
+    )
+    checks.check(
+        "note-same-two-cube-no-new-patch",
+        "twelve-vertex" in note
+        and "4×4×4" in note
+        and "not a new patch" in note,
+    )
+    checks.check(
+        "note-not-leftover-wav2run",
+        "leftover-char of wav2run" in note and "one labeling" in note,
+    )
+    checks.check(
+        "note-no-forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN_PHRASES),
+    )
+
+    checks.check("patch-twelve-vertices", len(patch) == 12)
+    checks.check(
+        "off-patch-occupancy-zero",
+        occupancy_bit((-1, 0, 0), frozenset({SEED})) == 0
+        and occupancy_bit((0, -1, 0), frozenset({SEED})) == 0
+        and occupancy_bit((3, 0, 0), frozenset({SEED})) == 0,
+    )
+
+    seed_locks = frozenset({SEED})
+    tick1_new = frozenset(site for site in patch if occupancy_forms(site, seed_locks))
+    expected_tick1 = frozenset(TICK1_SITES)
+    checks.check(
+        "tick1-new-locks",
+        tick1_new == expected_tick1,
+        f"new={sorted(tick1_new)}",
+    )
+    checks.check(
+        "tick1-not-hamming",
+        occupancy_forms((2, 0, 0), seed_locks) is False
+        and hamming_would_form((2, 0, 0), seed_locks) is False
+        and f_l1_bits((1, 1, 0, 0, 0, 0)) is False
+        and sum((1, 1, 0, 0, 0, 0)) != 0,
+    )
+
+    tick1_locks = seed_locks | tick1_new
+    unread = tuple(sorted(site for site in patch if site not in tick1_locks))
+    assignments = all_labelings()
+    rows = []
+    for assignment in assignments:
+        labels = labels_for(assignment)
+        new_sites = tick2_new_sites(unread, labels)
+        colorings = tuple(neighbor_coloring(site, labels) for site in unread)
+        rows.append(
+            {
+                "assignment": assignment,
+                "new_sites": new_sites,
+                "n_new": len(new_sites),
+                "colorings": colorings,
+                "labels": labels,
+            }
+        )
+
+    print("tick1_axis_order=(1,0,0),(0,1,0),(0,0,1)")
+    for row in rows:
+        assignment = "".join(row["assignment"])
+        new_txt = tuple(sorted(row["new_sites"]))
+        print(f"labeling {assignment} N_new={row['n_new']} new={new_txt}")
+
+    n_values = tuple(row["n_new"] for row in rows)
+    firing = [row for row in rows if row["n_new"] > 0]
+    n_fire = len(firing)
+    any_fire = n_fire > 0
+    lex_first = firing[0] if firing else None
+    firer_new_sets_p_odd = tuple(is_p_odd_set(row["new_sites"]) for row in firing)
+
+    print(f"any_fire={any_fire}")
+    print(f"N_fire={n_fire}")
+    if lex_first is None:
+        print("lex_first_firing=none")
+        print("theorem1: none of the 8 labelings has N_new>0")
+    else:
+        print(f"lex_first_firing={''.join(lex_first['assignment'])}")
+        print(f"lex_first_new={tuple(sorted(lex_first['new_sites']))}")
+        print(f"firer_new_sets_P_odd={firer_new_sets_p_odd}")
+
+    checks.check(
+        "july3-unique-k3-pair",
+        len(FORMING_ORBIT) == 24
+        and len(P_FORMING_ORBIT) == 24
+        and FORMING_ORBIT.isdisjoint(P_FORMING_ORBIT)
+        and REPRESENTATIVE in FORMING_ORBIT
+        and is_fully_mixed(REPRESENTATIVE)
+        and all(is_fully_mixed(coloring) for coloring in FORMING_ORBIT)
+        and P_PERM == (1, 0, 3, 2, 5, 4),
+    )
+    checks.check(
+        "theorem1-eight-labelings",
+        assignments == tuple(itertools.product(LABELS, repeat=3))
+        and len(assignments) == 8
+        and len(rows) == 8,
+        f"count={len(assignments)}",
+    )
+    checks.check(
+        "theorem1-N-new-all-zero",
+        n_values == (0,) * 8 and not any_fire,
+        f"N_new={n_values}",
+    )
+    checks.check(
+        "theorem1-none-report",
+        lex_first is None
+        and "none of the 8 labelings" in note
+        and "N_new>0" in note,
+    )
+    checks.check(
+        "theorem2-N-fire",
+        n_fire == 0 and "N_fire = 0" in note,
+        f"N_fire={n_fire}",
+    )
+    checks.check(
+        "theorem2-among-firers-P-odd-empty-domain",
+        n_fire == 0
+        and firer_new_sets_p_odd == ()
+        and all(is_p_odd_set(row["new_sites"]) for row in firing),
+    )
+    max_locked = max(locked_neighbor_count(site, tick1_locks) for site in unread)
+    checks.check(
+        "unread-at-most-two-locked-neighbors",
+        max_locked <= 2
+        and all(not is_fully_mixed(coloring) for row in rows for coloring in row["colorings"])
+        and all(not chiral_forms(coloring) for row in rows for coloring in row["colorings"]),
+        f"max_locked={max_locked}",
+    )
+    checks.check(
+        "tick2-does-not-overwrite",
+        all(SEED in row["labels"] and row["labels"][SEED] == SEED_CONTENT for row in rows)
+        and all(tick1_new.isdisjoint(row["new_sites"]) for row in rows)
+        and all(site not in tick1_locks for row in rows for site in row["new_sites"]),
+    )
+    sign_n_mu = ("−", "−", "−")
+    checks.check(
+        "wav2run-sign-n-mu-is-one-of-eight",
+        sign_n_mu in assignments
+        and n_vector((1, 0, 0), seed_locks) == (Fraction(-1, 3), Fraction(0), Fraction(0))
+        and next(row["n_new"] for row in rows if row["assignment"] == sign_n_mu) == 0,
+    )
+    checks.check(
+        "mutation-hamming-is-not-f-L1",
+        f_l1_bits((1, 1, 0, 0, 0, 0)) is False
+        and sum((1, 1, 0, 0, 0, 0)) == 2,
+    )
+    checks.check(
+        "mutation-occupancy-tick2-is-not-this-census",
+        occupancy_forms((1, 1, 0), tick1_locks)
+        and occupancy_forms((2, 0, 0), tick1_locks)
+        and all((1, 1, 0) not in row["new_sites"] for row in rows)
+        and all((2, 0, 0) not in row["new_sites"] for row in rows),
+    )
+    checks.check(
+        "note-reports-census",
+        "N_new = 0" in note
+        and "N_fire = 0" in note
+        and "lex-first" in note,
+    )
+    checks.check(
+        "theorem3-displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write a labeling rule into Admissibility" in note
+        and "Do not attach L1" in note
+        and "we adopt" not in note.lower()
+        and "Codex" not in note,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

On the two-cube with seed +, all 8 tick-1 {+,-} labelings of the three axis sites give tick-2 N_new=0 for the July-3 k=3 pair. Every unread site sees at most two locked neighbors, so no six-tuple is handed fully-mixed. N_fire=0. Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_cube_tick1_labeling_chiral_fire_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.