### PR TITLE
feat(need6): seed-grown front never has 6 occupied neighbors

### DIFF
--- a/docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,296 @@
+---
+claim_id: seed_grown_front_chiral_pair_support_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On Z^3 seed-grown ℓ¹ balls of radius 0..4, whether any next-shell site has 6 occupied neighbors — the support the July-3 k=3 chiral pair needs — is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/seed_grown_front_chiral_pair_support_2026_08_15.py
+---
+
+# Seed-Grown Front Support Of The July-3 Unique k=3 Chiral Pair
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** integer geometry of seed-grown ℓ¹ occupancy balls of radius
+`t = 0,1,2,3,4` on `Z^3`, scored only as six-neighbor occupancy of the next
+shell. No new occupancy member is grown on a new patch. The unique `k = 3`
+chiral pair of
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md)
+is used only as the already-classified support that needs six occupied
+neighbors. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none. It does not attach L1.
+**Primary runner:**
+[`scripts/seed_grown_front_chiral_pair_support_2026_08_15.py`](../scripts/seed_grown_front_chiral_pair_support_2026_08_15.py)
+
+## Result Up Front
+
+Let
+
+`B_t = { v ∈ Z^3 : |v|_1 ≤ t }`
+
+be the occupied seed-grown ℓ¹ ball of radius `t`, and let the next unread
+shell be
+
+`S_{t+1} = { v ∈ Z^3 : |v|_1 = t+1 }`.
+
+The occupied six-neighbors of `v ∈ S_{t+1}` are those of the six axial
+neighbors `v ± e_i` that lie in `B_t`.
+
+The July-3 classification supplies exactly one chiral pair at condition
+alphabet size `k = 3`. Its members are the handed fully-mixed patterns:
+every axis is bi-colored with two distinct contents. That pattern is a
+coloring of all six nearest-neighbor slots, so it can fire only when a site
+has **six occupied neighbors**.
+
+For each `t ∈ {0,1,2,3,4}` the maximum occupied six-neighbor count on
+`S_{t+1}` is strictly less than 6, and the number of next-shell sites with
+six occupied neighbors is exactly 0. The unique `k = 3` pair therefore has
+empty support on every such front.
+
+The displayed consequence is that seed-grown six-neighbor occupancy growth
+cannot turn on that unique `k = 3` chiral channel. The consequence is
+**displayed, not adopted**. It is not written into Admissibility. It is not
+an occupancy primitive. It is not leftover character of the mixlab one-wave
+census (that census closed eight labelings at `t = 1`); the residual scored
+here is only ℓ¹-ball geometry versus the pair’s six-neighbor support.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+The Record unread boundary used only to name the next shell as unread is:
+
+A site with no record cannot be read.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+Occupancy in this note is the geometric set `B_t`. The axiom
+does not supply the formation site, probability, or rate, and this
+note does not add one.
+Admissibility is not edited. The six-neighbor condition domain is used only
+to identify which occupied slots a next-shell site can see.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact six-neighbor occupancy counts on seed-grown ℓ¹ shells of radius 1..5; the unique k=3 pair support is empty on those fronts. Displayed, not adopted."
+trace_class: negative_route_pruning
+target_claim_id: admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+target_blocker_text: "whether ordinary seed-grown six-neighbor occupancy growth can present the six occupied neighbors the unique k=3 chiral pair requires"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "If a later construction wants the unique k=3 pair on a growing front, it must supply a different occupancy set than the seed-grown ℓ¹ ball, or a different neighbor predicate than the six axial neighbors."
+conditional_surface_status: "exact for B_t and S_{t+1} at t=0..4; not an Admissibility edit and not a physical formation law"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)` and `e_1, e_2, e_3` for the standard basis of `Z^3`.
+The open six-neighbor set is
+
+`N(v) = { v ± e_1, v ± e_2, v ± e_3 }`.
+
+The taxicab norm is `|v|_1 = |v_1| + |v_2| + |v_3|`. Occupied neighbors of a
+next-shell site are
+
+`N_occ(v; t) = N(v) ∩ B_t`.
+
+The fully-mixed `k = 3` support predicate used here is the occupancy
+necessary condition only: `|N_occ(v; t)| = 6`. Distinct contents on each
+axis are not scored; they cannot occur unless all six slots are occupied.
+
+## Theorem 1 — Next-Shell Occupied Six-Neighbor Count Is At Most Three
+
+For each `t ∈ {0,1,2,3,4}` and every `v ∈ S_{t+1}`,
+
+`|N_occ(v; t)| = # { i ∈ {1,2,3} : v_i ≠ 0 } ≤ 3 < 6`.
+
+*Proof.* Fix `v` with `|v|_1 = t+1` and an axis `i`.
+
+- If `v_i > 0`, then `|v - e_i|_1 = t` and `|v + e_i|_1 = t+2`, so exactly
+  one of the two axial neighbors lies in `B_t`.
+- If `v_i < 0`, then `|v + e_i|_1 = t` and `|v - e_i|_1 = t+2`, again
+  exactly one occupied axial neighbor.
+- If `v_i = 0`, then both `|v ± e_i|_1 = t+2`, so neither axial neighbor
+  lies in `B_t`.
+
+Summing over the three axes gives the identity. A next-shell site has at
+least one nonzero coordinate, so the count is in `{1,2,3}`. In particular
+the maximum over `S_{t+1}` is strictly less than 6.
+
+The same identity holds for every `t ≥ 0`. The executed census below
+restricts to the requested radii `t = 0,1,2,3,4`.
+
+## Theorem 2 — Unique k=3 Pair Support Is Empty On Each Front
+
+Write `N_shell = |S_{t+1}|`, `max_occ_nn = max_{v ∈ S_{t+1}} |N_occ(v; t)|`,
+and `N_with_6 = |{ v ∈ S_{t+1} : |N_occ(v; t)| = 6 }|`.
+
+The primary runner enumerates every integer point in the box
+`[-r, r]^3` with `r = t+1` and scores the next shell exactly. The finite
+table is
+
+| `t` | `N_shell` | `max_occ_nn` | `N_with_6` |
+|---:|---:|---:|---:|
+| 0 | 6 | 1 | 0 |
+| 1 | 18 | 2 | 0 |
+| 2 | 38 | 3 | 0 |
+| 3 | 66 | 3 | 0 |
+| 4 | 102 | 3 | 0 |
+
+For every listed `t`, `max_occ_nn < 6` and `N_with_6 = 0`. Therefore the
+July-3 unique `k = 3` pair has empty support on every such front: no unread
+next-shell site presents the six occupied neighbors the fully-mixed
+coloring requires.
+
+As a shell-cardinality cross-check, `|S_r| = 4r^2 + 2` for each `r ≥ 1`,
+so the five shell sizes are `6,18,38,66,102`.
+
+Interior contrast, not a counterexample to the theorem: for `t ≥ 1` the
+already-occupied origin has `|N(0) ∩ B_t| = 6`. The theorem scores only
+unread sites on `S_{t+1}`.
+
+## Theorem 3 — Displayed Non-Turn-On (Not Adopted)
+
+Displayed: seed-grown six-neighbor occupancy growth on the ℓ¹ balls `B_t`
+cannot turn on the unique `k = 3` chiral channel, because that channel’s
+support is empty on every next shell scored in Theorem 2.
+
+This line is **displayed, not adopted**. It is not an Admissibility clause,
+not a physical rule determination, and not a claim that no other occupancy
+set can ever present six occupied neighbors. It does not attach L1. It does
+not grow a new occupancy member on a new patch.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current six-neighbor Lattice and Admissibility premises | quoted; no edit |
+| current Record unread/lock/content boundary | quoted as naming only; no formation law added |
+| July-3 unique `k = 3` fully-mixed pair | cited as already-classified support needing six occupied neighbors |
+| occupied six-neighbor identity on `S_{t+1}` | proved by one-axis case analysis |
+| census `t = 0..4` of `N_shell`, `max_occ_nn`, `N_with_6` | exact finite enumeration |
+| `N_with_6 = 0` and `max_occ_nn < 6` | proved |
+| Admissibility rewrite or occupancy primitive | not claimed; displayed, not adopted |
+| mixlab leftover-character of eight `t = 1` labelings | not this residual |
+
+## Boundary And Imports
+
+No observation, fitted parameter, continuum limit, or new axiom is imported.
+The occupancy set is the ordinary seed-grown ℓ¹ ball. Six-neighbor occupancy
+is not a content coloring: the theorem stops at the necessary occupancy
+count the fully-mixed pair requires.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the unique `k = 3` pair can fire on the next shell of a seed-grown ℓ¹ ball. |
+| V2 | Current main classifies the pair but does not score its six-neighbor support on `B_t`. |
+| V3 | The identity and the five-radius census are independently finite and exact. |
+| V4 | The note is more than a restatement of Admissibility because it enumerates occupied six-neighbor counts on a named growing set. |
+| V5 | The non-turn-on line is displayed, not adopted, so it is not a physical compiler or axiom sentence. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: on seed-grown ℓ¹ balls of radius `0..4`, no
+next-shell site has six occupied six-neighbors. No global chirality
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| seed-grown ℓ¹ ball, six-neighbor occupancy | score `S_{t+1}` | executed; support empty |
+| interior of `B_t` | score already-occupied sites | origin has six occupied neighbors for `t ≥ 1`; not an unread front |
+| different occupancy set | occupy a set that is not an ℓ¹ ball | live; not scored |
+| different neighbor predicate | replace six-neighbors by a larger star | different premise |
+| content coloring on a full six-tuple | assign distinct axis contents | blocked already by missing occupancy |
+| mixlab leftover-character at `t = 1` | enumerate eight labelings after one wave | closed elsewhere; not this residual |
+| write the non-turn-on line into Admissibility | axiom edit | refused; displayed, not adopted |
+
+### N2 — wall independence
+
+Empty six-neighbor support on this occupancy set is independent of the
+separate questions of which contents would occupy a full six-tuple, how
+records form, and whether the physical rule is chiral. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The occupancy set is the ℓ¹ ball. The neighbor predicate is the six axial
+neighbors. Radii are `t = 0,1,2,3,4`. The fully-mixed pair is used only
+through its necessary occupancy count of six. Formation, contents, and
+axiom edits are not silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic six-neighbor substrate and the
+local-condition sentence. July-3 supplies the unique `k = 3` pair. The
+residual scored here is the occupancy-support gap between those two
+surfaces.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | every next-shell site in the `t = 0..4` boxes | no infinite-radius numeric table beyond the identity |
+| per site | occupied six-neighbor count | no content coloring |
+| per mode | no mode calculation | no spectral claim |
+| per block | five radii and the one-axis identity | no new occupancy member |
+| lattice wide | identity for all `t ≥ 0`; census only through `t = 4` | no physical rule determination |
+
+### N6 — live partial-closure paths
+
+Live routes are a different occupancy set, a different neighbor predicate,
+or a separately derived reason that the physical rule does not use the
+unique `k = 3` pair. Ordinary seed-grown ℓ¹ six-neighbor growth is no longer
+a live route to turning that pair on.
+
+### N7 — hostile steelman
+
+**Steelman:** After a few growth steps the front should look locally like a
+filled six-tuple, so the unique chiral pair should fire.
+
+**Answer:** Six-neighbor steps change ℓ¹ radius by exactly one. A next-shell
+site therefore sees only the inward axial unit on each of its nonzero
+coordinates, hence at most three occupied six-neighbors, never six.
+
+### N8 — cross-cycle echo
+
+July-3 classified the pair; it did not score growing occupancy. The mixlab
+one-wave leftover-character census closed eight labelings at `t = 1` and is
+not reused here. This note does not reopen either surface.
+
+**Gate disposition:** PASS for the finite occupancy census, the occupied
+six-neighbor identity, and the empty unique-`k = 3` support on these fronts.
+FAIL / DO NOT SHIP for “Admissibility is rewritten,” “the pair can never
+fire on any set,” “records form on `S_{t+1}`,” or “L1 is attached.”
+
+## Primary Runner
+
+The primary runner enumerates `B_t` and `S_{t+1}` for `t = 0,1,2,3,4`,
+recomputes `N_shell`, `max_occ_nn`, and `N_with_6`, checks the
+nonzero-coordinate identity, pins the current Lattice / Admissibility /
+Record sentences, and checks that the non-turn-on line is displayed, not
+adopted. It writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16657,6 +16657,10 @@
   "sector_summed_companion_channel_cycle733_bounded_theorem_note_2026-07-28": {
    "deps_hash": "7299ef75081c",
    "out_degree": 1
+  },
+  "seed_grown_front_chiral_pair_support_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "self_consistency_forces_poisson_note": {
    "deps_hash": "0c72e54e8637",

--- a/logs/runner-cache/seed_grown_front_chiral_pair_support_2026_08_15.txt
+++ b/logs/runner-cache/seed_grown_front_chiral_pair_support_2026_08_15.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/seed_grown_front_chiral_pair_support_2026_08_15.py
+runner_sha256: 00f4c136cf29f7b0ab0769033a15900094d9c689fec8afc6d57f67bfd56234d3
+input_fingerprint_sha256: c18f0490ccb5781cb9a2f4638ab2554c0a8222fa8e5ae518518bd18b44814150
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scientific_dependency: current Lattice/Admissibility/Record sentences; July-3 pair used only as six-neighbor support
+declared_math: seed-grown ℓ¹ balls B_t and six-neighbor occupancy of S_{t+1}
+PASS: audit-input-paths declared inputs are exactly the source note and current axiom memo
+PASS: audit-input-literals AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-record-unread current unread/lock/content boundary is pinned and formation stays outside
+t=0 N_shell=6 max_occ_nn=1 N_with_6=0
+t=1 N_shell=18 max_occ_nn=2 N_with_6=0
+t=2 N_shell=38 max_occ_nn=3 N_with_6=0
+t=3 N_shell=66 max_occ_nn=3 N_with_6=0
+t=4 N_shell=102 max_occ_nn=3 N_with_6=0
+PASS: theorem-1-max-lt-6 for each t in 0..4 the max occupied six-neighbor count on S_{t+1} is < 6
+PASS: theorem-2-n-with-6 N_with_6 = 0 on every scored next shell
+PASS: identity-occ-equals-nnz occupied six-neighbor count equals the number of nonzero coordinates
+PASS: shell-cardinality enumerated |S_{t+1}| equals the ℓ¹ shell formula 4 r^2 + 2
+PASS: t0-axis-occupancy the t=0 next shell is the six axis sites, each with one occupied neighbor
+PASS: interior-contrast the already-occupied origin at t>=1 has six occupied neighbors and is not a next-shell site
+PASS: note-table the note reports the computed N_shell, max_occ_nn, and N_with_6 for each t
+PASS: note-claim-scope claim_scope is the dispatched displayed-not-adopted occupancy-support sentence
+PASS: displayed-not-adopted Theorem 3 is displayed, not adopted, and Admissibility is not edited
+PASS: note-contract machine fields, required phrases, and forbidden-rhetoric hygiene hold
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/seed_grown_front_chiral_pair_support_2026_08_15.py
+++ b/scripts/seed_grown_front_chiral_pair_support_2026_08_15.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Exact six-neighbor occupancy census on seed-grown ℓ¹ balls.
+
+For occupied B_t = {v in Z^3 : |v|_1 <= t} and next shell
+S_{t+1} = {v : |v|_1 = t+1}, the runner counts how many of the six axial
+neighbors of each unread shell site lie in B_t.  The July-3 unique k=3
+chiral pair needs six occupied neighbors.  No cache is written.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+RADII = (0, 1, 2, 3, 4)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def neighbors(site: Point) -> tuple[Point, ...]:
+    return tuple(add(site, shift) for shift in SHIFTS)
+
+
+def nonzero_count(site: Point) -> int:
+    return sum(coordinate != 0 for coordinate in site)
+
+
+def shell(radius: int) -> tuple[Point, ...]:
+    if radius < 0:
+        raise ValueError("shell radius must be nonnegative")
+    if radius == 0:
+        return ((0, 0, 0),)
+    points: list[Point] = []
+    for x in range(-radius, radius + 1):
+        rest = radius - abs(x)
+        for y in range(-rest, rest + 1):
+            zabs = rest - abs(y)
+            if zabs == 0:
+                points.append((x, y, 0))
+            else:
+                points.append((x, y, zabs))
+                points.append((x, y, -zabs))
+    return tuple(points)
+
+
+def occupied_neighbor_count(site: Point, occupied_radius: int) -> int:
+    return sum(l1(neighbor) <= occupied_radius for neighbor in neighbors(site))
+
+
+def score_radius(occupied_radius: int) -> dict[str, int]:
+    next_shell = shell(occupied_radius + 1)
+    counts = tuple(occupied_neighbor_count(site, occupied_radius) for site in next_shell)
+    identities = tuple(count == nonzero_count(site) for site, count in zip(next_shell, counts, strict=True))
+    if not all(identities):
+        raise RuntimeError("occupied six-neighbor count must equal the nonzero-coordinate count")
+    return {
+        "t": occupied_radius,
+        "N_shell": len(next_shell),
+        "max_occ_nn": max(counts),
+        "N_with_6": sum(count == 6 for count in counts),
+        "min_occ_nn": min(counts),
+    }
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scientific_dependency: current Lattice/Admissibility/Record sentences; July-3 pair used only as six-neighbor support")
+    print("declared_math: seed-grown ℓ¹ balls B_t and six-neighbor occupancy of S_{t+1}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and current axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check(
+        "audit-input-literals",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        'AUDIT_INPUT_PATHS = (\n    "docs/SEED_GROWN_FRONT_CHIRAL_PAIR_SUPPORT_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_absence = "A site with no record cannot be read."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in axiom_flat and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in axiom_flat and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-record-unread",
+        "current unread/lock/content boundary is pinned and formation stays outside",
+        all(phrase in axiom_flat for phrase in (record_absence, record_lock, record_content, formation_boundary))
+        and all(phrase in note for phrase in (record_absence, record_lock, record_content, formation_boundary)),
+    )
+
+    rows = tuple(score_radius(radius) for radius in RADII)
+    for row in rows:
+        print(
+            f"t={row['t']} N_shell={row['N_shell']} "
+            f"max_occ_nn={row['max_occ_nn']} N_with_6={row['N_with_6']}"
+        )
+
+    checks.check(
+        "theorem-1-max-lt-6",
+        "for each t in 0..4 the max occupied six-neighbor count on S_{t+1} is < 6",
+        all(row["max_occ_nn"] < 6 for row in rows),
+        [row["max_occ_nn"] for row in rows],
+    )
+    checks.check(
+        "theorem-2-n-with-6",
+        "N_with_6 = 0 on every scored next shell",
+        all(row["N_with_6"] == 0 for row in rows),
+        [row["N_with_6"] for row in rows],
+    )
+    checks.check(
+        "identity-occ-equals-nnz",
+        "occupied six-neighbor count equals the number of nonzero coordinates",
+        all(row["max_occ_nn"] <= 3 and row["min_occ_nn"] >= 1 for row in rows),
+        rows,
+    )
+    checks.check(
+        "shell-cardinality",
+        "enumerated |S_{t+1}| equals the ℓ¹ shell formula 4 r^2 + 2",
+        all(row["N_shell"] == 4 * (row["t"] + 1) ** 2 + 2 for row in rows),
+        [row["N_shell"] for row in rows],
+    )
+
+    origin_interior = occupied_neighbor_count((0, 0, 0), 1)
+    axis_t0 = occupied_neighbor_count((1, 0, 0), 0)
+    checks.check(
+        "t0-axis-occupancy",
+        "the t=0 next shell is the six axis sites, each with one occupied neighbor",
+        rows[0]["N_shell"] == 6 and rows[0]["max_occ_nn"] == 1 and axis_t0 == 1,
+        (rows[0], axis_t0),
+    )
+    checks.check(
+        "interior-contrast",
+        "the already-occupied origin at t>=1 has six occupied neighbors and is not a next-shell site",
+        origin_interior == 6 and l1((0, 0, 0)) == 0,
+        origin_interior,
+    )
+
+    table_phrases = tuple(
+        f"| {row['t']} | {row['N_shell']} | {row['max_occ_nn']} | {row['N_with_6']} |"
+        for row in rows
+    )
+    claim_scope = (
+        "On Z^3 seed-grown ℓ¹ balls of radius 0..4, whether any next-shell "
+        "site has 6 occupied neighbors — the support the July-3 k=3 chiral "
+        "pair needs — is reported. Displayed, not adopted."
+    )
+    required = (
+        claim_scope,
+        "Displayed, not adopted",
+        "does not attach L1",
+        "hypothetical_axiom_status: \"no edit\"",
+        "N_with_6",
+        "max_occ_nn",
+        "N_shell",
+        "every axis is bi-colored",
+        "cannot turn on the unique `k = 3` chiral channel",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        *table_phrases,
+    )
+    forbidden = (
+        "G_N",
+        "1/r^2",
+        "1/r",
+        "Lattice-named",
+        "not a TOE",
+        "Admissibility now says",
+        "attach L1 ledger",
+        "trace_class: direct_blocker_closure",
+        "reachability_to_target: partially_closes",
+    )
+    other_retained = note
+    for line in (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    ):
+        other_retained = other_retained.replace(line, "")
+
+    checks.check(
+        "note-table",
+        "the note reports the computed N_shell, max_occ_nn, and N_with_6 for each t",
+        all(phrase in note for phrase in table_phrases),
+        [phrase for phrase in table_phrases if phrase not in note],
+    )
+    checks.check(
+        "note-claim-scope",
+        "claim_scope is the dispatched displayed-not-adopted occupancy-support sentence",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "Theorem 3 is displayed, not adopted, and Admissibility is not edited",
+        "displayed, not adopted" in note.lower()
+        and "not written into Admissibility" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "does not attach L1" in note,
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, required phrases, and forbidden-rhetoric hygiene hold",
+        all(phrase in note for phrase in required)
+        and not any(phrase in note for phrase in forbidden)
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "retained" not in other_retained,
+        {
+            "missing": [phrase for phrase in required if phrase not in note],
+            "forbidden_hits": [phrase for phrase in forbidden if phrase in note],
+        },
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On Z^3 seed-grown ell1 balls of radius 0..4, every next-shell site has at most 3 occupied 6-NN (the number of nonzero coordinates). N_with_6=0 at each t. The July-3 k=3 chiral pair needs 6 occupied neighbors, so it cannot fire on that front. Displayed, not adopted. No axiom edit.

## Runner

`scripts/seed_grown_front_chiral_pair_support_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.