### PR TITLE
feat(pluschi): July-3 pair fires on mixed seed, not on M2 plus

### DIFF
--- a/docs/PLUS_SEED_CHIRAL_PAIR_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PLUS_SEED_CHIRAL_PAIR_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,187 @@
+---
+claim_id: plus_seed_chiral_pair_fire_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the 6-NN star with six occupied neighbors and unread center, whether the July-3 k=3 pair fires at the center for the fully-mixed labeling and how many of the 64 {+,−} plus-labelings fire, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/plus_seed_chiral_pair_fire_2026_08_15.py
+---
+
+# Plus-Seed Fire Of The July-3 `k=3` Chiral Pair (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the same six-axis star as the July-3 classification, with unread
+center and six occupied axis neighbors; the July-3 unique `k=3` chiral pair
+evaluated at tick 1 on that 6-tuple, and on the `2^6=64` `{+,−}` plus
+labelings. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/plus_seed_chiral_pair_fire_2026_08_15.py`](../scripts/plus_seed_chiral_pair_fire_2026_08_15.py)
+
+Framework context on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) and the
+July-3 classification
+[`docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+The Qubit axiom is not edited. A plus-seed is not written into Admissibility.
+L1 is not attached.
+
+## Result Up Front
+
+Seed-grown ℓ¹ fronts never present six occupied nearest neighbors, so the
+July-3 unique `k=3` pair cannot fire during ordinary growth. That growth
+statement is not repeated as a theorem here. The residual is initial data
+that is already a plus: six occupied axis neighbors around one unread
+center, on the same 6-NN star.
+
+On that star the pair is scored in two ways.
+
+1. Label the six axis slots with the July-3 lex-first handed fully-mixed
+   representative `(0, 1, 0, 2, 1, 2)` in direction order
+   `(+x, −x, +y, −y, +z, −z)`. That 6-tuple is a member of the unique `k=3`
+   chiral pair. Tick 1 at the unread center therefore fires:
+   `N_new = 1`.
+2. Restrict the six occupied neighbors to lock contents `{+, −}` (empty
+   not allowed on the plus). Among the `64` such plus-labelings,
+   `N_fire = 0`. None is a handed fully-mixed `k=3` coloring.
+
+The pair *can* turn on as this fully-mixed seed labeling. It does *not*
+turn on as an `M_2` `{+, −}` plus-seed. Both counts are displayed, not
+adopted. No plus-seed is written into Admissibility. L1 is not attached.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact classification of the July-3 k=3 pair on one 6-NN plus star: the lex-first fully-mixed representative fires at the unread center, and none of the 64 {+,−} plus-labelings fire. Displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: "does the July-3 k=3 pair fire at an unread center whose six axis neighbors are already a plus?"
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "leave the plus-seed counts displayed; do not adopt a plus-seed rule and do not attach L1"
+conditional_surface_status: "exact on the declared 6-NN star, the July-3 k=3 pair, and the 64 plus-labelings; not a rule selection and not a growth-front restatement"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Support Boundary
+
+- **Lattice / Admissibility / Record quotes** from
+  [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), used only
+  to name the cubic nearest-neighbor star, the one fixed nearest-neighbor
+  rule, and unreadability of an absent record. No axiom sentence is edited.
+- **Qubit** remains one-site `M_2(C)`. The two lock letters `{+, −}` are
+  the spectral contents of one `M_2` record. The third neighbor letter is
+  unread/empty. This note does not enlarge Qubit.
+- **July-3 parent:** at `k=3` there is exactly one chiral pair, whose
+  members are the handed fully-mixed patterns (every axis bi-colored, every
+  value used twice). The runner re-earns the lex-first representative.
+- **Geometry:** the same 6-NN star only. No new spatial patch is grown.
+  Ordinary seed-grown front support is a closed parent residual, not this
+  theorem.
+- **External physics inputs:** none.
+
+## Exact Objects
+
+Write the six axis directions in the July-3 order
+
+`D = ((1,0,0), (−1,0,0), (0,1,0), (0,−1,0), (0,0,1), (0,0,−1))`.
+
+The plus star is the unread center `0` together with those six neighbors.
+A neighbor condition is a letter in the `k=3` alphabet `{0, 1, 2}`. The
+`M_2` plus-labelings identify `{1, 2}` with `{+, −}` and forbid letter `0`
+on the six axis slots.
+
+Proper cubic rotations act on colorings by the faithful direction
+permutation of the 24 determinant-`+1` signed permutation matrices.
+Inversion `P = −I` swaps opposite axis slots. A coloring lies in the unique
+`k=3` chiral pair when it is not proper-equivalent to its `P`-image. The
+pair fires at the unread center on a 6-tuple `c` exactly when `c` is in
+that pair. Then `N_new = 1` if it fires and `N_new = 0` if it does not.
+
+The July-3 lex-first representative of the pair is
+
+`c★ = (0, 1, 0, 2, 1, 2)`.
+
+Every axis is bi-colored and the letter counts are `2/2/2`.
+
+## Theorem 1 — Fully-mixed representative fires
+
+On the plus star, label the six occupied axis slots by `c★`. That 6-tuple
+is a member of the unique `k=3` chiral pair. Tick 1 at the unread center
+therefore fires the pair:
+
+`N_new = 1`.
+
+The representative uses all three `k=3` letters. Scoring `c★` is the
+specified fully-mixed labeling, not a claim that letter `0` is a second
+`M_2` lock content.
+
+## Theorem 2 — None of the 64 `{+, −}` plus-labelings fire
+
+Empty is not allowed on the plus. The 64 content assignments are the
+colorings `{1, 2}^6`. Each uses only two letters, so none can be fully
+mixed at `k=3` (three letters, each used twice). Direct orbit membership
+confirms
+
+`N_fire = 0`.
+
+If `N_fire` had been positive, the pair could turn on as an `M_2` plus
+seed rather than as a growth front. It is not positive.
+
+## Theorem 3 — Displayed, not adopted
+
+The two counts are displayed. They are not adopted as a rule. This note
+does not write a plus-seed into Admissibility. It does not attach L1. It
+does not change Qubit. It does not reopen ordinary growth: fronts never
+presenting six occupied neighbors remains a parent residual.
+
+`claim_scope`: On the 6-NN star with six occupied neighbors and unread
+center, whether the July-3 `k=3` pair fires at the center for the
+fully-mixed labeling and how many of the 64 `{+,−}` plus-labelings fire,
+is reported. Displayed, not adopted.
+
+## Honest Auditor / Boundary
+
+- The parent growth statement is used only as motivation. The theorems
+  score one already-plus 6-NN star.
+- Membership in the July-3 pair is a predicate on a 6-tuple. It is not a
+  dynamics, a formation rate, or a selected physical rule.
+- `N_new = 1` for `c★` does not license three lock contents. `N_fire = 0`
+  does not license a plus-seed axiom.
+- Observed weak `P`-violation is not derived here and is not used as a
+  fit target.
+- No audit verdict is authored.
+
+## Falsifiers And Mutation Targets
+
+The predicate `N_new == 0` on `c★` must fail.
+The predicate `N_fire == 64` must fail.
+The predicate `N_fire == 0` must hold.
+
+The runner re-earns `c★`, the unique pair, and both counts.
+
+## Quoted Live Premises
+
+From [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+A site with no record cannot be read.
+
+A readout value is determined by record content alone.
+
+The July-3 parent states that at `k = 3` there is exactly one chiral pair,
+whose members are the handed fully-mixed patterns.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -14301,6 +14301,10 @@
   "plaquette_value_derivation_program_specification_and_bracket_reduction_narrow_theorem_note_2026-06-10": {
    "deps_hash": "676d6bb16b79",
    "out_degree": 6
+  },
+  "plus_seed_chiral_pair_fire_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "pmns_active_four_real_source_from_transport_note": {
    "deps_hash": "fa20501d8998",

--- a/logs/runner-cache/plus_seed_chiral_pair_fire_2026_08_15.txt
+++ b/logs/runner-cache/plus_seed_chiral_pair_fire_2026_08_15.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/plus_seed_chiral_pair_fire_2026_08_15.py
+runner_sha256: e1ca25aa93a0d571cba09abf293680d7680e86b0b1217a8151df977bacdf877a
+input_fingerprint_sha256: 2fb220adf68c496b36ac9e7ba7b718c87cba965f8cad5af65b79ecb2d5bd234e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; no observational, fitted, literature, scale, or normalization value is used
+explicit_bounded_inputs: the same 6-NN star, the July-3 k=3 pair, and the 64 plus-labelings
+framework_context: Qubit remains one-site M_2(C); no plus-seed is written into Admissibility
+negative_scope: displayed counts only; L1 is not attached
+representative=(0, 1, 0, 2, 1, 2)
+chiral_pair_size=48
+N_new=1
+N_plus=64
+N_fire=0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the declared note-plus-axiom tuple
+PASS: source-qubit-m2 the axiom memo still names one-site M_2(C)
+PASS: source-admissibility the axiom memo still names one fixed nearest-neighbor rule
+PASS: source-unread the axiom memo still says a site with no record cannot be read
+PASS: july3-unique-pair the July-3 parent names exactly one chiral pair at k=3
+PASS: rep-lex-first the re-earned representative is the July-3 lex-first handed fully-mixed 6-tuple
+PASS: rep-fully-mixed the representative is axis-bicolored with letter counts 2/2/2
+PASS: thm1-fires the fully-mixed representative fires at the unread center
+PASS: thm2-sixty-four there are exactly 64 {+,−} plus-labelings and empty is forbidden
+PASS: thm2-n-fire none of the 64 plus-labelings fire the k=3 pair
+PASS: pair-size the unique pair contains 48 colorings in two proper orbits of 24
+PASS: claim-scope the note reports the required claim_scope
+PASS: displayed-not-adopted the note displays the counts and refuses a plus-seed axiom and L1
+PASS: same-star-only the note stays on the same 6-NN star and does not grow a new patch
+PASS: machine-status-contract the source uses the required bounded-support status fields
+PASS: forbidden-phrases the note omits the forbidden phrases
+PASS: axiom-unedited the axiom memo does not contain a plus-seed or L1 formation rule
+PASS: mutation-rep-silent predicate N_new == 0 on the representative fails
+PASS: mutation-all-fire predicate N_fire == 64 fails
+PASS: mutation-n-fire-zero predicate N_fire == 0 holds
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/plus_seed_chiral_pair_fire_2026_08_15.py
+++ b/scripts/plus_seed_chiral_pair_fire_2026_08_15.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Plus-seed fire of the July-3 k=3 chiral pair.
+
+Same 6-NN star only. Exact finite classification. No axiom edit, no cache
+write, no network, no L1 attachment.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "PLUS_SEED_CHIRAL_PAIR_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+JULY3_PATH = (
+    ROOT
+    / "docs"
+    / "ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/PLUS_SEED_CHIRAL_PAIR_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+Coloring = tuple[int, ...]
+Perm = tuple[int, ...]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def det3(matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_times_dir(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+    direction: tuple[int, int, int],
+) -> tuple[int, int, int]:
+    return (
+        matrix[0][0] * direction[0] + matrix[0][1] * direction[1] + matrix[0][2] * direction[2],
+        matrix[1][0] * direction[0] + matrix[1][1] * direction[1] + matrix[1][2] * direction[2],
+        matrix[2][0] * direction[0] + matrix[2][1] * direction[1] + matrix[2][2] * direction[2],
+    )
+
+
+def direction_perm(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+) -> Perm:
+    return tuple(DIR_INDEX[mat_times_dir(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: Perm, coloring: Coloring) -> Coloring:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def cubic_records() -> list[tuple[int, Perm]]:
+    records: list[tuple[int, Perm]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            key = matrix[0] + matrix[1] + matrix[2]
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append((det3(matrix), direction_perm(matrix)))
+    return records
+
+
+def all_colorings(k: int) -> list[Coloring]:
+    return list(itertools.product(range(k), repeat=len(DIRS)))
+
+
+def proper_orbits(proper_perms: list[Perm], k: int) -> list[set[Coloring]]:
+    unseen = set(all_colorings(k))
+    orbits: list[set[Coloring]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in proper_perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def chiral_pair_colorings(proper_perms: list[Perm], p_perm: Perm, k: int = 3) -> tuple[Coloring, set[Coloring]]:
+    orbits = proper_orbits(proper_perms, k)
+    ids = {coloring: index for index, orbit in enumerate(orbits) for coloring in orbit}
+    pair_ids: set[int] = set()
+    seen_pairs: set[tuple[int, int]] = set()
+    for index, orbit in enumerate(orbits):
+        image_id = ids[act_col(p_perm, next(iter(orbit)))]
+        if image_id == index:
+            continue
+        pair = tuple(sorted((index, image_id)))
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        pair_ids.update(pair)
+    if len(seen_pairs) != 1:
+        raise RuntimeError(f"expected one k=3 chiral pair, found {len(seen_pairs)}")
+    members = set().union(*(orbits[index] for index in pair_ids))
+    representative = min(members)
+    return representative, members
+
+
+def axis_bicolored(coloring: Coloring) -> bool:
+    return all(coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3))
+
+
+def letter_counts(coloring: Coloring, k: int = 3) -> list[int]:
+    return sorted(coloring.count(letter) for letter in range(k))
+
+
+def pair_fires(coloring: Coloring, members: set[Coloring]) -> bool:
+    return coloring in members
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    july3 = JULY3_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+
+    print("external_scientific_inputs: none; no observational, fitted, literature, scale, or normalization value is used")
+    print("explicit_bounded_inputs: the same 6-NN star, the July-3 k=3 pair, and the 64 plus-labelings")
+    print("framework_context: Qubit remains one-site M_2(C); no plus-seed is written into Admissibility")
+    print("negative_scope: displayed counts only; L1 is not attached")
+
+    records = cubic_records()
+    proper_perms = [perm for det, perm in records if det == 1]
+    p_perm = direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+    representative, members = chiral_pair_colorings(proper_perms, p_perm)
+    n_new = int(pair_fires(representative, members))
+    plus_labelings = list(itertools.product((1, 2), repeat=6))
+    n_fire = sum(1 for coloring in plus_labelings if pair_fires(coloring, members))
+
+    print(f"representative={representative}")
+    print(f"chiral_pair_size={len(members)}")
+    print(f"N_new={n_new}")
+    print(f"N_plus={len(plus_labelings)}")
+    print(f"N_fire={n_fire}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the declared note-plus-axiom tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/PLUS_SEED_CHIRAL_PAIR_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "source-qubit-m2",
+        "the axiom memo still names one-site M_2(C)",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`." in axiom,
+    )
+    checks.check(
+        "source-admissibility",
+        "the axiom memo still names one fixed nearest-neighbor rule",
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice" in axiom,
+    )
+    checks.check(
+        "source-unread",
+        "the axiom memo still says a site with no record cannot be read",
+        "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "july3-unique-pair",
+        "the July-3 parent names exactly one chiral pair at k=3",
+        "exactly **one** chiral pair" in july3
+        and "handed fully-mixed patterns" in july3,
+    )
+    checks.check(
+        "rep-lex-first",
+        "the re-earned representative is the July-3 lex-first handed fully-mixed 6-tuple",
+        representative == (0, 1, 0, 2, 1, 2),
+    )
+    checks.check(
+        "rep-fully-mixed",
+        "the representative is axis-bicolored with letter counts 2/2/2",
+        axis_bicolored(representative) and letter_counts(representative) == [2, 2, 2],
+    )
+    checks.check(
+        "thm1-fires",
+        "the fully-mixed representative fires at the unread center",
+        n_new == 1 and pair_fires(representative, members),
+    )
+    checks.check(
+        "thm2-sixty-four",
+        "there are exactly 64 {+,−} plus-labelings and empty is forbidden",
+        len(plus_labelings) == 64
+        and all(0 not in coloring for coloring in plus_labelings)
+        and all(set(coloring) <= {1, 2} for coloring in plus_labelings),
+    )
+    checks.check(
+        "thm2-n-fire",
+        "none of the 64 plus-labelings fire the k=3 pair",
+        n_fire == 0,
+    )
+    checks.check(
+        "pair-size",
+        "the unique pair contains 48 colorings in two proper orbits of 24",
+        len(members) == 48,
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the required claim_scope",
+        'claim_scope: "On the 6-NN star with six occupied neighbors and unread center, whether the July-3 k=3 pair fires at the center for the fully-mixed labeling and how many of the 64 {+,−} plus-labelings fire, is reported. Displayed, not adopted."'
+        in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays the counts and refuses a plus-seed axiom and L1",
+        "Displayed, not adopted" in note
+        and "does not write a plus-seed into Admissibility" in note
+        and "does not attach L1" in normalized_note
+        and "N_new = 1" in note
+        and "N_fire = 0" in note,
+    )
+    checks.check(
+        "same-star-only",
+        "the note stays on the same 6-NN star and does not grow a new patch",
+        "same 6-NN star" in note and "No new spatial patch is grown" in note,
+    )
+    checks.check(
+        "machine-status-contract",
+        "the source uses the required bounded-support status fields",
+        all(
+            phrase in note
+            for phrase in (
+                "actual_current_surface_status: bounded-support",
+                "trace_class: frontier_discovery",
+                "target_claim_id: null",
+                "next_trace_action:",
+                "hypothetical_axiom_status: null",
+                "**Type:** bounded_theorem",
+                "audit_required_before_effective_retained: true",
+                "bare_retained_allowed: false",
+            )
+        ),
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note omits the forbidden phrases",
+        all(phrase not in note for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "axiom-unedited",
+        "the axiom memo does not contain a plus-seed or L1 formation rule",
+        all(
+            phrase not in axiom
+            for phrase in (
+                "plus-seed",
+                "N_fire",
+                "handed fully-mixed",
+                "form iff",
+            )
+        ),
+    )
+    mutation_rep_silent = n_new == 0
+    mutation_all_fire = n_fire == 64
+    checks.check(
+        "mutation-rep-silent",
+        "predicate N_new == 0 on the representative fails",
+        mutation_rep_silent is False,
+    )
+    checks.check(
+        "mutation-all-fire",
+        "predicate N_fire == 64 fails",
+        mutation_all_fire is False,
+    )
+    checks.check(
+        "mutation-n-fire-zero",
+        "predicate N_fire == 0 holds",
+        n_fire == 0,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the 6-NN star, the July-3 lex-first fully-mixed 6-tuple (0,1,0,2,1,2) fires at the unread center (N_new=1). Among the 64 all-occupied {+,-} plus-labelings, N_fire=0. The pair can turn on as a 3-letter mixed seed, not as an M2 plus-seed. Displayed, not adopted. No axiom edit.

## Runner

`scripts/plus_seed_chiral_pair_fire_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.