### PR TITLE
feat(pairsupp): July-3 pair always has 4 occupied slots

### DIFF
--- a/docs/JULY3_K3_PAIR_OCCUPIED_SLOT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/JULY3_K3_PAIR_OCCUPIED_SLOT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,221 @@
+---
+claim_id: july3_k3_pair_occupied_slot_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the July-3 unique k=3 chiral-pair 6-tuples, the occupied-slot count min/max/histogram, and whether that min exceeds the seed-grown front’s max occupied NN of 3, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py
+---
+
+# Occupied-Slot Census Of The July-3 Unique k=3 Chiral Pair
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupied-slot counts on the two proper-cubic orbits that
+form the unique `k = 3` chiral pair of six-direction condition 6-tuples.
+The histogram is displayed on that named alphabet model. It is not adopted
+as Admissibility content and is not attached to L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py`](../scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+
+## Result Up Front
+
+July-3 Theorem 3 isolates a unique chiral pair at three condition letters:
+the two `G+` orbits of handed fully-mixed 6-tuples. Letters are `{0,1,2}`
+with `0` the empty/unread letter. The occupied-slot count of a 6-tuple is
+the number of nonzero slots.
+
+Direct enumeration of those two orbits gives `N_pair = 48` tuples (two
+orbits of size 24). Every member has occupied-slot count exactly 4. The
+histogram is therefore `{4: 48}`, with minimum 4 and maximum 4.
+
+The seed-grown front bound used for comparison is the need6 geometry fact
+that a seed-grown front site has at most 3 occupied nearest neighbors
+(`#6636`). Because every pair member has 4 occupied slots, no such front
+site can present a 6-tuple that equals any pair member.
+
+This is not leftover-char of pluschi, which inspected the single lex-first
+representative `(0,1,0,2,1,2)` and asked whether that one tuple fires. It
+is not need6, which is a front-geometry bound only. The census is over
+every tuple in both chiral orbits.
+
+The histogram is displayed, not adopted. It is not written into
+Admissibility. It is not attached to L1.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite orbit listing of the unique k=3 chiral pair and the occupied-slot histogram on that set are exact; the front comparison uses the cited max occupied-NN bound of 3; no axiom sentence is rewritten."
+trace_class: negative_route_pruning
+target_claim_id: july3_k3_pair_occupied_slot_census
+target_blocker_text: "among all 6-tuples in the two chiral G+ orbits, whether the occupied-slot minimum is at least 4, so a seed-grown front with max occupied NN of 3 cannot match any pair member"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact on the July-3 named k=3 alphabet model with 0 unread; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded census; do not write the histogram into Admissibility and do not attach L1"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+Quoted from the live memo, verbatim:
+
+```text
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+A site with no record cannot be read.
+```
+
+This note does not choose that rule and does not add a histogram clause to
+it. Letter `0` is the empty/unread letter on the July-3 three-letter
+model. Occupied means nonzero. The note does not assign a readout value to
+absence.
+- **July-3 Theorem 3.** At `k = 3` there is exactly one chiral pair, whose
+  members are the handed fully-mixed patterns: every axis bi-colored with
+  two distinct values, every value used twice. The runner re-earns the
+  pair by enumerating `G+` orbits; it does not import an external list.
+- **Cited comparison bound, not re-derived.** Seed-grown front sites have
+  at most 3 occupied nearest neighbors (`#6636`, need6 geometry). That
+  integer is a comparison input. This note does not re-prove front growth.
+- **External empirical inputs:** none.
+- **Not attached:** L1 is not a premise and is not a conclusion. The
+  census is not leftover-char of pluschi.
+
+## Exact Objects
+
+The six nearest-neighbor directions, in the July-3 order, are
+
+```text
+(+x, -x, +y, -y, +z, -z).
+```
+
+A `k = 3` condition 6-tuple is an element of `{0,1,2}^6`. Letter `0` is
+empty/unread. The occupied-slot count is
+
+```text
+occ(c) = |{ i in {0,...,5} : c_i != 0 }|.
+```
+
+`G+` is the 24-element proper cubic group of determinant-`+1` signed
+permutation matrices. It acts on 6-tuples by the induced permutation of
+the six axis directions. Spatial inversion `P = -I` is the central
+improper element; it swaps opposite directions and therefore exchanges
+some `G+` orbits.
+
+A chiral pair is a pair of distinct `G+` orbits exchanged by `P`. July-3
+Theorem 3 states there is exactly one such pair at `k = 3`. Write
+`Pair` for the union of those two orbits, and `N_pair = |Pair|`.
+
+The seed-grown front comparison integer is
+
+```text
+occ_front_max = 3.
+```
+
+## Theorem 1 — Occupied-Slot Census On The Unique Pair
+
+`N_pair = 48`. The occupied-slot minimum on `Pair` is 4, the maximum is
+4, and the histogram is `{4: 48}`.
+
+*Proof.* The 24 proper signed permutation matrices are generated
+exhaustively. Their action on the 729 colorings `{0,1,2}^6` partitions
+them into 57 `G+` orbits, matching the July-3 Burnside count. Exactly two
+of those orbits fail to meet their `P`-images; they form one pair, and
+each has size 24, so `N_pair = 48`. The lex-first representatives are
+
+```text
+(0,1,0,2,1,2)    and    (0,1,0,2,2,1).
+```
+
+Every tuple in `Pair` is fully mixed: each axis is bi-colored and the
+letter counts are `2/2/2`. In particular letter `0` occurs twice, so
+
+```text
+occ(c) = 6 - 2 = 4
+```
+
+for every `c` in `Pair`. Direct counting of the 48 tuples reproduces the
+same histogram `{4: 48}`.
+
+## Theorem 2 — Front Sites Cannot Match Any Pair Member
+
+The occupied-slot minimum on `Pair` is at least 4. Compared with the
+cited seed-grown front bound `occ_front_max = 3` (`#6636`), no
+seed-grown front site can present a 6-tuple equal to any member of
+`Pair`.
+
+*Proof.* Theorem 1 gives `min occ(Pair) = 4`. A site whose occupied
+nearest-neighbor count is at most 3 has `occ <= 3`, so it lies outside
+`Pair`. Equality of 6-tuples would require equal occupied-slot counts.
+The mismatch is therefore on every pair member, not on a single
+representative.
+
+This is a support-count obstruction on the named `k = 3` model. It does
+not assert that the physical admissibility rule is the chiral pair, and
+it does not identify the three letters with a derived physical alphabet.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The histogram `{4: 48}` is a finite report on the July-3 named alphabet
+model. It is displayed. It is not adopted.
+
+In particular:
+
+- the histogram is not written into Admissibility;
+- no axiom sentence is edited;
+- the census is not attached to L1.
+
+Admissibility continues to say only that there is one fixed
+nearest-neighbor rule, covariant under translations and proper cubic
+rotations, and that the local distribution varies with the
+nearest-neighbor conditions. Which histogram a named test alphabet
+happens to carry is not that rule.
+
+## What This Note Does And Does Not Claim
+
+- **It does claim** the exact pair cardinality, the occupied-slot
+  min/max/histogram, and the comparison `4 > 3` against the cited front
+  bound.
+- **It does not claim** that pluschi's leftover-char on
+  `(0,1,0,2,1,2)` is the pair obstruction. That representative does have
+  two empty slots, but so does every other pair member.
+- **It does not claim** need6. Need6 is the front-geometry bound that a
+  seed-grown front site has at most 3 occupied nearest neighbors. This
+  note only compares its census to that integer.
+- **It does not adopt** the histogram as Admissibility content and does
+  not attach L1.
+- **It does not** select the physical condition alphabet, derive a
+  formation process, or decide whether the framework's fixed rule is
+  chiral.
+
+## Machine-Readable Report
+
+```text
+N_pair = 48
+occupied_min = 4
+occupied_max = 4
+occupied_histogram = {4: 48}
+occ_front_max = 3
+min_occupied_ge_4 = true
+front_site_can_match_pair_member = false
+displayed_not_adopted = true
+attached_to_L1 = false
+written_into_admissibility = false
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10373,6 +10373,10 @@
   "joint_two_cell_full_update_physical_m2_compiler_cycle712_bounded_theorem_note_2026-07-26": {
    "deps_hash": "18d35b6d2ab0",
    "out_degree": 3
+  },
+  "july3_k3_pair_occupied_slot_census_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "k_dependence_review_safe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/july3_k3_pair_occupied_slot_census_2026_08_15.txt
+++ b/logs/runner-cache/july3_k3_pair_occupied_slot_census_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py
+runner_sha256: 310b4f78401f9a4b4dcbb02ebd13aeb9eae566d192705e828726ce7d9954575e
+input_fingerprint_sha256: 680241715702a9404b2854c2ac85e0720e097c9736d47f5a31463f21b9b07878
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+July-3 k=3 chiral-pair occupied-slot census
+AUDIT_INPUT_PATHS:
+  docs/JULY3_K3_PAIR_OCCUPIED_SLOT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+N_pair: 48
+orbit_sizes: [24, 24]
+lex_reps: ((0, 1, 0, 2, 1, 2), (0, 1, 0, 2, 2, 1))
+occupied_min: 4
+occupied_max: 4
+occupied_histogram: {4: 48}
+occ_front_max: 3
+min_occupied_ge_4: True
+front_site_can_match_pair_member: False
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-static-literals
+PASS: audit-timeout-declared
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread
+PASS: source-july3-unique-pair
+PASS: proper-group-order | full=48 proper=24
+PASS: unique-chiral-pair | orbits=57 chiral_ids=[28, 29]
+PASS: n-pair | N_pair=48 sizes=[24, 24]
+PASS: lex-first-representatives | lex_reps=((0, 1, 0, 2, 1, 2), (0, 1, 0, 2, 2, 1))
+PASS: pair-fully-mixed
+PASS: occupied-min-max | min=4 max=4
+PASS: occupied-histogram | histogram={4: 48}
+PASS: min-occupied-ge-4 | min=4
+PASS: front-cannot-match | min=4 front_max=3
+PASS: claim-scope-pinned
+PASS: note-census-numbers
+PASS: displayed-not-adopted
+PASS: not-attached-to-l1
+PASS: not-leftover-char-or-need6
+PASS: no-forbidden-phrases
+PASS: no-axiom-edit
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py
+++ b/scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Occupied-slot census of the July-3 unique k=3 chiral pair.
+
+Letters {0,1,2} with 0 empty/unread. Occupied count is the number of
+nonzero slots on each 6-tuple in the two chiral G+ orbits.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import Counter
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/JULY3_K3_PAIR_OCCUPIED_SLOT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+JULY3_PATH = ROOT / (
+    "docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_"
+    "OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_"
+    "BOUNDED_THEOREM_NOTE_2026-07-03.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/JULY3_K3_PAIR_OCCUPIED_SLOT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+OCC_FRONT_MAX = 3
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def det3(matrix: list[list[int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_mat(matrix: list[list[int]], vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )
+
+
+def direction_perm(matrix: list[list[int]]) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[apply_mat(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def signed_permutation_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0] for _ in range(3)]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(entry for row in matrix for entry in row)
+            if key not in seen:
+                seen.add(key)
+                records.append(
+                    {
+                        "matrix": matrix,
+                        "det": det3(matrix),
+                        "perm": direction_perm(matrix),
+                    }
+                )
+    return records
+
+
+def all_colorings(letters: int) -> list[tuple[int, ...]]:
+    return list(itertools.product(range(letters), repeat=len(DIRS)))
+
+
+def direct_orbits(
+    perms: list[tuple[int, ...]], letters: int
+) -> list[set[tuple[int, ...]]]:
+    unseen = set(all_colorings(letters))
+    orbits: list[set[tuple[int, ...]]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def occupied_count(coloring: tuple[int, ...]) -> int:
+    return sum(1 for letter in coloring if letter != 0)
+
+
+def fully_mixed(coloring: tuple[int, ...]) -> bool:
+    axis_bicolored = all(coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3))
+    counts = sorted(coloring.count(letter) for letter in range(3))
+    return axis_bicolored and counts == [2, 2, 2]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    july3 = JULY3_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_july3 = normalize(july3)
+
+    records = signed_permutation_records()
+    proper_perms = [record["perm"] for record in records if record["det"] == 1]
+    inversion = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+    p_perm = direction_perm(inversion)
+    proper_orbits = direct_orbits(proper_perms, 3)
+    orbit_id = {
+        coloring: index
+        for index, orbit in enumerate(proper_orbits)
+        for coloring in orbit
+    }
+
+    chiral_ids: set[int] = set()
+    for coloring in all_colorings(3):
+        image = act_col(p_perm, coloring)
+        if orbit_id[image] != orbit_id[coloring]:
+            chiral_ids.add(orbit_id[coloring])
+    chiral_ids_sorted = sorted(chiral_ids)
+    pair = set().union(*(proper_orbits[index] for index in chiral_ids_sorted))
+    occupied = [occupied_count(coloring) for coloring in pair]
+    histogram = dict(sorted(Counter(occupied).items()))
+    occupied_min = min(occupied)
+    occupied_max = max(occupied)
+    n_pair = len(pair)
+    lex_reps = tuple(min(proper_orbits[index]) for index in chiral_ids_sorted)
+    orbit_sizes = [len(proper_orbits[index]) for index in chiral_ids_sorted]
+    min_ge_4 = occupied_min >= 4
+    front_can_match = occupied_min <= OCC_FRONT_MAX
+
+    print("July-3 k=3 chiral-pair occupied-slot census")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"N_pair: {n_pair}")
+    print(f"orbit_sizes: {orbit_sizes}")
+    print(f"lex_reps: {lex_reps}")
+    print(f"occupied_min: {occupied_min}")
+    print(f"occupied_max: {occupied_max}")
+    print(f"occupied_histogram: {histogram}")
+    print(f"occ_front_max: {OCC_FRONT_MAX}")
+    print(f"min_occupied_ge_4: {min_ge_4}")
+    print(f"front_site_can_match_pair_member: {front_can_match}")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/JULY3_K3_PAIR_OCCUPIED_SLOT_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-unread",
+        unread_sentence in normalized_axiom and unread_sentence in note,
+    )
+    checks.check(
+        "source-july3-unique-pair",
+        "exactly one" in normalized_july3
+        and "chiral pair" in normalized_july3
+        and "handed fully-mixed" in normalized_note
+        and "exactly one chiral pair" in normalized_note,
+    )
+
+    checks.check(
+        "proper-group-order",
+        len(records) == 48 and len(proper_perms) == 24 and len(set(proper_perms)) == 24,
+        f"full={len(records)} proper={len(proper_perms)}",
+    )
+    checks.check(
+        "unique-chiral-pair",
+        len(chiral_ids_sorted) == 2 and len(proper_orbits) == 57,
+        f"orbits={len(proper_orbits)} chiral_ids={chiral_ids_sorted}",
+    )
+    checks.check(
+        "n-pair",
+        n_pair == 48 and orbit_sizes == [24, 24],
+        f"N_pair={n_pair} sizes={orbit_sizes}",
+    )
+    checks.check(
+        "lex-first-representatives",
+        lex_reps == ((0, 1, 0, 2, 1, 2), (0, 1, 0, 2, 2, 1)),
+        f"lex_reps={lex_reps}",
+    )
+    checks.check(
+        "pair-fully-mixed",
+        all(fully_mixed(coloring) for coloring in pair),
+    )
+    checks.check(
+        "occupied-min-max",
+        occupied_min == 4 and occupied_max == 4,
+        f"min={occupied_min} max={occupied_max}",
+    )
+    checks.check(
+        "occupied-histogram",
+        histogram == {4: 48} and sum(histogram.values()) == n_pair,
+        f"histogram={histogram}",
+    )
+    checks.check(
+        "min-occupied-ge-4",
+        min_ge_4,
+        f"min={occupied_min}",
+    )
+    checks.check(
+        "front-cannot-match",
+        min_ge_4 and occupied_min > OCC_FRONT_MAX and not front_can_match,
+        f"min={occupied_min} front_max={OCC_FRONT_MAX}",
+    )
+
+    claim_scope = (
+        "Among the July-3 unique k=3 chiral-pair 6-tuples, the occupied-slot "
+        "count min/max/histogram, and whether that min exceeds the seed-grown "
+        "front’s max occupied NN of 3, is reported. Displayed, not adopted."
+    )
+    checks.check("claim-scope-pinned", claim_scope in note)
+    checks.check(
+        "note-census-numbers",
+        "N_pair = 48" in note
+        and "occupied_min = 4" in note
+        and "occupied_max = 4" in note
+        and "occupied_histogram = {4: 48}" in note
+        and "front_site_can_match_pair_member = false" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "displayed, not adopted" in normalized_note
+        and "not written into Admissibility" in normalized_note
+        and "written_into_admissibility = false" in note,
+    )
+    checks.check(
+        "not-attached-to-l1",
+        "not attached to L1" in normalized_note
+        and "attached_to_L1 = false" in note
+        and "attach L1" in note,
+    )
+    checks.check(
+        "not-leftover-char-or-need6",
+        "not leftover-char of pluschi" in normalized_note
+        and "not need6" in normalized_note
+        and "front-geometry bound" in normalized_note,
+    )
+    checks.check(
+        "no-forbidden-phrases",
+        all(phrase not in note and phrase not in axiom for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "hypothetical_axiom_status: \"no edit\"" in note
+        and "does not add a histogram clause" in normalized_note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

All 48 six-tuples in the July-3 unique k=3 chiral pair have occupied-slot count exactly 4 (two empties). Min=4 exceeds seed-grown front max occupied NN=3, so no front site can match any pair member. Displayed, not adopted. No axiom edit.

## Runner

`scripts/july3_k3_pair_occupied_slot_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.