### PR TITLE
feat(2bchi): two-ball witness mask hosts the chiral pair

### DIFF
--- a/docs/TWO_BALL_WITNESS_CHIRAL_MASK_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_BALL_WITNESS_CHIRAL_MASK_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,258 @@
+---
+claim_id: two_ball_witness_chiral_mask_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Whether the two-ball unread witness occupancy mask (1,1,1,0,1,0) appears among the July-3 k=3 chiral-pair 6-tuples, and whether any {+,−} labeling of its four occupied slots is a pair member, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/two_ball_witness_chiral_mask_2026_08_15.py
+---
+
+# Two-Ball Witness Occupancy Mask Against The July-3 k=3 Chiral Pair
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-mask comparison of one unread 6-nearest-neighbor
+star against the 48 July-3 `k = 3` chiral-pair 6-tuples, then exact
+`{+,−}` filling of the four occupied slots. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_ball_witness_chiral_mask_2026_08_15.py`](../scripts/two_ball_witness_chiral_mask_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+
+## Result Up Front
+
+Direction order is `(+x, −x, +y, −y, +z, −z)`. The two-ball unread witness
+at `v = (1,-1,-1)` for `U = B_2(0) ∪ B_2((2,0,0))` occupies exactly
+`(+x, −x, +y, +z)` and leaves `(−y, −z)` empty. Its occupancy mask is
+
+```text
+m = (1, 1, 1, 0, 1, 0)
+```
+
+with `1` occupied and `0` empty.
+
+July-3 Theorem 3 isolates a unique chiral pair at three condition letters.
+Letters here are `{0, +, −}` with `0` empty. The pair is the union of two
+`G+` orbits and has `N_pair = 48` members. Every member has empty slots in
+exactly two of the six directions.
+
+Of those 48, `N_mask = 4` have empty slots exactly where `m` is `0`. The
+mask therefore appears. Among the `16` assignments of `{+, −}` to the four
+occupied slots, `N_fire = 4` are pair members. The lex-first firing
+labeling, under the letter order `0 < + < −`, is
+
+```text
+(+, −, +, 0, −, 0).
+```
+
+This is not leftover-char of the two-ball occupied-NN count, which asked
+only whether any unread site reaches four occupied neighbors. It is not
+leftover-char of the pair occupied-slot census, which asked only the
+occupied-slot histogram on the 48 members. The residual here is the mask
+and the signed filling of that one 6-NN star at `v`.
+
+The comparison is displayed, not adopted. Do not write the mask into
+Admissibility. Do not attach L1.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite occupancy-mask match of one 6-NN star against the 48 pair members, and the 16 signed fillings of the occupied slots, are exact; no axiom sentence is rewritten."
+trace_class: negative_route_pruning
+target_claim_id: two_ball_witness_chiral_mask
+target_blocker_text: "whether the two-ball unread witness occupancy mask (1,1,1,0,1,0) appears among the July-3 k=3 pair 6-tuples, and whether any {+,−} labeling of its four occupied slots is a pair member"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact on the July-3 named k=3 alphabet and the one two-ball 6-NN star at v; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of the mask and firing counts; do not write the mask into Admissibility and do not attach L1"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+Quoted from the live memo, verbatim:
+
+```text
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+A site with no record cannot be read.
+```
+
+This note does not choose that rule and does not add a mask clause to it.
+Letter `0` is the empty/unread letter on the July-3 three-letter model.
+Occupied means nonzero. The note does not assign a readout value to
+absence.
+- **July-3 Theorem 3.** At `k = 3` there is exactly one chiral pair, whose
+  members are the handed fully-mixed patterns: every axis bi-colored with
+  two distinct values, every value used twice. The runner re-earns the
+  pair by enumerating `G+` orbits; it does not import an external list.
+- **Two-ball witness, re-earned here.** Only the union `p = (2,0,0)`,
+  `r = s = 2` presents four occupied nearest neighbors to an unread site.
+  The lex-first such site is `v = (1,-1,-1)`. The runner rebuilds that
+  star; it does not import a stored mask.
+- **External empirical inputs:** none.
+- **Not attached:** L1 is not a premise and is not a conclusion. The
+  mask match is not leftover-char of the two-ball count or of the pair
+  census.
+
+## Exact Objects
+
+The six nearest-neighbor directions, in the July-3 order, are
+
+```text
+(+x, −x, +y, −y, +z, −z).
+```
+
+The closed ℓ¹ ball is `B_r(c) = { x in Z^3 : ||x − c||_1 ≤ r }`. The
+two-ball occupied set used here is only
+
+```text
+U = B_2(0) ∪ B_2((2,0,0)).
+```
+
+The unread witness is the single site `v = (1,-1,-1)`. Its 6-NN star is
+
+```text
+v + {+e_1, −e_1, +e_2, −e_2, +e_3, −e_3}.
+```
+
+Occupancy of a neighbor is membership in `U`. The occupancy mask is the
+`{0,1}` 6-tuple in the direction order above. No other site is scored.
+
+A `k = 3` condition 6-tuple is an element of `{0, +, −}^6`. Letter `0` is
+empty. The occupancy of a 6-tuple `c` is
+
+```text
+occ_mask(c)_i = 0 if c_i = 0 else 1.
+```
+
+`G+` is the 24-element proper cubic group of determinant-`+1` signed
+permutation matrices. It acts on 6-tuples by the induced permutation of
+the six axis directions. Spatial inversion `P = −I` is the central
+improper element. A chiral pair is a pair of distinct `G+` orbits
+exchanged by `P`. July-3 Theorem 3 states there is exactly one such pair
+at `k = 3`. Write `Pair` for the union of those two orbits, and
+`N_pair = |Pair|`.
+
+The 16 candidate fillings of the witness star are the 6-tuples that carry
+`0` wherever `m` is `0` and a letter from `{+, −}` wherever `m` is `1`.
+Letter order for lex comparison is `0 < + < −`.
+
+## Theorem 1 — Mask Count On The Unique Pair
+
+`N_pair = 48`. Exactly `N_mask = 4` members of `Pair` have empty slots
+exactly where `m` is `0`.
+
+*Proof.* The 24 proper signed permutation matrices are generated
+exhaustively. Their action on the 729 colorings `{0, +, −}^6` partitions
+them into 57 `G+` orbits, matching the July-3 Burnside count. Exactly two
+of those orbits fail to meet their `P`-images; they form one pair, and
+each has size 24, so `N_pair = 48`. Every pair member is fully mixed, so
+letter `0` occurs twice and every member has exactly two empty slots.
+
+Independently, the two-ball union `U` is constructed and the six axial
+neighbors of `v` are tested for membership in `U`. The occupied neighbors
+are `(2,-1,-1)`, `(0,-1,-1)`, `(1,0,-1)`, and `(1,-1,0)`; the empty
+neighbors are `(1,-2,-1)` and `(1,-1,-2)`. That is the mask `m`.
+
+Direct comparison of `occ_mask(c)` against `m` on all 48 pair members
+yields four matches:
+
+```text
+(+, −, +, 0, −, 0)
+(+, −, −, 0, +, 0)
+(−, +, +, 0, −, 0)
+(−, +, −, 0, +, 0).
+```
+
+Hence `N_mask = 4`. The occupancy mask appears among the pair members.
+
+## Theorem 2 — Signed Fillings That Fire The Pair
+
+Because `N_mask > 0`, the witness occupancy can host a pair member. Among
+the 16 `{+, −}` assignments to the four occupied slots, `N_fire = 4` yield
+a pair member. The lex-first firing labeling is `(+, −, +, 0, −, 0)`.
+
+*Proof.* The 16 fillings are enumerated by assigning `{+, −}` independently
+to the four occupied directions and leaving `−y` and `−z` empty. A filling
+fires if and only if it lies in `Pair`. The four fillings listed in
+Theorem 1 are exactly the firing set, so `N_fire = 4`. Under `0 < + < −`
+the first of those four is `(+, −, +, 0, −, 0)`.
+
+The remaining 12 fillings fail full mixing: they either repeat a letter
+on the `±x` axis or fail the `2/2/2` letter counts. They therefore lie
+outside `Pair`.
+
+The witness can host the pair as an occupancy pattern, and four signed
+labelings of that pattern are pair members. This is a support-mask
+statement on the named `k = 3` model at one 6-NN star. It does not assert
+that the physical admissibility rule is the chiral pair, and it does not
+identify `{0, +, −}` with a derived physical alphabet.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The mask `m`, the count `N_mask = 4`, and the firing count `N_fire = 4`
+are a finite report on the July-3 named alphabet model and one two-ball
+star. They are displayed. They are not adopted.
+
+In particular:
+
+- the mask is not written into Admissibility;
+- no axiom sentence is edited;
+- the comparison is not attached to L1.
+
+Admissibility continues to say only that there is one fixed
+nearest-neighbor rule, covariant under translations and proper cubic
+rotations, and that the local distribution varies with the
+nearest-neighbor conditions. Which occupancy mask a named test alphabet
+and a named two-ball star happen to share is not that rule.
+
+## What This Note Does And Does Not Claim
+
+- **It does claim** that the two-ball unread witness occupancy mask
+  `(1,1,1,0,1,0)` occurs on exactly four of the 48 July-3 `k = 3` pair
+  members, and that four of the sixteen `{+, −}` fillings of its occupied
+  slots are pair members, with lex-first firing labeling
+  `(+, −, +, 0, −, 0)`.
+- **It does not claim** leftover-char of the two-ball occupied-NN count.
+  That count only asked whether four occupied neighbors occur. The present
+  residual is which four directions they are, and whether that pattern
+  sits inside the pair.
+- **It does not claim** leftover-char of the pair occupied-slot census.
+  That census only asked the occupied-slot histogram `{4: 48}`. The
+  present residual is the location of the two empty slots and the signed
+  filling.
+- **It does not adopt** the mask as Admissibility content and does not
+  attach L1.
+- **It does not** score any site other than the 6-NN star at `v`, replace
+  the six-neighbor stencil, select the physical condition alphabet, or
+  decide whether the framework's fixed rule is chiral.
+
+## Machine-Readable Report
+
+```text
+N_pair = 48
+N_mask = 4
+N_fire = 4
+mask = (1, 1, 1, 0, 1, 0)
+lex_first_firing = (+, -, +, 0, -, 0)
+witness_can_host_pair_occupancy = true
+displayed_not_adopted = true
+attached_to_L1 = false
+written_into_admissibility = false
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18585,6 +18585,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_ball_witness_chiral_mask_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_ball_witness_chiral_mask_2026_08_15.txt
+++ b/logs/runner-cache/two_ball_witness_chiral_mask_2026_08_15.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/two_ball_witness_chiral_mask_2026_08_15.py
+runner_sha256: dc1736194f5391a8418ca34be9ee64abd102127f96ca7f09e1da59e73c4341cd
+input_fingerprint_sha256: 40293623e18f649ba0839f591da1cf2aa0b413aeea5ac29ba8596752814934ba
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+Two-ball witness occupancy mask versus July-3 k=3 pair
+AUDIT_INPUT_PATHS:
+  docs/TWO_BALL_WITNESS_CHIRAL_MASK_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+derived_mask: (1, 1, 1, 0, 1, 0)
+occupied_neighbors: ((2, -1, -1), (0, -1, -1), (1, 0, -1), (1, -1, 0))
+empty_neighbors: ((1, -2, -1), (1, -1, -2))
+N_pair: 48
+orbit_sizes: [24, 24]
+lex_reps: ('(0, +, 0, -, +, -)', '(0, +, 0, -, -, +)')
+N_mask: 4
+N_fire: 4
+lex_first_firing: (+, -, +, 0, -, 0)
+firing: ['(+, -, +, 0, -, 0)', '(+, -, -, 0, +, 0)', '(-, +, +, 0, -, 0)', '(-, +, -, 0, +, 0)']
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-static-literals
+PASS: audit-timeout-declared
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread
+PASS: source-july3-unique-pair
+PASS: two-ball-mask-derived | mask=(1, 1, 1, 0, 1, 0)
+PASS: proper-group-order | full=48 proper=24
+PASS: unique-chiral-pair | orbits=57 chiral_ids=[28, 29]
+PASS: n-pair | N_pair=48 sizes=[24, 24]
+PASS: pair-two-empties
+PASS: n-mask | N_mask=4
+PASS: sixteen-fillings | n_fillings=16
+PASS: n-fire | N_fire=4
+PASS: lex-first-firing | lex_first=(+, -, +, 0, -, 0)
+PASS: claim-scope-pinned
+PASS: note-report-numbers
+PASS: displayed-not-adopted
+PASS: not-attached-to-l1
+PASS: not-leftover-char
+PASS: no-forbidden-phrases
+PASS: no-axiom-edit
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_ball_witness_chiral_mask_2026_08_15.py
+++ b/scripts/two_ball_witness_chiral_mask_2026_08_15.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Two-ball unread witness occupancy mask versus the July-3 k=3 pair.
+
+Letters {0, +, −} with 0 empty. Occupancy mask of the 6-NN star at
+v = (1,-1,-1) for U = B_2(0) ∪ B_2((2,0,0)) is compared to the 48 pair
+members; the 16 {+,−} fillings of the four occupied slots are then tested.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/TWO_BALL_WITNESS_CHIRAL_MASK_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+JULY3_PATH = ROOT / (
+    "docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_"
+    "OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_"
+    "BOUNDED_THEOREM_NOTE_2026-07-03.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BALL_WITNESS_CHIRAL_MASK_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTERS = (EMPTY, PLUS, MINUS)
+LETTER_SHOW = {EMPTY: "0", PLUS: "+", MINUS: "-"}
+WITNESS = (1, -1, -1)
+CENTER_P = (2, 0, 0)
+RADIUS = 2
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def show_tuple(coloring: tuple[int, ...]) -> str:
+    return "(" + ", ".join(LETTER_SHOW[letter] for letter in coloring) + ")"
+
+
+def add(
+    left: tuple[int, int, int], right: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(
+    left: tuple[int, int, int], right: tuple[int, int, int] = (0, 0, 0)
+) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: tuple[int, int, int], radius: int) -> frozenset[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for offset in itertools.product(range(-radius, radius + 1), repeat=3):
+        if l1(offset) <= radius:
+            sites.append(add(center, offset))
+    return frozenset(sites)
+
+
+def occupancy_mask(coloring: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(0 if letter == EMPTY else 1 for letter in coloring)
+
+
+def det3(matrix: list[list[int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_mat(matrix: list[list[int]], vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )
+
+
+def direction_perm(matrix: list[list[int]]) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[apply_mat(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def signed_permutation_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0] for _ in range(3)]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(entry for row in matrix for entry in row)
+            if key not in seen:
+                seen.add(key)
+                records.append(
+                    {
+                        "matrix": matrix,
+                        "det": det3(matrix),
+                        "perm": direction_perm(matrix),
+                    }
+                )
+    return records
+
+
+def all_colorings() -> list[tuple[int, ...]]:
+    return list(itertools.product(LETTERS, repeat=len(DIRS)))
+
+
+def direct_orbits(perms: list[tuple[int, ...]]) -> list[set[tuple[int, ...]]]:
+    unseen = set(all_colorings())
+    orbits: list[set[tuple[int, ...]]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def fully_mixed(coloring: tuple[int, ...]) -> bool:
+    axis_bicolored = all(
+        coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3)
+    )
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_bicolored and counts == [2, 2, 2]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    july3 = JULY3_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_july3 = normalize(july3)
+
+    occupied = ball((0, 0, 0), RADIUS) | ball(CENTER_P, RADIUS)
+    neighbor_sites = tuple(add(WITNESS, direction) for direction in DIRS)
+    derived_mask = tuple(1 if site in occupied else 0 for site in neighbor_sites)
+    occupied_idx = tuple(index for index, bit in enumerate(derived_mask) if bit == 1)
+    empty_idx = tuple(index for index, bit in enumerate(derived_mask) if bit == 0)
+
+    records = signed_permutation_records()
+    proper_perms = [record["perm"] for record in records if record["det"] == 1]
+    inversion = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+    p_perm = direction_perm(inversion)
+    proper_orbits = direct_orbits(proper_perms)
+    orbit_id = {
+        coloring: index
+        for index, orbit in enumerate(proper_orbits)
+        for coloring in orbit
+    }
+
+    chiral_ids: set[int] = set()
+    for coloring in all_colorings():
+        image = act_col(p_perm, coloring)
+        if orbit_id[image] != orbit_id[coloring]:
+            chiral_ids.add(orbit_id[coloring])
+    chiral_ids_sorted = sorted(chiral_ids)
+    pair = set().union(*(proper_orbits[index] for index in chiral_ids_sorted))
+    n_pair = len(pair)
+    orbit_sizes = [len(proper_orbits[index]) for index in chiral_ids_sorted]
+    lex_reps = tuple(min(proper_orbits[index]) for index in chiral_ids_sorted)
+
+    mask_members = sorted(
+        coloring for coloring in pair if occupancy_mask(coloring) == derived_mask
+    )
+    n_mask = len(mask_members)
+
+    fillings: list[tuple[int, ...]] = []
+    for bits in itertools.product((PLUS, MINUS), repeat=len(occupied_idx)):
+        coloring = [EMPTY] * len(DIRS)
+        for index, letter in zip(occupied_idx, bits):
+            coloring[index] = letter
+        fillings.append(tuple(coloring))
+    firing = [coloring for coloring in fillings if coloring in pair]
+    n_fire = len(firing)
+    lex_first = min(firing) if firing else None
+
+    print("Two-ball witness occupancy mask versus July-3 k=3 pair")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"derived_mask: {derived_mask}")
+    print(f"occupied_neighbors: {tuple(neighbor_sites[i] for i in occupied_idx)}")
+    print(f"empty_neighbors: {tuple(neighbor_sites[i] for i in empty_idx)}")
+    print(f"N_pair: {n_pair}")
+    print(f"orbit_sizes: {orbit_sizes}")
+    print(f"lex_reps: {tuple(show_tuple(rep) for rep in lex_reps)}")
+    print(f"N_mask: {n_mask}")
+    print(f"N_fire: {n_fire}")
+    print(f"lex_first_firing: {show_tuple(lex_first) if lex_first else None}")
+    print(f"firing: {[show_tuple(item) for item in firing]}")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_BALL_WITNESS_CHIRAL_MASK_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-unread",
+        unread_sentence in normalized_axiom and unread_sentence in note,
+    )
+    checks.check(
+        "source-july3-unique-pair",
+        "exactly one" in normalized_july3
+        and "chiral pair" in normalized_july3
+        and "handed fully-mixed" in normalized_note
+        and "exactly one chiral pair" in normalized_note,
+    )
+
+    checks.check(
+        "two-ball-mask-derived",
+        derived_mask == (1, 1, 1, 0, 1, 0)
+        and l1(WITNESS) == 3
+        and l1(WITNESS, CENTER_P) == 3
+        and WITNESS not in occupied
+        and tuple(neighbor_sites[i] for i in occupied_idx)
+        == ((2, -1, -1), (0, -1, -1), (1, 0, -1), (1, -1, 0))
+        and tuple(neighbor_sites[i] for i in empty_idx)
+        == ((1, -2, -1), (1, -1, -2)),
+        f"mask={derived_mask}",
+    )
+    checks.check(
+        "proper-group-order",
+        len(records) == 48 and len(proper_perms) == 24 and len(set(proper_perms)) == 24,
+        f"full={len(records)} proper={len(proper_perms)}",
+    )
+    checks.check(
+        "unique-chiral-pair",
+        len(chiral_ids_sorted) == 2 and len(proper_orbits) == 57,
+        f"orbits={len(proper_orbits)} chiral_ids={chiral_ids_sorted}",
+    )
+    checks.check(
+        "n-pair",
+        n_pair == 48 and orbit_sizes == [24, 24],
+        f"N_pair={n_pair} sizes={orbit_sizes}",
+    )
+    checks.check(
+        "pair-two-empties",
+        all(coloring.count(EMPTY) == 2 for coloring in pair)
+        and all(fully_mixed(coloring) for coloring in pair),
+    )
+    checks.check(
+        "n-mask",
+        n_mask == 4 and derived_mask == (1, 1, 1, 0, 1, 0),
+        f"N_mask={n_mask}",
+    )
+    checks.check(
+        "sixteen-fillings",
+        len(fillings) == 16
+        and len(set(fillings)) == 16
+        and all(occupancy_mask(item) == derived_mask for item in fillings),
+        f"n_fillings={len(fillings)}",
+    )
+    checks.check(
+        "n-fire",
+        n_mask > 0 and n_fire == 4 and set(firing) == set(mask_members),
+        f"N_fire={n_fire}",
+    )
+    checks.check(
+        "lex-first-firing",
+        lex_first == (PLUS, MINUS, PLUS, EMPTY, MINUS, EMPTY),
+        f"lex_first={show_tuple(lex_first) if lex_first else None}",
+    )
+
+    claim_scope = (
+        "Whether the two-ball unread witness occupancy mask (1,1,1,0,1,0) "
+        "appears among the July-3 k=3 chiral-pair 6-tuples, and whether any "
+        "{+,−} labeling of its four occupied slots is a pair member, is "
+        "reported. Displayed, not adopted."
+    )
+    checks.check("claim-scope-pinned", claim_scope in note)
+    checks.check(
+        "note-report-numbers",
+        "N_pair = 48" in note
+        and "N_mask = 4" in note
+        and "N_fire = 4" in note
+        and "mask = (1, 1, 1, 0, 1, 0)" in note
+        and "lex_first_firing = (+, -, +, 0, -, 0)" in note
+        and "witness_can_host_pair_occupancy = true" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "displayed, not adopted" in normalized_note
+        and "not written into Admissibility" in normalized_note
+        and "written_into_admissibility = false" in note,
+    )
+    checks.check(
+        "not-attached-to-l1",
+        "not attached to L1" in normalized_note
+        and "attached_to_L1 = false" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "not-leftover-char",
+        "not leftover-char of the two-ball occupied-NN count" in normalized_note
+        and "not leftover-char of the pair occupied-slot census" in normalized_note
+        and "6-NN star at" in normalized_note,
+    )
+    checks.check(
+        "no-forbidden-phrases",
+        all(phrase not in note and phrase not in axiom for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "does not add a mask clause" in normalized_note
+        and "occupancy mask" not in axiom
+        and "chiral-pair" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The unread witness mask (1,1,1,0,1,0) appears in 4 of 48 July-3 k=3 pair 6-tuples. Of 16 {+,-} fillings of the four occupied slots, N_fire=4. Lex-first firing labeling (+,-,+,0,-,0). Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_ball_witness_chiral_mask_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.