### PR TITLE
feat(2bsign): natural occupancy-kernel labels do not fire the pair

### DIFF
--- a/docs/TWO_BALL_NATURAL_KERNEL_LABEL_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_BALL_NATURAL_KERNEL_LABEL_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,275 @@
+---
+claim_id: two_ball_natural_kernel_label_chiral_fire_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On U=B_2(0)∪B_2((2,0,0)) at unread v=(1,−1,−1), whether occupancy-kernel unique-axis labels of the four occupied neighbors form a July-3 k=3 pair member is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py
+---
+
+# Natural Occupancy-Kernel Labels At The Two-Ball Witness Versus The July-3 k=3 Pair
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy-kernel unique-axis labels of the four occupied
+nearest neighbors of one unread 6-nearest-neighbor star on
+`U = B_2(0) ∪ B_2((2,0,0))`, compared to the 48 July-3 `k = 3`
+chiral-pair 6-tuples. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py`](../scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+
+## Result Up Front
+
+Direction order is `(+x, −x, +y, −y, +z, −z)`. Scoring is only the occupied
+set `U = B_2(0) ∪ B_2((2,0,0))` and the 6-NN star at the unread witness
+`v = (1,-1,-1)`. No new spatial patch is opened.
+
+The four occupied neighbors of `v` are `(2,-1,-1)`, `(0,-1,-1)`,
+`(1,0,-1)`, and `(1,-1,0)`. The two unread neighbors are `(1,-2,-1)` and
+`(1,-1,-2)`. Occupancy mask of the star is `(1, 1, 1, 0, 1, 0)`.
+
+For a site `w ∈ U`, write `c(w) ∈ {0,1}^6` for the occupancy 6-tuple of
+its six axial neighbors inside `U`. The occupancy dipole and kernel are
+
+```text
+d_μ = c_{+μ}(w) − c_{−μ}(w),    n = d/3.
+```
+
+If `|supp n| = 1`, the unique-axis label of `w` is the sign of that unique
+nonzero `n_μ`. If `n` has any other support, `w` has no unique axis. Empty
+slots of the star at `v` stay the empty letter `0`.
+
+The natural 6-tuple assembled at `v` is
+
+```text
+c = (*, *, +, 0, +, 0),
+```
+
+where `*` means no unique axis. Not every occupied neighbor has a
+unique-axis label: the `±x` neighbors each have `n = (0, 1/3, 1/3)`.
+
+July-3 Theorem 3 isolates a unique chiral pair at three condition letters.
+Letters are `{0, +, −}` with `0` empty. The pair is the union of two `G+`
+orbits and has `N_pair = 48` members. The natural 6-tuple `c` is not a
+letter 6-tuple, so it is not a pair member: the pair does not fire. The
+Hamming distance to the lex-first firing labeling `(+, −, +, 0, −, 0)`,
+counting `*` as a distinct symbol, is `3`.
+
+This is not leftover-char of the two-ball occupied-NN count, which asked
+only whether any unread site reaches four occupied neighbors. It is not
+leftover-char of the existence of some `{+,−}` labeling of the witness
+mask: some signed fillings are pair members, but the occupancy-kernel
+unique-axis rule is not one of them.
+
+The comparison is displayed, not adopted. Do not write the kernel labeling
+into Admissibility. Do not attach L1.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite occupancy-kernel unique-axis labels of one 6-NN star, and the exact Hamming comparison to the July-3 k=3 pair, are exact; no axiom sentence is rewritten."
+trace_class: negative_route_pruning
+target_claim_id: two_ball_natural_kernel_label_chiral_fire
+target_blocker_text: "whether occupancy-kernel unique-axis labels of the four occupied neighbors of the two-ball unread witness form a July-3 k=3 pair member"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact on U and the 6-NN star at v against the July-3 named k=3 alphabet; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of the natural 6-tuple and Hamming distance; do not write the kernel labeling into Admissibility and do not attach L1"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+Quoted from the live memo, verbatim:
+
+```text
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+A site with no record cannot be read.
+```
+
+This note does not choose that rule and does not add a kernel-label clause
+to it. Letter `0` is the empty/unread letter on the July-3 three-letter
+model. Occupied means membership in `U`. The note does not assign a
+readout value to absence.
+- **July-3 Theorem 3.** At `k = 3` there is exactly one chiral pair, whose
+  members are the handed fully-mixed patterns: every axis bi-colored with
+  two distinct values, every value used twice. The runner re-earns the
+  pair by enumerating `G+` orbits; it does not import an external list.
+- **Two-ball witness, re-earned here.** Only the union `p = (2,0,0)`,
+  `r = s = 2` is used. The unread witness is `v = (1,-1,-1)`. The runner
+  rebuilds `U` and the star; it does not import a stored mask.
+- **Occupancy kernel, displayed here.** `d_μ = c_{+μ} − c_{−μ}` and
+  `n = d/3` are computed from occupancy of `U` at each occupied neighbor
+  of `v`. The unique-axis rule uses only the support and signs of `n`.
+- **External empirical inputs:** none.
+- **Not attached:** L1 is not a premise and is not a conclusion. The
+  kernel labeling is not leftover-char of the two-ball count or of the
+  existence of some signed filling of the mask.
+
+## Exact Objects
+
+The six nearest-neighbor directions, in the July-3 order, are
+
+```text
+(+x, −x, +y, −y, +z, −z).
+```
+
+The closed ℓ¹ ball is `B_r(c) = { x in Z^3 : ||x − c||_1 ≤ r }`. The
+occupied set used here is only
+
+```text
+U = B_2(0) ∪ B_2((2,0,0)).
+```
+
+The unread witness is the single site `v = (1,-1,-1)`. Its 6-NN star is
+
+```text
+v + {+e_1, −e_1, +e_2, −e_2, +e_3, −e_3}.
+```
+
+No other site is scored.
+
+A `k = 3` condition 6-tuple is an element of `{0, +, −}^6`. Letter `0` is
+empty. `G+` is the 24-element proper cubic group of determinant-`+1` signed
+permutation matrices. It acts on 6-tuples by the induced permutation of
+the six axis directions. Spatial inversion `P = −I` is the central
+improper element. A chiral pair is a pair of distinct `G+` orbits
+exchanged by `P`. July-3 Theorem 3 states there is exactly one such pair
+at `k = 3`. Write `Pair` for the union of those two orbits, and
+`N_pair = |Pair|`.
+
+The occupancy 6-tuple of a site `w` inside `U` is
+
+```text
+c(w)_i = 1 if w + e_i ∈ U else 0,
+```
+
+in the direction order above. The dipole and kernel are `d_μ = c_{+μ} −
+c_{−μ}` and `n = d/3`. Support is `{ μ : n_μ ≠ 0 }`. The unique-axis
+label is `sign(n_μ)` when that set is a singleton, and is the symbol `*`
+otherwise. The natural 6-tuple at `v` puts `0` on unread neighbors of `v`
+and the unique-axis label on occupied neighbors.
+
+Hamming distance between two 6-tuples over the extended alphabet
+`{0, +, −, *}` is the number of slots where the symbols differ. The
+lex-first firing labeling of the witness mask, under letter order
+`0 < + < −` among `{0, +, −}` fillings that lie in `Pair`, is
+`(+, −, +, 0, −, 0)`.
+
+## Theorem 1 — Natural 6-Tuple And Unique-Axis Coverage
+
+The natural 6-tuple at `v` is `c = (*, *, +, 0, +, 0)`. Not every
+occupied neighbor has a unique-axis label.
+
+*Proof.* The two-ball union `U` is constructed and the six axial
+neighbors of `v` are tested for membership in `U`. The occupied
+neighbors are `(2,-1,-1)`, `(0,-1,-1)`, `(1,0,-1)`, and `(1,-1,0)`; the
+empty neighbors are `(1,-2,-1)` and `(1,-1,-2)`. Each occupied neighbor
+`w` is scored by its occupancy 6-tuple inside `U`:
+
+| neighbor of `v` | `w` | occupancy `c(w)` | `d` | `n = d/3` | `|supp n|` | label |
+|---|---|---|---|---|---:|---|
+| `+x` | `(2,-1,-1)` | `(0,0,1,0,1,0)` | `(0,1,1)` | `(0, 1/3, 1/3)` | 2 | `*` |
+| `−x` | `(0,-1,-1)` | `(0,0,1,0,1,0)` | `(0,1,1)` | `(0, 1/3, 1/3)` | 2 | `*` |
+| `+y` | `(1,0,-1)` | `(1,1,0,0,1,0)` | `(0,0,1)` | `(0, 0, 1/3)` | 1 | `+` |
+| `−y` | `(1,-2,-1)` | unread | — | — | — | `0` |
+| `+z` | `(1,-1,0)` | `(1,1,1,0,0,0)` | `(0,1,0)` | `(0, 1/3, 0)` | 1 | `+` |
+| `−z` | `(1,-1,-2)` | unread | — | — | — | `0` |
+
+The `+y` and `+z` neighbors each have a unique nonzero kernel component,
+so the unique occupied-axis rule supplies the signs `+` and `+`. The
+`±x` neighbors each have two nonzero components, so they have no unique
+axis. Assembling in direction order gives `c = (*, *, +, 0, +, 0)`.
+Therefore it is false that every occupied neighbor has a unique-axis
+label.
+
+## Theorem 2 — The Pair Does Not Fire
+
+The natural 6-tuple `c` is not one of the 48 July-3 `k = 3` pair members.
+The pair does not fire. The Hamming distance to the lex-first firing
+labeling `(+, −, +, 0, −, 0)` is `3`.
+
+*Proof.* The 24 proper signed permutation matrices are generated
+exhaustively. Their action on the 729 colorings `{0, +, −}^6` partitions
+them into 57 `G+` orbits, matching the July-3 Burnside count. Exactly two
+of those orbits fail to meet their `P`-images; they form one pair, and
+each has size 24, so `N_pair = 48`. Every pair member is fully mixed, so
+letter `0` occurs twice and every member lies in `{0, +, −}^6`.
+
+The symbol `*` is not a letter of that alphabet, so `c ∉ Pair`. Among
+the 16 `{+, −}` fillings of the four occupied slots of the witness mask,
+exactly four lie in `Pair`. Under `0 < + < −` the lex-first of those four
+is `(+, −, +, 0, −, 0)`. Slotwise comparison against `c` differs in the
+`+x`, `−x`, and `+z` slots and agrees in the other three, hence Hamming
+distance `3`.
+
+Existence of some signed filling that lies in `Pair` is a different
+residual. The occupancy-kernel unique-axis rule is not such a filling.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The natural 6-tuple `c`, the failure of unique-axis coverage, the report
+that the pair does not fire, and the Hamming distance `3` are a finite
+report on the July-3 named alphabet model and one two-ball star. They are
+displayed. They are not adopted.
+
+In particular:
+
+- the kernel labeling is not written into Admissibility;
+- no axiom sentence is edited;
+- the comparison is not attached to L1.
+
+Admissibility continues to say only that there is one fixed
+nearest-neighbor rule, covariant under translations and proper cubic
+rotations, and that the local distribution varies with the
+nearest-neighbor conditions. Which unique-axis labels a displayed
+occupancy kernel assigns on a named two-ball star is not that rule.
+
+## What This Note Does And Does Not Claim
+
+- **It does claim** that on `U = B_2(0) ∪ B_2((2,0,0))` at unread
+  `v = (1,-1,-1)`, the occupancy-kernel unique-axis labels of the four
+  occupied neighbors assemble to `c = (*, *, +, 0, +, 0)`, that not every
+  occupied neighbor has a unique-axis label, that `c` is not a July-3
+  `k = 3` pair member, and that the Hamming distance to
+  `(+, −, +, 0, −, 0)` is `3`.
+- **It does not claim** leftover-char of the two-ball occupied-NN count.
+- **It does not claim** leftover-char of the existence of some `{+,−}`
+  labeling of the witness mask.
+- **It does not adopt** the kernel labeling as Admissibility content and
+  does not attach L1.
+- **It does not** score any site other than `U` and the 6-NN star at `v`,
+  replace the six-neighbor stencil, select the physical condition
+  alphabet, or decide whether the framework's fixed rule is chiral.
+
+## Machine-Readable Report
+
+```text
+N_pair = 48
+natural_c = (*, *, +, 0, +, 0)
+every_occupied_neighbor_has_unique_axis = false
+pair_fires = false
+hamming_to_lex_first = 3
+lex_first_firing = (+, -, +, 0, -, 0)
+displayed_not_adopted = true
+attached_to_L1 = false
+written_into_admissibility = false
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18585,6 +18585,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_ball_natural_kernel_label_chiral_fire_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_ball_natural_kernel_label_chiral_fire_2026_08_15.txt
+++ b/logs/runner-cache/two_ball_natural_kernel_label_chiral_fire_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py
+runner_sha256: 198825fbb333acfa01ff401df7b44a60ac8554bd579f9bbb060fb85f8544378d
+input_fingerprint_sha256: 4c00b5ed0ffa0632a6e996157db6f7809b7412334cdc096239fab55fbcebc936
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+Natural occupancy-kernel labels versus July-3 k=3 pair
+AUDIT_INPUT_PATHS:
+  docs/TWO_BALL_NATURAL_KERNEL_LABEL_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+|U|: 43
+derived_mask: (1, 1, 1, 0, 1, 0)
+occupied_neighbors: ((2, -1, -1), (0, -1, -1), (1, 0, -1), (1, -1, 0))
+empty_neighbors: ((1, -2, -1), (1, -1, -2))
+neighbor_bits: [(0, 0, 1, 0, 1, 0), (0, 0, 1, 0, 1, 0), (1, 1, 0, 0, 1, 0), None, (1, 1, 1, 0, 0, 0), None]
+neighbor_dipoles: [(0, 1, 1), (0, 1, 1), (0, 0, 1), None, (0, 1, 0), None]
+neighbor_kernels: [(Fraction(0, 1), Fraction(1, 3), Fraction(1, 3)), (Fraction(0, 1), Fraction(1, 3), Fraction(1, 3)), (Fraction(0, 1), Fraction(0, 1), Fraction(1, 3)), None, (Fraction(0, 1), Fraction(1, 3), Fraction(0, 1)), None]
+natural_c: (*, *, +, 0, +, 0)
+every_occupied_neighbor_has_unique_axis: False
+N_pair: 48
+pair_fires: False
+lex_first_firing: (+, -, +, 0, -, 0)
+hamming_to_lex_first: 3
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-static-literals
+PASS: audit-timeout-declared
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread
+PASS: source-july3-unique-pair
+PASS: two-ball-star-derived | mask=(1, 1, 1, 0, 1, 0) |U|=43
+PASS: occupancy-kernel-n-equals-d-over-3
+PASS: natural-six-tuple | (*, *, +, 0, +, 0)
+PASS: not-every-occupied-neighbor-unique-axis
+PASS: proper-group-order | full=48 proper=24
+PASS: unique-chiral-pair | orbits=57 chiral_ids=[28, 29]
+PASS: n-pair | N_pair=48
+PASS: pair-does-not-fire
+PASS: hamming-to-lex-first | lex_first=(+, -, +, 0, -, 0) ham=3
+PASS: claim-scope-pinned
+PASS: note-report-numbers
+PASS: displayed-not-adopted
+PASS: not-attached-to-l1
+PASS: not-leftover-char
+PASS: score-only-u-and-star
+PASS: no-forbidden-phrases
+PASS: no-axiom-edit
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py
+++ b/scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Natural occupancy-kernel unique-axis labels at the two-ball witness.
+
+On U = B_2(0) ∪ B_2((2,0,0)) at unread v = (1,-1,-1), each occupied
+neighbor is labeled by the unique-axis sign of n = d/3, or marked as
+having no unique axis. The assembled 6-tuple is compared to the 48
+July-3 k=3 pair members.
+"""
+
+from __future__ import annotations
+
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/TWO_BALL_NATURAL_KERNEL_LABEL_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+JULY3_PATH = ROOT / (
+    "docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_"
+    "OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_"
+    "BOUNDED_THEOREM_NOTE_2026-07-03.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BALL_NATURAL_KERNEL_LABEL_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+
+EMPTY, PLUS, MINUS, NO_AXIS = 0, 1, 2, 3
+LETTERS = (EMPTY, PLUS, MINUS)
+LETTER_SHOW = {EMPTY: "0", PLUS: "+", MINUS: "-", NO_AXIS: "*"}
+WITNESS = (1, -1, -1)
+CENTER_P = (2, 0, 0)
+RADIUS = 2
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def show_tuple(coloring: tuple[int, ...]) -> str:
+    return "(" + ", ".join(LETTER_SHOW[letter] for letter in coloring) + ")"
+
+
+def add(
+    left: tuple[int, int, int], right: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(
+    left: tuple[int, int, int], right: tuple[int, int, int] = (0, 0, 0)
+) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: tuple[int, int, int], radius: int) -> frozenset[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for offset in itertools.product(range(-radius, radius + 1), repeat=3):
+        if l1(offset) <= radius:
+            sites.append(add(center, offset))
+    return frozenset(sites)
+
+
+def occupancy_bits(
+    site: tuple[int, int, int], occupied: frozenset[tuple[int, int, int]]
+) -> tuple[int, ...]:
+    return tuple(1 if add(site, direction) in occupied else 0 for direction in DIRS)
+
+
+def dipole(bits: tuple[int, ...]) -> tuple[int, int, int]:
+    return (bits[0] - bits[1], bits[2] - bits[3], bits[4] - bits[5])
+
+
+def kernel(bits: tuple[int, ...]) -> tuple[Fraction, Fraction, Fraction]:
+    dx, dy, dz = dipole(bits)
+    return (Fraction(dx, 3), Fraction(dy, 3), Fraction(dz, 3))
+
+
+def unique_axis_label(n_vec: tuple[Fraction, Fraction, Fraction]) -> int:
+    support = [index for index, value in enumerate(n_vec) if value != 0]
+    if len(support) != 1:
+        return NO_AXIS
+    value = n_vec[support[0]]
+    if value > 0:
+        return PLUS
+    if value < 0:
+        return MINUS
+    return NO_AXIS
+
+
+def hamming(left: tuple[int, ...], right: tuple[int, ...]) -> int:
+    return sum(a != b for a, b in zip(left, right))
+
+
+def det3(matrix: list[list[int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_mat(matrix: list[list[int]], vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )
+
+
+def direction_perm(matrix: list[list[int]]) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[apply_mat(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def signed_permutation_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0] for _ in range(3)]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(entry for row in matrix for entry in row)
+            if key not in seen:
+                seen.add(key)
+                records.append(
+                    {
+                        "matrix": matrix,
+                        "det": det3(matrix),
+                        "perm": direction_perm(matrix),
+                    }
+                )
+    return records
+
+
+def all_colorings() -> list[tuple[int, ...]]:
+    return list(itertools.product(LETTERS, repeat=len(DIRS)))
+
+
+def direct_orbits(perms: list[tuple[int, ...]]) -> list[set[tuple[int, ...]]]:
+    unseen = set(all_colorings())
+    orbits: list[set[tuple[int, ...]]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def fully_mixed(coloring: tuple[int, ...]) -> bool:
+    axis_bicolored = all(
+        coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3)
+    )
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_bicolored and counts == [2, 2, 2]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    july3 = JULY3_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_july3 = normalize(july3)
+
+    occupied = ball((0, 0, 0), RADIUS) | ball(CENTER_P, RADIUS)
+    neighbor_sites = tuple(add(WITNESS, direction) for direction in DIRS)
+    derived_mask = tuple(1 if site in occupied else 0 for site in neighbor_sites)
+    occupied_idx = tuple(index for index, bit in enumerate(derived_mask) if bit == 1)
+    empty_idx = tuple(index for index, bit in enumerate(derived_mask) if bit == 0)
+
+    neighbor_bits = []
+    neighbor_dipoles = []
+    neighbor_kernels = []
+    neighbor_labels = []
+    natural = []
+    for site, bit in zip(neighbor_sites, derived_mask):
+        if bit == 0:
+            neighbor_bits.append(None)
+            neighbor_dipoles.append(None)
+            neighbor_kernels.append(None)
+            neighbor_labels.append(EMPTY)
+            natural.append(EMPTY)
+            continue
+        bits = occupancy_bits(site, occupied)
+        d_vec = dipole(bits)
+        n_vec = kernel(bits)
+        label = unique_axis_label(n_vec)
+        neighbor_bits.append(bits)
+        neighbor_dipoles.append(d_vec)
+        neighbor_kernels.append(n_vec)
+        neighbor_labels.append(label)
+        natural.append(label)
+    natural_c = tuple(natural)
+    unique_axis_all = all(
+        neighbor_labels[index] in (PLUS, MINUS) for index in occupied_idx
+    )
+
+    records = signed_permutation_records()
+    proper_perms = [record["perm"] for record in records if record["det"] == 1]
+    inversion = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+    p_perm = direction_perm(inversion)
+    proper_orbits = direct_orbits(proper_perms)
+    orbit_id = {
+        coloring: index
+        for index, orbit in enumerate(proper_orbits)
+        for coloring in orbit
+    }
+
+    chiral_ids: set[int] = set()
+    for coloring in all_colorings():
+        image = act_col(p_perm, coloring)
+        if orbit_id[image] != orbit_id[coloring]:
+            chiral_ids.add(orbit_id[coloring])
+    chiral_ids_sorted = sorted(chiral_ids)
+    pair = set().union(*(proper_orbits[index] for index in chiral_ids_sorted))
+    n_pair = len(pair)
+
+    fillings: list[tuple[int, ...]] = []
+    for bits in itertools.product((PLUS, MINUS), repeat=len(occupied_idx)):
+        coloring = [EMPTY] * len(DIRS)
+        for index, letter in zip(occupied_idx, bits):
+            coloring[index] = letter
+        fillings.append(tuple(coloring))
+    firing = [coloring for coloring in fillings if coloring in pair]
+    lex_first = min(firing) if firing else None
+    pair_fires = natural_c in pair
+    ham = hamming(natural_c, lex_first) if lex_first is not None else None
+
+    print("Natural occupancy-kernel labels versus July-3 k=3 pair")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"|U|: {len(occupied)}")
+    print(f"derived_mask: {derived_mask}")
+    print(f"occupied_neighbors: {tuple(neighbor_sites[i] for i in occupied_idx)}")
+    print(f"empty_neighbors: {tuple(neighbor_sites[i] for i in empty_idx)}")
+    print(f"neighbor_bits: {neighbor_bits}")
+    print(f"neighbor_dipoles: {neighbor_dipoles}")
+    print(f"neighbor_kernels: {neighbor_kernels}")
+    print(f"natural_c: {show_tuple(natural_c)}")
+    print(f"every_occupied_neighbor_has_unique_axis: {unique_axis_all}")
+    print(f"N_pair: {n_pair}")
+    print(f"pair_fires: {pair_fires}")
+    print(f"lex_first_firing: {show_tuple(lex_first) if lex_first else None}")
+    print(f"hamming_to_lex_first: {ham}")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_BALL_NATURAL_KERNEL_LABEL_CHIRAL_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-unread",
+        unread_sentence in normalized_axiom and unread_sentence in note,
+    )
+    checks.check(
+        "source-july3-unique-pair",
+        "exactly one" in normalized_july3
+        and "chiral pair" in normalized_july3
+        and "handed fully-mixed" in normalized_note
+        and "exactly one chiral pair" in normalized_note,
+    )
+
+    checks.check(
+        "two-ball-star-derived",
+        derived_mask == (1, 1, 1, 0, 1, 0)
+        and l1(WITNESS) == 3
+        and l1(WITNESS, CENTER_P) == 3
+        and WITNESS not in occupied
+        and len(occupied) == 43
+        and tuple(neighbor_sites[i] for i in occupied_idx)
+        == ((2, -1, -1), (0, -1, -1), (1, 0, -1), (1, -1, 0))
+        and tuple(neighbor_sites[i] for i in empty_idx)
+        == ((1, -2, -1), (1, -1, -2)),
+        f"mask={derived_mask} |U|={len(occupied)}",
+    )
+    expected_bits = {
+        (2, -1, -1): (0, 0, 1, 0, 1, 0),
+        (0, -1, -1): (0, 0, 1, 0, 1, 0),
+        (1, 0, -1): (1, 1, 0, 0, 1, 0),
+        (1, -1, 0): (1, 1, 1, 0, 0, 0),
+    }
+    expected_n = {
+        (2, -1, -1): (Fraction(0, 3), Fraction(1, 3), Fraction(1, 3)),
+        (0, -1, -1): (Fraction(0, 3), Fraction(1, 3), Fraction(1, 3)),
+        (1, 0, -1): (Fraction(0, 3), Fraction(0, 3), Fraction(1, 3)),
+        (1, -1, 0): (Fraction(0, 3), Fraction(1, 3), Fraction(0, 3)),
+    }
+    kernel_ok = True
+    for index in occupied_idx:
+        site = neighbor_sites[index]
+        if neighbor_bits[index] != expected_bits[site]:
+            kernel_ok = False
+        if neighbor_kernels[index] != expected_n[site]:
+            kernel_ok = False
+        if neighbor_dipoles[index] != tuple(3 * value for value in expected_n[site]):
+            kernel_ok = False
+    checks.check(
+        "occupancy-kernel-n-equals-d-over-3",
+        kernel_ok
+        and neighbor_labels[0] == NO_AXIS
+        and neighbor_labels[1] == NO_AXIS
+        and neighbor_labels[2] == PLUS
+        and neighbor_labels[4] == PLUS,
+    )
+    checks.check(
+        "natural-six-tuple",
+        natural_c == (NO_AXIS, NO_AXIS, PLUS, EMPTY, PLUS, EMPTY),
+        show_tuple(natural_c),
+    )
+    checks.check(
+        "not-every-occupied-neighbor-unique-axis",
+        unique_axis_all is False
+        and neighbor_labels[0] == NO_AXIS
+        and neighbor_labels[1] == NO_AXIS
+        and neighbor_labels[2] in (PLUS, MINUS)
+        and neighbor_labels[4] in (PLUS, MINUS),
+    )
+    checks.check(
+        "proper-group-order",
+        len(records) == 48 and len(proper_perms) == 24 and len(set(proper_perms)) == 24,
+        f"full={len(records)} proper={len(proper_perms)}",
+    )
+    checks.check(
+        "unique-chiral-pair",
+        len(chiral_ids_sorted) == 2 and len(proper_orbits) == 57,
+        f"orbits={len(proper_orbits)} chiral_ids={chiral_ids_sorted}",
+    )
+    checks.check(
+        "n-pair",
+        n_pair == 48 and all(fully_mixed(coloring) for coloring in pair),
+        f"N_pair={n_pair}",
+    )
+    checks.check(
+        "pair-does-not-fire",
+        pair_fires is False
+        and natural_c not in pair
+        and NO_AXIS in natural_c
+        and all(letter in LETTERS for member in pair for letter in member),
+    )
+    checks.check(
+        "hamming-to-lex-first",
+        lex_first == (PLUS, MINUS, PLUS, EMPTY, MINUS, EMPTY)
+        and ham == 3
+        and len(firing) == 4,
+        f"lex_first={show_tuple(lex_first) if lex_first else None} ham={ham}",
+    )
+
+    claim_scope = (
+        "On U=B_2(0)∪B_2((2,0,0)) at unread v=(1,−1,−1), whether "
+        "occupancy-kernel unique-axis labels of the four occupied neighbors "
+        "form a July-3 k=3 pair member is reported. Displayed, not adopted."
+    )
+    checks.check("claim-scope-pinned", claim_scope in note)
+    checks.check(
+        "note-report-numbers",
+        "N_pair = 48" in note
+        and "natural_c = (*, *, +, 0, +, 0)" in note
+        and "every_occupied_neighbor_has_unique_axis = false" in note
+        and "pair_fires = false" in note
+        and "hamming_to_lex_first = 3" in note
+        and "lex_first_firing = (+, -, +, 0, -, 0)" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "displayed, not adopted" in normalized_note
+        and "not written into Admissibility" in normalized_note
+        and "written_into_admissibility = false" in note,
+    )
+    checks.check(
+        "not-attached-to-l1",
+        "not attached to L1" in normalized_note
+        and "attached_to_L1 = false" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "not-leftover-char",
+        "not leftover-char of the two-ball occupied-NN count" in normalized_note
+        and "not leftover-char of the existence of some" in normalized_note
+        and "6-NN star at" in normalized_note,
+    )
+    checks.check(
+        "score-only-u-and-star",
+        "No new spatial patch is opened" in note
+        and "score any site other than `U` and the 6-NN star at `v`" in normalized_note,
+    )
+    checks.check(
+        "no-forbidden-phrases",
+        all(phrase not in note and phrase not in axiom for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "does not add a kernel-label clause" in normalized_note
+        and "occupancy kernel" not in axiom
+        and "unique-axis" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On U=B2(0)∪B2((2,0,0)) at v=(1,-1,-1), unique-axis kernel labels give c=(*,*,+,0,+,0). Two occupied neighbors have no unique axis. c is not a July-3 pair member. Hamming distance 3 to lex-first firing (+,-,+,0,-,0). Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_ball_natural_kernel_label_chiral_fire_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.