### PR TITLE
feat(2bcons): unique-axis signs exclude every firing labeling

### DIFF
--- a/docs/TWO_BALL_FIRING_VS_UNIQUE_AXIS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_BALL_FIRING_VS_UNIQUE_AXIS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,275 @@
+---
+claim_id: two_ball_firing_vs_unique_axis_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 4 July-3 pair members on the two-ball witness mask, how many agree with unique-axis labels +y=+ and +z=+ is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/two_ball_firing_vs_unique_axis_2026_08_15.py
+---
+
+# Two-Ball Firing 6-Tuples Versus Unique-Axis Signs
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact census of the four July-3 `k = 3` pair members on the
+two-ball witness occupancy mask `(1,1,1,0,1,0)` against the unique-axis
+fragment `+y = +` and `+z = +`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_ball_firing_vs_unique_axis_2026_08_15.py`](../scripts/two_ball_firing_vs_unique_axis_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+
+## Result Up Front
+
+Direction order is `(+x, −x, +y, −y, +z, −z)`. The two-ball unread witness
+occupancy mask on that order is
+
+```text
+m = (1, 1, 1, 0, 1, 0)
+```
+
+with `1` occupied and `0` empty. Occupied slots are `+x`, `−x`, `+y`, and
+`+z`. Empty slots are `−y` and `−z`.
+
+July-3 Theorem 3 isolates a unique chiral pair at three condition letters.
+Letters are `{0, +, −}` with `0` empty. The pair is the union of two `G+`
+orbits and has `N_pair = 48` members. Exactly four `{+, −}` fillings of
+`m` are pair members. Those four firing 6-tuples are
+
+```text
+(+, −, +, 0, −, 0)
+(+, −, −, 0, +, 0)
+(−, +, +, 0, −, 0)
+(−, +, −, 0, +, 0).
+```
+
+The occupancy-kernel unique-axis fragment on the two unambiguous occupied
+neighbors of the witness is `+y = +` and `+z = +`. Among the four firing
+6-tuples, `N_agree = 0` have both of those signs. Unique-axis labels on
+those two neighbors already exclude every firing labeling.
+
+This is not leftover-char of the full occupancy-kernel 6-tuple, which
+scored one full kernel labeling with `*` on the two ambiguous `±x` slots.
+The residual here is only the four-member firing census against the two
+unambiguous signs.
+
+The comparison is displayed, not adopted. Do not write a tie-break into Admissibility. Do not attach L1.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite agreement count of the four firing pair members on one witness mask against two unique-axis signs is exact; no axiom sentence is rewritten."
+trace_class: negative_route_pruning
+target_claim_id: two_ball_firing_vs_unique_axis
+target_blocker_text: "among the 4 firing 6-tuples on the two-ball witness mask, how many have +y=+ and +z=+"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+conditional_surface_status: "exact on the July-3 named k=3 alphabet and the one two-ball 6-tuple census; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of N_agree; do not write a tie-break into Admissibility and do not attach L1"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+Quoted from the live memo, verbatim:
+
+```text
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+A site with no record cannot be read.
+```
+
+This note does not choose that rule and does not add a unique-axis clause
+or a tie-break to it. Letter `0` is the empty/unread letter on the July-3
+three-letter model. Occupied means nonzero. The note does not assign a
+readout value to absence.
+- **July-3 Theorem 3.** At `k = 3` there is exactly one chiral pair, whose
+  members are the handed fully-mixed patterns: every axis bi-colored with
+  two distinct values, every value used twice. The runner re-earns the
+  pair by enumerating `G+` orbits; it does not import an external list.
+- **Two-ball witness mask, re-earned here.** The union
+  `U = B_2(0) ∪ B_2((2,0,0))` at unread `v = (1,-1,-1)` occupies
+  `(+x, −x, +y, +z)` and leaves `(−y, −z)` empty. The runner rebuilds
+  that mask and the four pair fillings; it does not import a stored list.
+- **Unique-axis fragment.** On the same `U`, the occupancy kernel
+  `n = d/3` of an occupied neighbor has a unique axis when exactly one
+  component is nonzero. The two unambiguous occupied neighbors of `v`
+  are the `+y` and `+z` sites; both receive label `+`. The `±x`
+  neighbors have no unique axis and are not used as constraints here.
+- **External empirical inputs:** none.
+- **Not attached:** L1 is not a premise and is not a conclusion. The
+  agreement count is not leftover-char of the full kernel 6-tuple with
+  `*`.
+
+## Exact Objects
+
+The six nearest-neighbor directions, in the July-3 order, are
+
+```text
+(+x, −x, +y, −y, +z, −z).
+```
+
+The closed ℓ¹ ball is `B_r(c) = { x in Z^3 : ||x − c||_1 ≤ r }`. The
+occupied set used to rebuild the mask is only
+
+```text
+U = B_2(0) ∪ B_2((2,0,0)).
+```
+
+The unread witness is the single site `v = (1,-1,-1)`. Occupancy of a
+neighbor is membership in `U`. The occupancy mask is the `{0,1}` 6-tuple
+in the direction order above.
+
+A `k = 3` condition 6-tuple is an element of `{0, +, −}^6`. Letter `0` is
+empty. `G+` is the 24-element proper cubic group of determinant-`+1` signed
+permutation matrices. It acts on 6-tuples by the induced permutation of
+the six axis directions. Spatial inversion `P = −I` is the central
+improper element. A chiral pair is a pair of distinct `G+` orbits
+exchanged by `P`. July-3 Theorem 3 states there is exactly one such pair
+at `k = 3`. Write `Pair` for the union of those two orbits, and
+`N_pair = |Pair|`.
+
+The four firing 6-tuples are the members of `Pair` whose occupancy mask
+equals `m`, equivalently the `{+, −}` fillings of the four occupied slots
+of `m` that lie in `Pair`.
+
+The occupancy 6-tuple of a site `w` inside `U` is `c(w)_i = 1` if
+`w + e_i ∈ U` and `0` otherwise. The dipole and kernel are
+`d_μ = c_{+μ} − c_{−μ}` and `n = d/3`. The unique-axis fragment used here
+is only the pair of signs of the unique nonzero components at the `+y`
+and `+z` neighbors of `v`. Those signs are both `+`.
+
+`N_agree` is the number of firing 6-tuples whose `+y` slot is `+` and
+whose `+z` slot is `+`.
+
+## Theorem 1 — Four Firing 6-Tuples And N_agree
+
+The four firing 6-tuples on `m` are
+
+```text
+(+, −, +, 0, −, 0)
+(+, −, −, 0, +, 0)
+(−, +, +, 0, −, 0)
+(−, +, −, 0, +, 0).
+```
+
+Exactly `N_agree = 0` of them have `+y = +` and `+z = +`.
+
+*Proof.* The 24 proper signed permutation matrices are generated
+exhaustively. Their action on the 729 colorings `{0, +, −}^6` partitions
+them into 57 `G+` orbits, matching the July-3 Burnside count. Exactly two
+of those orbits fail to meet their `P`-images; they form one pair, and
+each has size 24, so `N_pair = 48`. Every pair member is fully mixed:
+every axis is bi-colored and each letter occurs twice.
+
+Independently, `U` is constructed and the six axial neighbors of `v` are
+tested for membership in `U`. The occupied neighbors are `(2,-1,-1)`,
+`(0,-1,-1)`, `(1,0,-1)`, and `(1,-1,0)`; the empty neighbors are
+`(1,-2,-1)` and `(1,-1,-2)`. That is the mask `m`.
+
+The 16 `{+, −}` fillings of the four occupied slots are enumerated. A
+filling is a firing 6-tuple if and only if it lies in `Pair`. Direct
+membership yields exactly the four 6-tuples listed above.
+
+Slotwise, those four have `(+y, +z)` equal to `(+, −)`, `(−, +)`,
+`(+, −)`, and `(−, +)` respectively. None equals `(+, +)`. Hence
+`N_agree = 0`.
+
+The same vanishing is forced by full mixing on this mask. If `+y` and
+`+z` were both `+`, the two `+` letters would already be used, the two
+`0` letters would already occupy `−y` and `−z`, and both `±x` slots would
+have to be `−` to use `−` twice. The `x` axis would then fail to be
+bi-colored, so the 6-tuple would lie outside `Pair`.
+
+## Theorem 2 — Unique-Axis Fragment Excludes Every Firing Labeling
+
+Because `N_agree = 0`, unique-axis labels on the two unambiguous occupied
+neighbors already exclude every firing labeling.
+
+*Proof.* On the same `U`, the occupancy kernels of the four occupied
+neighbors of `v` are
+
+| neighbor of `v` | `w` | `n = d/3` | `|supp n|` | label |
+|---|---|---|---:|---|
+| `+x` | `(2,-1,-1)` | `(0, 1/3, 1/3)` | 2 | no unique axis |
+| `−x` | `(0,-1,-1)` | `(0, 1/3, 1/3)` | 2 | no unique axis |
+| `+y` | `(1,0,-1)` | `(0, 0, 1/3)` | 1 | `+` |
+| `+z` | `(1,-1,0)` | `(0, 1/3, 0)` | 1 | `+` |
+
+The unique-axis fragment is therefore `+y = +` and `+z = +`. By
+Theorem 1, no firing 6-tuple carries both of those signs. Any labeling
+that respects the unique-axis fragment on the two unambiguous neighbors
+fails to be a pair member on this mask.
+
+The two ambiguous `±x` slots are not used as a further constraint. The
+present census does not score a full kernel 6-tuple with `*`.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The four firing 6-tuples and the count `N_agree = 0` are a finite report
+on the July-3 named alphabet model and one two-ball mask. They are
+displayed. They are not adopted.
+
+In particular:
+
+- the unique-axis fragment is not written into Admissibility;
+- no tie-break is written into Admissibility;
+- no unique-axis clause is written into Admissibility;
+- no axiom sentence is edited;
+- the comparison is not attached to L1.
+
+Admissibility continues to say only that there is one fixed
+nearest-neighbor rule, covariant under translations and proper cubic
+rotations, and that the local distribution varies with the
+nearest-neighbor conditions. Which unique-axis fragment a displayed
+occupancy kernel assigns on a named two-ball star is not that rule.
+
+## What This Note Does And Does Not Claim
+
+- **It does claim** that the four July-3 pair members on the two-ball
+  witness mask are the 6-tuples listed in Theorem 1, that `N_agree = 0`
+  of them have `+y = +` and `+z = +`, and that the unique-axis fragment
+  on those two unambiguous neighbors therefore excludes every firing
+  labeling.
+- **It does not claim** leftover-char of the full occupancy-kernel
+  6-tuple with `*`. It is not leftover-char of the full occupancy-kernel
+  6-tuple. That residual scored one assembled labeling of all
+  four occupied slots. The present residual is only whether the two
+  unambiguous signs already meet any firing 6-tuple.
+- **It does not adopt** a unique-axis tie-break as Admissibility content
+  and does not attach L1.
+- **It does not** open a new spatial patch, replace the six-neighbor
+  stencil, select the physical condition alphabet, or decide whether the
+  framework's fixed rule is chiral.
+
+## Machine-Readable Report
+
+```text
+N_pair = 48
+N_fire = 4
+mask = (1, 1, 1, 0, 1, 0)
+firing = [(+, -, +, 0, -, 0), (+, -, -, 0, +, 0), (-, +, +, 0, -, 0), (-, +, -, 0, +, 0)]
+unique_axis_plus_y = +
+unique_axis_plus_z = +
+N_agree = 0
+unique_axis_excludes_every_firing = true
+displayed_not_adopted = true
+attached_to_L1 = false
+written_into_admissibility = false
+tie_break_written_into_admissibility = false
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18585,6 +18585,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_ball_firing_vs_unique_axis_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_ball_firing_vs_unique_axis_2026_08_15.txt
+++ b/logs/runner-cache/two_ball_firing_vs_unique_axis_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/two_ball_firing_vs_unique_axis_2026_08_15.py
+runner_sha256: b188a1510d541d90ef0b3f5fbafe1e9adb7bd12e23509ec2a9e649ed371c37d8
+input_fingerprint_sha256: 7a2099347c5bddcef8daa211a2e9d42dc610965c323537a632715e9128e218cd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+Two-ball firing 6-tuples versus unique-axis +y=+ and +z=+
+AUDIT_INPUT_PATHS:
+  docs/TWO_BALL_FIRING_VS_UNIQUE_AXIS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+derived_mask: (1, 1, 1, 0, 1, 0)
+occupied_neighbors: ((2, -1, -1), (0, -1, -1), (1, 0, -1), (1, -1, 0))
+empty_neighbors: ((1, -2, -1), (1, -1, -2))
+N_pair: 48
+N_fire: 4
+firing: ['(+, -, +, 0, -, 0)', '(+, -, -, 0, +, 0)', '(-, +, +, 0, -, 0)', '(-, +, -, 0, +, 0)']
+unique_axis_plus_y: +
+unique_axis_plus_z: +
+N_agree: 0
+agreeing: []
+unique_axis_excludes_every_firing: True
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-static-literals
+PASS: audit-timeout-declared
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread
+PASS: source-july3-unique-pair
+PASS: two-ball-mask-derived | mask=(1, 1, 1, 0, 1, 0)
+PASS: proper-group-order | full=48 proper=24
+PASS: unique-chiral-pair | orbits=57 chiral_ids=[28, 29]
+PASS: n-pair | N_pair=48
+PASS: four-firing-six-tuples | firing=['(+, -, +, 0, -, 0)', '(+, -, -, 0, +, 0)', '(-, +, +, 0, -, 0)', '(-, +, -, 0, +, 0)']
+PASS: unique-axis-fragment-plus-y-plus-z | +y=+ +z=+
+PASS: n-agree | N_agree=0
+PASS: unique-axis-excludes-every-firing
+PASS: claim-scope-pinned
+PASS: note-report-numbers
+PASS: displayed-not-adopted
+PASS: not-attached-to-l1
+PASS: not-leftover-char
+PASS: same-six-tuple-census-only
+PASS: no-forbidden-phrases
+PASS: no-axiom-edit
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_ball_firing_vs_unique_axis_2026_08_15.py
+++ b/scripts/two_ball_firing_vs_unique_axis_2026_08_15.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Four firing pair members versus unique-axis +y=+ and +z=+.
+
+Rebuild the July-3 k=3 pair members on the two-ball witness mask
+(1,1,1,0,1,0). Count how many of those four 6-tuples have +y=+ and +z=+.
+"""
+
+from __future__ import annotations
+
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/TWO_BALL_FIRING_VS_UNIQUE_AXIS_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+JULY3_PATH = ROOT / (
+    "docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_"
+    "OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_"
+    "BOUNDED_THEOREM_NOTE_2026-07-03.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BALL_FIRING_VS_UNIQUE_AXIS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+
+EMPTY, PLUS, MINUS, NO_AXIS = 0, 1, 2, 3
+LETTERS = (EMPTY, PLUS, MINUS)
+LETTER_SHOW = {EMPTY: "0", PLUS: "+", MINUS: "-", NO_AXIS: "*"}
+PLUS_Y_SLOT = 2
+PLUS_Z_SLOT = 4
+WITNESS = (1, -1, -1)
+CENTER_P = (2, 0, 0)
+RADIUS = 2
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def show_tuple(coloring: tuple[int, ...]) -> str:
+    return "(" + ", ".join(LETTER_SHOW[letter] for letter in coloring) + ")"
+
+
+def add(
+    left: tuple[int, int, int], right: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(
+    left: tuple[int, int, int], right: tuple[int, int, int] = (0, 0, 0)
+) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: tuple[int, int, int], radius: int) -> frozenset[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for offset in itertools.product(range(-radius, radius + 1), repeat=3):
+        if l1(offset) <= radius:
+            sites.append(add(center, offset))
+    return frozenset(sites)
+
+
+def occupancy_mask(coloring: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(0 if letter == EMPTY else 1 for letter in coloring)
+
+
+def occupancy_bits(
+    site: tuple[int, int, int], occupied: frozenset[tuple[int, int, int]]
+) -> tuple[int, ...]:
+    return tuple(1 if add(site, direction) in occupied else 0 for direction in DIRS)
+
+
+def dipole(bits: tuple[int, ...]) -> tuple[int, int, int]:
+    return (bits[0] - bits[1], bits[2] - bits[3], bits[4] - bits[5])
+
+
+def kernel(bits: tuple[int, ...]) -> tuple[Fraction, Fraction, Fraction]:
+    dx, dy, dz = dipole(bits)
+    return (Fraction(dx, 3), Fraction(dy, 3), Fraction(dz, 3))
+
+
+def unique_axis_label(n_vec: tuple[Fraction, Fraction, Fraction]) -> int:
+    support = [index for index, value in enumerate(n_vec) if value != 0]
+    if len(support) != 1:
+        return NO_AXIS
+    value = n_vec[support[0]]
+    if value > 0:
+        return PLUS
+    if value < 0:
+        return MINUS
+    return NO_AXIS
+
+
+def det3(matrix: list[list[int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_mat(matrix: list[list[int]], vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )
+
+
+def direction_perm(matrix: list[list[int]]) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[apply_mat(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def signed_permutation_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0] for _ in range(3)]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(entry for row in matrix for entry in row)
+            if key not in seen:
+                seen.add(key)
+                records.append(
+                    {
+                        "matrix": matrix,
+                        "det": det3(matrix),
+                        "perm": direction_perm(matrix),
+                    }
+                )
+    return records
+
+
+def all_colorings() -> list[tuple[int, ...]]:
+    return list(itertools.product(LETTERS, repeat=len(DIRS)))
+
+
+def direct_orbits(perms: list[tuple[int, ...]]) -> list[set[tuple[int, ...]]]:
+    unseen = set(all_colorings())
+    orbits: list[set[tuple[int, ...]]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def fully_mixed(coloring: tuple[int, ...]) -> bool:
+    axis_bicolored = all(
+        coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3)
+    )
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_bicolored and counts == [2, 2, 2]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    july3 = JULY3_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_july3 = normalize(july3)
+
+    occupied = ball((0, 0, 0), RADIUS) | ball(CENTER_P, RADIUS)
+    neighbor_sites = tuple(add(WITNESS, direction) for direction in DIRS)
+    derived_mask = tuple(1 if site in occupied else 0 for site in neighbor_sites)
+    occupied_idx = tuple(index for index, bit in enumerate(derived_mask) if bit == 1)
+    empty_idx = tuple(index for index, bit in enumerate(derived_mask) if bit == 0)
+
+    neighbor_labels = []
+    for site, bit in zip(neighbor_sites, derived_mask):
+        if bit == 0:
+            neighbor_labels.append(EMPTY)
+            continue
+        neighbor_labels.append(unique_axis_label(kernel(occupancy_bits(site, occupied))))
+    unique_axis_plus_y = neighbor_labels[PLUS_Y_SLOT]
+    unique_axis_plus_z = neighbor_labels[PLUS_Z_SLOT]
+
+    records = signed_permutation_records()
+    proper_perms = [record["perm"] for record in records if record["det"] == 1]
+    inversion = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+    p_perm = direction_perm(inversion)
+    proper_orbits = direct_orbits(proper_perms)
+    orbit_id = {
+        coloring: index
+        for index, orbit in enumerate(proper_orbits)
+        for coloring in orbit
+    }
+
+    chiral_ids: set[int] = set()
+    for coloring in all_colorings():
+        image = act_col(p_perm, coloring)
+        if orbit_id[image] != orbit_id[coloring]:
+            chiral_ids.add(orbit_id[coloring])
+    chiral_ids_sorted = sorted(chiral_ids)
+    pair = set().union(*(proper_orbits[index] for index in chiral_ids_sorted))
+    n_pair = len(pair)
+
+    fillings: list[tuple[int, ...]] = []
+    for bits in itertools.product((PLUS, MINUS), repeat=len(occupied_idx)):
+        coloring = [EMPTY] * len(DIRS)
+        for index, letter in zip(occupied_idx, bits):
+            coloring[index] = letter
+        fillings.append(tuple(coloring))
+    firing = sorted(coloring for coloring in fillings if coloring in pair)
+    n_fire = len(firing)
+    agreeing = [
+        coloring
+        for coloring in firing
+        if coloring[PLUS_Y_SLOT] == PLUS and coloring[PLUS_Z_SLOT] == PLUS
+    ]
+    n_agree = len(agreeing)
+    excludes_every_firing = n_agree == 0
+
+    print("Two-ball firing 6-tuples versus unique-axis +y=+ and +z=+")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"derived_mask: {derived_mask}")
+    print(f"occupied_neighbors: {tuple(neighbor_sites[i] for i in occupied_idx)}")
+    print(f"empty_neighbors: {tuple(neighbor_sites[i] for i in empty_idx)}")
+    print(f"N_pair: {n_pair}")
+    print(f"N_fire: {n_fire}")
+    print(f"firing: {[show_tuple(item) for item in firing]}")
+    print(f"unique_axis_plus_y: {LETTER_SHOW[unique_axis_plus_y]}")
+    print(f"unique_axis_plus_z: {LETTER_SHOW[unique_axis_plus_z]}")
+    print(f"N_agree: {n_agree}")
+    print(f"agreeing: {[show_tuple(item) for item in agreeing]}")
+    print(f"unique_axis_excludes_every_firing: {excludes_every_firing}")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_BALL_FIRING_VS_UNIQUE_AXIS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-unread",
+        unread_sentence in normalized_axiom and unread_sentence in note,
+    )
+    checks.check(
+        "source-july3-unique-pair",
+        "exactly one" in normalized_july3
+        and "chiral pair" in normalized_july3
+        and "handed fully-mixed" in normalized_note
+        and "exactly one chiral pair" in normalized_note,
+    )
+
+    checks.check(
+        "two-ball-mask-derived",
+        derived_mask == (1, 1, 1, 0, 1, 0)
+        and l1(WITNESS) == 3
+        and l1(WITNESS, CENTER_P) == 3
+        and WITNESS not in occupied
+        and tuple(neighbor_sites[i] for i in occupied_idx)
+        == ((2, -1, -1), (0, -1, -1), (1, 0, -1), (1, -1, 0))
+        and tuple(neighbor_sites[i] for i in empty_idx)
+        == ((1, -2, -1), (1, -1, -2)),
+        f"mask={derived_mask}",
+    )
+    checks.check(
+        "proper-group-order",
+        len(records) == 48 and len(proper_perms) == 24 and len(set(proper_perms)) == 24,
+        f"full={len(records)} proper={len(proper_perms)}",
+    )
+    checks.check(
+        "unique-chiral-pair",
+        len(chiral_ids_sorted) == 2 and len(proper_orbits) == 57,
+        f"orbits={len(proper_orbits)} chiral_ids={chiral_ids_sorted}",
+    )
+    checks.check(
+        "n-pair",
+        n_pair == 48 and all(fully_mixed(coloring) for coloring in pair),
+        f"N_pair={n_pair}",
+    )
+    expected_firing = [
+        (PLUS, MINUS, PLUS, EMPTY, MINUS, EMPTY),
+        (PLUS, MINUS, MINUS, EMPTY, PLUS, EMPTY),
+        (MINUS, PLUS, PLUS, EMPTY, MINUS, EMPTY),
+        (MINUS, PLUS, MINUS, EMPTY, PLUS, EMPTY),
+    ]
+    checks.check(
+        "four-firing-six-tuples",
+        n_fire == 4
+        and firing == expected_firing
+        and all(occupancy_mask(item) == derived_mask for item in firing),
+        f"firing={[show_tuple(item) for item in firing]}",
+    )
+    checks.check(
+        "unique-axis-fragment-plus-y-plus-z",
+        unique_axis_plus_y == PLUS
+        and unique_axis_plus_z == PLUS
+        and neighbor_labels[0] == NO_AXIS
+        and neighbor_labels[1] == NO_AXIS,
+        f"+y={LETTER_SHOW[unique_axis_plus_y]} +z={LETTER_SHOW[unique_axis_plus_z]}",
+    )
+    checks.check(
+        "n-agree",
+        n_agree == 0 and agreeing == [],
+        f"N_agree={n_agree}",
+    )
+    checks.check(
+        "unique-axis-excludes-every-firing",
+        excludes_every_firing is True
+        and n_agree == 0
+        and all(
+            not (item[PLUS_Y_SLOT] == PLUS and item[PLUS_Z_SLOT] == PLUS)
+            for item in firing
+        ),
+    )
+
+    claim_scope = (
+        "Among the 4 July-3 pair members on the two-ball witness mask, "
+        "how many agree with unique-axis labels +y=+ and +z=+ is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check("claim-scope-pinned", claim_scope in note)
+    checks.check(
+        "note-report-numbers",
+        "N_pair = 48" in note
+        and "N_fire = 4" in note
+        and "N_agree = 0" in note
+        and "mask = (1, 1, 1, 0, 1, 0)" in note
+        and "unique_axis_plus_y = +" in note
+        and "unique_axis_plus_z = +" in note
+        and "unique_axis_excludes_every_firing = true" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "displayed, not adopted" in normalized_note
+        and "not written into Admissibility" in normalized_note
+        and "written_into_admissibility = false" in note
+        and "Do not write a tie-break into Admissibility" in note
+        and "tie_break_written_into_admissibility = false" in note,
+    )
+    checks.check(
+        "not-attached-to-l1",
+        "not attached to L1" in normalized_note
+        and "attached_to_L1 = false" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "not-leftover-char",
+        "not leftover-char of the full occupancy-kernel" in normalized_note
+        and "full kernel 6-tuple with" in normalized_note
+        and "does not score a full kernel 6-tuple" in normalized_note,
+    )
+    checks.check(
+        "same-six-tuple-census-only",
+        "does not** open a new spatial patch" in normalized_note
+        or "does not open a new spatial patch" in normalized_note,
+    )
+    checks.check(
+        "no-forbidden-phrases",
+        all(phrase not in note and phrase not in axiom for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "does not add a unique-axis clause" in normalized_note
+        and "unique-axis" not in axiom
+        and "tie-break" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among the 4 July-3 pair members on the two-ball witness mask, N_agree=0 have +y=+ and +z=+. Each firing disagrees on +y or +z. Unique-axis labels on the two unambiguous neighbors already forbid firing. Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_ball_firing_vs_unique_axis_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.