### PR TITLE
feat(all4): two of four 4-NN sites have unique-axis agreement

### DIFF
--- a/docs/TWO_BALL_ALL_4NN_UNIQUE_AXIS_AGREE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_BALL_ALL_4NN_UNIQUE_AXIS_AGREE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,293 @@
+---
+claim_id: two_ball_all_4nn_unique_axis_agree_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On U=B_2(0)∪B_2((2,0,0)) inside the radius-6 box, whether any unread 4-occupied-NN site has a July-3 pair member agreeing with that site’s unique-axis labels is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py
+---
+
+# All 4-NN Unread Sites Of Two-Ball U Versus Unique-Axis Agreement
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact census, on the radius-6 box, of every unread site of
+`U = B_2(0) ∪ B_2((2,0,0))` with four occupied six-neighbors, scored
+against July-3 `k = 3` pair membership and occupancy-kernel unique-axis
+labels. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py`](../scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+
+## Result Up Front
+
+Direction order is `(+x, −x, +y, −y, +z, −z)`. Occupied set
+
+```text
+U = B_2(0) ∪ B_2((2,0,0))
+```
+
+is scored only inside the box `|x|,|y|,|z| ≤ 6`. An unread site is a box
+point not in `U`. Occupied-NN count is how many of its six axial neighbors
+lie in `U`.
+
+Exactly `N_4 = 4` unread box sites have occupied-NN count `4`. They are
+`(1,-1,-1)`, `(1,-1,1)`, `(1,1,-1)`, and `(1,1,1)`. For each, the occupancy
+mask, the number of July-3 pair fillings `N_fire`, the number of
+unambiguous unique-axis labels `N_unique_axis`, and the agreement count
+`N_agree` are
+
+| `v` | mask | `N_fire` | `N_unique_axis` | `N_agree` |
+|---|---|---:|---:|---:|
+| `(1,-1,-1)` | `(1,1,1,0,1,0)` | 4 | 2 | 0 |
+| `(1,-1,1)` | `(1,1,1,0,0,1)` | 4 | 2 | 2 |
+| `(1,1,-1)` | `(1,1,0,1,1,0)` | 4 | 2 | 2 |
+| `(1,1,1)` | `(1,1,0,1,0,1)` | 4 | 2 | 0 |
+
+`N_pos = 2` of those sites have `N_agree > 0`. The lex-first such site is
+`v = (1,-1,1)`. One agreeing 6-tuple there is `(+, −, −, 0, 0, +)`.
+Unique-axis therefore does not forbid firing at every 4-NN unread site of
+this `U`.
+
+The lex-first 4-NN unread site `(1,-1,-1)` still has `N_agree = 0`. The
+present residual is not leftover-char of the one-witness unique-axis
+agreement on that lex-first 4-NN unread site. The census does not stop at
+the lex-first witness.
+
+The comparison is displayed, not adopted. Do not write a site list into Admissibility. Do not attach L1.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite agreement census of every 4-NN unread site of one two-ball U against unique-axis labels is exact; no axiom sentence is rewritten."
+trace_class: negative_route_pruning
+target_claim_id: two_ball_all_4nn_unique_axis_agree
+target_blocker_text: "whether any unread 4-occupied-NN site of U=B_2(0)∪B_2((2,0,0)) has N_agree>0"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+conditional_surface_status: "exact on the July-3 named k=3 alphabet, this U, and the radius-6 box; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+next_trace_action: "independent audit of N_pos; do not write a site list into Admissibility and do not attach L1"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+Quoted from the live memo, verbatim:
+
+```text
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+A site with no record cannot be read.
+```
+
+This note does not choose that rule and does not add a unique-axis clause
+or a site list to it. Letter `0` is the empty/unread letter on the July-3
+three-letter model. Occupied means membership in the constructed set `U`.
+The note does not assign a readout value to absence.
+- **July-3 Theorem 3.** At `k = 3` there is exactly one chiral pair, whose
+  members are the handed fully-mixed patterns: every axis bi-colored with
+  two distinct values, every value used twice. The runner re-earns the
+  pair by enumerating `G+` orbits; it does not import an external list.
+- **Two-ball occupied set, re-earned here.** `U = B_2(0) ∪ B_2((2,0,0))`
+  is constructed as the union of two closed ℓ¹ balls. Unread sites are
+  enumerated in the radius-6 box only.
+- **Unique-axis label.** On the same `U`, the occupancy kernel `n = d/3`
+  of an occupied neighbor has a unique axis when exactly one component is
+  nonzero. The label is the sign of that unique nonzero component, or
+  ambiguous. Ambiguous slots are free in the agreement count.
+- **External empirical inputs:** none.
+- **Not attached:** L1 is not a premise and is not a conclusion. The
+  census is not leftover-char of the one-witness unique-axis agreement.
+
+## Exact Objects
+
+The six nearest-neighbor directions, in the July-3 order, are
+
+```text
+(+x, −x, +y, −y, +z, −z).
+```
+
+The closed ℓ¹ ball is `B_r(c) = { x in Z^3 : ||x − c||_1 ≤ r }`. The
+occupied set is only
+
+```text
+U = B_2(0) ∪ B_2((2,0,0)).
+```
+
+Scoring is restricted to the finite box `|x|,|y|,|z| ≤ 6`. A site `v` in
+that box is unread when `v ∉ U`. Occupancy of a neighbor is membership in
+`U`. The occupancy mask of `v` is the `{0,1}` 6-tuple of those memberships
+in the direction order above.
+
+A `k = 3` condition 6-tuple is an element of `{0, +, −}^6`. Letter `0` is
+empty. `G+` is the 24-element proper cubic group of determinant-`+1` signed
+permutation matrices. It acts on 6-tuples by the induced permutation of
+the six axis directions. Spatial inversion `P = −I` is the central
+improper element. A chiral pair is a pair of distinct `G+` orbits
+exchanged by `P`. July-3 Theorem 3 states there is exactly one such pair
+at `k = 3`. Write `Pair` for the union of those two orbits, and
+`N_pair = |Pair|`.
+
+For an unread `v` with exactly four occupied neighbors, `N_fire(v)` is the
+number of members of `Pair` whose occupancy mask equals the mask of `v`.
+Equivalently, it is the number of `{+, −}` fillings of those four occupied
+slots that lie in `Pair`.
+
+The occupancy 6-tuple of a site `w` inside `U` is `c(w)_i = 1` if
+`w + e_i ∈ U` and `0` otherwise. The dipole and kernel are
+`d_μ = c_{+μ} − c_{−μ}` and `n = d/3`. The unique-axis label of an
+occupied neighbor is the sign of the unique nonzero component of `n`, or
+ambiguous when `|supp n| ≠ 1`. `N_unique_axis(v)` is the number of
+occupied neighbors of `v` that receive a unique-axis label.
+
+`N_agree(v)` is the number of pair members on `v`'s mask that match every
+unique-axis label. Ambiguous slots are free. `N_4` is the number of unread
+box sites with occupied-NN count `4`. `N_pos` is how many of those have
+`N_agree > 0`.
+
+## Theorem 1 — Four Unread 4-NN Sites
+
+`N_4 = 4`. The four unread box sites with occupied-NN count `4`, together
+with their masks, fire counts, unique-axis counts, and agreement counts,
+are the rows of the table in the Result Up Front.
+
+*Proof.* The 24 proper signed permutation matrices are generated
+exhaustively. Their action on the 729 colorings `{0, +, −}^6` partitions
+them into 57 `G+` orbits, matching the July-3 Burnside count. Exactly two
+of those orbits fail to meet their `P`-images; they form one pair, and
+each has size 24, so `N_pair = 48`. Every pair member is fully mixed:
+every axis is bi-colored and each letter occurs twice.
+
+Independently, `U` is constructed as the union of the two radius-`2` ℓ¹
+balls. Every site of the box `|x|,|y|,|z| ≤ 6` outside `U` is tested for
+how many of its six axial neighbors lie in `U`. Exactly four sites reach
+count `4`: `(1,-1,-1)`, `(1,-1,1)`, `(1,1,-1)`, and `(1,1,1)`. Each has
+`|U| = 43` as the same occupied set.
+
+For each such `v`, the occupancy mask is read off membership of the six
+neighbors in `U`. The sixteen `{+, −}` fillings of the four occupied slots
+are enumerated; a filling is a fire if and only if it lies in `Pair`.
+Direct membership yields `N_fire = 4` at every one of the four sites.
+
+The occupancy kernel of each occupied neighbor is computed on the same
+`U`. In every case the two `±x` neighbors have two nonzero kernel
+components and are ambiguous, while the two remaining occupied neighbors
+each have a single nonzero component. Hence `N_unique_axis = 2` at every
+site. Matching pair members against those two labels yields
+
+```text
+N_agree(1,-1,-1) = 0
+N_agree(1,-1,1)  = 2
+N_agree(1,1,-1)  = 2
+N_agree(1,1,1)   = 0.
+```
+
+The unique-axis fragments and the agreeing 6-tuples are
+
+| `v` | unique-axis 6-tuple | agreeing pair members |
+|---|---|---|
+| `(1,-1,-1)` | `(*, *, +, 0, +, 0)` | none |
+| `(1,-1,1)` | `(*, *, −, 0, 0, +)` | `(+, −, −, 0, 0, +)`, `(−, +, −, 0, 0, +)` |
+| `(1,1,-1)` | `(*, *, 0, +, −, 0)` | `(+, −, 0, +, −, 0)`, `(−, +, 0, +, −, 0)` |
+| `(1,1,1)` | `(*, *, 0, −, 0, −)` | none |
+
+At `(1,-1,-1)` the two unique-axis labels force `+y = +` and `+z = +`.
+Full mixing on that mask then requires both `±x` slots to be `−`, so the
+`x` axis fails to be bi-colored and no pair member survives. The opposite
+corner `(1,1,1)` is the same obstruction with both unique-axis labels `−`.
+The two mixed-sign corners leave a bi-colored `x` axis free, and two pair
+members survive at each.
+
+## Theorem 2 — Two Sites Have N_agree > 0
+
+`N_pos = 2`. Unique-axis does not forbid firing at every 4-NN unread site
+of this `U`. The lex-first site with `N_agree > 0` is `v = (1,-1,1)`, and
+one agreeing 6-tuple there is `(+, −, −, 0, 0, +)`.
+
+*Proof.* Theorem 1 lists `N_agree` at the four sites. Exactly two values
+are positive, so `N_pos = 2`. Among those two sites, the lexicographic
+minimum is `(1,-1,1)`. At that site the unique-axis fragment is
+`+y = −` and `−z = +`, with `±x` ambiguous. Of the four firing 6-tuples
+on mask `(1,1,1,0,0,1)`, the two that carry those signs are
+`(+, −, −, 0, 0, +)` and `(−, +, −, 0, 0, +)`. The first of those in
+lexicographic letter order is `(+, −, −, 0, 0, +)`.
+
+Because `N_pos > 0`, it is not the case that unique-axis forbids firing at
+every 4-NN unread site of this `U`. The lex-first 4-NN unread site
+`(1,-1,-1)` remains a zero-agreement witness; the other three sites are
+part of the same residual and are not optional extras.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The four-site census and the count `N_pos = 2` are a finite report on the
+July-3 named alphabet model and one two-ball occupied set inside the
+radius-6 box. They are displayed. They are not adopted.
+
+In particular:
+
+- the unique-axis labels are not written into Admissibility;
+- no site list is written into Admissibility;
+- no unique-axis clause is written into Admissibility;
+- no axiom sentence is edited;
+- the comparison is not attached to L1.
+
+Admissibility continues to say only that there is one fixed
+nearest-neighbor rule, covariant under translations and proper cubic
+rotations, and that the local distribution varies with the
+nearest-neighbor conditions. Which unread 4-NN sites of a displayed
+two-ball union agree with occupancy-kernel unique-axis labels is not that
+rule.
+
+## What This Note Does And Does Not Claim
+
+- **It does claim** that this `U` has exactly four unread 4-NN sites in
+  the radius-6 box, that their masks, fire counts, unique-axis counts, and
+  agreement counts are the rows of Theorem 1, that `N_pos = 2`, and that
+  the lex-first positive site is `(1,-1,1)` with agreeing 6-tuple
+  `(+, −, −, 0, 0, +)`.
+- **It does not claim** leftover-char of the one-witness unique-axis
+  agreement on the lex-first 4-NN unread site. It is not leftover-char of
+  the one-witness unique-axis agreement. That residual scored only
+  `v = (1,-1,-1)`. The present residual enumerates every 4-NN unread site
+  of the same `U`.
+- **It does not adopt** a unique-axis rule or a site list as Admissibility
+  content and does not attach L1.
+- **It does not** open a larger box than `|x|,|y|,|z| ≤ 6`, replace the
+  six-neighbor stencil, select the physical condition alphabet, or decide
+  whether the framework's fixed rule is chiral.
+
+## Machine-Readable Report
+
+```text
+N_pair = 48
+N_4 = 4
+sites = [(1, -1, -1), (1, -1, 1), (1, 1, -1), (1, 1, 1)]
+masks = [(1, 1, 1, 0, 1, 0), (1, 1, 1, 0, 0, 1), (1, 1, 0, 1, 1, 0), (1, 1, 0, 1, 0, 1)]
+N_fire = [4, 4, 4, 4]
+N_unique_axis = [2, 2, 2, 2]
+N_agree = [0, 2, 2, 0]
+N_pos = 2
+lex_first_positive = (1, -1, 1)
+one_agreeing = (+, -, -, 0, 0, +)
+unique_axis_forbids_every_4nn = false
+displayed_not_adopted = true
+attached_to_L1 = false
+written_into_admissibility = false
+site_list_written_into_admissibility = false
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18585,6 +18585,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_ball_all_4nn_unique_axis_agree_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_ball_all_4nn_unique_axis_agree_2026_08_15.txt
+++ b/logs/runner-cache/two_ball_all_4nn_unique_axis_agree_2026_08_15.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py
+runner_sha256: 382f6f472e88987c2d574beeb2c29f94edb8609bc6712fa20feaafcd2f3b4db4
+input_fingerprint_sha256: 05e4fe9e22aff777ce5b5e8a94580ea8e17efe33fba94a8966c6c639647e947d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+All 4-NN unread sites of two-ball U versus unique-axis agreement
+AUDIT_INPUT_PATHS:
+  docs/TWO_BALL_ALL_4NN_UNIQUE_AXIS_AGREE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+|U|: 43
+box: |x|,|y|,|z|<=6
+N_pair: 48
+N_4: 4
+site=(1, -1, -1) mask=(1, 1, 1, 0, 1, 0) labels=(*, *, +, 0, +, 0) N_fire=4 N_unique_axis=2 N_agree=0
+site=(1, -1, 1) mask=(1, 1, 1, 0, 0, 1) labels=(*, *, -, 0, 0, +) N_fire=4 N_unique_axis=2 N_agree=2
+site=(1, 1, -1) mask=(1, 1, 0, 1, 1, 0) labels=(*, *, 0, +, -, 0) N_fire=4 N_unique_axis=2 N_agree=2
+site=(1, 1, 1) mask=(1, 1, 0, 1, 0, 1) labels=(*, *, 0, -, 0, -) N_fire=4 N_unique_axis=2 N_agree=0
+N_pos: 2
+lex_first_4nn: (1, -1, -1)
+lex_first_positive: (1, -1, 1)
+one_agreeing: (+, -, -, 0, 0, +)
+unique_axis_forbids_every_4nn: False
+PASS: audit-input-paths-exist
+PASS: audit-input-paths-static-literals
+PASS: audit-timeout-declared
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread
+PASS: source-july3-unique-pair
+PASS: score-radius-6-box-only
+PASS: proper-group-order | full=48 proper=24
+PASS: unique-chiral-pair | orbits=57 N_pair=48
+PASS: theorem-1-four-unread-4nn | N_4=4 sites=[(1, -1, -1), (1, -1, 1), (1, 1, -1), (1, 1, 1)]
+PASS: lex-first-4nn-n-agree-zero
+PASS: theorem-2-n-pos | N_pos=2 v=(1, -1, 1) c=(+, -, -, 0, 0, +)
+PASS: claim-scope-pinned
+PASS: note-report-numbers
+PASS: displayed-not-adopted
+PASS: not-attached-to-l1
+PASS: not-leftover-char-one-witness
+PASS: no-forbidden-phrases
+PASS: no-axiom-edit
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py
+++ b/scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""All 4-NN unread sites of U versus unique-axis July-3 agreement.
+
+On U = B_2(0) ∪ B_2((2,0,0)), enumerate every unread site in the
+|x|,|y|,|z| ≤ 6 box with exactly four occupied 6-NN. For each, rebuild
+the occupancy mask, count July-3 k=3 pair members on that mask, label
+unambiguous occupied neighbors by unique-axis sign, and count how many
+pair members match every unique-axis label.
+"""
+
+from __future__ import annotations
+
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / (
+    "docs/TWO_BALL_ALL_4NN_UNIQUE_AXIS_AGREE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs/MINIMAL_AXIOMS_2026-06-29.md"
+JULY3_PATH = ROOT / (
+    "docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_"
+    "OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_"
+    "BOUNDED_THEOREM_NOTE_2026-07-03.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BALL_ALL_4NN_UNIQUE_AXIS_AGREE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+
+EMPTY, PLUS, MINUS, NO_AXIS = 0, 1, 2, 3
+LETTERS = (EMPTY, PLUS, MINUS)
+LETTER_SHOW = {EMPTY: "0", PLUS: "+", MINUS: "-", NO_AXIS: "*"}
+CENTER_P = (2, 0, 0)
+RADIUS = 2
+BOX = 6
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def show_tuple(coloring: tuple[int, ...]) -> str:
+    return "(" + ", ".join(LETTER_SHOW[letter] for letter in coloring) + ")"
+
+
+def add(
+    left: tuple[int, int, int], right: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(
+    left: tuple[int, int, int], right: tuple[int, int, int] = (0, 0, 0)
+) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: tuple[int, int, int], radius: int) -> frozenset[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for offset in itertools.product(range(-radius, radius + 1), repeat=3):
+        if l1(offset) <= radius:
+            sites.append(add(center, offset))
+    return frozenset(sites)
+
+
+def occupancy_bits(
+    site: tuple[int, int, int], occupied: frozenset[tuple[int, int, int]]
+) -> tuple[int, ...]:
+    return tuple(1 if add(site, direction) in occupied else 0 for direction in DIRS)
+
+
+def dipole(bits: tuple[int, ...]) -> tuple[int, int, int]:
+    return (bits[0] - bits[1], bits[2] - bits[3], bits[4] - bits[5])
+
+
+def kernel(bits: tuple[int, ...]) -> tuple[Fraction, Fraction, Fraction]:
+    dx, dy, dz = dipole(bits)
+    return (Fraction(dx, 3), Fraction(dy, 3), Fraction(dz, 3))
+
+
+def unique_axis_label(n_vec: tuple[Fraction, Fraction, Fraction]) -> int:
+    support = [index for index, value in enumerate(n_vec) if value != 0]
+    if len(support) != 1:
+        return NO_AXIS
+    value = n_vec[support[0]]
+    if value > 0:
+        return PLUS
+    if value < 0:
+        return MINUS
+    return NO_AXIS
+
+
+def matches_unique_axis(coloring: tuple[int, ...], labels: tuple[int, ...]) -> bool:
+    for letter, label in zip(coloring, labels):
+        if label in (PLUS, MINUS) and letter != label:
+            return False
+    return True
+
+
+def det3(matrix: list[list[int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_mat(matrix: list[list[int]], vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(
+        sum(matrix[row][col] * vector[col] for col in range(3)) for row in range(3)
+    )
+
+
+def direction_perm(matrix: list[list[int]]) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[apply_mat(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def signed_permutation_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            matrix = [[0, 0, 0] for _ in range(3)]
+            for row, col in enumerate(perm):
+                matrix[row][col] = signs[row]
+            key = tuple(entry for row in matrix for entry in row)
+            if key not in seen:
+                seen.add(key)
+                records.append(
+                    {
+                        "matrix": matrix,
+                        "det": det3(matrix),
+                        "perm": direction_perm(matrix),
+                    }
+                )
+    return records
+
+
+def all_colorings() -> list[tuple[int, ...]]:
+    return list(itertools.product(LETTERS, repeat=len(DIRS)))
+
+
+def direct_orbits(perms: list[tuple[int, ...]]) -> list[set[tuple[int, ...]]]:
+    unseen = set(all_colorings())
+    orbits: list[set[tuple[int, ...]]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def fully_mixed(coloring: tuple[int, ...]) -> bool:
+    axis_bicolored = all(
+        coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3)
+    )
+    counts = sorted(coloring.count(letter) for letter in LETTERS)
+    return axis_bicolored and counts == [2, 2, 2]
+
+
+def july3_pair() -> tuple[set[tuple[int, ...]], int, int, int]:
+    records = signed_permutation_records()
+    proper_perms = [record["perm"] for record in records if record["det"] == 1]
+    inversion = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+    p_perm = direction_perm(inversion)
+    proper_orbits = direct_orbits(proper_perms)
+    orbit_id = {
+        coloring: index
+        for index, orbit in enumerate(proper_orbits)
+        for coloring in orbit
+    }
+    chiral_ids: set[int] = set()
+    for coloring in all_colorings():
+        image = act_col(p_perm, coloring)
+        if orbit_id[image] != orbit_id[coloring]:
+            chiral_ids.add(orbit_id[coloring])
+    pair = set().union(*(proper_orbits[index] for index in chiral_ids))
+    return pair, len(records), len(proper_perms), len(proper_orbits)
+
+
+def score_site(
+    site: tuple[int, int, int],
+    occupied: frozenset[tuple[int, int, int]],
+    pair: set[tuple[int, ...]],
+) -> dict[str, object]:
+    neighbor_sites = tuple(add(site, direction) for direction in DIRS)
+    mask = tuple(1 if neighbor in occupied else 0 for neighbor in neighbor_sites)
+    occupied_idx = tuple(index for index, bit in enumerate(mask) if bit == 1)
+    labels: list[int] = []
+    for neighbor, bit in zip(neighbor_sites, mask):
+        if bit == 0:
+            labels.append(EMPTY)
+            continue
+        labels.append(unique_axis_label(kernel(occupancy_bits(neighbor, occupied))))
+    labels_t = tuple(labels)
+    n_unique_axis = sum(1 for label in labels_t if label in (PLUS, MINUS))
+    fillings: list[tuple[int, ...]] = []
+    for bits in itertools.product((PLUS, MINUS), repeat=len(occupied_idx)):
+        coloring = [EMPTY] * len(DIRS)
+        for index, letter in zip(occupied_idx, bits):
+            coloring[index] = letter
+        fillings.append(tuple(coloring))
+    firing = sorted(coloring for coloring in fillings if coloring in pair)
+    agreeing = [
+        coloring for coloring in firing if matches_unique_axis(coloring, labels_t)
+    ]
+    return {
+        "site": site,
+        "mask": mask,
+        "labels": labels_t,
+        "N_fire": len(firing),
+        "N_unique_axis": n_unique_axis,
+        "N_agree": len(agreeing),
+        "firing": firing,
+        "agreeing": agreeing,
+        "occupied_neighbors": tuple(neighbor_sites[i] for i in occupied_idx),
+    }
+
+
+def box_unread_4nn(
+    occupied: frozenset[tuple[int, int, int]],
+) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for coords in itertools.product(range(-BOX, BOX + 1), repeat=3):
+        if coords in occupied:
+            continue
+        count = sum(1 for direction in DIRS if add(coords, direction) in occupied)
+        if count == 4:
+            sites.append(coords)
+    return sites
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    july3 = JULY3_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    normalized_july3 = normalize(july3)
+
+    occupied = ball((0, 0, 0), RADIUS) | ball(CENTER_P, RADIUS)
+    pair, n_signed, n_proper, n_orbits = july3_pair()
+    n_pair = len(pair)
+    four_nn = box_unread_4nn(occupied)
+    rows = [score_site(site, occupied, pair) for site in four_nn]
+    n_4 = len(rows)
+    positive = [row for row in rows if int(row["N_agree"]) > 0]
+    n_pos = len(positive)
+    lex_first_four = rows[0]["site"] if rows else None
+    lex_first_pos = positive[0]["site"] if positive else None
+    one_agreeing = positive[0]["agreeing"][0] if positive and positive[0]["agreeing"] else None
+    forbids_every = n_pos == 0
+    u_inside_box = all(max(abs(coord) for coord in site) <= BOX for site in occupied)
+
+    print("All 4-NN unread sites of two-ball U versus unique-axis agreement")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"|U|: {len(occupied)}")
+    print(f"box: |x|,|y|,|z|<={BOX}")
+    print(f"N_pair: {n_pair}")
+    print(f"N_4: {n_4}")
+    for row in rows:
+        print(
+            "site={0} mask={1} labels={2} N_fire={3} N_unique_axis={4} N_agree={5}".format(
+                row["site"],
+                row["mask"],
+                show_tuple(row["labels"]),
+                row["N_fire"],
+                row["N_unique_axis"],
+                row["N_agree"],
+            )
+        )
+    print(f"N_pos: {n_pos}")
+    print(f"lex_first_4nn: {lex_first_four}")
+    print(f"lex_first_positive: {lex_first_pos}")
+    print(
+        "one_agreeing: {0}".format(
+            show_tuple(one_agreeing) if one_agreeing is not None else None
+        )
+    )
+    print(f"unique_axis_forbids_every_4nn: {forbids_every}")
+
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-paths-static-literals",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_BALL_ALL_4NN_UNIQUE_AXIS_AGREE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-unread",
+        unread_sentence in normalized_axiom and unread_sentence in note,
+    )
+    checks.check(
+        "source-july3-unique-pair",
+        "exactly one" in normalized_july3
+        and "chiral pair" in normalized_july3
+        and "handed fully-mixed" in normalized_note
+        and "exactly one chiral pair" in normalized_note,
+    )
+
+    checks.check(
+        "score-radius-6-box-only",
+        BOX == 6
+        and u_inside_box
+        and all(max(abs(coord) for coord in row["site"]) <= BOX for row in rows)
+        and "radius-6 box" in normalized_note
+        and "|x|,|y|,|z| ≤ 6" in note,
+    )
+    checks.check(
+        "proper-group-order",
+        n_signed == 48 and n_proper == 24,
+        f"full={n_signed} proper={n_proper}",
+    )
+    checks.check(
+        "unique-chiral-pair",
+        n_orbits == 57 and n_pair == 48 and all(fully_mixed(item) for item in pair),
+        f"orbits={n_orbits} N_pair={n_pair}",
+    )
+
+    expected_sites = ((1, -1, -1), (1, -1, 1), (1, 1, -1), (1, 1, 1))
+    expected_masks = {
+        (1, -1, -1): (1, 1, 1, 0, 1, 0),
+        (1, -1, 1): (1, 1, 1, 0, 0, 1),
+        (1, 1, -1): (1, 1, 0, 1, 1, 0),
+        (1, 1, 1): (1, 1, 0, 1, 0, 1),
+    }
+    expected_labels = {
+        (1, -1, -1): (NO_AXIS, NO_AXIS, PLUS, EMPTY, PLUS, EMPTY),
+        (1, -1, 1): (NO_AXIS, NO_AXIS, MINUS, EMPTY, EMPTY, PLUS),
+        (1, 1, -1): (NO_AXIS, NO_AXIS, EMPTY, PLUS, MINUS, EMPTY),
+        (1, 1, 1): (NO_AXIS, NO_AXIS, EMPTY, MINUS, EMPTY, MINUS),
+    }
+    expected_agree = {
+        (1, -1, -1): 0,
+        (1, -1, 1): 2,
+        (1, 1, -1): 2,
+        (1, 1, 1): 0,
+    }
+    site_ok = (
+        n_4 == 4
+        and tuple(row["site"] for row in rows) == expected_sites
+        and all(row["mask"] == expected_masks[row["site"]] for row in rows)
+        and all(row["labels"] == expected_labels[row["site"]] for row in rows)
+        and all(row["N_fire"] == 4 for row in rows)
+        and all(row["N_unique_axis"] == 2 for row in rows)
+        and all(row["N_agree"] == expected_agree[row["site"]] for row in rows)
+    )
+    checks.check(
+        "theorem-1-four-unread-4nn",
+        site_ok and len(occupied) == 43,
+        f"N_4={n_4} sites={[row['site'] for row in rows]}",
+    )
+    checks.check(
+        "lex-first-4nn-n-agree-zero",
+        lex_first_four == (1, -1, -1)
+        and rows[0]["N_agree"] == 0
+        and rows[0]["mask"] == (1, 1, 1, 0, 1, 0),
+    )
+    expected_one = (PLUS, MINUS, MINUS, EMPTY, EMPTY, PLUS)
+    checks.check(
+        "theorem-2-n-pos",
+        n_pos == 2
+        and lex_first_pos == (1, -1, 1)
+        and one_agreeing == expected_one
+        and forbids_every is False
+        and expected_one in positive[0]["agreeing"],
+        f"N_pos={n_pos} v={lex_first_pos} c={show_tuple(one_agreeing) if one_agreeing else None}",
+    )
+
+    claim_scope = (
+        "On U=B_2(0)∪B_2((2,0,0)) inside the radius-6 box, whether any "
+        "unread 4-occupied-NN site has a July-3 pair member agreeing with "
+        "that site’s unique-axis labels is reported. Displayed, not adopted."
+    )
+    checks.check("claim-scope-pinned", claim_scope in note)
+    checks.check(
+        "note-report-numbers",
+        "N_4 = 4" in note
+        and "N_pos = 2" in note
+        and "N_pair = 48" in note
+        and "lex_first_positive = (1, -1, 1)" in note
+        and "one_agreeing = (+, -, -, 0, 0, +)" in note
+        and "unique_axis_forbids_every_4nn = false" in note
+        and "N_agree = [0, 2, 2, 0]" in note
+        and "N_fire = [4, 4, 4, 4]" in note
+        and "N_unique_axis = [2, 2, 2, 2]" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "displayed, not adopted" in normalized_note
+        and "not written into Admissibility" in normalized_note
+        and "written_into_admissibility = false" in note
+        and "Do not write a site list into Admissibility" in note
+        and "site_list_written_into_admissibility = false" in note,
+    )
+    checks.check(
+        "not-attached-to-l1",
+        "not attached to L1" in normalized_note
+        and "attached_to_L1 = false" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "not-leftover-char-one-witness",
+        "not leftover-char of the one-witness unique-axis agreement" in normalized_note
+        and "lex-first 4-NN unread site" in normalized_note
+        and "does not stop at the lex-first witness" in normalized_note,
+    )
+    checks.check(
+        "no-forbidden-phrases",
+        all(phrase not in note and phrase not in axiom for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "does not add a unique-axis clause" in normalized_note
+        and "unique-axis" not in axiom
+        and "site list" not in axiom
+        and axiom.count("B_2") == 0,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On U=B2(0)∪B2((2,0,0)), four unread 4-NN sites. N_agree is 0,2,2,0. N_pos=2. Lex-first positive site (1,-1,1) with agreeing 6-tuple (+,-,-,0,0,+). The original witness (1,-1,-1) still has N_agree=0. Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_ball_all_4nn_unique_axis_agree_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.