### PR TITLE
feat(posrun): pair fires at unique-axis-compatible two-ball site

### DIFF
--- a/docs/TWO_BALL_POSITIVE_SITE_CHIRAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_BALL_POSITIVE_SITE_CHIRAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,246 @@
+---
+claim_id: two_ball_positive_site_chiral_execution_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On U=B_2(0)∪B_2((2,0,0)) at unread v=(1,−1,1), whether the agreeing 6-tuple (+,−,−,0,0,+) is unique-axis compatible and fires the July-3 k=3 pair is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/two_ball_positive_site_chiral_execution_2026_08_15.py
+---
+
+# Two-Ball Positive-Site Chiral Execution (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact ℓ¹ two-ball occupancy on `U = B_2(0) ∪ B_2((2,0,0))` and
+one unread six-neighbor star at `v = (1,−1,1)`. The July-3 `k = 3` pair is
+reconstructed as a formation predicate on `{0,+,−}^6` and executed at `v`
+only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_ball_positive_site_chiral_execution_2026_08_15.py`](../scripts/two_ball_positive_site_chiral_execution_2026_08_15.py)
+
+Framework context on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) and the
+July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+Qubit remains `M_2(C)`.
+
+## Result Up Front
+
+Treat `U` as already locked. The site `v = (1,−1,1)` is unread: it lies in
+neither radius-two ℓ¹ ball. Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+The four occupied nearest neighbors of `v` in `U` are `+x`, `−x`, `+y`, and
+`−z`. The two empty slots are `−y` and `+z`. The displayed 6-tuple
+
+`c = (+, −, −, 0, 0, +)`
+
+has exactly that occupancy mask.
+
+The occupancy kernel on `U` assigns a unique-axis label to a neighbor `w`
+when the dipole `n = d/3` at `w` has exactly one nonzero component; the
+label is the sign of that component. On this star the unique-axis fragment
+is
+
+`(*, *, −, 0, 0, +)`,
+
+with `*` marking an ambiguous occupied neighbor. The two unambiguous occupied
+slots agree with `c`. Empty slots remain `0`.
+
+The July-3 unique `k = 3` chiral pair is the two proper-cubic orbits of
+handed fully-mixed 6-tuples. It has 48 members. The tuple `c` is one of
+them, so the pair fires at unread `v`. Execution at this star alone yields
+
+`N_new = 1`,
+
+and the new lock is `v`. Every site of `U` remains locked. The center `v`
+was not already in `U`.
+
+This is a displayed rival execution, not adopted. The 6-tuple `c` is not
+written into Admissibility. Do not attach L1. Occupancy-only formation
+(`n ≠ 0`) is not attached. The report is an execution at one
+unique-axis-compatible site, not a census of every
+four-occupied-neighbor unread site of `U`.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither the 6-tuple `c` nor the July-3 pair as the
+framework's fixed rule. Record permanence is used only to keep the locks on
+`U` after the displayed tick at `v`. Formation site and rate remain outside
+the axiom memo. Qubit remains `M_2(C)`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact ℓ¹ geometry on one two-ball union, unique-axis signs on one six-neighbor star, and membership of one 6-tuple in the reconstructed July-3 k=3 pair. Displayed execution only."
+trace_class: upstream_support
+target_claim_id: admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+target_blocker_text: "whether a unique-axis-compatible 6-tuple at an unread two-ball site can fire the July-3 k=3 pair"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the pair and the 6-tuple displayed; do not write them into Admissibility and do not attach occupancy-only formation."
+conditional_surface_status: "exact on U=B_2(0)∪B_2((2,0,0)) at unread v=(1,−1,1) for the agreeing 6-tuple (+,−,−,0,0,+); not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)` and `p = (2,0,0)`. The closed ℓ¹ ball of radius two is
+
+`B_2(q) = {x ∈ Z^3 : |x − q|_1 ≤ 2}`.
+
+The locked set is the already-given union
+
+`U = B_2(0) ∪ B_2((2,0,0))`.
+
+The runner enumerates a box large enough to contain both balls and obtains
+`|U| = 43`. The unread site is
+
+`v = (1,−1,1)`.
+
+Then `|v|_1 = 3` and `|v − p|_1 = 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` |
+|---|---|---|
+| `+x` | `(2,−1,1)` | yes |
+| `−x` | `(0,−1,1)` | yes |
+| `+y` | `(1,0,1)` | yes |
+| `−y` | `(1,−2,1)` | no |
+| `+z` | `(1,−1,2)` | no |
+| `−z` | `(1,−1,0)` | yes |
+
+Occupancy mask at `v`:
+
+`m = (1, 1, 1, 0, 0, 1)`.
+
+Letters are `{0, +, −}` with `0` empty/unread. The displayed 6-tuple is
+
+`c = (+, −, −, 0, 0, +)`.
+
+Its support is exactly `m`.
+
+At a site `w`, the occupancy 6-tuple of its neighbors inside `U` determines
+the dipole
+
+`d_μ = occ(w + e_μ) − occ(w − e_μ)`, `n = d/3`.
+
+If exactly one component of `n` is nonzero, the unique-axis label of `w` is
+the sign of that component. Otherwise the occupied neighbor is ambiguous.
+
+The July-3 pair is reconstructed, not imported as a table. Letters `{0,1,2}`
+with `0` empty, `1 = +`, and `2 = −` color the six axis directions. The
+proper cubic group `G+` is the 24 determinant-`+1` signed permutation
+matrices acting on those directions. Spatial inversion `P = −I` exchanges
+`+μ` with `−μ`. A `G+`-orbit is chiral when `P` sends it to a different
+`G+`-orbit. At three letters there is exactly one such pair; its two orbits
+have 24 members each. The formation predicate `f` is membership in that
+48-element set. Do not overwrite existing locks.
+
+## Theorem 1 — Unique-axis fragment agrees with `c`; `U` persists
+
+The occupancy dipoles on the four occupied neighbors are exact:
+
+| neighbor | occupancy 6-tuple | `d` | unique-axis |
+|---|---|---|---|
+| `(2,−1,1)` | `(0,0,1,0,0,1)` | `(0, 1, −1)` | ambiguous |
+| `(0,−1,1)` | `(0,0,1,0,0,1)` | `(0, 1, −1)` | ambiguous |
+| `(1,0,1)` | `(1,1,0,0,0,1)` | `(0, 0, −1)` | `−` |
+| `(1,−1,0)` | `(1,1,1,0,0,0)` | `(0, 1, 0)` | `+` |
+
+The unique-axis fragment at `v` is therefore
+
+`(*, *, −, 0, 0, +)`.
+
+Every unambiguous occupied neighbor matches the corresponding slot of `c`.
+Empty neighbors remain empty. The star center `v` is not already in `U`.
+After the displayed lock of `v`, the set `U` is still locked: records on
+`U` are permanent, and the execution does not unlock them.
+
+## Theorem 2 — The July-3 pair fires at `v`
+
+The reconstructed pair has `N_pair = 48`. Under the letter map
+`0 ↦ 0`, `+ ↦ 1`, `− ↦ 2`,
+
+`c ≡ (1, 2, 2, 0, 0, 1)`
+
+is a pair member. It is fully mixed: each axis is bi-colored and each letter
+appears twice. Scoring only `U` and the star at `v`, the pair fires at the
+single unread center, so
+
+`N_new = 1`
+
+and the new lock is `v`. The post-tick locked set is `U ∪ {v}`.
+
+This is an execution of one agreeing 6-tuple. It is not a census of every
+four-occupied-neighbor unread site of `U`.
+
+## Theorem 3 — Displayed rival execution, not adopted
+
+The predicate `f` and the 6-tuple `c` are displayed member data. They are
+not the framework's fixed Admissibility rule. This note does not write `c`
+into Admissibility. Do not attach L1. Occupancy-only formation (the
+`n ≠ 0` gate) is not attached. Qubit remains `M_2(C)`. No approved primitive
+is added.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On this `U`, at this unread `v`, the given 6-tuple is
+  unique-axis compatible on every unambiguous occupied neighbor, is a
+  July-3 `k = 3` pair member, and fires with `N_new = 1` while `U` persists.
+- **What is displayed only.** The pair, the letter identification
+  `{+, −}`, and the execution at `v` are one rival member. They are not
+  adopted.
+- **What is not claimed.** No census of all four-occupied-neighbor unread
+  sites; no attachment of occupancy-only formation; no axiom edit; no
+  formation rate; no lattice-wide dynamics; no claim that Admissibility
+  selects `c`.
+- **Mutation controls.** A unique-axis disagreement on `+y` or `−z` fails.
+  Non-membership of `c` in the pair fails. `N_new ≠ 1` fails. A note that
+  adopts `c` as axiom text, attaches occupancy-only formation, or authors
+  an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, unique-axis signs,
+the July-3 pair, the fire at `v`, permanence of `U`, the current premise
+boundary, and the mutation controls. It writes no cache and authors no
+audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18585,6 +18585,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_ball_positive_site_chiral_execution_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_ball_positive_site_chiral_execution_2026_08_15.txt
+++ b/logs/runner-cache/two_ball_positive_site_chiral_execution_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/two_ball_positive_site_chiral_execution_2026_08_15.py
+runner_sha256: 532e245cd31fbe46acf63298a5c2866774c1720238b8a6c92896523362a3fa7e
+input_fingerprint_sha256: 11ef5c3063afbb289c6bffeb3cb203253cd8165fae7dbd55cfe1334b11f9efd9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Qubit, Admissibility, and Record sentences plus the July-3 pair construction reconstructed locally
+integrity_reads: this runner, its note, and the current axiom memo; no cache written
+construction: U=B_2(0)∪B_2((2,0,0)), unread v=(1,−1,1), 6-tuple (+,−,−,0,0,+)
+negative_scope: displayed rival execution only; not adopted; L1 not attached
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-qubit Qubit remains M_2(C)
+PASS: source-record lock, permanence, content-only readout, and unreadability at absence are pinned
+U_card=43
+v_in_U=False
+occupancy_mask=(1, 1, 1, 0, 0, 1)
+displayed_c=(+,−,−,0,0,+)
+unique_axis_fragment=(*,*,−,0,0,+)
+N_pair=48
+c_is_pair_member=True
+N_new=1
+new_lock=(1, -1, 1)
+U_persists=True
+PASS: center-unread the star center v is not already in U
+PASS: u-cardinality the two radius-two balls union to 43 locked sites
+PASS: occupancy-mask occupied nearest neighbors of v are exactly +x,−x,+y,−z
+PASS: unique-axis-fragment unique-axis labels are ambiguous, ambiguous, −, 0, 0, +
+PASS: theorem-1-agreement c agrees with every unambiguous occupied unique-axis label
+PASS: pair-census the reconstructed July-3 k=3 pair has 48 members in one chiral pair
+PASS: theorem-2-member c is a pair member
+PASS: theorem-2-fire the pair fires at v with N_new=1 and new lock v
+PASS: theorem-1-permanence every lock in U persists after the displayed tick
+PASS: claim-scope the note reports the declared displayed claim_scope
+PASS: displayed-not-adopted the note keeps the execution displayed and not adopted
+PASS: l1-not-attached the note does not attach L1
+PASS: not-all4-census the note is an execution at v, not a leftover all-site census
+PASS: forbidden-absent the note avoids the dispatch-forbidden phrases
+PASS: canonical-nonmutation the axiom memo does not contain the displayed 6-tuple or pair as axiom text
+per_element: unique-axis signs, pair membership, and N_new are exact integers
+per_site: only the unread star center v is executed
+per_mode: no spectral calculation
+per_block: U and the six-neighbor star at v only
+lattice_wide: checked and not executed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_ball_positive_site_chiral_execution_2026_08_15.py
+++ b/scripts/two_ball_positive_site_chiral_execution_2026_08_15.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Execute the July-3 k=3 pair at one unique-axis-compatible two-ball site.
+
+U = B_2(0) ∪ B_2((2,0,0)) is treated as already locked. The unread center is
+v = (1, −1, 1). The displayed 6-tuple is c = (+, −, −, 0, 0, +). The runner
+rebuilds unique-axis signs on the star at v, reconstructs the July-3 pair,
+and reports fire, permanence of U, and unique-axis agreement. Displayed, not
+adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "TWO_BALL_POSITIVE_SITE_CHIRAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BALL_POSITIVE_SITE_CHIRAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+V: Point = (1, -1, 1)
+P_SHIFT: Point = (2, 0, 0)
+C: Coloring = (PLUS, MINUS, MINUS, EMPTY, EMPTY, PLUS)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def ball(center: Point, radius: int) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for x, y, z in itertools.product(span, repeat=3):
+        site = add(center, (x, y, z))
+        if l1(sub(site, center)) <= radius:
+            sites.add(site)
+    return frozenset(sites)
+
+
+def locked_union() -> frozenset[Point]:
+    return ball((0, 0, 0), 2) | ball(P_SHIFT, 2)
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def dipole(occ: Coloring) -> tuple[Fraction, Fraction, Fraction]:
+    return (
+        Fraction(occ[0] - occ[1], 3),
+        Fraction(occ[2] - occ[3], 3),
+        Fraction(occ[4] - occ[5], 3),
+    )
+
+
+def unique_axis_label(n: tuple[Fraction, Fraction, Fraction]) -> int | None:
+    support = [index for index, value in enumerate(n) if value != 0]
+    if len(support) != 1:
+        return None
+    return PLUS if n[support[0]] > 0 else MINUS
+
+
+def unique_axis_fragment(center: Point, occupied: frozenset[Point]) -> tuple[int | None, ...]:
+    labels: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(center, direction)
+        if neighbor not in occupied:
+            labels.append(EMPTY)
+            continue
+        label = unique_axis_label(dipole(occupancy_tuple(neighbor, occupied)))
+        labels.append(label)
+    return tuple(labels)
+
+
+def agrees_unique_axis(fragment: tuple[int | None, ...], coloring: Coloring) -> bool:
+    for slot, displayed in zip(fragment, coloring, strict=True):
+        if slot is None:
+            if displayed == EMPTY:
+                return False
+            continue
+        if slot != displayed:
+            return False
+    return True
+
+
+def det3(matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+    vector: Point,
+) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring) -> Coloring:
+    out = [0] * 6
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def cubic_signed_permutations() -> tuple[
+    list[tuple[int, ...]],
+    list[tuple[int, ...]],
+    tuple[int, ...],
+]:
+    records: list[tuple[tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]], int]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            key = tuple(value for row in matrix for value in row)
+            if key not in seen:
+                seen.add(key)
+                records.append((matrix, det3(matrix)))
+    proper = [direction_perm(matrix) for matrix, det in records if det == 1]
+    full = [direction_perm(matrix) for matrix, _det in records]
+    inversion = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    return proper, full, direction_perm(inversion)
+
+
+def july3_k3_pair() -> frozenset[Coloring]:
+    proper, _full, inversion = cubic_signed_permutations()
+    unseen = set(itertools.product((EMPTY, PLUS, MINUS), repeat=6))
+    orbits: list[set[Coloring]] = []
+    ids: dict[Coloring, int] = {}
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in proper}
+        index = len(orbits)
+        orbits.append(orbit)
+        unseen -= orbit
+        for coloring in orbit:
+            ids[coloring] = index
+    pair: set[Coloring] = set()
+    seen_pairs: set[tuple[int, int]] = set()
+    for index, orbit in enumerate(orbits):
+        sample = next(iter(orbit))
+        image = ids[act_col(inversion, sample)]
+        if image == index:
+            continue
+        key = tuple(sorted((index, image)))
+        if key in seen_pairs:
+            continue
+        seen_pairs.add(key)
+        pair |= orbits[index]
+        pair |= orbits[image]
+    if len(seen_pairs) != 1:
+        raise RuntimeError(f"expected one chiral pair, found {len(seen_pairs)}")
+    return frozenset(pair)
+
+
+def pair_fires(coloring: Coloring, pair: frozenset[Coloring]) -> bool:
+    return coloring in pair
+
+
+def execute_at_v(
+    occupied: frozenset[Point],
+    center: Point,
+    coloring: Coloring,
+    pair: frozenset[Coloring],
+) -> tuple[int, frozenset[Point]]:
+    if center in occupied:
+        return 0, occupied
+    if not pair_fires(coloring, pair):
+        return 0, occupied
+    return 1, occupied | {center}
+
+
+def format_tuple(coloring: Coloring) -> str:
+    return "(" + ",".join(LETTER[slot] for slot in coloring) + ")"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current Lattice, Qubit, Admissibility, "
+        "and Record sentences plus the July-3 pair construction reconstructed locally"
+    )
+    print("integrity_reads: this runner, its note, and the current axiom memo; no cache written")
+    print("construction: U=B_2(0)∪B_2((2,0,0)), unread v=(1,−1,1), 6-tuple (+,−,−,0,0,+)")
+    print("negative_scope: displayed rival execution only; not adopted; L1 not attached")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_BALL_POSITIVE_SITE_CHIRAL_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "it does not supply the formation site, probability,"
+    qubit_sentence = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_perm = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalized_axiom and admissibility_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in note,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit remains M_2(C)",
+        qubit_sentence in normalized_axiom
+        and qubit_sentence in note
+        and "Qubit remains `M_2(C)`" in note,
+    )
+    checks.check(
+        "source-record",
+        "lock, permanence, content-only readout, and unreadability at absence are pinned",
+        all(
+            phrase in normalized_axiom
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        )
+        and all(phrase in note for phrase in (record_lock, record_perm, record_content, record_absence)),
+    )
+
+    occupied = locked_union()
+    mask = occupancy_tuple(V, occupied)
+    fragment = unique_axis_fragment(V, occupied)
+    pair = july3_k3_pair()
+    n_new, locked_after = execute_at_v(occupied, V, C, pair)
+
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"occupancy_mask={mask}")
+    print(f"displayed_c={format_tuple(C)}")
+    print(
+        "unique_axis_fragment="
+        + "("
+        + ",".join("*" if slot is None else LETTER[slot] for slot in fragment)
+        + ")"
+    )
+    print(f"N_pair={len(pair)}")
+    print(f"c_is_pair_member={C in pair}")
+    print(f"N_new={n_new}")
+    print(f"new_lock={V if n_new == 1 else None}")
+    print(f"U_persists={occupied <= locked_after}")
+
+    checks.check(
+        "center-unread",
+        "the star center v is not already in U",
+        V not in occupied and l1(V) == 3 and l1(sub(V, P_SHIFT)) == 3,
+        residual=V in occupied,
+    )
+    checks.check(
+        "u-cardinality",
+        "the two radius-two balls union to 43 locked sites",
+        len(occupied) == 43 and len(ball((0, 0, 0), 2)) == 25 and len(ball(P_SHIFT, 2)) == 25,
+    )
+    checks.check(
+        "occupancy-mask",
+        "occupied nearest neighbors of v are exactly +x,−x,+y,−z",
+        mask == (1, 1, 1, 0, 0, 1) and mask == tuple(int(slot != EMPTY) for slot in C),
+    )
+    checks.check(
+        "unique-axis-fragment",
+        "unique-axis labels are ambiguous, ambiguous, −, 0, 0, +",
+        fragment == (None, None, MINUS, EMPTY, EMPTY, PLUS),
+    )
+    checks.check(
+        "theorem-1-agreement",
+        "c agrees with every unambiguous occupied unique-axis label",
+        agrees_unique_axis(fragment, C),
+    )
+    checks.check(
+        "pair-census",
+        "the reconstructed July-3 k=3 pair has 48 members in one chiral pair",
+        len(pair) == 48
+        and all(coloring.count(EMPTY) == 2 for coloring in pair)
+        and all(len({coloring[0], coloring[1]}) == 2 for coloring in pair)
+        and all(len({coloring[2], coloring[3]}) == 2 for coloring in pair)
+        and all(len({coloring[4], coloring[5]}) == 2 for coloring in pair),
+    )
+    checks.check(
+        "theorem-2-member",
+        "c is a pair member",
+        pair_fires(C, pair),
+    )
+    checks.check(
+        "theorem-2-fire",
+        "the pair fires at v with N_new=1 and new lock v",
+        n_new == 1 and locked_after == occupied | {V} and V in locked_after,
+    )
+    checks.check(
+        "theorem-1-permanence",
+        "every lock in U persists after the displayed tick",
+        occupied <= locked_after and len(locked_after) == len(occupied) + 1,
+    )
+
+    claim_scope = (
+        "On U=B_2(0)∪B_2((2,0,0)) at unread v=(1,−1,1), whether the agreeing "
+        "6-tuple (+,−,−,0,0,+) is unique-axis compatible and fires the July-3 "
+        "k=3 pair is reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the declared displayed claim_scope",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note keeps the execution displayed and not adopted",
+        "Displayed rival execution, not adopted" in note
+        and "does not write `c` into Admissibility" in normalized_note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "the note does not attach L1",
+        "Do not attach L1" in note
+        and "not attached" in normalized_note
+        and "we attach L1" not in normalized_note,
+    )
+    checks.check(
+        "not-all4-census",
+        "the note is an execution at v, not a leftover all-site census",
+        "not a census of every four-occupied-neighbor" in normalized_note,
+    )
+    checks.check(
+        "forbidden-absent",
+        "the note avoids the dispatch-forbidden phrases",
+        all(phrase not in note for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo does not contain the displayed 6-tuple or pair as axiom text",
+        "(+,−,−,0,0,+)" not in axiom
+        and "July-3 k=3 pair" not in axiom
+        and "we adopt" not in normalized_note.lower(),
+    )
+
+    print("per_element: unique-axis signs, pair membership, and N_new are exact integers")
+    print("per_site: only the unread star center v is executed")
+    print("per_mode: no spectral calculation")
+    print("per_block: U and the six-neighbor star at v only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On U=B2(0)∪B2((2,0,0)) at unread v=(1,-1,1), the agreeing 6-tuple (+,-,-,0,0,+) matches unique-axis labels and is a July-3 k=3 pair member. The pair fires: N_new=1, new lock is v. U persists. Displayed rival execution, not adopted. No axiom edit.

## Runner

`scripts/two_ball_positive_site_chiral_execution_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.