### PR TITLE
feat(ambpick): lex-first axis pick does not fire; two of four completions do

### DIFF
--- a/docs/TWO_BALL_AMBIGUOUS_SLOT_LOCAL_PICK_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_BALL_AMBIGUOUS_SLOT_LOCAL_PICK_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,292 @@
+---
+claim_id: two_ball_ambiguous_slot_local_pick_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On U at unread v=(1,−1,1), whether any of the 4 unique-axis-respecting completions of the two ambiguous slots is a July-3 pair member, and whether the lex-first-nonzero-axis completion is among them, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py
+---
+
+# Two-Ball Ambiguous-Slot Local Pick (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact ℓ¹ two-ball occupancy on `U = B_2(0) ∪ B_2((2,0,0))` and
+one unread six-neighbor star at `v = (1,−1,1)`. Unique-axis slots stay
+fixed. The two ambiguous occupied neighbors are completed in all four
+`{+,−}` ways and compared to the reconstructed July-3 `k = 3` pair. One
+displayed local function of those neighbors' occupancy kernels is scored:
+the sign of the lex-first nonzero axis of `n`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py`](../scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py)
+
+Framework context on `origin/main`: the axiom memo
+[`docs/MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) and the
+July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+Qubit remains `M_2(C)`.
+
+## Result Up Front
+
+Treat `U` as already locked. The site `v = (1,−1,1)` is unread: it lies in
+neither radius-two ℓ¹ ball. Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+The four occupied nearest neighbors of `v` in `U` are `+x`, `−x`, `+y`, and
+`−z`. The two empty slots are `−y` and `+z`. Occupancy mask
+
+`m = (1, 1, 1, 0, 0, 1)`.
+
+The occupancy kernel on `U` assigns a unique-axis label to a neighbor `w`
+when the dipole `n = d/3` at `w` has exactly one nonzero component; the
+label is the sign of that component. On this star the unique-axis fragment
+is
+
+`(*, *, −, 0, 0, +)`,
+
+with `*` marking an occupied neighbor whose `|supp n| ≠ 1`. Unique-axis
+slots stay fixed: `+y = −` and `−z = +`. Empty slots stay `0`.
+
+The two ambiguous occupied neighbors are `+x = (2,−1,1)` and
+`−x = (0,−1,1)`. Each has the same kernel
+
+`n = (0, 1/3, −1/3)`.
+
+Lex-first nonzero axis of that `n` is `y`, with sign `+`. The pair of
+signs of the two nonzero components is `(+, −)`.
+
+The four unique-axis-respecting completions are the four `{+,−}` fillings
+of the two `*` slots. Exactly `N_fire = 2` of them are July-3 pair
+members. The firing completions are
+
+`(+,−,−,0,0,+)`
+
+and
+
+`(−,+,−,0,0,+)`.
+
+The lex-first-nonzero-axis sign completion is
+
+`(+,+,−,0,0,+)`,
+
+which is not a pair member. It is not among the firing completions.
+
+This is not leftover-char of the one-tuple execution that locked `v` with
+one chosen pair member. The present residual is the four-way completion
+census of the two ambiguous slots and the comparison to one displayed
+local function of those two neighbors' `n`.
+
+The comparison is displayed, not adopted. This note does not write a
+tie-break into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither a local pick of the two ambiguous slots nor
+the July-3 pair as the framework's fixed rule. Record permanence is used
+only to treat the locks on `U` as already given. Formation site and rate
+remain outside the axiom memo. Qubit remains `M_2(C)`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact ℓ¹ geometry on one two-ball union, four unique-axis-respecting completions of two ambiguous slots on one six-neighbor star, and membership of those completions in the reconstructed July-3 k=3 pair. Displayed local function only."
+trace_class: upstream_support
+target_claim_id: admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+target_blocker_text: "among the 4 unique-axis-respecting completions of the two ambiguous slots at unread v=(1,−1,1), how many are July-3 pair members, and whether the lex-first-nonzero-axis completion is among them"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the four completions and the lex-first local function displayed; do not write a tie-break into Admissibility and do not attach L1."
+conditional_surface_status: "exact on U=B_2(0)∪B_2((2,0,0)) at unread v=(1,−1,1) for the four unique-axis-respecting completions; not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)` and `p = (2,0,0)`. The closed ℓ¹ ball of radius two is
+
+`B_2(q) = {x ∈ Z^3 : |x − q|_1 ≤ 2}`.
+
+The locked set is the already-given union
+
+`U = B_2(0) ∪ B_2((2,0,0))`.
+
+The runner enumerates a box large enough to contain both balls and obtains
+`|U| = 43`. The unread site is
+
+`v = (1,−1,1)`.
+
+Then `|v|_1 = 3` and `|v − p|_1 = 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` |
+|---|---|---|
+| `+x` | `(2,−1,1)` | yes |
+| `−x` | `(0,−1,1)` | yes |
+| `+y` | `(1,0,1)` | yes |
+| `−y` | `(1,−2,1)` | no |
+| `+z` | `(1,−1,2)` | no |
+| `−z` | `(1,−1,0)` | yes |
+
+Occupancy mask at `v`:
+
+`m = (1, 1, 1, 0, 0, 1)`.
+
+Letters are `{0, +, −}` with `0` empty/unread.
+
+At a site `w`, the occupancy 6-tuple of its neighbors inside `U` determines
+the dipole
+
+`d_μ = occ(w + e_μ) − occ(w − e_μ)`, `n = d/3`.
+
+If exactly one component of `n` is nonzero, the unique-axis label of `w` is
+the sign of that component. Otherwise the occupied neighbor is ambiguous.
+The lex-first nonzero axis of `n` is the first axis in order `(x, y, z)`
+with nonzero component; its sign is the displayed single-letter local
+function of `n`. The pair of signs of `n` is the ordered tuple of signs of
+the nonzero components, in that same axis order. Both objects are
+displayed. Neither is written into Admissibility.
+
+The July-3 pair is reconstructed, not imported as a table. Letters `{0,1,2}`
+with `0` empty, `1 = +`, and `2 = −` color the six axis directions. The
+proper cubic group `G+` is the 24 determinant-`+1` signed permutation
+matrices acting on those directions. Spatial inversion `P = −I` exchanges
+`+μ` with `−μ`. A `G+`-orbit is chiral when `P` sends it to a different
+`G+`-orbit. At three letters there is exactly one such pair; its two orbits
+have 24 members each. The formation predicate `f` is membership in that
+48-element set. Do not overwrite existing locks.
+
+## Theorem 1 — Four completions; `N_fire = 2`
+
+The occupancy dipoles on the four occupied neighbors are exact:
+
+| neighbor | occupancy 6-tuple | `d` | unique-axis |
+|---|---|---|---|
+| `(2,−1,1)` | `(0,0,1,0,0,1)` | `(0, 1, −1)` | ambiguous |
+| `(0,−1,1)` | `(0,0,1,0,0,1)` | `(0, 1, −1)` | ambiguous |
+| `(1,0,1)` | `(1,1,0,0,0,1)` | `(0, 0, −1)` | `−` |
+| `(1,−1,0)` | `(1,1,1,0,0,0)` | `(0, 1, 0)` | `+` |
+
+The unique-axis fragment at `v` is therefore
+
+`(*, *, −, 0, 0, +)`.
+
+The four unique-axis-respecting completions, and pair membership, are
+
+| completion | pair member |
+|---|---|
+| `(+,+,−,0,0,+)` | no |
+| `(+,−,−,0,0,+)` | yes |
+| `(−,+,−,0,0,+)` | yes |
+| `(−,−,−,0,0,+)` | no |
+
+So `N_fire = 2`. The firing completions are
+
+`(+,−,−,0,0,+)`
+
+and
+
+`(−,+,−,0,0,+)`.
+
+The reconstructed pair has `N_pair = 48`. Scoring only `U` and the star at
+`v`. The center `v` is not already in `U`.
+
+## Theorem 2 — Lex-first-nonzero-axis completion is not among them
+
+Both ambiguous neighbors have the same kernel
+
+`n = (0, 1/3, −1/3)`.
+
+For each, the lex-first nonzero axis is `y` and the sign of that component
+is `+`. The pair of signs of `n` is `(+, −)` at both neighbors.
+
+Filling each ambiguous slot by the lex-first-nonzero-axis sign therefore
+gives the single completion
+
+`c_lex = (+,+,−,0,0,+)`.
+
+That completion is not a pair member. It is not equal to either firing
+completion of Theorem 1.
+
+The pair of signs of `n` is a two-component pattern, not a single `{+,−}`
+slot label. Both neighbors carry the same pattern. Any single-letter local
+function of `n` alone therefore assigns the same letter to both ambiguous
+slots. Both firing completions assign opposite letters to those two slots.
+No such local function of the two neighbors' `n` equals a firing
+completion.
+
+The lex-first rule and the pair of signs are displayed local functions.
+They are not adopted as a pick.
+
+## Theorem 3 — Displayed, not adopted
+
+The four completions, the count `N_fire`, the lex-first-nonzero-axis
+completion, and the pair of signs of `n` are displayed member data. They
+are not the framework's fixed Admissibility rule. This note does not write
+a tie-break into Admissibility. Do not attach L1. Occupancy-only formation
+(the `n ≠ 0` gate) is not attached. Qubit remains `M_2(C)`. No approved
+primitive is added.
+
+This note is not leftover-char of the one-tuple execution that chose one
+pair member at this same unread site.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On this `U`, at this unread `v`, exactly two of the
+  four unique-axis-respecting completions of the two ambiguous slots are
+  July-3 `k = 3` pair members, and the lex-first-nonzero-axis sign
+  completion is not among them.
+- **What is displayed only.** The pair, the letter identification
+  `{+, −}`, the four completions, and the lex-first local function are
+  one rival comparison. They are not adopted.
+- **What is not claimed.** No attachment of a local pick to Admissibility;
+  no attachment of occupancy-only formation; no axiom edit; no formation
+  rate; no lattice-wide dynamics; no claim that Admissibility selects
+  either firing completion.
+- **Mutation controls.** `N_fire ≠ 2` fails. Membership of the lex-first
+  completion in the pair fails. A note that writes a tie-break into
+  Admissibility, attaches L1, or authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, unique-axis signs, the
+four completions, the July-3 pair, `N_fire`, the lex-first-nonzero-axis
+completion, the pair of signs of `n`, the current premise boundary, and
+the mutation controls. It writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18585,6 +18585,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_ball_ambiguous_slot_local_pick_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_ball_ambiguous_slot_local_pick_2026_08_15.txt
+++ b/logs/runner-cache/two_ball_ambiguous_slot_local_pick_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py
+runner_sha256: f01f8465c70a6bb6327b5f51fe921b403b846208e37f06763b003619e1c2a0d7
+input_fingerprint_sha256: 65059b67fbb70bf5e3b1e5d298b4b539d2b21a825dd4380de3f115adc510319a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Qubit, Admissibility, and Record sentences plus the July-3 pair construction reconstructed locally
+integrity_reads: this runner, its note, and the current axiom memo; no cache written
+construction: U=B_2(0)∪B_2((2,0,0)), unread v=(1,−1,1), two ambiguous slots
+negative_scope: displayed local pick only; not adopted; L1 not attached
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-qubit Qubit remains M_2(C)
+PASS: source-record lock, permanence, content-only readout, and unreadability at absence are pinned
+U_card=43
+v_in_U=False
+occupancy_mask=(1, 1, 1, 0, 0, 1)
+unique_axis_fragment=(*,*,−,0,0,+)
+completions=(+,+,−,0,0,+),(+,−,−,0,0,+),(−,+,−,0,0,+),(−,−,−,0,0,+)
+N_pair=48
+N_fire=2
+firing=(+,−,−,0,0,+),(−,+,−,0,0,+)
+c_lex=(+,+,−,0,0,+)
+lex_is_firing=False
+ambiguous w=(2, -1, 1) n=(0,1/3,-1/3) lex_axis=y lex_sign=+ pair_signs=(+,−)
+ambiguous w=(0, -1, 1) n=(0,1/3,-1/3) lex_axis=y lex_sign=+ pair_signs=(+,−)
+PASS: center-unread the star center v is not already in U
+PASS: u-cardinality the two radius-two balls union to 43 locked sites
+PASS: occupancy-mask occupied nearest neighbors of v are exactly +x,−x,+y,−z
+PASS: unique-axis-fragment unique-axis labels are ambiguous, ambiguous, −, 0, 0, +
+PASS: pair-census the reconstructed July-3 k=3 pair has 48 members in one chiral pair
+PASS: theorem-1-four there are exactly four unique-axis-respecting completions
+PASS: theorem-1-n-fire exactly two of the four completions are pair members
+PASS: theorem-1-firing-list the firing completions are (+,−,−,0,0,+) and (−,+,−,0,0,+)
+PASS: theorem-2-lex-local both ambiguous neighbors have n=(0,1/3,−1/3) with lex-first axis y and sign +
+PASS: theorem-2-lex-not-fire the lex-first-nonzero-axis completion is not a firing completion
+PASS: claim-scope the note reports the declared displayed claim_scope
+PASS: displayed-not-adopted the note keeps the local pick displayed and not adopted
+PASS: l1-not-attached the note does not attach L1
+PASS: not-leftover-posrun the note is the four-completion census, not leftover-char of one chosen c
+PASS: forbidden-absent the note avoids the dispatch-forbidden phrases
+PASS: canonical-nonmutation the axiom memo does not contain the displayed local pick as axiom text
+per_element: unique-axis signs, four completions, and N_fire are exact integers
+per_site: only the unread star center v is scored
+per_mode: no spectral calculation
+per_block: U and the six-neighbor star at v only
+lattice_wide: checked and not executed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py
+++ b/scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Four unique-axis-respecting completions of two ambiguous slots at v.
+
+U = B_2(0) ∪ B_2((2,0,0)) is treated as already locked. The unread center is
+v = (1, −1, 1). Unique-axis slots stay fixed. The two occupied neighbors with
+|supp n| ≠ 1 each receive {+, −}. The runner rebuilds those four completions,
+the July-3 pair, N_fire, and the lex-first-nonzero-axis sign completion.
+Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "TWO_BALL_AMBIGUOUS_SLOT_LOCAL_PICK_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_BALL_AMBIGUOUS_SLOT_LOCAL_PICK_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+AXIS_NAME = ("x", "y", "z")
+V: Point = (1, -1, 1)
+P_SHIFT: Point = (2, 0, 0)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def ball(center: Point, radius: int) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for x, y, z in itertools.product(span, repeat=3):
+        site = add(center, (x, y, z))
+        if l1(sub(site, center)) <= radius:
+            sites.add(site)
+    return frozenset(sites)
+
+
+def locked_union() -> frozenset[Point]:
+    return ball((0, 0, 0), 2) | ball(P_SHIFT, 2)
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def dipole(occ: Coloring) -> tuple[Fraction, Fraction, Fraction]:
+    return (
+        Fraction(occ[0] - occ[1], 3),
+        Fraction(occ[2] - occ[3], 3),
+        Fraction(occ[4] - occ[5], 3),
+    )
+
+
+def unique_axis_label(n: tuple[Fraction, Fraction, Fraction]) -> int | None:
+    support = [index for index, value in enumerate(n) if value != 0]
+    if len(support) != 1:
+        return None
+    return PLUS if n[support[0]] > 0 else MINUS
+
+
+def unique_axis_fragment(center: Point, occupied: frozenset[Point]) -> tuple[int | None, ...]:
+    labels: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(center, direction)
+        if neighbor not in occupied:
+            labels.append(EMPTY)
+            continue
+        label = unique_axis_label(dipole(occupancy_tuple(neighbor, occupied)))
+        labels.append(label)
+    return tuple(labels)
+
+
+def lex_first_nonzero_axis_sign(n: tuple[Fraction, Fraction, Fraction]) -> tuple[int, int]:
+    for index, value in enumerate(n):
+        if value != 0:
+            return index, (PLUS if value > 0 else MINUS)
+    raise RuntimeError("n has empty support")
+
+
+def pair_of_signs(n: tuple[Fraction, Fraction, Fraction]) -> tuple[int, ...]:
+    return tuple(PLUS if value > 0 else MINUS for value in n if value != 0)
+
+
+def completions_of(fragment: tuple[int | None, ...]) -> tuple[Coloring, ...]:
+    free = [index for index, slot in enumerate(fragment) if slot is None]
+    if len(free) != 2:
+        raise RuntimeError(f"expected two ambiguous slots, found {len(free)}")
+    out: list[Coloring] = []
+    for left, right in itertools.product((PLUS, MINUS), repeat=2):
+        coloring = [EMPTY if slot is None else slot for slot in fragment]
+        coloring[free[0]] = left
+        coloring[free[1]] = right
+        out.append(tuple(coloring))
+    return tuple(out)
+
+
+def lex_first_completion(
+    fragment: tuple[int | None, ...],
+    occupied: frozenset[Point],
+    center: Point,
+) -> Coloring:
+    coloring = [EMPTY if slot is None else slot for slot in fragment]
+    for index, slot in enumerate(fragment):
+        if slot is not None:
+            continue
+        neighbor = add(center, DIRS[index])
+        _axis, sign = lex_first_nonzero_axis_sign(
+            dipole(occupancy_tuple(neighbor, occupied))
+        )
+        coloring[index] = sign
+    return tuple(coloring)
+
+
+def det3(matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+    vector: Point,
+) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring) -> Coloring:
+    out = [0] * 6
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def cubic_signed_permutations() -> tuple[
+    list[tuple[int, ...]],
+    list[tuple[int, ...]],
+    tuple[int, ...],
+]:
+    records: list[tuple[tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]], int]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            key = tuple(value for row in matrix for value in row)
+            if key not in seen:
+                seen.add(key)
+                records.append((matrix, det3(matrix)))
+    proper = [direction_perm(matrix) for matrix, det in records if det == 1]
+    full = [direction_perm(matrix) for matrix, _det in records]
+    inversion = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    return proper, full, direction_perm(inversion)
+
+
+def july3_k3_pair() -> frozenset[Coloring]:
+    proper, _full, inversion = cubic_signed_permutations()
+    unseen = set(itertools.product((EMPTY, PLUS, MINUS), repeat=6))
+    orbits: list[set[Coloring]] = []
+    ids: dict[Coloring, int] = {}
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in proper}
+        index = len(orbits)
+        orbits.append(orbit)
+        unseen -= orbit
+        for coloring in orbit:
+            ids[coloring] = index
+    pair: set[Coloring] = set()
+    seen_pairs: set[tuple[int, int]] = set()
+    for index, orbit in enumerate(orbits):
+        sample = next(iter(orbit))
+        image = ids[act_col(inversion, sample)]
+        if image == index:
+            continue
+        key = tuple(sorted((index, image)))
+        if key in seen_pairs:
+            continue
+        seen_pairs.add(key)
+        pair |= orbits[index]
+        pair |= orbits[image]
+    if len(seen_pairs) != 1:
+        raise RuntimeError(f"expected one chiral pair, found {len(seen_pairs)}")
+    return frozenset(pair)
+
+
+def format_tuple(coloring: Coloring) -> str:
+    return "(" + ",".join(LETTER[slot] for slot in coloring) + ")"
+
+
+def format_fragment(fragment: tuple[int | None, ...]) -> str:
+    parts = []
+    for slot in fragment:
+        if slot is None:
+            parts.append("*")
+        else:
+            parts.append(LETTER[slot])
+    return "(" + ",".join(parts) + ")"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: current Lattice, Qubit, Admissibility, "
+        "and Record sentences plus the July-3 pair construction reconstructed locally"
+    )
+    print("integrity_reads: this runner, its note, and the current axiom memo; no cache written")
+    print("construction: U=B_2(0)∪B_2((2,0,0)), unread v=(1,−1,1), two ambiguous slots")
+    print("negative_scope: displayed local pick only; not adopted; L1 not attached")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TWO_BALL_AMBIGUOUS_SLOT_LOCAL_PICK_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "it does not supply the formation site, probability,"
+    qubit_sentence = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_perm = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalized_axiom and admissibility_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in note,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit remains M_2(C)",
+        qubit_sentence in normalized_axiom
+        and qubit_sentence in note
+        and "Qubit remains `M_2(C)`" in note,
+    )
+    checks.check(
+        "source-record",
+        "lock, permanence, content-only readout, and unreadability at absence are pinned",
+        all(
+            phrase in normalized_axiom
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        )
+        and all(phrase in note for phrase in (record_lock, record_perm, record_content, record_absence)),
+    )
+
+    occupied = locked_union()
+    mask = occupancy_tuple(V, occupied)
+    fragment = unique_axis_fragment(V, occupied)
+    pair = july3_k3_pair()
+    four = completions_of(fragment)
+    firing = tuple(coloring for coloring in four if coloring in pair)
+    lex_c = lex_first_completion(fragment, occupied, V)
+    ambiguous = []
+    for direction in DIRS:
+        neighbor = add(V, direction)
+        if neighbor not in occupied:
+            continue
+        n_vec = dipole(occupancy_tuple(neighbor, occupied))
+        if unique_axis_label(n_vec) is None:
+            axis, sign = lex_first_nonzero_axis_sign(n_vec)
+            ambiguous.append((neighbor, n_vec, axis, sign, pair_of_signs(n_vec)))
+
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"occupancy_mask={mask}")
+    print(f"unique_axis_fragment={format_fragment(fragment)}")
+    print("completions=" + ",".join(format_tuple(coloring) for coloring in four))
+    print(f"N_pair={len(pair)}")
+    print(f"N_fire={len(firing)}")
+    print("firing=" + ",".join(format_tuple(coloring) for coloring in firing))
+    print(f"c_lex={format_tuple(lex_c)}")
+    print(f"lex_is_firing={lex_c in firing}")
+    for neighbor, n_vec, axis, sign, signs in ambiguous:
+        print(
+            "ambiguous "
+            f"w={neighbor} n=({n_vec[0]},{n_vec[1]},{n_vec[2]}) "
+            f"lex_axis={AXIS_NAME[axis]} lex_sign={LETTER[sign]} "
+            "pair_signs=(" + ",".join(LETTER[s] for s in signs) + ")"
+        )
+
+    checks.check(
+        "center-unread",
+        "the star center v is not already in U",
+        V not in occupied and l1(V) == 3 and l1(sub(V, P_SHIFT)) == 3,
+        residual=V in occupied,
+    )
+    checks.check(
+        "u-cardinality",
+        "the two radius-two balls union to 43 locked sites",
+        len(occupied) == 43 and len(ball((0, 0, 0), 2)) == 25 and len(ball(P_SHIFT, 2)) == 25,
+    )
+    checks.check(
+        "occupancy-mask",
+        "occupied nearest neighbors of v are exactly +x,−x,+y,−z",
+        mask == (1, 1, 1, 0, 0, 1),
+    )
+    checks.check(
+        "unique-axis-fragment",
+        "unique-axis labels are ambiguous, ambiguous, −, 0, 0, +",
+        fragment == (None, None, MINUS, EMPTY, EMPTY, PLUS),
+    )
+    checks.check(
+        "pair-census",
+        "the reconstructed July-3 k=3 pair has 48 members in one chiral pair",
+        len(pair) == 48
+        and all(coloring.count(EMPTY) == 2 for coloring in pair)
+        and all(len({coloring[0], coloring[1]}) == 2 for coloring in pair)
+        and all(len({coloring[2], coloring[3]}) == 2 for coloring in pair)
+        and all(len({coloring[4], coloring[5]}) == 2 for coloring in pair),
+    )
+    checks.check(
+        "theorem-1-four",
+        "there are exactly four unique-axis-respecting completions",
+        len(four) == 4
+        and four
+        == (
+            (PLUS, PLUS, MINUS, EMPTY, EMPTY, PLUS),
+            (PLUS, MINUS, MINUS, EMPTY, EMPTY, PLUS),
+            (MINUS, PLUS, MINUS, EMPTY, EMPTY, PLUS),
+            (MINUS, MINUS, MINUS, EMPTY, EMPTY, PLUS),
+        ),
+    )
+    checks.check(
+        "theorem-1-n-fire",
+        "exactly two of the four completions are pair members",
+        len(firing) == 2,
+        residual=len(firing),
+    )
+    checks.check(
+        "theorem-1-firing-list",
+        "the firing completions are (+,−,−,0,0,+) and (−,+,−,0,0,+)",
+        firing
+        == (
+            (PLUS, MINUS, MINUS, EMPTY, EMPTY, PLUS),
+            (MINUS, PLUS, MINUS, EMPTY, EMPTY, PLUS),
+        )
+        and "(+,−,−,0,0,+)" in note
+        and "(−,+,−,0,0,+)" in note,
+    )
+    checks.check(
+        "theorem-2-lex-local",
+        "both ambiguous neighbors have n=(0,1/3,−1/3) with lex-first axis y and sign +",
+        len(ambiguous) == 2
+        and all(n_vec == (Fraction(0, 1), Fraction(1, 3), Fraction(-1, 3)) for _w, n_vec, _a, _s, _p in ambiguous)
+        and all(axis == 1 and sign == PLUS for _w, _n, axis, sign, _p in ambiguous)
+        and all(signs == (PLUS, MINUS) for _w, _n, _a, _s, signs in ambiguous),
+    )
+    checks.check(
+        "theorem-2-lex-not-fire",
+        "the lex-first-nonzero-axis completion is not a firing completion",
+        lex_c == (PLUS, PLUS, MINUS, EMPTY, EMPTY, PLUS)
+        and lex_c not in pair
+        and lex_c not in firing,
+    )
+
+    claim_scope = (
+        "On U at unread v=(1,−1,1), whether any of the 4 unique-axis-respecting "
+        "completions of the two ambiguous slots is a July-3 pair member, and "
+        "whether the lex-first-nonzero-axis completion is among them, is "
+        "reported. Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the declared displayed claim_scope",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note keeps the local pick displayed and not adopted",
+        "Displayed, not adopted" in note
+        and "does not write a tie-break into Admissibility" in normalized_note
+        and 'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "the note does not attach L1",
+        "Do not attach L1" in note
+        and "not attached" in normalized_note
+        and "we attach L1" not in normalized_note,
+    )
+    checks.check(
+        "not-leftover-posrun",
+        "the note is the four-completion census, not leftover-char of one chosen c",
+        "not leftover-char of the one-tuple execution" in normalized_note
+        and "four unique-axis-respecting completions" in normalized_note,
+    )
+    checks.check(
+        "forbidden-absent",
+        "the note avoids the dispatch-forbidden phrases",
+        all(phrase not in note for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "canonical-nonmutation",
+        "the axiom memo does not contain the displayed local pick as axiom text",
+        "lex-first-nonzero-axis" not in axiom
+        and "July-3 k=3 pair" not in axiom
+        and "we adopt" not in normalized_note.lower(),
+    )
+
+    print("per_element: unique-axis signs, four completions, and N_fire are exact integers")
+    print("per_site: only the unread star center v is scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: U and the six-neighbor star at v only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

At v=(1,-1,1) unique-axis fragment is (*,*,-,0,0,+). Of 4 completions, N_fire=2: (+,-,-,0,0,+) and (-,+,-,0,0,+). Lex-first-nonzero-axis completion (+,+,-,0,0,+) does not fire. Both ambiguous neighbors have the same n=(0,1/3,-1/3). Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_ball_ambiguous_slot_local_pick_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.