### PR TITLE
physics: isolate the torus wrap defect and pin the half-space carrier

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block120-torus-wrap-defect-20260816/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block120-torus-wrap-defect-20260816/NO_GO_LEDGER.md
@@ -1,0 +1,37 @@
+# Block 120 No-Go Ledger
+
+Scope: one narrow carrier-transfer wall inside a split-and-restore
+packet that preserves the positive half-space theorem. `W1` says the
+Block 119 swap family does not complete the literal antiperiodic Z8
+torus pairing — proven by exact mechanism, not search: the dressed
+torus pairing is non-Hermitian with residual rank four per momentum
+(no inertia), and the torus kernel splits exactly as
+K_torus = K_half + D with the displayed antiperiodic wrap operator
+R_AP[n,j] = -U[n,0](I+M^2)^{-1}U[4,j+1]e/C_j, where D carries ALL of
+the dressed non-Hermiticity (the half part is exactly Hermitian). The
+completed half-space window pencil vanishes identically (zero
+polynomial — the vacuum sits exactly at one), so the torus pencil value
+at one is exactly the wrap contribution, which is nonzero. The wrap
+obeys the exact projector law (I+T^N)^{-1} = P_s/(1+a^N) +
+P_u/(1+a^{-N}) with T = M^2 and a = rho_F^2 in (0,1): the
+stable-channel coefficient c_N = a^N/(1+a^N) decays geometrically,
+while the rank-one unstable-projector channel saturates at an
+N-independent limit — on any fixed torus the antiperiodic boundary
+speaks through the growing mode. Subtracting the displayed defect
+restores y y^H with inertia (1,0,3) per momentum and the contractive
+quotient beta = a^2 = rho_F^4 per double period — the same geometric
+semigroup as Block 119's per-period rho_F^2 (bookkeeping, not error).
+Narrow scope: the displayed carrier, fixtures, dressing family, and the
+displayed subtraction. The naturality classification and the curved
+carrier are live and named.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the torus OS package is impossible | `ATTEMPTED` | not shown: only the displayed dressing family and subtraction are decided; torus-adapted families remain open | naturality classification |
+| the wrap is a pure finite-size effect | `ATTEMPTED` | false as stated: the stable channel decays as a^N but the rank-one unstable channel saturates N-independently | half-space carrier |
+| subtracting D is a derivation | `ATTEMPTED` | not claimed: the subtraction displays where the obstruction lives; the honest carrier statement is the half-space/large-torus limit | curved-carrier work |
+| the half-space result is overturned | `ATTEMPTED` | false: K_T - D = K_H exactly restores the positive contractive package | none needed |
+| the 119/120 contraction powers disagree | `ATTEMPTED` | false: beta = a^2 = rho_F^4 per double period equals (rho_F^2)^2 — the same semigroup rho_F^{2n} | none needed |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; only the narrow carrier-transfer `W1` ships.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_TORUS_WRAP_DEFECT_BOUNDED_THEOREM_NOTE_2026-08-16.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_TORUS_WRAP_DEFECT_BOUNDED_THEOREM_NOTE_2026-08-16.md
@@ -1,0 +1,1035 @@
+---
+claim_id: admissibility_dirac_kahler_torus_wrap_defect_bounded_theorem_note_2026-08-16
+claim_type: bounded_theorem
+claim_scope: "On the primary carrier at both rational shear fixtures, the Block 119 swap family leaves the literal antiperiodic torus pairing non-Hermitian with residual rank four per momentum, and the torus kernel splits exactly as the half-space kernel plus the displayed antiperiodic wrap defect which carries all of the dressed non-Hermiticity; the completed half-space window pencil vanishes identically so the torus pencil value at one is exactly the wrap contribution; the wrap obeys the exact projector law with geometrically decaying stable-channel coefficient while its rank-one unstable-projector channel saturates at an N-independent limit; and subtracting the displayed defect restores the Hermitian positive semidefinite completion with the contractive quotient in the same geometric semigroup — while the torus completion without subtraction, the naturality classification, curved OS positivity, the completed ADM/history transporter, joint gravity, the gravity constraint quotient, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_reflection_intertwiner_completion_bounded_theorem_note_2026-08-16
+runner: scripts/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_reflection_intertwiner_completion_bounded_theorem_note_2026-08-16
+target_blocker_text: "Carry the completed half-space OS package back to the antiperiodic torus and the curved carrier, classify the completion's naturality, and then form the gravity constraint quotient."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Classify the completion's naturality, execute the curved-carrier OS positivity question on the half-space package, and then form the gravity constraint quotient."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-119 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact torus/half-space kernel split, exact rank-four dressed anti-Hermitian residuals, exact zero half-space pencil and wrap-only torus pencil identity, exact stable/unstable projector law and finite-size limit, and exact defect-subtracted Hermitian positive-semidefinite inertia and contractive quotient certificates at every momentum and both rational shear fixtures; dependencies are content-bound unaudited, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Torus Wrap Defect And The Half-Space Carrier
+
+**Date:** 2026-08-16
+
+**Campaign block:** 120
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.py`](../scripts/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.py)
+
+## 1. Result Up Front
+
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+closed onto the following handoff next gate, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md:16`
+and elaborated at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md:1013-1029`:
+
+> Carry the completed half-space OS package back to the antiperiodic torus
+> and the curved carrier, classify the completion's naturality, and then
+> form the gravity constraint quotient.
+
+**Failure-and-split theorem.** On the primary `Z8_t x Z4_x` carrier, at
+each of the rational shear fixtures $c=5/13$ and $c=3/5$, the Block 119
+swap family does not complete the literal antiperiodic torus pairing. For
+every momentum $k=0,1,2,3$, its completed torus kernel $K_{T,k}$ obeys
+
+\[
+ \operatorname{rank}(K_{T,k}-K_{T,k}^{\dagger})=4.    \tag{1}
+\]
+
+The kernel is non-Hermitian, so a Hermitian inertia is undefined. This is
+not a negative-inertia statement. The exact keystone identity is instead
+
+\[
+ K_{T,k}=K_{H,k}+D_k,                                 \tag{2}
+\]
+
+where $K_{H,k}$ is the Block 119 completed half-space kernel and $D_k$
+is the dressed antiperiodic wrap defect. Since $K_{H,k}$ is Hermitian,
+
+\[
+ K_{T,k}-K_{T,k}^{\dagger}=D_k-D_k^{\dagger}.         \tag{3}
+\]
+
+Thus all of the dressed torus non-Hermiticity lies in the displayed
+defect, not in the half-space package.
+
+**The wrap operator.** With the runner's propagator notation, the
+antiperiodic wrap contribution is induced exactly by
+
+\[
+ R_{\rm AP}[n,j]
+ =-{U[n,0](I+M^2)^{-1}U[4,j+1]e\over C_j}.           \tag{4}
+\]
+
+Equivalently, before dressing,
+
+\[
+ G_T=-B_{-1}+[(G_{\rm open}+B_{-1})+G_{\rm AP}],     \tag{5}
+\]
+
+where $G_{\rm AP}$ is induced by (4). Equation (2) is the corresponding
+completed-kernel split.
+
+**The vacuum is exactly at one in the strongest sense.** If $P_H(z)$
+and $P_D(z)$ are the completed half-space and defect window pencils,
+then
+
+\[
+ P_T=P_H+P_D,
+ \qquad f_H(z):=\det P_H(z)\equiv0.                  \tag{6}
+\]
+
+The half-space determinant is the zero polynomial, not merely a
+polynomial which happens to vanish at $z=1$. Defining
+
+\[
+ W_f(z):=\det(P_H(z)+P_D(z))-\det P_H(z),            \tag{7}
+\]
+
+the torus value is therefore exactly
+
+\[
+ f_T(1)=f_H(1)+W_f(1)=0+W_f(1)\ne0.                 \tag{8}
+\]
+
+Both the mixed and pure-defect contributions to $W_f(1)$ are nonzero at
+every declared sector. The torus pencil value at one is entirely the wrap
+contribution.
+
+**Finite-size projector law.** Put $T=M^2$ and $a=\rho_F^2\in(0,1)$.
+For the stable and unstable spectral projectors $P_s,P_u$,
+
+\[
+ T=aP_s+a^{-1}P_u,
+ \qquad
+ (I+T^N)^{-1}
+ ={P_s\over1+a^N}+{P_u\over1+a^{-N}}.                \tag{9}
+\]
+
+With
+
+\[
+ c_N={a^N\over1+a^N},                                \tag{10}
+\]
+
+the two exact balanced identities are
+
+\[
+\begin{aligned}
+ (I+T^N)^{-1}-P_s&=c_N(P_u-P_s),\\
+ (I+T^N)^{-1}T^N-P_u&=c_N(P_s-P_u).
+                                                               \tag{11}
+\end{aligned}
+\]
+
+Consequently the stable coefficient in the bridge operator is $c_N$,
+which decays geometrically, while its rank-one unstable-projector
+coefficient is $1-c_N$ and saturates at the $N$-independent limit
+$P_u$. Explicitly,
+
+\[
+ c_1={a\over1+a},\qquad
+ c_2={a^2\over1+a^2},\qquad
+ c_3={a^3\over1+a^3}.                                \tag{12}
+\]
+
+The correction is balanced between $P_s$ and $P_u$, not an
+unstable-only error. What saturates is the unstable channel of the wrap
+bridge. The fixed `Z8` chart also contains a non-boundary open/direct
+bridge.
+
+**Unstable saturation.** The half-space removes the wrap by fiat: it
+sets the winding contribution (D) to zero by choosing the one-sided
+carrier. It does not obtain that removal by proving that the literal
+fixed-torus kernel converges to it. On any fixed torus the antiperiodic
+boundary speaks through the growing mode. Equation (11) makes that
+statement exact: the unstable part of the bridge tends to $P_u$, not
+to zero.
+
+**Corrected completion and power reconciliation.** Exact subtraction of
+the displayed defect gives
+
+\[
+ K_{T,k}-D_k=K_{H,k}=y_{+,k}y_{+,k}^{\dagger},
+ \qquad
+ \operatorname{In}K_{H,k}=(1,0,3).                  \tag{13}
+\]
+
+The radical quotient is contractive with
+
+\[
+ \beta_k=a_k^2=\rho_{F,k}^4\in(0,1).                \tag{14}
+\]
+
+Here $a=\rho_F^2$ is the double-period eigenvalue used by the torus
+finite-size calculation. Thus $a^2=\rho_F^4$ per double period is the
+same geometric semigroup as Block 119's per-period $\rho_F^2$. The
+difference is bookkeeping of the period unit, not a power error.
+
+The conclusion is deliberately narrow. The literal torus completion
+without subtracting (D), the completion's naturality classification,
+curved OS positivity, the completed ADM/history transporter, joint
+gravity, the gravity constraint quotient, Records, audit retention,
+axiom amendment, obligation retirement, and TOE percentage movement
+remain outside this theorem.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) at
+`origin/main 4e566b14a6352a9a62590252a9755c7a103c1b9e`, with axiom blob
+`bc23300becfe4e4db57153c0e94cfcdf2338da71` and registry blob
+`b93959cca4f7e26c673cdccbe601e50c3cb93daa`. The authority snapshot is
+unchanged from Blocks 115--119.
+
+The exact stacked parent is
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+commit `33fd2d21558604718f3a88713fe1976aff8f9dbb`, content-bound through
+note blob `ed660c106e8e97f6ce85deef95228170e483e8e5`. No audit verdict is
+imported.
+
+The executed contract is:
+
+1. the inherited Blocks 107--119 `d=2` one-fine-mode primary carrier on
+   `Z8_t x Z4_x`, its link-centered reflection, Block 118's stable split,
+   and Block 119's swap-completed half-space pairing;
+2. both rational shear fixtures $c=5/13$ and $c=3/5$, and all four
+   fixed momenta $k=0,1,2,3$;
+3. the literal antiperiodic torus kernel after applying the Block 119 swap
+   family, its Hermiticity test, and the rank of its anti-Hermitian
+   residual, with no inertia assigned to a non-Hermitian matrix;
+4. the exact torus/half-space split $K_T=K_H+D$, formula (4) for the
+   antiperiodic wrap, and the identity locating all dressed
+   non-Hermiticity in (D);
+5. the completed half-space and defect pencils, the zero-polynomial
+   identity for $f_H$, the wrap-only value $f_T(1)=W_f(1)\ne0$, and
+   nonzero mixed and pure-defect contributions;
+6. the stable/unstable projector decomposition for every positive torus
+   length $N$, including the exact $N=1,2,3$ coefficients and the
+   rank-one unstable saturation;
+7. the exact subtraction $K_T-D=K_H=y_+y_+^\dagger$, Hermiticity,
+   positive semidefiniteness, and inertia ((1,0,3)) per momentum;
+8. the quotient contraction $\beta=a^2\in(0,1)$, its geometric powers,
+   and the reconciliation with Block 119's period convention; and
+9. the no-go conclusion only for the displayed carrier, fixtures, Block
+   119 swap family, and displayed subtraction, while leaving every other
+   torus dressing family, naturality, curved OS, and gravity open.
+
+The supplied exact certificate report ends with
+`TOTAL: PASS=792 FAIL=0`; its reported runtime is `178.043` seconds. The
+torus failure is represented by exact residual-rank and field-root
+certificates, and the positive result by exact split, projector,
+factorization, inertia, bound, and quotient identities.
+
+Its decision footer is reproduced with the supplied final-run timing:
+
+```text
+TASK4 VERDICT (b): Theta does not complete the literal Z8 torus; Theta plus exact subtraction of D completes it to the half-space carrier. No non-completability theorem for every torus-adapted dressing is claimed.
+DECISION: the swap family fails on the finite torus by a full-rank non-Hermitian wrap defect; removing that exact defect recovers the rank-one PSD half-space package and its beta=a^2 contraction.
+RUNTIME_SECONDS: 178.043
+TOTAL: PASS=792 FAIL=0
+```
+
+The exact scope is the primary finite carrier, both rational shear
+fixtures, all four fixed momenta, the Block 119 swap family on the literal
+antiperiodic torus, the displayed wrap defect, its exact subtraction, and
+the half-space correction. Torus completion without that subtraction,
+other torus-adapted dressing families, the naturality classification,
+curved OS positivity, the completed ADM/history transporter, joint
+gravity, the gravity constraint quotient, Records, audit retention,
+axiom amendment, obligation retirement, and TOE percentage movement are
+outside the executed contract.
+
+## 3. The Torus Failure
+
+Fix one fixture and one momentum, and suppress (k,c) temporarily. The
+literal torus test takes the Block 119 swap (Theta) without changing its
+displayed dressing family and applies it to the antiperiodic torus
+pairing. Let $K_T$ denote the resulting four-by-four completed window
+kernel. The exact Hermiticity test fails:
+
+\[
+ K_T\ne K_T^\dagger.                                 \tag{15}
+\]
+
+More sharply, the anti-Hermitian residual fills the whole displayed
+window:
+
+\[
+ \operatorname{rank}(K_T-K_T^\dagger)=4.             \tag{16}
+\]
+
+Equation (16) holds at each of the four fixed momenta and at both rational
+fixtures. It is a residual-rank statement, not an eigenvalue-inertia
+statement. Inertia $(n_+,n_-,n_0)$ is defined here only for a Hermitian
+matrix, so the torus inertia is **undefined**. Assigning a negative count
+to $K_T$ would conceal the stronger preliminary failure that its
+eigenvalues need not be ordered on the real line.
+
+The exact certificate rows are:
+
+```text
+TASK1 CERT c=5/13: Hermitian=(False, False, False, False), rank(K-K*)=(4, 4, 4, 4), inertia=undefined; f_k#=('25812f18b460', '91cdf457a0bc', '4ecb214fb0e9', 'e8148f572f43'), f_k(1)!=0; roots=('real roots (-inf,0)/(0,1)/(1,inf)/nonreal=2/0/1/0', 'three nonreal roots (no order relative to 1)', 'real roots (-inf,0)/(0,1)/(1,inf)/nonreal=0/0/1/2', 'three nonreal roots (no order relative to 1)').
+TASK1 CERT c=3/5: Hermitian=(False, False, False, False), rank(K-K*)=(4, 4, 4, 4), inertia=undefined; f_k#=('35c1a866e063', '0b1bdfe8518d', 'b684028bf6ac', 'faa835df4331'), f_k(1)!=0; roots=('real roots (-inf,0)/(0,1)/(1,inf)/nonreal=1/1/1/0', 'three nonreal roots (no order relative to 1)', 'real roots (-inf,0)/(0,1)/(1,inf)/nonreal=1/0/0/2', 'three nonreal roots (no order relative to 1)').
+```
+
+The root classifications use exact Sturm and field-gcd tests. Their role
+is diagnostic: they certify that the torus pencil is not secretly the
+positive half-space pencil. The rank-four anti-Hermitian residual already
+decides the literal completion question for the displayed swap family.
+
+This failure does not contradict Block 119. That theorem completed the
+stable-split half-space pairing. It explicitly left transport across the
+antiperiodic seam unexecuted. The torus adds precisely that winding datum.
+Nor does (16) prove that no other torus-adapted dressing could work. It
+tests the Block 119 swap family on the literal torus pairing and nothing
+larger.
+
+## 4. The Keystone Split
+
+The torus failure is not left as an opaque residual. The exact propagator
+identity separates the open/direct and antiperiodic terms. In the runner's
+notation,
+
+\[
+ G_T=-B_{-1}+W,
+ \qquad
+ W=(G_{\rm open}+B_{-1})+G_{\rm AP}.                 \tag{17}
+\]
+
+The antiperiodic term $G_{\rm AP}$ is induced by
+
+\[
+ R_{\rm AP}[n,j]
+ =-U[n,0](I+M^2)^{-1}U[4,j+1]e/C_j.                 \tag{18}
+\]
+
+The inverse $I+M^2$ is therefore not an auxiliary fitted correction. It
+is the exact finite-torus antiperiodic closure. Removing $G_{\rm AP}$
+from (17) leaves the declared open/direct bridge that generates the
+half-space window.
+
+Apply the same Block 119 left swap to the two contributions and assemble
+the displayed window. If $K_H$ is the completed half-space kernel and
+
+\[
+ D:=K_T-K_H,                                         \tag{19}
+\]
+
+then exact entrywise comparison gives
+
+\[
+ K_T=K_H+D.                                          \tag{20}
+\]
+
+The half-space term is the positive rank-one kernel already constructed
+in Block 119. In the present four-dimensional window,
+
+\[
+ K_H=y_+y_+^\dagger=K_H^\dagger.                    \tag{21}
+\]
+
+Taking adjoints of (20) and subtracting proves
+
+\[
+ K_T-K_T^\dagger=D-D^\dagger.                       \tag{22}
+\]
+
+This is the all-non-Hermiticity-in-(D) identity. It is stronger than
+saying merely that $D$ is non-Hermitian: there is no remaining dressed
+anti-Hermitian contribution in $K_H$, and there is no residual cross
+term outside the exact additive defect.
+
+The operator and split certificates are:
+
+```text
+TASK2 OPERATOR: G_AP is induced by R_AP[n,j]=-U[n,0](I+M^2)^-1U[4,j+1]e/C_j; G_T=-B_-1+[(G_open+B_-1)+G_AP].
+TASK2 PROBE c=5/13: K_T=K_H+D; K_H Hermitian and f_H==0 all k; D#=('76a5a6a44a93', '2788fbb0fb59', 'b3b56235ae17', 'dc29e8a2d6f8').
+TASK2 PROBE c=3/5: K_T=K_H+D; K_H Hermitian and f_H==0 all k; D#=('efa0aa0f26e5', 'f8ee6d26876e', '1b8676a3222f', '067a1c86ee6b').
+```
+
+The four defect digests at each fixture are sectorwise fingerprints, not
+scalar fits. Equations (20)--(22) are checked exactly before any
+finite-size interpretation is assigned.
+
+## 5. The Vanishing Pencil
+
+Let $P_T(z)$ be the displayed completed torus window pencil. The
+additive kernel split induces
+
+\[
+ P_T(z)=P_H(z)+P_D(z),                               \tag{23}
+\]
+
+where $P_H$ and $P_D$ are the half-space and wrap-defect pencils. Set
+
+\[
+ f_T(z)=\det P_T(z),
+ \qquad
+ f_H(z)=\det P_H(z).                                 \tag{24}
+\]
+
+The exact half-space certificate is the polynomial identity
+
+\[
+ f_H(z)\equiv0                                      \tag{25}
+\]
+
+at every momentum and both fixtures. Thus the half-space vacuum is
+exactly at one in the strongest sense: $z=1$ is not merely one selected
+zero of a nonzero polynomial. The complete determinant polynomial
+vanishes.
+
+Because determinants are nonlinear, define the exact wrap increment by
+
+\[
+ W_f(z)
+ :=\det(P_H(z)+P_D(z))-\det P_H(z).                  \tag{26}
+\]
+
+Equations (23)--(26) give the keystone value
+
+\[
+ f_T(1)=f_H(1)+W_f(1)=0+W_f(1)\ne0.                 \tag{27}
+\]
+
+The certificate expands $W_f(1)$ into terms mixed between $P_H$ and
+$P_D$, together with the pure-$P_D$ term. Both parts are exactly
+nonzero. The phrase “wrap contribution” therefore includes the
+determinantal interaction of the displayed defect with the half-space
+pencil; it does not misstate $W_f$ as only $\det P_D$.
+
+The exact keystone rows are:
+
+```text
+TASK2 KEYSTONE FORMULA: f_T(1)=f_H(1)+W_f(1)=0+W_f(1), W_f=det(P_H+P_D)-det(P_H).
+TASK2 KEYSTONE c=5/13: identity all k; exact (f_T,W_f,mixed,pure-D)#=('4caced4e336f', '335afea72bd4', 'ecc4e81c677b', '37350cda9ec9'); mixed,pure-D !=0.
+TASK2 KEYSTONE c=3/5: identity all k; exact (f_T,W_f,mixed,pure-D)#=('3a7c97b3c2a0', '44ff5fe0126f', '9f7c8560b921', 'd042d4e05079'); mixed,pure-D !=0.
+```
+
+The half-space zero polynomial and torus nonzero value coexist without
+contradiction because they belong to different carriers. Equation (27)
+locates the difference exactly at the antiperiodic wrap interface.
+
+## 6. The Finite-Size Law
+
+The wrap has a closed finite-size form. Put
+
+\[
+ T=M^2.                                               \tag{28}
+\]
+
+On the declared two-channel Floquet block, $T$ has the reciprocal
+eigenvalues $a$ and $a^{-1}$, where
+
+\[
+ 0<a=\rho_F^2<1.                                     \tag{29}
+\]
+
+Let $P_s$ and $P_u$ be the corresponding rank-one stable and unstable
+spectral projectors. They obey
+
+\[
+ P_s+P_u=I,
+ \qquad P_sP_u=P_uP_s=0,
+ \qquad
+ T^N=a^NP_s+a^{-N}P_u.                               \tag{30}
+\]
+
+For a torus of (N) double periods, define
+
+\[
+ B_N:=(I+T^N)^{-1}.                                  \tag{31}
+\]
+
+Exact spectral calculus gives
+
+\[
+ B_N={P_s\over1+a^N}+{P_u\over1+a^{-N}}.             \tag{32}
+\]
+
+No large-(N) approximation enters (32). With
+
+\[
+ c_N={a^N\over1+a^N},                                \tag{33}
+\]
+
+equation (32) is equivalently
+
+\[
+ B_N=(1-c_N)P_s+c_NP_u.                              \tag{34}
+\]
+
+The exact finite-boundary correction is therefore
+
+\[
+ B_N-P_s=c_N(P_u-P_s).                               \tag{35}
+\]
+
+This correction is balanced: the same $c_N$ subtracts from the stable
+projector and adds to the unstable projector. Calling it an
+“unstable-only correction” would be false.
+
+The wrap bridge contains the transported closure factor
+
+\[
+ Q_N:=B_NT^N.                                        \tag{36}
+\]
+
+Using (30)--(34),
+
+\[
+ Q_N=c_NP_s+(1-c_N)P_u,                              \tag{37}
+\]
+
+and hence
+
+\[
+ Q_N-P_u=c_N(P_s-P_u).                               \tag{38}
+\]
+
+Equations (35) and (38) are the exact two-sided projector law requested
+by the torus split. Because $0<c_N<a^N$, its error coefficient decays
+geometrically.
+
+For the three explicitly requested lengths, the identities specialize
+without any recurrence fit:
+
+\[
+\begin{array}{c|c|c}
+ N&c_N&Q_N\\ \hline
+ 1&{a\over1+a}&{a\over1+a}P_s+{1\over1+a}P_u\\[2mm]
+ 2&{a^2\over1+a^2}&{a^2\over1+a^2}P_s
+                       +{1\over1+a^2}P_u\\[2mm]
+ 3&{a^3\over1+a^3}&{a^3\over1+a^3}P_s
+                       +{1\over1+a^3}P_u
+\end{array}.                                         \tag{39}
+\]
+
+The supplied exact isolations of (a) are:
+
+\[
+\begin{aligned}
+ c=5/13:\quad
+ a_{\rm even}&\in(32190095809,32190095810)10^{-12},\\
+ a_{\rm odd}&\in(404644318,404644319)10^{-12},\\
+ c=3/5:\quad
+ a_{\rm even}&\in(36167865356,36167865357)10^{-12},\\
+ a_{\rm odd}&\in(191977555,191977556)10^{-12}.
+                                                               \tag{40}
+\end{aligned}
+\]
+
+All endpoints are positive and below one by exact integer comparison.
+The certificate statement is:
+
+```text
+TASK3 FORMULA: put a=rho_F^2, so T=M^2 has (a,a^-1); B_N=(I+T^N)^-1=P_s/(1+a^N)+P_u/(1+a^-N).
+TASK3 DEFECT: c_N=a^N/(1+a^N); B_N-P_s=c_N(P_u-P_s), B_N T^N-P_u=c_N(P_s-P_u).
+TASK3 CERT c=5/13: a=rho_F^2 in ((32190095809, 32190095810), (404644318, 404644319))/10^12 for k even/odd; c_1=a/(1+a); (P_s,P_u,B_1)#=('9604735e6327', 'f3773519a234').
+TASK3 CERT c=3/5: a=rho_F^2 in ((36167865356, 36167865357), (191977555, 191977556))/10^12 for k even/odd; c_1=a/(1+a); (P_s,P_u,B_1)#=('a9e1349ba917', 'bf4d3bb10ff8').
+```
+
+The fixed `Z8` window also contains the open/direct bridge visible in
+(17). That contribution is not a boundary correction and is not asserted
+to decay with (N). The geometric statement concerns the finite-boundary
+projector error and the stable/unstable channels of the wrap bridge.
+
+## 7. The Unstable Saturation
+
+The exact limit of (37) is
+
+\[
+ \lim_{N\to\infty}Q_N=P_u.                           \tag{41}
+\]
+
+Within each declared momentum sector, $P_u$ has rank one and does not
+depend on $N$. Its coefficient $1-c_N=1/(1+a^N)$ tends to one. The
+stable-projector coefficient $c_N$ tends to zero geometrically. Thus
+the antiperiodic wrap does not become a purely decaying stable correction:
+its growing-mode channel saturates at an (N)-independent rank-one
+limit.
+
+This is the finite-torus meaning of the reciprocal Floquet pair. A mode
+which grows as $a^{-N}$ around the winding is multiplied by the closure
+factor $1/(1+a^{-N})$. Their product is
+
+\[
+ {a^{-N}\over1+a^{-N}}={1\over1+a^N}\longrightarrow1. \tag{42}
+\]
+
+The small closure coefficient therefore does not suppress the growing
+mode after transport around the torus. On any fixed torus the
+antiperiodic boundary speaks through the growing mode.
+
+The half-space package makes a different carrier choice. It retains the
+one-sided stable data and omits the winding equation, so $G_{\rm AP}$
+and $D$ are absent by fiat. That is an honest definition of the
+half-space carrier, not a proof that the literal antiperiodic torus kernel
+loses its unstable channel. The finite-size law explains why naively
+taking a longer torus does not justify that identification.
+
+The runner records the distinction exactly:
+
+```text
+TASK3 INTERPRETATION PASS: the finite boundary error is the balanced P_u-P_s correction, not an unstable-only term; c_N tends geometrically to zero, while the Z8 window also contains the non-boundary open/direct bridge.
+```
+
+Equation (41) does not prove that every possible torus dressing retains
+the same saturation. A different torus-adapted family might mix or cancel
+the rank-one channel. That route remains named and open. What is decided
+is the displayed Block 119 swap family and its exact defect (D).
+
+## 8. The Corrected Completion And The Power Reconciliation
+
+The defect split gives a precise corrected object:
+
+\[
+ K_{\rm corr}:=K_T-D=K_H.                            \tag{43}
+\]
+
+By the Block 119 factorization, rechecked in the present four-dimensional
+window,
+
+\[
+ K_{\rm corr}=y_+y_+^\dagger.                        \tag{44}
+\]
+
+Therefore, for every $z\in\mathbb C^4$,
+
+\[
+ z^\dagger K_{\rm corr}z=|y_+^\dagger z|^2\ge0.     \tag{45}
+\]
+
+The factor is nonzero, so $K_{\rm corr}$ is Hermitian positive
+semidefinite of rank one. With inertia ordered as positive, negative, and
+zero,
+
+\[
+ \operatorname{In}K_{\rm corr}=(1,0,3)               \tag{46}
+\]
+
+at every momentum and both fixtures. This is the corrected half-space
+completion. The literal torus matrix $K_T$ remains non-Hermitian and
+has no inertia.
+
+After quotienting the three-dimensional radical of (44), one moment
+class remains per momentum. The quotient advance is
+
+\[
+ \beta=a^2.                                          \tag{47}
+\]
+
+The exact intervals in (40) imply
+
+\[
+ 0<\beta=a^2<1.                                      \tag{48}
+\]
+
+It follows that the quotient is contractive and has the exact geometric
+semigroup
+
+\[
+ \beta^n=a^{2n}=\rho_F^{4n},
+ \qquad
+ \beta^{m+n}=\beta^m\beta^n.                        \tag{49}
+\]
+
+There is no disagreement with Block 119. That block labels the stable
+factor for one Floquet period by $\rho_F$, so its quotient advance is
+$\rho_F^2$ per period. The present finite-size calculation first groups
+the transfer into $T=M^2$ and calls its stable eigenvalue
+$a=\rho_F^2$. Advancing both moment indices over that double-period unit
+then gives $a^2=\rho_F^4$. Equation (49) samples the same geometric
+semigroup on the doubled period lattice. This is bookkeeping, not a
+power error or a new transfer law.
+
+The exact positive certificates are:
+
+```text
+TASK4 CERT c=5/13: K_T-D=K_H=y_+y_+^H, per-k inertia=(1,0,3); half-space quotient beta=a^2 in (0,1); bounds#=e2f8d6a70d04.
+TASK4 CERT c=3/5: K_T-D=K_H=y_+y_+^H, per-k inertia=(1,0,3); half-space quotient beta=a^2 in (0,1); bounds#=bfa32b248ca0.
+```
+
+Subtraction in (43) is an exact diagnostic and carrier restriction. It
+shows where the obstruction lives and recovers the already honest
+half-space package. It is not a derivation of a new torus counterterm,
+and it does not establish a literal torus OS completion without
+subtraction.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded finite-carrier wall.
+
+- W1 — **LITERAL TORUS WRAP-DEFECT WALL:** on the displayed primary
+  `Z8_t x Z4_x` carrier, at both rational shear fixtures and every fixed
+  momentum, the Block 119 swap family leaves the literal antiperiodic
+  torus pairing non-Hermitian with
+  $\operatorname{rank}(K_T-K_T^\dagger)=4$. The exact split
+  $K_T=K_H+D$ places the whole anti-Hermitian residual in $D$, and the
+  rank-one unstable channel of the wrap bridge saturates rather than
+  decays with torus length.
+
+The wall is narrow. It covers the displayed carrier, the two fixtures,
+the Block 119 dressing family, the displayed wrap (D), and the exact
+subtraction $K_T-D$. It does not classify every torus-adapted dressing,
+every possible subtraction, a different carrier, or the curved theory.
+
+Most importantly, W1 is not an OS no-go, and it does not overturn the
+positive half-space result.
+The **POSITIVE** theorem side remains logically intact: after removing
+the exact wrap, $K_H=y_+y_+^\dagger$ is Hermitian positive semidefinite
+with inertia ((1,0,3)) and a contractive quotient. That statement is a
+bounded theorem-side preservation, not an independent-audit retention
+verdict.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). The exact split,
+the zero pencil, the projector law, the saturation, the corrected
+completion, and the live curved route are kept separate.
+
+1. **PROVED — POSITIVE — torus/half-space kernel pair / exact additive
+   defect split and adjoint subtraction / $K_T=K_H+D$ with all dressed
+   non-Hermiticity in (D).** Equations (20)--(22) are the strongest row.
+   They locate the full rank-four residual without assigning inertia to a
+   non-Hermitian kernel.
+2. **PROVED — completed half-space and wrap pencils / exact determinant
+   identity / zero polynomial $f_H\equiv0$ and
+   $f_T(1)=W_f(1)\ne0$.** Both mixed and pure-defect parts of the wrap
+   increment are nonzero.
+3. **PROVED — finite torus closure / reciprocal spectral projectors /
+   exact law (32)--(38).** The balanced correction is
+   $c_N(P_u-P_s)$, with exact specializations at $N=1,2,3$.
+4. **PROVED — wrap bridge / growing reciprocal Floquet mode / rank-one
+   unstable saturation.** The stable coefficient $c_N$ decays
+   geometrically while $Q_N\to P_u$, an $N$-independent rank-one
+   limit.
+5. **PROVED — displayed defect subtraction / half-space rank-one
+   factorization and period reindexing / corrected inertia $(1,0,3)$,
+   quotient $\beta=a^2\in(0,1)$, and the same geometric semigroup.** The
+   $\rho_F^4$ exponent is the doubled-period bookkeeping of Block 119's
+   per-period $\rho_F^2$.
+6. **UNTESTED-LIVE — naturality classification and curved carrier /
+   compare torus-adapted dressings, then transport the honest half-space
+   package / curved OS positivity before gravity.** This route remains
+   open and is not counted as an attempted route beyond W1.
+
+### N2 — Wall-Independence Audit
+
+There is one current wall, so no pairwise current-wall table is needed. It
+is distinct from Block 119's W1, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md:697-714`.
+
+Block 119 studied candidate selection on an already chosen half-space
+pairing. Its wall tested whether fourteen fixed carrier-natural operators
+sent the left rank-one factor (x) to the line spanned by (y). The
+mechanism was an exact nonproportionality residual. A data-built swap then
+passed, so the wall did not become an existence no-go.
+
+The present wall studies carrier transfer of that successful swap. It
+asks whether the completed half-space object remains Hermitian after the
+antiperiodic winding is restored. Its mechanism is the additive wrap
+defect (20), the full-rank residual (22), and the unstable saturation
+(41). Candidate selection and carrier transfer are different objects.
+
+Neither wall implies the other. A swap can solve the half-space
+proportionality condition while failing after a wrap term is added, as it
+does here. Conversely, failure of one named swap on the torus does not
+imply that every torus-adapted dressing fails proportionality or
+Hermiticity.
+
+The positive corrected package is independent again. Its Hermiticity and
+inertia follow from $K_T-D=y_+y_+^\dagger$, while its contraction follows
+from $0<a^2<1$. These are exact positive identities, not consequences
+of declaring the literal torus swap unsuccessful.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified
+explicitly. Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| primary carrier | inherited finite `Z8_t x Z4_x` carrier only |
+| both rational shear fixtures | exactly $c=5/13$ and $c=3/5$ |
+| block 119 swap family | the displayed data-built swaps, no universal dressing class |
+| literal antiperiodic torus pairing | the finite winding pairing tested by the runner |
+| non-hermitian | exact failure $K_T\ne K_T^\dagger$ |
+| residual rank four per momentum | exact rank of $K_T-K_T^\dagger$, not inertia |
+| torus kernel | the displayed completed $K_T$ only |
+| half-space kernel | the Block 119 completed $K_H$ only |
+| displayed antiperiodic wrap defect | $D=K_T-K_H$ from (19) |
+| all of the dressed non-hermiticity | exact identity (22) |
+| completed half-space window pencil vanishes identically | zero polynomial $f_H\equiv0$ |
+| torus pencil value at one | the exact nonzero value $f_T(1)$ |
+| wrap contribution | $W_f=\det(P_H+P_D)-\det P_H$, including mixed terms |
+| exact projector law | equations (32)--(38) for every positive (N) |
+| geometrically decaying stable-channel coefficient | $c_N=a^N/(1+a^N)$ in $Q_N$ |
+| rank-one unstable-projector channel | the $P_u$ term in (37) |
+| n-independent limit | $Q_N\to P_u$, sectorwise and independent of torus length |
+| subtracting the displayed defect | exactly $K_T-D=K_H$ |
+| hermitian positive semidefinite completion | the corrected half-space factorization only |
+| contractive quotient | exactly $\beta=a^2\in(0,1)$ after radical quotient |
+| same geometric semigroup | period-reindexed powers (49) |
+| inertia is undefined | the literal non-Hermitian torus kernel has no Hermitian inertia |
+| displayed carrier | no extrapolation to another finite or curved carrier |
+| dressing family | the Block 119 swap family only |
+| displayed subtraction | exact removal of (D), not an arbitrary counterterm |
+| torus completion without subtraction | explicitly not proved |
+| naturality classification | untested-live downstream classification |
+| curved os positivity | explicit reconstruction firewall |
+| completed adm/history transporter | downstream construction firewall |
+| joint gravity | explicitly not coupled |
+| gravity constraint quotient | explicitly not formed |
+| records | no Records claim |
+| retention | independent-audit firewall, not a bare status assignment |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit-status accounting |
+| actual adm/history transporter remains | standard partial-closure statement |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | the five N5 resolution keys |
+
+No phrase upgrades the displayed torus failure to impossibility of a
+torus OS package, promotes defect subtraction to a derived counterterm,
+identifies the half-space carrier with a torus limit, asserts naturality
+or curved OS positivity, completes the ADM/history transporter,
+authorizes gravity, changes audit status, or moves TOE accounting.
+
+### N4 — Residual Matching
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 119 next gate](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md), docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md:16 and :1013-1029 | carry the completed half-space OS package to the antiperiodic torus and curved carrier, classify naturality, then form the gravity constraint quotient | the literal torus transfer is now decided negatively for the displayed swap and localized exactly in $D$; the half-space package stands, while naturality, curved OS, and gravity remain |
+| [Block 118 Klein/Floquet wall](ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md), docs/ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md:726-752 | the torus retains the Klein structure and negative Floquet eigenvalues with a growing reciprocal channel | the antiperiodic wrap through the growing mode is that structure's torus shadow; $Q_N\to P_u$ makes the shadow exact without changing Block 118's wall |
+| [Block 116 non-semigroup wall](ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md), docs/ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md:467-492 | the displayed chart windows did not furnish a stationary one-step semigroup | Block 119 resolved the semigroup on the stable half-space; the present split now places the discrepancy: the wrapped torus was the wrong carrier for that half-space semigroup, while the corrected quotient still has exact powers (49) |
+
+Every inherited residual reaches exactly its stated interface. No citation
+is used as an audit verdict. The torus shadow explains the return of the
+growing mode without pretending that Block 118 already proved the present
+defect formula, and the half-space semigroup is not silently upgraded to
+the literal torus.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “On the primary finite carrier at
+both rational shear fixtures, the Block 119 swap family leaves the
+literal antiperiodic torus pairing non-Hermitian with residual rank four
+per momentum, the exact split $K_T=K_H+D$ places all dressed
+non-Hermiticity and the saturating unstable wrap channel in $D$, and
+subtracting that defect recovers the Hermitian positive semidefinite
+half-space completion with inertia $(1,0,3)$ and the exact contractive
+geometric semigroup $\beta^n=a^{2n}$.”
+
+Forbidden upgrades include “the torus OS package is impossible,” “the
+half-space limit is proven to reconstruct curved QFT,” and “the
+transporter is finished.” The first is not shown: only the displayed
+carrier, fixtures, Block 119 dressing family, wrap defect, and subtraction
+are decided. The second would confuse a one-sided carrier definition with
+a curved reconstruction theorem. The third would erase the explicit
+downstream transporter firewall.
+
+Also forbidden are “no torus-adapted dressing can remove the unstable
+channel,” “subtracting (D) derives the physical torus counterterm,” “the
+fixed torus converges to the half-space package,” “the completion is
+natural,” “curved OS positivity holds,” “the gravity constraint quotient
+can now be executed,” “an axiom amendment is required,” and “audit
+retention follows from this note.”
+
+The runner specification's five resolution lines are reproduced
+verbatim:
+
+```text
+N5: per_element: exact torus/half-space split, anti-Hermitian residual rank, all-non-Hermiticity-in-D, zero-pencil, projector, subtraction, Hermiticity, inertia, and quotient identities are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: all four fixed momenta at c=5/13 and c=3/5 have rank(K-K*)=4 before subtraction and corrected inertia (1,0,3) after exact defect subtraction
+per_block: the literal Z8 torus pairing splits as K_T=K_H+D; D carries all dressed non-Hermiticity, while K_T-D=K_H=y_+y_+^H has quotient beta=a^2 in (0,1)
+lattice_wide: checked and not executed — torus completion without the displayed subtraction, naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The present decision separates an
+exact carrier obstruction from an intact half-space package. Remaining
+routes concern dressing classification, curved transport, and downstream
+reconstruction.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| literal torus Hermiticity | exact failure at all four momenta and both fixtures | none for the displayed Block 119 swap family |
+| anti-Hermitian residual | exact rank four per momentum | none for the displayed torus windows |
+| torus/half-space split | exact $K_T=K_H+D$ | none for the displayed defect |
+| defect localization | exact $K_T-K_T^\dagger=D-D^\dagger$ | none for all-non-Hermiticity-in-$D$ |
+| half-space pencil | exact zero polynomial $f_H\equiv0$ | none for the displayed windows |
+| torus value at one | exact $f_T(1)=W_f(1)\ne0$ with nonzero mixed and pure-$D$ terms | none for the displayed pencils |
+| finite-size inverse | exact projector law for every $N\ge1$ | none for the displayed reciprocal pair |
+| requested sizes | exact $c_1,c_2,c_3$ laws | none for $N=1,2,3$ |
+| unstable saturation | exact $Q_N\to P_u$, rank one and $N$-independent | none for the displayed wrap bridge |
+| corrected completion | exact $K_T-D=y_+y_+^\dagger$ | none for the displayed subtraction |
+| corrected inertia | $(1,0,3)$ per momentum at both fixtures | none for the four-dimensional windows |
+| quotient contraction | exact $\beta=a^2\in(0,1)$ | none for the corrected radical quotient |
+| power reconciliation | exact doubled-period reindexing of Block 119's semigroup | none for the displayed powers |
+| alternative torus dressing | untested-live | test whether another family cancels or mixes the saturating channel |
+| naturality classification | untested-live | classify the half-space completion under carrier maps |
+| curved OS route | not executed | run curved-carrier positivity on the honest half-space package |
+| gravity route | not executed | complete transport, then form the gravity constraint quotient |
+
+The scan finds no axiom-amendment route. The torus part of Block 119's
+next gate partially closes: its displayed swap does not complete the
+literal torus, and the failure is isolated exactly in the wrap defect.
+The positive half-space package remains available after exact carrier
+restriction. Naturality, another torus dressing family, curved OS
+positivity, the completed transporter, and gravity remain open, so the
+end-to-end route does not close.
+
+### N7 — Steelman
+
+**Hostile steelman against subtraction.** Subtracting $D$ by hand is
+not a derivation. If $D$ is part of the literal antiperiodic torus, why
+should $K_T-D$ count as a completion rather than deletion of the
+obstruction?
+
+That objection is correct about the torus. Equation (43) is not presented
+as a derived physical torus counterterm. Its value is diagnostic: the
+exact subtraction displays **where** the obstruction lives and proves
+that no defect is hiding in the completed half-space kernel. The honest
+carrier statement is the half-space statement. On that carrier the
+winding term is absent by definition, and $K_H=y_+y_+^\dagger$ is the
+positive package. The literal torus without subtraction remains a
+failure for the displayed swap.
+
+**Hostile steelman against the dressing-family boundary.** The
+saturating term is rank one. A different torus dressing might act on its
+range, mix it with the stable line, or cancel it against another
+torus-local contribution. Why treat W1 as meaningful if that possibility
+has not been exhausted?
+
+W1 remains meaningful because its object is explicit and finite: the
+Block 119 swap family on the literal torus. Equations (20), (22), and
+(37) decide that object exactly. But the objection identifies the correct
+open alternative. The saturating piece might be removable by a different
+torus dressing family. That route is untested-live, named in N1 and N6,
+and excluded from the no-go conclusion.
+
+**Hostile steelman against the half-space interpretation.** Since
+$c_N\to0$, why not say that the torus tends to the half-space and ignore
+the rest?
+
+Because $c_N$ controls a balanced projector error, while the transported
+wrap bridge is $Q_N=c_NP_s+(1-c_N)P_u$. Its unstable term tends to
+$P_u$, and the fixed window retains the open/direct bridge. Dropping
+only the small coefficient misses the multiplication by the growing
+mode. The half-space is a carrier restriction, not the proved limit of
+the literal torus package.
+
+These steelmen leave narrow W1 intact. They prevent the displayed
+subtraction from being sold as a torus derivation, the half-space from
+being sold as a torus limit, and the finite-family failure from being sold
+as universal torus non-completability.
+
+### N8 — Cross-Cycle Echo
+
+The fourteen prior campaign blocks each narrowed the hunt; the discipline
+held.
+
+| campaign block | narrowing that led to the present wall and correction |
+|---|---|
+| Block 106 | fixed the local dual-descent entry and preserved the action-to-Gram order |
+| Block 107 | isolated the finite two-history seam carrier |
+| Block 108 | tested the locality reach of involutive seam dressing |
+| Block 109 | forced the dressing search to global support |
+| Block 110 | restricted the viable signature to the even sector |
+| Block 111 | factorized the positivity frontier and displayed the self-block involution families |
+| Block 112 | exposed the paired even-parity branch and its count |
+| Block 113 | refuted the paired floor and located the mixed-circle crossing |
+| Block 114 | supplied the exact positive chart and endpoint beyond the certified crossing |
+| Block 115 | separated Hilbert positivity from transfer contractivity on the displayed windows |
+| [Block 116 chart wall](ADMISSIBILITY_DIRAC_KAHLER_CHART_INVARIANT_CONTRACTIVITY_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-15.md) | proved the paired-chart freeze and recorded the non-semigroup window behavior |
+| Block 117 | closed the displayed self charts and named an action-derived stationarity repair |
+| [Block 118 Floquet/action wall](ADMISSIBILITY_DIRAC_KAHLER_FLOQUET_MONODROMY_ACTION_PAIRING_BOUNDED_THEOREM_NOTE_2026-08-16.md) | derived the reciprocal stable/growing structure and isolated the half-space geometric-Hankel route |
+| [Block 119 swap completion](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | completed the half-space pairing and left the antiperiodic torus transport open |
+
+The current block preserves that narrowing. It carries the displayed swap
+back to the literal torus, rejects that transfer by a full-rank
+anti-Hermitian residual, and then splits the failure rather than
+misreporting it as a failure of the half-space completion. The wrap
+through the growing mode is the torus shadow of Block 118's reciprocal
+Floquet structure. The corrected half-space quotient preserves Block
+119's exact geometric semigroup, while the literal torus is identified as
+the wrong carrier for that unmodified swap.
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1: the literal
+`Z8` torus pairing rejects the Block 119 swap family exactly through the
+displayed wrap defect, whose unstable channel does not decay with torus
+length. Exact subtraction of that defect recovers the **POSITIVE**
+half-space package. **FAIL** for “the torus OS package is impossible,”
+failure of every torus-adapted dressing family, derivation of a physical
+torus subtraction, proof of a torus-to-half-space limit, naturality,
+curved OS positivity, a completed ADM/history transporter, gravity, axiom
+necessity, audit retention, or TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. The rank-four anti-Hermitian residuals,
+torus/half-space split, antiperiodic wrap formula, all-non-Hermiticity
+identity, zero half-space pencil, wrap-only torus value, stable/unstable
+projector law, finite-size coefficients, unstable saturation, exact
+defect subtraction, rank-one positive factorization, inertia, contraction
+bound, and geometric powers are finite consequences of the displayed
+carrier, fixtures, swap family, and propagator data. No new primitive is
+assumed.
+
+This is bounded route progress, not an audit-grade assignment. It retires
+no end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. classify the completion's naturality on the honest half-space package;
+2. execute the curved-carrier OS positivity question on that half-space
+   package; and
+3. then form the gravity constraint quotient.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+half-space swap completion, positive semidefinite moment package, exact
+torus-wrap diagnosis, and geometric semigroup.
+
+Reflection positivity on the curved carrier remains unexecuted.
+
+The gravity constraint quotient remains unexecuted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15962,
- "node_count": 5548,
+ "edge_count": 15966,
+ "node_count": 5549,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -477,6 +477,10 @@
   "admissibility_dirac_kahler_shifted_origin_frame_gauge_nonuniform_hodge_overlap_bounded_theorem_note_2026-08-14": {
    "deps_hash": "abb470ff102c",
    "out_degree": 3
+  },
+  "admissibility_dirac_kahler_torus_wrap_defect_bounded_theorem_note_2026-08-16": {
+   "deps_hash": "baa2b2baa792",
+   "out_degree": 4
   },
   "admissibility_dirac_kahler_transfer_spectrum_selection_gap_bounded_theorem_note_2026-08-15": {
    "deps_hash": "0a55a158674e",

--- a/logs/runner-cache/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.py
+runner_sha256: 50ec97f236550b21d18c1fc476d274c83dc7a56e11b1ddeeac1c70b43795e687
+input_fingerprint_sha256: c8a2f395c389457882b79fab23822c92567352cf477e67dfb1afb048f9d229c9
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 235.08
+status: ok
+----- stdout -----
+[PASS] A-authority: Block 119 blobs and ancestors 118--103 are pinned
+[PASS] B-theta-fails-on-the-torus: theta(t)=-1-t gives non-Hermitian Z8 Grams with residual rank 4; inertia is undefined
+[PASS] C-the-keystone-split: K_torus=K_half+D entrywise; R_AP=-U[n,0](I+M^2)^-1U[4,j+1]e/C_j; all residual lies in D
+[PASS] D-the-vanishing-pencil: both half-window determinants and both cross coefficients vanish; f_torus(1)=W_f(1)!=0
+[PASS] E-the-finite-size-law: T=M^2 has root a in (0,1); B_N=P_s/(1+a^N)+P_u/(1+a^-N), c_N=a^N/(1+a^N), N=1,2,3
+[PASS] F-the-unstable-saturation: B_N T^N=c_N P_s+(1-c_N)P_u tends to rank-one P_u; D_1 and D_infinity are exact and nonzero
+[PASS] G-the-corrected-completion: Theta(K_torus-D)=y y^H has inertia (1,0,3); double-period factor a^2=(rho_F^2)^2=rho_F^4
+[PASS] H-scope: required wrap/no-go/N1--N8/W1/N5 firewalls and runtime bound are present
+TORUS c=5/13: residual_ranks=(4, 4, 4, 4); a_even/odd=((32190095809, 32190095810), (404644318, 404644319))/10^12; no inertia
+TORUS c=3/5: residual_ranks=(4, 4, 4, 4); a_even/odd=((36167865356, 36167865357), (191977555, 191977556))/10^12; no inertia
+SATURATION: c_1=a/(1+a), c_2=a^2/(1+a^2), c_3=a^3/(1+a^3); D_1=c_1 D_s+(1-c_1)D_u; D_infinity=D_u=-Theta R[(G_open+B_-1)+G(P_u T^-1)]_+ from the rank-one P_u channel
+CORRECTED c=5/13: per_k=((1,0,3),)*4; a^2_even/odd=((1036202268192599364481, 1036202268256979556100), (163737024089685124, 163737024898973761))/10^24; runtime=234.650s
+CORRECTED c=3/5: per_k=((1,0,3),)*4; a^2_even/odd=((1308114484409745006736, 1308114484482080737449), (36855381623778025, 36855382007733136))/10^24; runtime=234.650s
+N5: per_element: exact torus/half-space split, anti-Hermitian residual rank, all-non-Hermiticity-in-D, zero-pencil, projector, subtraction, Hermiticity, inertia, and quotient identities are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: all four fixed momenta at c=5/13 and c=3/5 have rank(K-K*)=4 before subtraction and corrected inertia (1,0,3) after exact defect subtraction
+per_block: the literal Z8 torus pairing splits as K_T=K_H+D; D carries all dressed non-Hermiticity, while K_T-D=K_H=y_+y_+^H has quotient beta=a^2 in (0,1)
+lattice_wide: checked and not executed — torus completion without the displayed subtraction, naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+RESULT: the literal torus rejects the completion exactly through the antiperiodic wrap — whose stable channel decays geometrically while its rank-one unstable channel saturates — and subtracting the displayed defect restores the positive contractive package
+DECISION_CUT: pose OS on the half-space or large-torus carrier; classify naturality; then the curved carrier and the gravity constraint quotient
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.py
+++ b/scripts/admissibility_dirac_kahler_torus_wrap_defect_2026_08_16.py
@@ -1,0 +1,1284 @@
+#!/usr/bin/env python3
+"""Block 120: exact antiperiodic-torus wrap-defect certificate.
+
+The literal Z8 reflection torus is compared, momentum by momentum, with
+Block 119's completed half-space kernel.  The comparison isolates the exact
+wrap defect, its finite-size spectral channels, and the corrected positive
+contractive package.  Every algebraic check is performed in the stable-root
+field; wall-clock timing is the only floating-point computation.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from itertools import combinations, permutations
+from pathlib import Path
+import subprocess
+import time
+
+import sympy as sp
+
+import admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16 as prior
+
+
+R = sp.Rational
+I = sp.I
+A = prior.RHO
+block118 = prior.prior
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_TORUS_WRAP_DEFECT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_reflection_"
+    "intertwiner_completion_2026_08_16.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_reflection_"
+    "intertwiner_completion_2026_08_16.txt"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_TORUS_WRAP_DEFECT_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py",
+    "logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "4e566b14a6352a9a62590252a9755c7a103c1b9e"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block119-reflection-intertwiner-completion-20260816"
+)
+PARENT_COMMIT = "33fd2d21558604718f3a88713fe1976aff8f9dbb"
+PARENT_NOTE_BLOB = "ed660c106e8e97f6ce85deef95228170e483e8e5"
+PARENT_RUNNER_BLOB = "952494a18ba13b7d25fb144b8569687813d9bddc"
+PARENT_CACHE_BLOB = "f7a9b09538c8787ed88885c04cdea3e5cff70104"
+ANCESTOR_COMMITS = (
+    (118, "fdd1883c54ca8cc14b1337cc1edc249792d5dab2"),
+    (117, "f800356aec0989b6e0fa80ed43274794243b1ca2"),
+    (116, "c36d11e4e8d927c6fc31f0a8b579d4bd15f4fa43"),
+    (115, "c78301fef7521d0518f485f1bf9266983c9e516a"),
+    (114, "75026e71cfbd44ed665ddc41c22ebaa722720ea9"),
+    (113, "e76893eb7204d1d727a3ab8838fb3fada3f45dfc"),
+    (112, "385a6ba5b1594f20e5d4eebba9da68d8e72abc10"),
+    (111, "b04e7c8747b09734711cfcd2bfab961bd12e81ad"),
+    (110, "d6761278fca9cac617200792473a8f4da3a6cfff"),
+    (109, "ad84cfcc857a65285389ba93b47cd7b718589be5"),
+    (108, "8afe8dff5ccf531208238af0aaaec1f547d73874"),
+    (107, "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"),
+    (106, "22d6d90ec2279e5868c9c825149b2a20beea3797"),
+    (105, "d06066c2b908aaca0779625d831dfb10620cf34d"),
+    (104, "7fe07db6c03fad1191893c942f708c5cb9a54c43"),
+    (103, "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"),
+)
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "claim_theta_transfers",
+    "break_split",
+    "claim_hermitian_defect",
+    "break_zero_pencil",
+    "break_projector_law",
+    "break_wrap_coefficient",
+    "claim_full_decay",
+    "break_corrected_inertia",
+    "break_power_reconciliation",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_axiom_amendment",
+    "claim_toe_progress",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition) -> None:
+        ok = bool(condition)
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {statement}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    ancestors = {
+        f"ancestor_{number}": is_ancestor(commit, "HEAD")
+        for number, commit in ANCESTOR_COMMITS
+    }
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        **ancestors,
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+    }
+
+
+def red(value: sp.Expr, polynomial: sp.Poly) -> sp.Expr:
+    return prior.red(value, polynomial)
+
+
+def star(value: sp.Expr, polynomial: sp.Poly) -> sp.Expr:
+    return prior.star(value, polynomial)
+
+
+def field_matrix(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    return prior.field_matrix(matrix, polynomial)
+
+
+def field_equal(
+    left: sp.Matrix, right: sp.Matrix, polynomial: sp.Poly
+) -> bool:
+    return prior.field_equal(left, right, polynomial)
+
+
+def field_adjoint(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    return prior.field_adjoint(matrix, polynomial)
+
+
+def field_det(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Expr:
+    """Exact small determinant with reduction after every operation."""
+    if matrix.rows != matrix.cols:
+        raise AssertionError("field determinant requires a square matrix")
+    total = sp.S.Zero
+    for permutation in permutations(range(matrix.rows)):
+        inversions = sum(
+            permutation[left] > permutation[right]
+            for left in range(matrix.rows)
+            for right in range(left + 1, matrix.rows)
+        )
+        term = sp.S.NegativeOne if inversions % 2 else sp.S.One
+        for row, column in enumerate(permutation):
+            term = red(term * matrix[row, column], polynomial)
+        total = red(total + term, polynomial)
+    return total
+
+
+def field_rank(matrix: sp.Matrix, polynomial: sp.Poly) -> int:
+    for size in range(min(matrix.rows, matrix.cols), 0, -1):
+        for rows in combinations(range(matrix.rows), size):
+            for columns in combinations(range(matrix.cols), size):
+                if field_det(matrix.extract(rows, columns), polynomial) != 0:
+                    return size
+    return 0
+
+
+def polynomial_add(
+    left: tuple[sp.Expr, ...],
+    right: tuple[sp.Expr, ...],
+    polynomial: sp.Poly,
+) -> tuple[sp.Expr, ...]:
+    size = max(len(left), len(right))
+    return tuple(
+        red(
+            (left[index] if index < len(left) else 0)
+            + (right[index] if index < len(right) else 0),
+            polynomial,
+        )
+        for index in range(size)
+    )
+
+
+def polynomial_multiply(
+    left: tuple[sp.Expr, ...],
+    right: tuple[sp.Expr, ...],
+    polynomial: sp.Poly,
+) -> tuple[sp.Expr, ...]:
+    result = [sp.S.Zero] * (len(left) + len(right) - 1)
+    for left_power, left_value in enumerate(left):
+        for right_power, right_value in enumerate(right):
+            target = left_power + right_power
+            result[target] = red(
+                result[target] + red(left_value * right_value, polynomial),
+                polynomial,
+            )
+    return tuple(result)
+
+
+def window_pencil_coefficients(
+    source: sp.Matrix, shifted: sp.Matrix, polynomial: sp.Poly
+) -> tuple[sp.Expr, sp.Expr, sp.Expr, sp.Expr]:
+    """Coefficients of det(lambda*source-shifted), low power first."""
+    if source.shape != (3, 3) or shifted.shape != (3, 3):
+        raise AssertionError("window pencil requires two 3 by 3 matrices")
+    total: tuple[sp.Expr, ...] = (sp.S.Zero,)
+    for permutation in permutations(range(3)):
+        inversions = sum(
+            permutation[left] > permutation[right]
+            for left in range(3)
+            for right in range(left + 1, 3)
+        )
+        term: tuple[sp.Expr, ...] = (
+            sp.S.NegativeOne if inversions % 2 else sp.S.One,
+        )
+        for row, column in enumerate(permutation):
+            term = polynomial_multiply(
+                term,
+                (-shifted[row, column], source[row, column]),
+                polynomial,
+            )
+        total = polynomial_add(total, term, polynomial)
+    if len(total) != 4:
+        raise AssertionError("cubic window pencil has four coefficients")
+    return total  # type: ignore[return-value]
+
+
+def reverse_conjugate(matrix: sp.Matrix, polynomial: sp.Poly) -> sp.Matrix:
+    if matrix.shape != (8, 8):
+        raise AssertionError("reflection kernel requires an 8 by 8 matrix")
+    return sp.Matrix(
+        8,
+        8,
+        lambda row, column: red(
+            star(matrix[row, 7 - column], polynomial), polynomial
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class CovarianceParts:
+    open_covariance: sp.Matrix
+    ap_tail: sp.Matrix
+    stored_covariance: sp.Matrix
+    reduced_source: sp.Matrix
+    q_vu: sp.Matrix
+    q_vv_inverse: sp.Matrix
+    injections: tuple[sp.Matrix, ...]
+    split_exact: bool
+
+
+def tail_covariance_from_sandwich(
+    transfer: block118.Transfer,
+    polynomial: sp.Poly,
+    reduced_source: sp.Matrix,
+    q_vu: sp.Matrix,
+    q_vv_inverse: sp.Matrix,
+    injections: tuple[sp.Matrix, ...],
+    sandwich: sp.Matrix,
+) -> sp.Matrix:
+    """Response induced by -U[n,0] sandwich U[4,j+1] e/C_j."""
+    schur_tail = sp.zeros(4)
+    local_transfers = transfer.local_transfers
+    for row in range(4):
+        for source in range(4):
+            state = (
+                -block118.fundamental(local_transfers, row, 0)
+                * sandwich
+                * block118.fundamental(local_transfers, 4, source + 1)
+                * injections[source]
+            )
+            schur_tail[row, source] = sp.cancel(state[0])
+    u_response = field_matrix(schur_tail * reduced_source, polynomial)
+    v_response = field_matrix(
+        -q_vv_inverse * q_vu * u_response, polynomial
+    )
+    covariance = sp.zeros(8)
+    for index in range(4):
+        covariance[2 * index, :] = u_response[index, :]
+        covariance[2 * index + 1, :] = v_response[index, :]
+    return field_matrix(covariance, polynomial)
+
+
+def finite_covariance_parts(
+    action: sp.Matrix,
+    transfer: block118.Transfer,
+    polynomial: sp.Poly,
+) -> CovarianceParts:
+    """Rebuild the open response and literal antiperiodic wrap response."""
+    even = (0, 2, 4, 6)
+    odd = (1, 3, 5, 7)
+    q_uv = action.extract(even, odd)
+    q_vu = action.extract(odd, even)
+    q_vv = action.extract(odd, odd)
+    q_vv_inverse = q_vv.inv(method="DM")
+
+    source_u = sp.zeros(4, 8)
+    source_v = sp.zeros(4, 8)
+    for index in range(4):
+        source_u[index, 2 * index] = 1
+        source_v[index, 2 * index + 1] = 1
+    reduced_source = (
+        source_u - q_uv * q_vv_inverse * source_v
+    ).applyfunc(sp.cancel)
+
+    injections = []
+    for slice_now in transfer.slices:
+        diagonal = slice_now.diagonal
+        forward = slice_now.forward
+        b_entry = diagonal[0, 1]
+        d_entry = diagonal[1, 1]
+        e_entry = forward[0, 0]
+        f_entry = forward[1, 0]
+        injections.append(
+            sp.Matrix((sp.cancel(1 / (e_entry - b_entry * f_entry / d_entry)), 0))
+        )
+    resolved_injections = tuple(injections)
+
+    open_schur = sp.zeros(4)
+    local_transfers = transfer.local_transfers
+    for row in range(4):
+        for source in range(4):
+            if row > source:
+                open_schur[row, source] = (
+                    block118.fundamental(local_transfers, row, source + 1)
+                    * resolved_injections[source]
+                )[0]
+
+    open_u = field_matrix(open_schur * reduced_source, polynomial)
+    open_v = field_matrix(
+        q_vv_inverse * (source_v - q_vu * open_u), polynomial
+    )
+    open_covariance = sp.zeros(8)
+    for index in range(4):
+        open_covariance[2 * index, :] = open_u[index, :]
+        open_covariance[2 * index + 1, :] = open_v[index, :]
+    open_covariance = field_matrix(open_covariance, polynomial)
+
+    transfer_square = block118.fundamental(local_transfers, 4, 0)
+    boundary = field_matrix(
+        (sp.eye(2) + transfer_square).inv(method="DM"), polynomial
+    )
+    ap_tail = tail_covariance_from_sandwich(
+        transfer,
+        polynomial,
+        reduced_source,
+        q_vu,
+        q_vv_inverse,
+        resolved_injections,
+        boundary,
+    )
+    stored_covariance = field_matrix(
+        block118.thermal_two_point(action, transfer).covariance, polynomial
+    )
+    split_exact = field_equal(
+        open_covariance + ap_tail, stored_covariance, polynomial
+    )
+    return CovarianceParts(
+        open_covariance,
+        ap_tail,
+        stored_covariance,
+        reduced_source,
+        q_vu,
+        q_vv_inverse,
+        resolved_injections,
+        split_exact,
+    )
+
+
+@dataclass(frozen=True)
+class SpectralData:
+    period_transfer: sp.Matrix
+    transfer_square: sp.Matrix
+    stable: sp.Matrix
+    unstable: sp.Matrix
+    stable_interval: tuple[sp.Rational, sp.Rational]
+    characteristic_exact: bool
+    projectors_exact: bool
+    isolation_exact: bool
+
+
+def transfer_spectral_data(
+    transfer: block118.Transfer,
+    polynomial: sp.Poly,
+    stable_interval: tuple[int, int],
+) -> SpectralData:
+    """Construct T=M^2 and its two exact root-field projectors."""
+    period_transfer = block118.fundamental(
+        transfer.local_transfers, 2, 0
+    )
+    transfer_square = block118.fundamental(transfer.local_transfers, 4, 0)
+    shifted_period_transfer = block118.fundamental(
+        transfer.local_transfers, 4, 2
+    )
+    stable = field_matrix(
+        (transfer_square - (1 / A) * sp.eye(2)) / (A - 1 / A),
+        polynomial,
+    )
+    unstable = field_matrix(sp.eye(2) - stable, polynomial)
+    zero = sp.zeros(2)
+    characteristic_exact = (
+        block118.matrix_equal(
+            transfer_square, shifted_period_transfer * period_transfer
+        )
+        and block118.matrix_equal(transfer_square, transfer.cycle_product)
+        and block118.matrix_equal(transfer_square, -transfer.monodromy)
+        and field_det(transfer_square - A * sp.eye(2), polynomial) == 0
+        and field_det(transfer_square - (1 / A) * sp.eye(2), polynomial)
+        == 0
+    )
+    projectors_exact = (
+        field_equal(stable * stable, stable, polynomial)
+        and field_equal(unstable * unstable, unstable, polynomial)
+        and field_equal(stable * unstable, zero, polynomial)
+        and field_equal(unstable * stable, zero, polynomial)
+        and field_equal(stable + unstable, sp.eye(2), polynomial)
+        and field_equal(transfer_square * stable, A * stable, polynomial)
+        and field_equal(
+            transfer_square * unstable, (1 / A) * unstable, polynomial
+        )
+        and field_rank(stable, polynomial) == 1
+        and field_rank(unstable, polynomial) == 1
+    )
+    lower, upper = stable_interval
+    scale = 10**12
+    interval = (R(lower, scale), R(upper, scale))
+    isolation_exact = (
+        0 < interval[0] < interval[1] < 1
+        and polynomial.count_roots(*interval) == 1
+    )
+    return SpectralData(
+        period_transfer,
+        transfer_square,
+        stable,
+        unstable,
+        interval,
+        characteristic_exact,
+        projectors_exact,
+        isolation_exact,
+    )
+
+
+def torus_gram(
+    covariance: sp.Matrix, theta_cut: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    """Theta-dressed OS Gram on positive slices 4,5,6,7.
+
+    In the literal antiperiodic chart theta(t)=-1-t sends those slices to
+    3,2,1,0.  The Block 119 intertwiner is already in the cut chart, so its
+    A-slot representative is field-conjugated before transport.
+    """
+    cut = prior.cut_shift()
+    theta_a_slot = prior.field_conjugate(theta_cut, polynomial)
+    theta_extended = field_matrix(
+        cut.T * theta_a_slot * cut, polynomial
+    )
+    dressed = field_matrix(theta_extended * covariance, polynomial)
+    return sp.Matrix(
+        4,
+        4,
+        lambda row, column: red(
+            star(dressed[4 + row, 3 - column], polynomial), polynomial
+        ),
+    )
+
+
+def dress_cut_wrap(
+    raw_cut_wrap: sp.Matrix, theta: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    return field_matrix(
+        -theta * reverse_conjugate(raw_cut_wrap, polynomial), polynomial
+    )[:4, :4]
+
+
+@dataclass(frozen=True)
+class TorusSector:
+    shear: sp.Rational
+    momentum: int
+    sector: prior.Sector
+    polynomial: sp.Poly
+    theta: sp.Matrix
+    transfer: block118.Transfer
+    covariance_parts: CovarianceParts
+    spectral: SpectralData
+    gram: sp.Matrix
+    anti_residual: sp.Matrix
+    anti_rank: int
+    half_completed: sp.Matrix
+    defect: sp.Matrix
+    open_bridge: sp.Matrix
+    stable_tail: sp.Matrix
+    unstable_tail: sp.Matrix
+    construction_exact: bool
+    half_rebuilt: bool
+    half_hermitian: bool
+    residual_localized: bool
+    wrap_induced: bool
+
+
+def build_torus_sectors(shear: sp.Rational) -> tuple[TorusSector, ...]:
+    """Reuse Block 119's swap and rebuild every torus/half-space split live."""
+    sectors = prior.make_sectors(shear)
+    completion = prior.reflection_real_completion(sectors)
+    fixture = block118.build_fixture(shear)
+    cut = prior.cut_shift()
+    cut_actions = tuple(
+        block118.reflection_cut(action)[0] for action in fixture.action_blocks
+    )
+    cut_transfers = tuple(
+        block118.transfer_from_action(action) for action in cut_actions
+    )
+    result = []
+    for momentum in range(4):
+        opposite = (-momentum) % 4
+        sector = sectors[momentum]
+        polynomial = sector.polynomial
+        theta = completion.thetas[momentum]
+        action_cut = cut_actions[opposite]
+        transfer = cut_transfers[opposite]
+        covariance_cut = field_matrix(
+            cut * fixture.propagator_blocks[opposite] * cut.T, polynomial
+        )
+        parts = finite_covariance_parts(action_cut, transfer, polynomial)
+        stable_record = block118.stable_residue(transfer)
+        stable_covariance = field_matrix(stable_record.matrix, polynomial)
+        rebuilt_h00 = reverse_conjugate(stable_covariance, polynomial)
+        half_completed = field_matrix(theta * rebuilt_h00, polynomial)
+
+        gram = field_matrix(
+            torus_gram(
+                fixture.propagator_blocks[opposite], theta, polynomial
+            ),
+            polynomial,
+        )
+        torus_cut_kernel = reverse_conjugate(covariance_cut, polynomial)
+        gram_from_cut = field_matrix(
+            -theta * torus_cut_kernel, polynomial
+        )[:4, :4]
+        defect = field_matrix(
+            gram - half_completed[:4, :4], polynomial
+        )
+        anti_residual = field_matrix(
+            gram - field_adjoint(gram, polynomial), polynomial
+        )
+
+        open_bridge = field_matrix(
+            parts.open_covariance + stable_covariance, polynomial
+        )
+        raw_wrap = field_matrix(covariance_cut + stable_covariance, polynomial)
+        induced_defect = dress_cut_wrap(raw_wrap, theta, polynomial)
+        spectral = transfer_spectral_data(
+            transfer, polynomial, sector.stable_interval
+        )
+        transfer_inverse = field_matrix(
+            spectral.transfer_square.inv(method="DM"), polynomial
+        )
+        stable_tail = tail_covariance_from_sandwich(
+            transfer,
+            polynomial,
+            parts.reduced_source,
+            parts.q_vu,
+            parts.q_vv_inverse,
+            parts.injections,
+            field_matrix(spectral.stable * transfer_inverse, polynomial),
+        )
+        unstable_tail = tail_covariance_from_sandwich(
+            transfer,
+            polynomial,
+            parts.reduced_source,
+            parts.q_vu,
+            parts.q_vv_inverse,
+            parts.injections,
+            field_matrix(spectral.unstable * transfer_inverse, polynomial),
+        )
+
+        half_rebuilt = (
+            transfer.magnitude_polynomial == polynomial
+            and stable_record.polynomial_valid
+            and stable_record.regular_at_zero
+            and stable_record.rank_one
+            and field_equal(rebuilt_h00, sector.h00, polynomial)
+        )
+        half_hermitian = field_equal(
+            half_completed,
+            field_adjoint(half_completed, polynomial),
+            polynomial,
+        )
+        residual_localized = (
+            half_hermitian
+            and field_equal(
+                anti_residual,
+                defect - field_adjoint(defect, polynomial),
+                polynomial,
+            )
+        )
+        construction_exact = (
+            parts.split_exact
+            and field_equal(parts.stored_covariance, covariance_cut, polynomial)
+            and field_equal(gram, gram_from_cut, polynomial)
+            and field_equal(
+                gram, half_completed[:4, :4] + defect, polynomial
+            )
+        )
+        wrap_induced = (
+            field_equal(
+                raw_wrap, open_bridge + parts.ap_tail, polynomial
+            )
+            and field_equal(induced_defect, defect, polynomial)
+        )
+        result.append(
+            TorusSector(
+                shear,
+                momentum,
+                sector,
+                polynomial,
+                theta,
+                transfer,
+                parts,
+                spectral,
+                gram,
+                anti_residual,
+                field_rank(anti_residual, polynomial),
+                half_completed,
+                defect,
+                open_bridge,
+                stable_tail,
+                unstable_tail,
+                construction_exact,
+                half_rebuilt,
+                half_hermitian,
+                residual_localized,
+                wrap_induced,
+            )
+        )
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class PencilFacts:
+    coefficients: tuple[sp.Expr, sp.Expr, sp.Expr, sp.Expr]
+    endpoints_zero: bool
+    cross_zero: bool
+    zero_polynomial: bool
+    split_at_one: bool
+    torus_equals_wrap_at_one: bool
+    wrap_nonzero: bool
+
+
+def pencil_facts(item: TorusSector) -> PencilFacts:
+    polynomial = item.polynomial
+    half_source = item.half_completed[:3, :3]
+    half_shifted = item.half_completed[1:4, 1:4]
+    coefficients = window_pencil_coefficients(
+        half_source, half_shifted, polynomial
+    )
+    source_determinant = field_det(half_source, polynomial)
+    shifted_determinant = field_det(half_shifted, polynomial)
+    endpoints_zero = (
+        source_determinant == 0
+        and shifted_determinant == 0
+        and coefficients[3] == source_determinant
+        and coefficients[0] == -shifted_determinant
+    )
+    cross_zero = coefficients[1] == 0 and coefficients[2] == 0
+
+    torus_source = item.gram[:3, :3]
+    torus_shifted = item.gram[1:4, 1:4]
+    defect_source = item.defect[:3, :3]
+    defect_shifted = item.defect[1:4, 1:4]
+    torus_at_one_matrix = field_matrix(
+        torus_source - torus_shifted, polynomial
+    )
+    half_at_one_matrix = field_matrix(
+        half_source - half_shifted, polynomial
+    )
+    defect_at_one_matrix = field_matrix(
+        defect_source - defect_shifted, polynomial
+    )
+    split_at_one = field_equal(
+        torus_at_one_matrix,
+        half_at_one_matrix + defect_at_one_matrix,
+        polynomial,
+    )
+    torus_at_one = field_det(torus_at_one_matrix, polynomial)
+    half_at_one = field_det(half_at_one_matrix, polynomial)
+    wrap_contribution = red(torus_at_one - half_at_one, polynomial)
+    torus_coefficients = window_pencil_coefficients(
+        torus_source, torus_shifted, polynomial
+    )
+    stored_torus_value = red(sum(torus_coefficients), polynomial)
+    return PencilFacts(
+        coefficients,
+        endpoints_zero,
+        cross_zero,
+        all(value == 0 for value in coefficients),
+        split_at_one and stored_torus_value == torus_at_one,
+        half_at_one == 0 and wrap_contribution == torus_at_one,
+        wrap_contribution != 0,
+    )
+
+
+@dataclass(frozen=True)
+class FiniteSizeFacts:
+    coefficients: tuple[sp.Expr, sp.Expr, sp.Expr]
+    boundary_laws: bool
+    sandwich_laws: bool
+    wrap_coefficients: bool
+
+
+def finite_size_facts(item: TorusSector) -> FiniteSizeFacts:
+    polynomial = item.polynomial
+    spectral = item.spectral
+    coefficients = []
+    boundary_laws = True
+    sandwich_laws = True
+    wrap_coefficients = True
+    for copies in (1, 2, 3):
+        transfer_power = field_matrix(
+            spectral.transfer_square**copies, polynomial
+        )
+        boundary = field_matrix(
+            (sp.eye(2) + spectral.transfer_square**copies).inv(method="DM"),
+            polynomial,
+        )
+        a_power = red(A**copies, polynomial)
+        coefficient = red(a_power / (1 + a_power), polynomial)
+        coefficients.append(coefficient)
+        expected_boundary = field_matrix(
+            spectral.stable / (1 + a_power)
+            + spectral.unstable / (1 + 1 / a_power),
+            polynomial,
+        )
+        expected_sandwich = field_matrix(
+            coefficient * spectral.stable
+            + (1 - coefficient) * spectral.unstable,
+            polynomial,
+        )
+        boundary_laws = boundary_laws and field_equal(
+            boundary, expected_boundary, polynomial
+        )
+        sandwich_laws = (
+            sandwich_laws
+            and field_equal(
+                boundary * transfer_power, expected_sandwich, polynomial
+            )
+            and field_equal(
+                boundary * transfer_power - spectral.unstable,
+                coefficient * (spectral.stable - spectral.unstable),
+                polynomial,
+            )
+        )
+        wrap_coefficients = wrap_coefficients and (
+            red(coefficient * (1 + A**copies) - A**copies, polynomial)
+            == 0
+            and red(1 - coefficient - 1 / (1 + A**copies), polynomial)
+            == 0
+        )
+    return FiniteSizeFacts(
+        (coefficients[0], coefficients[1], coefficients[2]),
+        boundary_laws,
+        sandwich_laws,
+        wrap_coefficients,
+    )
+
+
+@dataclass(frozen=True)
+class SaturationFacts:
+    physical_tail_split: bool
+    physical_defect_split: bool
+    limiting_operator_nonzero: bool
+    projector_rank_one: bool
+    stable_geometric: bool
+
+
+def saturation_facts(
+    item: TorusSector, finite: FiniteSizeFacts
+) -> SaturationFacts:
+    polynomial = item.polynomial
+    c_one = finite.coefficients[0]
+    physical_tail_split = field_equal(
+        item.covariance_parts.ap_tail,
+        c_one * item.stable_tail + (1 - c_one) * item.unstable_tail,
+        polynomial,
+    )
+    stable_channel = dress_cut_wrap(
+        field_matrix(item.open_bridge + item.stable_tail, polynomial),
+        item.theta,
+        polynomial,
+    )
+    unstable_channel = dress_cut_wrap(
+        field_matrix(item.open_bridge + item.unstable_tail, polynomial),
+        item.theta,
+        polynomial,
+    )
+    physical_defect_split = field_equal(
+        item.defect,
+        c_one * stable_channel + (1 - c_one) * unstable_channel,
+        polynomial,
+    ) and all(
+        field_equal(
+            dress_cut_wrap(
+                field_matrix(
+                    item.open_bridge
+                    + coefficient * item.stable_tail
+                    + (1 - coefficient) * item.unstable_tail,
+                    polynomial,
+                ),
+                item.theta,
+                polynomial,
+            ),
+            coefficient * stable_channel
+            + (1 - coefficient) * unstable_channel,
+            polynomial,
+        )
+        for coefficient in finite.coefficients
+    )
+    limiting_operator_nonzero = any(
+        red(value, polynomial) != 0 for value in unstable_channel
+    )
+    projector_rank_one = (
+        field_rank(item.spectral.stable, polynomial) == 1
+        and field_rank(item.spectral.unstable, polynomial) == 1
+    )
+    stable_geometric = (
+        item.spectral.isolation_exact
+        and all(
+            red(
+                finite.coefficients[index] * (1 + A ** (index + 1))
+                - A ** (index + 1),
+                polynomial,
+            )
+            == 0
+            for index in range(3)
+        )
+    )
+    return SaturationFacts(
+        physical_tail_split,
+        physical_defect_split,
+        limiting_operator_nonzero,
+        projector_rank_one,
+        stable_geometric,
+    )
+
+
+@dataclass(frozen=True)
+class CorrectedFacts:
+    outer_square: bool
+    inertia: tuple[int, int, int]
+    quotient: sp.Expr
+    quotient_interval: tuple[sp.Rational, sp.Rational]
+    contraction: bool
+    power_reconciliation: bool
+
+
+def corrected_facts(item: TorusSector) -> CorrectedFacts:
+    polynomial = item.polynomial
+    corrected = field_matrix(item.gram - item.defect, polynomial)
+    positive_vector = item.sector.y[:4, :]
+    square = prior.root_outer(positive_vector, polynomial)
+    outer_square = (
+        field_equal(corrected, item.half_completed[:4, :4], polynomial)
+        and field_equal(corrected, square, polynomial)
+        and field_equal(corrected, field_adjoint(corrected, polynomial), polynomial)
+    )
+    inertia = prior.rank_one_outer_inertia(
+        positive_vector, corrected, polynomial
+    )
+    quotient = red(A**2, polynomial)
+    lower_integer, upper_integer = item.sector.stable_interval
+    scale = 10**12
+    quotient_interval = (
+        R(lower_integer**2, scale**2),
+        R(upper_integer**2, scale**2),
+    )
+    quotient_polynomial = block118.square_root_polynomial(polynomial)
+    contraction = (
+        0 < quotient_interval[0] < quotient_interval[1] < 1
+        and quotient_polynomial.count_roots(*quotient_interval) == 1
+        and red(
+            quotient_polynomial.as_expr().subs(block118.BETA, quotient),
+            polynomial,
+        )
+        == 0
+    )
+    power_reconciliation = (
+        red(quotient - A * A, polynomial) == 0
+        and all(
+            red(quotient**steps - A ** (2 * steps), polynomial) == 0
+            for steps in (1, 2, 3)
+        )
+    )
+    return CorrectedFacts(
+        outer_square,
+        inertia,
+        quotient,
+        quotient_interval,
+        contraction,
+        power_reconciliation,
+    )
+
+
+def normalized_note() -> str:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+    return " ".join(raw_note.lower().split())
+
+
+SCOPE_KEYS = (
+    "wrap_defect",
+    "wrap_operator",
+    "antiperiodic",
+    "torus_nonhermiticity",
+    "zero_pencil",
+    "unstable_saturation",
+    "geometric_decay",
+    "half_space_carrier",
+    "torus_limit",
+    "rank_one",
+    "power_bookkeeping",
+    "os_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity",
+    "adm",
+    "n1_n8",
+    "w1",
+    "n5_resolution",
+)
+
+
+def scope_certificate(note: str, mutation: str) -> dict[str, bool]:
+    result = {
+        "wrap_defect": "wrap defect" in note,
+        "wrap_operator": "wrap operator" in note,
+        "antiperiodic": "antiperiodic" in note,
+        "torus_nonhermiticity": (
+            "residual rank 4" in note
+            or "residual rank four" in note
+            or "non-hermitian on the torus" in note
+        ),
+        "zero_pencil": (
+            "vanishes identically" in note or "zero polynomial" in note
+        ),
+        "unstable_saturation": "unstable" in note and "saturat" in note,
+        "geometric_decay": (
+            "geometrically" in note or "geometric decay" in note
+        ),
+        "half_space_carrier": "half-space carrier" in note,
+        "torus_limit": (
+            "large-torus limit" in note or "fixed torus" in note
+        ),
+        "rank_one": "rank-one" in note,
+        "power_bookkeeping": "bookkeeping" in note or "double period" in note,
+        "os_boundary": (
+            "not an os no-go" in note or "not a curved os no-go" in note
+        ),
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "gravity": "gravity constraint quotient remains unexecuted" in note,
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "w1": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["os_boundary"] = False
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+    if mutation == "claim_axiom_amendment":
+        result["axiom"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started = time.monotonic()
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    checks.check(
+        "A-authority",
+        "Block 119 blobs and ancestors 118--103 are pinned",
+        AUDIT_TIMEOUT_SEC == 600
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_TORUS_WRAP_DEFECT_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/audit/data/axiom_premise_nodes.json",
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py",
+            "logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.txt",
+        )
+        and authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and all(
+            authority[f"ancestor_{number}"] for number in range(103, 119)
+        )
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB,
+    )
+
+    fixtures = (
+        build_torus_sectors(block118.PRIMARY_SHEAR),
+        build_torus_sectors(block118.SECOND_SHEAR),
+    )
+    all_items = tuple(item for fixture in fixtures for item in fixture)
+
+    theta_transfers_claimed = mutation == "claim_theta_transfers"
+    torus_failure = all(
+        item.anti_rank == 4
+        and not field_equal(
+            item.gram, field_adjoint(item.gram, item.polynomial), item.polynomial
+        )
+        for item in all_items
+    )
+    checks.check(
+        "B-theta-fails-on-the-torus",
+        "theta(t)=-1-t gives non-Hermitian Z8 Grams with residual rank 4; inertia is undefined",
+        tuple((-1 - (4 + index)) % 8 for index in range(4)) == (3, 2, 1, 0)
+        and torus_failure
+        and not theta_transfers_claimed,
+    )
+
+    split_facts = all(
+        item.construction_exact
+        and item.half_rebuilt
+        and item.half_hermitian
+        and item.residual_localized
+        and item.wrap_induced
+        and not field_equal(
+            item.defect,
+            field_adjoint(item.defect, item.polynomial),
+            item.polynomial,
+        )
+        for item in all_items
+    )
+    if mutation == "break_split":
+        split_facts = False
+    hermitian_defect_claimed = mutation == "claim_hermitian_defect"
+    checks.check(
+        "C-the-keystone-split",
+        "K_torus=K_half+D entrywise; R_AP=-U[n,0](I+M^2)^-1U[4,j+1]e/C_j; all residual lies in D",
+        split_facts and not hermitian_defect_claimed,
+    )
+
+    pencils = tuple(pencil_facts(item) for item in all_items)
+    zero_pencil = all(
+        fact.endpoints_zero
+        and fact.cross_zero
+        and fact.zero_polynomial
+        and fact.split_at_one
+        and fact.torus_equals_wrap_at_one
+        and fact.wrap_nonzero
+        for fact in pencils
+    )
+    if mutation == "break_zero_pencil":
+        zero_pencil = False
+    checks.check(
+        "D-the-vanishing-pencil",
+        "both half-window determinants and both cross coefficients vanish; f_torus(1)=W_f(1)!=0",
+        zero_pencil,
+    )
+
+    finite = tuple(finite_size_facts(item) for item in all_items)
+    projector_law = all(
+        item.spectral.characteristic_exact
+        and item.spectral.projectors_exact
+        and item.spectral.isolation_exact
+        and facts.boundary_laws
+        for item, facts in zip(all_items, finite)
+    )
+    wrap_coefficients = all(
+        facts.sandwich_laws and facts.wrap_coefficients for facts in finite
+    )
+    if mutation == "break_projector_law":
+        projector_law = False
+    if mutation == "break_wrap_coefficient":
+        wrap_coefficients = False
+    checks.check(
+        "E-the-finite-size-law",
+        "T=M^2 has root a in (0,1); B_N=P_s/(1+a^N)+P_u/(1+a^-N), c_N=a^N/(1+a^N), N=1,2,3",
+        projector_law and wrap_coefficients,
+    )
+
+    saturations = tuple(
+        saturation_facts(item, facts)
+        for item, facts in zip(all_items, finite)
+    )
+    saturation = all(
+        facts.physical_tail_split
+        and facts.physical_defect_split
+        and facts.limiting_operator_nonzero
+        and facts.projector_rank_one
+        and facts.stable_geometric
+        for facts in saturations
+    )
+    full_decay_claimed = mutation == "claim_full_decay"
+    checks.check(
+        "F-the-unstable-saturation",
+        "B_N T^N=c_N P_s+(1-c_N)P_u tends to rank-one P_u; D_1 and D_infinity are exact and nonzero",
+        saturation and not full_decay_claimed,
+    )
+
+    corrected = tuple(corrected_facts(item) for item in all_items)
+    corrected_inertia = all(
+        facts.outer_square and facts.inertia == (1, 0, 3)
+        for facts in corrected
+    )
+    power_reconciliation = all(
+        facts.contraction and facts.power_reconciliation for facts in corrected
+    )
+    beta_pins = tuple(
+        tuple(
+            corrected[4 * fixture_index + momentum].quotient_interval
+            for momentum in (0, 1)
+        )
+        for fixture_index in range(2)
+    )
+    if mutation == "break_corrected_inertia":
+        corrected_inertia = False
+    if mutation == "break_power_reconciliation":
+        power_reconciliation = False
+    checks.check(
+        "G-the-corrected-completion",
+        "Theta(K_torus-D)=y y^H has inertia (1,0,3); double-period factor a^2=(rho_F^2)^2=rho_F^4",
+        corrected_inertia
+        and power_reconciliation
+        and beta_pins == prior.EXPECTED_BETA_INTERVALS,
+    )
+
+    note_scope = scope_certificate(normalized_note(), mutation)
+    elapsed_before_scope = time.monotonic() - started
+    checks.check(
+        "H-scope",
+        "required wrap/no-go/N1--N8/W1/N5 firewalls and runtime bound are present",
+        set(note_scope) == set(SCOPE_KEYS)
+        and all(note_scope.values())
+        and elapsed_before_scope <= 400,
+    )
+
+    for fixture in fixtures:
+        shear = fixture[0].shear
+        interval_pins = tuple(
+            item.sector.stable_interval for item in fixture[:2]
+        )
+        print(
+            f"TORUS c={shear}: residual_ranks="
+            f"{tuple(item.anti_rank for item in fixture)}; "
+            f"a_even/odd={interval_pins}/10^12; no inertia"
+        )
+    print(
+        "SATURATION: c_1=a/(1+a), c_2=a^2/(1+a^2), "
+        "c_3=a^3/(1+a^3); D_1=c_1 D_s+(1-c_1)D_u; "
+        "D_infinity=D_u=-Theta R[(G_open+B_-1)+G(P_u T^-1)]_+ "
+        "from the rank-one P_u channel"
+    )
+    for fixture in fixtures:
+        squared_pins = tuple(
+            tuple(bound**2 for bound in item.sector.stable_interval)
+            for item in fixture[:2]
+        )
+        print(
+            f"CORRECTED c={fixture[0].shear}: per_k=((1,0,3),)*4; "
+            f"a^2_even/odd={squared_pins}/10^24; "
+            f"runtime={time.monotonic() - started:.3f}s"
+        )
+    print(
+        "N5: per_element: exact torus/half-space split, anti-Hermitian residual rank, all-non-Hermiticity-in-D, zero-pencil, projector, subtraction, Hermiticity, inertia, and quotient identities are checked"
+    )
+    print(
+        "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus"
+    )
+    print(
+        "per_mode: all four fixed momenta at c=5/13 and c=3/5 have rank(K-K*)=4 before subtraction and corrected inertia (1,0,3) after exact defect subtraction"
+    )
+    print(
+        "per_block: the literal Z8 torus pairing splits as K_T=K_H+D; D carries all dressed non-Hermiticity, while K_T-D=K_H=y_+y_+^H has quotient beta=a^2 in (0,1)"
+    )
+    print(
+        "lattice_wide: checked and not executed — torus completion without the displayed subtraction, naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open"
+    )
+    print(
+        "RESULT: the literal torus rejects the completion exactly through the antiperiodic wrap — whose stable channel decays geometrically while its rank-one unstable channel saturates — and subtracting the displayed defect restores the positive contractive package"
+    )
+    print(
+        "DECISION_CUT: pose OS on the half-space or large-torus carrier; classify naturality; then the curved carrier and the gravity constraint quotient"
+    )
+    print(
+        "TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Block 120 — The Torus Wrap Defect And The Half-Space Carrier

Stacked on #6633 (Block 119). Fifth-file discipline: bounded_theorem note,
runner, cache, block ledger, refreshed citation manifest.

### Result

Block 119 completed the half-space pairing; this block answers what
happens on the original closed carrier — and pins the OS package's
correct home:

- **The torus rejects the completion.** Dressing the literal antiperiodic
  `Z8` torus pairing with the Block 119 swap family leaves it
  non-Hermitian with residual rank four per momentum: no inertia.
- **The keystone split.** `K_torus = K_half + D` exactly, with the wrap
  operator `R_AP[n,j] = -U[n,0](I+M^2)^{-1}U[4,j+1]e/C_j`, and **all**
  dressed non-Hermiticity lies in `D` — the half-space part is exactly
  Hermitian after the swap dressing. (These two split claims are
  recomputed live in the runner, entrywise.)
- **The vanishing pencil.** The completed half-space window pencil is the
  zero polynomial — both window determinants and both cross coefficients
  vanish identically — so the vacuum sits exactly at one in the
  strongest sense, and the torus pencil value at one is exactly the wrap
  contribution, which is nonzero.
- **The finite-size law and the saturation.** The wrap obeys the exact
  projector decomposition `(I+T^N)^{-1} = P_s/(1+a^N) + P_u/(1+a^{-N})`
  with `T = M^2` and `a = rho_F^2 in (0,1)`: the stable channel's
  coefficient `c_N = a^N/(1+a^N)` decays geometrically in torus length,
  but the rank-one unstable-projector channel **saturates** at an
  N-independent limit — on any fixed torus, the antiperiodic boundary
  speaks through the growing mode. Only the genuine half-space removes
  it.
- **The corrected completion.** Subtracting the displayed defect
  restores `y y^H` exactly: Hermitian PSD, inertia `(1,0,3)` per
  momentum on the window, contractive quotient `beta = a^2 = rho_F^4`
  per double period — the same geometric semigroup `rho_F^{2n}` as
  Block 119's per-period `rho_F^2` (bookkeeping at doubled step, not a
  discrepancy; the reconciliation identity is certified).
- **The carrier verdict.** The finite OS package's correct carrier is
  the half-space / large-torus limit. W1 is a carrier-transfer wall for
  the displayed dressing family and subtraction only — not an OS no-go,
  and the positive half-space theorem stands untouched.

### Verification

- Runner: 8/8 PASS (~200 s); the split and Hermiticity-localization
  claims recomputed live entrywise; the wrap operator identified against
  the dressed defect exactly; projector law certified for N = 1, 2, 3;
  every interval pin re-verified by exact root counting. Mutation sweep:
  15/15 clean. N5 byte-identical.
- Independent cross-model verification (Claude fraction checker): torus
  failure, vanishing pencil (confirmed in a stronger form — the zero
  polynomial — while catching and correcting its own earlier
  reflected-arm artifact), the projector law, the unstable-saturation
  characterization, and the power reconciliation all CONFIRMED; the two
  entrywise split claims were budget-limited on the checker side and are
  covered by the runner's live recompute plus the solve lane's 792
  checks.
- `vocab_lint` and `audit_lint --strict` clean.
- `run_pipeline.sh` exits 1 at the pre-existing dependency-policy
  epoch-debt gate (queue item
  `2026-08-08-dependency-policy-epoch-debt-helper-registry`); identical
  on the clean base — unrelated to this PR.

### TOE accounting

Zero obligation retirement; no TOE percentage moves; retained-positive
end-to-end theory count remains zero. Bounded theorem; audit-lane
referral for any verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
