### PR TITLE
feat(nstab): tied-n stabilizer swaps slots and forbids equivariant fire

### DIFF
--- a/docs/TIED_KERNEL_STABILIZER_FORBIDS_EQUIVARIANT_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TIED_KERNEL_STABILIZER_FORBIDS_EQUIVARIANT_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,189 @@
+---
+claim_id: tied_kernel_stabilizer_forbids_equivariant_fire_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Whether the G+ stabilizer of the tied occupancy kernels at the two positive two-ball sites contains an element swapping the tied slots, and whether that forbids every cube-equivariant firing labeling, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py
+---
+
+# The Stabilizer Of A Tied Occupancy Kernel Forbids Equivariant Fire
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** finite `G+` of order 24 acting in the 3-vector representation on
+the two declared tied occupancy kernels. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py`](../scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Investment context from the equal-`n` and opposite-label firings
+(`#6648`/`#6649`, `#6646`/`#6649`): the two positive two-ball sites carry
+tied `+x`/`-x` slots with a common occupancy kernel `n` on those neighbors,
+while a firing at either site requires opposite `{+,−}` letters on those
+two slots. A leftover slot-odd rule can fire, but it is not
+`G+`-equivariant. That leftover-char of slotn is not the residual here.
+
+Let `G+` be the 24 proper cube rotations. The action is the ordinary
+3-vector representation: `g · n` is the rotated vector. The declared
+kernels are
+
+```text
+n1 = (0, 1/3, −1/3)   at site v1,
+n2 = (0, −1/3, 1/3)   at site v2.
+```
+
+Tied slots at both sites are `+x` and `−x`. Write
+
+```text
+Stab(n) = { g in G+ : g · n = n }.
+```
+
+**Theorem 1.** `|Stab(n1)| = |Stab(n2)| = 2`. In each stabilizer the
+non-identity element sends `+x` to `−x` (and `−x` to `+x`). Explicitly
+that element is the rotation `x ↦ −x`, `y ↦ −z`, `z ↦ −y`.
+
+**Theorem 2.** Every `G+`-equivariant `{+,−}` labeling of the six slots
+that depends on `n` is invariant under `Stab(n)`. Because a stabilizer
+element swaps the tied slots, the two slots receive the same letter
+whenever the neighbors share that `n`. Combined with the investment that
+firings have opposite `x`-labels, no `G+`-equivariant local rule fires at
+that site. The slot-odd opposite-`x` assignment is a non-equivariant
+witness: it fires and fails stabilizer invariance. This is not
+leftover-char of slotn.
+
+**Theorem 3.** Displayed, not adopted. Do not write Stab into Admissibility.
+Do not attach L1. Finite `G+` = 24 only. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite enumeration of the 24 proper cube rotations computes Stab(n1) and Stab(n2) exactly and shows a tied-slot swap, which forces every equivariant {+,-} labeling to use the same letter on +x and -x."
+trace_class: frontier_discovery
+target_claim_id: tied_kernel_stabilizer_forbids_equivariant_fire
+target_blocker_text: "whether the G+ stabilizer of the tied occupancy kernels swaps the tied slots and thereby forbids every cube-equivariant firing labeling"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for finite G+ of order 24 and the two declared kernels; Stab is displayed, not adopted"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+next_trace_action: "independent audit of the displayed finite stabilizer report; do not adopt Stab as axiom content"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Objects
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility covariance clause is quoted only as the existing
+spatial-covariance contract. It is not edited. In particular this note does
+not insert `Stab` into that clause.
+
+Declared mathematical scaffolding, not a new axiom:
+
+- `G+` is exactly the 24 determinant-`+1` signed permutations of the three
+  coordinate axes (finite `G+` = 24 only);
+- the six neighbor slots are `±x`, `±y`, `±z`;
+- `n1` and `n2` are the two declared tied occupancy kernels above;
+- a `{+,−}` labeling depending on `n` is a function
+  `λ(slot, n) ∈ {+, −}`;
+- `G+`-equivariance means `λ(g · slot, g · n) = λ(slot, n)`.
+
+Investment statements `#6646`/`#6648`/`#6649` are used only as the
+equal-`n` / opposite-`x`-label firing context. They are not re-proved here
+and are not given an audit verdict.
+
+## Theorem 1 — orders and the tied-slot swap
+
+Every `g ∈ G+` is a signed permutation matrix of determinant `+1`. For
+`g · n1 = n1`, the unique zero coordinate of `n1` forces `g` to send the
+`x`-axis to the `x`-axis. The eight such rotations are the stabilizer of
+the unsigned `x`-axis. Direct evaluation on `n1 = (0, 1/3, −1/3)` leaves
+exactly two survivors:
+
+1. the identity, which fixes every slot;
+2. `s : (x, y, z) ↦ (−x, −z, −y)`, which sends `+x` to `−x`.
+
+The same pair is `Stab(n2)`, because `s · n2 = n2` as well. Thus
+`|Stab(n1)| = |Stab(n2)| = 2`, and each stabilizer contains an element
+swapping the tied slots.
+
+Orbit-stabilizer is consistent and unused as an extra premise: the `G+`
+orbit of `n1` has `24/2 = 12` distinct images.
+
+## Theorem 2 — equivariant labels cannot fire
+
+Restrict equivariance to `g ∈ Stab(n)`. Then `g · n = n`, so
+`λ(g · slot, n) = λ(slot, n)`. Taking the swapper `s` of Theorem 1 gives
+
+```text
+λ(−x, n) = λ(+x, n).
+```
+
+The six slots are paired by `s` into `{+x, −x}`, `{+y, −z}`, and
+`{−y, +z}`. There are therefore `2^3 = 8` stabilizer-invariant labelings
+of the six slots at a fixed `n`, and every one of them gives `+x` and `−x`
+the same letter.
+
+There are `32` labelings with opposite `x`-letters. None of them is
+stabilizer-invariant. Combined with the investment that a firing requires
+opposite `x`-labels, no `G+`-equivariant local rule fires at `v1` or `v2`
+for these kernels.
+
+A slot-odd assignment with `λ(+x) ≠ λ(−x)` is a firing witness that fails
+stabilizer invariance, hence fails `G+`-equivariance. That is one
+non-equivariant rule. It is not leftover-char of slotn, and this note does
+not attach L1.
+
+If no stabilizer element had swapped the tied slots, opposite labels would
+have been stabilizer-allowed. That counterfactual does not occur for `n1`
+or `n2`.
+
+## Theorem 3 — displayed, not adopted
+
+`Stab` is a reported finite-group invariant of the declared kernels.
+Displayed, not adopted. Do not write Stab into Admissibility. Do not
+attach L1. Finite `G+` = 24 only. No axiom edit.
+
+## Mutation Checks
+
+1. The identity lies in both stabilizers and does not swap `+x` with `−x`;
+   the swapper is a distinct second element.
+2. Replacing `G+` by a single orientation-reversing signed permutation can
+   enlarge the set that fixes `n1`, so the order-`2` count is specific to
+   determinant `+1`.
+3. Any opposite-`x` labeling, including slot-odd, fails the stabilizer
+   invariance test used in Theorem 2.
+
+## What This Does Not Claim
+
+- `Stab` is not added to Admissibility, Lattice, Qubit, or Record.
+- The leftover-char of slotn is not reused and L1 is not attached.
+- Continuous `SO(3)`, a larger octahedral group, or any group other than
+  the 24 proper cube rotations is outside the theorem.
+- The investment that firings need opposite `x`-labels is not re-derived.
+- No formation rule, Record lock, or physical occupancy process is selected.
+- No no-go against non-equivariant rules is claimed: slot-odd remains a
+  non-equivariant firing witness.
+
+These are scope boundaries. Accordingly no no-go verdict is authored here.
+
+## Primary Runner
+
+The primary runner enumerates the 24 rotations, computes both stabilizers,
+checks the tied-slot swap, exhausts the `64` six-slot labelings for
+stabilizer invariance, and pins the displayed-not-adopted / no-L1 / no
+axiom-edit boundary. It writes no runner cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18509,6 +18509,10 @@
   "tick_unitarity_from_spectrum_reflection_conjugacy_bounded_theorem_note_2026-06-10": {
    "deps_hash": "2db1d69feed5",
    "out_degree": 3
+  },
+  "tied_kernel_stabilizer_forbids_equivariant_fire_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "tier_a_korbit_determinant_and_orientation_invariance_bounded_note_2026-06-09": {
    "deps_hash": "baa4669e408d",

--- a/logs/runner-cache/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.txt
+++ b/logs/runner-cache/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py
+runner_sha256: f8f9b8aaafa3c39a71e04bd2e3fb505a13715548eaed487f946983f31f3d1d27
+input_fingerprint_sha256: 63f1a340aa5325fcf7f855ba34b823ead1d24bd89c659f52b1fb9a10010f5b4c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/TIED_KERNEL_STABILIZER_FORBIDS_EQUIVARIANT_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scientific_dependency: current minimal_axioms Lattice covariance clause
+declared_math: finite G+ in the 3-vector representation; tied kernels n1, n2
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: g-plus-order finite G+ is exactly the 24 proper cube rotations
+PASS: declared-kernels n1 and n2 are the declared tied occupancy kernels
+stab_n1_order: 2
+stab_n2_order: 2
+stab_n1_has_tied_swap: True
+stab_n2_has_tied_swap: True
+PASS: theorem-1-stab-orders |Stab(n1)| = |Stab(n2)| = 2
+PASS: theorem-1-tied-swap exactly one non-identity stabilizer element swaps +x with -x at both sites
+PASS: swapper-action the common swapper is x -> -x, y -> -z, z -> -y
+PASS: theorem-2-same-letter every Stab-invariant labeling gives +x and -x the same letter, so none fire
+PASS: slot-odd-not-equivariant a slot-odd opposite-x labeling fires and is not stabilizer-invariant
+PASS: lattice-clause the current Lattice wording supplies finite proper cubic rotations
+PASS: admissibility-unedited Stab is displayed and is not written into Admissibility
+PASS: displayed-not-adopted the note reports the stabilizer obstruction without adopting it or attaching L1
+PASS: forbidden-phrases the forbidden rhetoric strings are absent from the note and runner
+PASS: claim-scope claim_scope and machine status match the displayed-not-adopted residual
+PASS: no-axiom-edit the only axiom authority is the current memo; no cache or axiom rewrite
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py
+++ b/scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Exact stabilizer of the tied occupancy kernels on finite G+.
+
+G+ is the 24 proper cube rotations, acting in the 3-vector representation.
+The theorem reports Stab(n) at the two positive two-ball sites and whether
+a stabilizer element swaps the tied ±x slots. Stab is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from fractions import Fraction
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TIED_KERNEL_STABILIZER_FORBIDS_EQUIVARIANT_FIRE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TIED_KERNEL_STABILIZER_FORBIDS_EQUIVARIANT_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Vector = tuple[Fraction, Fraction, Fraction]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+PLUS_X: Vector = (Fraction(1), Fraction(0), Fraction(0))
+MINUS_X: Vector = (Fraction(-1), Fraction(0), Fraction(0))
+N1: Vector = (Fraction(0), Fraction(1, 3), Fraction(-1, 3))
+N2: Vector = (Fraction(0), Fraction(-1, 3), Fraction(1, 3))
+SLOTS: tuple[Vector, ...] = (
+    PLUS_X,
+    MINUS_X,
+    (Fraction(0), Fraction(1), Fraction(0)),
+    (Fraction(0), Fraction(-1), Fraction(0)),
+    (Fraction(0), Fraction(0), Fraction(1)),
+    (Fraction(0), Fraction(0), Fraction(-1)),
+)
+SLOT_NAMES = {
+    PLUS_X: "+x",
+    MINUS_X: "-x",
+    (Fraction(0), Fraction(1), Fraction(0)): "+y",
+    (Fraction(0), Fraction(-1), Fraction(0)): "-y",
+    (Fraction(0), Fraction(0), Fraction(1)): "+z",
+    (Fraction(0), Fraction(0), Fraction(-1)): "-z",
+}
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, len(permutation))
+    )
+    return -1 if inversions % 2 else 1
+
+
+G_PLUS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Vector) -> Vector:
+    permutation, signs = rotation
+    result = [Fraction(0), Fraction(0), Fraction(0)]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def stabilizer(kernel: Vector) -> tuple[Rotation, ...]:
+    return tuple(
+        rotation
+        for rotation in G_PLUS
+        if rotate_vector(rotation, kernel) == kernel
+    )
+
+
+def swaps_tied_slots(rotation: Rotation) -> bool:
+    return rotate_vector(rotation, PLUS_X) == MINUS_X
+
+
+def identity_rotation() -> Rotation:
+    return ((0, 1, 2), (1, 1, 1))
+
+
+def letters() -> tuple[str, str]:
+    return ("+", "-")
+
+
+def opposite_x_labelings() -> tuple[dict[Vector, str], ...]:
+    plus, minus = letters()
+    other = [slot for slot in SLOTS if slot not in (PLUS_X, MINUS_X)]
+    out: list[dict[Vector, str]] = []
+    for plus_letter, minus_letter in ((plus, minus), (minus, plus)):
+        for assignment in product(letters(), repeat=len(other)):
+            labeling = {PLUS_X: plus_letter, MINUS_X: minus_letter}
+            labeling.update(dict(zip(other, assignment, strict=True)))
+            out.append(labeling)
+    return tuple(out)
+
+
+def all_labelings() -> tuple[dict[Vector, str], ...]:
+    return tuple(
+        dict(zip(SLOTS, assignment, strict=True))
+        for assignment in product(letters(), repeat=len(SLOTS))
+    )
+
+
+def labeling_is_stab_invariant(
+    labeling: dict[Vector, str], stab: tuple[Rotation, ...]
+) -> bool:
+    return all(
+        labeling[rotate_vector(rotation, slot)] == labeling[slot]
+        for rotation in stab
+        for slot in SLOTS
+    )
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {detail}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scientific_dependency: current minimal_axioms Lattice covariance clause")
+    print("declared_math: finite G+ in the 3-vector representation; tied kernels n1, n2")
+
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/TIED_KERNEL_STABILIZER_FORBIDS_EQUIVARIANT_FIRE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+    checks.check(
+        "g-plus-order",
+        len(G_PLUS) == 24 and len(set(G_PLUS)) == 24,
+        "finite G+ is exactly the 24 proper cube rotations",
+    )
+    checks.check(
+        "declared-kernels",
+        N1 == (Fraction(0), Fraction(1, 3), Fraction(-1, 3))
+        and N2 == (Fraction(0), Fraction(-1, 3), Fraction(1, 3))
+        and N2 == tuple(-component for component in N1),
+        "n1 and n2 are the declared tied occupancy kernels",
+    )
+
+    stab1 = stabilizer(N1)
+    stab2 = stabilizer(N2)
+    swap1 = tuple(rotation for rotation in stab1 if swaps_tied_slots(rotation))
+    swap2 = tuple(rotation for rotation in stab2 if swaps_tied_slots(rotation))
+
+    print(f"stab_n1_order: {len(stab1)}")
+    print(f"stab_n2_order: {len(stab2)}")
+    print(f"stab_n1_has_tied_swap: {bool(swap1)}")
+    print(f"stab_n2_has_tied_swap: {bool(swap2)}")
+
+    checks.check(
+        "theorem-1-stab-orders",
+        len(stab1) == 2 and len(stab2) == 2,
+        "|Stab(n1)| = |Stab(n2)| = 2",
+    )
+    checks.check(
+        "theorem-1-tied-swap",
+        len(swap1) == 1
+        and len(swap2) == 1
+        and swap1 == swap2
+        and identity_rotation() in stab1
+        and identity_rotation() in stab2
+        and not swaps_tied_slots(identity_rotation()),
+        "exactly one non-identity stabilizer element swaps +x with -x at both sites",
+    )
+    swapper = swap1[0]
+    checks.check(
+        "swapper-action",
+        rotate_vector(swapper, N1) == N1
+        and rotate_vector(swapper, N2) == N2
+        and rotate_vector(swapper, PLUS_X) == MINUS_X
+        and rotate_vector(swapper, MINUS_X) == PLUS_X
+        and rotate_vector(swapper, (Fraction(0), Fraction(1), Fraction(0)))
+        == (Fraction(0), Fraction(0), Fraction(-1))
+        and rotate_vector(swapper, (Fraction(0), Fraction(0), Fraction(1)))
+        == (Fraction(0), Fraction(-1), Fraction(0)),
+        "the common swapper is x -> -x, y -> -z, z -> -y",
+    )
+
+    opposite = opposite_x_labelings()
+    invariant1 = [
+        labeling
+        for labeling in all_labelings()
+        if labeling_is_stab_invariant(labeling, stab1)
+    ]
+    invariant2 = [
+        labeling
+        for labeling in all_labelings()
+        if labeling_is_stab_invariant(labeling, stab2)
+    ]
+    firing_invariant1 = [
+        labeling
+        for labeling in opposite
+        if labeling_is_stab_invariant(labeling, stab1)
+    ]
+    firing_invariant2 = [
+        labeling
+        for labeling in opposite
+        if labeling_is_stab_invariant(labeling, stab2)
+    ]
+    checks.check(
+        "theorem-2-same-letter",
+        all(labeling[PLUS_X] == labeling[MINUS_X] for labeling in invariant1)
+        and all(labeling[PLUS_X] == labeling[MINUS_X] for labeling in invariant2)
+        and len(invariant1) == 8
+        and len(invariant2) == 8
+        and len(opposite) == 32
+        and firing_invariant1 == []
+        and firing_invariant2 == [],
+        "every Stab-invariant labeling gives +x and -x the same letter, so none fire",
+    )
+    slot_odd = {slot: ("+" if slot == PLUS_X else "-") for slot in SLOTS}
+    slot_odd[MINUS_X] = "-"
+    checks.check(
+        "slot-odd-not-equivariant",
+        slot_odd[PLUS_X] != slot_odd[MINUS_X]
+        and not labeling_is_stab_invariant(slot_odd, stab1)
+        and not labeling_is_stab_invariant(slot_odd, stab2),
+        "a slot-odd opposite-x labeling fires and is not stabilizer-invariant",
+    )
+    checks.check(
+        "lattice-clause",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site" in axiom_flat
+        and "proper cubic rotations about each site" in note_flat,
+        "the current Lattice wording supplies finite proper cubic rotations",
+    )
+    checks.check(
+        "admissibility-unedited",
+        "one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations"
+        in axiom_flat
+        and "Do not write Stab into Admissibility" in note
+        and "Stab(" not in axiom
+        and "stabilizer" not in axiom.lower(),
+        "Stab is displayed and is not written into Admissibility",
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not attach L1" in note
+        and "leftover-char" in note
+        and "not leftover-char of slotn" in note_flat
+        and "finite G+ = 24 only" in note_flat.replace("`", ""),
+        "the note reports the stabilizer obstruction without adopting it or attaching L1",
+    )
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    script_body = self_source.split("forbidden = ", 1)[0]
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in forbidden)
+        and all(phrase not in script_body for phrase in forbidden),
+        "the forbidden rhetoric strings are absent from the note and runner",
+    )
+    checks.check(
+        "claim-scope",
+        'claim_scope: "Whether the G+ stabilizer of the tied occupancy kernels at the two positive two-ball sites contains an element swapping the tied slots, and whether that forbids every cube-equivariant firing labeling, is reported. Displayed, not adopted."'
+        in note
+        and "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "hypothetical_axiom_status: no edit" in note,
+        "claim_scope and machine status match the displayed-not-adopted residual",
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "no axiom edit" in note_flat.lower()
+        and "cache_write: false" in self_source,
+        "the only axiom authority is the current memo; no cache or axiom rewrite",
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stab of each tied kernel has 2 elements; the non-identity swaps +x and -x. Every G+-equivariant labeling must give those slots the same letter, so none fire. Displayed, not adopted. No axiom edit.

## Runner

`scripts/tied_kernel_stabilizer_forbids_equivariant_fire_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.