### PR TITLE
feat(skew3): off-axis third seed yields unequal-n 4-NN sites

### DIFF
--- a/docs/SKEW_THREE_SEED_TIED_N_BREAK_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SKEW_THREE_SEED_TIED_N_BREAK_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,273 @@
+---
+claim_id: skew_three_seed_tied_n_break_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the union of three radius-2 ℓ¹ balls at 0, (2,0,0), and (1,2,1), whether any unread 4-occupied-NN site has unequal ambiguous n or a non-swapping stabilizer, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/skew_three_seed_tied_n_break_2026_08_15.py
+---
+
+# Off-Axis Third Seed Breaks Tied-n Swap By Unequal Ambiguous n
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the union `U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))` inside
+the box `|x|,|y|,|z| ≤ 6`. Occupancy geometry and the occupancy kernel
+`n = d/3` only. One off-axis triple only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/skew_three_seed_tied_n_break_2026_08_15.py`](../scripts/skew_three_seed_tied_n_break_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Investment `#6653` (axis-aligned L of three radius-2 balls): on
+`U3 = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((0,2,0))`, every unread site with
+four occupied nearest neighbors still has `N_uneq = N_noswap = 0`. The
+residual asked here is whether moving the third center off the
+coordinate L, to `(1,2,1)`, produces an unread 4-occupied-NN site whose
+ambiguous neighbors have unequal `n`, or a tied pair whose stabilizer
+contains no slot-swap.
+
+Write `B_2(c) = { p ∈ Z^3 : |p − c|_1 ≤ 2 }` and
+
+```text
+U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1)).
+```
+
+A site is occupied when it lies in `U`. Unread sites are the points of
+the box that are not in `U`. For any site `w`, the occupancy dipole is
+`d_μ(w) = occ(w + e_μ) − occ(w − e_μ)` with `occ ∈ {0,1}` the
+indicator of `U`, and `n(w) = d(w)/3`. A neighbor of an unread site
+`v` is ambiguous when it is occupied and `|supp n| ≠ 1`.
+
+`G+` is the 24 proper cube rotations, acting in the 3-vector
+representation. For a tied opposite-slot pair sharing one kernel `n`,
+
+```text
+Stab_{G+}(n) = { g in G+ : g · n = n }.
+```
+
+**Theorem 1.** Inside the box there are exactly `N_4 = 7` unread sites
+with four occupied 6-nearest neighbors. Four of them have two ambiguous
+neighbors with unequal `n`: `N_uneq = 4`. None of them has a tied pair
+whose stabilizer contains no slot-swap: `N_noswap = 0`.
+
+**Theorem 2.** Because `N_uneq + N_noswap = 4 > 0`, the off-axis triple
+does break the obstruction on this `U`. The lex-first breaker is
+`v = (−1, 1, 1)`. At that site the three ambiguous kernels are not all
+equal, there is no tied opposite pair, and opposite labels are
+equivariance-allowed.
+
+**Theorem 3.** Displayed, not adopted. Do not write the triple into
+Admissibility. Do not attach L1. Do not launch a 4th equal-radius ball clone.
+
+This is not leftover-char of 3ball (that center was `(0,2,0)`). The
+present report enumerates `U` occupancy and the kernels `n = d/3`; it
+does not reuse the axis-aligned three-seed census as input.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite occupancy census of U in the radius-6 box computes N_4, N_uneq, and N_noswap exactly and exhibits a lex-first unread 4-occupied-NN site with unequal ambiguous n."
+trace_class: frontier_discovery
+target_claim_id: skew_three_seed_tied_n_break
+target_blocker_text: "whether moving the third radius-2 center off the coordinate L to (1,2,1) presents an unread 4-occupied-NN site with unequal ambiguous n or a non-swapping stabilizer"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact for U, finite G+ of order 24, n = d/3 from occupancy, and the box |x|,|y|,|z|≤6; the off-axis triple is displayed, not adopted"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+next_trace_action: "independent audit of the displayed U census; do not adopt the triple, attach L1, or launch a 4th equal-radius ball clone"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises And Declared Objects
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility covariance clause is quoted only as the existing
+spatial-covariance contract. It is not edited. In particular this note does
+not insert the off-axis triple into that clause.
+
+Declared mathematical scaffolding, not a new axiom and not a new patch
+family:
+
+- `B_2(c)` is the closed radius-2 ℓ¹ ball on `Z^3`;
+- `U` is the union of those balls at `0`, `(2,0,0)`, and `(1,2,1)`;
+- the search box is `|x|,|y|,|z| ≤ 6`;
+- `n = d/3` is the occupancy dipole at a site, scored from membership in
+  `U` only;
+- ambiguous means occupied and `|supp n| ≠ 1`;
+- a tied pair at unread `v` is a pair of opposite occupied neighbors
+  that are both ambiguous and share one kernel `n`;
+- `G+` is exactly the 24 determinant-`+1` signed permutations of the
+  three coordinate axes (finite `G+` = 24 only);
+- a slot-swap in `Stab_{G+}(n)` is an element sending one tied slot
+  vector to the opposite slot vector.
+
+Investment `#6653` is used only as the axis-aligned three-seed context.
+It is not re-proved here and is not given an audit verdict. One off-axis
+triple only.
+
+## Theorem 1 — census of unread 4-occupied-NN sites
+
+The three balls each have 25 sites. Their pairwise overlaps are 7, 4,
+and 4, and the triple overlap has 2 sites, so `|U| = 62`. Every point
+of `U` lies strictly inside the box.
+
+An exhaustive scan of the `13^3 = 2197` box sites finds exactly seven
+unread locations whose six-nearest-neighbor occupancy is 4. In lex
+order on `Z^3`:
+
+```text
+v = (−1, 1, 1)                         N_uneq witness
+  occupied: +x, +y, −y, −z
+  n(+x) = (1/3, 0, −1/3)               ambiguous
+  n(+y) = (1/3, 0, 0)                  unique-axis
+  n(−y) = (1/3, 0, −1/3)               ambiguous
+  n(−z) = (1/3, −1/3, 0)               ambiguous
+  no tied opposite pair
+
+v = (0, 1, 2)                          N_uneq witness
+  occupied: +x, +y, −y, −z
+  n(+x) = (0, 1/3, −1/3)               ambiguous
+  n(+y) = (1/3, 0, −1/3)               ambiguous
+  n(−y) = (0, 0, −1/3)                 unique-axis
+  n(−z) = (1/3, 0, −1/3)               ambiguous
+  no tied opposite pair
+
+v = (1, −1, −1)
+  occupied: +x, −x, +y, +z
+  n(+x) = n(−x) = (0, 1/3, 1/3)        ambiguous, tied
+  n(+y) = (0, 0, 1/3)                  unique-axis
+  n(+z) = (0, 1/3, 0)                  unique-axis
+  |Stab_{G+}(n)| = 2 with slot-swap
+  s : (x, y, z) ↦ (−x, z, y) sends +x to −x
+
+v = (1, −1, 1)
+  occupied: +x, −x, +y, −z
+  n(+x) = n(−x) = n(+y) = (0, 1/3, −1/3)
+                                       ambiguous; +x/−x tied
+  n(−z) = (0, 1/3, 0)                  unique-axis
+  |Stab_{G+}(n)| = 2 with slot-swap
+  s : (x, y, z) ↦ (−x, −z, −y) sends +x to −x
+
+v = (1, 0, 2)
+  occupied: +x, −x, +y, −z
+  n(+x) = n(−x) = (0, 0, −1/3)         unique-axis
+  n(+y) = n(−z) = (0, 1/3, −1/3)       ambiguous, equal, not opposite
+  no tied opposite pair
+
+v = (2, 1, 2)                          N_uneq witness
+  occupied: −x, +y, −y, −z
+  n(−x) = (0, 1/3, −1/3)               ambiguous
+  n(+y) = (−1/3, 0, −1/3)              ambiguous
+  n(−y) = (0, 0, −1/3)                 unique-axis
+  n(−z) = (−1/3, 0, −1/3)              ambiguous
+  no tied opposite pair
+
+v = (3, 1, 1)                          N_uneq witness
+  occupied: −x, +y, −y, −z
+  n(−x) = (−1/3, 0, −1/3)              ambiguous
+  n(+y) = (−1/3, 0, 0)                 unique-axis
+  n(−y) = (−1/3, 0, −1/3)              ambiguous
+  n(−z) = (−1/3, −1/3, 0)              ambiguous
+  no tied opposite pair
+```
+
+Thus `N_4 = 7`, `N_uneq = 4`, and `N_noswap = 0`. The two sites that
+still carry a tied opposite pair inherit a slot-swap in `Stab_{G+}(n)`.
+The four unequal-`n` sites have no tied opposite pair at all.
+
+Moving the third center off the coordinate L changes the axis-aligned
+4-NN list: the U3 sites `(−1, 1, −1)` disappear, and `(0, 1, 2)`,
+`(1, 0, 2)`, `(2, 1, 2)`, and `(3, 1, 1)` appear. The new sites are not
+a rotate of the axis-aligned L.
+
+## Theorem 2 — lex-first breaker and equivariance-allowed opposite labels
+
+`N_uneq + N_noswap = 4 > 0`. The lex-first such unread site is
+`v = (−1, 1, 1)`.
+
+At that site the occupied star is `+x, +y, −y, −z`. The unique-axis
+neighbor is `+y` with `n = (1/3, 0, 0)`. The three ambiguous kernels
+are
+
+```text
+n(+x) = n(−y) = (1/3, 0, −1/3),
+n(−z) = (1/3, −1/3, 0).
+```
+
+Those kernels are not all equal, so `N_uneq` counts the site. There is
+no opposite occupied pair that is both ambiguous and shares one kernel,
+so there is no `Stab_{G+}(n)` slot-swap to apply.
+
+A `{+,−}` labeling that depends on `n` may therefore assign different
+letters to `−z` and to the `{+x, −y}` pair. The only opposite occupied
+pair is `+y` and `−y`, and those two neighbors also have unequal `n`.
+Restricting equivariance to `g ∈ Stab_{G+}(n)` does not force those
+opposite slots to share a letter. Opposite labels are
+equivariance-allowed.
+
+This off-axis triple therefore breaks the obstruction that survived on
+the axis-aligned L: unequal ambiguous `n` is realized, and at the
+lex-first witness opposite labels are equivariance-allowed.
+
+## Theorem 3 — displayed, not adopted
+
+The off-axis triple and the occupancy kernels scored on `U` are
+reported finite data. Displayed, not adopted. Do not write the triple
+into Admissibility. Do not attach L1. Do not launch a 4th equal-radius
+ball clone. Finite `G+` = 24 only. Score geometry and `n` only. No new
+patch family. No axiom edit. One off-axis triple only.
+
+## Mutation Checks
+
+1. Replacing `B_2((1,2,1))` by `B_2((0,2,0))` recovers the axis-aligned
+   census `N_4 = 4`, `N_uneq = 0`, `N_noswap = 0`; the off-axis center
+   is load-bearing for the unequal-`n` sites.
+2. Dropping the third ball recovers the two-ball 4-NN family
+   `{(1, ±1, ±1)}` and loses every `N_uneq` witness.
+3. A site with three or more occupied neighbors that failed
+   `|supp n| ≠ 1` equally is counted in `N_uneq` exactly when any two of
+   those kernels differ; four such unread 4-occupied-NN sites occur in
+   the box.
+
+## What This Does Not Claim
+
+- The off-axis triple is not added to Admissibility, Lattice, Qubit, or
+  Record.
+- L1 is not attached. No new patch family is introduced. A fourth
+  equal-radius ball is not launched.
+- The leftover-char of 3ball is not reused as a hypothesis: the kernels
+  here are recomputed from `U` occupancy at center `(1,2,1)`.
+- Continuous `SO(3)`, a larger octahedral group, or any group other than
+  the 24 proper cube rotations is outside the theorem.
+- Other seed placements, other radii, or a larger box are outside the
+  theorem.
+- No formation rule, Record lock, or physical occupancy process is
+  selected.
+- No no-go against non-equivariant rules is claimed. No firing count is
+  claimed: the report is the unread 4-occupied-NN census and the
+  equivariance status of opposite labels at the lex-first breaker.
+
+These are scope boundaries. Accordingly no no-go verdict is authored here.
+
+## Primary Runner
+
+The primary runner builds `U`, scans the box, computes `n = d/3` at
+every occupied neighbor of every unread 4-occupied-NN site, evaluates
+`N_4`, `N_uneq`, and `N_noswap`, reports the lex-first breaker, and
+checks the displayed-not-adopted / no-L1 / no-triple-in-Admissibility /
+no-fourth-ball / no axiom-edit boundary. It writes no runner cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17029,6 +17029,10 @@
   "sixth_family_sheared_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "skew_three_seed_tied_n_break_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
    "deps_hash": "9defae253834",

--- a/logs/runner-cache/skew_three_seed_tied_n_break_2026_08_15.txt
+++ b/logs/runner-cache/skew_three_seed_tied_n_break_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/skew_three_seed_tied_n_break_2026_08_15.py
+runner_sha256: b600274832e0ca00063ae4601311bda0232ad39e9158303c58092e076905659a
+input_fingerprint_sha256: b89eb59223a41df4d0e488c32529b8d6199dfe309a5c30ac38fd2d91b2065828
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SKEW_THREE_SEED_TIED_N_BREAK_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scientific_dependency: current minimal_axioms Lattice covariance clause
+declared_math: U occupancy; n = d/3; finite G+ in the 3-vector representation
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: g-plus-order finite G+ is exactly the 24 proper cube rotations
+U_size: 62
+ball_sizes: [25, 25, 25]
+pairwise_overlaps: [7, 4, 4]
+triple_overlap: 2
+PASS: u-geometry U is the union of three radius-2 ℓ¹ balls and lies inside the box
+N_4: 7
+N_uneq: 4
+N_noswap: 0
+site (-1, 1, 1) uneq=True noswap=False amb=[+x:(1/3, 0, -1/3), -y:(1/3, 0, -1/3), -z:(1/3, -1/3, 0)] tied=[]
+site (0, 1, 2) uneq=True noswap=False amb=[+x:(0, 1/3, -1/3), +y:(1/3, 0, -1/3), -z:(1/3, 0, -1/3)] tied=[]
+site (1, -1, -1) uneq=False noswap=False amb=[+x:(0, 1/3, 1/3), -x:(0, 1/3, 1/3)] tied=[+x/-x n=(0, 1/3, 1/3) |Stab|=2 swap=True]
+site (1, -1, 1) uneq=False noswap=False amb=[+x:(0, 1/3, -1/3), -x:(0, 1/3, -1/3), +y:(0, 1/3, -1/3)] tied=[+x/-x n=(0, 1/3, -1/3) |Stab|=2 swap=True]
+site (1, 0, 2) uneq=False noswap=False amb=[+y:(0, 1/3, -1/3), -z:(0, 1/3, -1/3)] tied=[]
+site (2, 1, 2) uneq=True noswap=False amb=[-x:(0, 1/3, -1/3), +y:(-1/3, 0, -1/3), -z:(-1/3, 0, -1/3)] tied=[]
+site (3, 1, 1) uneq=True noswap=False amb=[-x:(-1/3, 0, -1/3), -y:(-1/3, 0, -1/3), -z:(-1/3, -1/3, 0)] tied=[]
+PASS: theorem-1-n4 unread 4-occupied-NN count is N_4 = 7
+PASS: theorem-1-n-uneq four census sites have unequal ambiguous n; N_uneq = 4
+PASS: theorem-1-n-noswap no tied pair lacks a slot-swap in Stab(n); N_noswap = 0
+lex_first_breaker: (-1, 1, 1)
+PASS: theorem-2-lex-first lex-first breaker is the unread site (−1, 1, 1)
+PASS: theorem-2-opposite-labels at the lex-first breaker, opposite labels are equivariance-allowed
+PASS: theorem-1-site-list the seven census sites and four unequal-n witnesses match the note
+PASS: off-axis-is-load-bearing replacing the third center by (0,2,0) restores N_uneq = N_noswap = 0
+PASS: lattice-clause the current Lattice wording supplies finite proper cubic rotations
+PASS: admissibility-unedited the off-axis triple is displayed and is not written into Admissibility
+PASS: displayed-not-adopted the note reports the U census without adopting it, attaching L1, or cloning a 4th ball
+PASS: forbidden-phrases the forbidden rhetoric strings are absent from the note and runner
+PASS: claim-scope claim_scope and machine status match the displayed-not-adopted residual
+PASS: no-axiom-edit the only axiom authority is the current memo; no cache or axiom rewrite
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/skew_three_seed_tied_n_break_2026_08_15.py
+++ b/scripts/skew_three_seed_tied_n_break_2026_08_15.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Census whether an off-axis third radius-2 ℓ¹ seed breaks tied-n swap.
+
+U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1)). Unread 4-occupied-NN sites
+in the box |x|,|y|,|z|≤6 are scored by n = d/3 from U occupancy only.
+The theorem reports N_4, N_uneq, and N_noswap. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from fractions import Fraction
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SKEW_THREE_SEED_TIED_N_BREAK_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SKEW_THREE_SEED_TIED_N_BREAK_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BOX = 6
+RADIUS = 2
+SEEDS: tuple[tuple[int, int, int], ...] = ((0, 0, 0), (2, 0, 0), (1, 2, 1))
+AXIS_SEEDS: tuple[tuple[int, int, int], ...] = ((0, 0, 0), (2, 0, 0), (0, 2, 0))
+NEIGHBORS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SLOT_NAME = {
+    (1, 0, 0): "+x",
+    (-1, 0, 0): "-x",
+    (0, 1, 0): "+y",
+    (0, -1, 0): "-y",
+    (0, 0, 1): "+z",
+    (0, 0, -1): "-z",
+}
+TIED_AXES: tuple[tuple[tuple[int, int, int], tuple[int, int, int]], ...] = (
+    ((1, 0, 0), (-1, 0, 0)),
+    ((0, 1, 0), (0, -1, 0)),
+    ((0, 0, 1), (0, 0, -1)),
+)
+
+Vector = tuple[Fraction, Fraction, Fraction]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+Site = tuple[int, int, int]
+
+
+def add(left: Site, right: Site) -> Site:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Site, right: Site) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: Site, radius: int = RADIUS) -> frozenset[Site]:
+    lo = [axis - radius for axis in center]
+    hi = [axis + radius for axis in center]
+    return frozenset(
+        (x, y, z)
+        for x, y, z in product(
+            range(lo[0], hi[0] + 1),
+            range(lo[1], hi[1] + 1),
+            range(lo[2], hi[2] + 1),
+        )
+        if l1((x, y, z), center) <= radius
+    )
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, len(permutation))
+    )
+    return -1 if inversions % 2 else 1
+
+
+G_PLUS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Vector) -> Vector:
+    permutation, signs = rotation
+    result = [Fraction(0), Fraction(0), Fraction(0)]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def slot_vector(slot: Site) -> Vector:
+    return (Fraction(slot[0]), Fraction(slot[1]), Fraction(slot[2]))
+
+
+def occupancy_kernel(site: Site, occupied: frozenset[Site]) -> Vector:
+    components: list[Fraction] = []
+    for axis in range(3):
+        step = [0, 0, 0]
+        step[axis] = 1
+        plus = add(site, (step[0], step[1], step[2]))
+        minus = add(site, (-step[0], -step[1], -step[2]))
+        dipole = int(plus in occupied) - int(minus in occupied)
+        components.append(Fraction(dipole, 3))
+    return (components[0], components[1], components[2])
+
+
+def support_size(kernel: Vector) -> int:
+    return sum(component != 0 for component in kernel)
+
+
+def stabilizer(kernel: Vector) -> tuple[Rotation, ...]:
+    return tuple(
+        rotation
+        for rotation in G_PLUS
+        if rotate_vector(rotation, kernel) == kernel
+    )
+
+
+def swaps_slots(rotation: Rotation, plus: Site, minus: Site) -> bool:
+    return rotate_vector(rotation, slot_vector(plus)) == slot_vector(minus)
+
+
+def format_kernel(kernel: Vector) -> str:
+    return "(" + ", ".join(str(component) for component in kernel) + ")"
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {detail}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def census(occupied: frozenset[Site]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for site in product(range(-BOX, BOX + 1), repeat=3):
+        if site in occupied:
+            continue
+        occupied_slots = tuple(slot for slot in NEIGHBORS if add(site, slot) in occupied)
+        if len(occupied_slots) != 4:
+            continue
+        kernels = {
+            slot: occupancy_kernel(add(site, slot), occupied) for slot in occupied_slots
+        }
+        ambiguous = tuple(
+            (slot, kernels[slot])
+            for slot in occupied_slots
+            if support_size(kernels[slot]) != 1
+        )
+        ambiguous_kernels = [kernel for _, kernel in ambiguous]
+        unequal = any(
+            left != right for left in ambiguous_kernels for right in ambiguous_kernels
+        )
+        tied: list[tuple[Site, Site, Vector, int, bool]] = []
+        no_swap = False
+        for plus, minus in TIED_AXES:
+            if plus not in kernels or minus not in kernels:
+                continue
+            kernel = kernels[plus]
+            if kernel != kernels[minus]:
+                continue
+            if support_size(kernel) == 1 or support_size(kernels[minus]) == 1:
+                continue
+            stab = stabilizer(kernel)
+            swap = any(swaps_slots(rotation, plus, minus) for rotation in stab)
+            tied.append((plus, minus, kernel, len(stab), swap))
+            if not swap:
+                no_swap = True
+        rows.append(
+            {
+                "site": site,
+                "occupied_slots": occupied_slots,
+                "kernels": kernels,
+                "ambiguous": ambiguous,
+                "unequal": unequal,
+                "tied": tuple(tied),
+                "no_swap": no_swap,
+            }
+        )
+    rows.sort(key=lambda row: row["site"])
+    return rows
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scientific_dependency: current minimal_axioms Lattice covariance clause")
+    print("declared_math: U occupancy; n = d/3; finite G+ in the 3-vector representation")
+
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SKEW_THREE_SEED_TIED_N_BREAK_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+    checks.check(
+        "g-plus-order",
+        len(G_PLUS) == 24 and len(set(G_PLUS)) == 24,
+        "finite G+ is exactly the 24 proper cube rotations",
+    )
+
+    balls = tuple(ball(seed) for seed in SEEDS)
+    occupied = frozenset().union(*balls)
+    pairwise = (
+        len(balls[0] & balls[1]),
+        len(balls[0] & balls[2]),
+        len(balls[1] & balls[2]),
+    )
+    triple = len(balls[0] & balls[1] & balls[2])
+    print(f"U_size: {len(occupied)}")
+    print(f"ball_sizes: {[len(item) for item in balls]}")
+    print(f"pairwise_overlaps: {list(pairwise)}")
+    print(f"triple_overlap: {triple}")
+    checks.check(
+        "u-geometry",
+        all(len(item) == 25 for item in balls)
+        and pairwise == (7, 4, 4)
+        and triple == 2
+        and len(occupied) == 62
+        and all(max(abs(axis) for axis in site) <= BOX for site in occupied),
+        "U is the union of three radius-2 ℓ¹ balls and lies inside the box",
+    )
+
+    rows = census(occupied)
+    n4 = len(rows)
+    n_uneq = sum(1 for row in rows if row["unequal"])
+    n_noswap = sum(1 for row in rows if row["no_swap"])
+    print(f"N_4: {n4}")
+    print(f"N_uneq: {n_uneq}")
+    print(f"N_noswap: {n_noswap}")
+    for row in rows:
+        site = row["site"]
+        amb = ", ".join(
+            f"{SLOT_NAME[slot]}:{format_kernel(kernel)}"
+            for slot, kernel in row["ambiguous"]
+        )
+        tied = ", ".join(
+            f"{SLOT_NAME[plus]}/{SLOT_NAME[minus]} n={format_kernel(kernel)} "
+            f"|Stab|={order} swap={swap}"
+            for plus, minus, kernel, order, swap in row["tied"]
+        )
+        print(
+            f"site {site} uneq={row['unequal']} noswap={row['no_swap']} "
+            f"amb=[{amb}] tied=[{tied}]"
+        )
+
+    checks.check(
+        "theorem-1-n4",
+        n4 == 7 and f"N_4 = {n4}" in note,
+        f"unread 4-occupied-NN count is N_4 = {n4}",
+    )
+    checks.check(
+        "theorem-1-n-uneq",
+        n_uneq == 4
+        and sum(1 for row in rows if len(row["ambiguous"]) >= 2) == n4
+        and f"N_uneq = {n_uneq}" in note,
+        f"four census sites have unequal ambiguous n; N_uneq = {n_uneq}",
+    )
+    checks.check(
+        "theorem-1-n-noswap",
+        n_noswap == 0
+        and all(row["tied"][0][4] for row in rows if row["tied"])
+        and f"N_noswap = {n_noswap}" in note,
+        f"no tied pair lacks a slot-swap in Stab(n); N_noswap = {n_noswap}",
+    )
+
+    breakers = [row for row in rows if row["unequal"] or row["no_swap"]]
+    lex_first = breakers[0]
+    lex_site = lex_first["site"]
+    print(f"lex_first_breaker: {lex_site}")
+    n_plus_x = occupancy_kernel(add(lex_site, (1, 0, 0)), occupied)
+    n_plus_y = occupancy_kernel(add(lex_site, (0, 1, 0)), occupied)
+    n_minus_y = occupancy_kernel(add(lex_site, (0, -1, 0)), occupied)
+    n_minus_z = occupancy_kernel(add(lex_site, (0, 0, -1)), occupied)
+    opposite_allowed = bool(lex_first["unequal"]) and not any(
+        swap for *_, swap in lex_first["tied"]
+    )
+    checks.check(
+        "theorem-2-lex-first",
+        n_uneq + n_noswap > 0
+        and lex_site == (-1, 1, 1)
+        and lex_first["unequal"]
+        and lex_first["tied"] == ()
+        and "v = (−1, 1, 1)" in note
+        and "N_uneq + N_noswap = 4 > 0" in note,
+        "lex-first breaker is the unread site (−1, 1, 1)",
+    )
+    checks.check(
+        "theorem-2-opposite-labels",
+        opposite_allowed
+        and n_plus_x == n_minus_y == (Fraction(1, 3), Fraction(0), Fraction(-1, 3))
+        and n_minus_z == (Fraction(1, 3), Fraction(-1, 3), Fraction(0))
+        and n_plus_y == (Fraction(1, 3), Fraction(0), Fraction(0))
+        and n_plus_x != n_minus_z
+        and n_plus_y != n_minus_y
+        and "opposite labels are equivariance-allowed" in note,
+        "at the lex-first breaker, opposite labels are equivariance-allowed",
+    )
+
+    expected_sites = (
+        (-1, 1, 1),
+        (0, 1, 2),
+        (1, -1, -1),
+        (1, -1, 1),
+        (1, 0, 2),
+        (2, 1, 2),
+        (3, 1, 1),
+    )
+    uneq_sites = tuple(row["site"] for row in rows if row["unequal"])
+    checks.check(
+        "theorem-1-site-list",
+        tuple(row["site"] for row in rows) == expected_sites
+        and uneq_sites == ((-1, 1, 1), (0, 1, 2), (2, 1, 2), (3, 1, 1))
+        and "(−1, 1, 1)" in note
+        and "(0, 1, 2)" in note
+        and "(1, −1, −1)" in note
+        and "(1, −1, 1)" in note
+        and "(1, 0, 2)" in note
+        and "(2, 1, 2)" in note
+        and "(3, 1, 1)" in note,
+        "the seven census sites and four unequal-n witnesses match the note",
+    )
+
+    axis_occupied = frozenset().union(*(ball(seed) for seed in AXIS_SEEDS))
+    axis_rows = census(axis_occupied)
+    axis_uneq = sum(1 for row in axis_rows if row["unequal"])
+    axis_noswap = sum(1 for row in axis_rows if row["no_swap"])
+    checks.check(
+        "off-axis-is-load-bearing",
+        len(axis_rows) == 4
+        and axis_uneq == 0
+        and axis_noswap == 0
+        and "that center was `(0,2,0)`" in note,
+        "replacing the third center by (0,2,0) restores N_uneq = N_noswap = 0",
+    )
+    checks.check(
+        "lattice-clause",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "proper cubic rotations about each site" in axiom_flat
+        and "proper cubic rotations about each site" in note_flat,
+        "the current Lattice wording supplies finite proper cubic rotations",
+    )
+    checks.check(
+        "admissibility-unedited",
+        "one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations"
+        in axiom_flat
+        and "Do not write the triple into Admissibility" in note_flat
+        and "B_2((1,2,1))" not in axiom
+        and "off-axis" not in axiom.lower(),
+        "the off-axis triple is displayed and is not written into Admissibility",
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not attach L1" in note
+        and "not leftover-char of 3ball" in note_flat
+        and "that center was `(0,2,0)`" in note
+        and "Do not launch a 4th equal-radius ball clone" in note
+        and "One off-axis triple only" in note
+        and "finite G+ = 24 only" in note_flat.replace("`", "")
+        and "Score geometry and `n` only" in note
+        and "No new patch family" in note,
+        "the note reports the U census without adopting it, attaching L1, or cloning a 4th ball",
+    )
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    script_body = self_source.split("forbidden = ", 1)[0]
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in forbidden)
+        and all(phrase not in script_body for phrase in forbidden),
+        "the forbidden rhetoric strings are absent from the note and runner",
+    )
+    checks.check(
+        "claim-scope",
+        'claim_scope: "On the union of three radius-2 ℓ¹ balls at 0, (2,0,0), and (1,2,1), whether any unread 4-occupied-NN site has unequal ambiguous n or a non-swapping stabilizer, is reported. Displayed, not adopted."'
+        in note
+        and "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "hypothetical_axiom_status: no edit" in note,
+        "claim_scope and machine status match the displayed-not-adopted residual",
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "no axiom edit" in note_flat.lower()
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS,
+        "the only axiom authority is the current memo; no cache or axiom rewrite",
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On U=B2(0)∪B2((2,0,0))∪B2((1,2,1)), N_4=7, N_uneq=4, N_noswap=0. Lex-first breaker v=(-1,1,1) has unequal ambiguous n; opposite labels are equivariance-allowed. Replacing the third center by (0,2,0) restores N_uneq=0. Displayed, not adopted. No axiom edit. No 4th ball.

## Runner

`scripts/skew_three_seed_tied_n_break_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.