### PR TITLE
feat(skeweq): firing local-in-n map commutes with 1 of 24 rotations

### DIFF
--- a/docs/SKEW_THREE_SEED_LOCAL_N_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SKEW_THREE_SEED_LOCAL_N_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,252 @@
+---
+claim_id: skew_three_seed_local_n_equivariance_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the off-axis three-ball star at v=(-1,1,1), whether the firing local-in-n labeling is equivariant under the 24 proper cube rotations is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/skew_three_seed_local_n_equivariance_2026_08_15.py
+---
+
+# Local-In-`n` Firing Map Cube Equivariance On The Off-Axis Three-Seed Star (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the unread six-neighbor star at `v = (−1,1,1)` on
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`. The displayed firing
+local-in-`n` map of `#6655` is scored for commutation with the 24
+proper cube rotations acting jointly on slots and on `n`. Score the
+star at `v` only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/skew_three_seed_local_n_equivariance_2026_08_15.py`](../scripts/skew_three_seed_local_n_equivariance_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment `#6656` (skewrun execution) ran the local-in-`n` 6-tuple
+`c = (−,0,+,−,0,+)` at unread `v = (−1,1,1)` and reported a fire.
+Investment slotn displayed a different rule — a slot-odd tie-break —
+that fired and commuted for only `3/24` proper rotations. The residual
+here is not leftover-char of skewrun (execution) and not leftover-char
+of slotn (different rule). It is whether *this* `f(n)` labeling
+commutes with `G+` on the star at `v`.
+
+Treat `U` as already locked. The site `v = (−1,1,1)` is unread. Direction
+order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+Occupancy mask
+
+`m = (1, 0, 1, 1, 0, 1)`.
+
+The displayed local-in-`n` map labels an occupied neighbor `w` by the
+dipole `n = d/3` at `w`: unique-axis sign where `|supp n| = 1`;
+otherwise the letter that map assigns to that `n` (shared kernel
+`n = (1/3, 0, −1/3) → −`, and `n = (1/3, −1/3, 0) → +`). Empty stays
+`0`. On this star that map produces
+
+`c = (−,0,+,−,0,+)`.
+
+A rotation `g ∈ G+` acts on slots and on `n`. The commutation count on
+the six slots is
+
+`N_commute = 1`,
+
+so `1/24`. Only the identity keeps every rotated two-support kernel
+inside the displayed table and reproduces the transported letters. In
+particular `N_commute ≠ 24`, so the firing local-in-`n` map is not a
+cube-covariant Admissibility rule.
+
+The two two-support kernels lie in one `G+` orbit and receive opposite
+letters. No function of `n` alone that assigns those two letters can
+commute with every proper cube rotation.
+
+Displayed, not adopted. Do not write the map into Admissibility. Do not
+attach L1. Do not add a 4th ball. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither the 6-tuple `c` nor the displayed local-in-`n`
+table as the framework's fixed rule. The covariance clause is the test
+this note applies to that table on this star. Formation site and rate
+remain outside the axiom memo. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact ℓ¹ geometry on one unread six-neighbor star and a 24-element commutation count for one displayed local-in-n table. Displayed map only."
+trace_class: frontier_discovery
+target_claim_id: skew_three_seed_local_n_equivariance
+target_blocker_text: "on the off-axis three-ball star at v=(-1,1,1), whether the firing local-in-n labeling commutes with the 24 proper cube rotations"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_commute; do not write the map into Admissibility, attach L1, or add a 4th ball"
+conditional_surface_status: "exact on the star at v=(-1,1,1); N_commute=1 of 24; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)`, `p = (2,0,0)`, and `q = (1,2,1)`. The closed ℓ¹
+ball of radius two is
+
+`B_2(c) = { x ∈ Z^3 : |x − c|_1 ≤ 2 }`.
+
+The locked set is the already-given union
+
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`.
+
+The three balls each have 25 sites. Pairwise overlaps are 7, 4, and 4,
+and the triple overlap has 2 sites, so `|U| = 62`. The unread site is
+
+`v = (−1,1,1)`.
+
+Then `|v|_1 = 3`, `|v − p|_1 = 5`, and `|v − q|_1 = 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` |
+|---|---|---|
+| `+x` | `(0,1,1)` | yes |
+| `−x` | `(−2,1,1)` | no |
+| `+y` | `(−1,2,1)` | yes |
+| `−y` | `(−1,0,1)` | yes |
+| `+z` | `(−1,1,2)` | no |
+| `−z` | `(−1,1,0)` | yes |
+
+Occupancy mask at `v`:
+
+`m = (1, 0, 1, 1, 0, 1)`.
+
+At a site `w`, the occupancy 6-tuple of its neighbors inside `U`
+determines the dipole
+
+`d_μ = occ(w + e_μ) − occ(w − e_μ)`, `n = d/3`.
+
+The displayed local-in-`n` map `f` on a kernel is:
+
+- empty slot: `f = 0`;
+- `|supp n| = 1`: `f` is the sign of the unique nonzero component;
+- `n = (1/3, 0, −1/3)` (the shared kernel on this star): `f = −`;
+- `n = (1/3, −1/3, 0)`: `f = +`;
+- any other occupied kernel is outside the displayed table.
+
+`G+` is the 24 determinant-`+1` signed permutation matrices of the
+three axes. A matrix `g` sends slot `μ` to `gμ` and sends a kernel `n`
+to the vector `g n`. Letters move with their slots. Commutation at `g`
+is the identity
+
+`label(g · slot, g · n) = g · label(slot, n)`
+
+on all six slots. `N_commute` is the number of such `g`.
+
+## Theorem 1 — commutation count on this star
+
+The occupancy dipoles on the four occupied neighbors are exact:
+
+| neighbor | `n` | `f(n)` |
+|---|---|---|
+| `(0,1,1)` | `(1/3, 0, −1/3)` | `−` |
+| `(−1,2,1)` | `(1/3, 0, 0)` | `+` |
+| `(−1,0,1)` | `(1/3, 0, −1/3)` | `−` |
+| `(−1,1,0)` | `(1/3, −1/3, 0)` | `+` |
+
+Empty slots stay `0`. The labeled 6-tuple is therefore
+
+`c = (−,0,+,−,0,+)`.
+
+Enumerating all 24 elements of `G+` and comparing the transported
+labeling with the labeling rebuilt from the transported kernels gives
+
+`N_commute = 1`
+
+out of 24, written `1/24`. The identity commutes. Every non-identity
+`g` either sends a two-support kernel off the two-row displayed table
+or rebuilds a different 6-tuple. The two two-support kernels are
+`G+`-related: a proper rotation carries `(1/3, 0, −1/3)` to
+`(1/3, −1/3, 0)`, while the displayed table assigns those two vectors
+opposite letters.
+
+Scoring only the star at `v`. This is not leftover-char of skewrun
+(execution): the fire at `v` is not re-run. It is not leftover-char of
+slotn (different rule): slot-odd uses the slot name, not only `n`.
+
+## Theorem 2 — the firing map is not cube-equivariant
+
+Because `N_commute ≠ 24`, the displayed local-in-`n` map does not
+commute with every proper cube rotation of this star. The firing
+local-in-`n` map is not a cube-covariant Admissibility rule.
+
+The obstruction is already visible in the table: a cube-covariant
+function of `n` cannot send two `G+`-images of one kernel to opposite
+letters.
+
+## Theorem 3 — displayed, not adopted
+
+The map and the commutation count are displayed member data. They are
+not the framework's fixed Admissibility rule. This note does not write
+the map into Admissibility. Do not write the map into Admissibility.
+Do not attach L1. Do not add a 4th ball. Occupancy-only formation
+(the `n ≠ 0` gate) is not attached. Qubit remains `M_2(C)`. No approved
+primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On this unread star, the displayed local-in-`n`
+  map reproduces `c = (−,0,+,−,0,+)` and commutes with `1` of the `24`
+  proper cube rotations.
+- **What is displayed only.** The map, the letter identification
+  `{+, −}`, and the commutation count are one rival table. They are
+  not adopted.
+- **What is not claimed.** No attachment of a local-in-`n` labeling to
+  Admissibility; no attachment of occupancy-only formation; no axiom
+  edit; no formation rate; no lattice-wide dynamics; no claim that
+  Admissibility selects `c`; no fourth equal-radius ball; no re-run of
+  the skewrun fire; no slot-odd rule.
+- **Mutation controls.** A rebuilt `c` other than `(−,0,+,−,0,+)`
+  fails. `N_commute = 24` would fail the non-covariance report. A note
+  that writes the map into Admissibility, attaches L1, or authors an
+  audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, the displayed
+local-in-`n` table, the 24 proper cube rotations, `N_commute`, the
+current premise boundary, and the mutation controls. It writes no
+cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15744,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17029,6 +17029,10 @@
   "sixth_family_sheared_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "skew_three_seed_local_n_equivariance_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
    "deps_hash": "9defae253834",

--- a/logs/runner-cache/skew_three_seed_local_n_equivariance_2026_08_15.txt
+++ b/logs/runner-cache/skew_three_seed_local_n_equivariance_2026_08_15.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/skew_three_seed_local_n_equivariance_2026_08_15.py
+runner_sha256: 22101edee0369979fcc9c3e5d08effe9e3a87ecf32fa11021ac9570ff29db585
+input_fingerprint_sha256: 3ecc09facd299b52674794f56f070ba5bce3b12934b41388b7f71cc05d3a348e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SKEW_THREE_SEED_LOCAL_N_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Qubit, Admissibility, and Record sentences; G+ rebuilt as the 24 proper cube rotations
+construction: U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)), unread v=(-1,1,1)
+negative_scope: displayed local-in-n map only; not adopted; L1 not attached
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-covariance Admissibility still requires one proper-cubic covariant rule
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-qubit Qubit remains M_2(C)
+PASS: source-record lock, permanence, content-only readout, and unreadability at absence are pinned
+U_card=62
+v_in_U=False
+occupancy_mask=(1, 0, 1, 1, 0, 1)
+displayed_c=(−,0,+,−,0,+)
+slot dir=(1, 0, 0) w=(0, 1, 1) n=(1/3,0,-1/3) label=−
+slot dir=(-1, 0, 0) w=(-2, 1, 1) n=empty label=0
+slot dir=(0, 1, 0) w=(-1, 2, 1) n=(1/3,0,0) label=+
+slot dir=(0, -1, 0) w=(-1, 0, 1) n=(1/3,0,-1/3) label=−
+slot dir=(0, 0, 1) w=(-1, 1, 2) n=empty label=0
+slot dir=(0, 0, -1) w=(-1, 1, 0) n=(1/3,-1/3,0) label=+
+G_plus=24
+N_commute=1
+N_defined=1
+N_commute_over_24=1/24
+shared_other_same_orbit=True
+identity_commutes=True
+PASS: g-plus-order finite G+ is exactly the 24 proper cube rotations
+PASS: center-unread the star center v is not already in U
+PASS: u-geometry U is the union of three radius-2 ℓ¹ balls and has 62 sites
+PASS: occupancy-mask occupied nearest neighbors of v are exactly +x,+y,−y,−z
+PASS: theorem-1-map the displayed local-in-n map reproduces c=(−,0,+,−,0,+)
+PASS: theorem-1-commute N_commute among the 24 proper rotations is computed and reported
+PASS: theorem-2-not-equivariant N_commute is not 24, so the map is not cube-covariant
+PASS: claim-scope the note reports the declared displayed claim_scope
+PASS: displayed-not-adopted the map is displayed and is not written into Admissibility
+PASS: l1-not-attached the note does not attach L1 and does not add a fourth ball
+PASS: not-leftover-prior the note is not leftover-char of skewrun execution or slotn
+PASS: admissibility-unedited the firing local-in-n map is not written into Admissibility
+PASS: forbidden-phrases the forbidden rhetoric strings are absent from the note and runner
+PASS: no-axiom-edit the only axiom authority is the current memo; no cache or axiom rewrite
+per_element: local-in-n letters and N_commute are exact integers
+per_site: only the unread star center v is scored
+per_mode: no spectral calculation
+per_block: the six-neighbor star at v only
+lattice_wide: checked and not executed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/skew_three_seed_local_n_equivariance_2026_08_15.py
+++ b/scripts/skew_three_seed_local_n_equivariance_2026_08_15.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Cube equivariance of the firing local-in-n map on one three-seed star.
+
+U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1)). Score only the unread star at
+v = (−1, 1, 1). The displayed local-in-n map of the firing 6-tuple
+c = (−, 0, +, −, 0, +) is unique-axis sign on |supp n| = 1, shared kernel
+→ −, and n = (1/3, −1/3, 0) → +. Empty stays 0. Count how many of the
+24 proper cube rotations commute when n and slots rotate together.
+Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SKEW_THREE_SEED_LOCAL_N_EQUIVARIANCE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SKEW_THREE_SEED_LOCAL_N_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Kernel = tuple[Fraction, Fraction, Fraction]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY, PLUS, MINUS, UNDEF = 0, 1, 2, 99
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−", UNDEF: "?"}
+V: Point = (-1, 1, 1)
+SEEDS: tuple[Point, ...] = ((0, 0, 0), (2, 0, 0), (1, 2, 1))
+SHARED: Kernel = (Fraction(1, 3), Fraction(0), Fraction(-1, 3))
+OTHER: Kernel = (Fraction(1, 3), Fraction(-1, 3), Fraction(0))
+TABLE: dict[Kernel, int] = {SHARED: MINUS, OTHER: PLUS}
+C: Coloring = (MINUS, EMPTY, PLUS, MINUS, EMPTY, PLUS)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def ball(center: Point, radius: int = 2) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        site = add(center, offset)
+        if l1(sub(site, center)) <= radius:
+            sites.add(site)
+    return frozenset(sites)
+
+
+def locked_union() -> frozenset[Point]:
+    occupied = frozenset()
+    for seed in SEEDS:
+        occupied = occupied | ball(seed)
+    return occupied
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def dipole(occ: Coloring) -> Kernel:
+    return (
+        Fraction(occ[0] - occ[1], 3),
+        Fraction(occ[2] - occ[3], 3),
+        Fraction(occ[4] - occ[5], 3),
+    )
+
+
+def unique_axis_label(n: Kernel) -> int | None:
+    support = [index for index, value in enumerate(n) if value != 0]
+    if len(support) != 1:
+        return None
+    return PLUS if n[support[0]] > 0 else MINUS
+
+
+def star_kernels(center: Point, occupied: frozenset[Point]) -> tuple[Kernel | None, ...]:
+    kernels: list[Kernel | None] = []
+    for direction in DIRS:
+        neighbor = add(center, direction)
+        if neighbor not in occupied:
+            kernels.append(None)
+            continue
+        kernels.append(dipole(occupancy_tuple(neighbor, occupied)))
+    return tuple(kernels)
+
+
+def label_from_n(n: Kernel | None) -> int:
+    if n is None:
+        return EMPTY
+    unique = unique_axis_label(n)
+    if unique is not None:
+        return unique
+    return TABLE.get(n, UNDEF)
+
+
+def label_star(kernels: tuple[Kernel | None, ...]) -> Coloring:
+    return tuple(label_from_n(kernel) for kernel in kernels)
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: tuple[Fraction, ...] | Point) -> tuple:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def rotate_kernels(
+    matrix: Matrix, kernels: tuple[Kernel | None, ...]
+) -> tuple[Kernel | None, ...]:
+    out: list[Kernel | None] = [None] * 6
+    for source, direction in enumerate(DIRS):
+        image = DIR_INDEX[mat_vec(matrix, direction)]
+        kernel = kernels[source]
+        if kernel is None:
+            out[image] = None
+        else:
+            rotated = mat_vec(matrix, kernel)
+            out[image] = (rotated[0], rotated[1], rotated[2])
+    return tuple(out)
+
+
+def rotate_labels(matrix: Matrix, labels: Coloring) -> Coloring:
+    out = [EMPTY] * 6
+    for source, direction in enumerate(DIRS):
+        image = DIR_INDEX[mat_vec(matrix, direction)]
+        out[image] = labels[source]
+    return tuple(out)
+
+
+def commute_count(
+    kernels: tuple[Kernel | None, ...], rotations: tuple[Matrix, ...]
+) -> tuple[int, int]:
+    base = label_star(kernels)
+    n_commute = 0
+    n_defined = 0
+    for matrix in rotations:
+        rebuilt = label_star(rotate_kernels(matrix, kernels))
+        if UNDEF not in rebuilt:
+            n_defined += 1
+        n_commute += int(rebuilt == rotate_labels(matrix, base))
+    return n_commute, n_defined
+
+
+def same_orbit(left: Kernel, right: Kernel, rotations: tuple[Matrix, ...]) -> bool:
+    return any(mat_vec(matrix, left) == right for matrix in rotations)
+
+
+def format_tuple(coloring: Coloring) -> str:
+    return "(" + ",".join(LETTER[slot] for slot in coloring) + ")"
+
+
+def format_n(n: Kernel | None) -> str:
+    if n is None:
+        return "empty"
+    return "(" + ",".join(str(component) for component in n) + ")"
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Qubit, Admissibility, "
+        "and Record sentences; G+ rebuilt as the 24 proper cube rotations"
+    )
+    print("construction: U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)), unread v=(-1,1,1)")
+    print("negative_scope: displayed local-in-n map only; not adopted; L1 not attached")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SKEW_THREE_SEED_LOCAL_N_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    covariance_clause = (
+        "one fixed nearest-neighbor admissibility rule, covariant under "
+        "lattice translations and proper cubic rotations"
+    )
+    formation_boundary = "it does not supply the formation site, probability,"
+    qubit_sentence = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_perm = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in axiom_flat and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-covariance",
+        "Admissibility still requires one proper-cubic covariant rule",
+        covariance_clause in axiom_flat and covariance_clause in note_flat,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in axiom and formation_boundary in note,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit remains M_2(C)",
+        qubit_sentence in axiom and qubit_sentence in note and "Qubit remains `M_2(C)`" in note,
+    )
+    checks.check(
+        "source-record",
+        "lock, permanence, content-only readout, and unreadability at absence are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        )
+        and all(
+            phrase in note
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        ),
+    )
+
+    occupied = locked_union()
+    mask = occupancy_tuple(V, occupied)
+    kernels = star_kernels(V, occupied)
+    displayed = label_star(kernels)
+    rotations = proper_rotations()
+    n_commute, n_defined = commute_count(kernels, rotations)
+    orbit_same = same_orbit(SHARED, OTHER, rotations)
+    identity = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    identity_commutes = label_star(rotate_kernels(identity, kernels)) == rotate_labels(
+        identity, displayed
+    )
+    neighbor_rows: list[tuple[Point, Point, Kernel | None, int]] = []
+    for direction, kernel in zip(DIRS, kernels, strict=True):
+        neighbor_rows.append((direction, add(V, direction), kernel, label_from_n(kernel)))
+
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"occupancy_mask={mask}")
+    print(f"displayed_c={format_tuple(displayed)}")
+    for direction, neighbor, kernel, letter in neighbor_rows:
+        print(
+            f"slot dir={direction} w={neighbor} n={format_n(kernel)} "
+            f"label={LETTER[letter]}"
+        )
+    print(f"G_plus={len(rotations)}")
+    print(f"N_commute={n_commute}")
+    print(f"N_defined={n_defined}")
+    print(f"N_commute_over_24={n_commute}/24")
+    print(f"shared_other_same_orbit={orbit_same}")
+    print(f"identity_commutes={identity_commutes}")
+
+    balls = tuple(ball(seed) for seed in SEEDS)
+    pairwise = (
+        len(balls[0] & balls[1]),
+        len(balls[0] & balls[2]),
+        len(balls[1] & balls[2]),
+    )
+    triple = len(balls[0] & balls[1] & balls[2])
+
+    checks.check(
+        "g-plus-order",
+        "finite G+ is exactly the 24 proper cube rotations",
+        len(rotations) == 24 and len(set(rotations)) == 24,
+    )
+    checks.check(
+        "center-unread",
+        "the star center v is not already in U",
+        V not in occupied
+        and l1(V) == 3
+        and l1(sub(V, (2, 0, 0))) == 5
+        and l1(sub(V, (1, 2, 1))) == 3,
+        residual=V in occupied,
+    )
+    checks.check(
+        "u-geometry",
+        "U is the union of three radius-2 ℓ¹ balls and has 62 sites",
+        all(len(item) == 25 for item in balls)
+        and pairwise == (7, 4, 4)
+        and triple == 2
+        and len(occupied) == 62,
+    )
+    checks.check(
+        "occupancy-mask",
+        "occupied nearest neighbors of v are exactly +x,+y,−y,−z",
+        mask == (1, 0, 1, 1, 0, 1) and "(1, 0, 1, 1, 0, 1)" in note,
+    )
+    checks.check(
+        "theorem-1-map",
+        "the displayed local-in-n map reproduces c=(−,0,+,−,0,+)",
+        displayed == C
+        and kernels[0] == SHARED
+        and kernels[2] == (Fraction(1, 3), Fraction(0), Fraction(0))
+        and kernels[3] == SHARED
+        and kernels[5] == OTHER
+        and unique_axis_label(kernels[2]) == PLUS
+        and "(−,0,+,−,0,+)" in note,
+    )
+    checks.check(
+        "theorem-1-commute",
+        "N_commute among the 24 proper rotations is computed and reported",
+        n_commute == n_defined
+        and identity_commutes
+        and f"N_commute = {n_commute}" in note
+        and f"{n_commute}/24" in note,
+        residual=n_commute,
+    )
+    checks.check(
+        "theorem-2-not-equivariant",
+        "N_commute is not 24, so the map is not cube-covariant",
+        n_commute != 24
+        and n_commute < 24
+        and orbit_same
+        and TABLE[SHARED] != TABLE[OTHER]
+        and "not a cube-covariant Admissibility rule" in note,
+        residual=n_commute,
+    )
+
+    claim_scope = (
+        'claim_scope: "On the off-axis three-ball star at v=(-1,1,1), '
+        "whether the firing local-in-n labeling is equivariant under the "
+        '24 proper cube rotations is reported. Displayed, not adopted."'
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the declared displayed claim_scope",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the map is displayed and is not written into Admissibility",
+        "Displayed, not adopted" in note
+        and "Do not write the map into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "the note does not attach L1 and does not add a fourth ball",
+        "Do not attach L1" in note
+        and "Do not add a 4th ball" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-prior",
+        "the note is not leftover-char of skewrun execution or slotn",
+        "not leftover-char of skewrun" in note_flat
+        and "execution" in note_flat
+        and "not leftover-char of slotn" in note_flat
+        and "different rule" in note_flat,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the firing local-in-n map is not written into Admissibility",
+        covariance_clause in axiom_flat
+        and "(−,0,+,−,0,+)" not in axiom
+        and "local-in-n" not in axiom
+        and "B_2((1,2,1))" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the forbidden rhetoric strings are absent from the note and runner",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(phrase not in self_source.split("FORBIDDEN = ", 1)[0] for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the only axiom authority is the current memo; no cache or axiom rewrite",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: local-in-n letters and N_commute are exact integers")
+    print("per_site: only the unread star center v is scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: the six-neighbor star at v only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

At v=(-1,1,1) the displayed local-in-n map rebuilds c=(-,0,+,-,0,+). N_commute=1/24 (identity only). The two two-support kernels sit in one G+ orbit and get opposite letters. Not cube-covariant. Displayed, not adopted. No axiom edit. No 4th ball.

## Runner

`scripts/skew_three_seed_local_n_equivariance_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.