### PR TITLE
feat(delsgn): claim-delta sign product fully labels and fires

### DIFF
--- a/docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,281 @@
+---
+claim_id: skew_three_seed_delta_sign_product_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the off-axis three-ball union at unread v=(-1,1,1), whether the product of signs of nonzero coordinates of each tied claim-delta yields a July-3 k=3 pair member is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_rule_covariance_extension_classification_openness_achiral_oriented_frame_minimal_chiral_channel_bounded_theorem_note_2026-07-03
+runner: scripts/skew_three_seed_delta_sign_product_2026_08_15.py
+---
+
+# Product Of Claim-Delta Signs At The Off-Axis Three-Seed Breaker (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact occupancy on
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))` and the unread six-neighbor
+star at `v = (−1,1,1)`. For each occupied neighbor, unique-axis history
+labels from the nearest-seed ball, then — when `n_hist` is tied — the
+product of the signs of the nonzero coordinates of the claim-delta
+`δ = w − s*(w)`. Completed 6-tuple, whether every occupied neighbor is
+labeled, and whether that 6-tuple is a July-3 `k = 3` pair member.
+Score `U` and the star at `v` only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/skew_three_seed_delta_sign_product_2026_08_15.py`](../scripts/skew_three_seed_delta_sign_product_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+
+## Result Up Front
+
+Investment `#6660` (seedax, unique-axis of `δ`) reported that on this
+off-axis triple the three history-tied claim-deltas are two-support:
+`(0,1,1)`, `(−1,0,1)`, `(−1,1,0)`. Unique-axis of `δ` therefore fails,
+and the 6-tuple remains `(tied, 0, +, tied, 0, tied)`. The residual
+here is not leftover-char of seedax (that used the unique nonzero of
+`δ`). It is whether the product of the signs of the nonzero
+coordinates of each tied `δ` — a displayed two-support scalar —
+finishes the labels, and whether the completed 6-tuple is a July-3
+`k = 3` pair member.
+
+Treat `U` as already locked. The site `v = (−1,1,1)` is unread: it
+lies in none of the three radius-two ℓ¹ balls. Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+The four occupied nearest neighbors of `v` in `U` are `+x`, `+y`,
+`−y`, and `−z`. The two empty slots are `−x` and `+z`. Occupancy mask
+
+`m = (1, 0, 1, 1, 0, 1)`.
+
+Seeds are `S = {0, (2,0,0), (1,2,1)}`. For an occupied neighbor `w`,
+the nearest seed `s*(w)` is a seed of least ℓ¹ distance; ties take the
+lex-first seed. The history kernel `n_hist(w)` is the occupancy dipole
+`n = d/3` at `w` computed from occupancy in `B_2(s*(w))` only. If
+`n_hist(w)` has a unique nonzero coordinate, the label is the sign of
+that coordinate. Else let `δ = w − s*(w)`. The label is the product of
+the signs of the nonzero coordinates of `δ`. If the support of `δ` is
+empty, the empty product is undefined and the slot stays tied. Empty
+slots stay `0`.
+
+The completed 6-tuple is
+
+`(+,0,+,−,0,−)`.
+
+Every occupied neighbor is labeled. The three history-tied slots
+receive the two-support products `+x → +`, `−y → −`, `−z → −`. The
+unique-axis history label at `+y` remains `+`. That slot is not
+reassigned by the product (its `δ = (−2, 0, 0)` is unused because
+`n_hist` already has a unique axis).
+
+That 6-tuple is a July-3 `k = 3` pair member. It is one of the two
+known firing completions of the seedax residual
+`(tied, 0, +, tied, 0, tied)`.
+
+The comparison is displayed, not adopted.
+Do not write the product rule into Admissibility.
+Do not attach L1. Failed-bar: no 4th equal-radius ball.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither a product of claim-delta signs of
+history-tied neighbors nor the July-3 pair as the framework's fixed
+rule. Record permanence is used only to treat the locks on `U` as
+already given. Formation site and rate remain outside the axiom memo.
+Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact ℓ¹ geometry on one off-axis three-ball union, nearest-seed history kernels, product of signs of nonzero coordinates of each tied claim-delta, completed 6-tuple, and membership in the reconstructed July-3 k=3 pair. Displayed only."
+trace_class: frontier_discovery
+target_claim_id: skew_three_seed_delta_sign_product
+target_blocker_text: "at unread v=(-1,1,1), whether the product of signs of nonzero coordinates of each tied claim-delta yields a July-3 k=3 pair member"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the completed 6-tuple and pair membership; do not write the product rule into Admissibility, attach L1, or launch a 4th equal-radius ball"
+conditional_surface_status: "exact on U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)) at unread v=(-1,1,1); displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)`, `p = (2,0,0)`, and `q = (1,2,1)`. The closed ℓ¹
+ball of radius two is
+
+`B_2(c) = { x ∈ Z^3 : |x − c|_1 ≤ 2 }`.
+
+The locked set is the already-given union
+
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`.
+
+The three balls each have 25 sites. Pairwise overlaps are 7, 4, and 4,
+and the triple overlap has 2 sites, so `|U| = 62`. The unread site is
+
+`v = (−1,1,1)`.
+
+Then `|v|_1 = 3`, `|v − p|_1 = 5`, and `|v − q|_1 = 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` |
+|---|---|---|
+| `+x` | `(0,1,1)` | yes |
+| `−x` | `(−2,1,1)` | no |
+| `+y` | `(−1,2,1)` | yes |
+| `−y` | `(−1,0,1)` | yes |
+| `+z` | `(−1,1,2)` | no |
+| `−z` | `(−1,1,0)` | yes |
+
+Occupancy mask at `v`:
+
+`m = (1, 0, 1, 1, 0, 1)`.
+
+Letters are `{0, +, −}` with `0` empty/unread.
+
+For occupied `w`, `s*(w)` is a nearest seed of `w` among `S`, lex-first
+if tied. The history occupancy 6-tuple of `w` uses only the indicator
+of `B_2(s*(w))`. That 6-tuple determines the dipole
+
+`d_μ = occ_hist(w + e_μ) − occ_hist(w − e_μ)`, `n_hist = d/3`.
+
+If exactly one component of `n_hist` is nonzero, the label of `w` is
+the sign of that component. Otherwise the claim-axis vector is
+
+`δ = w − s*(w)`,
+
+the direction from the claiming seed to the neighbor. The label is the
+product of the signs of the nonzero coordinates of `δ`. If
+`|supp δ| = 0`, the empty product is undefined and the occupied
+neighbor stays `tied`. Empty neighbors of `v` stay `0`. This is not
+leftover-char of seedax, which used the unique nonzero of `δ`.
+
+The July-3 pair is reconstructed, not imported as a table. Letters
+`{0,1,2}` with `0` empty, `1 = +`, and `2 = −` color the six axis
+directions. The proper cubic group `G+` is the 24 determinant-`+1`
+signed permutation matrices acting on those directions. Spatial
+inversion `P = −I` exchanges `+μ` with `−μ`. A `G+`-orbit is chiral
+when `P` sends it to a different `G+`-orbit. At three letters there is
+exactly one such pair; its two orbits have 24 members each. The
+formation predicate `f` is membership in that 48-element set. Do not
+overwrite existing locks.
+
+## Theorem 1 — Completed 6-tuple after the product of claim-delta signs
+
+Nearest seeds, history kernels, claim-deltas, and sign products on the
+four occupied neighbors are exact:
+
+| neighbor | `s*(w)` | `n_hist` | hist | `δ = w − s*(w)` | `supp δ` | product | label |
+|---|---|---|---|---|---|---|---|
+| `(0,1,1)` | `(0,0,0)` | `(0, −1/3, −1/3)` | tied | `(0, 1, 1)` | 2 | `(+)(+)=+` | `+` |
+| `(−1,2,1)` | `(1,2,1)` | `(1/3, 0, 0)` | `+` | `(−2, 0, 0)` | 1 | unused | `+` |
+| `(−1,0,1)` | `(0,0,0)` | `(1/3, 0, −1/3)` | tied | `(−1, 0, 1)` | 2 | `(−)(+)=−` | `−` |
+| `(−1,1,0)` | `(0,0,0)` | `(1/3, −1/3, 0)` | tied | `(−1, 1, 0)` | 2 | `(−)(+)=−` | `−` |
+
+The neighbor `(0,1,1)` is ℓ¹-tied between `0` and `(1,2,1)` at
+distance 2; lex-first selects `0`. The other three occupied neighbors
+have a unique nearest seed.
+
+The product is applied only when `n_hist` is tied. Each of the three
+history-tied `δ` is two-support, so unique-axis of `δ` fails and the
+label is the displayed two-support scalar: product of the nonzero
+signs. The unique-axis history label at `(−1,2,1)` is kept; its
+`δ = (−2, 0, 0)` is not used to overwrite that sign.
+
+The completed 6-tuple at `v` is therefore
+
+`(+,0,+,−,0,−)`.
+
+Every occupied neighbor is labeled: all four occupied slots receive a
+letter. Empty slots remain `0`.
+
+Scoring only `U` and the star at `v`. The center `v` is not already in
+`U`. This is not leftover-char of seedax (unique nonzero of `δ`): the
+present object is the product of the signs of the nonzero coordinates
+of each tied claim-delta.
+
+## Theorem 2 — The completed 6-tuple is a July-3 `k = 3` pair member
+
+The 6-tuple is fully labeled. The reconstructed July-3 `k = 3` pair
+has `N_pair = 48`. The completed coloring
+
+`(+,0,+,−,0,−)`
+
+is a member of that pair. There is one completion of the (now empty)
+tie set, and `N_fire = 1`.
+
+## Theorem 3 — Displayed, not adopted
+
+The completed 6-tuple, the claim-delta table, the three two-support
+products, and pair membership are displayed member data. They are not
+the framework's fixed Admissibility rule.
+Do not write the product rule into Admissibility.
+Do not attach L1. Failed-bar: no 4th equal-radius ball.
+Occupancy-only formation (the `n ≠ 0` gate) is not attached. Qubit
+remains `M_2(C)`. No approved primitive is added. No axiom edit.
+
+This note is not leftover-char of seedax (unique nonzero of `δ`),
+which asked only whether unique-axis of each claim-delta fully labeled
+the star.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On this `U`, at this unread `v`, the product of
+  the signs of the nonzero coordinates of each tied claim-delta
+  completes the 6-tuple to `(+,0,+,−,0,−)`. Every occupied neighbor
+  is labeled. That 6-tuple is a July-3 `k = 3` pair member.
+- **What is displayed only.** The pair, the letter identification
+  `{+, −}`, and the product of claim-delta signs are one rival
+  comparison. They are not adopted.
+- **What is not claimed.** No attachment of the product rule to
+  Admissibility; no attachment of occupancy-only formation; no axiom
+  edit; no formation rate; no lattice-wide dynamics; no claim that
+  Admissibility selects this labeling; no fourth equal-radius ball.
+- **Mutation controls.** The completed 6-tuple differing from
+  `(+,0,+,−,0,−)` fails. Failure of pair membership fails. A note that
+  writes the product rule into Admissibility, attaches L1, or authors
+  an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, nearest seeds,
+history kernels, claim-deltas, products of nonzero signs, the
+completed 6-tuple, the July-3 pair, pair membership, the current
+premise boundary, and the mutation controls. It writes no cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5544,
+ "edge_count": 15745,
+ "node_count": 5545,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17029,6 +17029,10 @@
   "sixth_family_sheared_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "skew_three_seed_delta_sign_product_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
    "deps_hash": "9defae253834",

--- a/logs/runner-cache/skew_three_seed_delta_sign_product_2026_08_15.txt
+++ b/logs/runner-cache/skew_three_seed_delta_sign_product_2026_08_15.txt
@@ -1,0 +1,68 @@
+===== runner cache v1 =====
+runner: scripts/skew_three_seed_delta_sign_product_2026_08_15.py
+runner_sha256: 908c1687f3eba6c90f5427156a7f7c45ebc9f66c54b1afc293423be8af5dd364
+input_fingerprint_sha256: 5c43bf4e16bef750ac21d07e1d603b0429cd1ea8b84b46ac1a31797145c2ad00
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Qubit, Admissibility, and Record sentences plus the July-3 pair reconstructed locally
+construction: U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)), unread v=(-1,1,1)
+negative_scope: displayed product of claim-delta signs only; not adopted; L1 not attached; no 4th equal-radius ball
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-qubit Qubit remains M_2(C)
+PASS: source-record lock, permanence, content-only readout, and unreadability at absence are pinned
+U_card=62
+v_in_U=False
+occupancy_mask=(1, 0, 1, 1, 0, 1)
+delta_sign_product_6tuple=(+,0,+,−,0,−)
+every_occupied_labeled=True
+N_product_broke=3
+unique_axis_of_delta_fails=True
+neighbor dir=(1, 0, 0) w=(0, 1, 1) s*=(0, 0, 0) occ_hist=(0, 0, 0, 1, 0, 1) n_hist=(0,-1/3,-1/3) hist-tied delta=(0, 1, 1) supp=2 sign_product=+ label=+
+neighbor dir=(0, 1, 0) w=(-1, 2, 1) s*=(1, 2, 1) occ_hist=(1, 0, 0, 0, 0, 0) n_hist=(1/3,0,0) unique-axis delta=(-2, 0, 0) supp=1 sign_product=− label=+
+neighbor dir=(0, -1, 0) w=(-1, 0, 1) s*=(0, 0, 0) occ_hist=(1, 0, 0, 0, 0, 1) n_hist=(1/3,0,-1/3) hist-tied delta=(-1, 0, 1) supp=2 sign_product=− label=−
+neighbor dir=(0, 0, -1) w=(-1, 1, 0) s*=(0, 0, 0) occ_hist=(1, 0, 0, 1, 0, 0) n_hist=(1/3,-1/3,0) hist-tied delta=(-1, 1, 0) supp=2 sign_product=− label=−
+N_tied=0
+N_comp=1
+completions=(+,0,+,−,0,−)
+N_pair=48
+N_fire=1
+fire=(+,0,+,−,0,−)
+empty_product_undefined=True
+PASS: g-plus-order finite G+ is exactly the 24 proper cube rotations
+PASS: center-unread the star center v is not already in U
+PASS: u-geometry U is the union of three radius-2 ℓ¹ balls and has 62 sites
+PASS: theorem-1-mask occupancy mask at v is (1,0,1,1,0,1)
+PASS: theorem-1-nearest-seeds nearest seeds are lex-first among least ℓ¹ distance
+PASS: theorem-1-hist-kernels history kernels use only occupancy in each neighbor's nearest-seed ball
+PASS: theorem-1-two-support-deltas the three history-tied claim-deltas are two-support; unique-axis of δ fails
+PASS: theorem-1-sign-products product of nonzero δ signs labels the three history ties +, −, −
+PASS: theorem-1-completed-tuple the completed 6-tuple is (+,0,+,−,0,−) and every occupied neighbor is labeled
+PASS: pair-census the reconstructed July-3 k=3 pair has 48 members in one chiral pair
+PASS: theorem-2-pair-member the completed 6-tuple is a July-3 k=3 pair member
+PASS: claim-scope the note reports the declared displayed claim_scope
+PASS: displayed-not-adopted the product rule is displayed and is not written into Admissibility
+PASS: l1-not-attached the note does not attach L1 and records the failed-bar against a fourth ball
+PASS: not-leftover-seedax the note is not leftover-char of seedax unique-nonzero of δ
+PASS: admissibility-unedited the product rule and the off-axis triple are not written into Admissibility
+PASS: forbidden-phrases the forbidden rhetoric strings are absent from the note and runner
+PASS: no-axiom-edit the only axiom authority is the current memo; no cache or axiom rewrite
+per_element: product of claim-delta signs and pair membership are exact
+per_site: only the unread star center v is scored
+per_mode: no spectral calculation
+per_block: U and the six-neighbor star at v only
+lattice_wide: checked and not executed
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/skew_three_seed_delta_sign_product_2026_08_15.py
+++ b/scripts/skew_three_seed_delta_sign_product_2026_08_15.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Product of claim-delta signs at the off-axis three-seed breaker.
+
+U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1)). Score only the unread star at
+v = (−1, 1, 1). For each occupied neighbor, n_hist is the occupancy
+kernel from that neighbor's nearest-seed ball (lex-first if tied). If
+n_hist has a unique axis, that sign is the label. Else δ = w − s*(w)
+and the label is the product of the signs of the nonzero coordinates
+of δ. Empty product (support of δ empty) is undefined: the slot stays
+tied. Completions against the July-3 k=3 pair. Displayed, not adopted.
+No cache.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Kernel = tuple[Fraction, Fraction, Fraction]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+V: Point = (-1, 1, 1)
+SEEDS: tuple[Point, ...] = ((0, 0, 0), (2, 0, 0), (1, 2, 1))
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def ball(center: Point, radius: int = 2) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        site = add(center, offset)
+        if l1(sub(site, center)) <= radius:
+            sites.add(site)
+    return frozenset(sites)
+
+
+def locked_union() -> frozenset[Point]:
+    occupied = frozenset()
+    for seed in SEEDS:
+        occupied = occupied | ball(seed)
+    return occupied
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def dipole(occ: Coloring) -> Kernel:
+    return (
+        Fraction(occ[0] - occ[1], 3),
+        Fraction(occ[2] - occ[3], 3),
+        Fraction(occ[4] - occ[5], 3),
+    )
+
+
+def unique_nonzero_sign(vec: tuple[object, ...]) -> int | None:
+    support = [index for index, value in enumerate(vec) if value != 0]
+    if len(support) != 1:
+        return None
+    return PLUS if vec[support[0]] > 0 else MINUS
+
+
+def nonzero_sign_product(vec: tuple[object, ...]) -> int | None:
+    product = 1
+    support = 0
+    for value in vec:
+        if value == 0:
+            continue
+        support += 1
+        product *= 1 if value > 0 else -1
+    if support == 0:
+        return None
+    return PLUS if product > 0 else MINUS
+
+
+def nearest_seed(site: Point) -> Point:
+    ranked = sorted((l1(sub(site, seed)), seed) for seed in SEEDS)
+    return ranked[0][1]
+
+
+def product_label(n_vec: Kernel, delta: Point) -> int | None:
+    hist = unique_nonzero_sign(n_vec)
+    if hist is not None:
+        return hist
+    return nonzero_sign_product(delta)
+
+
+def completions_of(fragment: tuple[int | None, ...]) -> tuple[Coloring, ...]:
+    free = [index for index, slot in enumerate(fragment) if slot is None]
+    out: list[Coloring] = []
+    for fill in itertools.product((PLUS, MINUS), repeat=len(free)):
+        coloring = [EMPTY if slot is None else slot for slot in fragment]
+        for index, letter in zip(free, fill):
+            coloring[index] = letter
+        out.append(tuple(coloring))
+    return tuple(out)
+
+
+def det3(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+    vector: Point,
+) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(
+    matrix: tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]],
+) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring) -> Coloring:
+    out = [0] * 6
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def cubic_signed_permutations() -> tuple[list[tuple[int, ...]], tuple[int, ...]]:
+    records: list[
+        tuple[tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]], int]
+    ] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            key = tuple(value for row in matrix for value in row)
+            if key not in seen:
+                seen.add(key)
+                records.append((matrix, det3(matrix)))
+    proper = [direction_perm(matrix) for matrix, det in records if det == 1]
+    inversion = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    return proper, direction_perm(inversion)
+
+
+def july3_k3_pair() -> frozenset[Coloring]:
+    proper, inversion = cubic_signed_permutations()
+    unseen = set(itertools.product((EMPTY, PLUS, MINUS), repeat=6))
+    orbits: list[set[Coloring]] = []
+    ids: dict[Coloring, int] = {}
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in proper}
+        index = len(orbits)
+        orbits.append(orbit)
+        unseen -= orbit
+        for coloring in orbit:
+            ids[coloring] = index
+    pair: set[Coloring] = set()
+    seen_pairs: set[tuple[int, int]] = set()
+    for index, orbit in enumerate(orbits):
+        sample = next(iter(orbit))
+        image = ids[act_col(inversion, sample)]
+        if image == index:
+            continue
+        key = tuple(sorted((index, image)))
+        if key in seen_pairs:
+            continue
+        seen_pairs.add(key)
+        pair |= orbits[index]
+        pair |= orbits[image]
+    if len(seen_pairs) != 1:
+        raise RuntimeError(f"expected one chiral pair, found {len(seen_pairs)}")
+    return frozenset(pair)
+
+
+def format_tuple(coloring: Coloring) -> str:
+    return "(" + ",".join(LETTER[slot] for slot in coloring) + ")"
+
+
+def format_fragment(fragment: tuple[int | None, ...]) -> str:
+    parts = []
+    for slot in fragment:
+        if slot is None:
+            parts.append("tied")
+        else:
+            parts.append(LETTER[slot])
+    return "(" + ",".join(parts) + ")"
+
+
+def format_n(n: Kernel) -> str:
+    return "(" + ",".join(str(component) for component in n) + ")"
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Qubit, Admissibility, "
+        "and Record sentences plus the July-3 pair reconstructed locally"
+    )
+    print("construction: U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)), unread v=(-1,1,1)")
+    print(
+        "negative_scope: displayed product of claim-delta signs only; "
+        "not adopted; L1 not attached; no 4th equal-radius ball"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "it does not supply the formation site, probability,"
+    qubit_sentence = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_perm = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in axiom_flat and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in axiom and formation_boundary in note,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit remains M_2(C)",
+        qubit_sentence in axiom and qubit_sentence in note and "Qubit remains `M_2(C)`" in note,
+    )
+    checks.check(
+        "source-record",
+        "lock, permanence, content-only readout, and unreadability at absence are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        )
+        and all(
+            phrase in note
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        ),
+    )
+
+    occupied = locked_union()
+    balls = {seed: ball(seed) for seed in SEEDS}
+    mask = occupancy_tuple(V, occupied)
+    pair = july3_k3_pair()
+    neighbor_rows: list[
+        tuple[Point, Point, Point, Coloring, Kernel, Point, int | None, int | None]
+    ] = []
+    fragment_slots: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(V, direction)
+        if neighbor not in occupied:
+            fragment_slots.append(EMPTY)
+            continue
+        seed_star = nearest_seed(neighbor)
+        occ = occupancy_tuple(neighbor, balls[seed_star])
+        n_vec = dipole(occ)
+        delta = sub(neighbor, seed_star)
+        hist_only = unique_nonzero_sign(n_vec)
+        label = product_label(n_vec, delta)
+        neighbor_rows.append(
+            (direction, neighbor, seed_star, occ, n_vec, delta, hist_only, label)
+        )
+        fragment_slots.append(label)
+    fragment = tuple(fragment_slots)
+    completions = completions_of(fragment)
+    firing = tuple(coloring for coloring in completions if coloring in pair)
+    every_labeled = all(label is not None for _d, _w, _s, _o, _n, _δ, _h, label in neighbor_rows)
+    tied_count = sum(1 for _d, _w, _s, _o, _n, _δ, _h, label in neighbor_rows if label is None)
+    product_broke = sum(
+        1
+        for _d, _w, _s, _o, _n, delta, hist_only, label in neighbor_rows
+        if hist_only is None and label is not None
+    )
+    unique_axis_delta_fails = all(
+        unique_nonzero_sign(delta) is None
+        for _d, _w, _s, _o, _n, delta, hist_only, _label in neighbor_rows
+        if hist_only is None
+    )
+    expected = (PLUS, EMPTY, PLUS, MINUS, EMPTY, MINUS)
+
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"occupancy_mask={mask}")
+    print(f"delta_sign_product_6tuple={format_fragment(fragment)}")
+    print(f"every_occupied_labeled={every_labeled}")
+    print(f"N_product_broke={product_broke}")
+    print(f"unique_axis_of_delta_fails={unique_axis_delta_fails}")
+    for direction, neighbor, seed_star, occ, n_vec, delta, hist_only, label in neighbor_rows:
+        hist_kind = "unique-axis" if hist_only is not None else "hist-tied"
+        letter = LETTER[label] if label is not None else "tied"
+        product = nonzero_sign_product(delta)
+        product_letter = LETTER[product] if product is not None else "tied"
+        print(
+            f"neighbor dir={direction} w={neighbor} s*={seed_star} "
+            f"occ_hist={occ} n_hist={format_n(n_vec)} {hist_kind} "
+            f"delta={delta} supp={sum(1 for c in delta if c != 0)} "
+            f"sign_product={product_letter} label={letter}"
+        )
+    print(f"N_tied={tied_count}")
+    print(f"N_comp={len(completions)}")
+    print("completions=" + ",".join(format_tuple(coloring) for coloring in completions))
+    print(f"N_pair={len(pair)}")
+    print(f"N_fire={len(firing)}")
+    print("fire=" + ",".join(format_tuple(coloring) for coloring in firing))
+    print(f"empty_product_undefined={nonzero_sign_product((0, 0, 0)) is None}")
+
+    pairwise = (
+        len(balls[(0, 0, 0)] & balls[(2, 0, 0)]),
+        len(balls[(0, 0, 0)] & balls[(1, 2, 1)]),
+        len(balls[(2, 0, 0)] & balls[(1, 2, 1)]),
+    )
+    triple = len(balls[(0, 0, 0)] & balls[(2, 0, 0)] & balls[(1, 2, 1)])
+    proper, _inversion = cubic_signed_permutations()
+
+    checks.check(
+        "g-plus-order",
+        "finite G+ is exactly the 24 proper cube rotations",
+        len(proper) == 24 and len(set(proper)) == 24,
+    )
+    checks.check(
+        "center-unread",
+        "the star center v is not already in U",
+        V not in occupied
+        and l1(V) == 3
+        and l1(sub(V, (2, 0, 0))) == 5
+        and l1(sub(V, (1, 2, 1))) == 3,
+        residual=V in occupied,
+    )
+    checks.check(
+        "u-geometry",
+        "U is the union of three radius-2 ℓ¹ balls and has 62 sites",
+        all(len(balls[seed]) == 25 for seed in SEEDS)
+        and pairwise == (7, 4, 4)
+        and triple == 2
+        and len(occupied) == 62,
+    )
+    checks.check(
+        "theorem-1-mask",
+        "occupancy mask at v is (1,0,1,1,0,1)",
+        mask == (1, 0, 1, 1, 0, 1) and "(1, 0, 1, 1, 0, 1)" in note,
+    )
+    checks.check(
+        "theorem-1-nearest-seeds",
+        "nearest seeds are lex-first among least ℓ¹ distance",
+        neighbor_rows[0][1] == (0, 1, 1)
+        and neighbor_rows[0][2] == (0, 0, 0)
+        and neighbor_rows[1][1] == (-1, 2, 1)
+        and neighbor_rows[1][2] == (1, 2, 1)
+        and neighbor_rows[2][1] == (-1, 0, 1)
+        and neighbor_rows[2][2] == (0, 0, 0)
+        and neighbor_rows[3][1] == (-1, 1, 0)
+        and neighbor_rows[3][2] == (0, 0, 0)
+        and l1(sub((0, 1, 1), (0, 0, 0))) == 2
+        and l1(sub((0, 1, 1), (1, 2, 1))) == 2,
+    )
+    checks.check(
+        "theorem-1-hist-kernels",
+        "history kernels use only occupancy in each neighbor's nearest-seed ball",
+        neighbor_rows[0][3] == (0, 0, 0, 1, 0, 1)
+        and neighbor_rows[0][4] == (Fraction(0), Fraction(-1, 3), Fraction(-1, 3))
+        and neighbor_rows[0][6] is None
+        and neighbor_rows[1][3] == (1, 0, 0, 0, 0, 0)
+        and neighbor_rows[1][4] == (Fraction(1, 3), Fraction(0), Fraction(0))
+        and neighbor_rows[1][6] == PLUS
+        and neighbor_rows[2][3] == (1, 0, 0, 0, 0, 1)
+        and neighbor_rows[2][4] == (Fraction(1, 3), Fraction(0), Fraction(-1, 3))
+        and neighbor_rows[2][6] is None
+        and neighbor_rows[3][3] == (1, 0, 0, 1, 0, 0)
+        and neighbor_rows[3][4] == (Fraction(1, 3), Fraction(-1, 3), Fraction(0))
+        and neighbor_rows[3][6] is None,
+    )
+    checks.check(
+        "theorem-1-two-support-deltas",
+        "the three history-tied claim-deltas are two-support; unique-axis of δ fails",
+        neighbor_rows[0][5] == (0, 1, 1)
+        and unique_nonzero_sign(neighbor_rows[0][5]) is None
+        and neighbor_rows[1][5] == (-2, 0, 0)
+        and neighbor_rows[2][5] == (-1, 0, 1)
+        and unique_nonzero_sign(neighbor_rows[2][5]) is None
+        and neighbor_rows[3][5] == (-1, 1, 0)
+        and unique_nonzero_sign(neighbor_rows[3][5]) is None
+        and unique_axis_delta_fails
+        and "(0, 1, 1)" in note
+        and "(−1, 0, 1)" in note
+        and "(−1, 1, 0)" in note
+        and "two-support" in note,
+    )
+    checks.check(
+        "theorem-1-sign-products",
+        "product of nonzero δ signs labels the three history ties +, −, −",
+        nonzero_sign_product((0, 1, 1)) == PLUS
+        and nonzero_sign_product((-1, 0, 1)) == MINUS
+        and nonzero_sign_product((-1, 1, 0)) == MINUS
+        and nonzero_sign_product((0, 0, 0)) is None
+        and neighbor_rows[0][7] == PLUS
+        and neighbor_rows[1][7] == PLUS
+        and neighbor_rows[2][7] == MINUS
+        and neighbor_rows[3][7] == MINUS
+        and product_broke == 3
+        and neighbor_rows[1][6] == PLUS,
+    )
+    checks.check(
+        "theorem-1-completed-tuple",
+        "the completed 6-tuple is (+,0,+,−,0,−) and every occupied neighbor is labeled",
+        fragment == expected
+        and format_fragment(fragment) == "(+,0,+,−,0,−)"
+        and every_labeled
+        and tied_count == 0
+        and "(+,0,+,−,0,−)" in note
+        and "Every occupied neighbor is labeled" in note,
+        residual=format_fragment(fragment),
+    )
+    checks.check(
+        "pair-census",
+        "the reconstructed July-3 k=3 pair has 48 members in one chiral pair",
+        len(pair) == 48
+        and all(coloring.count(EMPTY) == 2 for coloring in pair)
+        and all(len({coloring[0], coloring[1]}) == 2 for coloring in pair)
+        and all(len({coloring[2], coloring[3]}) == 2 for coloring in pair)
+        and all(len({coloring[4], coloring[5]}) == 2 for coloring in pair),
+    )
+    checks.check(
+        "theorem-2-pair-member",
+        "the completed 6-tuple is a July-3 k=3 pair member",
+        fragment == expected
+        and fragment in pair
+        and len(completions) == 1
+        and completions == (expected,)
+        and firing == (expected,)
+        and len(firing) == 1
+        and "July-3" in note
+        and "pair member" in note
+        and "(+,0,+,−,0,−)" in note,
+        residual=format_fragment(fragment),
+    )
+
+    claim_scope = (
+        'claim_scope: "On the off-axis three-ball union at unread v=(-1,1,1), '
+        "whether the product of signs of nonzero coordinates of each tied "
+        "claim-delta yields a July-3 k=3 pair member is reported. "
+        'Displayed, not adopted."'
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the declared displayed claim_scope",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the product rule is displayed and is not written into Admissibility",
+        "Displayed, not adopted" in note
+        and "Do not write the product rule into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "the note does not attach L1 and records the failed-bar against a fourth ball",
+        "Do not attach L1" in note
+        and "Failed-bar: no 4th equal-radius ball" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-seedax",
+        "the note is not leftover-char of seedax unique-nonzero of δ",
+        "not leftover-char of seedax" in note_flat
+        and "unique nonzero" in note
+        and "product of the signs" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the product rule and the off-axis triple are not written into Admissibility",
+        "one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations"
+        in axiom_flat
+        and "B_2((1,2,1))" not in axiom
+        and "n_hist" not in axiom
+        and "sign product" not in axiom
+        and "delta_sign_product" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the forbidden rhetoric strings are absent from the note and runner",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(phrase not in self_source.split("FORBIDDEN = ", 1)[0] for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the only axiom authority is the current memo; no cache or axiom rewrite",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: product of claim-delta signs and pair membership are exact")
+    print("per_site: only the unread star center v is scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: U and the six-neighbor star at v only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

At v=(-1,1,1) the product of signs of nonzero coordinates of each tied claim-delta yields c=(+,0,+,-,0,-). Every occupied neighbor is labeled. That 6-tuple is a July-3 k=3 pair member. Displayed, not adopted. No axiom edit. No 4th ball.

## Runner

`scripts/skew_three_seed_delta_sign_product_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.